### PR TITLE
Selection.direction's value is "none" regardless of the selection

### DIFF
--- a/LayoutTests/editing/selection/drag-selection-direction-expected.txt
+++ b/LayoutTests/editing/selection/drag-selection-direction-expected.txt
@@ -1,0 +1,14 @@
+PASS testSelectionDirection('mac', 'first', 'second') is "forward"
+PASS testSelectionDirection('windows', 'first', 'second') is "forward"
+PASS testSelectionDirection('unix', 'first', 'second') is "forward"
+PASS testSelectionDirection('mac', 'second', 'first') is "backward"
+PASS testSelectionDirection('windows', 'second', 'first') is "backward"
+PASS testSelectionDirection('unix', 'second', 'first') is "backward"
+PASS testSelectionDirection('mac', 'first', 'first') is "none"
+FAIL testSelectionDirection('windows', 'first', 'first') should be none. Was forward.
+FAIL testSelectionDirection('unix', 'first', 'first') should be none. Was forward.
+PASS successfullyParsed is true
+Some tests failed.
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/drag-selection-direction.html
+++ b/LayoutTests/editing/selection/drag-selection-direction.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+
+<head>
+<script src="../../resources/js-test.js"></script>
+<script>
+
+function moveToElement(id)
+{
+    let rect = document.getElementById(id).getBoundingClientRect()
+    let x = rect.x + rect.width / 2
+    let y = rect.y + rect.height / 2
+    eventSender.mouseMoveTo(x, y)
+}
+
+function testSelectionDirection(behavior, start, end)
+{
+    internals.settings.setEditingBehavior(behavior);
+    moveToElement(start)
+    eventSender.mouseDown()
+    moveToElement(end)
+    eventSender.mouseUp()
+    return window.getSelection().direction
+}
+
+function runTest()
+{
+    testRunner.dumpAsText()
+
+    shouldBeEqualToString("testSelectionDirection('mac', 'first', 'second')", "forward")
+    shouldBeEqualToString("testSelectionDirection('windows', 'first', 'second')", "forward")
+    shouldBeEqualToString("testSelectionDirection('unix', 'first', 'second')", "forward")
+
+    shouldBeEqualToString("testSelectionDirection('mac', 'second', 'first')", "backward")
+    shouldBeEqualToString("testSelectionDirection('windows', 'second', 'first')", "backward")
+    shouldBeEqualToString("testSelectionDirection('unix', 'second', 'first')", "backward")
+
+    shouldBeEqualToString("testSelectionDirection('mac', 'first', 'first')", "none")
+    shouldBeEqualToString("testSelectionDirection('windows', 'first', 'first')", "none")
+    shouldBeEqualToString("testSelectionDirection('unix', 'first', 'first')", "none")
+
+    let element = document.getElementById("test")
+    element.parentNode.removeChild(element)
+}
+
+var successfullyParsed = true
+
+</script></head>
+
+<body onload="runTest()">
+<div id="test"><span id="first">first</span> <span id="second">second</span></div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/selection-pointer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/selection-pointer-expected.txt
@@ -3,24 +3,24 @@ foo
 bar
 
 FAIL Selecting texts across <input type=button> should not cancel selection assert_equals: anchorNode expected Text node "foo" but got Element node <span id="foo">foo</span>
