### PR TITLE
[Remote Inspection] Adjust the heuristic when computing the adjustment rect count

### DIFF
--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -1638,14 +1638,23 @@ uint64_t ElementTargetingController::numberOfVisibilityAdjustmentRects() const
 
     Vector<FloatRect> clientRects;
     clientRects.reserveInitialCapacity(m_adjustedElements.computeSize());
+
+    unsigned numberOfParentedEmptyOrNonRenderedElements = 0;
     for (auto& element : m_adjustedElements) {
-        CheckedPtr renderer = element.renderer();
-        if (!renderer)
+        if (!element.isConnected())
             continue;
 
-        auto clientRect = computeClientRect(*renderer);
-        if (clientRect.isEmpty())
+        CheckedPtr renderer = element.renderer();
+        if (!renderer) {
+            numberOfParentedEmptyOrNonRenderedElements++;
             continue;
+        }
+
+        auto clientRect = computeClientRect(*renderer);
+        if (clientRect.isEmpty()) {
+            numberOfParentedEmptyOrNonRenderedElements++;
+            continue;
+        }
 
         clientRects.append(clientRect);
     }
@@ -1667,7 +1676,7 @@ uint64_t ElementTargetingController::numberOfVisibilityAdjustmentRects() const
         adjustedRegion.unite(enclosingRect);
     }
 
-    return numberOfRects;
+    return numberOfParentedEmptyOrNonRenderedElements + numberOfRects;
 }
 
 void ElementTargetingController::cleanUpAdjustmentClientRects()

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
@@ -351,6 +351,12 @@ TEST(ElementTargeting, AdjustVisibilityFromSelectors)
         EXPECT_TRUE([adjustedSelectors containsObject:@".absolute.bottom-right"]);
         EXPECT_TRUE([adjustedSelectors containsObject:@".fixed.container"]);
         EXPECT_TRUE([adjustedSelectors containsObject:@".absolute.bottom-left"]);
+
+        [webView objectByEvaluatingJavaScript:@"[...document.querySelectorAll('.fixed,.absolute')].map(e => e.style.display = 'none')"];
+        [webView waitForNextPresentationUpdate];
+        EXPECT_GT([webView numberOfVisibilityAdjustmentRects], 0U);
+        [webView objectByEvaluatingJavaScript:@"[...document.querySelectorAll('.fixed,.absolute')].map(e => e.style.display = '')"];
+        [webView waitForNextPresentationUpdate];
     }
 
     [webView resetVisibilityAdjustmentsForTargets:nil];


### PR DESCRIPTION
#### 3abd48ae06eaeb85830aa83b2983cf0b80fefa15
<pre>
[Remote Inspection] Adjust the heuristic when computing the adjustment rect count
<a href="https://bugs.webkit.org/show_bug.cgi?id=274810">https://bugs.webkit.org/show_bug.cgi?id=274810</a>
<a href="https://rdar.apple.com/128885913">rdar://128885913</a>

Reviewed by Abrar Rahman Protyasha and Megan Gardner.

Make a minor adjustment to how we handle empty (or `display: none;`) elements when getting the total
adjustment rect count, so that they count towards the final result.

* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::ElementTargetingController::numberOfVisibilityAdjustmentRects const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm:
(TestWebKitAPI::TEST(ElementTargeting, AdjustVisibilityFromSelectors)):

Canonical link: <a href="https://commits.webkit.org/279424@main">https://commits.webkit.org/279424@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a2baaa97063105b3ba0b32a1e42421dde034a0d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56746 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4192 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40267 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3971 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43334 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2743 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31006 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46202 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24469 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3522 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2348 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3696 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58341 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28623 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3687 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50737 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29830 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46398 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11652 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30758 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29600 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->