### PR TITLE
Do further std::span adoption in PDFIncrementalLoader

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
@@ -77,7 +77,7 @@ public:
 #endif
 
     // Only public for the callbacks
-    size_t dataProviderGetBytesAtPosition(void* buffer, off_t position, size_t count);
+    size_t dataProviderGetBytesAtPosition(std::span<uint8_t> buffer, off_t position);
     void dataProviderGetByteRanges(CFMutableArrayRef buffers, const CFRange* ranges, size_t count);
 
 private:
@@ -90,11 +90,11 @@ private:
 
     void appendAccumulatedDataToDataBuffer(ByteRangeRequest&);
 
-    std::span<const uint8_t> dataPtrForRange(uint64_t position, size_t count, CheckValidRanges) const;
+    std::span<const uint8_t> dataSpanForRange(uint64_t position, size_t count, CheckValidRanges) const;
     uint64_t availableDataSize() const;
 
     void getResourceBytesAtPosition(size_t count, off_t position, DataRequestCompletionHandler&&);
-    size_t getResourceBytesAtPositionAfterLoadingComplete(void* buffer, off_t position, size_t count);
+    size_t getResourceBytesAtPositionAfterLoadingComplete(std::span<uint8_t> buffer, off_t position);
 
     void unconditionalCompleteOutstandingRangeRequests();
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -276,9 +276,9 @@ private:
     void insertRangeRequestData(uint64_t offset, const Vector<uint8_t>&);
 
     // Returns the number of bytes copied.
-    size_t copyDataAtPosition(void* buffer, uint64_t sourcePosition, size_t count) const;
+    size_t copyDataAtPosition(std::span<uint8_t> buffer, uint64_t sourcePosition) const;
     // FIXME: It would be nice to avoid having both the "copy into a buffer" and "return a pointer" ways of getting data.
-    std::span<const uint8_t> dataPtrForRange(uint64_t sourcePosition, size_t count, CheckValidRanges) const;
+    std::span<const uint8_t> dataSpanForRange(uint64_t sourcePosition, size_t count, CheckValidRanges) const;
     // Returns true only if we can satisfy all of the requests.
     bool getByteRanges(CFMutableArrayRef, const CFRange*, size_t count) const;
 


### PR DESCRIPTION
#### dac9c240c87194928dc8755a2202d8120b683a53
<pre>
Do further std::span adoption in PDFIncrementalLoader
<a href="https://bugs.webkit.org/show_bug.cgi?id=274813">https://bugs.webkit.org/show_bug.cgi?id=274813</a>

Reviewed by Abrar Rahman Protyasha and Darin Adler.

* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::ByteRangeRequest::completeUnconditionally):
(WebKit::PDFIncrementalLoader::dataSpanForRange const):
(WebKit::PDFIncrementalLoader::getResourceBytesAtPositionAfterLoadingComplete):
(WebKit::PDFIncrementalLoader::requestCompleteIfPossible):
(WebKit::dataProviderGetBytesAtPositionCallback):
(WebKit::PDFIncrementalLoader::dataProviderGetBytesAtPosition):
(WebKit::PDFIncrementalLoader::dataPtrForRange const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::copyDataAtPosition const):
(WebKit::PDFPluginBase::dataSpanForRange const):
(WebKit::PDFPluginBase::dataPtrForRange const): Deleted.

Canonical link: <a href="https://commits.webkit.org/279440@main">https://commits.webkit.org/279440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f83205e9c2dd4b8a61d2fcd72099540a6fa5e8e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53476 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/5982 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56756 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4202 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/3983 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43342 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2754 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31017 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46210 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24477 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27876 "4 new passes 3 flakes") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2358 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49636 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3704 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58351 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28633 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3699 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50744 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29840 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46406 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50088 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30768 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7875 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29610 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->