### PR TITLE
Add an initial WebKit User Agent Overrides file

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -2878,6 +2878,8 @@ list(APPEND WebCore_SOURCES ${WebCore_DERIVED_SOURCES_DIR}/NodeName.cpp)
 GENERATE_DOM_NAME_ENUM(Namespace)
 list(APPEND WebCore_SOURCES ${WebCore_DERIVED_SOURCES_DIR}/Namespace.cpp)
 
+USER_AGENT_STRING_OVERRIDES_VALIDATION(${WEBCORE_DIR}/page/UserAgentStringOverrides.json)
+
 WEBKIT_COMPUTE_SOURCES(WebCore)
 
 target_precompile_headers(WebCore PRIVATE WebCorePrefix.h)

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1903,6 +1903,7 @@ $(PROJECT_DIR)/page/ShareData.idl
 $(PROJECT_DIR)/page/StructuredSerializeOptions.idl
 $(PROJECT_DIR)/page/UndoItem.idl
 $(PROJECT_DIR)/page/UndoManager.idl
+$(PROJECT_DIR)/page/UserAgentStringOverrides.json
 $(PROJECT_DIR)/page/UserMessageHandler.idl
 $(PROJECT_DIR)/page/UserMessageHandlersNamespace.idl
 $(PROJECT_DIR)/page/VisualViewport.idl
@@ -1917,6 +1918,7 @@ $(PROJECT_DIR)/page/WindowPostMessageOptions.idl
 $(PROJECT_DIR)/page/WindowSessionStorage.idl
 $(PROJECT_DIR)/page/WorkerNavigator.idl
 $(PROJECT_DIR)/page/csp/CSPViolationReportBody.idl
+$(PROJECT_DIR)/page/make-user-agent-string-overrides.py
 $(PROJECT_DIR)/platform/ColorData.gperf
 $(PROJECT_DIR)/platform/network/HTTPHeaderNames.in
 $(PROJECT_DIR)/platform/network/create-http-header-name-table

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -2368,6 +2368,18 @@ $(EVENT_NAME_FILES_PATTERNS) : $(WebCore)/dom/make-event-names.py $(EVENT_NAME_J
 
 # --------
 
+# User Agent String overrides
+
+USER_AGENT_STRING_OVERRIDE_JSON := $(WebCore)/page/UserAgentStringOverrides.json
+
+#
+
+all : $(USER_AGENT_STRING_OVERRIDE_JSON)
+$(USER_AGENT_STRING_OVERRIDE_FILES_PATTERNS) : $(WebCore)/page/make-user-agent-string-overrides.py $(USER_AGENT_STRING_OVERRIDE_JSON)
+	$(PYTHON) "$(WebCore)/page/make-user-agent-string-overrides.py" --input $(USER_AGENT_STRING_OVERRIDE_JSON)
+
+# --------
+
 # MathML tag and attribute names, and element factory
 
 MATH_ML_GENERATED_FILES = \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1653,6 +1653,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/TextIndicator.h
     page/TranslationContextMenuInfo.h
     page/UndoManager.h
+    page/UserAgentStringOverrides.h
     page/UserContentController.h
     page/UserContentProvider.h
     page/UserContentTypes.h
@@ -2752,6 +2753,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     ${WebCore_DERIVED_SOURCES_DIR}/StreamInternalsBuiltins.h
     ${WebCore_DERIVED_SOURCES_DIR}/TagName.h
     ${WebCore_DERIVED_SOURCES_DIR}/TransformStreamInternalsBuiltins.h
+    ${WebCore_DERIVED_SOURCES_DIR}/UserAgentStringOverrides.h
     ${WebCore_DERIVED_SOURCES_DIR}/UserAgentParts.h
     ${WebCore_DERIVED_SOURCES_DIR}/UserAgentStyleSheets.h
     ${WebCore_DERIVED_SOURCES_DIR}/WebCoreJSBuiltinInternals.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2127,6 +2127,7 @@ page/SpatialNavigation.cpp
 page/TextIndicator.cpp
 page/UndoItem.cpp
 page/UndoManager.cpp
+page/UserAgentStringOverrides.cpp
 page/UserContentController.cpp
 page/UserContentProvider.cpp
 page/UserContentURLPattern.cpp

--- a/Source/WebCore/WebCoreMacros.cmake
+++ b/Source/WebCore/WebCoreMacros.cmake
@@ -220,3 +220,14 @@ function(GENERATE_DOM_NAME_ENUM _enum)
         COMMAND ${PERL_EXECUTABLE} ${WEBCORE_DIR}/dom/make_names.pl --outputDir ${WebCore_DERIVED_SOURCES_DIR} --enum ${_enum} --elements ${WEBCORE_DIR}/html/HTMLTagNames.in --elements ${WEBCORE_DIR}/svg/svgtags.in --elements ${WEBCORE_DIR}/mathml/mathtags.in --attrs ${WEBCORE_DIR}/html/HTMLAttributeNames.in --attrs ${WEBCORE_DIR}/mathml/mathattrs.in --attrs ${WEBCORE_DIR}/svg/svgattrs.in --attrs ${WEBCORE_DIR}/svg/xlinkattrs.in --attrs ${WEBCORE_DIR}/xml/xmlattrs.in --attrs ${WEBCORE_DIR}/xml/xmlnsattrs.in
         VERBATIM)
 endfunction()
