### PR TITLE
Do more std::span adoption in SQLiteDatabase

### DIFF
--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -64,6 +64,7 @@ public:
     constexpr const char* characters() const { return m_charactersWithNullTerminator.data(); }
     constexpr size_t length() const { return !m_charactersWithNullTerminator.empty() ? m_charactersWithNullTerminator.size() - 1 : 0; }
     std::span<const LChar> span8() const { return { bitwise_cast<const LChar*>(characters()), length() }; }
+    std::span<const char> spanIncludingNullTerminator() const { return m_charactersWithNullTerminator; }
     size_t isEmpty() const { return m_charactersWithNullTerminator.size() <= 1; }
 
     constexpr char operator[](size_t index) const { return m_charactersWithNullTerminator[index]; }

--- a/Source/WTF/wtf/text/CString.h
+++ b/Source/WTF/wtf/text/CString.h
@@ -73,7 +73,7 @@ public:
     std::string toStdString() const { return m_buffer ? std::string(m_buffer->data()) : std::string(); }
 
     std::span<const uint8_t> span() const;
-    std::span<const uint8_t> spanIncludingNullTerminator() const;
+    std::span<const char> spanIncludingNullTerminator() const;
 
     WTF_EXPORT_PRIVATE char* mutableData();
     size_t length() const;
@@ -129,10 +129,10 @@ inline std::span<const uint8_t> CString::span() const
     return { };
 }
 
-inline std::span<const uint8_t> CString::spanIncludingNullTerminator() const
+inline std::span<const char> CString::spanIncludingNullTerminator() const
 {
     if (m_buffer)
-        return { byteCast<uint8_t>(m_buffer->data()), m_buffer->length() + 1 };
+        return { m_buffer->data(), m_buffer->length() + 1 };
     return { };
 }
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
@@ -161,7 +161,7 @@ static void addStringToSHA1(SHA1& sha1, const String& string)
         return;
     }
 
-    sha1.addBytes(string.utf8().spanIncludingNullTerminator());
+    sha1.addBytes(string.utf8());
 }
 
 String RealtimeMediaSourceCenter::hashStringWithSalt(const String& id, const String& hashSalt)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1501,7 +1501,7 @@ void NetworkConnectionToWebProcess::installMockContentFilter(WebCore::MockConten
 #endif
 
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
-void NetworkConnectionToWebProcess::logOnBehalfOfWebContent(std::span<const uint8_t> logSubsystem, std::span<const uint8_t> logCategory, std::span<const uint8_t> logString, uint8_t logType, int32_t pid)
+void NetworkConnectionToWebProcess::logOnBehalfOfWebContent(std::span<const char> logSubsystem, std::span<const char> logCategory, std::span<const uint8_t> logString, uint8_t logType, int32_t pid)
 {
     auto isNullTerminated = [](std::span<const uint8_t> view) {
         return view.data() && !view.empty() && view.back() == '\0';
@@ -1513,8 +1513,8 @@ void NetworkConnectionToWebProcess::logOnBehalfOfWebContent(std::span<const uint
     // os_log_hook on sender side sends a null category and subsystem when logging to OS_LOG_DEFAULT.
     auto osLog = OSObjectPtr<os_log_t>();
     if (isNullTerminated(logSubsystem) && isNullTerminated(logCategory)) {
-        auto subsystem = byteCast<char>(logSubsystem.data());
-        auto category = byteCast<char>(logCategory.data());
+        auto subsystem = logSubsystem.data();
+        auto category = logCategory.data();
         osLog = adoptOSObject(os_log_create(subsystem, category));
     }
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -227,7 +227,7 @@ public:
     void installMockContentFilter(WebCore::MockContentFilterSettings&&);
 #endif
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
-    void logOnBehalfOfWebContent(std::span<const uint8_t> logChannel, std::span<const uint8_t> logCategory, std::span<const uint8_t> logString, uint8_t logType, int32_t pid);
+    void logOnBehalfOfWebContent(std::span<const char> logChannelIncludingNullTerminator, std::span<const char> logCategoryIncludingNullTerminator, std::span<const uint8_t> logString, uint8_t logType, int32_t pid);
 #endif
 
     void useRedirectionForCurrentNavigation(WebCore::ResourceLoaderIdentifier, WebCore::ResourceResponse&&);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -121,7 +121,7 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
     InstallMockContentFilter(WebCore::MockContentFilterSettings settings)
 #endif
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
-    LogOnBehalfOfWebContent(std::span<const uint8_t> logChannel, std::span<const uint8_t> logCategory, std::span<const uint8_t> logString, uint8_t logType, int32_t pid)
+    LogOnBehalfOfWebContent(std::span<const char> logChannelIncludingNullTerminator, std::span<const char> logCategoryIncludingNullTerminator, std::span<const uint8_t> logString, uint8_t logType, int32_t pid)
 #endif
 
     UseRedirectionForCurrentNavigation(WebCore::ResourceLoaderIdentifier resourceLoadIdentifier, WebCore::ResourceResponse response)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.cpp
@@ -93,7 +93,7 @@ static void hashString(SHA1& sha1, const String& string)
         return;
     }
 
-    sha1.addBytes(string.utf8().spanIncludingNullTerminator());
+    sha1.addBytes(string.utf8());
 }
 
 Key::HashType Key::computeHash(const Salt& salt) const


### PR DESCRIPTION
#### 55f14e59c3ad6c60a6aeb3c402d9b46458fda8e9
<pre>
Do more std::span adoption in SQLiteDatabase
<a href="https://bugs.webkit.org/show_bug.cgi?id=274845">https://bugs.webkit.org/show_bug.cgi?id=274845</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/text/ASCIILiteral.h:
* Source/WebCore/platform/sql/SQLiteDatabase.cpp:
(WebCore::constructAndPrepareStatement):
(WebCore::SQLiteDatabase::prepareStatement):
(WebCore::SQLiteDatabase::prepareHeapStatementSlow):
(WebCore::SQLiteDatabase::prepareHeapStatement):

Canonical link: <a href="https://commits.webkit.org/279467@main">https://commits.webkit.org/279467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e71fa3f40ad27ebc9ec46bbab1b33fa6d0cdf50

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53556 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32913 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56836 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4282 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55862 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4082 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43420 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2816 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31122 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46286 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24558 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27959 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3605 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2438 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/46916 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58433 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/53071 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28714 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3796 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50819 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29920 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/46459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50161 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30849 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65376 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7892 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29692 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12458 "Passed tests") | 
<!--EWS-Status-Bubble-End-->