### PR TITLE
[view-transitions] Visible clipping at the end of animation on https://www.kvin.me/posts/cards

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/inline-with-offset-from-containing-block-clipped-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/inline-with-offset-from-containing-block-clipped-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: capture elements with display inline (ref)</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<style>
+html {
+  background: pink;
+}
+#box {
+  will-change: opacity;
+  background: blue;
+}
+
+div {
+  padding-left: 8px;
+  padding-top: 8px;
+}
+</style>
+
+<div>
+  <span id=box>&nbsp;&nbsp;&nbsp;&nbsp;</span>
+</div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-inline-with-offset-from-containing-block-clipped-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-inline-with-offset-from-containing-block-clipped-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: capture elements with display inline (ref)</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<style>
+html {
+  background: pink;
+}
+#box {
+  will-change: opacity;
+  background: blue;
+}
+
+div {
+  padding-left: 8px;
+  padding-top: 8px;
+}
+</style>
+
+<div>
+  <span id=box>&nbsp;&nbsp;&nbsp;&nbsp;</span>
+</div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-inline-with-offset-from-containing-block-clipped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-inline-with-offset-from-containing-block-clipped.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>View transitions: capture elements with display inline</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<link rel="author" href="mailto:mattwoodrow@apple.com">
+<link rel="match" href="inline-with-offset-from-containing-block-clipped-ref.html">
+<script src="/common/reftest-wait.js"></script>
+<style>
+#box {
+  background: blue;
+  view-transition-name: target;
+}
+
+div {
+  padding-left: 8px;
+  padding-top: 8px;
+  background-color: green;
+}
+
+/* We're verifying what we capture, so just display the contents for 5 minutes.  */
+html::view-transition-group(*) { animation-duration: 300s; }
+html::view-transition-group(target) { background: green; }
+html::view-transition-new(*) { animation: unset; opacity: 1; }
+html::view-transition-old(*) { animation: unset; opacity: 0; }
+/* hide the root so we show transition background to ensure we're in a transition */
+html::view-transition-group(root) { animation: unset; opacity: 0; }
+html::view-transition { background: pink; }
+
+::view-transition-image-pair(target) {
+    overflow:clip;
+}
+</style>
+
+<div>
+  <span id=box>&nbsp;&nbsp&nbsp;&nbsp;</span>
+</div>
+<script>
+
+async function runTest() {
+  let t = document.startViewTransition();
+  t.ready.then(takeScreenshot);
+}
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-inline-with-offset-from-containing-block-clipped-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-inline-with-offset-from-containing-block-clipped-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: capture elements with display inline (ref)</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<style>
+html {
+  background: pink;
+}
+#box {
+  will-change: opacity;
+  background: blue;
+}
+
+div {
+  padding-left: 8px;
+  padding-top: 8px;
+}
+</style>
+
+<div>
+  <span id=box>&nbsp;&nbsp;&nbsp;&nbsp;</span>
+</div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-inline-with-offset-from-containing-block-clipped.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-inline-with-offset-from-containing-block-clipped.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>View transitions: capture elements with display inline</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<link rel="author" href="mailto:mattwoodrow@apple.com">
+<link rel="match" href="inline-with-offset-from-containing-block-clipped-ref.html">
+<script src="/common/reftest-wait.js"></script>
+<style>
+#box {
+  background: blue;
+  view-transition-name: target;
+}
+
+div {
+  padding-left: 8px;
+  padding-top: 8px;
+  background-color: green;
+}
+
+/* We're verifying what we capture, so just display the contents for 5 minutes.  */
+html::view-transition-group(*) { animation-duration: 300s; }
+html::view-transition-group(target) { background: green; }
+html::view-transition-new(*) { animation: unset; opacity: 0; }
+html::view-transition-old(*) { animation: unset; opacity: 1; }
+/* hide the root so we show transition background to ensure we're in a transition */
+html::view-transition-group(root) { animation: unset; opacity: 0; }
+html::view-transition { background: pink; }
+
+::view-transition-image-pair(target) {
+    overflow:clip;
+}
+</style>
+
+<div>
+  <span id=box>&nbsp;&nbsp&nbsp;&nbsp;</span>
+</div>
+<script>
+failIfNot(document.startViewTransition, "Missing document.startViewTransition");
+
+async function runTest() {
+  let t = document.startViewTransition();
+  t.ready.then(takeScreenshot);
+}
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>
+
+</html>

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -61,6 +61,7 @@ public:
     // nullptr represents an absent snapshot on an capturable element.
     std::optional<RefPtr<ImageBuffer>> oldImage;
     LayoutRect oldOverflowRect;
