### PR TITLE
[Win] ASSERTION FAILED: ::DuplicateHandle failed with error 5 in ArgumentCoder<Win32Handle>::decode

### DIFF
--- a/Source/WebKit/Platform/IPC/win/ArgumentCodersWin.cpp
+++ b/Source/WebKit/Platform/IPC/win/ArgumentCodersWin.cpp
@@ -53,7 +53,8 @@ std::optional<Win32Handle> ArgumentCoder<Win32Handle>::decode(Decoder& decoder)
     HANDLE duplicatedHandle;
     // Copy the handle into our process and close the handle that the sending process created for us.
     if (!::DuplicateHandle(sourceProcess.get(), reinterpret_cast<HANDLE>(*sourceHandle), ::GetCurrentProcess(), &duplicatedHandle, 0, FALSE, DUPLICATE_SAME_ACCESS | DUPLICATE_CLOSE_SOURCE)) {
-        ASSERT_WITH_MESSAGE(false, "::DuplicateHandle failed with error %lu", ::GetLastError());
+        // The source process may exit after the above OpenProcess calling.
+        // DuplicateHandle fails with ERROR_INVALID_HANDLE in such a case.
         return std::nullopt;
     }
     return Win32Handle::adopt(duplicatedHandle);


### PR DESCRIPTION
#### 279f09128a7c6ecbb4812584d9946908eb0a8498
<pre>
[Win] ASSERTION FAILED: ::DuplicateHandle failed with error 5 in ArgumentCoder&lt;Win32Handle&gt;::decode
<a href="https://bugs.webkit.org/show_bug.cgi?id=258440">https://bugs.webkit.org/show_bug.cgi?id=258440</a>

Reviewed by Ross Kirsling.

ArgumentCoder&lt;Win32Handle&gt;::decode had an assertion ensuring
DuplicateHandle passed. However, Windows port debug layout tests were
observing that the assertion is randomly failing. If the source
process has exited just before the DuplicateHandle calling,
DuplicateHandle may fails with ERROR_INVALID_HANDLE.

* Source/WebKit/Platform/IPC/win/ArgumentCodersWin.cpp:
Removed the false assertion.

Canonical link: <a href="https://commits.webkit.org/279361@main">https://commits.webkit.org/279361@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/329c3a0695ddde1ccfd2428d0eb786272e6fcd83

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53292 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56571 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4018 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/39986 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3766 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43204 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2624 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55390 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/30771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46028 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24334 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2174 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3511 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58167 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28441 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3500 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50603 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29656 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46235 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49928 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30579 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7832 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29419 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->