### PR TITLE
Unreviewed, reverting 279420@main (1cf2af72f97e)

### DIFF
--- a/LayoutTests/fast/forms/select/mac-wk2/inactive-appearance-expected-mismatch.html
+++ b/LayoutTests/fast/forms/select/mac-wk2/inactive-appearance-expected-mismatch.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ runSingly=true ] -->
 <!DOCTYPE html>
 <html>
 <body>

--- a/LayoutTests/fast/forms/select/mac-wk2/inactive-appearance.html
+++ b/LayoutTests/fast/forms/select/mac-wk2/inactive-appearance.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ runSingly=true ] -->
 <!DOCTYPE html>
 <html>
     <head>
@@ -15,8 +14,8 @@ if (window.testRunner)
     testRunner.waitUntilDone();
 
 addEventListener("load", async () => {
-    if (window.testRunner)
-        testRunner.setWindowIsKey(false);
+    if (window.internals)
+        window.internals.setPageIsFocusedAndActive(false);
 
     await UIHelper.renderingUpdate();
     if (window.testRunner)

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1852,6 +1852,8 @@ webkit.org/b/272685 [ Ventura+ x86_64 ] imported/w3c/web-platform-tests/svg/pain
 
 webkit.org/b/273012 [ Ventura+ x86_64 ] imported/w3c/web-platform-tests/svg/painting/reftests/percentage.svg [ ImageOnlyFailure ]
 
+webkit.org/b/273588 fast/forms/select/mac-wk2/inactive-appearance.html [ Pass ImageOnlyFailure ]
+
 webkit.org/b/273905 [ X86_64 ] svg/filters/filter-on-root-tile-boundary.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/274130 [ Debug ] media/video-pause-immediately.html [ Pass Failure ]

--- a/Source/WebCore/PAL/pal/spi/mac/NSCellSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/NSCellSPI.h
@@ -29,14 +29,6 @@
 
 #import <AppKit/NSCell_Private.h>
 
-#else
-
-typedef NS_ENUM(NSInteger, NSPresentationState) {
-    NSPresentationStateActiveKey = 0,
-    NSPresentationStateActive,
-    NSPresentationStateInactive,
-};
-
 #endif
 
 WTF_EXTERN_C_BEGIN
@@ -45,6 +37,7 @@ void _NSDrawCarbonThemeListBox(NSRect, BOOL enabled, BOOL flipped, BOOL textured
 
 WTF_EXTERN_C_END
 
+typedef NS_ENUM(NSInteger, NSPresentationState);
 typedef NS_ENUM(NSInteger, NSViewSemanticContext);
 
 @interface NSCell ()

--- a/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
+++ b/Source/WebCore/platform/graphics/mac/controls/ControlMac.mm
@@ -206,9 +206,6 @@ static void applyViewlessCellSettings(float deviceScaleFactor, const ControlStyl
 
     [cell _setFallbackBackingScaleFactor:deviceScaleFactor];
 
-    bool isInActiveWindow = style.states.contains(ControlStyle::State::WindowActive);
-    [cell _setFallbackBezelPresentationState:isInActiveWindow ? NSPresentationStateActiveKey : NSPresentationStateInactive];
-
 #if USE(NSVIEW_SEMANTICCONTEXT)
     if (style.states.contains(ControlStyle::State::FormSemanticContext))
         [cell _setFallbackSemanticContext:NSViewSemanticContextForm];


### PR DESCRIPTION
#### 5f77e4141897ac68b37c3ea87c034938feae4dda
<pre>
Unreviewed, reverting 279420@main (1cf2af72f97e)
<a href="https://bugs.webkit.org/show_bug.cgi?id=274842">https://bugs.webkit.org/show_bug.cgi?id=274842</a>
<a href="https://rdar.apple.com/128946761">rdar://128946761</a>

Broke internal build

Reverted change:

    REGRESSION (macOS 14): Form controls draw with an active appearance when the window is inactive
    <a href="https://bugs.webkit.org/show_bug.cgi?id=273588">https://bugs.webkit.org/show_bug.cgi?id=273588</a>
    <a href="https://rdar.apple.com/127391198">rdar://127391198</a>
    279420@main (1cf2af72f97e)

Canonical link: <a href="https://commits.webkit.org/279445@main">https://commits.webkit.org/279445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c9e30616d9cb1b5ea82654ab2dc42cf1f27bbe4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/53549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32906 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56829 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/4275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/55855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4073 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/4275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/55647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/46276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/24544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/27945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/3595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2431 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/3767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/58426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/28707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/58426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/29913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/46452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/58426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7878 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/29685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->