### PR TITLE
[JSC] Remove wasm entrypoint thunk generation

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -33,6 +33,7 @@
 #include "JITCompilation.h"
 #include "JITOpaqueByproducts.h"
 #include "JSToWasm.h"
+#include "LLIntData.h"
 #include "LLIntThunks.h"
 #include "LinkBuffer.h"
 #include "WasmCallee.h"
@@ -72,8 +73,17 @@ bool IPIntPlan::prepareImpl()
     const auto& functions = m_moduleInformation->functions;
     if (!tryReserveCapacity(m_wasmInternalFunctions, functions.size(), "WebAssembly functions"_s))
         return false;
-
     m_wasmInternalFunctions.resize(functions.size());
+
+    if (!tryReserveCapacity(m_entrypoints, functions.size(), " WebAssembly functions"_s))
+        return false;
+    m_entrypoints.resize(functions.size());
+
+    if (!m_callees) {
+        if (!tryReserveCapacity(m_calleesVector, functions.size(), " WebAssembly functions"_s))
+            return false;
+        m_calleesVector.resize(functions.size());
+    }
     return true;
 }
 
@@ -109,6 +119,70 @@ void IPIntPlan::compileFunction(uint32_t functionIndex)
     }
 
     m_wasmInternalFunctions[functionIndex] = WTFMove(*parseAndCompileResult);
+
+    IPIntCallee* ipintCallee = nullptr;
+    if (!m_callees) {
+        auto callee = IPIntCallee::create(*m_wasmInternalFunctions[functionIndex], functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace));
+        ASSERT(!callee->entrypoint());
+
+        if (Options::useJIT()) {
+#if ENABLE(JIT)
+            if (m_moduleInformation->usesSIMD(functionIndex))
+                callee->setEntrypoint(LLInt::inPlaceInterpreterEntryThunkSIMD().retaggedCode<WasmEntryPtrTag>());
+            else
+                callee->setEntrypoint(LLInt::inPlaceInterpreterEntryThunk().retaggedCode<WasmEntryPtrTag>());
+#endif
+        } else
+            callee->setEntrypoint(LLInt::getCodeFunctionPtr<CFunctionPtrTag>(wasm_function_prologue_trampoline));
+        ipintCallee = callee.ptr();
+        m_calleesVector[functionIndex] = WTFMove(callee);
+    } else
+        ipintCallee = m_callees[functionIndex].ptr();
+
+    // If the function is exported via module, then we ensure JSToWasm entrypoint.
+    if (m_compilerMode != CompilerMode::Validation) {
+        if (m_exportedFunctionIndices.contains(functionIndex)) {
+            if (!ensureEntrypoint(*ipintCallee, functionIndex)) {
+                Locker locker { m_lock };
+                Base::fail(makeString("JIT is disabled, but the entrypoint for "_s, functionIndex, " requires JIT"_s));
+                return;
+            }
+        }
+    }
+
+}
+
+bool IPIntPlan::ensureEntrypoint(IPIntCallee& ipintCallee, unsigned functionIndex)
+{
+    if (m_entrypoints[functionIndex])
+        return true;
+
+    if (!LIKELY(Options::useJIT()))
+        return false;
+
+#if ENABLE(JIT)
+    TypeIndex typeIndex = m_moduleInformation->internalFunctionTypeIndices[functionIndex];
+    const TypeDefinition& signature = TypeInformation::get(typeIndex).expand();
+    CCallHelpers jit;
+    // The LLInt always bounds checks
+    MemoryMode mode = MemoryMode::BoundsChecking;
+    auto callee = JSEntrypointJITCallee::create();
+    std::unique_ptr<InternalFunction> function = createJSToWasmWrapper(jit, callee.get(), &ipintCallee, signature, &m_unlinkedWasmToWasmCalls[functionIndex], m_moduleInformation.get(), mode, functionIndex);
+
+    LinkBuffer linkBuffer(jit, nullptr, LinkBuffer::Profile::WasmThunk, JITCompilationCanFail);
+    if (UNLIKELY(linkBuffer.didFailToAllocate()))
+        return false;
+
+    function->entrypoint.compilation = makeUnique<Compilation>(
+        FINALIZE_CODE(linkBuffer, JITCompilationPtrTag, nullptr, "JS->WebAssembly entrypoint[%i] %s", functionIndex, signature.toString().ascii().data()),
+        nullptr);
+
+    callee->setEntrypoint(WTFMove(function->entrypoint));
+    m_entrypoints[functionIndex] = WTFMove(callee);
+    return true;
+#else
+    return false;
+#endif
 }
 
 void IPIntPlan::didCompleteCompilation()