-FAIL Selecting texts across <input type=checkbox> should not cancel selection assert_equals: anchorNode expected Text node "foo" but got Element node <span id="foo">foo</span>
-FAIL Selecting texts across <input type=color> should not cancel selection assert_equals: anchorNode expected Text node "foo" but got Element node <span id="foo">foo</span>
-FAIL Selecting texts across <input type=date> should not cancel selection assert_equals: anchorNode expected Text node "foo" but got Element node <span id="foo">foo</span>
-FAIL Selecting texts across <input type=datetime-local> should not cancel selection assert_equals: anchorNode expected Text node "foo" but got Element node <span id="foo">foo</span>
-FAIL Selecting texts across <input type=email> should not cancel selection assert_equals: anchorNode expected Text node "foo" but got Element node <span id="foo">foo</span>
-FAIL Selecting texts across <input type=file> should not cancel selection assert_equals: anchorNode expected Text node "foo" but got Element node <span id="foo">foo</span>
-FAIL Selecting texts across <input type=image> should not cancel selection assert_equals: anchorNode expected Text node "foo" but got Element node <span id="foo">foo</span>
-FAIL Selecting texts across <input type=month> should not cancel selection assert_equals: anchorNode expected Text node "foo" but got Element node <span id="foo">foo</span>
-FAIL Selecting texts across <input type=number> should not cancel selection assert_equals: anchorNode expected Text node "foo" but got Element node <span id="foo">foo</span>
-FAIL Selecting texts across <input type=password> should not cancel selection assert_equals: anchorNode expected Text node "foo" but got Element node <span id="foo">foo</span>
-FAIL Selecting texts across <input type=radio> should not cancel selection assert_equals: anchorNode expected Text node "foo" but got Element node <span id="foo">foo</span>
-FAIL Selecting texts across <input type=range> should not cancel selection assert_equals: anchorNode expected Text node "foo" but got Element node <span id="foo">foo</span>
-FAIL Selecting texts across <input type=reset> should not cancel selection assert_equals: anchorNode expected Text node "foo" but got Element node <span id="foo">foo</span>
-FAIL Selecting texts across <input type=search> should not cancel selection assert_equals: anchorNode expected Text node "foo" but got Element node <span id="foo">foo</span>
-FAIL Selecting texts across <input type=submit> should not cancel selection assert_equals: anchorNode expected Text node "foo" but got Element node <span id="foo">foo</span>
-FAIL Selecting texts across <input type=tel> should not cancel selection assert_equals: anchorNode expected Text node "foo" but got Element node <span id="foo">foo</span>
-FAIL Selecting texts across <input type=text> should not cancel selection assert_equals: anchorNode expected Text node "foo" but got Element node <span id="foo">foo</span>
-FAIL Selecting texts across <input type=time> should not cancel selection assert_equals: anchorNode expected Text node "foo" but got Element node <span id="foo">foo</span>
-FAIL Selecting texts across <input type=url> should not cancel selection assert_equals: anchorNode expected Text node "foo" but got Element node <span id="foo">foo</span>
-FAIL Selecting texts across <input type=week> should not cancel selection assert_equals: anchorNode expected Text node "foo" but got Element node <span id="foo">foo</span>
+PASS Selecting texts across <input type=checkbox> should not cancel selection
+PASS Selecting texts across <input type=color> should not cancel selection
+PASS Selecting texts across <input type=date> should not cancel selection
+PASS Selecting texts across <input type=datetime-local> should not cancel selection
+PASS Selecting texts across <input type=email> should not cancel selection
+PASS Selecting texts across <input type=file> should not cancel selection
+PASS Selecting texts across <input type=image> should not cancel selection
+PASS Selecting texts across <input type=month> should not cancel selection
+PASS Selecting texts across <input type=number> should not cancel selection
+PASS Selecting texts across <input type=password> should not cancel selection
+PASS Selecting texts across <input type=radio> should not cancel selection
+PASS Selecting texts across <input type=range> should not cancel selection
+PASS Selecting texts across <input type=reset> should not cancel selection
+PASS Selecting texts across <input type=search> should not cancel selection
+PASS Selecting texts across <input type=submit> should not cancel selection
+PASS Selecting texts across <input type=tel> should not cancel selection
+PASS Selecting texts across <input type=text> should not cancel selection
+PASS Selecting texts across <input type=time> should not cancel selection
+PASS Selecting texts across <input type=url> should not cancel selection
+PASS Selecting texts across <input type=week> should not cancel selection
 

--- a/Source/WebCore/editing/ApplyBlockElementCommand.cpp
+++ b/Source/WebCore/editing/ApplyBlockElementCommand.cpp
@@ -71,7 +71,7 @@ void ApplyBlockElementCommand::doApply()
     // margin/padding, but not others.  We should make the gap painting more consistent and 
     // then use a left margin/padding rule here.
     if (visibleEnd != visibleStart && isStartOfParagraph(visibleEnd)) {
-        VisibleSelection newSelection(visibleStart, visibleEnd.previous(CannotCrossEditingBoundary), endingSelection().isDirectional());
+        VisibleSelection newSelection(visibleStart, visibleEnd.previous(CannotCrossEditingBoundary), endingSelection().directionality());
         if (newSelection.isNone())
             return;
         setEndingSelection(newSelection);
@@ -106,9 +106,9 @@ void ApplyBlockElementCommand::doApply()
         if (start.isNotNull() && end.isNull())
             end = lastPositionInNode(endScope.get());
         if (start.isNotNull() && end.isNotNull()) {
-            VisibleSelection selection { start, end, endingSelection().isDirectional() };
+            VisibleSelection selection { start, end, endingSelection().directionality() };
             // Use canonicalized positions for start & end.
-            setEndingSelection(VisibleSelection(selection.start(), selection.end(), selection.isDirectional()));
+            setEndingSelection(VisibleSelection(selection.start(), selection.end(), selection.directionality()));
         }
     }
 }
@@ -123,7 +123,7 @@ void ApplyBlockElementCommand::formatSelection(const VisiblePosition& startOfSel
         insertNodeAt(blockquote.copyRef(), start);
         auto placeholder = HTMLBRElement::create(protectedDocument());
         appendNode(placeholder.copyRef(), WTFMove(blockquote));
-        setEndingSelection(VisibleSelection(positionBeforeNode(placeholder.ptr()), Affinity::Downstream, endingSelection().isDirectional()));
+        setEndingSelection(VisibleSelection(positionBeforeNode(placeholder.ptr()), Affinity::Downstream, endingSelection().directionality()));
         return;
     }
 

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -166,9 +166,9 @@ void ApplyStyleCommand::updateStartEnd(const Position& newStart, const Position&
     if (!m_useEndingSelection && (newStart != m_start || newEnd != m_end))
         m_useEndingSelection = true;
 
-    bool wasBaseFirst = startingSelection().isBaseFirst() || !startingSelection().isDirectional();
+    bool wasBaseFirst = startingSelection().isBaseFirst() || startingSelection().directionality() != Directionality::Strong;
     setEndingSelection(VisibleSelection(VisiblePosition(wasBaseFirst ? newStart : newEnd), VisiblePosition(wasBaseFirst ? newEnd : newStart),
-        endingSelection().isDirectional()));
+        endingSelection().directionality()));
     m_start = newStart;
     m_end = newEnd;
 }

