### PR TITLE
Faulty assert in RenderTreeBuilder::Ruby::findOrCreateParentForStyleBasedRubyChild

### DIFF
--- a/LayoutTests/fast/ruby/ruby-block-anonymous-assert-expected.txt
+++ b/LayoutTests/fast/ruby/ruby-block-anonymous-assert-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/ruby/ruby-block-anonymous-assert.html
+++ b/LayoutTests/fast/ruby/ruby-block-anonymous-assert.html
@@ -1,0 +1,10 @@
+<style>
+#abs_pos {
+  position: absolute;
+}
+</style>
+<ruby id=abs_pos><ruby></ruby><span></ruby>This test passes if it doesn't crash.
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp
@@ -70,7 +70,8 @@ RenderElement& RenderTreeBuilder::Ruby::findOrCreateParentForStyleBasedRubyChild
         // FIXME: It should be the immediate child but continuations can break this assumption.
         for (CheckedPtr first = parent.firstChild(); first; first = first->firstChildSlow()) {
             if (!first->isAnonymous()) {
-                ASSERT_NOT_REACHED();
+                // <ruby blockified><ruby> is valid and still requires construction of an anonymous inline ruby box.
+                ASSERT(first->style().display() == DisplayType::Ruby);
                 break;
             }
             if (first->style().display() == DisplayType::Ruby)


### PR DESCRIPTION
#### 935af36335b81e63a237452fa99fb95c08b52dc6
<pre>
Faulty assert in RenderTreeBuilder::Ruby::findOrCreateParentForStyleBasedRubyChild
<a href="https://bugs.webkit.org/show_bug.cgi?id=274751">https://bugs.webkit.org/show_bug.cgi?id=274751</a>
<a href="https://rdar.apple.com/128789974">rdar://128789974</a>

Reviewed by Alan Baradlay.

&lt;ruby blockified&gt;&lt;ruby&gt; hits asssert.

* LayoutTests/fast/ruby/ruby-block-anonymous-assert-expected.txt: Added.
* LayoutTests/fast/ruby/ruby-block-anonymous-assert.html: Added.
* Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp:
(WebCore::RenderTreeBuilder::Ruby::findOrCreateParentForStyleBasedRubyChild):

Fix the assert. Ruby-block may have a non-anonymous &lt;ruby&gt; child.

Canonical link: <a href="https://commits.webkit.org/279351@main">https://commits.webkit.org/279351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6de9307abcc9afbd032d7bd423562fe2e180011f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53252 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32601 "Hash 6de9307a for PR 29148 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56531 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3978 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3721 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43169 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2592 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55350 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/30682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45981 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24299 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3305 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2134 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3463 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58127 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28398 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3444 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50570 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29614 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46199 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49888 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11610 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30536 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29374 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->