@@ -118,40 +192,6 @@ void IPIntPlan::didCompleteCompilation()
 #if ENABLE(JIT)
     unsigned functionCount = m_wasmInternalFunctions.size();
     if (!m_callees && functionCount) {
-        // IPInt entrypoint thunks generation
-        CCallHelpers jit;
-        m_calleesVector.resize(functionCount);
-        Vector<CCallHelpers::Label> entrypoints(functionCount);
-        Vector<CCallHelpers::Jump> jumps(functionCount);
-        for (unsigned i = 0; i < functionCount; ++i) {
-            size_t functionIndexSpace = i + m_moduleInformation->importFunctionCount();
-
-            // TODO: dump option
-
-            m_calleesVector[i] = IPIntCallee::create(*m_wasmInternalFunctions[i], functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace));
-            ASSERT(!m_calleesVector[i]->entrypoint());
-            entrypoints[i] = jit.label();
-            if (m_moduleInformation->usesSIMD(i))
-                JIT_COMMENT(jit, "SIMD function entrypoint");
-            JIT_COMMENT(jit, "Entrypoint for function[", i, "]");
-            jumps[i] = jit.jump();
-        }
-
-        LinkBuffer linkBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::WasmThunk, JITCompilationCanFail);
-        if (UNLIKELY(linkBuffer.didFailToAllocate())) {
-            Base::fail("Out of executable memory in Wasm IPInt entry thunks"_s);
-            return;
-        }
-
-        for (unsigned i = 0; i < functionCount; ++i) {
-            m_calleesVector[i]->setEntrypoint(linkBuffer.locationOf<WasmEntryPtrTag>(entrypoints[i]));
-            if (m_moduleInformation->usesSIMD(i))
-                linkBuffer.link<JITThunkPtrTag>(jumps[i], CodeLocationLabel<JITThunkPtrTag>(LLInt::inPlaceInterpreterEntryThunkSIMD().code()));
-            else
-                linkBuffer.link<JITThunkPtrTag>(jumps[i], CodeLocationLabel<JITThunkPtrTag>(LLInt::inPlaceInterpreterEntryThunk().code()));
-        }
-
-        m_entryThunks = FINALIZE_CODE(linkBuffer, JITCompilationPtrTag, nullptr, "Wasm IPInt entry thunks");
         m_callees = m_calleesVector.data();
         if (!m_moduleInformation->clobberingTailCalls().isEmpty())
             computeTransitiveTailCalls();
@@ -161,35 +201,19 @@ void IPIntPlan::didCompleteCompilation()
     if (m_compilerMode == CompilerMode::Validation)
         return;
 
