### PR TITLE
Support using Ref for IDLInterfaces in IDL records

### DIFF
--- a/Source/WebCore/Modules/async-clipboard/ClipboardItem.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItem.cpp
@@ -58,7 +58,7 @@ static ClipboardItem::PresentationStyle clipboardItemPresentationStyle(const Pas
     return ClipboardItem::PresentationStyle::Unspecified;
 }
 
-ClipboardItem::ClipboardItem(Vector<KeyValuePair<String, RefPtr<DOMPromise>>>&& items, const Options& options)
+ClipboardItem::ClipboardItem(Vector<KeyValuePair<String, Ref<DOMPromise>>>&& items, const Options& options)
     : m_dataSource(makeUnique<ClipboardItemBindingsDataSource>(*this, WTFMove(items)))
     , m_presentationStyle(options.presentationStyle)
 {
@@ -72,7 +72,7 @@ ClipboardItem::ClipboardItem(Clipboard& clipboard, const PasteboardItemInfo& inf
 {
 }
 
-Ref<ClipboardItem> ClipboardItem::create(Vector<KeyValuePair<String, RefPtr<DOMPromise>>>&& data, const Options& options)
+Ref<ClipboardItem> ClipboardItem::create(Vector<KeyValuePair<String, Ref<DOMPromise>>>&& data, const Options& options)
 {
     return adoptRef(*new ClipboardItem(WTFMove(data), options));
 }

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItem.h
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItem.h
@@ -55,7 +55,7 @@ public:
         PresentationStyle presentationStyle { PresentationStyle::Unspecified };
     };
 
-    static Ref<ClipboardItem> create(Vector<KeyValuePair<String, RefPtr<DOMPromise>>>&&, const Options&);
+    static Ref<ClipboardItem> create(Vector<KeyValuePair<String, Ref<DOMPromise>>>&&, const Options&);
     static Ref<ClipboardItem> create(Clipboard&, const PasteboardItemInfo&);
     static Ref<Blob> blobFromString(ScriptExecutionContext*, const String& stringData, const String& type);
 
@@ -69,7 +69,7 @@ public:
     Clipboard* clipboard();
 
 private:
-    ClipboardItem(Vector<KeyValuePair<String, RefPtr<DOMPromise>>>&&, const Options&);
+    ClipboardItem(Vector<KeyValuePair<String, Ref<DOMPromise>>>&&, const Options&);
     ClipboardItem(Clipboard&, const PasteboardItemInfo&);
 
     WeakPtr<Clipboard, WeakPtrImplWithEventTargetData> m_clipboard;

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
@@ -67,7 +67,7 @@ static FileReaderLoader::ReadType readTypeForMIMEType(const String& type)
     return FileReaderLoader::ReadAsArrayBuffer;
 }
 