+    LayoutPoint oldLayerToLayoutOffset;
     LayoutSize oldSize;
     RefPtr<MutableStyleProperties> oldProperties;
     WeakStyleable newElement;

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
@@ -48,12 +48,13 @@ void RenderViewTransitionCapture::setImage(RefPtr<ImageBuffer> oldImage)
     m_oldImage = oldImage;
 }
 
-bool RenderViewTransitionCapture::setSize(const LayoutSize& size, const LayoutRect& overflowRect)
+bool RenderViewTransitionCapture::setCapturedSize(const LayoutSize& size, const LayoutRect& overflowRect, const LayoutPoint& layerToLayoutOffset)
 {
-    if (m_overflowRect == overflowRect && intrinsicSize() == size)
+    if (m_overflowRect == overflowRect && intrinsicSize() == size && m_layerToLayoutOffset == layerToLayoutOffset)
         return false;
     setIntrinsicSize(size);
     m_overflowRect = overflowRect;
+    m_layerToLayoutOffset = layerToLayoutOffset;
     return true;
 }
 
@@ -76,10 +77,14 @@ void RenderViewTransitionCapture::paintReplaced(PaintInfo& paintInfo, const Layo
 void RenderViewTransitionCapture::layout()
 {
     RenderReplaced::layout();
+    // Move the overflow rect of the captured renderer into layout coords, and then scale/position so that the intrinsic size subset covers
+    // our replaced content rect.
     m_localOverflowRect = m_overflowRect;
+    m_localOverflowRect.moveBy(-m_layerToLayoutOffset);
     m_scale = { replacedContentRect().width().toFloat() / intrinsicSize().width().toFloat() , replacedContentRect().height().toFloat() / intrinsicSize().height().toFloat()  };
     m_localOverflowRect.scale(m_scale.width(), m_scale.height());
     m_localOverflowRect.moveBy(replacedContentRect().location());
+
     addVisualOverflow(m_localOverflowRect);
 }
 

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.h
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.h
@@ -37,7 +37,7 @@ public:
     virtual ~RenderViewTransitionCapture();
 
     void setImage(RefPtr<ImageBuffer>);
-    bool setSize(const LayoutSize&, const LayoutRect& overflowRect);
+    bool setCapturedSize(const LayoutSize&, const LayoutRect& overflowRect, const LayoutPoint& layerToLayoutOffset);
 
     void paintReplaced(PaintInfo&, const LayoutPoint& paintOffset) override;
 
@@ -45,8 +45,7 @@ public:
 
     FloatSize scale() const { return m_scale; }
 
-    // Rect covered by the captured contents, relative to the
-    // intrinsic size.
+    // Rect covered by the captured contents, in RenderLayer coordinates of the captured renderer
     LayoutRect captureOverflowRect() const { return m_overflowRect; }
 
     // Inset of the scaled capture from the visualOverflowRect()
@@ -61,9 +60,18 @@ private:
     void updateFromStyle() override;
 
     RefPtr<ImageBuffer> m_oldImage;
+    // The overflow rect that the captured image represents, in RenderLayer coordinates
+    // of the captured renderer (see layerToLayoutOffset in ViewTransition.cpp).
+    // The intrisic size subset of the image is stored as the intrinsic size of the RenderReplaced.
     LayoutRect m_overflowRect;
-    FloatSize m_scale;
+    // The offset between coordinates used by RenderLayer, and RenderObject
+    // for the captured renderer
+    LayoutPoint m_layerToLayoutOffset;
+    // The overflow rect of the snapshot (replaced content), scaled and positioned
+    // so that the intrinsic size of the image fits the replaced content rect.
     LayoutRect m_localOverflowRect;
+    // Scale factor between the intrinsic size and the replaced content rect size.
+    FloatSize m_scale;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp
@@ -130,7 +130,7 @@ static RenderPtr<RenderBox> createRendererIfNeeded(RenderElement& documentElemen
         RenderPtr<RenderViewTransitionCapture> rendererViewTransition = WebCore::createRenderer<RenderViewTransitionCapture>(RenderObject::Type::ViewTransitionCapture, document, RenderStyle::clone(*style));
         if (pseudoId == PseudoId::ViewTransitionOld)
             rendererViewTransition->setImage(capturedElement->oldImage.value_or(nullptr));
-        rendererViewTransition->setSize(capturedElement->oldSize, capturedElement->oldOverflowRect);
+        rendererViewTransition->setCapturedSize(capturedElement->oldSize, capturedElement->oldOverflowRect, capturedElement->oldLayerToLayoutOffset);
         renderer = WTFMove(rendererViewTransition);
     } else
         renderer = WebCore::createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, document, RenderStyle::clone(*style), RenderObject::BlockFlowFlag::IsViewTransitionContainer);


