### PR TITLE
Web Inspector: Remove a`border-color` in LocalResourceOverridePopover.css

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/LocalResourceOverridePopover.css
+++ b/Source/WebInspectorUI/UserInterface/Views/LocalResourceOverridePopover.css
@@ -64,9 +64,8 @@
     width: 100%;
     padding: 4px 0 2px;
     appearance: unset;
-    border: 1px solid hsl(0, 0%, 78%);
+    border: 1px solid var(--text-color-quaternary);
     background: var(--background-color-content);
-    border-color: var(--text-color-quaternary);
 }
 
 .popover .local-resource-override-popover-content .editor > .CodeMirror {


### PR DESCRIPTION
#### 9db53fe59a38be5ece234a0e2693d76ee6ab2a22
<pre>
Web Inspector: Remove a`border-color` in LocalResourceOverridePopover.css
<a href="https://bugs.webkit.org/show_bug.cgi?id=274793">https://bugs.webkit.org/show_bug.cgi?id=274793</a>

Reviewed by Devin Rousso.

There are `border` and `border-color` in `.popover .local-resource-override-popover-content.editor` in LocalResourceOverridePopover.css.
Removing `border-color` because we do not need both `border` and `border-color`.

* Source/WebInspectorUI/UserInterface/Views/LocalResourceOverridePopover.css:
(.popover .local-resource-override-popover-content .editor):

Canonical link: <a href="https://commits.webkit.org/279436@main">https://commits.webkit.org/279436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a51ad79ed9c687df9c21bb365d15ee396db42c8d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53482 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56762 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4208 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40301 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43351 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2757 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55580 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46220 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24487 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27891 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3540 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2364 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49651 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3710 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58357 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28639 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3708 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50750 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29846 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46412 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50095 "Found 3 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11663 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30774 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29616 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->