+
+
+macro(USER_AGENT_STRING_OVERRIDES_VALIDATION _infile)
+    set(OVERRIDES_VALIDATION_SCRIPT ${WEBCORE_DIR}/page/make-user-agent-string-overrides.py)
+
+    add_custom_command(
+        TARGET WebCore PRE_LINK
+        WORKING_DIRECTORY ${arg_BASE_DIR}
+        COMMAND ${PYTHON_EXECUTABLE} ${OVERRIDES_VALIDATION_SCRIPT} --input ${_infile}
+        VERBATIM)
+endmacro()

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3142,11 +3142,6 @@ int FrameLoader::numPendingOrLoadingRequests(bool recurse) const
 String FrameLoader::userAgent(const URL& url) const
 {
     String userAgent;
-    if (RefPtr document = m_frame->document()) {
-        if (auto userAgentQuirk = document->quirks().storageAccessUserAgentStringQuirkForDomain(url); !userAgentQuirk.isEmpty())
-            userAgent = userAgentQuirk;
-    }
-
     if (userAgent.isEmpty()) {
         Ref mainFrame = m_frame->mainFrame();
         if (m_frame->settings().needsSiteSpecificQuirks())

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -95,13 +95,6 @@ static inline OptionSet<AutoplayQuirk> allowedAutoplayQuirks(Document& document)
     return loader->allowedAutoplayQuirks();
 }
 
-static UncheckedKeyHashMap<RegistrableDomain, String>& updatableStorageAccessUserAgentStringQuirks()
-{
-    // FIXME: Make this a member of Quirks.
-    static MainThreadNeverDestroyed<UncheckedKeyHashMap<RegistrableDomain, String>> map;
-    return map.get();
-}
-
 #if PLATFORM(IOS_FAMILY)
 static inline bool isYahooMail(Document& document)
 {
@@ -334,29 +327,6 @@ bool Quirks::shouldDisableWritingSuggestionsByDefault() const
         return false;
     auto& url = m_document->topDocument().url();
     return url.host() == "mail.google.com"_s;
-}
-
-void Quirks::updateStorageAccessUserAgentStringQuirks(UncheckedKeyHashMap<RegistrableDomain, String>&& userAgentStringQuirks)
-{
-    auto& quirks = updatableStorageAccessUserAgentStringQuirks();
-    quirks.clear();
-    for (auto&& [domain, userAgent] : userAgentStringQuirks)
-        quirks.add(WTFMove(domain), WTFMove(userAgent));
-}
-
-String Quirks::storageAccessUserAgentStringQuirkForDomain(const URL& url)
-{
-    if (!needsQuirks())
-        return { };
-
-    const auto& quirks = updatableStorageAccessUserAgentStringQuirks();
-    RegistrableDomain domain { url };
-    auto iterator = quirks.find(domain);
-    if (iterator == quirks.end())
-        return { };
-    if (domain == "live.com"_s && url.host() != "teams.live.com"_s)
-        return { };
-    return iterator->value;
 }
 
 bool Quirks::isYoutubeEmbedDomain() const

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -96,8 +96,6 @@ public:
 
     WEBCORE_EXPORT bool shouldDisableWritingSuggestionsByDefault() const;
 
-    WEBCORE_EXPORT static void updateStorageAccessUserAgentStringQuirks(UncheckedKeyHashMap<RegistrableDomain, String>&&);
-    WEBCORE_EXPORT String storageAccessUserAgentStringQuirkForDomain(const URL&);
     WEBCORE_EXPORT static bool needsIPadMiniUserAgent(const URL&);
     WEBCORE_EXPORT static bool needsIPhoneUserAgent(const URL&);
     WEBCORE_EXPORT static bool needsDesktopUserAgent(const URL&);

--- a/Source/WebCore/page/UserAgentStringOverrides.cpp
+++ b/Source/WebCore/page/UserAgentStringOverrides.cpp
@@ -1,0 +1,418 @@
+/*
+ * Copyright (C) 2017-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2012, 2014, 2016 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "UserAgentStringOverrides.h"
+
+#include "Logging.h"
+#include "RegistrableDomain.h"
+#include <wtf/FileSystem.h>
+#include <wtf/JSONValues.h>
+#include <wtf/URL.h>
+#include <wtf/text/StringBuilder.h>
+
+#if PLATFORM(IOS_FAMILY)
+#include <pal/system/ios/UserInterfaceIdiom.h>
+#endif
+
+namespace WebCore {
+
+UserAgentStringPlatform UserAgentStringOverrides::getPlatform()
+{
+#if OS(MACOS)
+    return UserAgentStringPlatform::Mac;
+#elif PLATFORM(IOS)
+    return PAL::currentUserInterfaceIdiomIsSmallScreen() ? UserAgentStringPlatform::Iphone : UserAgentStringPlatform::Ipad;
+#else
+    return UserAgentStringPlatform::Unknown;
+#endif
+}
+
+UserAgentStringPlatform UserAgentStringOverrides::stringToUserAgentPlatform(const String& platform)
+{
+    if (platform == "ipad"_s)
+        return UserAgentStringPlatform::Ipad;
+    if (platform == "iphone"_s)
+        return UserAgentStringPlatform::Iphone;
+    if (platform == "mac"_s)
+        return UserAgentStringPlatform::Mac;
+    if (platform == "all"_s)
+        return UserAgentStringPlatform::All;
+    return UserAgentStringPlatform::Unknown;
+}
+
+UserAgentStringAgent UserAgentStringOverrides::stringToUserAgent(const String& agent)
+{
+    if (agent == "chrome"_s)
+        return UserAgentStringAgent::Chrome;
+    if (agent == "safari12"_s)
+        return UserAgentStringAgent::Safari12;
+    if (agent == "safari13"_s)
+        return UserAgentStringAgent::Safari13;
+    if (agent == "safari13"_s)
+        return UserAgentStringAgent::Safari13;
+    if (agent == "safari"_s)
+        return UserAgentStringAgent::Safari;
+    return UserAgentStringAgent::Unknown;
+}
+
+String UserAgentStringOverrides::userAgentAttributeToString(UserAgentStringAgent agent)
+{
+    switch (agent) {
+    case UserAgentStringAgent::Chrome:
+        return "Chrome"_s;
+    case UserAgentStringAgent::Safari12:
+        FALLTHROUGH;
+    case UserAgentStringAgent::Safari13:
+        FALLTHROUGH;
+    case UserAgentStringAgent::Safari:
+        return "Safari"_s;
+    case UserAgentStringAgent::Unknown:
+        return emptyString();
+    }
+    return emptyString();
+}
+
+static String platformToNavigatorPlatformString(UserAgentStringPlatform userAgentStringPlatform)
+{
+    switch (userAgentStringPlatform) {
+    case UserAgentStringPlatform::Ipad:
+        return "iPad"_s;
+    case UserAgentStringPlatform::Iphone:
+        return "iPhone"_s;
+    case UserAgentStringPlatform::Mac:
+        return "MacIntel"_s;
+    case UserAgentStringPlatform::All:
+        FALLTHROUGH;
+    case UserAgentStringPlatform::Unknown:
+        ASSERT_NOT_REACHED();
+        return emptyString();
+    }
+    return emptyString();
+}
+
+static String platformToPlatformString(UserAgentStringPlatform userAgentStringPlatform)
+{
+    switch (userAgentStringPlatform) {
+    case UserAgentStringPlatform::Ipad:
+        return "iPad"_s;
+    case UserAgentStringPlatform::Iphone:
+        return "iPhone"_s;
+    case UserAgentStringPlatform::Mac:
+        return "Macintosh"_s;
+    case UserAgentStringPlatform::All:
+        FALLTHROUGH;
+    case UserAgentStringPlatform::Unknown:
+        ASSERT_NOT_REACHED();
+        return emptyString();
+    }
+    return emptyString();
+}
+
+static String agentToAgentVersionString(UserAgentStringAgent userAgentStringAgent)
+{
+    switch (userAgentStringAgent) {
+    case UserAgentStringAgent::Chrome:
+        return "110.0.0.0"_s;
+    case UserAgentStringAgent::Safari12:
+        return "12.1.2"_s;
+    case UserAgentStringAgent::Safari13:
+        return "13.1.2"_s;
+    case UserAgentStringAgent::Safari:
+        FALLTHROUGH;
+    case UserAgentStringAgent::Unknown:
+        return "18.1"_s;
+    }
+
+    ASSERT_NOT_REACHED();
+    return emptyString();
+}
+
+static String agentToAgentString(UserAgentStringAgent userAgentStringAgent)
+{
+    switch (userAgentStringAgent) {
+    case UserAgentStringAgent::Chrome:
+        return "Chrome"_s;
+    case UserAgentStringAgent::Safari12:
+        FALLTHROUGH;
+    case UserAgentStringAgent::Safari13:
+        FALLTHROUGH;
+    case UserAgentStringAgent::Safari:
+        return "Safari"_s;
+    case UserAgentStringAgent::Unknown:
+        ASSERT_NOT_REACHED();
+        return emptyString();
+    }
+    ASSERT_NOT_REACHED();
+    return emptyString();
+}
+
+String UserAgentStringOverrides::attributesToPlatformString(const Vector<UserAgentOverridesAttributes>& attributes)
+{
+    for (auto attribute : attributes) {
+        if (auto platform = std::get_if<UserAgentStringPlatform>(&attribute))
+            return platformToPlatformString(*platform);
+    }
+    return emptyString();
+}
+
+String UserAgentStringOverrides::attributesToNavigatorPlatformString(const Vector<UserAgentOverridesAttributes>& attributes)
+{
+    for (auto attribute : attributes) {
+        if (auto platform = std::get_if<UserAgentStringPlatform>(&attribute))
+            return platformToNavigatorPlatformString(*platform);
+    }
+    return emptyString();
+}
+
+String UserAgentStringOverrides::attributesToAgentString(const Vector<UserAgentOverridesAttributes>& attributes)
+{
+    for (auto attribute : attributes) {
+        if (auto agent = std::get_if<UserAgentStringAgent>(&attribute))
+            return agentToAgentString(*agent);
+    }
+    return emptyString();
+}
+
+String UserAgentStringOverrides::attributesToPlatformVersionString(const Vector<UserAgentOverridesAttributes>& attributes)
+{
+    UserAgentStringAgent userAgent { UserAgentStringAgent::Unknown };
+    UserAgentStringPlatform userAgentPlatform { UserAgentStringPlatform::Unknown };
+
+    for (auto attribute : attributes) {
+        if (auto agent = std::get_if<UserAgentStringAgent>(&attribute))
+            userAgent = *agent;
+        else if (auto platform = std::get_if<UserAgentStringPlatform>(&attribute))
+            userAgentPlatform = *platform;
+    }
+
+    auto safariVersion = agentToAgentVersionString(userAgent);
+    if (userAgent == UserAgentStringAgent::Safari || userAgent == UserAgentStringAgent::Chrome) {
+        if (userAgentPlatform == UserAgentStringPlatform::Iphone || userAgentPlatform == UserAgentStringPlatform::Ipad) {
+            StringBuilder builder;
+            builder.append("CPU "_s);
+            if (userAgentPlatform == UserAgentStringPlatform::Iphone)
+                builder.append("iPhone "_s);
+            builder.append("OS "_s, makeStringByReplacingAll(safariVersion, "."_s, "_"_s), "like Mac OS X"_s);
+            return builder.toString();
+        }
+        return "Intel Mac OS X 10_15_7"_s;
+    }
+    return "Intel Mac OS X 10_15_7"_s;
+}
+
+String UserAgentStringOverrides::attributesToAgentVersionString(const Vector<UserAgentOverridesAttributes>& attributes)
+{
+    for (auto attribute : attributes) {
+        if (auto agent = std::get_if<UserAgentStringAgent>(&attribute))
+            return agentToAgentVersionString(*agent);
+    }
+    return emptyString();
+}
+
+String UserAgentStringOverrides::userAgentToString(UserAgentStringPlatform defaultPlatform, const Vector<UserAgentOverridesAttributes>& attributes)
+{
+    StringBuilder uaString;
+
+    uaString.append("Mozilla/5.0 ("_s);
+    auto platform = attributesToPlatformString(attributes);
+    if (platform.isEmpty())
+        platform = attributesToPlatformString({ defaultPlatform });
+    auto platformVersion = attributesToPlatformVersionString(attributes);
+    if (platformVersion.isEmpty())
+        platformVersion = attributesToPlatformVersionString({ defaultPlatform });
+    uaString.append(platform, "; "_s, platformVersion);
+    uaString.append(") AppleWebKit/605.1.15 (KHTML, like Gecko) "_s);
+
+    auto agent = attributesToAgent(attributes);
+    if (agent == UserAgentStringAgent::Chrome) {
+        // Note that Chrome UAs advertise *both* Chrome/X and Safari/X, but it does
+        // not advertise Version/X.
+        uaString.append(agentToAgentString(agent), "/"_s, agentToAgentVersionString(agent), " "_s);
+    } else {
+        // Version/X is mandatory *before* Safari/X to be a valid Safari UA. See
+        // https://bugs.webkit.org/show_bug.cgi?id=133403 for details.
+        uaString.append("Version/"_s, agentToAgentVersionString(agent), " "_s);
+    }
+
+    uaString.append("Safari/605.1.15"_s);
+
+    return uaString.toString();
+}
+
+UserAgentOverridesMap UserAgentStringOverrides::parseUserAgentOverrides(const String& resourcePath)
+{
+    constexpr auto overridesFileName = "UserAgentStringOverrides.json"_s;
+    auto path = FileSystem::pathByAppendingComponent(resourcePath, overridesFileName);
+    auto buffer = FileSystem::readEntireFile(path);
+    if (!buffer) {
+        RELEASE_LOG(Network, "UserAgentStringOverrides::parseUserAgentOverrides: Failed to read file: %" PUBLIC_LOG_STRING ". Aborting", path.ascii().data());
+        return { };
+    }
+
+    RefPtr value = JSON::Value::parseJSON(buffer->span());
+    if (!value) {
+        RELEASE_LOG(Network, "UserAgentStringOverrides::parseUserAgentOverrides: Failed to parse JSON from file. Aborting");
+        return { };
+    }
+
+    RefPtr root = value->asObject();
+    if (!root) {
+        RELEASE_LOG(Network, "UserAgentStringOverrides::parseUserAgentOverrides: root is not an Object. Aborting");
+        return { };
+    }
+
+    if (auto version = root->getInteger("version"_s)) {
+        if (*version != 1) {
+            RELEASE_LOG(Network, "UserAgentStringOverrides::parseUserAgentOverrides: Version number not recognized: %d. Aborting.", *version);
+            return { };
+        }
+    } else {
+        RELEASE_LOG(Network, "UserAgentStringOverrides::parseUserAgentOverrides: Version number not specified. Aborting.");
+        return { };
+    }
+    UserAgentOverridesMap overridesMap;
+    for (auto&& [domain, pathsOverride] : *root) {
+        if (domain == "version"_s)
+            continue;
+        RefPtr pathsObject = pathsOverride->asObject();
+        if (!pathsObject) {
+            RELEASE_LOG(Network, "UserAgentStringOverrides::parseUserAgentOverrides: paths is not an Object. Skipping");
+            continue;
+        }
+        for (auto&& [path, platformOverride] : *pathsObject) {
+            RefPtr platformObject = platformOverride->asObject();
+            if (!platformObject) {
+                RELEASE_LOG(Network, "UserAgentStringOverrides::parseUserAgentOverrides: platform is not an Object. Skipping");
+                continue;
+            }
+            for (auto&& [platform, attributesValue] : *platformObject) {
+                Ref protectedAttributesValue { attributesValue };
+                auto targetPlatform = stringToUserAgentPlatform(platform);
+                if (targetPlatform == UserAgentStringPlatform::Unknown) {
+                    RELEASE_LOG(Network, "UserAgentStringOverrides::parseUserAgentOverrides: Unknown platform %" PUBLIC_LOG_STRING ". Skipping", platform.ascii().data());
+                    continue;
+                }
+                RefPtr attributes = attributesValue->asArray();
+                if (!attributes) {
+                    String attributeString = attributesValue->asString();
+                    if (attributeString.isEmpty()) {
+                        RELEASE_LOG(Network, "UserAgentStringOverrides::parseUserAgentOverrides: %" PUBLIC_LOG_STRING " attribute are not an array or string. Skipping", platform.ascii().data());
+                        continue;
+                    }
+                    if (auto entry = overridesMap.add({ domain, path, targetPlatform }, String { })) {
+                        if (auto* customString = std::get_if<String>(&entry.iterator->value))
+                            *customString = attributeString;
+                        else
+                            RELEASE_LOG(Network, "UserAgentStringOverrides::parseUserAgentOverrides: Skipping custom %" PUBLIC_LOG_STRING " user agent string (%" PUBLIC_LOG_STRING ") because attributes were previously set.", platform.ascii().data(), attributeString.ascii().data());
+                    }
+                    continue;
+                }
+                if (attributes->length() > 2) {
+                    RELEASE_LOG(Network, "UserAgentStringOverrides::parseUserAgentOverrides: Too many attributes for %" PUBLIC_LOG_STRING ". Found %zu. Skipping", platform.ascii().data(), attributes->length());
+                    continue;
+                }
+                for (auto&& attributeString : *attributes) {
+                    auto attribute = attributeString->asString();
+                    if (attribute.isEmpty()) {
+                        RELEASE_LOG(Network, "UserAgentStringOverrides::parseUserAgentOverrides: Attributes for %" PUBLIC_LOG_STRING " is not a String. Skipping", platform.ascii().data());
+                        continue;
+                    }
+
+                    if (auto userAgent = stringToUserAgent(attribute); userAgent != UserAgentStringAgent::Unknown) {
+                        RELEASE_LOG(Network, "UserAgentStringOverrides::parseUserAgentOverrides: domain: %s, platform: %s, path: %s, attribute: %s, targetPlatform: %hhu", domain.ascii().data(), platform.ascii().data(), path.ascii().data(), attribute.ascii().data(), targetPlatform);
+                        auto entry = overridesMap.add({ domain, path, targetPlatform }, Vector<UserAgentOverridesAttributes> { });
+                        if (auto* attributeVector = std::get_if<Vector<UserAgentOverridesAttributes>>(&entry.iterator->value))
+                            attributeVector->append(userAgent);
+                        else
+                            RELEASE_LOG(Network, "UserAgentStringOverrides::parseUserAgentOverrides: Skipping %" PUBLIC_LOG_STRING " user agent attribute (%" PUBLIC_LOG_STRING ") because explicit string was previously set.", platform.ascii().data(), attribute.ascii().data());
+                    } else if (auto overridePlatform = stringToUserAgentPlatform(attribute); overridePlatform != UserAgentStringPlatform::Unknown) {
+                        auto entry = overridesMap.add({ domain, path, targetPlatform }, Vector<UserAgentOverridesAttributes> { });
+                        if (auto* attributeVector = std::get_if<Vector<UserAgentOverridesAttributes>>(&entry.iterator->value))
+                            attributeVector->append(overridePlatform);
+                        else
+                            RELEASE_LOG(Network, "UserAgentStringOverrides::parseUserAgentOverrides: Skipping %" PUBLIC_LOG_STRING " platform attribute (%" PUBLIC_LOG_STRING ") because explicit string was previously set.", platform.ascii().data(), attribute.ascii().data());
+                    } else {
+                        RELEASE_LOG(Network, "UserAgentStringOverrides::parseUserAgentOverrides: Attributes for %" PUBLIC_LOG_STRING " is not recognized: %" PUBLIC_LOG_STRING ". Skipping", platform.ascii().data(), attribute.ascii().data());
+                        continue;
+                    }
+                }
+            }
+        }
+    }
+
+    return overridesMap;
+}
+
+UserAgentStringPlatform UserAgentStringOverrides::attributesToPlatform(const Vector<UserAgentOverridesAttributes>& attributes)
+{
+    for (auto attribute : attributes) {
+        if (auto platform = std::get_if<UserAgentStringPlatform>(&attribute))
+            return *platform;
+    }
+    return UserAgentStringPlatform::Unknown;
+}
+
+UserAgentStringAgent UserAgentStringOverrides::attributesToAgent(const Vector<UserAgentOverridesAttributes>& attributes)
+{
+    for (auto attribute : attributes) {
+        if (auto agent = std::get_if<UserAgentStringAgent>(&attribute))
+            return *agent;
+    }
+    return UserAgentStringAgent::Unknown;
+}
+
+void UserAgentStringOverrides::setUserAgentStringQuirks(const UserAgentOverridesMap& userAgentStringQuirks)
+{
+    for (const auto& [domain, userAgent] : userAgentStringQuirks)
+        m_overrides.add(domain, userAgent);
+}
+
+std::optional<std::variant<Vector<UserAgentOverridesAttributes>, String>> UserAgentStringOverrides::overrideAttributesForURLAndType(const URL& url, UserAgentStringPlatform userAgentStringPlatform) const
+{
+    if (url.host().isEmpty() || url.path().isEmpty() || userAgentStringPlatform == UserAgentStringPlatform::Unknown)
+        return std::nullopt;
+    auto entry = m_overrides.find({ url.host().toString(), url.path().toString(), userAgentStringPlatform });
+    if (entry == m_overrides.end())
+        entry = m_overrides.find({ url.host().toString(), "*"_s, userAgentStringPlatform });
+    if (entry == m_overrides.end())
+        entry = m_overrides.find({ RegistrableDomain { url }.string(), url.path().toString(), userAgentStringPlatform });
+    if (entry == m_overrides.end())
+        entry = m_overrides.find({ RegistrableDomain { url }.string(), "*"_s, userAgentStringPlatform });
+    if (entry == m_overrides.end())
+        entry = m_overrides.find({ url.host().toString(), url.path().toString(), UserAgentStringPlatform::All });
+    if (entry == m_overrides.end())
+        entry = m_overrides.find({ url.host().toString(), "*"_s, UserAgentStringPlatform::All });
+    if (entry == m_overrides.end())
+        entry = m_overrides.find({ RegistrableDomain { url }.string(), url.path().toString(), UserAgentStringPlatform::All });
+    if (entry == m_overrides.end())
+        entry = m_overrides.find({ RegistrableDomain { url }.string(), "*"_s, UserAgentStringPlatform::All });
+    if (entry != m_overrides.end())
+        return std::optional { entry->value };
+    return std::nullopt;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/page/UserAgentStringOverrides.h
+++ b/Source/WebCore/page/UserAgentStringOverrides.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/EnumTraits.h>
+
+namespace WebCore {
+
+enum class UserAgentStringPlatform : uint8_t {
+    Unknown,
+    All,
+    Ipad,
+    Iphone,
+    Mac,
+};
+
+enum class UserAgentStringAgent : uint8_t {
+    Unknown,
+    Chrome,
+    Safari12,
+    Safari13,
+    Safari,
+};
+
+using DomainPlatformUserAgentString = std::tuple<String, String, UserAgentStringPlatform>;
+using UserAgentOverridesAttributes = std::variant<UserAgentStringPlatform, UserAgentStringAgent>;
+using UserAgentOverridesMap = HashMap<DomainPlatformUserAgentString, std::variant<Vector<UserAgentOverridesAttributes>, String>>;
+
+class UserAgentStringOverrides {
+    WTF_MAKE_NONCOPYABLE(UserAgentStringOverrides); WTF_MAKE_FAST_ALLOCATED;
+public:
+    UserAgentStringOverrides() = default;
+    WEBCORE_EXPORT std::optional<std::variant<Vector<UserAgentOverridesAttributes>, String>> overrideAttributesForURLAndType(const URL&, UserAgentStringPlatform) const;
+    WEBCORE_EXPORT void setUserAgentStringQuirks(const UserAgentOverridesMap&);
+
+    static UserAgentStringAgent stringToUserAgent(const String&);
+    WEBCORE_EXPORT static UserAgentStringAgent attributesToAgent(const Vector<UserAgentOverridesAttributes>&);
+    WEBCORE_EXPORT static String attributesToAgentVersionString(const Vector<UserAgentOverridesAttributes>&);
+    static String userAgentAttributeToString(UserAgentStringAgent);
+    WEBCORE_EXPORT static UserAgentStringPlatform getPlatform();
+    static String attributesToPlatformString(const Vector<UserAgentOverridesAttributes>&);
+    WEBCORE_EXPORT static String attributesToNavigatorPlatformString(const Vector<UserAgentOverridesAttributes>&);
+    static String attributesToPlatformVersionString(const Vector<UserAgentOverridesAttributes>&);
+    static UserAgentStringPlatform stringToUserAgentPlatform(const String&);
+    WEBCORE_EXPORT static UserAgentStringPlatform attributesToPlatform(const Vector<UserAgentOverridesAttributes>&);
+    WEBCORE_EXPORT static String attributesToAgentString(const Vector<UserAgentOverridesAttributes>&);
+    WEBCORE_EXPORT static String userAgentToString(UserAgentStringPlatform, const Vector<UserAgentOverridesAttributes>&);
+
+    WEBCORE_EXPORT static UserAgentOverridesMap parseUserAgentOverrides(const String&);
+
+private:
+    UserAgentOverridesMap m_overrides;
+};
+} // namespace WebCore
+
+namespace WTF {
+template<typename T> struct DefaultHash;
+template<> struct DefaultHash<WebCore::UserAgentStringPlatform> : IntHash<WebCore::UserAgentStringPlatform> { };
+
+template<> struct EnumTraits<WebCore::UserAgentStringPlatform> {
+    using values = EnumValues<
+        WebCore::UserAgentStringPlatform,
+        WebCore::UserAgentStringPlatform::Unknown,
+        WebCore::UserAgentStringPlatform::All,
+        WebCore::UserAgentStringPlatform::Ipad,
+        WebCore::UserAgentStringPlatform::Iphone,
+        WebCore::UserAgentStringPlatform::Mac
+    >;
+};
+
+template<> struct EnumTraits<WebCore::UserAgentStringAgent> {
+    using values = EnumValues<
+        WebCore::UserAgentStringAgent,
+        WebCore::UserAgentStringAgent::Unknown,
+        WebCore::UserAgentStringAgent::Chrome,
+        WebCore::UserAgentStringAgent::Safari12,
+        WebCore::UserAgentStringAgent::Safari13,
+        WebCore::UserAgentStringAgent::Safari
+    >;
+};
+}

--- a/Source/WebCore/page/UserAgentStringOverrides.json
+++ b/Source/WebCore/page/UserAgentStringOverrides.json
@@ -1,0 +1,5 @@
+{
+    "version": 1,
+    "teams.live.com": { "*": { "mac": [ "chrome" ] } },
+    "shopee.sg": { "/payment/account-linking/landing": { "ipad": [ "iphone" ] } }
+}

--- a/Source/WebCore/page/make-user-agent-string-overrides.py
+++ b/Source/WebCore/page/make-user-agent-string-overrides.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import json
+
+platforms = ['mac', 'iphone', 'ipad']
+user_agents = {
+    'chrome': '110.0.0.0',
+    'safari12': '12.1.2',
+    'safari13': '13.1.2',
+    'safari': '18.1',
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Generate UserAgentOverride.h')
+    parser.add_argument('--input')
+    args = parser.parse_args()
+
+    # Version 1 input JSON file contains an object with:
+    #   - a version, currently the only supported value is the integer 1.
+    #   - objects where the key is a domain:
+    #     - objects where the key is either the target platform (e.g., "macos") or "all", and the value is either:
+    #       - an array of attributes that should be used in the overridden string:
+    #         - user agent (e.g., chrome)
+    #         - platform (e.g., mac)
+    #       - a string specifying a hard-coded user agent string
+    #
+    # For example, overriding iPhone with the Mac Chrome user agent string, and Mac with Chrome's could look like:
+    #   "target.site.example": { "ios": [ "chrome", "mac" ], "mac": [ "chrome" ] }
+    with open(args.input, 'r', encoding='utf-8') as input_file:
+        overrides = json.load(input_file)
+        if len(overrides) == 0:
+            raise Exception("Failed to parse {}".format(args.input))
+        if "version" not in overrides:
+            raise Exception("Version not declared")
+        if overrides["version"] != 1:
+            raise Exception("Unrecognized version: {}".format(overrides["version"]))
+        for domain in overrides:
+            if domain == "version":
+                continue
+            for path in overrides[domain]:
+                if type(overrides[domain][path]) is not dict:
+                    raise Exception("{} attributes for path {} was not parsed as a dict".format(domain, path))
+                for platform in overrides[domain][path]:
+                    if platform not in platforms and platform != "all":
+                        raise Exception("Unknown platform: {}".format(platform))
+                    attributes = overrides[domain][path][platform]
+                    if type(attributes) is not list:
+                        if type(attributes) is not str:
+                            raise Exception("{} attributes for {} with path {} is not a list or string".format(domain, platform, path))
+                        continue
+                    if len(attributes) > 2:
+                        raise Exception("Too many attributes for {} on {} with path: {}".format(domain, platform, path, len(attributes)))
+                    for attribute in attributes:
+                        if attribute not in platforms and attribute not in user_agents:
+                            raise Exception("Unknown attribute for {} on {}: {}".format(domain, platform, attribute))
+
+
+if __name__ == '__main__':
+    main()

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -224,6 +224,8 @@ enum class TextAnimationRunMode : uint8_t;
 enum class TextCheckingType : uint8_t;
 enum class TextGranularity : uint8_t;
 enum class TrackingType : uint8_t;
+enum class UserAgentStringAgent : uint8_t;
+enum class UserAgentStringPlatform : uint8_t;
 enum class UserInterfaceLayoutDirection : bool;
 enum class VideoFrameRotation : uint16_t;
 enum class WheelEventProcessingSteps : uint8_t;
@@ -1290,6 +1292,7 @@ public:
 #else
     String predictedUserAgentForRequest(const WebCore::ResourceRequest&) const { return userAgent(); }
 #endif
+    void adjustPolicyWithCustomUserAgentAndPlatform(API::WebsitePolicies&, WebCore::UserAgentStringPlatform, const Vector<std::variant<WebCore::UserAgentStringPlatform, WebCore::UserAgentStringAgent>>&);
 
     bool supportsTextEncoding() const;
     void setCustomTextEncodingName(const String&);

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -110,6 +110,7 @@ struct MockMediaDevice;
 #if PLATFORM(COCOA)
 class PowerSourceNotifier;
 #endif
+class UserAgentStringOverrides;
 }
 
 namespace WebKit {
@@ -565,6 +566,10 @@ public:
 #endif
 #endif
 
+    template<typename T>
+    void setUserAgentStringQuirks(T);
+    WebCore::UserAgentStringOverrides* userAgentStringQuirks() const;
+
     static void platformInitializeNetworkProcess(NetworkProcessCreationParameters&);
     static Vector<String> urlSchemesWithCustomProtocolHandlers();
 
@@ -609,6 +614,9 @@ private:
 
     void platformInitializeWebProcess(const WebProcessProxy&, WebProcessCreationParameters&);
     void platformInvalidateContext();
+
+    static String userAgentOverrideDirectory();
+    static String additionalUserAgentOverrideDirectoryForTesting();
 
     std::tuple<Ref<WebProcessProxy>, SuspendedPageProxy*, ASCIILiteral> processForNavigationInternal(WebPageProxy&, const API::Navigation&, Ref<WebProcessProxy>&& sourceProcess, const URL& sourceURL, ProcessSwapRequestedByClient, WebProcessProxy::LockdownMode, const FrameInfoData&, Ref<WebsiteDataStore>&&);
     void prepareProcessForNavigation(Ref<WebProcessProxy>&&, WebPageProxy&, SuspendedPageProxy*, ASCIILiteral reason, const WebCore::RegistrableDomain&, const API::Navigation&, WebProcessProxy::LockdownMode, Ref<WebsiteDataStore>&&, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral)>&&, unsigned previousAttemptsCount = 0);
@@ -816,6 +824,7 @@ private:
     ProcessSuppressionDisabledCounter m_processSuppressionDisabledForPageCounter;
     HiddenPageThrottlingAutoIncreasesCounter m_hiddenPageThrottlingAutoIncreasesCounter;
     RunLoop::Timer m_hiddenPageThrottlingTimer;
+    std::unique_ptr<WebCore::UserAgentStringOverrides> m_userAgentStringOverrides;
 
 #if ENABLE(GPU_PROCESS)
     RunLoop::Timer m_resetGPUProcessCrashCountTimer;

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1497,12 +1497,6 @@ WebContentMode WebPageProxy::effectiveContentModeAfterAdjustingPolicies(API::Web
     if (auto selectors = Quirks::defaultVisibilityAdjustmentSelectors(request.url()))
         policies.setVisibilityAdjustmentSelectors({ WTFMove(*selectors) });
 
-    if (Quirks::needsIPhoneUserAgent(request.url())) {
-        policies.setCustomUserAgent(makeStringByReplacingAll(standardUserAgentWithApplicationName(m_applicationNameForUserAgent), "iPad"_s, "iPhone"_s));
-        policies.setCustomNavigatorPlatform("iPhone"_s);
-        return WebContentMode::Mobile;
-    }
-
     bool useDesktopBrowsingMode = useDesktopClassBrowsing(policies, request);
 
     m_preferFasterClickOverDoubleTap = false;

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -643,7 +643,6 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
         prewarmGlobally();
 #endif
 
-    updateStorageAccessUserAgentStringQuirks(WTFMove(parameters.storageAccessUserAgentStringQuirksData));
     updateDomainsWithStorageAccessQuirks(WTFMove(parameters.storageAccessPromptQuirksDomains));
     updateScriptTelemetryFilter(WTFMove(parameters.scriptTelemetryRules));
 
@@ -883,11 +882,6 @@ WebPage* WebProcess::focusedWebPage() const
     return 0;
 }
 
-void WebProcess::updateStorageAccessUserAgentStringQuirks(UncheckedKeyHashMap<RegistrableDomain, String>&& userAgentStringQuirk)
-{
-    Quirks::updateStorageAccessUserAgentStringQuirks(WTFMove(userAgentStringQuirk));
-}
-    
 WebPage* WebProcess::webPage(PageIdentifier pageID) const
 {
     return m_pageMap.get(pageID);

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -227,8 +227,6 @@ public:
     void setHasStylusDevice(bool);
 #endif
 
-    void updateStorageAccessUserAgentStringQuirks(UncheckedKeyHashMap<WebCore::RegistrableDomain, String>&&);
-
     WebFrame* webFrame(std::optional<WebCore::FrameIdentifier>) const;
     void addWebFrame(WebCore::FrameIdentifier, WebFrame*);
     void removeWebFrame(WebCore::FrameIdentifier, std::optional<WebPageProxyIdentifier>);

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -53,7 +53,6 @@ messages -> WebProcess : AuxiliaryProcess NotRefCounted WantsAsyncDispatchMessag
     ClearResourceLoadStatistics();
     UserPreferredLanguagesChanged(Vector<String> languages)
     FullKeyboardAccessModeChanged(bool fullKeyboardAccessEnabled)
-    UpdateStorageAccessUserAgentStringQuirks(UncheckedKeyHashMap<WebCore::RegistrableDomain, String> userAgentStringQuirks)
 
 #if HAVE(MOUSE_DEVICE_OBSERVATION)
     SetHasMouseDevice(bool hasMouseDevice)

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1202,6 +1202,7 @@
 		CE78705F2107AB980053AC67 /* MoveOnlyLifecycleLogger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE78705D2107AB8C0053AC67 /* MoveOnlyLifecycleLogger.cpp */; };
 		CEA7F57D2089624B0078EF6E /* DidResignInputElementStrongPasswordAppearance.mm in Sources */ = {isa = PBXBuildFile; fileRef = CEA7F57B20895F5B0078EF6E /* DidResignInputElementStrongPasswordAppearance.mm */; };
 		D04CF93F285C77CA005D6337 /* MachSendRight.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D04CF93E285C77C9005D6337 /* MachSendRight.cpp */; };