--- a/Source/WebCore/editing/BreakBlockquoteCommand.cpp
+++ b/Source/WebCore/editing/BreakBlockquoteCommand.cpp
@@ -99,7 +99,7 @@ void BreakBlockquoteCommand::doApply()
     // Instead, insert the break before the blockquote, unless the position is as the end of the quoted content.
     if (isFirstVisiblePositionInNode(visiblePos, topBlockquote.get()) && !isLastVisPosInNode) {
         insertNodeBefore(breakNode.copyRef(), *topBlockquote);
-        setEndingSelection(VisibleSelection(positionBeforeNode(breakNode.ptr()), Affinity::Downstream, endingSelection().isDirectional()));
+        setEndingSelection(VisibleSelection(positionBeforeNode(breakNode.ptr()), Affinity::Downstream, endingSelection().directionality()));
         rebalanceWhitespace();   
         return;
     }
@@ -109,7 +109,7 @@ void BreakBlockquoteCommand::doApply()
 
     // If we're inserting the break at the end of the quoted content, we don't need to break the quote.
     if (isLastVisPosInNode) {
-        setEndingSelection(VisibleSelection(positionBeforeNode(breakNode.ptr()), Affinity::Downstream, endingSelection().isDirectional()));
+        setEndingSelection(VisibleSelection(positionBeforeNode(breakNode.ptr()), Affinity::Downstream, endingSelection().directionality()));
         rebalanceWhitespace();
         return;
     }
@@ -142,7 +142,7 @@ void BreakBlockquoteCommand::doApply()
     
     // If there's nothing inside topBlockquote to move, we're finished.
     if (!startNode->isDescendantOf(*topBlockquote)) {
-        setEndingSelection(VisibleSelection(VisiblePosition(firstPositionInOrBeforeNode(startNode.get())), endingSelection().isDirectional()));
+        setEndingSelection(VisibleSelection(VisiblePosition(firstPositionInOrBeforeNode(startNode.get())), endingSelection().directionality()));
         return;
     }
     
@@ -207,7 +207,7 @@ void BreakBlockquoteCommand::doApply()
 
     // Put the selection right before br or at the first position in div.
     auto beforeBROrFirstPositionInDiv = isAtomicNode(breakNode.ptr()) ? positionBeforeNode(breakNode.ptr()) : firstPositionInNode(breakNode.ptr());
