### PR TITLE
Enforce bounds checking in FixedVector

### DIFF
--- a/Source/WTF/wtf/FixedVector.h
+++ b/Source/WTF/wtf/FixedVector.h
@@ -144,11 +144,11 @@ public:
     const_reverse_iterator rbegin() const { return m_storage ? m_storage->rbegin() : const_reverse_iterator(nullptr); }
     const_reverse_iterator rend() const { return m_storage ? m_storage->rend() : const_reverse_iterator(nullptr); }
 
-    T& at(size_t i) { return m_storage->at(i); }
-    const T& at(size_t i) const { return m_storage->at(i); }
+    T& at(size_t i) { RELEASE_ASSERT(i < m_storage->size()); return m_storage->at(i); }
+    const T& at(size_t i) const { RELEASE_ASSERT(i < m_storage->size()); return m_storage->at(i); }
 
-    T& operator[](size_t i) { return m_storage->at(i); }
-    const T& operator[](size_t i) const { return m_storage->at(i); }
+    T& operator[](size_t i) { RELEASE_ASSERT(i < m_storage->size()); return m_storage->at(i); }
+    const T& operator[](size_t i) const { RELEASE_ASSERT(i < m_storage->size()); return m_storage->at(i); }
 
     T& first() { return (*this)[0]; }
     const T& first() const { return (*this)[0]; }


### PR DESCRIPTION
#### 966bb6ff4463ee03a265c34655184a179d20889c
<pre>
Enforce bounds checking in FixedVector
<a href="https://bugs.webkit.org/show_bug.cgi?id=274783">https://bugs.webkit.org/show_bug.cgi?id=274783</a>

Reviewed by Darin Adler.

Enforce bounds checking in FixedVector for safety. This tested as
performance neutral on the benchmarks we track.

* Source/WTF/wtf/FixedVector.h:
(WTF::FixedVector::at):
(WTF::FixedVector::at const):
(WTF::FixedVector::operator[]):
(WTF::FixedVector::operator[] const):

Canonical link: <a href="https://commits.webkit.org/279392@main">https://commits.webkit.org/279392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fde8c7d85f14ab6f9e9a93e5eedabceb5b61c97

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56666 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4112 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40198 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3879 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43288 "Found 1 new test failure: http/tests/scroll-to-text-fragment/no-scroll-after-stylesheet-load.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2699 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55484 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/30957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46123 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24420 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3442 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2268 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/46746 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3615 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58261 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/52900 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28537 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3611 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50693 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29750 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46325 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50030 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30674 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65206 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7847 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29517 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12431 "Found 7 new JSC stress test failures: stress/sampling-profiler-display-name.js.dfg-eager-no-cjit-validate, stress/spread-non-array.js.mini-mode, wasm.yaml/wasm/function-tests/br-as-return.js.wasm-eager, wasm.yaml/wasm/function-tests/dead-call.js.wasm-eager, wasm.yaml/wasm/function-tests/f32-const.js.wasm-eager, wasm.yaml/wasm/js-api/extension-MemoryMode.js.wasm-eager-jettison, wasm.yaml/wasm/stress/immutable-globals.js.wasm-eager (failure)") | 
<!--EWS-Status-Bubble-End-->