### PR TITLE
[Win] Enable HAVE_INT128_T

### DIFF
--- a/Source/WTF/wtf/Int128.h
+++ b/Source/WTF/wtf/Int128.h
@@ -1250,8 +1250,13 @@ constexpr Int128Impl operator>>(Int128Impl lhs, int amount) {
 }
 
 #if HAVE(INT128_T)
+#if COMPILER(MSVC) // Workaround for a clang-cl bug <https://webkit.org/b/274765>
+typedef __uint128_t UInt128 __attribute__((aligned(16)));
+typedef __int128_t Int128 __attribute__((aligned(16)));
+#else
 using UInt128 = __uint128_t;
 using Int128 = __int128_t;
+#endif
 #else
 using UInt128 = UInt128Impl;
 using Int128 = Int128Impl;

--- a/Source/cmake/OptionsMSVC.cmake
+++ b/Source/cmake/OptionsMSVC.cmake
@@ -198,10 +198,6 @@ if (COMPILER_IS_CLANG_CL)
     find_library(CLANG_BUILTINS_LIBRARY clang_rt.builtins-x86_64 PATHS ${CLANG_CL_DIR} REQUIRED NO_DEFAULT_PATH)
     string(APPEND CMAKE_SHARED_LINKER_FLAGS " \"${CLANG_BUILTINS_LIBRARY}\"")
     string(APPEND CMAKE_EXE_LINKER_FLAGS " \"${CLANG_BUILTINS_LIBRARY}\"")
-
-    # FIXME: remove these lines after fixing UUID serialization
-    set(HAVE_INT128_T OFF)
-    list(REMOVE_ITEM _WEBKIT_CONFIG_FILE_VARIABLES HAVE_INT128_T)
 endif ()
 
 # Enable the new lambda processor for better C++ conformance


### PR DESCRIPTION
#### d06b72cc3780ef6093f2f98d307ee8d6ee43fd58
<pre>
[Win] Enable HAVE_INT128_T
<a href="https://bugs.webkit.org/show_bug.cgi?id=274765">https://bugs.webkit.org/show_bug.cgi?id=274765</a>

Reviewed by Alex Christensen and Yusuke Suzuki.

Clang-cl has a bug that it generates incorrectly-aligned movaps
instructions. &lt;<a href="https://github.com/llvm/llvm-project/issues/55844">https://github.com/llvm/llvm-project/issues/55844</a>&gt;

We have to specify &apos;aligned(16)&apos; attribute and use &apos;typedef&apos; instead
of &apos;using&apos; for int128 types.

* Source/WTF/wtf/Int128.h:
* Source/cmake/OptionsMSVC.cmake:

Canonical link: <a href="https://commits.webkit.org/279419@main">https://commits.webkit.org/279419@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3c532cb7dd256343325bf7eaa8a32dbe0351123

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53428 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32784 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56708 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4154 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40221 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3927 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43319 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2722 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55526 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/30974 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46165 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24453 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3482 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2310 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/46788 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3656 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58303 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52943 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28585 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3652 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50712 "Found 1 new test failure: imported/w3c/web-platform-tests/pointerevents/compat/pointerevent_mouseevent_key_pressed.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29792 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46358 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50052 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30720 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65248 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7862 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29562 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12441 "Passed tests") | 
<!--EWS-Status-Bubble-End-->