### PR DESCRIPTION
#### 14d2ee99d4aaacbe10cb5f00a01b783ee45a0708
<pre>
[view-transitions] Visible clipping at the end of animation on <a href="https://www.kvin.me/posts/cards">https://www.kvin.me/posts/cards</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=274404">https://bugs.webkit.org/show_bug.cgi?id=274404</a>
&lt;<a href="https://rdar.apple.com/128406756">rdar://128406756</a>&gt;

Reviewed by Alan Baradlay.

RenderLayer&apos;s use of RenderInline doesn&apos;t include any padding from its containing block in its position, and instead accounts for it
in the position of the lines boxes themselves.

This means that the computed (web visible) transform (using the renderer&apos;s position) for the ::view-transition-group doesn&apos;t
include the offset between the inline element and its container. It also means that an overflow:clip on the
::view-transition-image-pair applies the clip in the wrong coordinate space for the snapshots.

This change computes the offset between the position of the renderer, and that used by RenderLayer. It uses this
to adjust the computed transform, and the overflow rect of the snapshot so that they correctly account for the position of the
renderer.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/inline-with-offset-from-containing-block-clipped-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-inline-with-offset-from-containing-block-clipped-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/new-content-inline-with-offset-from-containing-block-clipped.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-inline-with-offset-from-containing-block-clipped-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-inline-with-offset-from-containing-block-clipped.html: Added.
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::layerToLayoutOffset):
(WebCore::ViewTransition::captureOldState):
(WebCore::ViewTransition::copyElementBaseProperties):
(WebCore::ViewTransition::updatePseudoElementStyles):
* Source/WebCore/dom/ViewTransition.h:
* Source/WebCore/rendering/RenderViewTransitionCapture.cpp:
(WebCore::RenderViewTransitionCapture::setCapturedSize):
(WebCore::RenderViewTransitionCapture::layout):
(WebCore::RenderViewTransitionCapture::setSize): Deleted.
* Source/WebCore/rendering/RenderViewTransitionCapture.h:
* Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp:
(WebCore::createRendererIfNeeded):

Canonical link: <a href="https://commits.webkit.org/279433@main">https://commits.webkit.org/279433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3411a0fbf5f076aba88fde13682833c20345f3af

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56717 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4163 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55743 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3966 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43317 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2737 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30985 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46172 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24451 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27845 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3488 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2319 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49605 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58312 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28594 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3682 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50716 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29801 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46364 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50057 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11659 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30729 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29571 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->