### PR TITLE
CanvasBase contains 2D context specific drawing methods

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1453,6 +1453,7 @@ webkit.org/b/272582 fast/canvas/canvas-strokeRect-gradient-shadow.html [ Failure
 webkit.org/b/274513 imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-canvas.html [ ImageOnlyFailure ]
 
 webkit.org/b/273239 fast/canvas/canvas-scale-shadowBlur.html [ Failure ]
+webkit.org/b/275353 fast/canvas/canvas-filter-repaint-rect.html [ Failure ]
 webkit.org/b/273239 imported/w3c/web-platform-tests/html/canvas/element/shadows/2d.shadow.composite.1.html [ Failure ]
 webkit.org/b/273239 imported/w3c/web-platform-tests/html/canvas/element/shadows/2d.shadow.composite.2.html [ Failure ]
 webkit.org/b/273239 imported/w3c/web-platform-tests/html/canvas/element/shadows/2d.shadow.enable.blur.html [ Failure ]

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -67,34 +67,11 @@ CanvasBase::~CanvasBase()
     m_canvasNoiseHashSalt = std::nullopt;
 }
 
-GraphicsContext* CanvasBase::drawingContext() const
-{
-    auto* context = renderingContext();
-    if (context && !context->is2d() && !context->isOffscreen2d())
-        return nullptr;
-
-    return buffer() ? &m_imageBuffer->context() : nullptr;
-}
-
-GraphicsContext* CanvasBase::existingDrawingContext() const
-{
-    if (!hasCreatedImageBuffer())
-        return nullptr;
-
-    return drawingContext();
-}
-
 ImageBuffer* CanvasBase::buffer() const
 {
     if (!hasCreatedImageBuffer())
         createImageBuffer();
     return m_imageBuffer.get();
-}
-
-AffineTransform CanvasBase::baseTransform() const
-{
-    ASSERT(hasCreatedImageBuffer());
-    return m_imageBuffer->baseTransform();
 }
 
 RefPtr<ImageBuffer> CanvasBase::makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect shouldApplyPostProcessingToDirtyRect)

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -93,8 +93,6 @@ public:
 
     virtual void setImageBufferAndMarkDirty(RefPtr<ImageBuffer>&&) { }
 
-    virtual AffineTransform baseTransform() const;
-
     RefPtr<ImageBuffer> makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect = ShouldApplyPostProcessingToDirtyRect::Yes);
 
     size_t memoryCost() const;
@@ -125,9 +123,6 @@ public:
     bool hasDisplayBufferObservers() const { return !m_displayBufferObservers.isEmptyIgnoringNullReferences(); }
 
     HashSet<Element*> cssCanvasClients() const;
-
-    virtual GraphicsContext* drawingContext() const;
-    virtual GraphicsContext* existingDrawingContext() const;
 
     // !rect means caller knows the full canvas is invalidated previously.
     void didDraw(const std::optional<FloatRect>& rect) { return didDraw(rect, ShouldApplyPostProcessingToDirtyRect::Yes); }

--- a/Source/WebCore/html/CustomPaintCanvas.cpp
+++ b/Source/WebCore/html/CustomPaintCanvas.cpp
@@ -29,9 +29,6 @@
 #include "BitmapImage.h"
 #include "CSSParserContext.h"
 #include "CanvasRenderingContext.h"
-#include "DisplayListDrawingContext.h"
-#include "DisplayListRecorder.h"
-#include "DisplayListReplayer.h"
 #include "ImageBitmap.h"
 #include "PaintRenderingContext2D.h"
 #include "ScriptExecutionContext.h"
@@ -59,11 +56,9 @@ CustomPaintCanvas::~CustomPaintCanvas()
 
 RefPtr<PaintRenderingContext2D> CustomPaintCanvas::getContext()
 {
-    if (m_context)
-        return &downcast<PaintRenderingContext2D>(*m_context);
-
-    m_context = PaintRenderingContext2D::create(*this);
-    return static_cast<PaintRenderingContext2D*>(m_context.get());
+    if (!m_context)
+        m_context = PaintRenderingContext2D::create(*this);
+    return m_context.get();
 }
 
 void CustomPaintCanvas::replayDisplayList(GraphicsContext& target)
@@ -77,17 +72,9 @@ void CustomPaintCanvas::replayDisplayList(GraphicsContext& target)
         return;
     auto& imageTarget = image->context();
     imageTarget.translate(-clipBounds.location());
-    replayDisplayListImpl(imageTarget);
+    if (m_context)
+        m_context->replayDisplayList(imageTarget);
     target.drawImageBuffer(*image, clipBounds);
