### PR TITLE
General cleanup of FilterOperations

### DIFF
--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -1483,11 +1483,12 @@ private:
 };
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(PropertyWrapperFilter);
-class PropertyWrapperFilter final : public PropertyWrapper<const FilterOperations&> {
+class PropertyWrapperFilter final : public PropertyWrapperGetter<const FilterOperations&> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(PropertyWrapperFilter);
 public:
-    PropertyWrapperFilter(CSSPropertyID propertyID, const FilterOperations& (RenderStyle::*getter)() const, void (RenderStyle::*setter)(const FilterOperations&))
-        : PropertyWrapper(propertyID, getter, setter)
+    PropertyWrapperFilter(CSSPropertyID property, const FilterOperations& (RenderStyle::*getter)() const, void (RenderStyle::*setter)(FilterOperations&&))
+        : PropertyWrapperGetter<const FilterOperations&>(property, getter)
+        , m_setter(setter)
     {
     }
 
@@ -1510,6 +1511,8 @@ private:
     {
         (destination.*m_setter)(blendFunc(value(from), value(to), context));
     }
+
+    void (RenderStyle::*m_setter)(FilterOperations&&);
 };
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(PropertyWrapperFilter);
 

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -973,13 +973,13 @@ Ref<CSSValue> ComputedStyleExtractor::valueForShadow(const ShadowData* shadow, C
 
 Ref<CSSValue> ComputedStyleExtractor::valueForFilter(const RenderStyle& style, const FilterOperations& filterOperations, AdjustPixelValuesForComputedStyle adjust)
 {
-    if (filterOperations.operations().isEmpty())
+    if (filterOperations.isEmpty())
         return CSSPrimitiveValue::create(CSSValueNone);
 
     CSSValueListBuilder list;
 
-    for (auto& filterOperationPointer : filterOperations.operations()) {
-        auto& filterOperation = *filterOperationPointer;
+    for (auto& filterOperationRef : filterOperations) {
+        auto& filterOperation = filterOperationRef.get();
 
         if (auto* referenceOperation = dynamicDowncast<ReferenceFilterOperation>(filterOperation))
             list.append(CSSPrimitiveValue::createURI(referenceOperation->url()));

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -578,7 +578,7 @@ static bool fragmentNeedsColorTransformed(ReplacementFragment& fragment, const P
             return false;
 
         const auto& colorFilter = editableRootRenderer->style().appleColorFilter();
-        for (const auto& colorFilterOperation : colorFilter.operations()) {
+        for (const auto& colorFilterOperation : colorFilter) {
             if (colorFilterOperation->type() != FilterOperation::Type::AppleInvertLightness)
                 return false;
         }

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -467,9 +467,8 @@ void AcceleratedEffect::validateFilters(const AcceleratedEffectValues& baseValue
         // has it as its final operation since it will be applied by a separate CALayer property
         // from the other filter operations and it will be applied to the layer as the last filer.
         ASSERT(longestFilterList);
-        auto& longestFilterOperations = longestFilterList->operations();
-        for (auto& operation : longestFilterOperations) {
-            if (operation->type() == FilterOperation::Type::DropShadow && operation != longestFilterOperations.last())
+        for (auto& operation : *longestFilterList) {
+            if (operation->type() == FilterOperation::Type::DropShadow && operation != longestFilterList->last())
                 return false;
         }
 

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
@@ -61,13 +61,8 @@ AcceleratedEffectValues::AcceleratedEffectValues(const AcceleratedEffectValues& 
     offsetAnchor = src.offsetAnchor;
     offsetRotate = src.offsetRotate;
 
-    filter.setOperations(src.filter.operations().map([](const auto& operation) {
-        return operation.copyRef();
-    }));
-
-    backdropFilter.setOperations(src.backdropFilter.operations().map([](const auto& operation) {
-        return operation.copyRef();
-    }));
+    filter = src.filter;
+    backdropFilter = src.backdropFilter;
 }
 
 AcceleratedEffectValues AcceleratedEffectValues::clone() const
@@ -103,13 +98,8 @@ AcceleratedEffectValues AcceleratedEffectValues::clone() const
     auto clonedOffsetAnchor = offsetAnchor;
     auto clonedOffsetRotate = offsetRotate;
 
-    FilterOperations clonedFilter { filter.operations().map([](const auto& operation) {
-        return RefPtr { operation->clone() };
-    }) };
-
-    FilterOperations clonedBackdropFilter { backdropFilter.operations().map([](const auto& operation) {
-        return RefPtr { operation->clone() };
-    }) };
+    auto clonedFilter = filter.clone();
+    auto clonedBackdropFilter = backdropFilter.clone();
 
     return {
         opacity,
@@ -179,13 +169,8 @@ AcceleratedEffectValues::AcceleratedEffectValues(const RenderStyle& style, const
         offsetDistance = { path ? path->length() : 0.0f, LengthType:: Fixed };
     }
 
-    filter.setOperations(style.filter().operations().map([](const auto& operation) {
-        return operation.copyRef();
-    }));
-
-    backdropFilter.setOperations(style.backdropFilter().operations().map([](const auto& operation) {
-        return operation.copyRef();
-    }));
+    filter = style.filter();
+    backdropFilter = style.backdropFilter();
 }
 
 TransformationMatrix AcceleratedEffectValues::computedTransformationMatrix(const FloatRect& boundingBox) const

--- a/Source/WebCore/platform/graphics/GraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.cpp
@@ -792,7 +792,7 @@ int GraphicsLayer::validateFilterOperations(const KeyframeValueList& valueList)
     // Empty filters match anything, so find the first non-empty entry as the reference
     size_t firstIndex = 0;
     for ( ; firstIndex < valueList.size(); ++firstIndex) {
-        if (!filterOperationsAt(valueList, firstIndex).operations().isEmpty())
+        if (!filterOperationsAt(valueList, firstIndex).isEmpty())
             break;
     }
 
@@ -804,8 +804,8 @@ int GraphicsLayer::validateFilterOperations(const KeyframeValueList& valueList)
     for (size_t i = firstIndex + 1; i < valueList.size(); ++i) {
         const FilterOperations& val = filterOperationsAt(valueList, i);
         
-        // An emtpy filter list matches anything.
-        if (val.operations().isEmpty())
+        // An empty filter list matches anything.
+        if (val.isEmpty())
             continue;
         
         if (!firstVal.operationsMatch(val))

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -199,10 +199,8 @@ public:
 
     FilterAnimationValue(const FilterAnimationValue& other)
         : AnimationValue(other)
+        , m_value(other.m_value.clone())
     {
-        m_value.operations().appendContainerWithMapping(other.m_value.operations(), [](auto& operation) {
-            return operation->clone();
-        });
     }
 
     FilterAnimationValue(FilterAnimationValue&&) = default;
@@ -706,8 +704,8 @@ protected:
     // This method is used by platform GraphicsLayer classes to clear the filters
     // when compositing is not done in hardware. It is not virtual, so the caller
     // needs to notifiy the change to the platform layer as needed.
-    void clearFilters() { m_filters.clear(); }
-    void clearBackdropFilters() { m_backdropFilters.clear(); }
+    void clearFilters() { m_filters = { }; }
+    void clearBackdropFilters() { m_backdropFilters = { }; }
 
     // Given a KeyframeValueList containing filterOperations, return true if the operations are valid.
     static int validateFilterOperations(const KeyframeValueList&);

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -560,7 +560,7 @@ private:
     }
 
     bool appendToUncommittedAnimations(const KeyframeValueList&, const TransformOperation::Type, const Animation*, const String& animationName, const FloatSize& boxSize, unsigned animationIndex, Seconds timeOffset, bool isMatrixAnimation, bool keyframesShouldUseAnimationWideTimingFunction);
-    bool appendToUncommittedAnimations(const KeyframeValueList&, const FilterOperation*, const Animation*, const String& animationName, int animationIndex, Seconds timeOffset, bool keyframesShouldUseAnimationWideTimingFunction);
+    bool appendToUncommittedAnimations(const KeyframeValueList&, const FilterOperation&, const Animation*, const String& animationName, int animationIndex, Seconds timeOffset, bool keyframesShouldUseAnimationWideTimingFunction);
 
     enum LayerChange : uint64_t {
         NoChange                                = 0,

--- a/Source/WebCore/platform/graphics/ca/PlatformCAAnimation.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCAAnimation.h
@@ -125,14 +125,14 @@ public:
     virtual void setFromValue(const WebCore::TransformationMatrix&) = 0;
     virtual void setFromValue(const FloatPoint3D&) = 0;
     virtual void setFromValue(const WebCore::Color&) = 0;
-    virtual void setFromValue(const FilterOperation*) = 0;
+    virtual void setFromValue(const FilterOperation&) = 0;
     virtual void copyFromValueFrom(const PlatformCAAnimation&) = 0;
 
     virtual void setToValue(float) = 0;
     virtual void setToValue(const WebCore::TransformationMatrix&) = 0;
     virtual void setToValue(const FloatPoint3D&) = 0;
     virtual void setToValue(const WebCore::Color&) = 0;
-    virtual void setToValue(const FilterOperation*) = 0;
+    virtual void setToValue(const FilterOperation&) = 0;
     virtual void copyToValueFrom(const PlatformCAAnimation&) = 0;
 
     // Keyframe-animation properties.
@@ -140,7 +140,7 @@ public:
     virtual void setValues(const Vector<WebCore::TransformationMatrix>&) = 0;
     virtual void setValues(const Vector<FloatPoint3D>&) = 0;
     virtual void setValues(const Vector<WebCore::Color>&) = 0;
-    virtual void setValues(const Vector<RefPtr<FilterOperation>>&) = 0;
+    virtual void setValues(const Vector<Ref<FilterOperation>>&) = 0;
     virtual void copyValuesFrom(const PlatformCAAnimation&) = 0;
 
     virtual void setKeyTimes(const Vector<float>&) = 0;

--- a/Source/WebCore/platform/graphics/ca/PlatformCAFilters.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCAFilters.h
@@ -53,7 +53,7 @@ public:
     static String animatedFilterPropertyName(FilterOperation::Type);
     static bool isValidAnimatedFilterPropertyName(const String&);
 
-    WEBCORE_EXPORT static RetainPtr<NSValue> filterValueForOperation(const FilterOperation*);
+    WEBCORE_EXPORT static RetainPtr<NSValue> filterValueForOperation(const FilterOperation&);
 
     // A null operation indicates that we should make a "no-op" filter of the given type.
     static RetainPtr<NSValue> colorMatrixValueForFilter(FilterOperation::Type, const FilterOperation*);

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.h
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.h
@@ -99,14 +99,14 @@ public:
     void setFromValue(const WebCore::TransformationMatrix&) override;
     void setFromValue(const FloatPoint3D&) override;
     void setFromValue(const WebCore::Color&) override;
-    void setFromValue(const FilterOperation*) override;
+    void setFromValue(const FilterOperation&) override;
     void copyFromValueFrom(const PlatformCAAnimation&) override;
 
     void setToValue(float) override;
     void setToValue(const WebCore::TransformationMatrix&) override;
     void setToValue(const FloatPoint3D&) override;
     void setToValue(const WebCore::Color&) override;
-    void setToValue(const FilterOperation*) override;
+    void setToValue(const FilterOperation&) override;
     void copyToValueFrom(const PlatformCAAnimation&) override;
 
     // Keyframe-animation properties.
@@ -114,7 +114,7 @@ public:
     void setValues(const Vector<WebCore::TransformationMatrix>&) override;
     void setValues(const Vector<FloatPoint3D>&) override;
     void setValues(const Vector<WebCore::Color>&) override;
-    void setValues(const Vector<RefPtr<FilterOperation>>&) override;
+    void setValues(const Vector<Ref<FilterOperation>>&) override;
     void copyValuesFrom(const PlatformCAAnimation&) override;
 
     void setKeyTimes(const Vector<float>&) override;

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
@@ -429,7 +429,7 @@ void PlatformCAAnimationCocoa::setFromValue(const Color& value)
     [static_cast<CABasicAnimation *>(m_animation.get()) setFromValue:@[@(r), @(g), @(b), @(a)]];
 }
 
-void PlatformCAAnimationCocoa::setFromValue(const FilterOperation* operation)
+void PlatformCAAnimationCocoa::setFromValue(const FilterOperation& operation)
 {
     auto value = PlatformCAFilters::filterValueForOperation(operation);
     [static_cast<CABasicAnimation *>(m_animation.get()) setFromValue:value.get()];
@@ -472,7 +472,7 @@ void PlatformCAAnimationCocoa::setToValue(const Color& value)
     [static_cast<CABasicAnimation *>(m_animation.get()) setToValue:@[@(r), @(g), @(b), @(a)]];
 }
 
-void PlatformCAAnimationCocoa::setToValue(const FilterOperation* operation)
+void PlatformCAAnimationCocoa::setToValue(const FilterOperation& operation)
 {
     auto value = PlatformCAFilters::filterValueForOperation(operation);
     [static_cast<CABasicAnimation *>(m_animation.get()) setToValue:value.get()];
@@ -530,13 +530,13 @@ void PlatformCAAnimationCocoa::setValues(const Vector<Color>& value)
     }).get()];
 }
 
-void PlatformCAAnimationCocoa::setValues(const Vector<RefPtr<FilterOperation>>& values)
+void PlatformCAAnimationCocoa::setValues(const Vector<Ref<FilterOperation>>& values)
 {
     if (animationType() != AnimationType::Keyframe)
         return;
 
-    [static_cast<CAKeyframeAnimation *>(m_animation.get()) setValues:createNSArray(values, [&] (auto& value) {
-        return PlatformCAFilters::filterValueForOperation(value.get());
+    [static_cast<CAKeyframeAnimation *>(m_animation.get()) setValues:createNSArray(values, [&](auto& value) {
+        return PlatformCAFilters::filterValueForOperation(value);
     }).get()];
 }
 

--- a/Source/WebCore/platform/graphics/filters/FilterOperations.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterOperations.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,7 +35,7 @@
 
 namespace WebCore {
 
-FilterOperations::FilterOperations(Vector<RefPtr<FilterOperation>>&& operations)
+FilterOperations::FilterOperations(Vector<Ref<FilterOperation>>&& operations)
     : m_operations(WTFMove(operations))
 {
 }
@@ -46,7 +46,7 @@ bool FilterOperations::operator==(const FilterOperations& other) const
     if (size != other.m_operations.size())
         return false;
     for (size_t i = 0; i < size; i++) {
-        if (*m_operations[i] != *other.m_operations[i])
+        if (m_operations[i].get() != other.m_operations[i].get())
             return false;
     }
     return true;
@@ -54,11 +54,11 @@ bool FilterOperations::operator==(const FilterOperations& other) const
 
 bool FilterOperations::operationsMatch(const FilterOperations& other) const
 {
-    size_t size = operations().size();
-    if (size != other.operations().size())
+    size_t size = m_operations.size();
+    if (size != other.m_operations.size())
         return false;
     for (size_t i = 0; i < size; ++i) {
-        if (!operations()[i]->isSameType(*other.operations()[i]))
+        if (!m_operations[i]->isSameType(other.m_operations[i]))
             return false;
     }
     return true;
@@ -66,11 +66,7 @@ bool FilterOperations::operationsMatch(const FilterOperations& other) const
 
 bool FilterOperations::hasReferenceFilter() const
 {
-    for (auto& operation : m_operations) {
-        if (operation->type() == FilterOperation::Type::Reference)
-            return true;
-    }
-    return false;
+    return hasFilterOfType<FilterOperation::Type::Reference>();
 }
 
 bool FilterOperations::isReferenceFilter() const
@@ -84,7 +80,7 @@ IntOutsets FilterOperations::outsets() const
     for (auto& operation : m_operations) {
         switch (operation->type()) {
         case FilterOperation::Type::Blur: {
-            auto& blurOperation = downcast<BlurFilterOperation>(*operation);
+            auto& blurOperation = downcast<BlurFilterOperation>(operation.get());
             float stdDeviation = floatValueForLength(blurOperation.stdDeviation(), 0);
             IntSize outsetSize = FEGaussianBlur::calculateOutsetSize({ stdDeviation, stdDeviation });
             IntOutsets outsets(outsetSize.height(), outsetSize.width(), outsetSize.height(), outsetSize.width());
@@ -92,7 +88,7 @@ IntOutsets FilterOperations::outsets() const
             break;
         }
         case FilterOperation::Type::DropShadow: {
-            auto& dropShadowOperation = downcast<DropShadowFilterOperation>(*operation);
+            auto& dropShadowOperation = downcast<DropShadowFilterOperation>(operation.get());
             float stdDeviation = dropShadowOperation.stdDeviation();
             IntSize outsetSize = FEGaussianBlur::calculateOutsetSize({ stdDeviation, stdDeviation });
             
@@ -155,29 +151,17 @@ bool FilterOperations::inverseTransformColor(Color& color) const
 
 bool FilterOperations::hasFilterThatAffectsOpacity() const
 {
-    for (auto& operation : m_operations) {
-        if (operation->affectsOpacity())
-            return true;
-    }
-    return false;
+    return WTF::anyOf(m_operations, [](auto& op) { return op->affectsOpacity(); });
 }
 
 bool FilterOperations::hasFilterThatMovesPixels() const
 {
-    for (auto& operation : m_operations) {
-        if (operation->movesPixels())
-            return true;
-    }
-    return false;
+    return WTF::anyOf(m_operations, [](auto& op) { return op->movesPixels(); });
 }
 
 bool FilterOperations::hasFilterThatShouldBeRestrictedBySecurityOrigin() const
 {
-    for (auto& operation : m_operations) {
-        if (operation->shouldBeRestrictedBySecurityOrigin())
-            return true;
-    }
-    return false;
+    return WTF::anyOf(m_operations, [](auto& op) { return op->shouldBeRestrictedBySecurityOrigin(); });
 }
 
 bool FilterOperations::canInterpolate(const FilterOperations& to, CompositeOperation compositeOperation) const
@@ -211,10 +195,14 @@ FilterOperations FilterOperations::blend(const FilterOperations& to, const Blend
 {
     if (context.compositeOperation == CompositeOperation::Add) {
         ASSERT(context.progress == 1.0);
-        FilterOperations result;
-        result.operations().appendVector(m_operations);
-        result.operations().appendVector(to.operations());
-        return result;
+
+        Vector<Ref<FilterOperation>> operations;
+        operations.reserveInitialCapacity(size() + to.size());
+
+        operations.appendVector(m_operations);
+        operations.appendVector(to.m_operations);
+
+        return FilterOperations { WTFMove(operations) };
     }
 
     if (context.isDiscrete) {
@@ -222,13 +210,16 @@ FilterOperations FilterOperations::blend(const FilterOperations& to, const Blend
         return context.progress ? to : *this;
     }
 
-    FilterOperations result;
     auto fromSize = m_operations.size();
-    auto toSize = to.operations().size();
+    auto toSize = to.m_operations.size();
     auto size = std::max(fromSize, toSize);
+
+    Vector<Ref<FilterOperation>> operations;
+    operations.reserveInitialCapacity(size);
+
     for (size_t i = 0; i < size; ++i) {
-        RefPtr<FilterOperation> fromOp = (i < fromSize) ? m_operations[i].get() : nullptr;
-        RefPtr<FilterOperation> toOp = (i < toSize) ? to.operations()[i].get() : nullptr;
+        RefPtr<FilterOperation> fromOp = (i < fromSize) ? m_operations[i].ptr() : nullptr;
+        RefPtr<FilterOperation> toOp = (i < toSize) ? to.m_operations[i].ptr() : nullptr;
 
         RefPtr<FilterOperation> blendedOp;
         if (toOp)
@@ -237,30 +228,29 @@ FilterOperations FilterOperations::blend(const FilterOperations& to, const Blend
             blendedOp = fromOp->blend(nullptr, context, true);
 
         if (blendedOp)
-            result.operations().append(blendedOp);
+            operations.append(blendedOp.releaseNonNull());
         else {
             auto identityOp = PassthroughFilterOperation::create();
-            if (context.progress > 0.5)
-                result.operations().append(toOp ? toOp : WTFMove(identityOp));
-            else
-                result.operations().append(fromOp ? fromOp : WTFMove(identityOp));
+            if (context.progress > 0.5) {
+                if (toOp)
+                    operations.append(toOp.releaseNonNull());
+                else
+                    operations.append(WTFMove(identityOp));
+            } else {
+                if (fromOp)
+                    operations.append(fromOp.releaseNonNull());
+                else
+                    operations.append(WTFMove(identityOp));
+            }
         }
     }
-    return result;
+
+    return FilterOperations { WTFMove(operations) };
 }
 
 TextStream& operator<<(TextStream& ts, const FilterOperations& filters)
 {
-    for (size_t i = 0; i < filters.size(); ++i) {
-        auto filter = filters.at(i);
-        if (filter)
-            ts << *filter;
-        else
-            ts << "(null)";
-        if (i < filters.size() - 1)
-            ts << " ";
-    }
-    return ts;
+    return ts << filters.m_operations;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/FilterOperations.h
+++ b/Source/WebCore/platform/graphics/filters/FilterOperations.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,7 +27,8 @@
 
 #include "CompositeOperation.h"
 #include "FilterOperation.h"
-#include <wtf/RefPtr.h>
+#include <wtf/ArgumentCoder.h>
+#include <wtf/Ref.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -37,20 +38,32 @@ struct BlendingContext;
 class FilterOperations {
     WTF_MAKE_FAST_ALLOCATED;
 public:
+    using const_iterator = Vector<Ref<FilterOperation>>::const_iterator;
+    using const_reverse_iterator = Vector<Ref<FilterOperation>>::const_reverse_iterator;
+    using value_type = Vector<Ref<FilterOperation>>::value_type;
+
     FilterOperations() = default;
-    WEBCORE_EXPORT explicit FilterOperations(Vector<RefPtr<FilterOperation>>&&);
+    WEBCORE_EXPORT explicit FilterOperations(Vector<Ref<FilterOperation>>&&);
 
     WEBCORE_EXPORT bool operator==(const FilterOperations&) const;
 
-    void clear() { m_operations.clear(); }
+    FilterOperations clone() const
+    {
+        return FilterOperations { m_operations.map([](const auto& op) { return op->clone(); }) };
+    }
 
-    Vector<RefPtr<FilterOperation>>& operations() { return m_operations; }
-    const Vector<RefPtr<FilterOperation>>& operations() const { return m_operations; }
-    void setOperations(Vector<RefPtr<FilterOperation>>&& operations) { m_operations = WTFMove(operations); }
+    const_iterator begin() const { return m_operations.begin(); }
+    const_iterator end() const { return m_operations.end(); }
+    const_reverse_iterator rbegin() const { return m_operations.rbegin(); }
+    const_reverse_iterator rend() const { return m_operations.rend(); }
 
     bool isEmpty() const { return m_operations.isEmpty(); }
     size_t size() const { return m_operations.size(); }
-    const FilterOperation* at(size_t index) const { return index < m_operations.size() ? m_operations[index].get() : nullptr; }
+    const FilterOperation* at(size_t index) const { return index < m_operations.size() ? m_operations[index].ptr() : nullptr; }
+
+    const Ref<FilterOperation>& operator[](size_t i) const { return m_operations[i]; }
+    const Ref<FilterOperation>& first() const { return m_operations.first(); }
+    const Ref<FilterOperation>& last() const { return m_operations.last(); }
 
     bool operationsMatch(const FilterOperations&) const;
 
@@ -60,6 +73,12 @@ public:
     bool hasFilterThatAffectsOpacity() const;
     bool hasFilterThatMovesPixels() const;
     bool hasFilterThatShouldBeRestrictedBySecurityOrigin() const;
+
+    template<FilterOperation::Type Type>
+    bool hasFilterOfType() const
+    {
+        return WTF::anyOf(m_operations, [](auto& op) { return op->type() == Type; });
+    }
 
     bool hasReferenceFilter() const;
     bool isReferenceFilter() const;
@@ -71,7 +90,10 @@ public:
     WEBCORE_EXPORT FilterOperations blend(const FilterOperations&, const BlendingContext&) const;
 
 private:
-    Vector<RefPtr<FilterOperation>> m_operations;
+    friend struct IPC::ArgumentCoder<FilterOperations, void>;
+    WEBCORE_EXPORT friend WTF::TextStream& operator<<(WTF::TextStream&, const FilterOperations&);
+
+    Vector<Ref<FilterOperation>> m_operations;
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const FilterOperations&);

--- a/Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsLayerTextureMapper.cpp
@@ -601,12 +601,7 @@ bool GraphicsLayerTextureMapper::filtersCanBeComposited(const FilterOperations& 
     if (!filters.size())
         return false;
 
-    for (const auto& filterOperation : filters.operations()) {
-        if (filterOperation->type() == FilterOperation::Type::Reference)
-            return false;
-    }
-
-    return true;
+    return !filters.hasReferenceFilter();
 }
 
 bool GraphicsLayerTextureMapper::addAnimation(const KeyframeValueList& valueList, const FloatSize& boxSize, const Animation* anim, const String& keyframesName, double timeOffset)

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.h
@@ -100,10 +100,10 @@ private:
 
     enum class Direction { X, Y };
 
-    RefPtr<BitmapTexture> applyFilter(RefPtr<BitmapTexture>&, const RefPtr<const FilterOperation>&, bool defersLastPass);
+    RefPtr<BitmapTexture> applyFilter(RefPtr<BitmapTexture>&, const Ref<const FilterOperation>&, bool defersLastPass);
     RefPtr<BitmapTexture> applyBlurFilter(RefPtr<BitmapTexture>&, const BlurFilterOperation&);
     RefPtr<BitmapTexture> applyDropShadowFilter(RefPtr<BitmapTexture>&, const DropShadowFilterOperation&);
-    RefPtr<BitmapTexture> applySinglePassFilter(RefPtr<BitmapTexture>&, const RefPtr<const FilterOperation>&, bool shouldDefer);
+    RefPtr<BitmapTexture> applySinglePassFilter(RefPtr<BitmapTexture>&, const Ref<const FilterOperation>&, bool shouldDefer);
 
     void drawTextureCopy(const BitmapTexture& sourceTexture, const FloatRect& sourceRect, const FloatRect& targetRect);
     void drawBlurred(const BitmapTexture& sourceTexture, const FloatRect&, float radius, Direction, bool alphaBlur = false);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -538,12 +538,7 @@ bool CoordinatedGraphicsLayer::filtersCanBeComposited(const FilterOperations& fi
     if (!filters.size())
         return false;
 
-    for (const auto& filterOperation : filters.operations()) {
-        if (filterOperation->type() == FilterOperation::Type::Reference)
-            return false;
-    }
-
-    return true;
+    return !filters.hasReferenceFilter();
 }
 
 bool CoordinatedGraphicsLayer::setFilters(const FilterOperations& newFilters)
@@ -1371,8 +1366,8 @@ bool CoordinatedGraphicsLayer::shouldHaveBackingStore() const
     bool isInvisibleBecauseOpacityZero = !opacity() && !m_animations.hasActiveAnimationsOfType(AnimatedProperty::Opacity);
 
     // Check if there's a filter that sets the opacity to zero.
-    bool hasOpacityZeroFilter = notFound != filters().operations().findIf([&](const auto& operation) {
-        return operation->type() == FilterOperation::Type::Opacity && !downcast<BasicComponentTransferFilterOperation>(*operation).amount();
+    bool hasOpacityZeroFilter = WTF::anyOf(filters(), [](auto& operation) {
+        return operation->type() == FilterOperation::Type::Opacity && !downcast<BasicComponentTransferFilterOperation>(operation.get()).amount();
     });
 
     // If there's a filter that sets opacity to 0 and the filters are not being animated, the layer is invisible.

--- a/Source/WebCore/rendering/CSSFilter.cpp
+++ b/Source/WebCore/rendering/CSSFilter.cpp
@@ -239,54 +239,54 @@ bool CSSFilter::buildFilterFunctions(RenderElement& renderer, const FilterOperat
 {
     RefPtr<FilterFunction> function;
 
-    for (auto& operation : operations.operations()) {
+    for (auto& operation : operations) {
         switch (operation->type()) {
         case FilterOperation::Type::AppleInvertLightness:
             ASSERT_NOT_REACHED(); // AppleInvertLightness is only used in -apple-color-filter.
             break;
 
         case FilterOperation::Type::Blur:
-            function = createBlurEffect(uncheckedDowncast<BlurFilterOperation>(*operation));
+            function = createBlurEffect(uncheckedDowncast<BlurFilterOperation>(operation));
             break;
 
         case FilterOperation::Type::Brightness:
-            function = createBrightnessEffect(downcast<BasicComponentTransferFilterOperation>(*operation));
+            function = createBrightnessEffect(downcast<BasicComponentTransferFilterOperation>(operation));
             break;
 
         case FilterOperation::Type::Contrast:
-            function = createContrastEffect(downcast<BasicComponentTransferFilterOperation>(*operation));
+            function = createContrastEffect(downcast<BasicComponentTransferFilterOperation>(operation));
             break;
 
         case FilterOperation::Type::DropShadow:
-            function = createDropShadowEffect(uncheckedDowncast<DropShadowFilterOperation>(*operation));
+            function = createDropShadowEffect(uncheckedDowncast<DropShadowFilterOperation>(operation));
             break;
 
         case FilterOperation::Type::Grayscale:
-            function = createGrayScaleEffect(downcast<BasicColorMatrixFilterOperation>(*operation));
+            function = createGrayScaleEffect(downcast<BasicColorMatrixFilterOperation>(operation));
             break;
 
         case FilterOperation::Type::HueRotate:
-            function = createHueRotateEffect(downcast<BasicColorMatrixFilterOperation>(*operation));
+            function = createHueRotateEffect(downcast<BasicColorMatrixFilterOperation>(operation));
             break;
 
         case FilterOperation::Type::Invert:
-            function = createInvertEffect(downcast<BasicComponentTransferFilterOperation>(*operation));
+            function = createInvertEffect(downcast<BasicComponentTransferFilterOperation>(operation));
             break;
 
         case FilterOperation::Type::Opacity:
-            function = createOpacityEffect(downcast<BasicComponentTransferFilterOperation>(*operation));
+            function = createOpacityEffect(downcast<BasicComponentTransferFilterOperation>(operation));
             break;
 
         case FilterOperation::Type::Saturate:
-            function = createSaturateEffect(downcast<BasicColorMatrixFilterOperation>(*operation));
+            function = createSaturateEffect(downcast<BasicColorMatrixFilterOperation>(operation));
             break;
 
         case FilterOperation::Type::Sepia:
-            function = createSepiaEffect(downcast<BasicColorMatrixFilterOperation>(*operation));
+            function = createSepiaEffect(downcast<BasicColorMatrixFilterOperation>(operation));
             break;
 
         case FilterOperation::Type::Reference:
-            function = createReferenceFilter(*this, uncheckedDowncast<ReferenceFilterOperation>(*operation), renderer, preferredFilterRenderingModes, targetBoundingBox, destinationContext);
+            function = createReferenceFilter(*this, uncheckedDowncast<ReferenceFilterOperation>(operation), renderer, preferredFilterRenderingModes, targetBoundingBox, destinationContext);
             break;
 
         default:
@@ -387,8 +387,8 @@ bool CSSFilter::isIdentity(RenderElement& renderer, const FilterOperations& oper
     if (operations.hasFilterThatShouldBeRestrictedBySecurityOrigin())
         return false;
 
-    for (auto& operation : operations.operations()) {
-        if (RefPtr referenceOperation = dynamicDowncast<ReferenceFilterOperation>(*operation)) {
+    for (auto& operation : operations) {
+        if (RefPtr referenceOperation = dynamicDowncast<ReferenceFilterOperation>(operation)) {
             if (!isIdentityReferenceFilter(*referenceOperation, renderer))
                 return false;
             continue;
@@ -405,8 +405,8 @@ IntOutsets CSSFilter::calculateOutsets(RenderElement& renderer, const FilterOper
 {
     IntOutsets outsets;
 
-    for (auto& operation : operations.operations()) {
-        if (RefPtr referenceOperation = dynamicDowncast<ReferenceFilterOperation>(*operation)) {
+    for (auto& operation : operations) {
+        if (RefPtr referenceOperation = dynamicDowncast<ReferenceFilterOperation>(operation)) {
             outsets += calculateReferenceFilterOutsets(*referenceOperation, renderer, targetBoundingBox);
             continue;
         }

--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -123,9 +123,8 @@ ReferencedSVGResources::SVGElementIdentifierAndTagPairs ReferencedSVGResources::
 
     if (style.hasFilter()) {
         const auto& filterOperations = style.filter();
-        for (auto& operation : filterOperations.operations()) {
-            auto& filterOperation = *operation;
-            if (auto* referenceFilterOperation = dynamicDowncast<ReferenceFilterOperation>(filterOperation)) {
+        for (auto& operation : filterOperations) {
+            if (RefPtr referenceFilterOperation = dynamicDowncast<ReferenceFilterOperation>(operation)) {
                 if (!referenceFilterOperation->fragment().isEmpty())
                     referencedResources.append({ referenceFilterOperation->fragment(), { SVGNames::filterTag } });
             }

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -80,8 +80,8 @@ void RenderLayerFilters::updateReferenceFilterClients(const FilterOperations& op
 {
     removeReferenceFilterClients();
 
-    for (auto& operation : operations.operations()) {
-        RefPtr referenceOperation = dynamicDowncast<ReferenceFilterOperation>(*operation);
+    for (auto& operation : operations) {
+        RefPtr referenceOperation = dynamicDowncast<ReferenceFilterOperation>(operation);
         if (!referenceOperation)
             continue;
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1072,16 +1072,13 @@ public:
 
     inline OptionSet<SpeakAs> speakAs() const;
 
-    inline FilterOperations& mutableFilter();
     inline const FilterOperations& filter() const;
     inline bool hasFilter() const;
     bool hasReferenceFilterOnly() const;
 
-    inline FilterOperations& mutableAppleColorFilter();
     inline const FilterOperations& appleColorFilter() const;
     inline bool hasAppleColorFilter() const;
 
-    inline FilterOperations& mutableBackdropFilter();
     inline const FilterOperations& backdropFilter() const;
     inline bool hasBackdropFilter() const;
 
@@ -1513,10 +1510,10 @@ public:
     inline void setColorScheme(StyleColorScheme);
 #endif
 
-    inline void setFilter(const FilterOperations&);
-    inline void setAppleColorFilter(const FilterOperations&);
+    inline void setFilter(FilterOperations&&);
+    inline void setAppleColorFilter(FilterOperations&&);
 
-    inline void setBackdropFilter(const FilterOperations&);
+    inline void setBackdropFilter(FilterOperations&&);
 
     inline void setTabSize(const TabSize&);
 

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -254,7 +254,7 @@ inline bool RenderStyle::hasAnyFixedBackground() const { return backgroundLayers
 inline bool RenderStyle::hasAnyLocalBackground() const { return backgroundLayers().hasImageWithAttachment(FillAttachment::LocalBackground); }
 inline bool RenderStyle::hasAnyPublicPseudoStyles() const { return m_nonInheritedFlags.hasAnyPublicPseudoStyles(); }
 inline bool RenderStyle::hasAppearance() const { return appearance() != StyleAppearance::None; }
-inline bool RenderStyle::hasAppleColorFilter() const { return !appleColorFilter().operations().isEmpty(); }
+inline bool RenderStyle::hasAppleColorFilter() const { return !appleColorFilter().isEmpty(); }
 inline bool RenderStyle::hasAspectRatio() const { return aspectRatioType() == AspectRatioType::Ratio || aspectRatioType() == AspectRatioType::AutoAndRatio; }
 inline bool RenderStyle::hasAttrContent() const { return m_nonInheritedData->miscData->hasAttrContent; }
 inline bool RenderStyle::hasAutoAccentColor() const { return m_rareInheritedData->hasAutoAccentColor; }
@@ -286,7 +286,7 @@ inline bool RenderStyle::hasExplicitlySetBorderRadius() const { return hasExplic
 inline bool RenderStyle::hasExplicitlySetBorderTopLeftRadius() const { return m_nonInheritedData->surroundData->hasExplicitlySetBorderTopLeftRadius; }
 inline bool RenderStyle::hasExplicitlySetBorderTopRightRadius() const { return m_nonInheritedData->surroundData->hasExplicitlySetBorderTopRightRadius; }
 inline bool RenderStyle::hasExplicitlySetStrokeColor() const { return m_rareInheritedData->hasSetStrokeColor; }
-inline bool RenderStyle::hasFilter() const { return !filter().operations().isEmpty(); }
+inline bool RenderStyle::hasFilter() const { return !filter().isEmpty(); }
 inline bool RenderStyle::hasInFlowPosition() const { return position() == PositionType::Relative || position() == PositionType::Sticky; }
 inline bool RenderStyle::hasIsolation() const { return isolation() != Isolation::Auto; }
 inline bool RenderStyle::hasMargin() const { return !m_nonInheritedData->surroundData->margin.isZero(); }
@@ -785,7 +785,7 @@ inline bool RenderStyle::hasExplicitlySetColorScheme() const { return m_nonInher
 #endif
 
 inline const FilterOperations& RenderStyle::backdropFilter() const { return m_nonInheritedData->rareData->backdropFilter->operations; }
-inline bool RenderStyle::hasBackdropFilter() const { return !backdropFilter().operations().isEmpty(); }
+inline bool RenderStyle::hasBackdropFilter() const { return !backdropFilter().isEmpty(); }
 inline FilterOperations RenderStyle::initialBackdropFilter() { return { }; }
 
 inline bool RenderStyle::hasExplicitlySetDirection() const { return m_nonInheritedData->miscData->hasExplicitlySetDirection; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -58,8 +58,6 @@ inline FillLayer& RenderStyle::ensureMaskLayers() { return m_nonInheritedData.ac
 inline void RenderStyle::inheritBackgroundLayers(const FillLayer& parent) { m_nonInheritedData.access().backgroundData.access().background = FillLayer::create(parent); }
 inline void RenderStyle::inheritColumnPropertiesFrom(const RenderStyle& parent) { m_nonInheritedData.access().miscData.access().multiCol = parent.m_nonInheritedData->miscData->multiCol; }
 inline void RenderStyle::inheritMaskLayers(const FillLayer& parent) { m_nonInheritedData.access().miscData.access().mask = FillLayer::create(parent); }
-inline FilterOperations& RenderStyle::mutableAppleColorFilter() { return m_rareInheritedData.access().appleColorFilter.access().operations; }
-inline FilterOperations& RenderStyle::mutableFilter() { return m_nonInheritedData.access().miscData.access().filter.access().operations; }
 inline void RenderStyle::resetBorderBottom() { SET_NESTED(m_nonInheritedData, surroundData, border.m_bottom, BorderValue()); }
 inline void RenderStyle::resetBorderBottomLeftRadius() { SET_NESTED(m_nonInheritedData, surroundData, border.m_radii.bottomLeft, initialBorderRadius()); }
 inline void RenderStyle::resetBorderBottomRightRadius() { SET_NESTED(m_nonInheritedData, surroundData, border.m_radii.bottomRight, initialBorderRadius()); }
@@ -80,7 +78,7 @@ inline void RenderStyle::setAlignItemsPosition(ItemPosition position) { m_nonInh
 inline void RenderStyle::setAlignSelf(const StyleSelfAlignmentData& data) { SET_NESTED(m_nonInheritedData, miscData, alignSelf, data); }
 inline void RenderStyle::setAlignSelfPosition(ItemPosition position) { m_nonInheritedData.access().miscData.access().alignSelf.setPosition(position); }
 inline void RenderStyle::setAppearance(StyleAppearance appearance) { SET_NESTED_PAIR(m_nonInheritedData, miscData, appearance, static_cast<unsigned>(appearance), usedAppearance, static_cast<unsigned>(appearance)); }
-inline void RenderStyle::setAppleColorFilter(const FilterOperations& ops) { SET_NESTED(m_rareInheritedData, appleColorFilter, operations, ops); }
+inline void RenderStyle::setAppleColorFilter(FilterOperations&& ops) { SET_NESTED(m_rareInheritedData, appleColorFilter, operations, WTFMove(ops)); }
 inline void RenderStyle::setAspectRatio(double width, double height) { SET_NESTED_PAIR(m_nonInheritedData, miscData, aspectRatioWidth, width, aspectRatioHeight, height); }
 inline void RenderStyle::setAspectRatioType(AspectRatioType aspectRatioType) { SET_NESTED(m_nonInheritedData, miscData, aspectRatioType, static_cast<unsigned>(aspectRatioType)); }
 inline void RenderStyle::setBackfaceVisibility(BackfaceVisibility b) { SET_NESTED(m_nonInheritedData, rareData, backfaceVisibility, static_cast<unsigned>(b)); }
@@ -155,7 +153,7 @@ inline void RenderStyle::setUsedAppearance(StyleAppearance a) { SET_NESTED(m_non
 inline void RenderStyle::setEffectiveInert(bool effectiveInert) { SET(m_rareInheritedData, effectiveInert, effectiveInert); }
 inline void RenderStyle::setUsedTouchActions(OptionSet<TouchAction> touchActions) { SET(m_rareInheritedData, usedTouchActions, touchActions); }
 inline void RenderStyle::setEventListenerRegionTypes(OptionSet<EventListenerRegionType> eventListenerTypes) { SET(m_rareInheritedData, eventListenerRegionTypes, eventListenerTypes); }
-inline void RenderStyle::setFilter(const FilterOperations& ops) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, filter, operations, ops); }
+inline void RenderStyle::setFilter(FilterOperations&& ops) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, filter, operations, WTFMove(ops)); }
 inline void RenderStyle::setFlexBasis(Length&& length) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, flexibleBox, flexBasis, WTFMove(length)); }
 inline void RenderStyle::setFlexDirection(FlexDirection direction) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, flexibleBox, flexDirection, static_cast<unsigned>(direction)); }
 inline void RenderStyle::setFlexWrap(FlexWrap wrap) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, flexibleBox, flexWrap, static_cast<unsigned>(wrap)); }
@@ -359,8 +357,7 @@ inline void RenderStyle::setColorScheme(StyleColorScheme scheme) { SET(m_rareInh
 inline void RenderStyle::setHasExplicitlySetColorScheme() { SET_NESTED(m_nonInheritedData, miscData, hasExplicitlySetColorScheme, true); }
 #endif
 
-inline FilterOperations& RenderStyle::mutableBackdropFilter() { return m_nonInheritedData.access().rareData.access().backdropFilter.access().operations; }
-inline void RenderStyle::setBackdropFilter(const FilterOperations& ops) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, backdropFilter, operations, ops); }
+inline void RenderStyle::setBackdropFilter(FilterOperations&& ops) { SET_DOUBLY_NESTED(m_nonInheritedData, rareData, backdropFilter, operations, WTFMove(ops)); }
 
 #if PLATFORM(IOS_FAMILY)
 inline void RenderStyle::setTouchCalloutEnabled(bool value) { SET(m_rareInheritedData, touchCalloutEnabled, value); }

--- a/Source/WebCore/rendering/style/StyleFilterImage.cpp
+++ b/Source/WebCore/rendering/style/StyleFilterImage.cpp
@@ -101,8 +101,8 @@ void StyleFilterImage::load(CachedResourceLoader& cachedResourceLoader, const Re
             m_cachedImage->addClient(*this);
     }
 
-    for (auto& filterOperation : m_filterOperations.operations()) {
-        if (auto* referenceFilterOperation = dynamicDowncast<ReferenceFilterOperation>(filterOperation.get()))
+    for (auto& filterOperation : m_filterOperations) {
+        if (RefPtr referenceFilterOperation = dynamicDowncast<ReferenceFilterOperation>(filterOperation))
             referenceFilterOperation->loadExternalDocumentIfNeeded(cachedResourceLoader, options);
     }
 

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -70,6 +70,7 @@ inline Length forwardInheritedValue(const Length& value) { auto copy = value; re
 inline LengthSize forwardInheritedValue(const LengthSize& value) { auto copy = value; return copy; }
 inline LengthBox forwardInheritedValue(const LengthBox& value) { auto copy = value; return copy; }
 inline GapLength forwardInheritedValue(const GapLength& value) { auto copy = value; return copy; }
+inline FilterOperations forwardInheritedValue(const FilterOperations& value) { auto copy = value; return copy; }
 
 // Note that we assume the CSS parser only allows valid CSSValue types.
 class BuilderCustom {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7090,7 +7090,7 @@ struct WebCore::KeypressCommand {
 
 #if !USE(COORDINATED_GRAPHICS)
 class WebCore::FilterOperations {
-    Vector<RefPtr<WebCore::FilterOperation>> operations();
+    Vector<Ref<WebCore::FilterOperation>> m_operations;
 }
 #endif // !USE(COORDINATED_GRAPHICS)
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -522,12 +522,11 @@ void UnifiedPDFPlugin::updatePageBackgroundLayers()
         destinationRect.scale(m_documentLayout.scale());
 
         auto addLayerShadow = [](GraphicsLayer& layer, IntPoint shadowOffset, const Color& shadowColor, int shadowStdDeviation) {
-            Vector<RefPtr<FilterOperation>> filterOperations;
-            filterOperations.append(DropShadowFilterOperation::create(shadowOffset, shadowStdDeviation, shadowColor));
-
-            FilterOperations filters;
-            filters.setOperations(WTFMove(filterOperations));
-            layer.setFilters(filters);
+            layer.setFilters(FilterOperations {
+                Vector<Ref<FilterOperation>> {
+                    DropShadowFilterOperation::create(shadowOffset, shadowStdDeviation, shadowColor)
+                }
+            });
         };
 
         const auto containerShadowOffset = IntPoint { 0, 1 };

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.h
@@ -90,14 +90,14 @@ public:
     void setFromValue(const WebCore::TransformationMatrix&) override;
     void setFromValue(const WebCore::FloatPoint3D&) override;
     void setFromValue(const WebCore::Color&) override;
-    void setFromValue(const WebCore::FilterOperation*) override;
+    void setFromValue(const WebCore::FilterOperation&) override;
     void copyFromValueFrom(const WebCore::PlatformCAAnimation&) override;
 
     void setToValue(float) override;
     void setToValue(const WebCore::TransformationMatrix&) override;
     void setToValue(const WebCore::FloatPoint3D&) override;
     void setToValue(const WebCore::Color&) override;
-    void setToValue(const WebCore::FilterOperation*) override;
+    void setToValue(const WebCore::FilterOperation&) override;
     void copyToValueFrom(const WebCore::PlatformCAAnimation&) override;
 
     // Keyframe-animation properties.
@@ -105,7 +105,7 @@ public:
     void setValues(const Vector<WebCore::TransformationMatrix>&) override;
     void setValues(const Vector<WebCore::FloatPoint3D>&) override;
     void setValues(const Vector<WebCore::Color>&) override;
-    void setValues(const Vector<RefPtr<WebCore::FilterOperation>>&) override;
+    void setValues(const Vector<Ref<WebCore::FilterOperation>>&) override;
     void copyValuesFrom(const WebCore::PlatformCAAnimation&) override;
 
     void setKeyTimes(const Vector<float>&) override;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm
@@ -312,13 +312,13 @@ void PlatformCAAnimationRemote::setFromValue(const Color& value)
     m_properties.keyValues[0] = KeyframeValue(value);
 }
 
-void PlatformCAAnimationRemote::setFromValue(const FilterOperation* operation)
+void PlatformCAAnimationRemote::setFromValue(const FilterOperation& operation)
 {
     if (animationType() != AnimationType::Basic)
         return;
 
     m_properties.keyValues.resize(2);
-    m_properties.keyValues[0] = KeyframeValue(operation->clone());
+    m_properties.keyValues[0] = KeyframeValue(operation.clone());
 }
 
 void PlatformCAAnimationRemote::copyFromValueFrom(const PlatformCAAnimation& value)
@@ -368,14 +368,13 @@ void PlatformCAAnimationRemote::setToValue(const Color& value)
     m_properties.keyValues[1] = KeyframeValue(value);
 }
 
-void PlatformCAAnimationRemote::setToValue(const FilterOperation* operation)
+void PlatformCAAnimationRemote::setToValue(const FilterOperation& operation)
 {
     if (animationType() != AnimationType::Basic)
         return;
     
-    ASSERT(operation);
     m_properties.keyValues.resize(2);
-    m_properties.keyValues[1] = KeyframeValue(operation->clone());
+    m_properties.keyValues[1] = KeyframeValue(operation.clone());
 }
 
 void PlatformCAAnimationRemote::copyToValueFrom(const PlatformCAAnimation& value)
@@ -421,7 +420,7 @@ void PlatformCAAnimationRemote::setValues(const Vector<Color>& values)
     m_properties.keyValues = toKeyframeValueVector(values);
 }
 
-void PlatformCAAnimationRemote::setValues(const Vector<RefPtr<FilterOperation>>& values)
+void PlatformCAAnimationRemote::setValues(const Vector<Ref<FilterOperation>>& values)
 {
     if (animationType() != AnimationType::Keyframe)
         return;
@@ -476,7 +475,9 @@ void PlatformCAAnimationRemote::copyAnimationsFrom(const PlatformCAAnimation& va
 static RetainPtr<NSObject> animationValueFromKeyframeValue(const PlatformCAAnimationRemote::KeyframeValue& keyframeValue)
 {
     return WTF::switchOn(keyframeValue,
-        [&](const float number) -> RetainPtr<NSObject> { return @(number); },
+        [&](const float number) -> RetainPtr<NSObject> {
+            return @(number);
+        },
         [&](const WebCore::Color color) -> RetainPtr<NSObject> {
             auto [r, g, b, a] =  color.toColorTypeLossy<SRGBA<uint8_t>>().resolved();
             return @[ @(r), @(g), @(b), @(a) ];
@@ -487,7 +488,7 @@ static RetainPtr<NSObject> animationValueFromKeyframeValue(const PlatformCAAnima
         [&](const WebCore::TransformationMatrix matrix) -> RetainPtr<NSObject> {
             return [NSValue valueWithCATransform3D:matrix];
         },
-        [&](const RefPtr<WebCore::FilterOperation> filter) -> RetainPtr<NSObject> {
+        [&](const Ref<WebCore::FilterOperation> filter) -> RetainPtr<NSObject> {
             return PlatformCAFilters::filterValueForOperation(filter.get());
         }
     );
@@ -707,7 +708,7 @@ TextStream& operator<<(TextStream& ts, const PlatformCAAnimationRemote::Properti
                 [&](const WebCore::Color color) { ts << "color=" << color; },
                 [&](const WebCore::FloatPoint3D point) { ts << "point=" << point; },
                 [&](const WebCore::TransformationMatrix matrix) { ts << "transform=" << matrix; },
-                [&](const RefPtr<WebCore::FilterOperation> filter) { ts << "filter=" << ValueOrNull(filter.get()); }
+                [&](const Ref<WebCore::FilterOperation> filter) { ts << "filter=" << filter; }
             );
             ts.endGroup();
         }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemoteProperties.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemoteProperties.h
@@ -52,7 +52,7 @@ struct PlatformCAAnimationRemoteProperties {
 
     // For basic animations, these vectors have two entries. For keyframe animations, two or more.
     // timingFunctions has n-1 entries.
-    using KeyframeValue = std::variant<float, WebCore::Color, WebCore::FloatPoint3D, WebCore::TransformationMatrix, RefPtr<WebCore::FilterOperation>>;
+    using KeyframeValue = std::variant<float, WebCore::Color, WebCore::FloatPoint3D, WebCore::TransformationMatrix, Ref<WebCore::FilterOperation>>;
     Vector<KeyframeValue> keyValues;
     Vector<float> keyTimes;
     Vector<Ref<WebCore::TimingFunction>> timingFunctions;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemoteProperties.serialization.in
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemoteProperties.serialization.in
@@ -47,4 +47,4 @@ struct WebKit::PlatformCAAnimationRemoteProperties {
     Vector<WebKit::PlatformCAAnimationRemoteProperties> animations;
 };
 
-using WebKit::PlatformCAAnimationRemoteProperties::KeyframeValue = std::variant<float, WebCore::Color, WebCore::FloatPoint3D, WebCore::TransformationMatrix, RefPtr<WebCore::FilterOperation>>
+using WebKit::PlatformCAAnimationRemoteProperties::KeyframeValue = std::variant<float, WebCore::Color, WebCore::FloatPoint3D, WebCore::TransformationMatrix, Ref<WebCore::FilterOperation>>

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
@@ -469,7 +469,7 @@ static bool filtersCanBeComposited(const FilterOperations& filters)
 {
     if (!filters.size())
         return false;
-    for (const auto& filterOperation : filters.operations()) {
+    for (const auto& filterOperation : filters) {
         if (filterOperation->type() == FilterOperation::Type::Reference)
             return false;
     }


### PR DESCRIPTION
#### 265f430df9e58c0d9c2ebcea32a2d4da4f047d59
<pre>
General cleanup of FilterOperations
<a href="https://bugs.webkit.org/show_bug.cgi?id=274781">https://bugs.webkit.org/show_bug.cgi?id=274781</a>

Reviewed by Darin Adler.

Makes some small improvements to the FilterOperations type:

- Use Ref instead of RefPtr in operations vector.
- Made immutable. All construction already happened in one shot in the builder
  or blend functions, or was a full replacement, so this just meant removing
  non-const accessors and removing the clear() function.
- Expose iterators directly to avoid clients accessing the underlying vector.

The fallout of using Ref for the operations vector led to some fallout requiring
more use of Ref or reference types to indicate non-null state.

* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForFilter):
    - Use isEmpty() from FilterOperations directly, and update for Ref values
      during iteration.

* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp:
(WebCore::AcceleratedEffectValues::AcceleratedEffectValues):
(WebCore::AcceleratedEffectValues::clone const):
    - Use clone() helper and copy construction.

* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::validateFilterOperations):
     - Use isEmpty() from FilterOperations directly.

* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::FilterAnimationValue::FilterAnimationValue):
    - Use clone() helper.

(WebCore::GraphicsLayer::clearFilters):
(WebCore::GraphicsLayer::clearBackdropFilters):
    - Re-initialize the whole type rather than clearing internal state.

* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::createFilterAnimationsFromKeyframes):
(WebCore::GraphicsLayerCA::setFilterAnimationEndpoints):
(WebCore::GraphicsLayerCA::setFilterAnimationKeyframes):
    - Update to account for Ref FilterOperations.

* Source/WebCore/platform/graphics/ca/PlatformCAAnimation.h:
* Source/WebCore/platform/graphics/ca/PlatformCAFilters.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm:
    - Update to use FilterOperation&amp; and Ref&lt;FilterOperation&gt; parameters. All
      implementations already assumed the values were non-null, so now the types
      also know it.

* Source/WebCore/platform/graphics/filters/FilterOperations.cpp:
(WebCore::FilterOperations::FilterOperations):
(WebCore::FilterOperations::operator== const):
(WebCore::FilterOperations::operationsMatch const):
    - Update to account for Ref values in m_operations.

(WebCore::FilterOperations::hasReferenceFilter const):
    - Use new hasFilterOfType&lt;T&gt; helper.

(WebCore::FilterOperations::outsets const):
    - Update to account for Ref values in m_operations.

(WebCore::FilterOperations::hasFilterThatAffectsOpacity const):
(WebCore::FilterOperations::hasFilterThatMovesPixels const):
(WebCore::FilterOperations::hasFilterThatShouldBeRestrictedBySecurityOrigin const):
    - Use WTF::anyOf rather than explicit loop.

(WebCore::FilterOperations::blend const):
    - Use explicit Vector&lt;Ref&lt;FilterOperation&gt;&gt; for constructing blended results,
      allowing for the use of reserveInitialCapacity optimization.

(WebCore::operator&lt;&lt;):
    - Remove now unnecessary null-check and use existing container serializer
      instead of re-implementing.

* Source/WebCore/platform/graphics/filters/FilterOperations.h:
(WebCore::FilterOperations::FilterOperations):
    - Add copy and move constructors/assignment operators.

(WebCore::FilterOperations::clone const):
    - Add helper to create a clone() of each operation.

(WebCore::FilterOperations::operations const):
    - Remove non-const overloads.

(WebCore::FilterOperations::at const):
    - Update to account for Ref in m_operations.

(WebCore::FilterOperations::hasFilterOfType const):
    - Helper which can check if any operation is a particular type.

(WebCore::FilterOperations::clear): Deleted.
(WebCore::FilterOperations::operations): Deleted.
(WebCore::FilterOperations::setOperations): Deleted.
    - Remove member functions that mutated the underlying vector.

* Source/WebCore/style/FilterOperationsBuilder.cpp:
(WebCore::Style::createFilterOperations):
    - Use explicit Vector&lt;Ref&lt;FilterOperation&gt;&gt; for constructing results
      and shrinkToFit at the end.

* Source/WebCore/rendering/CSSFilter.cpp:
* Source/WebCore/rendering/ReferencedSVGResources.cpp:
* Source/WebCore/rendering/RenderLayerFilters.cpp:
* Source/WebCore/rendering/style/StyleFilterImage.cpp:
    - Update to account for Ref in m_operations.

* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::hasAppleColorFilter const):
(WebCore::RenderStyle::hasFilter const):
(WebCore::RenderStyle::hasBackdropFilter const):
    - Use isEmpty() directly on FilterOperations.

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
    - Update to account for Ref in m_operations.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::updatePageBackgroundLayers):
    - Construct FilterOperations directly rather than using temporary vector.

* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemote.mm:
(WebKit::PlatformCAAnimationRemote::setFromValue):
(WebKit::PlatformCAAnimationRemote::setToValue):
(WebKit::PlatformCAAnimationRemote::setValues):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemoteProperties.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCAAnimationRemoteProperties.serialization.in:
    - Update for use of Ref and reference types for FilterOperation.

Canonical link: <a href="https://commits.webkit.org/279490@main">https://commits.webkit.org/279490@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b6bc67850b5d026bb15f640f400d671fc77e3b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wincairo-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-17-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11686 "Built successfully and passed tests") | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-10-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-10-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->