### PR TITLE
Enable copy-pasting file lists to run-webkit-tests from EWS “Found N new test failures” output

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -563,6 +563,9 @@ def run(port, options, args, logging_stream):
         manager = Manager(port, options, printer)
         printer.print_config(port.results_directory())
 
+        # Facilitate pasting in a comma-separated list of pathnames from the
+        # “Found N new test failures” list at the top of EWS builder report pages.
+        args = [arg.rstrip(",") for arg in args]
         run_details = manager.run(args)
         _log.debug("Testing completed, Exit status: %d" % run_details.exit_code)
         return run_details


### PR DESCRIPTION
#### 68d34dc31e583d15ac6d61dde0a587a3c2b14818
<pre>
Enable copy-pasting file lists to run-webkit-tests from EWS “Found N new test failures” output
<a href="https://bugs.webkit.org/show_bug.cgi?id=274814">https://bugs.webkit.org/show_bug.cgi?id=274814</a>

Reviewed by NOBODY (OOPS!).

This change makes run-webkit-tests accept/allow (optional) comma
separators in the list of test-case pathnames you give it to run.

That enables you to copy a list of pathnames from the “Found N new test
failures” part of an EWS build-report page — which is a comma-separated
list — and paste that comma-separated list directly, unmodified, into
the run-webkit-tests command line in your shell

Otherwise, without this change, if you want to run the tests listed in
EWS “Found N new test failures” build-report output, you have to manually
remove the commas from the list before feeding it to run-webkit-tests.

* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py:
(run):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68d34dc31e583d15ac6d61dde0a587a3c2b14818

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/132721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/43795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140250 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/84748 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/134591 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/4975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101466 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/68767 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/135667 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/118897 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82259 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/132070 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27880 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/1472 "Found 2 new API test failures: TestWebKitAPI.FormValidation.PresentingFormValidationUIWithoutViewControllerDoesNotCrash, TestWebKitAPI.ObscuredContentInsets.TopOverhangColorExtensionLayer (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/83484 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113061 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/37012 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/142906 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/4886 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/37600 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/109843 "Found 1 new test failure: fast/scrolling/rtl-scrollbars-sticky-document.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/4968 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/4225 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110020 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/3727 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115168 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/58368 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28635 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33515 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29842 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30770 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29612 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->