-#if ENABLE(JIT)
     for (uint32_t functionIndex = 0; functionIndex < m_moduleInformation->functions.size(); functionIndex++) {
-        const uint32_t functionIndexSpace = functionIndex + m_moduleInformation->importFunctionCount();
-        if (m_exportedFunctionIndices.contains(functionIndex) || m_moduleInformation->hasReferencedFunction(functionIndexSpace)) {
-            TypeIndex typeIndex = m_moduleInformation->internalFunctionTypeIndices[functionIndex];
-            const TypeDefinition& signature = TypeInformation::get(typeIndex).expand();
-            CCallHelpers jit;
-            // The LLInt always bounds checks
-            MemoryMode mode = MemoryMode::BoundsChecking;
-            auto callee = JSEntrypointJITCallee::create();
-            std::unique_ptr<InternalFunction> function = createJSToWasmWrapper(jit, callee.get(), m_callees[functionIndex].ptr(), signature, &m_unlinkedWasmToWasmCalls[functionIndex], m_moduleInformation.get(), mode, functionIndex);
-
-            LinkBuffer linkBuffer(jit, nullptr, LinkBuffer::Profile::WasmThunk, JITCompilationCanFail);
-            if (UNLIKELY(linkBuffer.didFailToAllocate())) {
-                Base::fail(makeString("Out of executable memory in function entrypoint at index "_s, functionIndex));
-                return;
+        if (!m_entrypoints[functionIndex]) {
+            const uint32_t functionIndexSpace = functionIndex + m_moduleInformation->importFunctionCount();
+            if (m_exportedFunctionIndices.contains(functionIndex) || m_moduleInformation->hasReferencedFunction(functionIndexSpace)) {
+                if (!ensureEntrypoint(m_callees[functionIndex].get(), functionIndex)) {
+                    Base::fail(makeString("JIT is disabled, but the entrypoint for "_s, functionIndex, " requires JIT"_s));
+                    return;
+                }
             }
-
-            function->entrypoint.compilation = makeUnique<Compilation>(
-                FINALIZE_CODE(linkBuffer, JITCompilationPtrTag, nullptr, "JS->WebAssembly entrypoint[%i] %s", functionIndex, signature.toString().ascii().data()),
-                nullptr);
-
-            callee->setEntrypoint(WTFMove(function->entrypoint));
-
-            auto result = m_jsEntrypointCallees.add(functionIndex, WTFMove(callee));
-            ASSERT_UNUSED(result, result.isNewEntry);
         }
+        if (auto& callee = m_entrypoints[functionIndex])
+            m_jsEntrypointCallees.add(functionIndex, callee);
     }
-#endif
 
     for (auto& unlinked : m_unlinkedWasmToWasmCalls) {
         for (auto& call : unlinked) {

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.h
@@ -51,12 +51,6 @@ public:
     IPIntPlan(VM&, Ref<ModuleInformation>, const Ref<IPIntCallee>*, CompletionTask&&);
     IPIntPlan(VM&, Ref<ModuleInformation>, CompilerMode, CompletionTask&&); // For StreamingCompiler.
 
-    MacroAssemblerCodeRef<JITCompilationPtrTag>&& takeEntryThunks()
-    {
-        RELEASE_ASSERT(!failed() && !hasWork());
-        return WTFMove(m_entryThunks);
-    }
-
     Vector<Ref<IPIntCallee>>&& takeCallees()
     {
         RELEASE_ASSERT(!failed() && !hasWork());
@@ -93,12 +87,14 @@ private:
     void addTailCallEdge(uint32_t, uint32_t);
     void computeTransitiveTailCalls() const;
 
+    bool ensureEntrypoint(IPIntCallee&, unsigned functionIndex);
+
     Vector<std::unique_ptr<FunctionIPIntMetadataGenerator>> m_wasmInternalFunctions;
     const Ref<IPIntCallee>* m_callees { nullptr };
     Vector<Ref<IPIntCallee>> m_calleesVector;
+    Vector<RefPtr<JSEntrypointCallee>> m_entrypoints;
     JSEntrypointCalleeMap m_jsEntrypointCallees;
     TailCallGraph m_tailCallGraph;
-    MacroAssemblerCodeRef<JITCompilationPtrTag> m_entryThunks;
 };
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
@@ -74,8 +74,17 @@ bool LLIntPlan::prepareImpl()
     const auto& functions = m_moduleInformation->functions;
     if (!tryReserveCapacity(m_wasmInternalFunctions, functions.size(), " WebAssembly functions"_s))
         return false;
-
     m_wasmInternalFunctions.resize(functions.size());
+
+    if (!tryReserveCapacity(m_entrypoints, functions.size(), " WebAssembly functions"_s))
+        return false;
+    m_entrypoints.resize(functions.size());
+
+    if (!m_callees) {
+        if (!tryReserveCapacity(m_calleesVector, functions.size(), " WebAssembly functions"_s))
+            return false;
+        m_calleesVector.resize(functions.size());
+    }
 
     return true;
 }
@@ -112,10 +121,81 @@ void LLIntPlan::compileFunction(uint32_t functionIndex)
     }
 
     m_wasmInternalFunctions[functionIndex] = WTFMove(*parseAndCompileResult);
+
+    LLIntCallee* llintCallee = nullptr;
+    if (!m_callees) {
+        auto callee = LLIntCallee::create(*m_wasmInternalFunctions[functionIndex], functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace));
+        ASSERT(!callee->entrypoint());
+
+        if (Options::useJIT()) {
+#if ENABLE(JIT)
+            if (m_moduleInformation->usesSIMD(functionIndex))
+                callee->setEntrypoint(LLInt::wasmFunctionEntryThunkSIMD().retaggedCode<WasmEntryPtrTag>());
+            else
+                callee->setEntrypoint(LLInt::wasmFunctionEntryThunk().retaggedCode<WasmEntryPtrTag>());
+#endif
+        } else
+            callee->setEntrypoint(LLInt::getCodeFunctionPtr<CFunctionPtrTag>(wasm_function_prologue_trampoline));
+        llintCallee = callee.ptr();
+        m_calleesVector[functionIndex] = WTFMove(callee);
+    } else
+        llintCallee = m_callees[functionIndex].ptr();
+
+    // If the function is exported via module, then we ensure JSToWasm entrypoint.
+    if (m_compilerMode != CompilerMode::Validation) {
+        if (m_exportedFunctionIndices.contains(functionIndex)) {
+            if (!ensureEntrypoint(*llintCallee, functionIndex)) {
+                Locker locker { m_lock };
+                Base::fail(makeString("JIT is disabled, but the entrypoint for "_s, functionIndex, " requires JIT"_s));
+                return;
+            }
+        }
+    }
+}
+
+bool LLIntPlan::ensureEntrypoint(LLIntCallee& llintCallee, unsigned functionIndex)
+{
+    if (m_entrypoints[functionIndex])
+        return true;
+
+    if (auto callee = tryCreateInterpretedJSToWasmCallee(functionIndex)) {
+        m_entrypoints[functionIndex] = WTFMove(callee);
+        return true;
+    }
+
+    if (!LIKELY(Options::useJIT()))
+        return false;
+
+#if ENABLE(JIT)
+    CCallHelpers jit;
+
+    TypeIndex typeIndex = m_moduleInformation->internalFunctionTypeIndices[functionIndex];
+    const TypeDefinition& signature = TypeInformation::get(typeIndex).expand();
+
+    // The LLInt always bounds checks
+    MemoryMode mode = MemoryMode::BoundsChecking;
+
+    auto callee = JSEntrypointJITCallee::create();
+    std::unique_ptr<InternalFunction> function = createJSToWasmWrapper(jit, callee.get(), &llintCallee, signature, &m_unlinkedWasmToWasmCalls[functionIndex], m_moduleInformation.get(), mode, functionIndex);
+
+    LinkBuffer linkBuffer(jit, nullptr, LinkBuffer::Profile::WasmThunk, JITCompilationCanFail);
+    if (UNLIKELY(linkBuffer.didFailToAllocate()))
+        return false;
+
+    function->entrypoint.compilation = makeUnique<Compilation>(
+        FINALIZE_WASM_CODE(linkBuffer, JITCompilationPtrTag, nullptr, "JS->WebAssembly entrypoint[%i] %s", functionIndex, signature.toString().ascii().data()),
+        nullptr);
+
+    callee->setEntrypoint(WTFMove(function->entrypoint));
+    m_entrypoints[functionIndex] = WTFMove(callee);
+    return true;
+#else
+    return false;
+#endif
 }
 
 #if USE(JSVALUE64)