+		D2A7EEC62C234A7700AED0C5 /* UserAgentStringOverrides.json in Copy Resources */ = {isa = PBXBuildFile; fileRef = D2A7EEBE2C234A7600AED0C5 /* UserAgentStringOverrides.json */; };
 		D84FAD9A29FAC1D0008D338F /* RenderStyleChange.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D84FAD9829FAC1D0008D338F /* RenderStyleChange.cpp */; };
 		DD0EDF8D2798A6AD005152AD /* libgtest.a in Product Dependencies */ = {isa = PBXBuildFile; fileRef = F3FC3EE213678B7300126A65 /* libgtest.a */; };
 		DD403D4A28EB932F009B4684 /* libbmalloc.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DD403D4928EB932F009B4684 /* libbmalloc.a */; };
@@ -1989,6 +1990,7 @@
 				A17C48132C98E5C20023F3C7 /* two-paragraph-contenteditable.html in Copy Resources */,
 				A17C484A2C98E6360023F3C7 /* two-videos.html in Copy Resources */,
 				A17C48142C98E5C20023F3C7 /* UnitBox.usdz in Copy Resources */,
+				D2A7EEC62C234A7700AED0C5 /* UserAgentStringOverrides.json in Copy Resources */,
 				A17C46FA2C98E54B0023F3C7 /* UserInstalledAhem.html in Copy Resources */,
 				A17C46882C98E4D20023F3C7 /* verboseMarkup.html in Copy Resources */,
 				A17C48152C98E5C20023F3C7 /* video-with-audio-and-web-audio.html in Copy Resources */,
