### PR TITLE
_WKWebExtensionSQLiteStore object is being deallocated before extension storage is removed

### DIFF
--- a/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm
+++ b/Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm
@@ -92,13 +92,8 @@ using namespace WebKit;
 
 - (void)deleteDatabaseWithCompletionHandler:(void (^)(NSString *errorMessage))completionHandler
 {
-    auto weakSelf = WeakObjCPtr<_WKWebExtensionSQLiteStore> { self };
     dispatch_async(_databaseQueue, ^{
-        auto strongSelf = weakSelf.get();
-        if (!strongSelf)
-            return;
-
-        NSString *deleteDatabaseErrorMessage = [strongSelf _deleteDatabase];
+        NSString *deleteDatabaseErrorMessage = [self _deleteDatabase];
         dispatch_async(dispatch_get_main_queue(), ^{
             completionHandler(deleteDatabaseErrorMessage);
         });


### PR DESCRIPTION
#### 0d9af47d152ce4be12e3ca78ca9685cab1720592
<pre>
_WKWebExtensionSQLiteStore object is being deallocated before extension storage is removed
<a href="https://bugs.webkit.org/show_bug.cgi?id=274850">https://bugs.webkit.org/show_bug.cgi?id=274850</a>
<a href="https://rdar.apple.com/128907598">rdar://128907598</a>

Reviewed by Timothy Hatcher and Brian Weinstein.

In Release builds, the _WKWebExtensionSQLiteStore object being used to remove extension storage
is being deallocated before we make the call to remove the extension data. To prevent this from
happening, don&apos;t use weakSelf in `deleteDatabaseWithCompletionHandler` to keep the object alive
longer.

* Source/WebKit/Shared/Extensions/_WKWebExtensionSQLiteStore.mm:
(-[_WKWebExtensionSQLiteStore deleteDatabaseWithCompletionHandler:]):

Canonical link: <a href="https://commits.webkit.org/279465@main">https://commits.webkit.org/279465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3efce9c020f147b0eb47b9e2ef6d8e487ff53c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53563 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56843 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4289 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4090 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43421 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2817 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55661 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31117 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24559 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27961 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2445 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58440 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3804 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50821 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29927 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/46465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50164 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 8 api tests failed or timed out; 6 api tests failed or timed out; Running compile-webkit-without-change") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7891 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29699 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->