### PR TITLE
Add forward declarations and supplement missing header files.

### DIFF
--- a/Source/JavaScriptCore/jit/JITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/JITStubRoutine.h
@@ -41,7 +41,8 @@ class GCAwareJITStubRoutineWithExceptionHandler;
 class PolymorphicAccessJITStubRoutine;
 class PolymorphicCallStubRoutine;
 class MarkingGCAwareJITStubRoutine;
-
+class CallLinkInfo;
+class ConcurrentJSLocker;
 class AccessCase;
 
 // This is a base-class for JIT stub routines, and also the class you want

--- a/Source/JavaScriptCore/runtime/ExceptionScope.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionScope.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "ExceptionScope.h"
 
+#include "ErrorInstance.h"
+#include "Exception.h"
 #include <wtf/StackTrace.h>
 #include <wtf/StringPrintStream.h>
 #include <wtf/Threading.h>


### PR DESCRIPTION
#### 309cc59bd2d54605fc8b370b723110edfa9d7796
<pre>
Add forward declarations and supplement missing header files.
<a href="https://bugs.webkit.org/show_bug.cgi?id=274755">https://bugs.webkit.org/show_bug.cgi?id=274755</a>

Reviewed by Justin Michaud.

* Source/JavaScriptCore/jit/JITStubRoutine.h:
* Source/JavaScriptCore/runtime/ExceptionScope.cpp:

Canonical link: <a href="https://commits.webkit.org/279374@main">https://commits.webkit.org/279374@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc6665936e3ceeb70b0b52c200a05832a27cbeb3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56541 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/3988 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39939 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3732 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43179 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2602 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55360 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30727 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/45992 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24309 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27661 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3315 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2144 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/46618 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49427 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3475 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58137 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52775 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28408 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3457 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50580 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29624 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46208 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49901 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11620 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30546 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65080 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29384 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12392 "Found 17 new JSC stress test failures: stress/map-iteration.js.dfg-eager, stress/shadow-realm-remote-function-copy-length-and-name.js.dfg-eager, wasm.yaml/wasm/function-tests/add-12.js.wasm-eager, wasm.yaml/wasm/function-tests/brTableAsIf.js.wasm-eager, wasm.yaml/wasm/function-tests/f32-const.js.wasm-eager, wasm.yaml/wasm/function-tests/factorial.js.wasm-eager, wasm.yaml/wasm/function-tests/trap-from-start-async.js.wasm-eager, wasm.yaml/wasm/function-tests/trap-store-2.js.wasm-eager, wasm.yaml/wasm/js-api/element-data.js.wasm-eager, wasm.yaml/wasm/js-api/global-mutate.js.wasm-eager ... (failure)") | 
<!--EWS-Status-Bubble-End-->