### PR TITLE
Interaction Regions size checks should be independent from page zoom

### DIFF
--- a/LayoutTests/interaction-region/full-page-overlay-page-zoom-expected.txt
+++ b/LayoutTests/interaction-region/full-page-overlay-page-zoom-expected.txt
@@ -1,0 +1,19 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 1536.00 2008.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 1536.00 2008.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=1536 height=2008)
+
+      (interaction regions [
+        (occlusion (0,0) width=1536 height=2008)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/full-page-overlay-page-zoom.html
+++ b/LayoutTests/interaction-region/full-page-overlay-page-zoom.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta name="viewport" content="initial-scale=1">
+    <style>
+        html, body {
+            margin: 0;
+        }
+
+        .overlay {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            z-index: 1;
+            background-color: purple;
+        }
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+<div class="spacer">
+    <div id="dynamic" class="overlay"></div>
+</div>
+
+<pre id="results"></pre>
+<script>
+document.body.addEventListener("click", function(e) {
+    console.log(e, "event delegation");
+});
+
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (window.internals)
+        internals.setPageZoomFactor(2);
+    await UIHelper.renderingUpdate();
+
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+    if (window.testRunner)
+        testRunner.notifyDone();
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 8a36e70185b493f63385ca48a275a6d29a098c72
<pre>
Interaction Regions size checks should be independent from page zoom
<a href="https://bugs.webkit.org/show_bug.cgi?id=274777">https://bugs.webkit.org/show_bug.cgi?id=274777</a>
&lt;<a href="https://rdar.apple.com/128606404">rdar://128606404</a>&gt;

Reviewed by Simon Fraser.

The input bounds we use to generate Interaction Regions come from the
renderer&apos;s paint offset and size (unchanged by scale factor).

In the `isTooBigForInteraction` and `isTooBigForOcclusion` checks, we
compare the region&apos;s bounds to the viewport.
Use `baseLayoutViewportSize()` to do so since it&apos;s in Document
coordinates (also unchanged by scale factor) and can be safely compared
to the region&apos;s bounds.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
Move the main frame view lookup to where it&apos;s actually used.
Remove the (sometimes erroneous) use of `visibleContentScaleFactor`.

* LayoutTests/interaction-region/full-page-overlay-page-zoom-expected.txt: Added.
* LayoutTests/interaction-region/full-page-overlay-page-zoom.html: Added.
Add a test at high page zoom to cover the change.

Canonical link: <a href="https://commits.webkit.org/279820@main">https://commits.webkit.org/279820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/004d92478ae49a236b0d2012f16ab5927a7d652a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57390 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4839 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56418 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4734 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43826 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3221 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56211 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31739 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46850 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24968 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28552 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4167 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2988 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50277 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4373 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58984 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29310 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4477 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51241 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30489 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46964 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51041 "Found 3 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11973 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31452 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30269 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->