### PR TITLE
Improve memory safety in SandboxInitializationParameters

### DIFF
--- a/Source/WebKit/Shared/SandboxInitializationParameters.h
+++ b/Source/WebKit/Shared/SandboxInitializationParameters.h
@@ -42,16 +42,15 @@ public:
     ~SandboxInitializationParameters();
 
 #if PLATFORM(COCOA)
-    // Name must be a literal.
-    void addConfDirectoryParameter(const char* name, int confID);
-    void addPathParameter(const char* name, NSString *path);
-    void addPathParameter(const char* name, const char* path);
-    void addParameter(const char* name, const char* value);
+    void addConfDirectoryParameter(ASCIILiteral name, int confID);
+    void addPathParameter(ASCIILiteral name, NSString *path);
+    void addPathParameter(ASCIILiteral name, const char* path);
+    void addParameter(ASCIILiteral name, CString&& value);
 
-    const char* const* namedParameterArray() const;
+    Vector<const char*> namedParameterVector() const;
 
     size_t count() const;
-    const char* name(size_t index) const;
+    ASCIILiteral name(size_t index) const;
     const char* value(size_t index) const;
 
     enum class ProfileSelectionMode : uint8_t {
@@ -92,9 +91,10 @@ public:
 
 private:
 #if PLATFORM(COCOA)
-    void appendPathInternal(const char* name, const char* path);
+    void appendPathInternal(ASCIILiteral name, const char* path);
 
-    mutable Vector<const char*> m_namedParameters;
+    mutable Vector<ASCIILiteral> m_parameterNames;
+    mutable Vector<CString> m_parameterValues;
     String m_userDirectorySuffix;
 
     ProfileSelectionMode m_profileSelectionMode;


### PR DESCRIPTION
#### c916962d69eb9ee4d2ab92a6f9dc74ca1c2b0cf2
<pre>
Improve memory safety in SandboxInitializationParameters
<a href="https://bugs.webkit.org/show_bug.cgi?id=274836">https://bugs.webkit.org/show_bug.cgi?id=274836</a>

Reviewed by Per Arne Vollan.

Improve memory safety in SandboxInitializationParameters by adopting
ASCIILiteral and CString.

* Source/WebKit/Shared/Cocoa/SandboxInitialiationParametersCocoa.mm:
(WebKit::SandboxInitializationParameters::appendPathInternal):
(WebKit::SandboxInitializationParameters::addConfDirectoryParameter):
(WebKit::SandboxInitializationParameters::addPathParameter):
(WebKit::SandboxInitializationParameters::addParameter):
(WebKit:: const):
(WebKit::SandboxInitializationParameters::count const):
(WebKit::SandboxInitializationParameters::name const):
(WebKit::SandboxInitializationParameters::value const):
(WebKit::SandboxInitializationParameters::~SandboxInitializationParameters): Deleted.
(WebKit::SandboxInitializationParameters::namedParameterArray const): Deleted.
* Source/WebKit/Shared/SandboxInitializationParameters.h:
* Source/WebKit/Shared/mac/AuxiliaryProcessMac.mm:
(WebKit::compileAndApplySandboxSlowCase):
(WebKit::populateSandboxInitializationParameters):
(WebKit::AuxiliaryProcess::initializeSandbox):

Canonical link: <a href="https://commits.webkit.org/279450@main">https://commits.webkit.org/279450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5de21c1eb57b21d5027fe4941536643fc3cbe0e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56826 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4272 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4069 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43402 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2804 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55644 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31094 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46274 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24541 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27942 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2428 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3765 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58423 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3781 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50807 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29910 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/46450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30839 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7883 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29682 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->