### PR TITLE
General cleanup of TransformOperations

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2497,15 +2497,16 @@ platform/graphics/transforms/IdentityTransformOperation.cpp
 platform/graphics/transforms/Matrix3DTransformOperation.cpp
 platform/graphics/transforms/MatrixTransformOperation.cpp
 platform/graphics/transforms/PerspectiveTransformOperation.cpp
+platform/graphics/transforms/Quaternion.cpp
 platform/graphics/transforms/RotateTransformOperation.cpp
 platform/graphics/transforms/ScaleTransformOperation.cpp
 platform/graphics/transforms/SkewTransformOperation.cpp
 platform/graphics/transforms/TransformOperation.cpp
 platform/graphics/transforms/TransformOperations.cpp
+platform/graphics/transforms/TransformOperationsSharedPrimitivesPrefix.cpp
 platform/graphics/transforms/TransformState.cpp
 platform/graphics/transforms/TransformationMatrix.cpp
 platform/graphics/transforms/TranslateTransformOperation.cpp
-platform/graphics/transforms/Quaternion.cpp
 platform/mediacapabilities/MediaCapabilitiesLogging.cpp
 platform/mediacapabilities/MediaEngineConfigurationFactory.cpp
 platform/mediarecorder/MediaRecorderPrivate.cpp

