### PR TITLE
Fix broken WebAuthn U2F test

### DIFF
--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-u2f.https-expected.txt
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-u2f.https-expected.txt
@@ -4,7 +4,6 @@ PASS PublicKeyCredential's [[get]] with more allow credentials in a mock hid aut
 PASS PublicKeyCredential's [[get]] with test of user presence in a mock hid authenticator.
 PASS PublicKeyCredential's [[get]] with empty extensions in a mock hid authenticator.
 PASS PublicKeyCredential's [[get]] with same site AppID but not used in a mock hid authenticator.
-PASS PublicKeyCredential's [[get]] with empty AppID in a mock hid authenticator.
 PASS PublicKeyCredential's [[get]] with an AppID in a mock hid authenticator.
 PASS PublicKeyCredential's [[get]] with multiple credentials and AppID is not used in a mock hid authenticator.
 PASS PublicKeyCredential's [[get]] with multiple credentials and AppID is used in a mock hid authenticator.

--- a/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-u2f.https.html
+++ b/LayoutTests/http/wpt/webauthn/public-key-credential-get-success-u2f.https.html
@@ -87,23 +87,6 @@
         });
     }, "PublicKeyCredential's [[get]] with same site AppID but not used in a mock hid authenticator.");
 
-    promise_test(t => {
-        const options = {
-            publicKey: {
-                challenge: Base64URL.parse("MTIzNDU2"),
-                allowCredentials: [{ type: "public-key", id: Base64URL.parse(testU2fCredentialIdBase64) }],
-                timeout: 100,
-                extensions: { appid: "" }
-            }
-        };
-
-        if (window.internals)
-            internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "success", isU2f: true, payloadBase64: [testU2fApduWrongDataOnlyResponseBase64, testU2fSignResponse] } });
-        return navigator.credentials.get(options).then(credential => {
-            return checkU2fGetAssertionResult(credential, true);
-        });
-    }, "PublicKeyCredential's [[get]] with empty AppID in a mock hid authenticator.");
-
     // FIXME: Sub domains need to be tested as well. However, localhost has no sub domains.
     promise_test(t => {
         const options = {
@@ -128,7 +111,7 @@
                 challenge: Base64URL.parse("MTIzNDU2"),
                 allowCredentials: [{ type: "public-key", id: Base64URL.parse(testCredentialIdBase64) }, { type: "public-key", id: Base64URL.parse(testU2fCredentialIdBase64) }],
                 timeout: 100,
-                extensions: { appid: "" }
+                extensions: { appid: "https://localhost:666/appid" }
             }
         };
 
@@ -145,14 +128,14 @@
                 challenge: Base64URL.parse("MTIzNDU2"),
                 allowCredentials: [{ type: "public-key", id: Base64URL.parse(testCredentialIdBase64) }, { type: "public-key", id: Base64URL.parse(testU2fCredentialIdBase64) }],
                 timeout: 100,
-                extensions: { appid: "" }
+                extensions: { appid: "https://localhost:666/appid" }
             }
         };
 
         if (window.internals)
             internals.setMockWebAuthenticationConfiguration({ hid: { stage: "request", subStage: "msg", error: "success", isU2f: true, payloadBase64: [testU2fApduWrongDataOnlyResponseBase64, testU2fApduWrongDataOnlyResponseBase64, testU2fApduWrongDataOnlyResponseBase64, testU2fSignResponse] } });
         return navigator.credentials.get(options).then(credential => {
-            return checkU2fGetAssertionResult(credential, true);
+            return checkU2fGetAssertionResult(credential, true, "7eabc5cc3251bdc59115ef87b5f7ee74cb03747e39ba8341748565cc129c0719");
         });
     }, "PublicKeyCredential's [[get]] with multiple credentials and AppID is used in a mock hid authenticator.");
 


### PR DESCRIPTION
#### a3f169032e635841b8dd2af1b7f6e3e2d2fac30e
<pre>
Fix broken WebAuthn U2F test
<a href="https://bugs.webkit.org/show_bug.cgi?id=274807">https://bugs.webkit.org/show_bug.cgi?id=274807</a>
<a href="https://rdar.apple.com/problem/128904316">rdar://problem/128904316</a>

Reviewed by Pascoe.

Tests with an empty appid should not pass

* LayoutTests/http/wpt/webauthn/public-key-credential-get-success-u2f.https-expected.txt:
* LayoutTests/http/wpt/webauthn/public-key-credential-get-success-u2f.https.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/279709@main">https://commits.webkit.org/279709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6be6d9bd26e0cdc1f2a519d0f99a5c2604a9b03b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57446 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4894 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4875 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43866 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3268 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31805 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46905 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25013 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28609 "Found 1 new test failure: imported/w3c/web-platform-tests/html/dom/idlharness.https.html?exclude=(Document|Window|HTML.*) (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4225 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-autofocus.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3043 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50313 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4430 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59039 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29371 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4615 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51288 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30545 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47017 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50644 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11817 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31512 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30325 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->