-}
-
-AffineTransform CustomPaintCanvas::baseTransform() const
-{
-    // The base transform of the display list.
-    // FIXME: this is actually correct, but the display list will not behave correctly with respect to
-    // playback. The GraphicsContext should be fixed to start at identity transform, and the
-    // device transform should be a separate concept that the display list or context2d cannot reset.
-    return { };
 }
 
 Image* CustomPaintCanvas::copiedImage() const
@@ -97,7 +84,8 @@ Image* CustomPaintCanvas::copiedImage() const
     m_copiedImage = nullptr;
     auto buffer = ImageBuffer::create(size(), RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
     if (buffer) {
-        replayDisplayListImpl(buffer->context());
+        if (m_context)
+            m_context->replayDisplayList(buffer->context());
         m_copiedImage = BitmapImage::create(ImageBuffer::sinkIntoNativeImage(buffer));
     }
     return m_copiedImage.get();
@@ -106,30 +94,6 @@ Image* CustomPaintCanvas::copiedImage() const
 void CustomPaintCanvas::clearCopiedImage() const
 {
     m_copiedImage = nullptr;
-}
-
-GraphicsContext* CustomPaintCanvas::drawingContext() const
-{
-    if (!m_recordingContext)
-        m_recordingContext = makeUnique<DisplayList::DrawingContext>(size());
-    return &m_recordingContext->context();
-}
-
-GraphicsContext* CustomPaintCanvas::existingDrawingContext() const
-{
-    return m_recordingContext ? &m_recordingContext->context() : nullptr;
-}
-
-void CustomPaintCanvas::replayDisplayListImpl(GraphicsContext& target) const
-{
-    if (!m_recordingContext)
-        return;
-    auto& displayList = m_recordingContext->displayList();
-    if (!displayList.isEmpty()) {
-        DisplayList::Replayer replayer(target, displayList);
-        replayer.replay(FloatRect { { }, size() });
-        displayList.clear();
-    }
 }
 
 const CSSParserContext& CustomPaintCanvas::cssParserContext() const

--- a/Source/WebCore/html/CustomPaintCanvas.h
+++ b/Source/WebCore/html/CustomPaintCanvas.h
@@ -32,6 +32,7 @@
 #include "ExceptionOr.h"
 #include "ImageBuffer.h"
 #include "IntSize.h"
+#include "PaintRenderingContext2D.h"
 #include "ScriptWrappable.h"
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
@@ -39,9 +40,7 @@
 
 namespace WebCore {
 
-class CanvasRenderingContext;
 class ImageBitmap;
-class PaintRenderingContext2D;
 
 namespace DisplayList {
 class DrawingContext;
@@ -58,12 +57,9 @@ public:
     RefPtr<PaintRenderingContext2D> getContext();
 
     CanvasRenderingContext* renderingContext() const final { return m_context.get(); }
-    GraphicsContext* drawingContext() const final;
-    GraphicsContext* existingDrawingContext() const final;
 
     void didDraw(const std::optional<FloatRect>&, ShouldApplyPostProcessingToDirtyRect) final { }
 
-    AffineTransform baseTransform() const final;
     Image* copiedImage() const final;
     void clearCopiedImage() const final;
 
@@ -83,12 +79,9 @@ private:
     void refCanvasBase() const final { ref(); }
     void derefCanvasBase() const final { deref(); }
     ScriptExecutionContext* canvasBaseScriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
-    void replayDisplayListImpl(GraphicsContext& target) const;
 
-    std::unique_ptr<CanvasRenderingContext> m_context;
-    mutable std::unique_ptr<DisplayList::DrawingContext> m_recordingContext;
+    std::unique_ptr<PaintRenderingContext2D> m_context;
     mutable RefPtr<Image> m_copiedImage;
-
     mutable std::unique_ptr<CSSParserContext> m_cssParserContext;
 };
 

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -125,7 +125,7 @@ public:
 
     SecurityOrigin* securityOrigin() const final;
 
-    // FIXME: Only some canvas rendering contexts need an ImageBuffer.
+    // FIXME(https://bugs.webkit.org/show_bug.cgi?id=275100): Only some canvas rendering contexts need an ImageBuffer.
     // It would be better to have the contexts own the buffers.
     void setImageBufferAndMarkDirty(RefPtr<ImageBuffer>&&) final;
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -317,7 +317,10 @@ protected:
     void realizeSaves();
     State& modifiableState() { ASSERT(!m_unrealizedSaveCount || m_stateStack.size() >= MaxSaveCount); return m_stateStack.last(); }
 
-    GraphicsContext* drawingContext() const;
+    virtual GraphicsContext* drawingContext() const;
+    virtual GraphicsContext* existingDrawingContext() const;
+    virtual AffineTransform baseTransform() const;
+
     enum class DidDrawOption {
         ApplyTransform = 1 << 0,
         ApplyShadow = 1 << 1,

--- a/Source/WebCore/html/canvas/PaintRenderingContext2D.h
+++ b/Source/WebCore/html/canvas/PaintRenderingContext2D.h
@@ -27,23 +27,32 @@
 
 #include "CanvasRenderingContext2DBase.h"
 
-#include "CustomPaintCanvas.h"
-
 namespace WebCore {
+
+namespace DisplayList {
+class DrawingContext;
+}
+
+class CustomPaintCanvas;
 
 class PaintRenderingContext2D final : public CanvasRenderingContext2DBase {
     WTF_MAKE_ISO_ALLOCATED(PaintRenderingContext2D);
 public:
-    static std::unique_ptr<PaintRenderingContext2D> create(CanvasBase&);
+    static std::unique_ptr<PaintRenderingContext2D> create(CustomPaintCanvas&);
 
     virtual ~PaintRenderingContext2D();
 
-    CustomPaintCanvas& canvas() const { return downcast<CustomPaintCanvas>(canvasBase()); }
+    GraphicsContext* drawingContext() const final;
+    GraphicsContext* existingDrawingContext() const final;
+    AffineTransform baseTransform() const final;
+
+    CustomPaintCanvas& canvas() const;
+    void replayDisplayList(GraphicsContext& target) const;
 
 private:
+    PaintRenderingContext2D(CustomPaintCanvas&);
     bool isPaint() const override { return true; }
-
-    PaintRenderingContext2D(CanvasBase&);
+    mutable std::unique_ptr<DisplayList::DrawingContext> m_recordingContext;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### ea2135ab14ff38d8adaa16c94ee1666c4b9ff2dd
<pre>
CanvasBase contains 2D context specific drawing methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=274750">https://bugs.webkit.org/show_bug.cgi?id=274750</a>
<a href="https://rdar.apple.com/128788730">rdar://128788730</a>

Reviewed by Said Abou-Hallawa.

Move drawingContext(), existingDrawingContext(), baseTransform() to
CanvasRenderingContext2DBase as they are only related to 2D context
implementation.

This is work towards CanvasRenderingContext subclasses themselves managing
the copied buffers.

* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::drawingContext const): Deleted.
(WebCore::CanvasBase::existingDrawingContext const): Deleted.
(WebCore::CanvasBase::baseTransform const): Deleted.
* Source/WebCore/html/CanvasBase.h:
(WebCore::CanvasBase::hasCreatedImageBuffer const):
* Source/WebCore/html/CustomPaintCanvas.cpp:
(WebCore::CustomPaintCanvas::getContext):
(WebCore::CustomPaintCanvas::replayDisplayList):
(WebCore::CustomPaintCanvas::copiedImage const):
(WebCore::CustomPaintCanvas::baseTransform const): Deleted.
(WebCore::CustomPaintCanvas::drawingContext const): Deleted.
(WebCore::CustomPaintCanvas::existingDrawingContext const): Deleted.
(WebCore::CustomPaintCanvas::replayDisplayListImpl const): Deleted.
* Source/WebCore/html/CustomPaintCanvas.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::didDraw):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::unwindStateStack):
(WebCore::CanvasRenderingContext2DBase::isAccelerated const):
(WebCore::CanvasRenderingContext2DBase::reset):
(WebCore::CanvasRenderingContext2DBase::resetTransform):
(WebCore::CanvasRenderingContext2DBase::clearCanvas):
(WebCore::CanvasRenderingContext2DBase::transformAreaToDevice const):
(WebCore::CanvasRenderingContext2DBase::calculateCompositingBufferRect):
(WebCore::CanvasRenderingContext2DBase::compositeBuffer):
(WebCore::CanvasRenderingContext2DBase::didDraw):
(WebCore::CanvasRenderingContext2DBase::drawingContext const):
(WebCore::CanvasRenderingContext2DBase::existingDrawingContext const):
(WebCore::CanvasRenderingContext2DBase::baseTransform const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/html/canvas/PaintRenderingContext2D.cpp:
(WebCore::PaintRenderingContext2D::create):
(WebCore::PaintRenderingContext2D::PaintRenderingContext2D):
(WebCore::PaintRenderingContext2D::canvas const):
(WebCore::PaintRenderingContext2D::drawingContext const):
(WebCore::PaintRenderingContext2D::existingDrawingContext const):
(WebCore::PaintRenderingContext2D::baseTransform const):
(WebCore::PaintRenderingContext2D::replayDisplayList const):
* Source/WebCore/html/canvas/PaintRenderingContext2D.h:

Canonical link: <a href="https://commits.webkit.org/279912@main">https://commits.webkit.org/279912@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3761452db96e0a31472f8bad6170d530db63ac1d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58179 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5632 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57201 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5656 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44464 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3818 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32450 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47567 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25591 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29240 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4908 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3773 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5130 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59769 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30158 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5275 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51886 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31295 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47645 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51311 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12068 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32310 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31083 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->