### PR TITLE
Drop NetworkCache::Data::data() in favor of span()

### DIFF
--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -254,9 +254,9 @@ public:
     MappedFileData& operator=(MappedFileData&&);
 
     explicit operator bool() const { return !!m_fileData; }
-    const void* data() const { return m_fileData; }
+    const void* data() const { return m_fileData; } // FIXME: Port callers to span() and remove.
     unsigned size() const { return m_fileSize; }
-    std::span<const uint8_t> span() { return { static_cast<const uint8_t *>(data()), size() }; }
+    std::span<const uint8_t> span() const { return { static_cast<const uint8_t *>(data()), size() }; }
 
 #if PLATFORM(COCOA)
     void* leakHandle() { return std::exchange(m_fileData, nullptr); }

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheData.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheData.cpp
@@ -28,6 +28,7 @@
 
 #include <fcntl.h>
 #include <wtf/FileSystem.h>
+#include <wtf/StdLibExtras.h>
 
 #if !OS(WINDOWS)
 #include <sys/mman.h>
@@ -97,9 +98,7 @@ bool bytesEqual(const Data& a, const Data& b)
 {
     if (a.isNull() || b.isNull())
         return false;
-    if (a.size() != b.size())
-        return false;
-    return !memcmp(a.data(), b.data(), a.size());
+    return equalSpans(a.span(), b.span());
 }
 
 } // namespace NetworkCache

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
@@ -75,9 +75,8 @@ public:
     bool isNull() const;
     bool isEmpty() const { return !m_size; }
 
-    const uint8_t* data() const;
+    std::span<const uint8_t> span() const;
     size_t size() const { return m_size; }
-    std::span<const uint8_t> span() const { return { data(), size() }; }
     bool isMap() const { return m_isMap; }
     RefPtr<WebCore::SharedMemory> tryCreateSharedMemory() const;
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm
@@ -52,7 +52,7 @@ Data Data::empty()
     return { OSObjectPtr<dispatch_data_t> { dispatch_data_empty } };
 }
 
-const uint8_t* Data::data() const
+std::span<const uint8_t> Data::span() const
 {
     if (!m_data && m_dispatchData) {
         const void* data;
@@ -61,7 +61,7 @@ const uint8_t* Data::data() const
         ASSERT(size == m_size);
         m_data = static_cast<const uint8_t*>(data);
     }
-    return m_data;
+    return { m_data, m_size };
 }
 
 bool Data::isNull() const

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp
@@ -63,9 +63,11 @@ Data Data::empty()
     return { adoptGRef(g_bytes_new(nullptr, 0)) };
 }
 
-const uint8_t* Data::data() const
+std::span<const uint8_t> Data::span() const
 {
-    return m_buffer ? reinterpret_cast<const uint8_t*>(g_bytes_get_data(m_buffer.get(), nullptr)) : nullptr;
+    if (!m_buffer)
+        return { };
+    return { reinterpret_cast<const uint8_t*>(g_bytes_get_data(m_buffer.get(), nullptr)), m_size };
 }
 
 bool Data::isNull() const

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
@@ -453,7 +453,7 @@ static WTF::String getContentRuleListSourceFromMappedFile(const MappedData& mapp
         return { };
 
     auto headerSizeBytes = headerSize(mappedData.metaData.version);
-    bool is8Bit = mappedData.data.data()[headerSizeBytes];
+    bool is8Bit = mappedData.data.span()[headerSizeBytes];
     size_t start = headerSizeBytes + sizeof(bool);
     size_t length = mappedData.metaData.sourceSize - sizeof(bool);
     if (is8Bit)
@@ -464,7 +464,7 @@ static WTF::String getContentRuleListSourceFromMappedFile(const MappedData& mapp
         return { };
     }
 
-    return WTF::String({ reinterpret_cast<const UChar*>(mappedData.data.data() + start), length / sizeof(UChar) });
+    return spanReinterpretCast<const UChar>(mappedData.data.span().subspan(start, length));
 }
 
 void ContentRuleListStore::lookupContentRuleList(WTF::String&& identifier, CompletionHandler<void(RefPtr<API::ContentRuleList>, std::error_code)> completionHandler)


### PR DESCRIPTION
#### 9d8aaf204b714840ed87ce50cce54109a41e94da
<pre>
Drop NetworkCache::Data::data() in favor of span()
<a href="https://bugs.webkit.org/show_bug.cgi?id=274760">https://bugs.webkit.org/show_bug.cgi?id=274760</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/FileSystem.h:
(WTF::FileSystemImpl::MappedFileData::data const):
* Source/WebKit/NetworkProcess/cache/NetworkCacheData.cpp:
(WebKit::NetworkCache::bytesEqual):
* Source/WebKit/NetworkProcess/cache/NetworkCacheData.h:
(WebKit::NetworkCache::Data::size const):
(WebKit::NetworkCache::Data::span const): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCacheDataCocoa.mm:
(WebKit::NetworkCache::Data::span const):
(WebKit::NetworkCache::Data::data const): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCacheDataCurl.cpp:
(WebKit::NetworkCache::Data::span const):
(WebKit::NetworkCache::Data::data const): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp:
(WebKit::NetworkCache::Data::data const):
* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::getContentRuleListSourceFromMappedFile):

Canonical link: <a href="https://commits.webkit.org/279395@main">https://commits.webkit.org/279395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a06f1b16f231dec251f5d652d1e200bebb2b591

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53381 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5880 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56661 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4107 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/40208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3885 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43283 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2694 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55479 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30928 "16 new passes 5 flakes 2 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46117 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24415 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3437 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2263 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/46741 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49552 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3610 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58256 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52895 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3617 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50683 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29745 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46319 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50018 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30669 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65201 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7850 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29512 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12430 "Found 7 new JSC stress test failures: stress/proxy-set-prototype-of.js.bytecode-cache, stress/proxy-set-prototype-of.js.default, stress/spread-non-array.js.default, stress/spread-non-array.js.no-llint, wasm.yaml/wasm/js-api/extension-MemoryMode.js.wasm-eager-jettison, wasm.yaml/wasm/stress/osr-entry-many-locals-f64.js.wasm-eager, wasm.yaml/wasm/stress/osr-entry-many-locals-i32.js.wasm-eager (failure)") | 
<!--EWS-Status-Bubble-End-->