-    setEndingSelection(VisibleSelection(beforeBROrFirstPositionInDiv, Affinity::Downstream, endingSelection().isDirectional()));
+    setEndingSelection(VisibleSelection(beforeBROrFirstPositionInDiv, Affinity::Downstream, endingSelection().directionality()));
     rebalanceWhitespace();
 }
 

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -1464,7 +1464,7 @@ void CompositeEditCommand::moveParagraphs(const VisiblePosition& startOfParagrap
 
     std::optional<uint64_t> startIndex;
     std::optional<uint64_t> endIndex;
-    bool originalIsDirectional = endingSelection().isDirectional();
+    auto originalDirectionality = endingSelection().directionality();
     if (preserveSelection && !endingSelection().isNone()) {
         auto visibleStart = endingSelection().visibleStart();
         auto visibleEnd = endingSelection().visibleEnd();
@@ -1530,7 +1530,7 @@ void CompositeEditCommand::moveParagraphs(const VisiblePosition& startOfParagrap
     cleanupAfterDeletion(destination);
 
     // FIXME (Bug 211793): We should redesign cleanupAfterDeletion or find another destination when it is removed.
-    if (destination.deepEquivalent().isOrphan() || VisibleSelection(destination, originalIsDirectional).isNone())
+    if (destination.deepEquivalent().isOrphan() || VisibleSelection(destination, originalDirectionality).isNone())
         return;
 
     // Add a br if pruning an empty block level element caused a collapse. For example:
@@ -1555,7 +1555,7 @@ void CompositeEditCommand::moveParagraphs(const VisiblePosition& startOfParagrap
 
     auto destinationIndex = characterCount({ { *editableRoot, 0 }, *makeBoundaryPoint(destination) }, TextIteratorBehavior::EmitsCharactersBetweenAllVisiblePositions);
 
-    setEndingSelection(VisibleSelection(destination, originalIsDirectional));
+    setEndingSelection(VisibleSelection(destination, originalDirectionality));
     ASSERT(endingSelection().isCaretOrRange());
     OptionSet<ReplaceSelectionCommand::CommandOption> options { ReplaceSelectionCommand::SelectReplacement, ReplaceSelectionCommand::MovingParagraph };
     if (!preserveStyle)
@@ -1577,7 +1577,7 @@ void CompositeEditCommand::moveParagraphs(const VisiblePosition& startOfParagrap
         // of the document (which will return null).
         auto start = makeDeprecatedLegacyPosition(resolveCharacterLocation(makeRangeSelectingNodeContents(*editableRoot), destinationIndex + *startIndex, TextIteratorBehavior::EmitsCharactersBetweenAllVisiblePositions));
         auto end = makeDeprecatedLegacyPosition(resolveCharacterLocation(makeRangeSelectingNodeContents(*editableRoot), destinationIndex + *endIndex, TextIteratorBehavior::EmitsCharactersBetweenAllVisiblePositions));
-        setEndingSelection({ start, end, Affinity::Downstream, originalIsDirectional });
+        setEndingSelection({ start, end, Affinity::Downstream, originalDirectionality });
     }
 }
 
@@ -1649,7 +1649,7 @@ bool CompositeEditCommand::breakOutOfEmptyListItem()
     }
 
     appendBlockPlaceholder(*newBlock);
-    setEndingSelection(VisibleSelection(firstPositionInNode(newBlock.get()), Affinity::Downstream, endingSelection().isDirectional()));
+    setEndingSelection(VisibleSelection(firstPositionInNode(newBlock.get()), Affinity::Downstream, endingSelection().directionality()));
 
     style->prepareToApplyAt(endingSelection().start());
     if (!style->isEmpty())
@@ -1688,8 +1688,8 @@ bool CompositeEditCommand::breakOutOfEmptyMailBlockquotedParagraph()
     // a second one.
     if (!isStartOfParagraph(atBR))
         insertNodeBefore(HTMLBRElement::create(document), br.get());
-    setEndingSelection(VisibleSelection(atBR, endingSelection().isDirectional()));
-    
+    setEndingSelection(VisibleSelection(atBR, endingSelection().directionality()));
+
     // If this is an empty paragraph there must be a line break here.
     if (!lineBreakExistsAtVisiblePosition(caret))
         return false;

--- a/Source/WebCore/editing/CreateLinkCommand.cpp
+++ b/Source/WebCore/editing/CreateLinkCommand.cpp
@@ -52,7 +52,7 @@ void CreateLinkCommand::doApply()
     else {
         insertNodeAt(anchorElement.copyRef(), endingSelection().start());
         appendNode(Text::create(document, String { m_url }), anchorElement.copyRef());
-        setEndingSelection(VisibleSelection(positionInParentBeforeNode(anchorElement.ptr()), positionInParentAfterNode(anchorElement.ptr()), Affinity::Downstream, endingSelection().isDirectional()));
+        setEndingSelection(VisibleSelection(positionInParentBeforeNode(anchorElement.ptr()), positionInParentAfterNode(anchorElement.ptr()), Affinity::Downstream, endingSelection().directionality()));
     }
 }
 

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -250,7 +250,7 @@ void DeleteSelectionCommand::setStartingSelectionOnSmartDelete(const Position& s
         newBase = end;
         newExtent = start;        
     }
-    setStartingSelection(VisibleSelection(newBase, newExtent, startingSelection().isDirectional())); 
+    setStartingSelection(VisibleSelection(newBase, newExtent, startingSelection().directionality()));
 }
     
 bool DeleteSelectionCommand::shouldSmartDeleteParagraphSpacers()
@@ -1026,7 +1026,7 @@ void DeleteSelectionCommand::doApply()
     // want to replace it with a placeholder BR!
     if (handleSpecialCaseBRDelete()) {
         calculateTypingStyleAfterDelete();
-        setEndingSelection(VisibleSelection(m_endingPosition, affinity, endingSelection().isDirectional()));
+        setEndingSelection(VisibleSelection(m_endingPosition, affinity, endingSelection().directionality()));
         clearTransientState();
         rebalanceWhitespace();
         return;
@@ -1069,7 +1069,7 @@ void DeleteSelectionCommand::doApply()
     if (!originalString.isEmpty())
         document->editor().deletedAutocorrectionAtPosition(m_endingPosition, originalString);
 
-    setEndingSelection(VisibleSelection(VisiblePosition(m_endingPosition, affinity), endingSelection().isDirectional()));
+    setEndingSelection(VisibleSelection(VisiblePosition(m_endingPosition, affinity), endingSelection().directionality()));
     clearTransientState();
 }
 

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -312,7 +312,7 @@ VisibleSelection Editor::selectionForCommand(Event* event)
         auto start = selection.start();
         if (start.isNull() || event->target() != enclosingTextFormControl(start)) {
             if (auto range = target->selection())
-                return { *range, Affinity::Downstream, selection.isDirectional() };
+                return { *range, Affinity::Downstream, selection.directionality() };
         }
     }
     return selection;

--- a/Source/WebCore/editing/InsertLineBreakCommand.cpp
+++ b/Source/WebCore/editing/InsertLineBreakCommand.cpp
@@ -103,7 +103,7 @@ void InsertLineBreakCommand::doApply()
             insertNodeBefore(nodeToInsert->cloneNode(false), *nodeToInsert);
         
         VisiblePosition endingPosition(positionBeforeNode(nodeToInsert.get()));
