### PR TITLE
Don't consider 'fill' a presentation attribute on animation elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-special-cases-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-special-cases-expected.txt
@@ -16,11 +16,11 @@ FAIL x, y, width, and height presentation attributes not supported on other elem
 FAIL r presentation attribute not supported on other elements assert_false: Presentation attribute r="1" should not be supported on g element expected false got true
 FAIL rx and ry presentation attributes not supported on other elements assert_false: Presentation attribute rx="1" should not be supported on g element expected false got true
 PASS d presentation attribute not supported on other elements
-FAIL fill presentation attribute not supported on animate assert_false: Presentation attribute fill="blue" should not be supported on animate element expected false got true
-FAIL fill presentation attribute not supported on animateMotion assert_false: Presentation attribute fill="blue" should not be supported on animateMotion element expected false got true
-FAIL fill presentation attribute not supported on animateTransform assert_false: Presentation attribute fill="blue" should not be supported on animateTransform element expected false got true
+PASS fill presentation attribute not supported on animate
+PASS fill presentation attribute not supported on animateMotion
+PASS fill presentation attribute not supported on animateTransform
 FAIL fill presentation attribute not supported on discard assert_false: Presentation attribute fill="blue" should not be supported on discard element expected false got true
-FAIL fill presentation attribute not supported on set assert_false: Presentation attribute fill="blue" should not be supported on set element expected false got true
+PASS fill presentation attribute not supported on set
 FAIL transform presentation attribute supported on g assert_true: Presentation attribute transform="scale(2)" should be supported on g element expected true got false
 FAIL patternTransform presentation attribute supported on pattern assert_true: Presentation attribute patternTransform="scale(2)" should be supported on pattern element expected true got false
 FAIL patternTransform presentation attribute supported on linearGradient assert_true: Presentation attribute gradientTransform="scale(2)" should be supported on linearGradient element expected true got false

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -213,6 +213,14 @@ void SVGSMILElement::buildPendingResource()
         svgTarget->addReferencingElement(*this);
 }
 
+bool SVGSMILElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const
+{
+    // https://svgwg.org/svg2-draft/styling.html#PresentationAttributes
+    if (name == SVGNames::fillAttr)
+        return false;
+    return StyledElement::hasPresentationalHintsForAttribute(name);
+}
+
 inline QualifiedName SVGSMILElement::constructAttributeName() const
 {
     auto parseResult = Document::parseQualifiedName(attributeWithoutSynchronization(SVGNames::attributeNameAttr));

--- a/Source/WebCore/svg/animation/SVGSMILElement.h
+++ b/Source/WebCore/svg/animation/SVGSMILElement.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2008-2024 Apple Inc. All rights reserved.
- * Copyright (C) 2013 Google Inc. All rights reserved.
+ * Copyright (C) 2013-2020 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -137,6 +137,7 @@ private:
     virtual void updateAnimation(float percent, unsigned repeat) = 0;
 
     static bool isSupportedAttribute(const QualifiedName&);
+    bool hasPresentationalHintsForAttribute(const QualifiedName&) const override;
     QualifiedName constructAttributeName() const;
     void updateAttributeName();
 


### PR DESCRIPTION
#### a0c45ccc4d6a65ce7f2df1f684cfe0abc03f07cd
<pre>
Don&apos;t consider &apos;fill&apos; a presentation attribute on animation elements

<a href="https://bugs.webkit.org/show_bug.cgi?id=274796">https://bugs.webkit.org/show_bug.cgi?id=274796</a>
<a href="https://rdar.apple.com/problem/128896937">rdar://problem/128896937</a>

Reviewed by Simon Fraser.

Merge: <a href="https://chromium-review.googlesource.com/c/chromium/src/+/2080237">https://chromium-review.googlesource.com/c/chromium/src/+/2080237</a>

This patch aligns WebKit with Gecko / Firefox,
Blink / Chromium and web-specification [1]:

[1] <a href="https://svgwg.org/svg2-draft/styling.html#PresentationAttributes">https://svgwg.org/svg2-draft/styling.html#PresentationAttributes</a>

Elements that support the presentation attribute:

&quot;Any element in the SVG namespace except for animation elements,
which have a different ‘fill’ attribute.&quot;

* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::hasPresentationalHintsForAttribute const):
* Source/WebCore/svg/animation/SVGSMILElement.h:
* LayoutTests/imported/w3c/web-platform-tests/svg/styling/presentation-attributes-special-cases-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/282100@main">https://commits.webkit.org/282100@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9e0627eba113435e0a147d29c7999d543763169

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66071 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12636 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64210 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49131 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/12976 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50005 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8730 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65160 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38466 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53773 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30836 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35110 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11009 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11567 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/56905 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67799 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6034 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11076 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57383 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6060 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53722 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57633 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13797 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/4946 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37245 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38329 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39425 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38074 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->