-bool LLIntPlan::makeInterpretedJSToWasmCallee(unsigned functionIndex)
+RefPtr<JSEntrypointCallee> LLIntPlan::tryCreateInterpretedJSToWasmCallee(unsigned functionIndex)
 {
     TypeIndex typeIndex = m_moduleInformation->internalFunctionTypeIndices[functionIndex];
     const TypeDefinition& signature = TypeInformation::get(typeIndex).expand();
@@ -125,7 +205,7 @@ bool LLIntPlan::makeInterpretedJSToWasmCallee(unsigned functionIndex)
         || m_moduleInformation->usesSIMD(functionIndex)
         || functionSignature.argumentCount() > 16
         || functionSignature.returnCount() > 16)
-        return false;
+        return nullptr;
 
     RegisterSet registersToSpill = RegisterSetBuilder::wasmPinnedRegisters();
     registersToSpill.add(GPRInfo::regCS1, IgnoreVectors);
@@ -165,7 +245,7 @@ bool LLIntPlan::makeInterpretedJSToWasmCallee(unsigned functionIndex)
             (jsFrameConvention.params[i].location.offsetFromFP() + static_cast<int>(PayloadOffset)) / 8));
 
         if (!type.isI32())
-            return false; // TODO: eventually we should support this
+            return nullptr; // FIXME: eventually we should support this
 
         if (wasmFrameConvention.params[i].location.isStackArgument()) {
             auto wasmParam = static_cast<JSEntrypointInterpreterCalleeMetadata>(safeCast<int8_t>(
@@ -199,7 +279,7 @@ bool LLIntPlan::makeInterpretedJSToWasmCallee(unsigned functionIndex)
                     metadata.append(jsEntrypointMetadataForGPR(wasmFrameConvention.params[i].location.jsr().tagGPR(), MetadataReadMode::Write));
                 }
             } else
-                return false;
+                return nullptr;
         }
     }
 
