### PR TITLE
[WebGPU] Replace asynchronous .requestAdapterInfo() with synchronous .info

### DIFF
--- a/LayoutTests/fast/webgpu/write-to-destroyed-buffer.html
+++ b/LayoutTests/fast/webgpu/write-to-destroyed-buffer.html
@@ -68,14 +68,6 @@ mappedAtCreation: true,
 }
 );
 
-try {
-await adapter0.requestAdapterInfo(
-[
-`a`
-]
-);
-} catch {}
-
 let pipelineLayout0 = device0.createPipelineLayout(
 {
 label: 'a',
@@ -182,12 +174,7 @@ label: 'a',
 try {
 await device0.queue.onSubmittedWorkDone();
 } catch {}
-let promise3 = adapter1.requestAdapterInfo(
-[
-`a`,
-`a`
-]
-);
+
 try {
 buffer0.unmap();
 } catch {}
@@ -202,13 +189,7 @@ try {
 await device0.queue.onSubmittedWorkDone();
 } catch {}
 let canvas1 = document.createElement('canvas');
-try {
-await adapter1.requestAdapterInfo(
-[
-`a`
-]
-);
-} catch {}
+
 try {
 buffer0.unmap();
 } catch {}
@@ -308,9 +289,7 @@ maxColorAttachmentBytesPerSample: 32 + Math.floor((adapter0.limits.maxColorAttac
 );
 
 let imageData0 = new ImageData(56, 248);
-try {
-await adapter0.requestAdapterInfo();
-} catch {}
+
 let gpuCanvasContext0 = canvas1.getContext('webgpu');
 let adapter2 = await navigator.gpu.requestAdapter();
 let querySet1 = device2.createQuerySet(
@@ -548,13 +527,7 @@ commandEncoder1.insertDebugMarker(
 try {
 await device2.popErrorScope();
 } catch {}
-try {
-await adapter2.requestAdapterInfo(
-[
-`a`
-]
-);
-} catch {}
+
 let adapter5 = await promise4;
 
 try {

--- a/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
@@ -121,9 +121,9 @@ void GPUAdapter::requestDevice(ScriptExecutionContext& scriptExecutionContext, c
     });
 }
 
-void GPUAdapter::requestAdapterInfo(const std::optional<Vector<String>>&, RequestAdapterInfoPromise&& promise)
+Ref<GPUAdapterInfo> GPUAdapter::info()
 {
-    promise.resolve(GPUAdapterInfo::create(name()));
+    return GPUAdapterInfo::create(name());
 }
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUAdapter.h
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapter.h
@@ -55,8 +55,7 @@ public:
     using RequestDevicePromise = DOMPromiseDeferred<IDLInterface<GPUDevice>>;
     void requestDevice(ScriptExecutionContext&, const std::optional<GPUDeviceDescriptor>&, RequestDevicePromise&&);
 
-    using RequestAdapterInfoPromise = DOMPromiseDeferred<IDLInterface<GPUAdapterInfo>>;
-    void requestAdapterInfo(const std::optional<Vector<String>>&, RequestAdapterInfoPromise&&);
+    Ref<GPUAdapterInfo> info();
 
     WebGPU::Adapter& backing() { return m_backing; }
     const WebGPU::Adapter& backing() const { return m_backing; }

--- a/Source/WebCore/Modules/WebGPU/GPUAdapter.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapter.idl
@@ -31,11 +31,10 @@
     SecureContext
 ]
 interface GPUAdapter {
-    readonly attribute DOMString name;
     [SameObject] readonly attribute GPUSupportedFeatures features;
     [SameObject] readonly attribute GPUSupportedLimits limits;
+    [SameObject] readonly attribute GPUAdapterInfo info;
     readonly attribute boolean isFallbackAdapter;
 
     [CallWith=CurrentScriptExecutionContext] Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor);
-    Promise<GPUAdapterInfo> requestAdapterInfo(optional sequence<DOMString> unmaskHints = []);
 };


### PR DESCRIPTION
#### 47fff30b64bae1af23c31003286f81691f9f115b
<pre>
[WebGPU] Replace asynchronous .requestAdapterInfo() with synchronous .info
<a href="https://bugs.webkit.org/show_bug.cgi?id=274797">https://bugs.webkit.org/show_bug.cgi?id=274797</a>
&lt;radar://128896785&gt;

Reviewed by Dan Glastonbury.

Per recent spec change, requestAdapterInfo has become a synchronous info
call.

Our implementation already resolved the promise synchronously, so the impact
is minimal.

* Source/WebCore/Modules/WebGPU/GPUAdapter.cpp:
(WebCore::GPUAdapter::info):
(WebCore::GPUAdapter::requestAdapterInfo): Deleted.
* Source/WebCore/Modules/WebGPU/GPUAdapter.h:
* Source/WebCore/Modules/WebGPU/GPUAdapter.idl:

Canonical link: <a href="https://commits.webkit.org/279461@main">https://commits.webkit.org/279461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/948eb5b0fd6ddef2e7a638ca332be6f092768248

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32900 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56823 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4269 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55849 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40369 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4087 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43400 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2803 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55641 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31092 "Found 3 new test failures: compositing/overflow/clipping-ancestor-with-accelerated-scrolling-ancestor.html, compositing/reflections/animation-inside-reflection.html, compositing/rtl/rtl-overflow-scrolling.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46272 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24539 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27940 "Found 2 new test failures: imported/w3c/web-platform-tests/beacon/beacon-cors.https.window.html, imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/inferred-mrow-stretchy.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3591 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2425 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3763 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58420 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28701 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3800 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50806 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29907 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/46448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50144 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11677 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30836 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29679 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->