-        setEndingSelection(VisibleSelection(endingPosition, endingSelection().isDirectional()));
+        setEndingSelection(VisibleSelection(endingPosition, endingSelection().directionality()));
     } else if (position.deprecatedEditingOffset() <= caretMinOffset(*position.deprecatedNode())) {
         insertNodeAt(*nodeToInsert, position);
         
@@ -111,12 +111,12 @@ void InsertLineBreakCommand::doApply()
         if (!isStartOfParagraph(positionBeforeNode(nodeToInsert.get())))
             insertNodeBefore(nodeToInsert->cloneNode(false), *nodeToInsert);
         
-        setEndingSelection(VisibleSelection(positionInParentAfterNode(nodeToInsert.get()), Affinity::Downstream, endingSelection().isDirectional()));
+        setEndingSelection(VisibleSelection(positionInParentAfterNode(nodeToInsert.get()), Affinity::Downstream, endingSelection().directionality()));
     // If we're inserting after all of the rendered text in a text node, or into a non-text node,
     // a simple insertion is sufficient.
     } else if (position.deprecatedEditingOffset() >= caretMaxOffset(*position.deprecatedNode()) || !is<Text>(*position.deprecatedNode())) {
         insertNodeAt(*nodeToInsert, position);
-        setEndingSelection(VisibleSelection(positionInParentAfterNode(nodeToInsert.get()), Affinity::Downstream, endingSelection().isDirectional()));
+        setEndingSelection(VisibleSelection(positionInParentAfterNode(nodeToInsert.get()), Affinity::Downstream, endingSelection().directionality()));
     } else if (RefPtr textNode = dynamicDowncast<Text>(*position.deprecatedNode())) {
         // Split a text node
         splitTextNode(*textNode, position.deprecatedEditingOffset());
@@ -140,7 +140,7 @@ void InsertLineBreakCommand::doApply()
             }
         }
         
-        setEndingSelection(VisibleSelection(endingPosition, Affinity::Downstream, endingSelection().isDirectional()));
+        setEndingSelection(VisibleSelection(endingPosition, Affinity::Downstream, endingSelection().directionality()));
     }
 
     // Handle the case where there is a typing style.

--- a/Source/WebCore/editing/InsertListCommand.cpp
+++ b/Source/WebCore/editing/InsertListCommand.cpp
@@ -132,7 +132,7 @@ void InsertListCommand::doApply()
     // margin/padding, but not others.  We should make the gap painting more consistent and 
     // then use a left margin/padding rule here.
     if (visibleEnd != visibleStart && isStartOfParagraph(visibleEnd, CanSkipOverEditingBoundary)) {
-        setEndingSelection(VisibleSelection(visibleStart, visibleEnd.previous(CannotCrossEditingBoundary), endingSelection().isDirectional()));
+        setEndingSelection(VisibleSelection(visibleStart, visibleEnd.previous(CannotCrossEditingBoundary), endingSelection().directionality()));
         if (!endingSelection().rootEditableElement())
             return;
     }
@@ -198,7 +198,7 @@ void InsertListCommand::doApply()
                 endOfSelection = endingSelection().visibleEnd();
                 if (startOfSelection.isOrphan())
                     startOfSelection = visiblePositionForIndex(startIndex, startScope.get());
-                setEndingSelection(VisibleSelection(startOfSelection, endOfSelection, endingSelection().isDirectional()));
+                setEndingSelection(VisibleSelection(startOfSelection, endOfSelection, endingSelection().directionality()));
                 return;
             }
         }

--- a/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
+++ b/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
@@ -340,7 +340,7 @@ void InsertParagraphSeparatorCommand::doApply()
         if (!appendBlockPlaceholder(parent.copyRef()))
             return;
 
-        setEndingSelection(VisibleSelection(VisiblePosition(firstPositionInNode(parent.ptr()), Affinity::Downstream), endingSelection().isDirectional()));
+        setEndingSelection(VisibleSelection(VisiblePosition(firstPositionInNode(parent.ptr()), Affinity::Downstream), endingSelection().directionality()));
         return;
     }
     
@@ -380,7 +380,7 @@ void InsertParagraphSeparatorCommand::doApply()
             return;
         
         // In this case, we need to set the new ending selection.
-        setEndingSelection(VisibleSelection(VisiblePosition(insertionPosition, Affinity::Downstream), endingSelection().isDirectional()));
+        setEndingSelection(VisibleSelection(VisiblePosition(insertionPosition, Affinity::Downstream), endingSelection().directionality()));
         return;
     }
 
@@ -400,7 +400,7 @@ void InsertParagraphSeparatorCommand::doApply()
         // If the insertion point is a break element, there is nothing else
         // we need to do.
         if (auto* renderer = visiblePos.deepEquivalent().anchorNode()->renderer(); renderer && renderer->isBR()) {
-            setEndingSelection(VisibleSelection(VisiblePosition(insertionPosition, Affinity::Downstream), endingSelection().isDirectional()));
+            setEndingSelection(VisibleSelection(VisiblePosition(insertionPosition, Affinity::Downstream), endingSelection().directionality()));
             return;
         }
     }
@@ -501,7 +501,7 @@ void InsertParagraphSeparatorCommand::doApply()
         }
     }
 
-    setEndingSelection(VisibleSelection(VisiblePosition(firstPositionInNode(blockToInsert.get()), Affinity::Downstream), endingSelection().isDirectional()));
+    setEndingSelection(VisibleSelection(VisiblePosition(firstPositionInNode(blockToInsert.get()), Affinity::Downstream), endingSelection().directionality()));
     applyStyleAfterInsertion(startBlock.get());
 }
 