@@ -214,7 +294,7 @@ bool LLIntPlan::makeInterpretedJSToWasmCallee(unsigned functionIndex)
         }
     } else if (functionSignature.returnCount() == 1) {
         if (!functionSignature.returnType(0).isI32())
-            return false; // TODO: eventually we should support this
+            return nullptr; // FIXME: eventually we should support this
 
         JSValueRegs inputJSR = wasmFrameConvention.results[0].location.jsr();
         JSValueRegs outputJSR = jsFrameConvention.results[0].location.jsr();
@@ -224,27 +304,24 @@ bool LLIntPlan::makeInterpretedJSToWasmCallee(unsigned functionIndex)
         else if (functionSignature.returnType(0).isI32())
             metadata.append(JSEntrypointInterpreterCalleeMetadata::BoxInt32);
         else
-            return false; // TODO
+            return nullptr; // FIXME
         metadata.append(jsEntrypointMetadataForGPR(outputJSR.payloadGPR(), MetadataReadMode::Write));
         if (!is64Bit()) {
             metadata.append(JSEntrypointInterpreterCalleeMetadata::ShiftTag);
             metadata.append(jsEntrypointMetadataForGPR(outputJSR.tagGPR(), MetadataReadMode::Write));
         }
     } else
-        return false;
+        return nullptr;
     metadata.append(JSEntrypointInterpreterCalleeMetadata::Done);
 
     if ((false))
         dumpJSEntrypointInterpreterCalleeMetadata(metadata);
 
     auto callee = JSEntrypointInterpreterCallee::create(WTFMove(metadata), &m_callees[functionIndex].get());
-    auto result = m_jsEntrypointCallees.add(functionIndex, WTFMove(callee));
-    ASSERT_UNUSED(result, result.isNewEntry);
-
-    return true;
+    return callee;
 }
 #else
-bool LLIntPlan::makeInterpretedJSToWasmCallee(unsigned) { return false; }
+RefPtr<JSEntrypointCallee> LLIntPlan::tryCreateInterpretedJSToWasmCallee(unsigned) { return nullptr; }
 #endif
 
 void LLIntPlan::didCompleteCompilation()