@@ -3519,6 +3521,7 @@
 		CEDA12402437C9EA00C28A9E /* editable-region-composited-and-non-composited-overlap.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; name = "editable-region-composited-and-non-composited-overlap.html"; path = "ios/editable-region-composited-and-non-composited-overlap.html"; sourceTree = SOURCE_ROOT; };
 		D04CF93E285C77C9005D6337 /* MachSendRight.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MachSendRight.cpp; sourceTree = "<group>"; };
 		D20C03AE2B704A26004C414A /* download.example.webarchive */ = {isa = PBXFileReference; lastKnownFileType = file.bplist; name = download.example.webarchive; path = Tests/WebKitCocoa/download.example.webarchive; sourceTree = "<group>"; };
+		D2A7EEBE2C234A7600AED0C5 /* UserAgentStringOverrides.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = UserAgentStringOverrides.json; sourceTree = "<group>"; };
 		D3BE5E341E4CE85E00FD563A /* WKWebViewGetContents.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewGetContents.mm; sourceTree = "<group>"; };
 		D84FAD9829FAC1D0008D338F /* RenderStyleChange.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RenderStyleChange.cpp; sourceTree = "<group>"; };
 		DC69AA621CF77C6500C6272F /* ScopedLambda.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ScopedLambda.cpp; sourceTree = "<group>"; };
@@ -5783,6 +5786,7 @@
 				524BBCA019E30C63002F1AF1 /* test.mp4 */,
 				7AE9E5081AE5AE8B00CF874B /* test.pdf */,
 				44D3F8422BE1DAD800BE0218 /* test.xml */,
