### PR TITLE
Adopt more std::span in WebGPU code

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp
@@ -81,8 +81,7 @@ void QueueImpl::writeBuffer(
 
 void QueueImpl::writeTexture(
     const ImageCopyTexture&,
-    const void*,
-    size_t,
+    std::span<const uint8_t>,
     const ImageDataLayout&,
     const Extent3D&)
 {
@@ -96,14 +95,12 @@ void QueueImpl::writeBufferNoCopy(
     Size64 dataOffset,
     std::optional<Size64> size)
 {
-    // FIXME: Use checked arithmetic and check the cast
-    wgpuQueueWriteBuffer(m_backing.get(), m_convertToBackingContext->convertToBacking(buffer), bufferOffset, static_cast<uint8_t*>(source.data()) + dataOffset, static_cast<size_t>(size.value_or(source.size() - dataOffset)));
+    wgpuQueueWriteBuffer(m_backing.get(), m_convertToBackingContext->convertToBacking(buffer), bufferOffset, source.subspan(dataOffset, size.value_or(source.size() - dataOffset)));
 }
 
 void QueueImpl::writeTexture(
     const ImageCopyTexture& destination,
-    void* source,
-    size_t byteLength,
+    std::span<uint8_t> source,
     const ImageDataLayout& dataLayout,
     const Extent3D& size)
 {
@@ -124,7 +121,7 @@ void QueueImpl::writeTexture(
 
     WGPUExtent3D backingSize = m_convertToBackingContext->convertToBacking(size);
 
-    wgpuQueueWriteTexture(m_backing.get(), &backingDestination, source, byteLength, &backingDataLayout, &backingSize);
+    wgpuQueueWriteTexture(m_backing.get(), &backingDestination, source, &backingDataLayout, &backingSize);
 }
 
 void QueueImpl::copyExternalImageToTexture(

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h
@@ -71,8 +71,7 @@ private:
 
     void writeTexture(
         const ImageCopyTexture& destination,
-        const void* source,
-        size_t byteLength,
+        std::span<const uint8_t> source,
         const ImageDataLayout&,
         const Extent3D& size) final;
 
@@ -85,8 +84,7 @@ private:
 
     void writeTexture(
         const ImageCopyTexture& destination,
-        void* source,
-        size_t byteLength,
+        std::span<uint8_t> source,
         const ImageDataLayout&,
         const Extent3D& size) final;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h
@@ -70,8 +70,7 @@ public:
 
     virtual void writeTexture(
         const ImageCopyTexture& destination,
-        const void* source,
-        size_t byteLength,
+        std::span<const uint8_t> source,
         const ImageDataLayout&,
         const Extent3D& size) = 0;
 
@@ -84,8 +83,7 @@ public:
 
     virtual void writeTexture(
         const ImageCopyTexture& destination,
-        void* source,
-        size_t byteLength,
+        std::span<uint8_t> source,
         const ImageDataLayout&,
         const Extent3D& size) = 0;
 

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -63,9 +63,9 @@ public:
 
     void onSubmittedWorkDone(CompletionHandler<void(WGPUQueueWorkDoneStatus)>&& callback);
     void submit(Vector<std::reference_wrapper<CommandBuffer>>&& commands);
-    void writeBuffer(const Buffer&, uint64_t bufferOffset, void* data, size_t);
-    void writeBuffer(id<MTLBuffer>, uint64_t bufferOffset, void* data, size_t);
-    void writeTexture(const WGPUImageCopyTexture& destination, void* data, size_t dataSize, const WGPUTextureDataLayout&, const WGPUExtent3D& writeSize, bool skipValidation = false);
+    void writeBuffer(const Buffer&, uint64_t bufferOffset, std::span<uint8_t> data);
+    void writeBuffer(id<MTLBuffer>, uint64_t bufferOffset, std::span<uint8_t> data);
+    void writeTexture(const WGPUImageCopyTexture& destination, std::span<uint8_t> data, const WGPUTextureDataLayout&, const WGPUExtent3D& writeSize, bool skipValidation = false);
     void setLabel(String&&);
 
     void onSubmittedWorkScheduled(Function<void()>&&);

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -36,6 +36,7 @@
 #import "Texture.h"
 #import "TextureView.h"
 #import <wtf/CheckedArithmetic.h>
+#import <wtf/StdLibExtras.h>
 
 namespace WebGPU {
 
@@ -337,7 +338,7 @@ bool Queue::validateWriteBuffer(const Buffer& buffer, uint64_t bufferOffset, siz
     return true;
 }
 
-void Queue::writeBuffer(const Buffer& buffer, uint64_t bufferOffset, void* data, size_t size)
+void Queue::writeBuffer(const Buffer& buffer, uint64_t bufferOffset, std::span<uint8_t> data)
 {
     auto device = m_device.get();
     if (!device)
@@ -345,12 +346,12 @@ void Queue::writeBuffer(const Buffer& buffer, uint64_t bufferOffset, void* data,
 
     // https://gpuweb.github.io/gpuweb/#dom-gpuqueue-writebuffer
 
-    if (!validateWriteBuffer(buffer, bufferOffset, size) || !isValidToUseWith(buffer, *this)) {
+    if (!validateWriteBuffer(buffer, bufferOffset, data.size()) || !isValidToUseWith(buffer, *this)) {
         device->generateAValidationError("Validation failure."_s);
         return;
     }
 
-    if (!size)
+    if (data.empty())
         return;
 
     if (buffer.isDestroyed()) {
@@ -363,12 +364,12 @@ void Queue::writeBuffer(const Buffer& buffer, uint64_t bufferOffset, void* data,
     if (isIdle()) {
         switch (buffer.buffer().storageMode) {
         case MTLStorageModeShared:
-            memcpy(static_cast<char*>(buffer.buffer().contents) + bufferOffset, data, size);
+            memcpySpan(std::span { static_cast<uint8_t*>(buffer.buffer().contents) + bufferOffset, data.size() }, data);
             return;
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
         case MTLStorageModeManaged:
-            memcpy(static_cast<char*>(buffer.buffer().contents) + bufferOffset, data, size);
-            [buffer.buffer() didModifyRange:NSMakeRange(bufferOffset, size)];
+            memcpySpan(std::span { static_cast<uint8_t*>(buffer.buffer().contents) + bufferOffset, data.size() }, data);
+            [buffer.buffer() didModifyRange:NSMakeRange(bufferOffset, data.size())];
             return;
 #endif
         case MTLStorageModePrivate:
@@ -380,10 +381,10 @@ void Queue::writeBuffer(const Buffer& buffer, uint64_t bufferOffset, void* data,
         }
     }
 
-    writeBuffer(buffer.buffer(), bufferOffset, data, size);
+    writeBuffer(buffer.buffer(), bufferOffset, data);
 }
 
-void Queue::writeBuffer(id<MTLBuffer> buffer, uint64_t bufferOffset, void* data, size_t size)
+void Queue::writeBuffer(id<MTLBuffer> buffer, uint64_t bufferOffset, std::span<uint8_t> data)
 {
     auto device = m_device.get();
     if (!device)
@@ -392,8 +393,8 @@ void Queue::writeBuffer(id<MTLBuffer> buffer, uint64_t bufferOffset, void* data,
     ensureBlitCommandEncoder();
     // FIXME(PERFORMANCE): Suballocate, so the common case doesn't need to hit the kernel.
     // FIXME(PERFORMANCE): Should this temporary buffer really be shared?
-    bool noCopy = size >= largeBufferSize;
-    id<MTLBuffer> temporaryBuffer = noCopy ? device->newBufferWithBytesNoCopy(data, static_cast<NSUInteger>(size), MTLResourceStorageModeShared) : device->newBufferWithBytes(data, static_cast<NSUInteger>(size), MTLResourceStorageModeShared);
+    bool noCopy = data.size() >= largeBufferSize;
+    id<MTLBuffer> temporaryBuffer = noCopy ? device->newBufferWithBytesNoCopy(data.data(), data.size(), MTLResourceStorageModeShared) : device->newBufferWithBytes(data.data(), data.size(), MTLResourceStorageModeShared);
     if (!temporaryBuffer) {
         ASSERT_NOT_REACHED();
         return;
@@ -403,8 +404,8 @@ void Queue::writeBuffer(id<MTLBuffer> buffer, uint64_t bufferOffset, void* data,
         copyFromBuffer:temporaryBuffer
         sourceOffset:0
         toBuffer:buffer
-        destinationOffset:static_cast<NSUInteger>(bufferOffset)
-        size:static_cast<NSUInteger>(size)];
+        destinationOffset:bufferOffset
+        size:data.size()];
 
     if (noCopy)
         finalizeBlitCommandEncoder();
@@ -492,7 +493,7 @@ bool Queue::writeWillCompletelyClear(WGPUTextureDimension textureDimension, uint
     return false;
 }
 
-void Queue::writeTexture(const WGPUImageCopyTexture& destination, void* data, size_t dataSize, const WGPUTextureDataLayout& dataLayout, const WGPUExtent3D& size, bool skipValidation)
+void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint8_t> data, const WGPUTextureDataLayout& dataLayout, const WGPUExtent3D& size, bool skipValidation)
 {
     auto device = m_device.get();
     if (destination.nextInChain || dataLayout.nextInChain || !device)
@@ -500,7 +501,7 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, void* data, si
 
     // https://gpuweb.github.io/gpuweb/#dom-gpuqueue-writetexture
 
-    auto dataByteSize = dataSize;
+    auto dataByteSize = data.size();
     auto& texture = fromAPI(destination.texture);
     if (texture.isDestroyed()) {
         device->generateAValidationError("GPUQueue.writeTexture: destination texture is destroyed"_s);
@@ -523,7 +524,7 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, void* data, si
         }
     }
 
-    if (!data || !dataByteSize || dataByteSize <= dataLayout.offset)
+    if (data.empty() || !dataByteSize || dataByteSize <= dataLayout.offset)
         return;
 
     uint32_t blockSize = Texture::texelBlockSize(textureFormat);
@@ -537,7 +538,7 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, void* data, si
 
     NSUInteger bytesPerRow = dataLayout.bytesPerRow;
     if (bytesPerRow == WGPU_COPY_STRIDE_UNDEFINED)
-        bytesPerRow = size.height ? (dataSize / size.height) : dataSize;
+        bytesPerRow = size.height ? (data.size() / size.height) : data.size();
 
     switch (texture.dimension()) {
     case WGPUTextureDimension_1D:
@@ -623,10 +624,10 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, void* data, si
                         newDestination.origin.x = destination.origin.x + x;
                         auto offset = x + y * bytesPerRow + z * bytesPerImage;
                         auto size = (y + 1 == endY) ? bytesInLastRow.value() : (bytesPerRow * newSize.height);
-                        if (offset + size > dataSize)
+                        if (offset + size > data.size())
                             return;
 
-                        writeTexture(newDestination, static_cast<uint8_t*>(data) + offset, size, newDataLayout, newSize);
+                        writeTexture(newDestination, data.subspan(offset, size), newDataLayout, newSize);
                     }
                 }
             }
@@ -679,17 +680,17 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, void* data, si
 
         if (maxY) {
             if ((maxY - 1) * newBytesPerRow + (maxZ - 1) * newBytesPerImage + newBytesPerRow > newData.size()
-                || (maxY - 1) * bytesPerRow + (maxZ - 1) * bytesPerImage + dataLayout.offset + newBytesPerRow > dataSize) {
+                || (maxY - 1) * bytesPerRow + (maxZ - 1) * bytesPerImage + dataLayout.offset + newBytesPerRow > data.size()) {
                 auto y = (maxY - 1);
                 auto z = (maxZ - 1);
-                device->generateAValidationError([NSString stringWithFormat:@"y(%zu) * newBytesPerRow(%u) + z(%zu) * newBytesPerImage(%lu) + newBytesPerRow(%u) > newData.size()(%zu) || y(%zu) * bytesPerRow(%lu) + z(%zu) * bytesPerImage(%lu) + newBytesPerRow(%u) > dataSize(%zu), copySize %u, %u, %u, textureSize %u, %u, %u, offset %llu", y, newBytesPerRow, z, newBytesPerImage, newBytesPerRow, newData.size(), y, static_cast<unsigned long>(bytesPerRow), z, static_cast<unsigned long>(bytesPerImage), newBytesPerRow, dataSize, widthForMetal, heightForMetal, depthForMetal, logicalSize.width, logicalSize.height, logicalSize.depthOrArrayLayers, dataLayout.offset]);
+                device->generateAValidationError([NSString stringWithFormat:@"y(%zu) * newBytesPerRow(%u) + z(%zu) * newBytesPerImage(%lu) + newBytesPerRow(%u) > newData.size()(%zu) || y(%zu) * bytesPerRow(%lu) + z(%zu) * bytesPerImage(%lu) + newBytesPerRow(%u) > dataSize(%zu), copySize %u, %u, %u, textureSize %u, %u, %u, offset %llu", y, newBytesPerRow, z, newBytesPerImage, newBytesPerRow, newData.size(), y, static_cast<unsigned long>(bytesPerRow), z, static_cast<unsigned long>(bytesPerImage), newBytesPerRow, data.size(), widthForMetal, heightForMetal, depthForMetal, logicalSize.width, logicalSize.height, logicalSize.depthOrArrayLayers, dataLayout.offset]);
                 return;
             }
         }
 
         for (size_t z = 0; z < maxZ; ++z) {
             for (size_t y = 0; y < maxY; ++y) {
-                auto sourceBytes = static_cast<const uint8_t*>(data) + y * bytesPerRow + z * bytesPerImage + dataLayout.offset;
+                auto sourceBytes = data.data() + y * bytesPerRow + z * bytesPerImage + dataLayout.offset;
                 auto destBytes = &newData[0] + y * newBytesPerRow + z * newBytesPerImage;
                 memcpy(destBytes, sourceBytes, newBytesPerRow);
             }
@@ -698,7 +699,7 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, void* data, si
         bytesPerRow = newBytesPerRow;
         dataByteSize = newData.size();
         bytesPerImage = newBytesPerImage;
-        data = &newData[0];
+        data = newData.mutableSpan();
     }
 
     // FIXME(PERFORMANCE): Instead of checking whether or not the whole queue is idle,
@@ -725,7 +726,7 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, void* data, si
                             replaceRegion:region
                             mipmapLevel:destination.mipLevel
                             slice:destinationSlice
-                            withBytes:static_cast<const char*>(data) + sourceOffset
+                            withBytes:byteCast<char>(data.data()) + sourceOffset
                             bytesPerRow:0
                             bytesPerImage:0];
                     }
@@ -745,7 +746,7 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, void* data, si
                             replaceRegion:region
                             mipmapLevel:destination.mipLevel
                             slice:destinationSlice
-                            withBytes:static_cast<const char*>(data) + sourceOffset
+                            withBytes:byteCast<char>(data.data()) + sourceOffset
                             bytesPerRow:bytesPerRow
                             bytesPerImage:0];
                     }
@@ -763,7 +764,7 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, void* data, si
                         replaceRegion:region
                         mipmapLevel:destination.mipLevel
                         slice:0
-                        withBytes:static_cast<const char*>(data) + sourceOffset
+                        withBytes:byteCast<char>(data.data()) + sourceOffset
                         bytesPerRow:bytesPerRow
                         bytesPerImage:bytesPerImage];
                     break;
@@ -788,7 +789,7 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, void* data, si
     // FIXME(PERFORMANCE): Should this temporary buffer really be shared?
     NSUInteger newBufferSize = dataByteSize - dataLayoutOffset;
     bool noCopy = newBufferSize >= largeBufferSize;
-    id<MTLBuffer> temporaryBuffer = noCopy ? device->newBufferWithBytesNoCopy(static_cast<char*>(data) + dataLayoutOffset, static_cast<NSUInteger>(newBufferSize), MTLResourceStorageModeShared) : device->newBufferWithBytes(static_cast<const char*>(data) + dataLayoutOffset, static_cast<NSUInteger>(newBufferSize), MTLResourceStorageModeShared);
+    id<MTLBuffer> temporaryBuffer = noCopy ? device->newBufferWithBytesNoCopy(byteCast<char>(data.data()) + dataLayoutOffset, static_cast<NSUInteger>(newBufferSize), MTLResourceStorageModeShared) : device->newBufferWithBytes(byteCast<char>(data.data()) + dataLayoutOffset, static_cast<NSUInteger>(newBufferSize), MTLResourceStorageModeShared);
     if (!temporaryBuffer)
         return;
 
@@ -950,14 +951,14 @@ void wgpuQueueSubmit(WGPUQueue queue, size_t commandCount, const WGPUCommandBuff
     WebGPU::fromAPI(queue).submit(WTFMove(commandsToForward));
 }
 
-void wgpuQueueWriteBuffer(WGPUQueue queue, WGPUBuffer buffer, uint64_t bufferOffset, void* data, size_t size)
+void wgpuQueueWriteBuffer(WGPUQueue queue, WGPUBuffer buffer, uint64_t bufferOffset, std::span<uint8_t> data)
 {
-    WebGPU::fromAPI(queue).writeBuffer(WebGPU::fromAPI(buffer), bufferOffset, data, size);
+    WebGPU::fromAPI(queue).writeBuffer(WebGPU::fromAPI(buffer), bufferOffset, data);
 }
 
-void wgpuQueueWriteTexture(WGPUQueue queue, const WGPUImageCopyTexture* destination, void* data, size_t dataSize, const WGPUTextureDataLayout* dataLayout, const WGPUExtent3D* writeSize)
+void wgpuQueueWriteTexture(WGPUQueue queue, const WGPUImageCopyTexture* destination, std::span<uint8_t> data, const WGPUTextureDataLayout* dataLayout, const WGPUExtent3D* writeSize)
 {
-    WebGPU::fromAPI(queue).writeTexture(*destination, data, dataSize, *dataLayout, *writeSize);
+    WebGPU::fromAPI(queue).writeTexture(*destination, data, *dataLayout, *writeSize);
 }
 
 void wgpuQueueSetLabel(WGPUQueue queue, const char* label)

--- a/Source/WebGPU/WebGPU/RenderBundle.mm
+++ b/Source/WebGPU/WebGPU/RenderBundle.mm
@@ -93,7 +93,7 @@ void RenderBundle::updateMinMaxDepths(float minDepth, float maxDepth)
     m_maxDepth = maxDepth;
     float twoFloats[2] = { m_minDepth, m_maxDepth };
     for (RenderBundleICBWithResources* icb in m_renderBundlesResources)
-        m_device->getQueue().writeBuffer(icb.fragmentDynamicOffsetsBuffer, 0, twoFloats, sizeof(float) * 2);
+        m_device->getQueue().writeBuffer(icb.fragmentDynamicOffsetsBuffer, 0, { reinterpret_cast<uint8_t*>(twoFloats), sizeof(float) * 2 });
 }
 
 uint64_t RenderBundle::drawCount() const

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -68,6 +68,7 @@
 #include <stddef.h>
 
 #ifdef __cplusplus
+#include <span>
 #include <wtf/text/WTFString.h>
 #endif
 
@@ -1701,8 +1702,10 @@ WGPU_EXPORT void wgpuQuerySetRelease(WGPUQuerySet querySet) WGPU_FUNCTION_ATTRIB
 WGPU_EXPORT void wgpuQueueOnSubmittedWorkDone(WGPUQueue queue, WGPUQueueWorkDoneCallback callback, void * userdata) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuQueueSetLabel(WGPUQueue queue, char const * label) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuQueueSubmit(WGPUQueue queue, size_t commandCount, WGPUCommandBuffer const * commands) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuQueueWriteBuffer(WGPUQueue queue, WGPUBuffer buffer, uint64_t bufferOffset, void * data, size_t size) WGPU_FUNCTION_ATTRIBUTE;
-WGPU_EXPORT void wgpuQueueWriteTexture(WGPUQueue queue, WGPUImageCopyTexture const * destination, void * data, size_t dataSize, WGPUTextureDataLayout const * dataLayout, WGPUExtent3D const * writeSize) WGPU_FUNCTION_ATTRIBUTE;
+#ifdef __cplusplus
+WGPU_EXPORT void wgpuQueueWriteBuffer(WGPUQueue queue, WGPUBuffer buffer, uint64_t bufferOffset, std::span<uint8_t> data) WGPU_FUNCTION_ATTRIBUTE;
+WGPU_EXPORT void wgpuQueueWriteTexture(WGPUQueue queue, WGPUImageCopyTexture const * destination, std::span<uint8_t> data, WGPUTextureDataLayout const * dataLayout, WGPUExtent3D const * writeSize) WGPU_FUNCTION_ATTRIBUTE;
+#endif
 WGPU_EXPORT void wgpuQueueReference(WGPUQueue queue) WGPU_FUNCTION_ATTRIBUTE;
 WGPU_EXPORT void wgpuQueueRelease(WGPUQueue queue) WGPU_FUNCTION_ATTRIBUTE;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
@@ -105,7 +105,7 @@ void RemoteQueue::writeTexture(
     if (!convertedDestination || !convertedDestination || !convertedSize)
         return;
 
-    m_backing->writeTexture(*convertedDestination, data.data(), data.size(), *convertedDataLayout, *convertedSize);
+    m_backing->writeTexture(*convertedDestination, data.mutableSpan(), *convertedDataLayout, *convertedSize);
 }
 
 void RemoteQueue::copyExternalImageToTexture(

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
@@ -86,8 +86,7 @@ void RemoteQueueProxy::writeBuffer(
 
 void RemoteQueueProxy::writeTexture(
     const WebCore::WebGPU::ImageCopyTexture& destination,
-    const void* source,
-    size_t byteLength,
+    std::span<const uint8_t> source,
     const WebCore::WebGPU::ImageDataLayout& dataLayout,
     const WebCore::WebGPU::Extent3D& size)
 {
@@ -100,7 +99,7 @@ void RemoteQueueProxy::writeTexture(
     if (!convertedDestination || !convertedDataLayout || !convertedSize)
         return;
 
-    auto sendResult = send(Messages::RemoteQueue::WriteTexture(*convertedDestination, Vector(std::span { static_cast<const uint8_t*>(source), byteLength }), *convertedDataLayout, *convertedSize));
+    auto sendResult = send(Messages::RemoteQueue::WriteTexture(*convertedDestination, Vector(source), *convertedDataLayout, *convertedSize));
     UNUSED_VARIABLE(sendResult);
 }
 
@@ -116,8 +115,7 @@ void RemoteQueueProxy::writeBufferNoCopy(
 
 void RemoteQueueProxy::writeTexture(
     const WebCore::WebGPU::ImageCopyTexture&,
-    void*,
-    size_t,
+    std::span<uint8_t>,
     const WebCore::WebGPU::ImageDataLayout&,
     const WebCore::WebGPU::Extent3D&)
 {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
@@ -86,8 +86,7 @@ private:
 
     void writeTexture(
         const WebCore::WebGPU::ImageCopyTexture& destination,
-        const void* source,
-        size_t byteLength,
+        std::span<const uint8_t> source,
         const WebCore::WebGPU::ImageDataLayout&,
         const WebCore::WebGPU::Extent3D& size) final;
 
@@ -100,8 +99,7 @@ private:
 
     void writeTexture(
         const WebCore::WebGPU::ImageCopyTexture& destination,
-        void* source,
-        size_t byteLength,
+        std::span<uint8_t> source,
         const WebCore::WebGPU::ImageDataLayout&,
         const WebCore::WebGPU::Extent3D& size) final;
 


### PR DESCRIPTION
#### 1c1b3b86b53bd5c1b729718ef6e988b977338078
<pre>
Adopt more std::span in WebGPU code
<a href="https://bugs.webkit.org/show_bug.cgi?id=274816">https://bugs.webkit.org/show_bug.cgi?id=274816</a>

Reviewed by Mike Wyrzykowski and Darin Adler.

* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::GPUQueue::writeTexture):
(WebCore::GPUQueue::copyExternalImageToTexture):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.cpp:
(WebCore::WebGPU::QueueImpl::writeTexture):
(WebCore::WebGPU::QueueImpl::writeBufferNoCopy):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUQueueImpl.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUQueue.h:
* Source/WebGPU/WebGPU/Queue.h:
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::writeBuffer):
(WebGPU::Queue::writeTexture):
(wgpuQueueWriteBuffer):
(wgpuQueueWriteTexture):
* Source/WebGPU/WebGPU/RenderBundle.mm:
(WebGPU::RenderBundle::updateMinMaxDepths):
* Source/WebGPU/WebGPU/WebGPU.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp:
(WebKit::RemoteQueue::writeTexture):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp:
(WebKit::WebGPU::RemoteQueueProxy::writeTexture):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h:

Canonical link: <a href="https://commits.webkit.org/279456@main">https://commits.webkit.org/279456@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df29587befa549a19b0db9f95f38c0f4a543d175

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32907 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6056 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56830 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4276 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55856 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/40408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4074 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43407 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2809 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55648 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31100 "Exiting early after 60 failures. 16175 tests run. 7 new passes 60 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46280 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24546 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27948 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3599 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2432 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3771 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58427 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28708 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3786 "Found 1 new test failure: media/track/track-text-track-destructor-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50809 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29914 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/46454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50148 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30843 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7886 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29686 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->