### PR TITLE
AX Web Inspector Panel: Switch form controls report "Checked: true/false" rather than something like "State: on/off"

### DIFF
--- a/LayoutTests/inspector/dom/getAccessibilityPropertiesForNode-expected.txt
+++ b/LayoutTests/inspector/dom/getAccessibilityPropertiesForNode-expected.txt
@@ -4,10 +4,10 @@ Checking Web Inspector protocol for the Accessibility Node Inspector.
     exists: true
     label:
     role:
-    childNodeIds.length: 93
+    childNodeIds.length: 96
 
 
-Total elements to be tested: 123.
+Total elements to be tested: 126.
 
 <div onclick="void(0);">click</div>
     exists: true
@@ -777,11 +777,37 @@ Total elements to be tested: 123.
     readonly: true
     required: false
 
-<div role="switch" aria-required="true">Required switch.</div>
+<input type="checkbox" switch="" checked="">
     exists: true
-    label: Required switch.
+    label:
     role: switch
-    checked: false
+    switchState: on
+    focused: false
+    parentNodeId: exists
+    required: false
+
+<input type="checkbox" switch="">
+    exists: true
+    label:
+    role: switch
+    switchState: off
+    focused: false
+    parentNodeId: exists
+    required: false
+
+<div role="switch" aria-checked="true">On-state ARIA switch.</div>
+    exists: true
+    label: On-state ARIA switch.
+    role: switch
+    switchState: on
+    parentNodeId: exists
+    required: false
+
+<div role="switch" aria-required="true">Required, off-state ARIA switch.</div>
+    exists: true
+    label: Required, off-state ARIA switch.
+    role: switch
+    switchState: off
     parentNodeId: exists
     required: true
 

--- a/LayoutTests/inspector/dom/getAccessibilityPropertiesForNode.html
+++ b/LayoutTests/inspector/dom/getAccessibilityPropertiesForNode.html
@@ -57,7 +57,10 @@
 <input class="ex" aria-invalid="foo" value="fake value will eval to true">
 <input class="ex" readonly value="readonly">
 
-<div class="ex" role="switch" aria-required="true">Required switch.</div>
+<div class="ex" role="switch" aria-required="true">Required, off-state ARIA switch.</div>
+<div class="ex" role="switch" aria-checked="true">On-state ARIA switch.</div>
+<input class="ex" type="checkbox" switch>
+<input class="ex" type="checkbox" switch checked>
 
 <div class="ex" role="textbox" tabindex="0" aria-readonly="true">readonly</div>
 <input class="ex" disabled value="disabled">

--- a/Source/JavaScriptCore/inspector/protocol/DOM.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
@@ -135,7 +135,8 @@
                 { "name": "required", "type": "boolean", "optional": true, "description": "Required state of form controls." },
                 { "name": "role", "type": "string", "description": "Computed value for first recognized role token, default role per element, or overridden role." },
                 { "name": "selected", "type": "boolean", "optional": true, "description": "Selected state of certain form controls." },
-                { "name": "selectedChildNodeIds", "type": "array", "items": { "$ref": "NodeId" }, "optional": true, "description": "Array of <code>DOMNode</code> ids of any children marked as selected." }
+                { "name": "selectedChildNodeIds", "type": "array", "items": { "$ref": "NodeId" }, "optional": true, "description": "Array of <code>DOMNode</code> ids of any children marked as selected." },
+                { "name": "switchState", "type": "string", "optional": true, "enum": ["off", "on"], "description": "On / off state of switch form controls." }
             ]
         },
         {

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1190,6 +1190,8 @@ localizedStrings["Observer Callback"] = "Observer Callback";
 localizedStrings["Observer Handlers:"] = "Observer Handlers:";
 localizedStrings["Observers:"] = "Observers:";
 localizedStrings["Off"] = "Off";
+/* Label indicating that an input of type switch is off. */
+localizedStrings["Off @ Switch State"] = "Off";
 /* Label for a preference that is turned off. */
 localizedStrings["Off @ User Preferences Overrides"] = "Off";
 /* Input label for the x-axis of the offset of a CSS box shadow */
@@ -1198,6 +1200,8 @@ localizedStrings["Offset X @ Box Shadow Editor"] = "Offset X";
 localizedStrings["Offset Y @ Box Shadow Editor"] = "Offset Y";
 /* Property value for `font-variant-numeric: oldstyle-nums`. */
 localizedStrings["Old-Style Numerals @ Font Details Sidebar Property Value"] = "Old-Style Numerals";
+/* Label indicating that an input of type switch is on. */
+localizedStrings["On @ Switch State"] = "On";
 /* Label for a preference that is turned on. */
 localizedStrings["On @ User Preferences Overrides"] = "On";
 localizedStrings["Once"] = "Once";

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -935,7 +935,8 @@ WI.DOMNode = class DOMNode extends WI.Object
                     required: accessibilityProperties.required,
                     role: accessibilityProperties.role,
                     selected: accessibilityProperties.selected,
-                    selectedChildNodeIds: accessibilityProperties.selectedChildNodeIds
+                    selectedChildNodeIds: accessibilityProperties.selectedChildNodeIds,
+                    switchState: accessibilityProperties.switchState,
                 });
             }
         }

--- a/Source/WebInspectorUI/UserInterface/Views/DOMNodeDetailsSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMNodeDetailsSidebarPanel.js
@@ -109,6 +109,7 @@ WI.DOMNodeDetailsSidebarPanel = class DOMNodeDetailsSidebarPanel extends WI.DOMD
             this._accessibilityNodeActiveDescendantRow = new WI.DetailsSectionSimpleRow(WI.UIString("Shared Focus"));
             this._accessibilityNodeBusyRow = new WI.DetailsSectionSimpleRow(WI.UIString("Busy"));
             this._accessibilityNodeCheckedRow = new WI.DetailsSectionSimpleRow(WI.UIString("Checked"));
