### PR TITLE
NEW TEST (279267@main): [ MacOS iOS Debug ] TestWebKitAPI.AdvancedPrivacyProtections.NoiseInjectionForOffscreenCanvasInSharedWorker is a consistent crash

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm
@@ -1181,7 +1181,7 @@ inline static String sharedWorkerMainBytes()
 
 inline static String sharedWorkerBytes()
 {
-    return R"TESTRESOURCE(
+    return String::fromUTF8(R"TESTRESOURCE(
         onconnect = (event) => {
             const port = event.ports[0];
             port.onmessage = function(event) {
@@ -1216,7 +1216,7 @@ inline static String sharedWorkerBytes()
                 });
             };
         };
-        )TESTRESOURCE"_s;
+        )TESTRESOURCE");
 }
 
 TEST(AdvancedPrivacyProtections, NoiseInjectionForOffscreenCanvasInSharedWorker)


### PR DESCRIPTION
#### 34fbb92a4327f71b18e359e11a89a114427f320e
<pre>
NEW TEST (279267@main): [ MacOS iOS Debug ] TestWebKitAPI.AdvancedPrivacyProtections.NoiseInjectionForOffscreenCanvasInSharedWorker is a consistent crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=274786">https://bugs.webkit.org/show_bug.cgi?id=274786</a>
<a href="https://rdar.apple.com/128876237">rdar://128876237</a>

Reviewed by Abrar Rahman Protyasha and Chris Dumez.

`sharedWorkerBytes()` currently attempts to create an `ASCIILiteral` from a multiline string literal
that contains the 🙃 emoji; this results in a debug assertion (as expected). Fix this by simply
using `String::fromUTF8` instead.

* Tools/TestWebKitAPI/Tests/WebKit/AdvancedPrivacyProtections.mm:
(TestWebKitAPI::(AdvancedPrivacyProtections, NoiseInjectionForOffscreenCanvasInSharedWorker)): Deleted.

Canonical link: <a href="https://commits.webkit.org/279466@main">https://commits.webkit.org/279466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d7424e72d2bd517aed9e60f9c27f5d47a9b6342

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53562 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56842 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4288 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55868 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40391 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4101 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43414 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2815 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55660 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31116 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46290 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24553 "Found 1 new API test failure: /WPE/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27965 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3609 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2444 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3781 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58439 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28720 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3813 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50820 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29926 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/46463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50163 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11674 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30855 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29698 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->