+				D2A7EEBE2C234A7600AED0C5 /* UserAgentStringOverrides.json */,
 				1C51534B261596BD00FBC4FE /* UserInstalledAhem.html */,
 				C9C9A91C21DED79400FDE96E /* video-with-play-button.html */,
 				07CD32F72065B72A0064A4BE /* video.html */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/UserAgentStringOverrides.json
+++ b/Tools/TestWebKitAPI/Tests/WebKit/UserAgentStringOverrides.json
@@ -1,0 +1,8 @@
+{
+    "version": 1,
+    "nonexistant.example": { "/path1.html": { "mac": "not a real user agent string" } },
+    "nonexistant2.example": { "*": { "all": [ "mac", "chrome" ] } },
+    "nonexistant3.example": { "/page1.html": {"all": [ "mac", "chrome" ], "mac": "not a real user agent string" } },
+    "nonexistant4.example": { "/page1.html": {"iphone": [ "mac", "chrome" ] }, "/page2.html": { "mac": "not a real user agent string" } },
+    "nonexistant5.example": { "*": {"all": [ "mac" ] } }
+}

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
@@ -1446,43 +1446,6 @@ TEST(ResourceLoadStatistics, UserGestureLogsUserInteraction)
     TestWebKitAPI::Util::run(&done);
 }
 