@@ -253,110 +330,30 @@ void LLIntPlan::didCompleteCompilation()
 
     unsigned functionCount = m_wasmInternalFunctions.size();
     if (!m_callees && functionCount) {
-        m_calleesVector.resize(functionCount);
-
-        for (unsigned i = 0; i < functionCount; ++i) {
-            size_t functionIndexSpace = i + m_moduleInformation->importFunctionCount();
-
-            if (UNLIKELY(Options::dumpGeneratedWasmBytecodes()))
-                BytecodeDumper::dumpBlock(m_wasmInternalFunctions[i].get(), m_moduleInformation, WTF::dataFile());
-
-            m_calleesVector[i] = LLIntCallee::create(*m_wasmInternalFunctions[i], functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace));
-            ASSERT(!m_calleesVector[i]->entrypoint());
-        }
-
-#if ENABLE(JIT)
-        // LLInt entrypoint thunks generation
-        CCallHelpers jit;
-
-        if (LIKELY(Options::useJIT())) {
-            Vector<CCallHelpers::Label> entrypoints(functionCount);
-            Vector<CCallHelpers::Jump> jumps(functionCount);
-            for (unsigned i = 0; i < functionCount; ++i) {
-                entrypoints[i] = jit.label();
-                if (m_moduleInformation->usesSIMD(i))
-                    JIT_COMMENT(jit, "SIMD function entrypoint");
-                JIT_COMMENT(jit, "Entrypoint for function[", i, "]");
-                {
-                    CCallHelpers::Address calleeSlot(CCallHelpers::stackPointerRegister, CallFrameSlot::callee * static_cast<int>(sizeof(Register)) - prologueStackPointerDelta());
-                    jit.loadPtr(calleeSlot.withOffset(PayloadOffset), GPRInfo::nonPreservedNonArgumentGPR0);
-                    auto good = jit.branchPtr(MacroAssembler::Equal, GPRInfo::nonPreservedNonArgumentGPR0,
-                        MacroAssembler::TrustedImmPtr(reinterpret_cast<uint64_t>(CalleeBits::boxNativeCallee(m_calleesVector[i].ptr()))));
-                    jit.breakpoint();
-                    good.link(&jit);
-                }
-                jumps[i] = jit.jump();
-            }
-
-            LinkBuffer linkBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::WasmThunk, JITCompilationCanFail);
-            if (UNLIKELY(linkBuffer.didFailToAllocate())) {
-                Base::fail("Out of executable memory in Wasm LLInt entry thunks"_s);
-                return;
-            }
-
-            for (unsigned i = 0; i < functionCount; ++i) {
-                m_calleesVector[i]->setEntrypoint(linkBuffer.locationOf<WasmEntryPtrTag>(entrypoints[i]));
-                if (m_moduleInformation->usesSIMD(i))
-                    linkBuffer.link<JITThunkPtrTag>(jumps[i], CodeLocationLabel<JITThunkPtrTag>(LLInt::wasmFunctionEntryThunkSIMD().code()));
-                else
-                    linkBuffer.link<JITThunkPtrTag>(jumps[i], CodeLocationLabel<JITThunkPtrTag>(LLInt::wasmFunctionEntryThunk().code()));
-            }
-
-            m_entryThunks = FINALIZE_WASM_CODE(linkBuffer, JITCompilationPtrTag, nullptr, "Wasm LLInt entry thunks");
-        } else
-#endif
-        {
+        if (UNLIKELY(Options::dumpGeneratedWasmBytecodes())) {
             for (unsigned i = 0; i < functionCount; ++i)
-                m_calleesVector[i]->setEntrypoint(LLInt::getCodeFunctionPtr<CFunctionPtrTag>(wasm_function_prologue_trampoline));
+                BytecodeDumper::dumpBlock(m_wasmInternalFunctions[i].get(), m_moduleInformation, WTF::dataFile());
         }
         m_callees = m_calleesVector.data();
+        if (!m_moduleInformation->clobberingTailCalls().isEmpty())
+            computeTransitiveTailCalls();
     }