--- a/Source/WebCore/editing/InsertTextCommand.cpp
+++ b/Source/WebCore/editing/InsertTextCommand.cpp
@@ -81,7 +81,7 @@ void InsertTextCommand::setEndingSelectionWithoutValidation(const Position& star
     // <http://bugs.webkit.org/show_bug.cgi?id=15781>
     VisibleSelection forcedEndingSelection;
     forcedEndingSelection.setWithoutValidation(startPosition, endPosition);
-    forcedEndingSelection.setIsDirectional(endingSelection().isDirectional());
+    forcedEndingSelection.setDirectionality(endingSelection().directionality());
     setEndingSelection(forcedEndingSelection);
 }
 
@@ -102,7 +102,7 @@ bool InsertTextCommand::performTrivialReplace(const String& text, bool selectIns
 
     setEndingSelectionWithoutValidation(start, endPosition);
     if (!selectInsertedText)
-        setEndingSelection(VisibleSelection(endingSelection().visibleEnd(), endingSelection().isDirectional()));
+        setEndingSelection(VisibleSelection(endingSelection().visibleEnd(), endingSelection().directionality()));
 
     return true;
 }
@@ -123,7 +123,7 @@ bool InsertTextCommand::performOverwrite(const String& text, bool selectInserted
     Position endPosition = Position(textNode.get(), start.offsetInContainerNode() + text.length());
     setEndingSelectionWithoutValidation(start, endPosition);
     if (!selectInsertedText)
-        setEndingSelection(VisibleSelection(endingSelection().visibleEnd(), endingSelection().isDirectional()));
+        setEndingSelection(VisibleSelection(endingSelection().visibleEnd(), endingSelection().directionality()));
 
     return true;
 }
@@ -238,7 +238,7 @@ void InsertTextCommand::doApply()
     }
 
     if (!m_selectInsertedText)
-        setEndingSelection(VisibleSelection(endingSelection().end(), endingSelection().affinity(), endingSelection().isDirectional()));
+        setEndingSelection(VisibleSelection(endingSelection().end(), endingSelection().affinity(), endingSelection().directionality()));
 }
 
 Position InsertTextCommand::insertTab(const Position& pos)

--- a/Source/WebCore/editing/MoveSelectionCommand.cpp
+++ b/Source/WebCore/editing/MoveSelectionCommand.cpp
@@ -76,7 +76,7 @@ void MoveSelectionCommand::doApply()
 
     cleanupAfterDeletion(pos);
 
-    setEndingSelection(VisibleSelection(pos, endingSelection().affinity(), endingSelection().isDirectional()));
+    setEndingSelection(VisibleSelection(pos, endingSelection().affinity(), endingSelection().directionality()));
     setStartingSelection(endingSelection());
     if (!pos.anchorNode()->isConnected()) {
         // Document was modified out from under us.

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -1683,9 +1683,9 @@ void ReplaceSelectionCommand::completeHTMLReplacement(const Position &lastPositi
         m_visibleSelectionForInsertedText = VisibleSelection(start, end);
 
     if (m_selectReplacement)
-        setEndingSelection(VisibleSelection(start, end, VisibleSelection::defaultAffinity, endingSelection().isDirectional()));
+        setEndingSelection(VisibleSelection(start, end, VisibleSelection::defaultAffinity, endingSelection().directionality()));
     else
-        setEndingSelection(VisibleSelection(end, VisibleSelection::defaultAffinity, endingSelection().isDirectional()));
+        setEndingSelection(VisibleSelection(end, VisibleSelection::defaultAffinity, endingSelection().directionality()));
 }
 
 void ReplaceSelectionCommand::mergeTextNodesAroundPosition(Position& position, Position& positionOnlyToBeUpdated)

--- a/Source/WebCore/editing/TypingCommand.cpp
+++ b/Source/WebCore/editing/TypingCommand.cpp
@@ -641,7 +641,7 @@ bool TypingCommand::makeEditableRootEmpty()
         removeNode(*child);
 
     addBlockPlaceholderIfNeeded(root.get());
-    setEndingSelection(VisibleSelection(firstPositionInNode(root.get()), Affinity::Downstream, endingSelection().isDirectional()));
+    setEndingSelection(VisibleSelection(firstPositionInNode(root.get()), Affinity::Downstream, endingSelection().directionality()));
 
     return true;
 }
@@ -713,7 +713,7 @@ void TypingCommand::deleteKeyPressed(TextGranularity granularity, bool shouldAdd
             selection.modify(FrameSelection::Alteration::Extend, SelectionDirection::Backward, granularity);
         // If the caret is just after a table, select the table and don't delete anything.
         } else if (RefPtr table = isFirstPositionAfterTable(visibleStart)) {
-            setEndingSelection(VisibleSelection(positionBeforeNode(table.get()), endingSelection().start(), Affinity::Downstream, endingSelection().isDirectional()));
+            setEndingSelection(VisibleSelection(positionBeforeNode(table.get()), endingSelection().start(), Affinity::Downstream, endingSelection().directionality()));
             typingAddedToOpenCommand(Type::DeleteKey);
             return;
         }