--- a/Source/WebCore/animation/BlendingKeyframes.cpp
+++ b/Source/WebCore/animation/BlendingKeyframes.cpp
@@ -331,8 +331,8 @@ void BlendingKeyframes::analyzeKeyframe(const BlendingKeyframe& keyframe)
             return;
 
         if (keyframe.animatesProperty(CSSPropertyTransform)) {
-            for (auto& operation : style->transform().operations()) {
-                if (auto* translate = dynamicDowncast<TranslateTransformOperation>(operation.get())) {
+            for (auto& operation : style->transform()) {
+                if (RefPtr translate = dynamicDowncast<TranslateTransformOperation>(operation.get())) {
                     if (translate->x().isPercent())
                         m_hasWidthDependentTransform = true;
                     if (translate->y().isPercent())

--- a/Source/WebCore/css/CSSCustomPropertyValue.cpp
+++ b/Source/WebCore/css/CSSCustomPropertyValue.cpp
@@ -94,7 +94,7 @@ String CSSCustomPropertyValue::customCSSText() const
         }, [&](const String& value) {
             return value;
         }, [&](const TransformSyntaxValue& value) {
-            auto cssValue = transformOperationAsCSSValue(*value.transform, RenderStyle::defaultStyle());
+            auto cssValue = transformOperationAsCSSValue(value.transform, RenderStyle::defaultStyle());
             if (!cssValue)
                 return emptyString();
             return cssValue->cssText();

--- a/Source/WebCore/css/CSSCustomPropertyValue.h
+++ b/Source/WebCore/css/CSSCustomPropertyValue.h
@@ -49,8 +49,8 @@ public:
     };
 
     struct TransformSyntaxValue {
-        RefPtr<TransformOperation> transform;
-        bool operator==(const TransformSyntaxValue& other) const { return arePointingToEqualData(transform, other.transform); }
+        Ref<TransformOperation> transform;
+        bool operator==(const TransformSyntaxValue& other) const { return transform.get() == other.transform.get(); }
     };
 
     using SyntaxValue = std::variant<Length, NumericSyntaxValue, StyleColor, RefPtr<StyleImage>, URL, String, TransformSyntaxValue>;

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -880,8 +880,8 @@ static Ref<CSSValue> computedTransform(RenderElement* renderer, const RenderStyl
         return CSSPrimitiveValue::create(CSSValueNone);
 
     CSSValueListBuilder list;
-    for (auto& operation : style.transform().operations()) {
-        if (auto functionValue = transformOperationAsCSSValue(*operation, style))
+    for (auto& operation : style.transform()) {
+        if (auto functionValue = transformOperationAsCSSValue(operation, style))
             list.append(functionValue.releaseNonNull());
     }
     if (!list.isEmpty())

--- a/Source/WebCore/css/DOMMatrixReadOnly.cpp
+++ b/Source/WebCore/css/DOMMatrixReadOnly.cpp
@@ -242,7 +242,7 @@ ExceptionOr<DOMMatrixReadOnly::AbstractMatrix> DOMMatrixReadOnly::parseStringInt
         return Exception { ExceptionCode::SyntaxError };
 
     AbstractMatrix matrix;
-    for (auto& operation : operations->operations()) {
+    for (auto& operation : *operations) {
         if (operation->apply(matrix.matrix, { 0, 0 }))
             return Exception { ExceptionCode::SyntaxError };
         if (operation->is3DOperation())

--- a/Source/WebCore/css/TransformFunctions.cpp
+++ b/Source/WebCore/css/TransformFunctions.cpp
@@ -110,14 +110,16 @@ std::optional<TransformOperations> transformsForValue(const CSSValue& value, con
     if (!valueList)
         return { };
 
-    TransformOperations operations;
-    for (auto& currentValue : *valueList) {
-        auto transform  = transformForValue(currentValue, conversionData);
+    Vector<Ref<TransformOperation>> operations(valueList->size(), [&](size_t i) -> std::optional<Ref<TransformOperation>> {
+        auto transform  = transformForValue((*valueList)[i], conversionData);
         if (!transform)
             return { };
-        operations.operations().append(WTFMove(transform));
-    }
-    return operations;
+        return transform.releaseNonNull();
+    });
+    if (operations.size() != valueList->size())
+        return { };
+
+    return TransformOperations { WTFMove(operations) };
 }
 
 RefPtr<TransformOperation> transformForValue(const CSSValue& value, const CSSToLengthConversionData& conversionData)

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -490,8 +490,8 @@ RefPtr<CSSCustomPropertyValue> CSSPropertyParser::parseTypedCustomPropertyValue(
 
         case CSSCustomPropertySyntax::Type::TransformFunction:
         case CSSCustomPropertySyntax::Type::TransformList:
-            if (auto transform = transformForValue(value, builderState.cssToLengthConversionData()))
-                return { CSSCustomPropertyValue::TransformSyntaxValue { transform } };
+            if (RefPtr transform = transformForValue(value, builderState.cssToLengthConversionData()))
+                return { CSSCustomPropertyValue::TransformSyntaxValue { transform.releaseNonNull() } };
             return { };
         case CSSCustomPropertySyntax::Type::Unknown:
             return { };

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.h
@@ -63,10 +63,8 @@ struct AcceleratedEffectValues {
     FilterOperations filter { };
     FilterOperations backdropFilter { };
 
-    AcceleratedEffectValues()
-    {
-    }
-
+    AcceleratedEffectValues() = default;
+    AcceleratedEffectValues(const RenderStyle&, const IntRect&, const RenderLayerModelObject* = nullptr);
     AcceleratedEffectValues(float opacity, std::optional<TransformOperationData>&& transformOperationData, LengthPoint&& transformOrigin, TransformBox transformBox, TransformOperations&& transform, RefPtr<TransformOperation>&& translate, RefPtr<TransformOperation>&& scale, RefPtr<TransformOperation>&& rotate, RefPtr<PathOperation>&& offsetPath, Length&& offsetDistance, LengthPoint&& offsetPosition, LengthPoint&& offsetAnchor, OffsetRotation&& offsetRotate, FilterOperations&& filter, FilterOperations&& backdropFilter)
         : opacity(opacity)
         , transformOperationData(WTFMove(transformOperationData))
@@ -87,11 +85,6 @@ struct AcceleratedEffectValues {
     }
 
     WEBCORE_EXPORT AcceleratedEffectValues clone() const;
-
-    WEBCORE_EXPORT AcceleratedEffectValues(const AcceleratedEffectValues&);
-    AcceleratedEffectValues(const RenderStyle&, const IntRect&, const RenderLayerModelObject* = nullptr);
-    AcceleratedEffectValues& operator=(const AcceleratedEffectValues&) = default;
-
     WEBCORE_EXPORT TransformationMatrix computedTransformationMatrix(const FloatRect&) const;
 };
 

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -156,9 +156,8 @@ public:
 
     TransformAnimationValue(double keyTime, TransformOperation* value, TimingFunction* timingFunction = nullptr)
         : AnimationValue(keyTime, timingFunction)
+        , m_value(value ? TransformOperations { *value } : TransformOperations { })
     {
-        if (value)
-            m_value.operations().append(value);
     }
 
     std::unique_ptr<AnimationValue> clone() const override
@@ -168,10 +167,8 @@ public:
 
     TransformAnimationValue(const TransformAnimationValue& other)
         : AnimationValue(other)
+        , m_value(other.m_value.clone())
     {
-        m_value.operations().appendContainerWithMapping(other.m_value.operations(), [](auto& operation) {
-            return operation->clone();
-        });
     }
 
     TransformAnimationValue(TransformAnimationValue&&) = default;

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -51,6 +51,7 @@
 #include "ScaleTransformOperation.h"
 #include "Settings.h"
 #include "TiledBacking.h"
+#include "TransformOperationsSharedPrimitivesPrefix.h"
 #include "TransformState.h"
 #include "TranslateTransformOperation.h"
 #include <QuartzCore/CATransform3D.h>
@@ -3566,7 +3567,7 @@ static const TransformOperations& transformationAnimationValueAt(const KeyframeV
     return static_cast<const TransformAnimationValue&>(valueList.at(i)).value();
 }
 
-static bool hasBig3DRotation(const KeyframeValueList& valueList, const SharedPrimitivesPrefix& prefix)
+static bool hasBig3DRotation(const KeyframeValueList& valueList, const TransformOperationsSharedPrimitivesPrefix& prefix)
 {
     // Hardware non-matrix animations are used for every function in the shared primitives prefix.
     // These kind of animations have issues with large rotation angles, so for every function that
@@ -3606,7 +3607,7 @@ bool GraphicsLayerCA::createTransformAnimationsFromKeyframes(const KeyframeValue
     // FIXME: Currently, this only supports situations where every keyframe shares the same prefix of shared
     // transformation primitives, but the specification says direct interpolation should be determined by
     // the primitives shared between any two adjacent keyframes.
-    SharedPrimitivesPrefix prefix;
+    TransformOperationsSharedPrimitivesPrefix prefix;
     for (size_t i = 0; i < valueList.size(); ++i)
         prefix.update(transformationAnimationValueAt(valueList, i));
 
@@ -3838,8 +3839,8 @@ bool GraphicsLayerCA::setTransformAnimationEndpoints(const KeyframeValueList& va
 
     if (isMatrixAnimation) {
         TransformationMatrix fromTransform, toTransform;
-        startValue.apply(boxSize, fromTransform);
-        endValue.apply(boxSize, toTransform);
+        startValue.apply(fromTransform, boxSize);
+        endValue.apply(toTransform, boxSize);
 
         // If any matrix is singular, CA won't animate it correctly. So fall back to software animation
         if (!fromTransform.isInvertible() || !toTransform.isInvertible())
@@ -3899,7 +3900,7 @@ bool GraphicsLayerCA::setTransformAnimationKeyframes(const KeyframeValueList& va
 
         if (isMatrixAnimation) {
             TransformationMatrix transform;
-            curValue.value().apply(functionIndex, boxSize, transform);
+            curValue.value().apply(transform, boxSize, functionIndex);
 
             // If any matrix is singular, CA won't animate it correctly. So fall back to software animation
             if (!transform.isInvertible())

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaAnimation.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaAnimation.cpp
@@ -125,17 +125,17 @@ static TransformationMatrix applyTransformAnimation(const TransformOperations& f
 
     // First frame of an animation.
     if (!progress) {
-        from.apply(boxSize, matrix);
+        from.apply(matrix, boxSize);
         return matrix;
     }
 
     // Last frame of an animation.
     if (progress == 1) {
-        to.apply(boxSize, matrix);
+        to.apply(matrix, boxSize);
         return matrix;
     }
 
-    to.blend(from, progress, LayoutSize { boxSize }).apply(boxSize, matrix);
+    to.blend(from, progress, LayoutSize { boxSize }).apply(matrix, boxSize);
     return matrix;
 }
 
@@ -161,9 +161,8 @@ static KeyframeValueList createThreadsafeKeyFrames(const KeyframeValueList& orig
     KeyframeValueList keyframes = originalKeyframes;
     for (unsigned i = 0; i < keyframes.size(); i++) {
         const auto& transformValue = static_cast<const TransformAnimationValue&>(keyframes.at(i));
-        for (auto& operation : transformValue.value().operations()) {
-            if (is<TranslateTransformOperation>(operation)) {
-                TranslateTransformOperation* translation = static_cast<TranslateTransformOperation*>(operation.get());
+        for (auto& operation : transformValue.value()) {
+            if (RefPtr translation = dynamicDowncast<TranslateTransformOperation>(operation)) {
                 translation->setX(Length(translation->xAsFloat(boxSize), LengthType::Fixed));
                 translation->setY(Length(translation->yAsFloat(boxSize), LengthType::Fixed));
                 translation->setZ(Length(translation->zAsFloat(), LengthType::Fixed));

--- a/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/RotateTransformOperation.h
@@ -40,7 +40,7 @@ public:
 
     WEBCORE_EXPORT static Ref<RotateTransformOperation> create(double, double, double, double, TransformOperation::Type);
 
-    Ref<TransformOperation> clone() const override
+    Ref<TransformOperation> clone() const final
     {
         return adoptRef(*new RotateTransformOperation(m_x, m_y, m_z, m_angle, type()));
     }
@@ -53,7 +53,7 @@ public:
     TransformOperation::Type primitiveType() const final { return type() == Type::Rotate ? Type::Rotate : Type::Rotate3D; }
 
     bool operator==(const RotateTransformOperation& other) const { return operator==(static_cast<const TransformOperation&>(other)); }
-    bool operator==(const TransformOperation&) const override;
+    bool operator==(const TransformOperation&) const final;
 
     Ref<TransformOperation> blend(const TransformOperation* from, const BlendingContext&, bool blendToIdentity = false) final;
 
@@ -61,10 +61,9 @@ public:
 
     bool isRepresentableIn2D() const final { return (!m_x && !m_y) || !m_angle; }
 
-private:
-    bool isAffectedByTransformOrigin() const override { return !isIdentity(); }
+    bool isAffectedByTransformOrigin() const final { return !isIdentity(); }
 
-    bool apply(TransformationMatrix& transform, const FloatSize& /*borderBoxSize*/) const override
+    bool apply(TransformationMatrix& transform, const FloatSize& /*borderBoxSize*/) const final
     {
         if (type() == TransformOperation::Type::Rotate)
             transform.rotate(m_angle);
@@ -73,7 +72,7 @@ private:
         return false;
     }
 
-    bool applyUnrounded(TransformationMatrix& transform, const FloatSize& /*borderBoxSize*/) const override
+    bool applyUnrounded(TransformationMatrix& transform, const FloatSize& /*borderBoxSize*/) const final
     {
         if (type() == TransformOperation::Type::Rotate)
             transform.rotate(m_angle, TransformationMatrix::RotationSnapping::None);
@@ -85,6 +84,7 @@ private:
 
     void dump(WTF::TextStream&) const final;
 
+private:
     RotateTransformOperation(double, double, double, double, TransformOperation::Type);
 
     double m_x;

--- a/Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.h
+++ b/Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.h
@@ -40,7 +40,7 @@ public:
 
     WEBCORE_EXPORT static Ref<ScaleTransformOperation> create(double, double, double, TransformOperation::Type);
 
-    Ref<TransformOperation> clone() const override
+    Ref<TransformOperation> clone() const final
     {
         return adoptRef(*new ScaleTransformOperation(m_x, m_y, m_z, type()));
     }
@@ -60,10 +60,9 @@ public:
 
     bool isRepresentableIn2D() const final { return m_z == 1; }
 
-private:
-    bool isAffectedByTransformOrigin() const override { return !isIdentity(); }
+    bool isAffectedByTransformOrigin() const final { return !isIdentity(); }
 
-    bool apply(TransformationMatrix& transform, const FloatSize&) const override
+    bool apply(TransformationMatrix& transform, const FloatSize&) const final
     {
         transform.scale3d(m_x, m_y, m_z);
         return false;
@@ -71,6 +70,7 @@ private:
 
     void dump(WTF::TextStream&) const final;
 
+private:
     ScaleTransformOperation(double, double, double, TransformOperation::Type);
 
     double m_x;

--- a/Source/WebCore/platform/graphics/transforms/TransformOperations.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperations.cpp
@@ -29,7 +29,12 @@
 
 namespace WebCore {
 
-TransformOperations::TransformOperations(Vector<RefPtr<TransformOperation>>&& operations)
+TransformOperations::TransformOperations(Ref<TransformOperation>&& operation)
+    : m_operations({ WTFMove(operation) })
+{
+}
+
+TransformOperations::TransformOperations(Vector<Ref<TransformOperation>>&& operations)
     : m_operations(WTFMove(operations))
 {
 }
@@ -38,78 +43,83 @@ bool TransformOperations::operator==(const TransformOperations& o) const
 {
     if (m_operations.size() != o.m_operations.size())
         return false;
-        
-    unsigned s = m_operations.size();
-    for (unsigned i = 0; i < s; i++) {
-        if (*m_operations[i] != *o.m_operations[i])
+
+    unsigned size = m_operations.size();
+    for (unsigned i = 0; i < size; i++) {
+        if (m_operations[i].get() != o.m_operations[i].get())
             return false;
     }
     
     return true;
 }
 
-void SharedPrimitivesPrefix::update(const TransformOperations& operations)
+TransformOperations TransformOperations::clone() const
 {
-    size_t maxIteration = operations.operations().size();
-    if (m_indexOfFirstMismatch.has_value())
-        maxIteration = std::min(*m_indexOfFirstMismatch, maxIteration);
+    return TransformOperations { m_operations.map([](const auto& op) { return op->clone(); }) };
+}
 
-    for (size_t i = 0; i < maxIteration; ++i) {
-        const auto* operation = operations.at(i);
+TransformOperations TransformOperations::selfOrCopyWithResolvedCalculatedValues(const FloatSize& size) const
+{
+    return TransformOperations { m_operations.map([&size](const auto& op) { return op->selfOrCopyWithResolvedCalculatedValues(size); }) };
+}
 
-        // If we haven't seen an operation at this index before, we can simply use our primitive type.
-        if (i >= m_primitives.size()) {
-            ASSERT(i == m_primitives.size());
-            m_primitives.append(operation->primitiveType());
-            continue;
-        }
+void TransformOperations::apply(TransformationMatrix& matrix, const FloatSize& size, unsigned start) const
+{
+    for (unsigned i = start; i < m_operations.size(); ++i)
+        m_operations[i]->apply(matrix, size);
+}
 
-        if (auto sharedPrimitive = operation->sharedPrimitiveType(m_primitives[i]))
-            m_primitives[i] = *sharedPrimitive;
-        else {
-            m_indexOfFirstMismatch = i;
-            m_primitives.shrink(i);
-            return;
-        }
-    }
+bool TransformOperations::has3DOperation() const
+{
+    return WTF::anyOf(m_operations, [](auto& op) { return op->is3DOperation(); });
+}
+
+bool TransformOperations::isRepresentableIn2D() const
+{
+    return WTF::allOf(m_operations, [](auto& op) { return op->isRepresentableIn2D(); });
 }
 
 bool TransformOperations::affectedByTransformOrigin() const
 {
-    for (const auto& operation : m_operations) {
-        if (operation->isAffectedByTransformOrigin())
-            return true;
-    }
-    return false;
+    return WTF::anyOf(m_operations, [](auto& op) { return op->isAffectedByTransformOrigin(); });
+}
+
+bool TransformOperations::isInvertible(const LayoutSize& size) const
+{
+    TransformationMatrix transform;
+    apply(transform, size);
+    return transform.isInvertible();
 }
 
 bool TransformOperations::shouldFallBackToDiscreteAnimation(const TransformOperations& from, const LayoutSize& boxSize) const
 {
-    return (from.hasMatrixOperation() || hasMatrixOperation()) && (!from.isInvertible(boxSize) || !isInvertible(boxSize));
+    return (from.hasTransformOfType<TransformOperation::Type::Matrix>() || hasTransformOfType<TransformOperation::Type::Matrix>())
+        && (!from.isInvertible(boxSize) || !isInvertible(boxSize));
 }
 
 TransformOperations TransformOperations::blend(const TransformOperations& from, const BlendingContext& context, const LayoutSize& boxSize, std::optional<unsigned> prefixLength) const
 {
-    TransformOperations result;
+    if (shouldFallBackToDiscreteAnimation(from, boxSize))
+        return TransformOperations { createBlendedMatrixOperationFromOperationsSuffix(from, 0, context, boxSize) };
 
-    unsigned fromOperationCount = from.operations().size();
-    unsigned toOperationCount = operations().size();
+    unsigned fromOperationCount = from.size();
+    unsigned toOperationCount = size();
     unsigned maxOperationCount = std::max(fromOperationCount, toOperationCount);
 
-    if (shouldFallBackToDiscreteAnimation(from, boxSize)) {
-        result.operations().append(createBlendedMatrixOperationFromOperationsSuffix(from, 0, context, boxSize));
-        return result;
-    }
+    Vector<Ref<TransformOperation>> operations;
+    operations.reserveInitialCapacity(maxOperationCount);
 
     for (unsigned i = 0; i < maxOperationCount; i++) {
-        RefPtr<TransformOperation> fromOperation = (i < fromOperationCount) ? from.operations()[i].get() : nullptr;
-        RefPtr<TransformOperation> toOperation = (i < toOperationCount) ? operations()[i].get() : nullptr;
+        RefPtr<TransformOperation> fromOperation = (i < fromOperationCount) ? from.m_operations[i].ptr() : nullptr;
+        RefPtr<TransformOperation> toOperation = (i < toOperationCount) ? m_operations[i].ptr() : nullptr;
 
         // If either of the transform list is empty, then we should not attempt to do a matrix blend.
         if (fromOperationCount && toOperationCount) {
             if ((prefixLength && i >= *prefixLength) || (fromOperation && toOperation && !fromOperation->sharedPrimitiveType(toOperation.get()))) {
-                result.operations().append(createBlendedMatrixOperationFromOperationsSuffix(from, i, context, boxSize));
-                return result;
+                operations.append(createBlendedMatrixOperationFromOperationsSuffix(from, i, context, boxSize));
+                operations.shrinkToFit();
+
+                return TransformOperations { WTFMove(operations) };
             }
         }
 
@@ -124,18 +134,19 @@ TransformOperations TransformOperations::blend(const TransformOperations& from, 
         // We should have exited early above if the fromOperation and toOperation didn't share a transform
         // function primitive, so blending the two operations should always yield a result.
         ASSERT(blendedOperation);
-        result.operations().append(blendedOperation);
+        operations.append(blendedOperation.releaseNonNull());
     }
 
-    return result;
+    return TransformOperations { WTFMove(operations) };
 }
 
-RefPtr<TransformOperation> TransformOperations::createBlendedMatrixOperationFromOperationsSuffix(const TransformOperations& from, unsigned start, const BlendingContext& context, const LayoutSize& referenceBoxSize) const
+Ref<TransformOperation> TransformOperations::createBlendedMatrixOperationFromOperationsSuffix(const TransformOperations& from, unsigned start, const BlendingContext& context, const LayoutSize& referenceBoxSize) const
 {
     TransformationMatrix fromTransform;
-    from.apply(start, referenceBoxSize, fromTransform);
+    from.apply(fromTransform, referenceBoxSize, start);
+
     TransformationMatrix toTransform;
-    apply(start, referenceBoxSize, toTransform);
+    apply(toTransform, referenceBoxSize, start);
 
     auto progress = context.progress;
     auto compositeOperation = context.compositeOperation;
@@ -150,9 +161,7 @@ RefPtr<TransformOperation> TransformOperations::createBlendedMatrixOperationFrom
 
 TextStream& operator<<(TextStream& ts, const TransformOperations& ops)
 {
-    for (const auto& operation : ops.operations())
-        ts << *operation;
-    return ts;
+    return ts << ops.m_operations;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/transforms/TransformOperationsSharedPrimitivesPrefix.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperationsSharedPrimitivesPrefix.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#include "config.h"
+#include "TransformOperationsSharedPrimitivesPrefix.h"
+
+#include "TransformOperations.h"
+#include <algorithm>
+
+namespace WebCore {
+
+void TransformOperationsSharedPrimitivesPrefix::update(const TransformOperations& operations)
+{
+    size_t maxIteration = operations.size();
+    if (m_indexOfFirstMismatch.has_value())
+        maxIteration = std::min(*m_indexOfFirstMismatch, maxIteration);
+
+    for (size_t i = 0; i < maxIteration; ++i) {
+        Ref operation = operations[i];
+
+        // If we haven't seen an operation at this index before, we can simply use our primitive type.
+        if (i >= m_primitives.size()) {
+            ASSERT(i == m_primitives.size());
+            m_primitives.append(operation->primitiveType());
+            continue;
+        }
+
+        if (auto sharedPrimitive = operation->sharedPrimitiveType(m_primitives[i]))
+            m_primitives[i] = *sharedPrimitive;
+        else {
+            m_indexOfFirstMismatch = i;
+            m_primitives.shrink(i);
+            return;
+        }
+    }
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/transforms/TransformOperationsSharedPrimitivesPrefix.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperationsSharedPrimitivesPrefix.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+#include "TransformOperation.h"
+#include <optional>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+class TransformOperations;
+
+// This class is used to find a shared prefix of transform function primitives (as
+// defined by CSS Transforms Level 1 & 2). Given a series of `TransformOperations` in
+// the keyframes of an animation. After `update()` is called with the `TransformOperations`
+// of every keyframe, `primitives()` will return the prefix of primitives that are shared
+// by all keyframes passed to `update()`.
+class TransformOperationsSharedPrimitivesPrefix final {
+public:
+    void update(const TransformOperations&);
+
+    bool hadIncompatibleTransformFunctions() { return m_indexOfFirstMismatch.has_value(); }
+    const Vector<TransformOperation::Type>& primitives() const { return m_primitives; }
+
+private:
+    std::optional<size_t> m_indexOfFirstMismatch;
+    Vector<TransformOperation::Type> m_primitives;
+};
+
+} // namespace WebCore
+

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5560,30 +5560,39 @@ RenderStyle RenderLayer::createReflectionStyle()
     newStyle.inheritFrom(renderer().style());
     
     // Map in our transform.
-    TransformOperations transform;
+    Vector<Ref<TransformOperation>> operations;
+
     switch (renderer().style().boxReflect()->direction()) {
     case ReflectionDirection::Below:
-        transform.operations().append(TranslateTransformOperation::create(Length(0, LengthType::Fixed), Length(100., LengthType::Percent), TransformOperation::Type::Translate));
-        transform.operations().append(TranslateTransformOperation::create(Length(0, LengthType::Fixed), renderer().style().boxReflect()->offset(), TransformOperation::Type::Translate));
-        transform.operations().append(ScaleTransformOperation::create(1.0, -1.0, ScaleTransformOperation::Type::Scale));
+        operations = {
+            TranslateTransformOperation::create(Length(0, LengthType::Fixed), Length(100., LengthType::Percent), TransformOperation::Type::Translate),
+            TranslateTransformOperation::create(Length(0, LengthType::Fixed), renderer().style().boxReflect()->offset(), TransformOperation::Type::Translate),
+            ScaleTransformOperation::create(1.0, -1.0, ScaleTransformOperation::Type::Scale)
+        };
         break;
     case ReflectionDirection::Above:
-        transform.operations().append(ScaleTransformOperation::create(1.0, -1.0, ScaleTransformOperation::Type::Scale));
-        transform.operations().append(TranslateTransformOperation::create(Length(0, LengthType::Fixed), Length(100., LengthType::Percent), TransformOperation::Type::Translate));
-        transform.operations().append(TranslateTransformOperation::create(Length(0, LengthType::Fixed), renderer().style().boxReflect()->offset(), TransformOperation::Type::Translate));
+        operations = {
+            ScaleTransformOperation::create(1.0, -1.0, ScaleTransformOperation::Type::Scale),
+            TranslateTransformOperation::create(Length(0, LengthType::Fixed), Length(100., LengthType::Percent), TransformOperation::Type::Translate),
+            TranslateTransformOperation::create(Length(0, LengthType::Fixed), renderer().style().boxReflect()->offset(), TransformOperation::Type::Translate)
+        };
         break;
     case ReflectionDirection::Right:
-        transform.operations().append(TranslateTransformOperation::create(Length(100., LengthType::Percent), Length(0, LengthType::Fixed), TransformOperation::Type::Translate));
-        transform.operations().append(TranslateTransformOperation::create(renderer().style().boxReflect()->offset(), Length(0, LengthType::Fixed), TransformOperation::Type::Translate));
-        transform.operations().append(ScaleTransformOperation::create(-1.0, 1.0, ScaleTransformOperation::Type::Scale));
+        operations = {
+            TranslateTransformOperation::create(Length(100., LengthType::Percent), Length(0, LengthType::Fixed), TransformOperation::Type::Translate),
+            TranslateTransformOperation::create(renderer().style().boxReflect()->offset(), Length(0, LengthType::Fixed), TransformOperation::Type::Translate),
+            ScaleTransformOperation::create(-1.0, 1.0, ScaleTransformOperation::Type::Scale)
+        };
         break;
     case ReflectionDirection::Left:
-        transform.operations().append(ScaleTransformOperation::create(-1.0, 1.0, ScaleTransformOperation::Type::Scale));
-        transform.operations().append(TranslateTransformOperation::create(Length(100., LengthType::Percent), Length(0, LengthType::Fixed), TransformOperation::Type::Translate));
-        transform.operations().append(TranslateTransformOperation::create(renderer().style().boxReflect()->offset(), Length(0, LengthType::Fixed), TransformOperation::Type::Translate));
+        operations = {
+            ScaleTransformOperation::create(-1.0, 1.0, ScaleTransformOperation::Type::Scale),
+            TranslateTransformOperation::create(Length(100., LengthType::Percent), Length(0, LengthType::Fixed), TransformOperation::Type::Translate),
+            TranslateTransformOperation::create(renderer().style().boxReflect()->offset(), Length(0, LengthType::Fixed), TransformOperation::Type::Translate)
+        };
         break;
     }
-    newStyle.setTransform(transform);
+    newStyle.setTransform(TransformOperations { WTFMove(operations) });
 
     // Map in our mask.
     newStyle.setMaskBorder(renderer().style().boxReflect()->mask());

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -4385,7 +4385,7 @@ TransformationMatrix RenderLayerBacking::transformMatrixForProperty(AnimatedProp
     else if (property == AnimatedProperty::Rotate)
         applyTransformOperation(renderer().style().rotate());
     else if (property == AnimatedProperty::Transform)
-        renderer().style().transform().apply(snappedIntRect(m_owningLayer.rendererBorderBoxRect()).size(), matrix);
+        renderer().style().transform().apply(matrix, snappedIntRect(m_owningLayer.rendererBorderBoxRect()).size());
     else
         ASSERT_NOT_REACHED();
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp
@@ -39,8 +39,6 @@
 #include "RenderBoxModelObjectInlines.h"
 #include "RenderStyleInlines.h"
 #include "RenderText.h"
-#include "ScaleTransformOperation.h"
-#include "TransformOperations.h"
 #include <cmath>
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/MathExtras.h>

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2278,14 +2278,13 @@ void RenderStyle::setHasAttrContent()
 
 bool RenderStyle::affectedByTransformOrigin() const
 {
-    if (m_nonInheritedData->rareData->rotate && !m_nonInheritedData->rareData->rotate->isIdentity())
+    if (rotate() && !rotate()->isIdentity())
         return true;
 
-    if (m_nonInheritedData->rareData->scale && !m_nonInheritedData->rareData->scale->isIdentity())
+    if (scale() && !scale()->isIdentity())
         return true;
 
-    auto& transformOperations = m_nonInheritedData->miscData->transform->operations;
-    if (transformOperations.affectedByTransformOrigin())
+    if (transform().affectedByTransformOrigin())
         return true;
 
     if (offsetPath())
@@ -2362,21 +2361,22 @@ void RenderStyle::applyCSSTransform(TransformationMatrix& transform, const Trans
     // 2. Translate by the computed X, Y, and Z values of transform-origin.
     // (implemented in applyTransformOrigin)
     auto& boundingBox = operationData.boundingBox;
+
     // 3. Translate by the computed X, Y, and Z values of translate.
     if (options.contains(RenderStyle::TransformOperationOption::Translate)) {
-        if (TransformOperation* translate = m_nonInheritedData->rareData->translate.get())
+        if (auto* translate = this->translate())
             translate->apply(transform, boundingBox.size());
     }
 
     // 4. Rotate by the computed <angle> about the specified axis of rotate.
     if (options.contains(RenderStyle::TransformOperationOption::Rotate)) {
-        if (TransformOperation* rotate = m_nonInheritedData->rareData->rotate.get())
+        if (auto* rotate = this->rotate())
             rotate->apply(transform, boundingBox.size());
     }
 
     // 5. Scale by the computed X, Y, and Z values of scale.
     if (options.contains(RenderStyle::TransformOperationOption::Scale)) {
-        if (TransformOperation* scale = m_nonInheritedData->rareData->scale.get())
+        if (auto* scale = this->scale())
             scale->apply(transform, boundingBox.size());
     }
 
@@ -2385,9 +2385,7 @@ void RenderStyle::applyCSSTransform(TransformationMatrix& transform, const Trans
         MotionPath::applyMotionPathTransform(*this, operationData, transform);
 
     // 7. Multiply by each of the transform functions in transform from left to right.
-    auto& transformOperations = m_nonInheritedData->miscData->transform->operations;
-    for (auto& operation : transformOperations.operations())
-        operation->apply(transform, boundingBox.size());
+    this->transform().apply(transform, boundingBox.size());
 
     // 8. Translate by the negated computed X, Y and Z values of transform-origin.
     // (implemented in unapplyTransformOrigin)
@@ -2397,9 +2395,8 @@ void RenderStyle::setPageScaleTransform(float scale)
 {
     if (scale == 1)
         return;
-    TransformOperations transform;
-    transform.operations().append(ScaleTransformOperation::create(scale, scale, TransformOperation::Type::Scale));
-    setTransform(transform);
+
+    setTransform(TransformOperations { ScaleTransformOperation::create(scale, scale, TransformOperation::Type::Scale) });
     setTransformOriginX(Length(0, LengthType::Fixed));
     setTransformOriginY(Length(0, LengthType::Fixed));
 }

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1481,7 +1481,7 @@ public:
     inline void setColumnSpan(ColumnSpan);
     inline void inheritColumnPropertiesFrom(const RenderStyle& parent);
 
-    inline void setTransform(const TransformOperations&);
+    inline void setTransform(TransformOperations&&);
     inline void setTransformOriginX(Length&&);
     inline void setTransformOriginY(Length&&);
     inline void setTransformOriginZ(float);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -303,7 +303,7 @@ inline bool RenderStyle::hasPseudoStyle(PseudoId pseudo) const { return m_nonInh
 inline bool RenderStyle::hasStaticBlockPosition(bool horizontal) const { return horizontal ? hasAutoTopAndBottom() : hasAutoLeftAndRight(); }
 inline bool RenderStyle::hasStaticInlinePosition(bool horizontal) const { return horizontal ? hasAutoLeftAndRight() : hasAutoTopAndBottom(); }
 inline bool RenderStyle::hasTextCombine() const { return textCombine() != TextCombine::None; }
-inline bool RenderStyle::hasTransform() const { return !transform().operations().isEmpty() || offsetPath(); }
+inline bool RenderStyle::hasTransform() const { return !transform().isEmpty() || offsetPath(); }
 inline bool RenderStyle::hasTransformRelatedProperty() const { return hasTransform() || translate() || scale() || rotate() || transformStyle3D() == TransformStyle3D::Preserve3D || hasPerspective(); }
 inline bool RenderStyle::hasTransitions() const { return transitions() && transitions()->size(); }
 inline bool RenderStyle::hasViewportConstrainedPosition() const { return position() == PositionType::Fixed || position() == PositionType::Sticky; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -316,7 +316,7 @@ inline void RenderStyle::setTextUnderlinePosition(TextUnderlinePosition position
 inline void RenderStyle::setTextZoom(TextZoom zoom) { SET(m_rareInheritedData, textZoom, static_cast<unsigned>(zoom)); }
 inline void RenderStyle::setTop(Length&& length) { SET_NESTED(m_nonInheritedData, surroundData, offset.top(), WTFMove(length)); }
 inline void RenderStyle::setTouchActions(OptionSet<TouchAction> actions) { SET_NESTED(m_nonInheritedData, rareData, touchActions, actions); }
-inline void RenderStyle::setTransform(const TransformOperations& operations) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, transform, operations, operations); }
+inline void RenderStyle::setTransform(TransformOperations&& operations) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, transform, operations, WTFMove(operations)); }
 inline void RenderStyle::setTransformBox(TransformBox box) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, transform, transformBox, box); }
 inline void RenderStyle::setTransformOriginX(Length&& length) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, transform, x, WTFMove(length)); }
 inline void RenderStyle::setTransformOriginY(Length&& length) { SET_DOUBLY_NESTED(m_nonInheritedData, miscData, transform, y, WTFMove(length)); }

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -71,6 +71,7 @@ inline LengthSize forwardInheritedValue(const LengthSize& value) { auto copy = v
 inline LengthBox forwardInheritedValue(const LengthBox& value) { auto copy = value; return copy; }
 inline GapLength forwardInheritedValue(const GapLength& value) { auto copy = value; return copy; }
 inline FilterOperations forwardInheritedValue(const FilterOperations& value) { auto copy = value; return copy; }
+inline TransformOperations forwardInheritedValue(const TransformOperations& value) { auto copy = value; return copy; }
 
 // Note that we assume the CSS parser only allows valid CSSValue types.
 class BuilderCustom {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2844,7 +2844,7 @@ class WebCore::CAAudioStreamDescription {
 #endif
 
 class WebCore::TransformOperations {
-    Vector<RefPtr<WebCore::TransformOperation>> operations();
+    Vector<Ref<WebCore::TransformOperation>> m_operations;
 }
 
 [Nested, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::Gradient::LinearData {


### PR DESCRIPTION
#### 747e839981525e26209151149e110e2ab07b4ded
<pre>
General cleanup of TransformOperations
<a href="https://bugs.webkit.org/show_bug.cgi?id=274851">https://bugs.webkit.org/show_bug.cgi?id=274851</a>

Reviewed by Darin Adler.

Makes some small improvements to the TransformOperations type:

- Use Ref instead of RefPtr in operations vector.
- Made immutable. All construction already happened in one shot in the builder
  or blend functions, or was a full replacement, so this just meant removing
  non-const accessors and removing the clear() function.
- Expose iterators directly to avoid clients accessing the underlying vector.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/transforms/TransformOperationsSharedPrimitivesPrefix.cpp: Added.
* Source/WebCore/platform/graphics/transforms/TransformOperationsSharedPrimitivesPrefix.h: Added.
    - Split SharedPrimitivesPrefix class into its own file.

* Source/WebCore/platform/graphics/transforms/TransformOperations.cpp:
* Source/WebCore/platform/graphics/transforms/TransformOperations.h:
    - Convert to use a Vector&lt;Ref&lt;TransformOperation&gt;&gt; for the implementation,
      remove all mutating functionality, and add some helpers to make call sites
      more clear.
    - Swap the size and matrix arguments in apply to match individual transforms.

* Source/WebCore/animation/BlendingKeyframes.cpp:
    - Update to use new direct iteration.

* Source/WebCore/animation/CSSPropertyAnimation.cpp:
    - Use an explicit construction of a Vector&lt;Ref&lt;TransformOperation&gt;&gt; to build the
      TransformOperations, this allows for an exactly sized result.
    - Specialize the property wrapper for TransformOperations to allow moving in the
      result to the setter, avoiding a Vector copy.

* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::checkForMatchingTransformFunctionLists):
(WebCore::KeyframeEffect::computeTransformedExtentViaTransformList const):
(WebCore::containsRotation): Deleted.
    - Use new helpers to simplify use.

* Source/WebCore/css/CSSCustomPropertyValue.cpp:
* Source/WebCore/css/CSSCustomPropertyValue.h:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
    - Made TransformSyntaxValue store a Ref, allowing for removing some
      null checks that were never possibly null.

* Source/WebCore/css/ComputedStyleExtractor.cpp:
* Source/WebCore/css/DOMMatrixReadOnly.cpp:
    - Update to use new direct iteration.

* Source/WebCore/css/TransformFunctions.cpp:
    - Use an explicit construction of a Vector&lt;Ref&lt;TransformOperation&gt;&gt; to build the
      TransformOperations using a failable generator constructor.

* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp:
* Source/WebCore/platform/animation/AcceleratedEffectValues.h:
    - Use initialization syntax in copy constructor to avoid unnecessary
      re-initialization. Use new helpers to simplify use.

* Source/WebCore/platform/graphics/GraphicsLayer.h:
    - Use new helpers to simplify use.

* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::hasBig3DRotation):
    - Update for new, more clear, name of SharedPrimitivesPrefix.

* Source/WebCore/platform/graphics/transforms/RotateTransformOperation.h:
* Source/WebCore/platform/graphics/transforms/ScaleTransformOperation.h:
    - Mark final overrides final, and make them public so callers that have
      the specific type can avoid a virtual call (RenderStyle makes use of
      this below).

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
    - Use an explicit construction of a Vector&lt;Ref&lt;TransformOperation&gt;&gt; to build the
      TransformOperations. By using the initialization_list constructor, the vector
      is perfectly sized.

* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::transformMatrixForProperty const):
    - Update for swapped apply arguments.

* Source/WebCore/rendering/mathml/RenderMathMLOperator.cpp:
    - Remove unused includes.

* Source/WebCore/rendering/style/RenderStyle.cpp:
    - Use existing accessors rather than writing full path out each time.
    - Use auto* rather than TransformOperation* to allow for de-virtualization
      of the calls to apply().

* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleSetters.h:
    - Take TransformOperations by r-value to avoid all sets causing a copy. Like
      with Length, StyleBuilder will do an explicit copy when forwarding.

* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::forwardInheritedValue):
    - Add overload of forwardInheritedValue for TransformOperations that copies
      before moving into RenderStyle.

* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::hasTransform const):
    - Call isEmpty() directly on the container.

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
    - Update to directly access operations via the member variable, necessary
      now that there is no operations() function.

* Source/WebCore/platform/graphics/nicosia/NicosiaAnimation.cpp:
(Nicosia::applyTransformAnimation):
    - Update for swapped apply arguments.

Canonical link: <a href="https://commits.webkit.org/279618@main">https://commits.webkit.org/279618@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a2b25989df57ed91b6114732e9b889fc90b0076

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53999 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33371 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57275 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4724 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56301 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4615 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43720 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3121 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46725 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24861 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28418 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4047 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2873 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4247 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58869 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29179 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4333 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51136 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30365 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46855 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50479 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11763 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31319 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30142 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->