### PR TITLE
The stack-overflow-in-syntax-checker.js JSC stress test is flaky.

### DIFF
--- a/JSTests/stress/stack-overflow-in-syntax-checker.js
+++ b/JSTests/stress/stack-overflow-in-syntax-checker.js
@@ -1,4 +1,4 @@
-//@ runDefault
+//@ runDefault("--ignoreUncaughtExceptions")
 
 // This is just check that we have sufficient Reserved Zone size to handle stack
 // overflows, especially on ASAN builds. The test passes if it does not crash.
@@ -10,14 +10,11 @@ for (var i = 0; i < 1000; i++) {
 
 try {
     $262.agent.start(`
-        try {
-            $262.agent.receiveBroadcast(function(sab) {
-                const i32a = new Int32Array(sab);
-                Atomics.add(i32a, ${r1}, 1);
-                $262.agent.report(Atomics.wait(i32a, 0, 0, ${r1}));
-            });
-        } catch (e) {
-        }
+        $262.agent.receiveBroadcast(function(sab) {
+            const i32a = new Int32Array(sab);
+            Atomics.add(i32a, ${r1}, 1);
+            $262.agent.report(Atomics.wait(i32a, 0, 0, ${r1}));
+        });
     `);
 } catch (e) {
 }

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -480,6 +480,7 @@ public:
     bool m_exitCode { false };
     bool m_destroyVM { false };
     bool m_treatWatchdogExceptionAsSuccess { false };
+    bool m_ignoreUncaughtExceptions { false };
     bool m_alwaysDumpUncaughtException { false };
     bool m_dumpMemoryFootprint { false };
     bool m_dumpLinkBufferStats { false };
@@ -3678,13 +3679,13 @@ static void checkException(GlobalObject* globalObject, bool isLastFile, bool has
     }
 
     if (!options.m_uncaughtExceptionName || !isLastFile) {
-        success = success && !hasException;
+        success = success && (!hasException || options.m_ignoreUncaughtExceptions);
         if (options.m_dump && !hasException)
             printf("End: %s\n", value.toWTFString(globalObject).utf8().data());
-        if (hasException)
+        if (hasException && !options.m_ignoreUncaughtExceptions)
             dumpException(globalObject, value);
     } else
-        success = success && checkUncaughtException(vm, globalObject, (hasException) ? value : JSValue(), options);
+        success = success && (checkUncaughtException(vm, globalObject, (hasException) ? value : JSValue(), options) || options.m_ignoreUncaughtExceptions);
 }
 
 void GlobalObject::reportUncaughtExceptionAtEventLoop(JSGlobalObject* globalObject, Exception* exception)
@@ -3896,6 +3897,7 @@ static NO_RETURN void printUsageStatement(bool help = false)
     fprintf(stderr, "  --strict-file=<file>       Parse the given file as if it were in strict mode (this option may be passed more than once)\n");
     fprintf(stderr, "  --module-file=<file>       Parse and evaluate the given file as module (this option may be passed more than once)\n");
     fprintf(stderr, "  --exception=<name>         Check the last script exits with an uncaught exception with the specified name\n");
+    fprintf(stderr, "  --ignoreUncaughtExceptions Do not error out if an uncaught exception is observed\n");
     fprintf(stderr, "  --watchdog-exception-ok    Uncaught watchdog exceptions exit with success\n");
     fprintf(stderr, "  --dumpException            Dump uncaught exception text\n");
     fprintf(stderr, "  --footprint                Dump memory footprint after done executing\n");
@@ -4095,6 +4097,11 @@ void CommandLine::parseArguments(int argc, char** argv)
             continue;
         }
 
+        if (!strcmp(arg, "--ignoreUncaughtExceptions")) {
+            m_ignoreUncaughtExceptions = true;
+            continue;
+        }
+
         if (!strcmp(arg, "--footprint")) {
             m_dumpMemoryFootprint = true;
             continue;
@@ -4162,6 +4169,7 @@ void CommandLine::parseArguments(int argc, char** argv)
 
 CommandLine::CommandLine(CommandLineForWorkersTag)
     : m_treatWatchdogExceptionAsSuccess(mainCommandLine->m_treatWatchdogExceptionAsSuccess)
+    , m_ignoreUncaughtExceptions(mainCommandLine->m_ignoreUncaughtExceptions)
 {
 }
 


### PR DESCRIPTION
#### 866927170c083846d494376c653608dfd5d29360
<pre>
The stack-overflow-in-syntax-checker.js JSC stress test is flaky.
<a href="https://bugs.webkit.org/show_bug.cgi?id=274749">https://bugs.webkit.org/show_bug.cgi?id=274749</a>
<a href="https://rdar.apple.com/128786930">rdar://128786930</a>

Reviewed by Justin Michaud.

We observed that the stack-overflow-in-syntax-checker.js test is flaky.  After a lot of
investigation, the issue turns out to be a test issue:

1. The test starts a worker thread using $262.agent.start.
2. The worker thread will always fail to parse its script: the script will cause the parser
   to recurse too deeply, thereby resulting in a StackOverflowError.
3. Since the StackOverflowError occurs during parsing, adding a try-catch block around the
   worker payload script (in 279015@main) does not help because the error occurs before the
   script even gets to execute.
4. If the worker thread throws the StackOverflowError, and propagate it all the way out,
   resulting in an uncaught exception before the main thread terminates, this will result
   in the process exiting with EXIT_FAILURE.  The test fails.
5. On the other hand, if the main thread finishes first before the worker thread can exit
   with EXIT_FAILURE, then the test passes.

The test is flaky because its result is dependent on whether the main thread or the worker
thread wins the race.

The purpose of this test is to ensure that the stack overflow in the parser does not result
in a crash.  Hence, whether we get an uncaught exception or not is irrelevant and should not
fail the test.

The fix is to add a new `--ignoreUncaughtExceptions` option to the jsc shell, and require
that option for this test.

* JSTests/stress/stack-overflow-in-syntax-checker.js:
(try.262.agent.start.262.agent.receiveBroadcast):
(try.262.agent.start.try.262.agent.receiveBroadcast): Deleted.
(try.catch): Deleted.
* Source/JavaScriptCore/jsc.cpp:
(checkException):
(printUsageStatement):
(CommandLine::parseArguments):
(CommandLine::CommandLine):

Canonical link: <a href="https://commits.webkit.org/279380@main">https://commits.webkit.org/279380@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d938183422474507c173dabf789bb25149d3a2ab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53248 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56527 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3974 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43165 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2588 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55346 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30739 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45974 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24295 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27667 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3300 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2130 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/46604 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49433 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3458 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58123 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52761 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28394 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3445 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50565 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29610 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46194 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49883 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30531 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65066 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7841 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29370 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12390 "Found 256 new JSC stress test failures: basic-tests.yaml/stress-test.js.bytecode-cache, basic-tests.yaml/stress-test.js.dfg-eager, basic-tests.yaml/stress-test.js.dfg-eager-no-cjit-validate, basic-tests.yaml/stress-test.js.eager-jettison-no-cjit, basic-tests.yaml/stress-test.js.no-cjit-collect-continuously, basic-tests.yaml/stress-test.js.no-cjit-validate-phases, jsc-layout-tests.yaml/js/script-tests/statement-list-item-syntax-errors.js.layout-dfg-eager-no-cjit, microbenchmarks/large-map-iteration.js.bytecode-cache, stress/big-int-unary-plus.js.dfg-eager-no-cjit-validate, stress/compare-bigint-with-number.js.bytecode-cache ... (failure)") | 
<!--EWS-Status-Bubble-End-->