### PR TITLE
[Site Isolation] Add a test for window.length on an opened window

### DIFF
--- a/LayoutTests/http/tests/site-isolation/opened-window-length-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/opened-window-length-expected.txt
@@ -1,0 +1,10 @@
+Verifies that windows opened with same-origin and cross-origin iframes have a correct length.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS lengths is [2, 2]
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/opened-window-length.html
+++ b/LayoutTests/http/tests/site-isolation/opened-window-length.html
@@ -1,0 +1,26 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Verifies that windows opened with same-origin and cross-origin iframes have a correct length.");
+jsTestIsAsync = true;
+
+var lengths = [];
+onmessage = (event) => {
+    if (event.data == "#w1")
+        lengths.push(w1.length);
+    else if (event.data == "#w2")
+        lengths.push(w2.length);
+
+    if (lengths.length == 2) {
+        shouldBe("lengths", "[2, 2]");
+        finishJSTest();
+    }
+}
+
+function runTest() {
+    w1 = window.open("http://localhost:8000/site-isolation/resources/post-message-to-opener-on-iframes-load.html#w1");
+    w2 = window.open("http://127.0.0.1:8000/site-isolation/resources/post-message-to-opener-on-iframes-load.html#w2");
+}
+</script>
+<body onload="runTest()">
+</body>

--- a/LayoutTests/http/tests/site-isolation/resources/post-message-to-opener-on-iframes-load.html
+++ b/LayoutTests/http/tests/site-isolation/resources/post-message-to-opener-on-iframes-load.html
@@ -1,0 +1,9 @@
+<script>
+var i = 0;
+function load() {
+    if (++i == 2)
+        window.opener.postMessage(location.hash, "*");
+}
+</script>
+<iframe onload="load()" src="http://127.0.0.1:8000/site-isolation/resources/green-background.html"></iframe>
+<iframe onload="load()" src="http://localhost:8000/site-isolation/resources/green-background.html"></iframe>


### PR DESCRIPTION
#### c9a7758190f779d1ab23fee09243e74ccf0b05ef
<pre>
[Site Isolation] Add a test for window.length on an opened window
<a href="https://bugs.webkit.org/show_bug.cgi?id=274806">https://bugs.webkit.org/show_bug.cgi?id=274806</a>
<a href="https://rdar.apple.com/128903816">rdar://128903816</a>

Reviewed by Sihui Liu.

This already works, but there is no test.

* LayoutTests/http/tests/site-isolation/opened-window-length-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/opened-window-length.html: Added.
* LayoutTests/http/tests/site-isolation/resources/post-message-to-opener-on-iframes-load.html: Added.

Canonical link: <a href="https://commits.webkit.org/279412@main">https://commits.webkit.org/279412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57b1543e6342872385ed7a374736cbf234d1eec8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32806 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5955 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/56730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/4176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3953 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/56730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/4176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55548 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/30993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46184 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/56730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3500 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/2332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58325 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28607 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/29814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46376 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7857 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29584 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->