### PR TITLE
Draft: cleaning up Font::applyTransforms

### DIFF
--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -550,7 +550,7 @@ RefPtr<Font> Font::createScaledFont(const FontDescription& fontDescription, floa
 }
 
 #if !USE(CORE_TEXT)
-GlyphBufferAdvance Font::applyTransforms(GlyphBuffer&, unsigned, unsigned, bool, bool, const AtomString&, StringView, TextDirection) const
+GlyphBufferAdvance Font::applyTransforms(GlyphBuffer&, unsigned, bool, bool, const AtomString&, StringView, TextDirection) const
 {
     return makeGlyphBufferAdvance();
 }

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -220,7 +220,7 @@ public:
 #endif
 
     bool canRenderCombiningCharacterSequence(StringView) const;
-    GlyphBufferAdvance applyTransforms(GlyphBuffer&, unsigned beginningGlyphIndex, unsigned beginningStringIndex, bool enableKerning, bool requiresShaping, const AtomString& locale, StringView text, TextDirection) const;
+    GlyphBufferAdvance applyTransforms(GlyphBuffer&, unsigned beginningGlyphIndex, bool enableKerning, bool requiresShaping, const AtomString& locale, StringView text, TextDirection) const;
 
     // Returns nullopt if none of the glyphs are OT-SVG glyphs.
     std::optional<BitVector> findOTSVGGlyphs(const GlyphBufferGlyph*, unsigned count) const;

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -344,7 +344,7 @@ NEVER_INLINE float FontCascade::widthForSimpleTextSlow(StringView text, TextDire
     else
         addGlyphsFromText(glyphBuffer, font, text.span16());
 
-    auto initialAdvance = font->applyTransforms(glyphBuffer, 0, 0, enableKerning(), requiresShaping(), fontDescription().computedLocale(), text, textDirection);
+    auto initialAdvance = font->applyTransforms(glyphBuffer, 0, enableKerning(), requiresShaping(), fontDescription().computedLocale(), text, textDirection);
     auto width = 0.f;
     for (size_t i = 0; i < glyphBuffer.size(); ++i)
         width += WebCore::width(glyphBuffer.advanceAt(i));

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -87,7 +87,7 @@ inline auto WidthIterator::applyFontTransforms(GlyphBuffer& glyphBuffer, unsigne
     for (unsigned i = lastGlyphCount; i < glyphBufferSize; ++i)
         beforeWidth += width(advances[i]);
 
-    auto initialAdvance = font.applyTransforms(glyphBuffer, lastGlyphCount, m_currentCharacterIndex, m_enableKerning, m_requiresShaping, m_font->fontDescription().computedLocale(), m_run->text(), direction());
+    auto initialAdvance = font.applyTransforms(glyphBuffer, lastGlyphCount, m_enableKerning, m_requiresShaping, m_font->fontDescription().computedLocale(), m_run->text(), direction());
 
     glyphBufferSize = glyphBuffer.size();
     advances = glyphBuffer.advances(0);


### PR DESCRIPTION
#### e5b56be17b819ea59826c8c4f02b1bc7df172893
<pre>
Draft: cleaning up Font::applyTransforms
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/platform/graphics/Font.cpp:
(WebCore::Font::applyTransforms const):
* Source/WebCore/platform/graphics/Font.h:
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::widthForSimpleText const):
* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::applyFontTransforms):
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::applyTransforms const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5b56be17b819ea59826c8c4f02b1bc7df172893

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62201 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9019 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60704 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45539 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9217 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47425 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6433 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60606 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35483 "Found 4 new test failures: fast/attachment/cocoa/wide-attachment-rendering.html fast/text/fallback-font-and-zero-width-glyph.html fast/text/international/bidi-explicit-embedding.html fast/text/international/old-turkic-direction.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50650 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28277 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32231 "Found 13 new test failures: imported/w3c/web-platform-tests/css/css-text/line-breaking/segment-break-transformation-rules-011.html imported/w3c/web-platform-tests/css/css-text/line-breaking/segment-break-transformation-rules-018.html imported/w3c/web-platform-tests/css/css-text/line-breaking/segment-break-transformation-rules-022.html imported/w3c/web-platform-tests/css/css-text/line-breaking/segment-break-transformation-rules-029.html imported/w3c/web-platform-tests/css/css-text/line-breaking/segment-break-transformation-rules-030.html imported/w3c/web-platform-tests/css/css-text/line-breaking/segment-break-transformation-rules-032.html imported/w3c/web-platform-tests/css/css-text/line-breaking/segment-break-transformation-rules-035.html imported/w3c/web-platform-tests/css/css-text/line-breaking/segment-break-transformation-rules-036.html imported/w3c/web-platform-tests/css/css-text/line-breaking/segment-break-transformation-rules-037.html imported/w3c/web-platform-tests/css/css-text/line-breaking/segment-break-transformation-rules-038.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7952 "Found 60 new test failures: fast/dom/52776.html fast/text/drawBidiText.html fast/text/fallback-font-and-zero-width-glyph.html fast/text/international/bdi-dir-default-to-auto.html fast/text/international/bdi-neutral-wrapped.html fast/text/international/bidi-LDB-2-formatting-characters.html fast/text/international/bidi-neutral-run.html fast/text/international/bidi-override.html fast/text/international/old-turkic-direction.html fast/text/isolate-ignore.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8023 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54184 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8224 "Found 60 new test failures: editing/input/scroll-viewport-page-up-down.html fast/attachment/cocoa/wide-attachment-rendering.html fast/attachment/mac/wide-attachment-title-with-rtl.html fast/dom/52776.html fast/text/drawBidiText.html fast/text/fallback-font-and-zero-width-glyph.html fast/text/international/bdi-dir-default-to-auto.html fast/text/international/bdi-neutral-wrapped.html fast/text/international/bidi-LDB-2-formatting-characters.html fast/text/international/bidi-neutral-run.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63904 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2488 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8229 "Found 60 new test failures: fast/attachment/cocoa/wide-attachment-rendering.html fast/attachment/mac/wide-attachment-title-with-rtl.html fast/css-grid-layout/grid-item-z-index-stacking-context.html fast/dom/52776.html fast/text/drawBidiText.html fast/text/fallback-font-and-zero-width-glyph.html fast/text/international/bdi-dir-default-to-auto.html fast/text/international/bdi-neutral-wrapped.html fast/text/international/bidi-LDB-2-formatting-characters.html fast/text/international/bidi-neutral-run.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54746 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2497 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50676 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54829 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2108 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33731 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34817 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35901 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34562 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->