@@ -809,7 +809,7 @@ void TypingCommand::forwardDeleteKeyPressed(TextGranularity granularity, bool sh
         // When deleting tables: Select the table first, then perform the deletion
         if (downstreamEnd.containerNode() && downstreamEnd.containerNode()->renderer() && downstreamEnd.containerNode()->renderer()->isRenderTable()
             && downstreamEnd.computeOffsetInContainerNode() <= caretMinOffset(*downstreamEnd.containerNode())) {
-            setEndingSelection(VisibleSelection(endingSelection().end(), positionAfterNode(downstreamEnd.containerNode()), Affinity::Downstream, endingSelection().isDirectional()));
+            setEndingSelection(VisibleSelection(endingSelection().end(), positionAfterNode(downstreamEnd.containerNode()), Affinity::Downstream, endingSelection().directionality()));
             typingAddedToOpenCommand(Type::ForwardDeleteKey);
             return;
         }

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -52,40 +52,36 @@ const VisibleSelection& VisibleSelection::emptySelection()
     return selection.get();
 }
 
-VisibleSelection::VisibleSelection()
-    : m_anchorIsFirst(true)
-    , m_isDirectional(false)
-{
-}
+VisibleSelection::VisibleSelection() = default;
 
-VisibleSelection::VisibleSelection(const Position& anchor, const Position& focus, Affinity affinity, bool isDirectional)
+VisibleSelection::VisibleSelection(const Position& anchor, const Position& focus, Affinity affinity, Directionality directionality)
     : m_anchor(anchor)
     , m_focus(focus)
     , m_affinity(affinity)
-    , m_isDirectional(isDirectional)
+    , m_directionality(directionality)
 {
     validate();
 }
 
-VisibleSelection::VisibleSelection(const Position& position, Affinity affinity, bool isDirectional)
-    : VisibleSelection(position, position, affinity, isDirectional)
+VisibleSelection::VisibleSelection(const Position& position, Affinity affinity, Directionality directionality)
+    : VisibleSelection(position, position, affinity, directionality)
 {
 }
 
-VisibleSelection::VisibleSelection(const VisiblePosition& position, bool isDirectional)
-    : VisibleSelection(position.deepEquivalent(), position.affinity(), isDirectional)
+VisibleSelection::VisibleSelection(const VisiblePosition& position, Directionality directionality)
+    : VisibleSelection(position.deepEquivalent(), position.affinity(), directionality)
 {
     // FIXME: Wasteful that this re-canonicalizes, but risky to change since the VisiblePosition object could be from before a mutation and its position may no longer be canonical.
 }
 
-VisibleSelection::VisibleSelection(const VisiblePosition& anchor, const VisiblePosition& focus, bool isDirectional)
-    : VisibleSelection(anchor.deepEquivalent(), focus.deepEquivalent(), anchor.affinity(), isDirectional)
+VisibleSelection::VisibleSelection(const VisiblePosition& anchor, const VisiblePosition& focus, Directionality directionality)
+    : VisibleSelection(anchor.deepEquivalent(), focus.deepEquivalent(), anchor.affinity(), directionality)
 {
     // FIXME: Wasteful that this re-canonicalizes, but risky to change since the VisiblePosition objects could be from before a mutation and their positions may no longer be canonical.
 }
 
-VisibleSelection::VisibleSelection(const SimpleRange& range, Affinity affinity, bool isDirectional)
-    : VisibleSelection(makeDeprecatedLegacyPosition(range.start), makeDeprecatedLegacyPosition(range.end), affinity, isDirectional)
+VisibleSelection::VisibleSelection(const SimpleRange& range, Affinity affinity, Directionality directionality)
+    : VisibleSelection(makeDeprecatedLegacyPosition(range.start), makeDeprecatedLegacyPosition(range.end), affinity, directionality)
 {
 }
 

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -487,7 +487,7 @@ TextFieldSelectionDirection HTMLTextFormControlElement::computeSelectionDirectio
         return SelectionHasNoDirection;
 
     const VisibleSelection& selection = frame->selection().selection();
-    return selection.isDirectional() ? (selection.isBaseFirst() ? SelectionHasForwardDirection : SelectionHasBackwardDirection) : SelectionHasNoDirection;
+    return selection.directionality() == Directionality::Strong ? (selection.isBaseFirst() ? SelectionHasForwardDirection : SelectionHasBackwardDirection) : SelectionHasNoDirection;
 }
 
 static void setContainerAndOffsetForRange(Node& node, unsigned offset, RefPtr<Node>& containerNode, unsigned& offsetInContainer)

--- a/Source/WebCore/page/DOMSelection.cpp
+++ b/Source/WebCore/page/DOMSelection.cpp
@@ -201,7 +201,8 @@ String DOMSelection::direction() const
     if (!frame)
         return noneAtom();
     auto& selection = frame->selection().selection();
-    if (!selection.isDirectional() || selection.isNone())
+    // FIXME: This can return a direction for a caret, which does not make logical sense.
+    if (selection.directionality() == Directionality::None || selection.isNone())
         return noneAtom();
     return selection.isBaseFirst() ? "forward"_s : "backward"_s;
 }


### PR DESCRIPTION
#### 04376ce723b5511d02b5f7151884b909e11ace8a
<pre>
Selection.direction&apos;s value is &quot;none&quot; regardless of the selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=274725">https://bugs.webkit.org/show_bug.cgi?id=274725</a>
<a href="https://rdar.apple.com/128812268">rdar://128812268</a>

Reviewed by NOBODY (OOPS!).

