### PR TITLE
[WPE] Fix debug build after 279376@main

### DIFF
--- a/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp
+++ b/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp
@@ -222,21 +222,21 @@ static void doKeyStrokeEvent(WebPageProxy &page, bool pressed, uint32_t keyVal, 
     GUniqueOutPtr<GError> error;
     auto* keymap = WPE_KEYMAP(wpe_display_get_keymap(display, &error.outPtr()));
     if (error) {
-        LOG(Automation, "WebAutomationSession::doKeyStrokeEvent: Failed to get keymap: %s. Ignoring event.", error->message);
+        RELEASE_LOG(Automation, "WebAutomationSession::doKeyStrokeEvent: Failed to get keymap: %s. Ignoring event.", error->message);
         return;
     }
 
     WPEKeymapEntry* entries;
     guint entriesCount;
     if (!wpe_keymap_get_entries_for_keyval(keymap, keyVal, &entries, &entriesCount)) {
-        LOG(Automation, "WebAutomationSession::doKeyStrokeEvent: Failed to get keymap entries for keyval %u. Ignoring event.", keyVal);
+        RELEASE_LOG(Automation, "WebAutomationSession::doKeyStrokeEvent: Failed to get keymap entries for keyval %u. Ignoring event.", keyVal);
         return;
     }
     unsigned keyCode = entries[0].keycode;
 
     WPEModifiers consumedModifiers;
     if (!wpe_keymap_translate_keyboard_state(keymap, keyCode, static_cast<WPEModifiers>(modifiers), entries[0].group, &keyVal, nullptr, nullptr, &consumedModifiers)) {
-        LOG(Automation, "WebAutomationSession::doKeyStrokeEvent: Failed to translate keyboard state for keycode %u. Ignoring event.", keyCode);
+        RELEASE_LOG(Automation, "WebAutomationSession::doKeyStrokeEvent: Failed to translate keyboard state for keycode %u. Ignoring event.", keyCode);
         return;
     }
 


### PR DESCRIPTION
#### d31ab91d63855cb721b8bf67c873c241820eeb27
<pre>
[WPE] Fix debug build after 279376@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=273750">https://bugs.webkit.org/show_bug.cgi?id=273750</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp:
(WebKit::doKeyStrokeEvent): Replace LOG for RELEASE_LOG.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d31ab91d63855cb721b8bf67c873c241820eeb27

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6022 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56796 "Hash d31ab91d for PR 29217 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4242 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40338 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4034 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/56796 "Hash d31ab91d for PR 29217 does not build (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2781 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55614 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31070 "Found 2 new test failures: animations/3d/change-transform-in-end-event.html, compositing/overflow/image-load-overflow-scrollbars.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46249 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/56796 "Hash d31ab91d for PR 29217 does not build (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2398 "Hash d31ab91d for PR 29217 does not build (failure)") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49670 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58393 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28674 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3751 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50781 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29880 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/46433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30809 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29652 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->