### PR TITLE
REGRESSION (macOS 14): Form controls draw with an active appearance when the window is inactive

### DIFF
--- a/LayoutTests/fast/forms/select/mac-wk2/inactive-appearance-expected-mismatch.html
+++ b/LayoutTests/fast/forms/select/mac-wk2/inactive-appearance-expected-mismatch.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ runSingly=true ] -->
 <!DOCTYPE html>
 <html>
 <body>

--- a/LayoutTests/fast/forms/select/mac-wk2/inactive-appearance.html
+++ b/LayoutTests/fast/forms/select/mac-wk2/inactive-appearance.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ runSingly=true ] -->
 <!DOCTYPE html>
 <html>
     <head>
@@ -14,8 +15,8 @@ if (window.testRunner)
     testRunner.waitUntilDone();
 
 addEventListener("load", async () => {
-    if (window.internals)
-        window.internals.setPageIsFocusedAndActive(false);
+    if (window.testRunner)
+        testRunner.setWindowIsKey(false);
 
     await UIHelper.renderingUpdate();
     if (window.testRunner)

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1875,8 +1875,6 @@ webkit.org/b/272685 [ Ventura+ x86_64 ] imported/w3c/web-platform-tests/svg/pain
 
 webkit.org/b/273012 [ Ventura+ x86_64 ] imported/w3c/web-platform-tests/svg/painting/reftests/percentage.svg [ ImageOnlyFailure ]
 
-webkit.org/b/273588 fast/forms/select/mac-wk2/inactive-appearance.html [ Pass ImageOnlyFailure ]
-
 webkit.org/b/273905 [ X86_64 ] svg/filters/filter-on-root-tile-boundary.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/274130 [ Debug ] media/video-pause-immediately.html [ Pass Failure ]

--- a/Source/WebCore/PAL/pal/spi/mac/NSCellSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSCellSPI.h
@@ -29,6 +29,14 @@
 
 #import <AppKit/NSCell_Private.h>
 
+#else
+
+typedef NS_ENUM(NSInteger, NSPresentationState) {
+    NSPresentationStateActiveKey = 0,
+    NSPresentationStateActive,
+    NSPresentationStateInactive,
+};
+
 #endif
 
 WTF_EXTERN_C_BEGIN
@@ -37,7 +45,6 @@ void _NSDrawCarbonThemeListBox(NSRect, BOOL enabled, BOOL flipped, BOOL textured
 
 WTF_EXTERN_C_END
 
-typedef NS_ENUM(NSInteger, NSPresentationState);
 typedef NS_ENUM(NSInteger, NSViewSemanticContext);
 
 @interface NSCell ()

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
@@ -206,6 +206,9 @@ static void applyViewlessCellSettings(float deviceScaleFactor, const ControlStyl
 
     [cell _setFallbackBackingScaleFactor:deviceScaleFactor];
 
+    bool isInActiveWindow = style.states.contains(ControlStyle::State::WindowActive);
+    [cell _setFallbackBezelPresentationState:isInActiveWindow ? NSPresentationStateActiveKey : NSPresentationStateInactive];
+
 #if USE(NSVIEW_SEMANTICCONTEXT)
     if (style.states.contains(ControlStyle::State::FormSemanticContext))
         [cell _setFallbackSemanticContext:NSViewSemanticContextForm];


### PR DESCRIPTION
#### 1cf2af72f97ef4de30a5d7edad747d3360dece65
<pre>
REGRESSION (macOS 14): Form controls draw with an active appearance when the window is inactive
<a href="https://bugs.webkit.org/show_bug.cgi?id=273588">https://bugs.webkit.org/show_bug.cgi?id=273588</a>
<a href="https://rdar.apple.com/127391198">rdar://127391198</a>

Reviewed by Richard Robinson.

Prior to GPU process support on macOS, inactive form controls were drawn by
overriding the return value of `hasKeyAppearance` on the backing window as
necessary. However, with the introduction of GPU process, `NSCell`s are no longer
backed by a control view, and do not have a window. Consequently, they are
always drawn with an active appearance.

This is not an issue in configurations where GPU process is disabled, as the
control view path still exists.

Fix by adopting AppKit SPI to specify the presentation state of `NSCell`s that
are not backed by control views.

This regression was previously missed as the regression test responsible for the
behavior was broken until 278267@main.

* LayoutTests/fast/forms/select/mac-wk2/inactive-appearance-expected-mismatch.html:
* LayoutTests/fast/forms/select/mac-wk2/inactive-appearance.html:

Adjust the test to use `testRunner.setWindowIsKey` rather than
`internals.setPageIsFocusedAndActive`. The latter results in flakiness, as
an activity state update can come after the override, but before taking the
snapshot, invalidating the test result.

Also, use `runSingly` to ensure window key-state is reset, to avoid flakiness.

* LayoutTests/platform/mac-wk2/TestExpectations:

Mark the test as passing.

* Source/WebCore/PAL/pal/spi/mac/NSCellSPI.h:
* Source/WebCore/platform/graphics/mac/controls/ControlMac.mm:
(WebCore::applyViewlessCellSettings):

Use `-[NSCell _setFallbackBezelPresentationState:]` to set an appropriate presentation
state, matching the window&apos;s active state. Note that only the `NSPresentationStateActiveKey`
and `NSPresentationStateInactive` are used, matching the control view path.

Canonical link: <a href="https://commits.webkit.org/279420@main">https://commits.webkit.org/279420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b73605c1d3f054fe658b19a17d452814938b3535

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5963 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56738 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4184 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55764 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3962 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2736 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55556 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/30999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46188 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/24464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3508 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2340 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3682 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58333 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28615 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3678 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/29822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46384 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11644 "Found 1 new test failure: fast/dom/intersection-observer-document-leak.html (failure)") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7863 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29592 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->