### PR TITLE
Rename ByteArrayPixelBuffer::dataSpan() to span() for consistency

### DIFF
--- a/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp
@@ -103,10 +103,10 @@ RefPtr<PixelBuffer> ByteArrayPixelBuffer::createScratchPixelBuffer(const IntSize
     return ByteArrayPixelBuffer::tryCreate(m_format, size);
 }
 
-std::span<const uint8_t> ByteArrayPixelBuffer::dataSpan() const
+std::span<const uint8_t> ByteArrayPixelBuffer::span() const
 {
     ASSERT(m_data->byteLength() == (m_size.area() * 4));
-    return { m_data->data(), m_data->byteLength() };
+    return m_data->span();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h
+++ b/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h
@@ -40,7 +40,7 @@ public:
 
     JSC::Uint8ClampedArray& data() const { return m_data.get(); }
     Ref<JSC::Uint8ClampedArray>&& takeData() { return WTFMove(m_data); }
-    WEBCORE_EXPORT std::span<const uint8_t> dataSpan() const;
+    WEBCORE_EXPORT std::span<const uint8_t> span() const;
 
     RefPtr<PixelBuffer> createScratchPixelBuffer(const IntSize&) const override;
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7250,7 +7250,7 @@ enum class WebCore::RepaintRectCalculation : bool;
 [RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::ByteArrayPixelBuffer {
     WebCore::PixelBufferFormat format();
     WebCore::IntSize size();
-    std::span<const uint8_t> dataSpan();
+    std::span<const uint8_t> span();
 }
 
 #if ENABLE(WEB_AUTHN)


### PR DESCRIPTION
#### 53f9232763fe508e71bf08a2995f961f3dad249c
<pre>
Rename ByteArrayPixelBuffer::dataSpan() to span() for consistency
<a href="https://bugs.webkit.org/show_bug.cgi?id=274838">https://bugs.webkit.org/show_bug.cgi?id=274838</a>

Reviewed by Sam Weinig.

Rename ByteArrayPixelBuffer::dataSpan() to span() for consistency with other
types.

* Source/WebCore/platform/graphics/ByteArrayPixelBuffer.cpp:
(WebCore::ByteArrayPixelBuffer::span const):
(WebCore::ByteArrayPixelBuffer::dataSpan const): Deleted.
* Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/279447@main">https://commits.webkit.org/279447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10d2e8168ded5cf0345f7afb95d5daa2bfd91100

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56828 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4274 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55854 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40374 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4071 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43404 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2806 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55646 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46278 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24543 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27943 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3597 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2430 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3769 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58425 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28706 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3784 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50808 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29912 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/46453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7880 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29684 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->