-TEST(ResourceLoadStatistics, UserAgentStringForSite)
-{
-    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
-    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]).get()]);
-    [configuration setWebsiteDataStore:dataStore.get()];
-
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
-    auto delegate = adoptNS([TestNavigationDelegate new]);
-    auto userAgent = @"NotARealUserAgent";
-
-    __block bool done = false;
-    [dataStore _setUserAgentStringQuirkForTesting:@"webkit.org" withUserAgent:userAgent completionHandler:^{
-        done = true;
-    }];
-    TestWebKitAPI::Util::run(&done);
-    done = false;
-
-    delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^decisionHandler)(WKNavigationActionPolicy)) {
-        EXPECT_WK_STREQ(action.request.allHTTPHeaderFields[@"User-Agent"], userAgent);
-        decisionHandler(WKNavigationActionPolicyCancel);
-        done = true;
-    };
-    [webView setNavigationDelegate:delegate.get()];
-
-    [webView loadHTMLString:@"" baseURL:[NSURL URLWithString:@"http://webkit.org"]];
-    TestWebKitAPI::Util::run(&done);
-    done = false;
-
-    delegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *action, void (^decisionHandler)(WKNavigationActionPolicy)) {
-        EXPECT_FALSE([action.request.allHTTPHeaderFields[@"User-Agent"] isEqual:userAgent]);
-        decisionHandler(WKNavigationActionPolicyCancel);
-        done = true;
-    };
-    [webView loadHTMLString:@"" baseURL:[NSURL URLWithString:@"http://not-webkit.org"]];
-    TestWebKitAPI::Util::run(&done);
-}
-
 TEST(ResourceLoadStatistics, StorageAccessPromptSiteWithQuirk)
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);


