### PR TITLE
Fire open and closed events when a tab is replaced.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
@@ -132,6 +132,11 @@ void WebExtensionContext::runtimeSendMessage(const String& extensionID, const St
     WebExtensionMessageSenderParameters completeSenderParameters = senderParameters;
     if (RefPtr tab = getTab(senderParameters.pageProxyIdentifier))
         completeSenderParameters.tabParameters = tab->parameters();
+    else if (senderParameters.contentWorldType == WebExtensionContentWorldType::ContentScript) {
+        RELEASE_LOG_ERROR(Extensions, "Tab not found for message for content script message");
+        completionHandler(toWebExtensionError(apiName, nil, @"tab not found"));
+        return;
+    }
 
     constexpr auto targetContentWorldType = WebExtensionContentWorldType::Main;
     constexpr auto eventType = WebExtensionEventListenerType::RuntimeOnMessage;
@@ -177,6 +182,11 @@ void WebExtensionContext::runtimeConnect(const String& extensionID, WebExtension
     WebExtensionMessageSenderParameters completeSenderParameters = senderParameters;
     if (RefPtr tab = getTab(senderParameters.pageProxyIdentifier))
         completeSenderParameters.tabParameters = tab->parameters();
+    else if (senderParameters.contentWorldType == WebExtensionContentWorldType::ContentScript) {
+        RELEASE_LOG_ERROR(Extensions, "Tab not found for message for content script port");
+        completionHandler(toWebExtensionError(apiName, nil, @"tab not found"));
+        return;
+    }
 
     constexpr auto eventType = WebExtensionEventListenerType::RuntimeOnConnect;
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -2138,8 +2138,10 @@ void WebExtensionContext::didCloseTab(WebExtensionTab& tab, WindowIsClosing wind
     ASSERT(isValidTab(tab));
 
     // The tab might already be closed, don't log an error.
-    if (!tab.isOpen())
+    if (!tab.isOpen()) {
+        forgetTab(tab.identifier());
         return;
+    }
 
     RELEASE_LOG_DEBUG(Extensions, "Closed tab %{public}llu %{public}s", tab.identifier().toUInt64(), windowIsClosing == WindowIsClosing::Yes ? "(window closing)" : "");
 
@@ -2269,25 +2271,32 @@ void WebExtensionContext::didMoveTab(WebExtensionTab& tab, size_t oldIndex, cons
     }
 }
 
-void WebExtensionContext::didReplaceTab(WebExtensionTab& oldTab, WebExtensionTab& newTab)
+void WebExtensionContext::didReplaceTab(WebExtensionTab& oldTab, WebExtensionTab& newTab, SuppressEvents suppressEvents)
 {
     ASSERT(isValidTab(oldTab));
     ASSERT(isValidTab(newTab));
 
-    if (!oldTab.isOpen()) {
-        RELEASE_LOG_ERROR(Extensions, "Replaced tab %{public}llu with tab %{public}llu, but old tab is not open", oldTab.identifier().toUInt64(), newTab.identifier().toUInt64());
+    if (oldTab == newTab) {
+        RELEASE_LOG_ERROR(Extensions, "Replaced tab %{public}llu with the same tab", newTab.identifier().toUInt64());
         return;
     }
 
-    didCloseTab(oldTab, WindowIsClosing::No, SuppressEvents::Yes);
-    didOpenTab(newTab, SuppressEvents::Yes);
+    Ref protectedOldTab { oldTab };
+
+    didOpenTab(newTab, suppressEvents);
+
+    if (!oldTab.isOpen()) {
+        RELEASE_LOG_ERROR(Extensions, "Replaced tab %{public}llu with tab %{public}llu, but old tab is not open", oldTab.identifier().toUInt64(), newTab.identifier().toUInt64());
+        forgetTab(oldTab.identifier());
+        return;
+    }
 
     RELEASE_LOG_DEBUG(Extensions, "Replaced tab %{public}llu with tab %{public}llu", oldTab.identifier().toUInt64(), newTab.identifier().toUInt64());
 
-    if (!isLoaded() || !newTab.extensionHasAccess())
-        return;
+    if (isLoaded() && newTab.extensionHasAccess() && suppressEvents == SuppressEvents::No)
+        fireTabsReplacedEventIfNeeded(oldTab.identifier(), newTab.identifier());
 
-    fireTabsReplacedEventIfNeeded(oldTab.identifier(), newTab.identifier());
+    didCloseTab(oldTab, WindowIsClosing::No, suppressEvents);
 }
 
 void WebExtensionContext::didChangeTabProperties(WebExtensionTab& tab, OptionSet<WebExtensionTab::ChangedProperties> properties)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -120,9 +120,9 @@ WebExtensionTabParameters WebExtensionTab::parameters() const
         hasPermission ? url() : URL { },
         hasPermission ? title() : nullString(),
 
-        window ? std::optional(window->identifier()) : std::nullopt,
+        window ? window->identifier() : WebExtensionWindowConstants::NoneIdentifier,
+        index,
 
-        index != notFound ? std::optional(index) : std::nullopt,
         size(),
 
         parentTab ? std::optional(parentTab->identifier()) : std::nullopt,

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -400,7 +400,7 @@ public:
     void didSelectOrDeselectTabs(const TabSet&);
 
     void didMoveTab(WebExtensionTab&, size_t oldIndex, const WebExtensionWindow* oldWindow = nullptr);
-    void didReplaceTab(WebExtensionTab& oldTab, WebExtensionTab& newTab);
+    void didReplaceTab(WebExtensionTab& oldTab, WebExtensionTab& newTab, SuppressEvents = SuppressEvents::No);
     void didChangeTabProperties(WebExtensionTab&, OptionSet<WebExtensionTab::ChangedProperties> = { });
 
     void didStartProvisionalLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -146,7 +146,7 @@ NSDictionary *toWebAPI(const WebExtensionTabParameters& parameters)
         result[windowIdKey] = @(toWebAPI(parameters.windowIdentifier.value()));
 
     if (parameters.index)
-        result[indexKey] = @(parameters.index.value());
+        result[indexKey] = toWebAPI(parameters.index.value());
 
     if (parameters.size) {
         auto size = parameters.size.value();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
@@ -1171,9 +1171,23 @@ TEST(WKWebExtensionAPITabs, RemovedEvent)
 TEST(WKWebExtensionAPITabs, ReplacedEvent)
 {
     auto backgroundScript = Util::constructScript(@[
+        @"let createdTabId = null",
+        @"let removedTabId = null",
+
+        @"browser.tabs.onCreated.addListener((tab) => {",
+        @"  browser.test.assertEq(createdTabId, null, 'No tab should be created yet')",
+        @"  createdTabId = tab.id",
+        @"})",
+
+        @"browser.tabs.onRemoved.addListener((tabId) => {",
+        @"  browser.test.assertEq(removedTabId, null, 'No tab should be removed yet')",
+        @"  removedTabId = tabId",
+        @"})",
+
         @"browser.tabs.onReplaced.addListener((addedTabId, removedTabId) => {",
-        @"  browser.test.assertTrue(addedTabId !== removedTabId, 'The addedTabId should not match the removedTabId')",
-        @"  browser.test.assertEq(removedTabId, initialTabId, 'The initial tab id should match the removedTabId')",
+        @"  browser.test.assertTrue(addedTabId !== removedTabId, 'The added tab should not match the removed tab')",
+        @"  browser.test.assertEq(addedTabId, createdTabId, 'The added tab should match the created tab')",
+        @"  browser.test.assertEq(removedTabId, initialTabId, 'The removed tab should match the initial tab')",
 
         @"  browser.test.notifyPass()",
         @"})",

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -735,6 +735,9 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
     [oldTab.mainWebView _close];
     oldTab.mainWebView = nil;
 
+    if (_activeTab == oldTab)
+        _activeTab = newTab;
+
     [_tabs replaceObjectAtIndex:[_tabs indexOfObject:oldTab] withObject:newTab];
     [_extensionController didReplaceTab:oldTab withTab:newTab];
 }


### PR DESCRIPTION
#### d0a6863b9a013dedac63c644883b0736f5d5dd63
<pre>
Fire open and closed events when a tab is replaced.
<a href="https://webkit.org/b/274794">https://webkit.org/b/274794</a>
<a href="https://rdar.apple.com/123344546">rdar://123344546</a>

Reviewed by Brian Weinstein.

Fire the onCreated and onRemoved events when tabs are replaced. Also return errors
where an extension messages a tab that does not exist to prevent more confusing errors
later when tab properties are missing, etc. Also make sure to always include the windowId
and index properties on the tab object, even if they are -1 and NaN.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm:
(WebKit::WebExtensionContext::runtimeSendMessage): Added error if tab is not found.
(WebKit::WebExtensionContext::runtimeConnect): Ditto.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::didCloseTab): Call forgetTab if the tab is already closed.
(WebKit::WebExtensionContext::didReplaceTab): Fire open and closed events.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::parameters const): Always include window and index.
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::toWebAPI): Use toWebAPI for the index of notFound is returned as NaN.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, ReplacedEvent)): Added.
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionWindow replaceTab:withTab:]): Swap activeTab if it was active.

Canonical link: <a href="https://commits.webkit.org/279464@main">https://commits.webkit.org/279464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/555871392e9974f748c971356758c5913e943b25

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32917 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6066 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56840 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4286 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55866 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4086 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43413 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2813 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55658 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31108 "Found unexpected failure with change (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24552 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27982 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3606 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2442 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58437 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28718 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3797 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50818 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29924 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/46460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50160 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30853 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7890 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29696 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->