-ClipboardItemBindingsDataSource::ClipboardItemBindingsDataSource(ClipboardItem& item, Vector<KeyValuePair<String, RefPtr<DOMPromise>>>&& itemPromises)
+ClipboardItemBindingsDataSource::ClipboardItemBindingsDataSource(ClipboardItem& item, Vector<KeyValuePair<String, Ref<DOMPromise>>>&& itemPromises)
     : ClipboardItemDataSource(item)
     , m_itemPromises(WTFMove(itemPromises))
 {
@@ -77,14 +77,14 @@ ClipboardItemBindingsDataSource::~ClipboardItemBindingsDataSource() = default;
 
 Vector<String> ClipboardItemBindingsDataSource::types() const
 {
-    return m_itemPromises.map([&] (auto& typeAndItem) {
+    return m_itemPromises.map([&](auto& typeAndItem) {
         return typeAndItem.key;
     });
 }
 
 void ClipboardItemBindingsDataSource::getType(const String& type, Ref<DeferredPromise>&& promise)
 {
-    auto matchIndex = m_itemPromises.findIf([&] (auto& item) {
+    auto matchIndex = m_itemPromises.findIf([&](auto& item) {
         return type == item.key;
     });
 
@@ -93,7 +93,7 @@ void ClipboardItemBindingsDataSource::getType(const String& type, Ref<DeferredPr
         return;
     }
 
-    auto itemPromise = m_itemPromises[matchIndex].value;
+    Ref itemPromise = m_itemPromises[matchIndex].value;
     itemPromise->whenSettled([itemPromise, promise = WTFMove(promise), type] () mutable {
         if (itemPromise->status() != DOMPromise::Status::Fulfilled) {
             promise->reject(ExceptionCode::AbortError);
@@ -140,7 +140,7 @@ void ClipboardItemBindingsDataSource::collectDataForWriting(Clipboard& destinati
     m_completionHandler = WTFMove(completion);
     m_writingDestination = destination;
     m_numberOfPendingClipboardTypes = m_itemPromises.size();
-    m_itemTypeLoaders = m_itemPromises.map([&] (auto& typeAndItem) {
+    m_itemTypeLoaders = m_itemPromises.map([&](auto& typeAndItem) {
         auto type = typeAndItem.key;
         auto itemTypeLoader = ClipboardItemTypeLoader::create(destination, type, [this, protectedItem = Ref { m_item }] {
             ASSERT(m_numberOfPendingClipboardTypes);

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h
@@ -44,7 +44,7 @@ class ScriptExecutionContext;
 class ClipboardItemBindingsDataSource : public ClipboardItemDataSource {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    ClipboardItemBindingsDataSource(ClipboardItem&, Vector<KeyValuePair<String, RefPtr<DOMPromise>>>&&);
+    ClipboardItemBindingsDataSource(ClipboardItem&, Vector<KeyValuePair<String, Ref<DOMPromise>>>&&);
     ~ClipboardItemBindingsDataSource();
 
 private:
@@ -99,7 +99,7 @@ private:
     Vector<Ref<ClipboardItemTypeLoader>> m_itemTypeLoaders;
     WeakPtr<Clipboard, WeakPtrImplWithEventTargetData> m_writingDestination;
 
-    Vector<KeyValuePair<String, RefPtr<DOMPromise>>> m_itemPromises;
+    Vector<KeyValuePair<String, Ref<DOMPromise>>> m_itemPromises;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/IDLTypes.h
+++ b/Source/WebCore/bindings/IDLTypes.h
@@ -298,12 +298,12 @@ template<typename T> struct IDLFrozenArray : IDLType<Vector<typename T::InnerPar
     using NullableParameterType = const std::optional<Vector<typename T::InnerParameterType>>&;
 };
 
-template<typename K, typename V> struct IDLRecord : IDLType<Vector<KeyValuePair<typename K::ImplementationType, typename V::ImplementationType>>> {
+template<typename K, typename V> struct IDLRecord : IDLType<Vector<KeyValuePair<typename K::InnerParameterType, typename V::InnerParameterType>>> {
     using KeyType = K;
     using ValueType = V;
 
-    using ParameterType = const Vector<KeyValuePair<typename K::ImplementationType, typename V::ImplementationType>>&;
-    using NullableParameterType = const std::optional<Vector<KeyValuePair<typename K::ImplementationType, typename V::ImplementationType>>>&;
+    using ParameterType = const Vector<KeyValuePair<typename K::InnerParameterType, typename V::InnerParameterType>>&;
+    using NullableParameterType = const std::optional<Vector<KeyValuePair<typename K::InnerParameterType, typename V::InnerParameterType>>>&;
 };
 
 template<typename T> struct IDLPromise : IDLWrapper<DOMPromise> {

--- a/Source/WebCore/testing/TypeConversions.h
+++ b/Source/WebCore/testing/TypeConversions.h
@@ -121,8 +121,8 @@ public:
 
     const Vector<KeyValuePair<String, int>>& testLongRecord() const { return m_longRecord; }
     void setTestLongRecord(const Vector<KeyValuePair<String, int>>& value) { m_longRecord = value; }
-    const Vector<KeyValuePair<String, RefPtr<Node>>>& testNodeRecord() const { return m_nodeRecord; }
-    void setTestNodeRecord(const Vector<KeyValuePair<String, RefPtr<Node>>>& value) { m_nodeRecord = value; }
+    const Vector<KeyValuePair<String, Ref<Node>>>& testNodeRecord() const { return m_nodeRecord; }
+    void setTestNodeRecord(const Vector<KeyValuePair<String, Ref<Node>>>& value) { m_nodeRecord = value; }
     const Vector<KeyValuePair<String, Vector<String>>>& testSequenceRecord() const { return m_sequenceRecord; }
     void setTestSequenceRecord(const Vector<KeyValuePair<String, Vector<String>>>& value) { m_sequenceRecord = value; }
 
@@ -169,7 +169,7 @@ private:
     String m_byteString;
     String m_treatNullAsEmptyString;
     Vector<KeyValuePair<String, int>> m_longRecord;
-    Vector<KeyValuePair<String, RefPtr<Node>>> m_nodeRecord;
+    Vector<KeyValuePair<String, Ref<Node>>> m_nodeRecord;
     Vector<KeyValuePair<String, Vector<String>>> m_sequenceRecord;
 
     Dictionary m_testDictionary;


### PR DESCRIPTION
#### 9752ce405aad243af0d5ddcef0c04cf303fd82f2
<pre>
Support using Ref for IDLInterfaces in IDL records
<a href="https://bugs.webkit.org/show_bug.cgi?id=274757">https://bugs.webkit.org/show_bug.cgi?id=274757</a>

Reviewed by Darin Adler.

Continues effort to improve non-null hygiene by correctly mapping
WebIDL record values with non-optional IDL interface members to Ref&lt;T&gt;
rather than RefPtr&lt;T&gt;. For instance, the IDL record:

   record&lt;DOMString, Node&gt;

previously would have mapped to:

   Vector&lt;KeyValuePair&lt;String, RefPtr&lt;Node&gt;&gt;&gt;

and now maps to:

   Vector&lt;KeyValuePair&lt;String, Ref&lt;Node&gt;&gt;&gt;

* Source/WebCore/bindings/IDLTypes.h:
    - Switch to using InnerParameterType for the key/value types rather
      than ImplementationType. This has no effect on the key, as strings
      have the same ImplementationType and InnerParameterType, but is done
      for consistency.

* Source/WebCore/Modules/async-clipboard/ClipboardItem.cpp:
(WebCore::ClipboardItem::ClipboardItem):
(WebCore::ClipboardItem::create):
* Source/WebCore/Modules/async-clipboard/ClipboardItem.h:
* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp:
(WebCore::ClipboardItemBindingsDataSource::ClipboardItemBindingsDataSource):
(WebCore::ClipboardItemBindingsDataSource::types const):
(WebCore::ClipboardItemBindingsDataSource::getType):
(WebCore::ClipboardItemBindingsDataSource::collectDataForWriting):
* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.h:
* Source/WebCore/testing/TypeConversions.h:
(WebCore::TypeConversions::testNodeRecord const):
(WebCore::TypeConversions::setTestNodeRecord):
    - Updates RefPtrs to Refs.

Canonical link: <a href="https://commits.webkit.org/279398@main">https://commits.webkit.org/279398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69ca99a24c8193e79cb8374da79ad72bbaf6f6e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32624 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5771 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56553 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4000 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55580 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3745 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43190 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2611 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30722 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46006 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24320 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27660 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3331 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2156 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49426 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3487 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58149 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28420 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3473 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50593 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29638 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46220 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49916 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11633 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30559 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29399 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->