Mouse selection code was never setting &quot;is directional&quot; on Apple platforms.
To do this and preserve editing behavior we need to separate the concept of directional,
which is specified unambiguously, and the direction-based editing behavior that is part
of the Mac and iOS platforms. So we now have &quot;weak directionality&quot;, which does not affect
editing behavior, based on making a selection with the mouse, and &quot;strong directionality&quot;,
which does affect editing behavior. There may be an opportunity to clean up further,
since the way we do directionality on non-Apple platforms is unnecessarily different.
The only real difference we want is in editing behavior, not in tracking of directionality.

* LayoutTests/editing/selection/drag-selection-direction-expected.txt: Added.
* LayoutTests/editing/selection/drag-selection-direction.html: Added.
Test succeeds except on non-Apple platforms for non-range selection.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/selection-pointer-expected.txt:
Updated for progression.

* Source/WebCore/editing/ApplyBlockElementCommand.cpp:
(WebCore::ApplyBlockElementCommand::doApply): Use directionality instead of isDirectional.
(WebCore::ApplyBlockElementCommand::formatSelection): Ditto.
* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::ApplyStyleCommand::updateStartEnd): Ditto.
* Source/WebCore/editing/BreakBlockquoteCommand.cpp:
(WebCore::BreakBlockquoteCommand::doApply): Ditto.
* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::CompositeEditCommand::moveParagraphs): Ditto.
* Source/WebCore/editing/CreateLinkCommand.cpp:
(WebCore::CreateLinkCommand::doApply): Ditto.
* Source/WebCore/editing/DeleteSelectionCommand.cpp:
(WebCore::DeleteSelectionCommand::setStartingSelectionOnSmartDelete): Ditto.
(WebCore::DeleteSelectionCommand::doApply): Ditto.
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::selectionForCommand): Ditto.
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::FrameSelection): Ditto.
(WebCore::FrameSelection::moveTo): Ditto.
(WebCore::FrameSelection::moveWithoutValidationTo): Ditto.
(WebCore::FrameSelection::setSelectionByMouseIfDifferent): Ditto.
(WebCore::FrameSelection::setSelectionWithoutUpdatingAppearance): Ditto.
(WebCore::FrameSelection::textWasReplaced): Ditto.
(WebCore::FrameSelection::willBeModified): Ditto.
(WebCore::FrameSelection::modify): Ditto.
(WebCore::FrameSelection::setBase): Ditto.
(WebCore::FrameSelection::setExtent): Ditto.
* Source/WebCore/editing/InsertLineBreakCommand.cpp:
(WebCore::InsertLineBreakCommand::doApply): Ditto.
* Source/WebCore/editing/InsertListCommand.cpp:
(WebCore::InsertListCommand::doApply): Ditto.
* Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp:
(WebCore::InsertParagraphSeparatorCommand::doApply): Ditto.
* Source/WebCore/editing/InsertTextCommand.cpp:
(WebCore::InsertTextCommand::setEndingSelectionWithoutValidation): Ditto.
(WebCore::InsertTextCommand::performTrivialReplace): Ditto.
(WebCore::InsertTextCommand::performOverwrite): Ditto.
(WebCore::InsertTextCommand::doApply): Ditto.
* Source/WebCore/editing/MoveSelectionCommand.cpp:
(WebCore::MoveSelectionCommand::doApply): Ditto.
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplaceSelectionCommand::completeHTMLReplacement): Ditto.
* Source/WebCore/editing/TypingCommand.cpp:
(WebCore::TypingCommand::makeEditableRootEmpty): Ditto.
(WebCore::TypingCommand::deleteKeyPressed): Ditto.
(WebCore::TypingCommand::forwardDeleteKeyPressed): Ditto.
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::VisibleSelection): Ditto.

* Source/WebCore/editing/VisibleSelection.h: Added directionality and removed
isDirectional.

* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::computeSelectionDirection const):
Use directionality instead of isDirectional.

* Source/WebCore/page/DOMSelection.cpp:
(WebCore::DOMSelection::direction const): Changed to return the direction
for both weak and strong directionality. This is only place where weak
directionality currently has any effect, other code treats it as non-directional.

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleMousePressEventSingleClick): Use directionality
instead of isDirectional.
(WebCore::EventHandler::updateSelectionForMouseDrag): Refactored code for
clarity. Added code to set weak directionality when the user is dragging.
This is the only place that sets weak directionality.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04376ce723b5511d02b5f7151884b909e11ace8a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/61111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13692 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/65053 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11660 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/63241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/48149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11935 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49404 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/selection-pointer.html (failure)") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8111 "Found 1 new test failure: editing/selection/drag-selection-direction.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/63145 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37657 "Found 1 new test failure: editing/selection/drag-selection-direction.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52947 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30234 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34337 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/selection-pointer.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/10172 "Found 1 new test failure: imported/w3c/web-platform-tests/content-security-policy/reporting-api/reporting-api-report-only-sends-reports-on-violation.https.sub.html (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10572 "Hash 04376ce7 for PR 29156 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56154 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10467 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66785 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/5058 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10281 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56777 "Found 2 new test failures: editing/selection/drag-selection-direction.html imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/selection-pointer.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/5080 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52910 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56970 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4189 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/36276 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37359 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38453 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/37103 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->