+            this._accessibilityNodeSwitchStateRow = new WI.DetailsSectionSimpleRow(WI.UIString("State"));
             this._accessibilityNodeChildrenRow = new WI.DetailsSectionSimpleRow(WI.UIString("Children"));
             this._accessibilityNodeControlsRow = new WI.DetailsSectionSimpleRow(WI.UIString("Controls"));
             this._accessibilityNodeCurrentRow = new WI.DetailsSectionSimpleRow(WI.UIString("Current"));
@@ -546,6 +547,19 @@ WI.DOMNodeDetailsSidebarPanel = class DOMNodeDetailsSidebarPanel extends WI.DOMD
                         checked = WI.UIString("No");
                 }
 
+                let switchState = "";
+                // COMPATIBILITY (macOS X.0, iOS X.0): DOM.AccessibilityProperties.switchState did not exist yet.
+                if (InspectorBackend.Enum.DOM.AccessibilityPropertiesSwitchState) {
+                    switch (accessibilityProperties.switchState) {
+                    case InspectorBackend.Enum.DOM.AccessibilityPropertiesSwitchState.On:
+                        switchState = WI.UIString("On", "On @ Switch State", "Label indicating that an input of type switch is on.");
+                        break;
+                    case InspectorBackend.Enum.DOM.AccessibilityPropertiesSwitchState.Off:
+                        switchState = WI.UIString("Off", "Off @ Switch State", "Label indicating that an input of type switch is off.");
+                        break;
+                    }
+                }
+
                 // Accessibility tree children are not a 1:1 mapping with DOM tree children.
                 var childNodeLinkList = linkListForNodeIds(accessibilityProperties.childNodeIds);
                 var controlledNodeLinkList = linkListForNodeIds(accessibilityProperties.controlledNodeIds);
@@ -728,6 +742,7 @@ WI.DOMNodeDetailsSidebarPanel = class DOMNodeDetailsSidebarPanel extends WI.DOMD
                 this._accessibilityNodeInvalidRow.value = invalid;
                 this._accessibilityNodeLabelRow.value = label;
                 this._accessibilityNodeLiveRegionStatusRow.value = liveRegionStatusNode || liveRegionStatus;
+                this._accessibilityNodeSwitchStateRow.value = switchState;
 
                 // Row label changes based on whether the value is a delegate node link.
                 this._accessibilityNodeMouseEventRow.label = mouseEventNodeLink ? WI.UIString("Click Listener") : WI.UIString("Clickable");
@@ -777,7 +792,8 @@ WI.DOMNodeDetailsSidebarPanel = class DOMNodeDetailsSidebarPanel extends WI.DOMD
                     this._accessibilityNodeExpandedRow,
                     this._accessibilityNodePressedRow,
                     this._accessibilityNodeReadonlyRow,
-                    this._accessibilityNodeSelectedRow
+                    this._accessibilityNodeSelectedRow,
+                    this._accessibilityNodeSwitchStateRow,
                 ];
 
                 this._accessibilityEmptyRow.hideEmptyMessage();


### PR DESCRIPTION
#### 132e20aa121367262caab344e193535bef849955
<pre>
AX Web Inspector Panel: Switch form controls report &quot;Checked: true/false&quot; rather than something like &quot;State: on/off&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=274846">https://bugs.webkit.org/show_bug.cgi?id=274846</a>
<a href="https://rdar.apple.com/128952449">rdar://128952449</a>

Reviewed by Devin Rousso.

Switches are like checkboxes without a mixed state, and are exposed in the web platform in this way — HTML switches
are created via `input type=&quot;checkbox&quot;` plus the `switch` attribute, and are &quot;enabled&quot; via the `checked` attribute.
And ARIA switches (`role=&quot;switch&quot;`) use `aria-checked`.

A side effect of this is that when we added support for switch controls, we forgot to update Web Inspector to handle
the nuanced difference between these types of controls, and thus switch controls report a &quot;Checked: true/false&quot; state
rather than &quot;State: on/off&quot;, which is more appropriate terminology. This patch addresses this issue.

* LayoutTests/inspector/dom/getAccessibilityPropertiesForNode-expected.txt:
* LayoutTests/inspector/dom/getAccessibilityPropertiesForNode.html:
* Source/JavaScriptCore/inspector/protocol/DOM.json:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::buildObjectForAccessibilityProperties):
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
(WI.DOMNode.prototype.accessibilityProperties.accessibilityPropertiesCallback):
(WI.DOMNode.prototype.accessibilityProperties):
* Source/WebInspectorUI/UserInterface/Views/DOMNodeDetailsSidebarPanel.js:
(WI.DOMNodeDetailsSidebarPanel.prototype.initialLayout):
(WI.DOMNodeDetailsSidebarPanel.prototype._refreshAccessibility.accessibilityPropertiesCallback):
(WI.DOMNodeDetailsSidebarPanel.prototype._refreshAccessibility):

Canonical link: <a href="https://commits.webkit.org/279772@main">https://commits.webkit.org/279772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc6a4496e8d71868ab10cd4b089afad339593b9c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57505 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4954 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56531 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4901 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43928 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3322 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56324 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46964 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25070 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28688 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4291 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3101 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/47608 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50558 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4497 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59097 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/53736 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29440 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4653 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51347 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30606 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50710 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11907 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31581 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/66037 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30389 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12580 "Passed tests") | 
<!--EWS-Status-Bubble-End-->