### PR TITLE
Digital credentials API should be tested for non-fully active docs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/non-fully-active.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/non-fully-active.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS non-fully active document behavior for CredentialsContainer
+

--- a/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/non-fully-active.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/digital-credentials/non-fully-active.https.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Digital Credentials Test: non-fully active document</title>
+<link
+  rel="help"
+  href="https://github.com/w3c/webappsec-credential-management"
+/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body>
+  <iframe></iframe>
+</body>
+<script>
+  promise_setup(async () => {
+    const iframe = document.querySelector("iframe");
+    await new Promise((resolve) => {
+      iframe.addEventListener("load", resolve, { once: true });
+      iframe.src = "about:blank";
+      document.body.appendChild(iframe);
+    });
+  });
+
+  promise_test(async (t) => {
+    const iframe = document.querySelector("iframe");
+    
+    // The signal check happens after the fully active check.
+    // This allows us to confirm the the right error is thrown
+    // and in the right order.
+    const controller = new iframe.contentWindow.AbortController();
+    const signal = controller.signal;
+    controller.abort();
+
+    // Steal all the needed references.
+    const { identity } = iframe.contentWindow.navigator;
+    const DOMExceptionCtor = iframe.contentWindow.DOMException;
+
+    // No longer fully active.
+    iframe.remove();
+
+    // Try to get credentials while not fully active...
+    await promise_rejects_dom(
+      t,
+      "NotAllowedError",
+      DOMExceptionCtor,
+      identity.get({ signal }),
+      "Expected NotAllowedError for get() on non-fully-active document"
+    );
+
+    // Try to create credentials while not fully active...
+    await promise_rejects_dom(
+      t,
+      "NotAllowedError",
+      DOMExceptionCtor,
+      identity.create({ signal }),
+      "Expected NotAllowedError for create() on non-fully-active document"
+    );
+
+    // Try to prevent silent access while not fully active...
+    await promise_rejects_dom(
+      t,
+      "NotAllowedError",
+      DOMExceptionCtor,
+      identity.preventSilentAccess(),
+      "Expected NotAllowedError for preventSilentAccess() on non-fully-active document"
+    );
+  }, "non-fully active document behavior for CredentialsContainer");
+</script>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2793,6 +2793,7 @@ imported/w3c/web-platform-tests/credential-management/ [ Skip ]
 
 # Digital Crendentials API
 http/wpt/identity/ [ Skip ]
+imported/w3c/web-platform-tests/digital-credentials/ [ Skip ]
 
 # WebGL2
 webkit.org/b/166536 fast/canvas/webgl/webgl-transformed-varying-name-crash.html [ Skip ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1818,6 +1818,7 @@ imported/w3c/web-platform-tests/credential-management/ [ Skip ]
 
 # Skip Digital Credentials API
 http/wpt/identity/ [ Skip ]
+imported/w3c/web-platform-tests/digital-credentials/ [ Skip ]
 
 webkit.org/b/182554 transitions/transition-display-property.html [ Pass ImageOnlyFailure ]
 

--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -1691,6 +1691,7 @@ imported/w3c/web-platform-tests/console [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy [ Skip ]
 imported/w3c/web-platform-tests/cors [ Skip ]
 imported/w3c/web-platform-tests/credential-management [ Skip ]
+imported/w3c/web-platform-tests/digital-credentials [ Skip ]
 
 imported/w3c/web-platform-tests/css/compositing [ Skip ]
 imported/w3c/web-platform-tests/css/css-align [ Skip ]


### PR DESCRIPTION
#### ea41c4b338ed40e45bc65ede49fdd3593cd6fb32
<pre>
Digital credentials API should be tested for non-fully active docs
<a href="https://bugs.webkit.org/show_bug.cgi?id=274763">https://bugs.webkit.org/show_bug.cgi?id=274763</a>
<a href="https://rdar.apple.com/128827081">rdar://128827081</a>

Reviewed by Anne van Kesteren.

Tests Digital Credentials API against a non-fully active document.

* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/non-fully-active.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/digital-credentials/non-fully-active.https.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* LayoutTests/platform/wincairo/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/279502@main">https://commits.webkit.org/279502@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c509dc923f4e010d2360363ab23be4af438921c4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53309 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56588 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4035 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40017 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3785 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43218 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2643 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46040 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24348 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27702 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3359 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2191 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49465 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3523 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58184 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28458 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3518 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50618 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29673 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46248 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/49948 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11695 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30596 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29436 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->