### PR DESCRIPTION
#### c8a200f9821c0925fb949defb10ca51d1f6cc34d
<pre>
Add an initial WebKit User Agent Overrides file
<a href="https://bugs.webkit.org/show_bug.cgi?id=263619">https://bugs.webkit.org/show_bug.cgi?id=263619</a>
<a href="https://rdar.apple.com/59289090">rdar://59289090</a>

Reviewed by NOBODY (OOPS!).

Create a new user agent string override configuration file. The configuration
file is JSON, and it is parsed and roughly validated at compile-time as a
sanity check. At run-time the JSON file is read in the UI process where it is
re-parsed and re-validated. This additional step allows for testing new user
agent quirks at runtime without needing to recompile WebKit.

The behavior is currently somewhat minimal, but it can easily be extended and
enhanced depending on our needs.

Version 1 input JSON file contains an object with:
  - a version, currently the only supported value is the integer 1.
  - objects where the key is a domain:
    - objects where the key is either the target platform (e.g., &quot;mac&quot;) or &quot;all&quot;, and the value is either:
      - an array of attributes that should be used in the overridden string:
        - user agent (e.g., chrome)
        - platform (e.g., mac; the current platform is the default, if not specified)
      - a string specifying a hard-coded user agent string

For example, overriding iOS with the Mac Chrome user agent string, and Mac with Chrome&apos;s Mac user agent string could look like:
  &quot;target.site.example&quot;: { &quot;ios&quot;: [ &quot;chrome&quot;, &quot;mac&quot; ], &quot;mac&quot;: [ &quot;chrome&quot; ] }

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/WebCoreMacros.cmake:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::userAgent const):
* Source/WebCore/page/Quirks.cpp:
(WebCore::updatableStorageAccessUserAgentStringQuirks): Deleted.
(WebCore::Quirks::updateStorageAccessUserAgentStringQuirks): Deleted.
(WebCore::Quirks::storageAccessUserAgentStringQuirkForDomain): Deleted.
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/UserAgentStringOverrides.cpp: Added.
(WebCore::UserAgentStringOverrides::getPlatform):
(WebCore::UserAgentStringOverrides::stringToUserAgentPlatform):
(WebCore::UserAgentStringOverrides::stringToUserAgent):
(WebCore::UserAgentStringOverrides::userAgentAttributeToString):
(WebCore::platformToNavigatorPlatformString):
(WebCore::platformToPlatformString):
(WebCore::agentToAgentVersionString):
(WebCore::agentToAgentString):
(WebCore::UserAgentStringOverrides::attributesToPlatformString):
(WebCore::UserAgentStringOverrides::attributesToNavigatorPlatformString):
(WebCore::UserAgentStringOverrides::attributesToAgentString):
(WebCore::UserAgentStringOverrides::attributesToPlatformVersionString):
(WebCore::UserAgentStringOverrides::attributesToAgentVersionString):
(WebCore::UserAgentStringOverrides::userAgentToString):
(WebCore::UserAgentStringOverrides::parseUserAgentOverrides):
(WebCore::UserAgentStringOverrides::attributesToPlatform):
(WebCore::UserAgentStringOverrides::attributesToAgent):
(WebCore::UserAgentStringOverrides::setUserAgentStringQuirks):
(WebCore::UserAgentStringOverrides::overrideAttributesForURLAndType const):
* Source/WebCore/page/UserAgentStringOverrides.h: Added.
* Source/WebCore/page/UserAgentStringOverrides.json: Added.
* Source/WebCore/page/make-user-agent-string-overrides.py: Added.
(main):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::userAgentOverrideDirectory):
(WebKit::WebProcessPool::additionalUserAgentOverrideDirectoryForTesting):
(WebKit::WebProcessPool::platformInitializeWebProcess):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
(WebKit::WebPageProxy::adjustPolicyWithCustomUserAgentAndPlatform):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::userAgentOverrideDirectory):
(WebKit::WebProcessPool::additionalUserAgentOverrideDirectory):
(WebKit::readUserAgentStringOverridesFromFile):
(WebKit::WebProcessPool::setUserAgentStringQuirks):
(WebKit::WebProcessPool::userAgentStringQuirks const):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::effectiveContentModeAfterAdjustingPolicies):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::initializeWebProcess):
(WebKit::WebProcess::updateStorageAccessUserAgentStringQuirks): Deleted.
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/UserAgentStringOverrides.json: Added.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm:
(TEST(WKNavigation, UserAgentOverrideQuirks)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm:
(TEST(ResourceLoadStatistics, UserAgentStringForSite)): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8a200f9821c0925fb949defb10ca51d1f6cc34d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/72435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/51856 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/25223 "Build is in progress. Recent messages:Running configuration; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/76616 "Hash c8a200f9 for PR 29163 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/23644 "Hash c8a200f9 for PR 29163 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/74550 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/59660 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/23466 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/76616 "Hash c8a200f9 for PR 29163 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/23644 "Hash c8a200f9 for PR 29163 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/75502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/46951 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/62382 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/76616 "Hash c8a200f9 for PR 29163 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/43602 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/19848 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/21994 "Hash c8a200f9 for PR 29163 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/65483 "34 api tests failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/20206 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/78283 "Failed to compile WebKit") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16676 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/19340 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/78283 "Failed to compile WebKit") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16724 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/62394 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/78283 "Failed to compile WebKit") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13033 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/6673 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/47654 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/2439 "Found 1 new failure in page/UserAgentStringOverrides.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/48723 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/50012 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/48466 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->