-
-    if (!m_moduleInformation->clobberingTailCalls().isEmpty())
-        computeTransitiveTailCalls();
 
     if (m_compilerMode == CompilerMode::Validation)
         return;
 
     for (uint32_t functionIndex = 0; functionIndex < m_moduleInformation->functions.size(); functionIndex++) {
-        const uint32_t functionIndexSpace = functionIndex + m_moduleInformation->importFunctionCount();
-        if (m_exportedFunctionIndices.contains(functionIndex) || m_moduleInformation->hasReferencedFunction(functionIndexSpace)) {
-            if (makeInterpretedJSToWasmCallee(functionIndex))
-                continue;
-
-            if (!LIKELY(Options::useJIT())) {
-                Base::fail(makeString("JIT is disabled, but the entrypoint for "_s, functionIndex, " requires JIT"_s));
-                return;
+        if (!m_entrypoints[functionIndex]) {
+            const uint32_t functionIndexSpace = functionIndex + m_moduleInformation->importFunctionCount();
+            if (m_exportedFunctionIndices.contains(functionIndex) || m_moduleInformation->hasReferencedFunction(functionIndexSpace)) {
+                if (!ensureEntrypoint(m_callees[functionIndex].get(), functionIndex)) {
+                    Base::fail(makeString("JIT is disabled, but the entrypoint for "_s, functionIndex, " requires JIT"_s));
+                    return;
+                }
             }
-
-#if ENABLE(JIT)
-            CCallHelpers jit;
-
-            TypeIndex typeIndex = m_moduleInformation->internalFunctionTypeIndices[functionIndex];
-            const TypeDefinition& signature = TypeInformation::get(typeIndex).expand();
-
-            // The LLInt always bounds checks
-            MemoryMode mode = MemoryMode::BoundsChecking;
-
-            auto callee = JSEntrypointJITCallee::create();
-            std::unique_ptr<InternalFunction> function = createJSToWasmWrapper(jit, callee.get(), m_callees[functionIndex].ptr(), signature, &m_unlinkedWasmToWasmCalls[functionIndex], m_moduleInformation.get(), mode, functionIndex);
-
-            LinkBuffer linkBuffer(jit, nullptr, LinkBuffer::Profile::WasmThunk, JITCompilationCanFail);
-            if (UNLIKELY(linkBuffer.didFailToAllocate())) {
-                Base::fail(makeString("Out of executable memory in function entrypoint at index "_s, functionIndex));
-                return;
-            }
-
-            function->entrypoint.compilation = makeUnique<Compilation>(
-                FINALIZE_WASM_CODE(linkBuffer, JITCompilationPtrTag, nullptr, "JS->WebAssembly entrypoint[%i] %s", functionIndex, signature.toString().ascii().data()),
-                nullptr);
-
-            callee->setEntrypoint(WTFMove(function->entrypoint));
-
-            auto result = m_jsEntrypointCallees.add(functionIndex, WTFMove(callee));
-            ASSERT_UNUSED(result, result.isNewEntry);
-#endif
         }
+        if (auto& callee = m_entrypoints[functionIndex])
+            m_jsEntrypointCallees.add(functionIndex, callee);
     }
 
     for (auto& unlinked : m_unlinkedWasmToWasmCalls) {

--- a/Source/JavaScriptCore/wasm/WasmLLIntPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmLLIntPlan.h
@@ -53,12 +53,6 @@ public:
     LLIntPlan(VM&, Ref<ModuleInformation>, const Ref<LLIntCallee>*, CompletionTask&&);
     LLIntPlan(VM&, Ref<ModuleInformation>, CompilerMode, CompletionTask&&); // For StreamingCompiler.
 
-    MacroAssemblerCodeRef<JITCompilationPtrTag>&& takeEntryThunks()
-    {
-        RELEASE_ASSERT(!failed() && !hasWork());
-        return WTFMove(m_entryThunks);
-    }
-
     Vector<Ref<LLIntCallee>>&& takeCallees()
     {
         RELEASE_ASSERT(!failed() && !hasWork());
@@ -93,14 +87,16 @@ private:
     void addTailCallEdge(uint32_t, uint32_t);
     void computeTransitiveTailCalls() const;
 
-    bool makeInterpretedJSToWasmCallee(unsigned functionIndex);
+    bool ensureEntrypoint(LLIntCallee&, unsigned functionIndex);
+
+    RefPtr<JSEntrypointCallee> tryCreateInterpretedJSToWasmCallee(unsigned functionIndex);
 
     Vector<std::unique_ptr<FunctionCodeBlockGenerator>> m_wasmInternalFunctions;
     const Ref<LLIntCallee>* m_callees { nullptr };
     Vector<Ref<LLIntCallee>> m_calleesVector;
+    Vector<RefPtr<JSEntrypointCallee>> m_entrypoints;
     JSEntrypointCalleeMap m_jsEntrypointCallees;
     TailCallGraph m_tailCallGraph;
-    MacroAssemblerCodeRef<JITCompilationPtrTag> m_entryThunks;
 };
 
 

--- a/Source/JavaScriptCore/wasm/WasmModule.cpp
+++ b/Source/JavaScriptCore/wasm/WasmModule.cpp
@@ -39,7 +39,6 @@ Module::Module(LLIntPlan& plan)
     : m_moduleInformation(plan.takeModuleInformation())
     , m_llintCallees(LLIntCallees::createFromVector(plan.takeCallees()))
     , m_ipintCallees(IPIntCallees::create(0))
-    , m_llintEntryThunks(plan.takeEntryThunks())
     , m_wasmToJSExitStubs(plan.takeWasmToJSExitStubs())
 {
 }
@@ -48,7 +47,6 @@ Module::Module(IPIntPlan& plan)
     : m_moduleInformation(plan.takeModuleInformation())
     , m_llintCallees(LLIntCallees::create(0))
     , m_ipintCallees(IPIntCallees::createFromVector(plan.takeCallees()))
-    , m_llintEntryThunks(plan.takeEntryThunks())
     , m_wasmToJSExitStubs(plan.takeWasmToJSExitStubs())
 {
 }

--- a/Source/JavaScriptCore/wasm/WasmModule.h
+++ b/Source/JavaScriptCore/wasm/WasmModule.h
@@ -88,7 +88,6 @@ private:
     RefPtr<CalleeGroup> m_calleeGroups[numberOfMemoryModes];
     Ref<LLIntCallees> m_llintCallees;
     Ref<IPIntCallees> m_ipintCallees;
-    MacroAssemblerCodeRef<JITCompilationPtrTag> m_llintEntryThunks;
     FixedVector<MacroAssemblerCodeRef<WasmEntryPtrTag>> m_wasmToJSExitStubs;
     Lock m_lock;
 };


### PR DESCRIPTION
#### e522f11064930938fafd62938d82d37709757d36
<pre>
[JSC] Remove wasm entrypoint thunk generation
<a href="https://bugs.webkit.org/show_bug.cgi?id=274764">https://bugs.webkit.org/show_bug.cgi?id=274764</a>
<a href="https://rdar.apple.com/128826832">rdar://128826832</a>

Reviewed by Justin Michaud.

Because caller stores callee to a specific stack slot, we do not need to generate LLInt/IPInt entrypoint thunk anymore.
This patch wipes it. And we move LLIntCallee / IPIntCallee generation from the last part of LLIntPlan / IPIntPlan to each function compilation.
We also move entrypoint thunk generation from the last phase to the each function compilation.

* Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp:
(JSC::Wasm::IPIntPlan::prepareImpl):
(JSC::Wasm::IPIntPlan::compileFunction):
(JSC::Wasm::IPIntPlan::didCompleteCompilation):
* Source/JavaScriptCore/wasm/WasmIPIntPlan.h:
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::prepareImpl):
(JSC::Wasm::LLIntPlan::compileFunction):
(JSC::Wasm::LLIntPlan::didCompleteCompilation):
* Source/JavaScriptCore/wasm/WasmLLIntPlan.h:
* Source/JavaScriptCore/wasm/WasmModule.cpp:
(JSC::Wasm::Module::Module):
* Source/JavaScriptCore/wasm/WasmModule.h:

Canonical link: <a href="https://commits.webkit.org/279369@main">https://commits.webkit.org/279369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f5eeccbb8a25060b47c60f5c434dd095e66798f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56583 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4030 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43213 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2634 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55402 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/30826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46039 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24343 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3358 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2186 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/46661 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3522 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58179 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52818 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3512 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50615 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29668 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46247 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49950 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30591 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65122 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7835 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29431 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12410 "Found 9 new JSC stress test failures: stress/proxy-set-prototype-of.js.mini-mode, stress/spread-non-array.js.dfg-eager, wasm.yaml/wasm/function-tests/brTableWithLoop.js.wasm-eager, wasm.yaml/wasm/function-tests/dead-call.js.wasm-eager, wasm.yaml/wasm/function-tests/float-sub.js.wasm-eager, wasm.yaml/wasm/function-tests/ret5.js.wasm-eager, wasm.yaml/wasm/function-tests/shr-s.js.wasm-eager, wasm.yaml/wasm/js-api/extension-MemoryMode.js.wasm-eager-jettison, wasm.yaml/wasm/stress/dont-stack-overflow-in-air.js.wasm-eager (failure)") | 
<!--EWS-Status-Bubble-End-->