### PR TITLE
Fix WTF handling for logging to a file in DataLog.cpp

### DIFF
--- a/Source/WTF/wtf/DataLog.cpp
+++ b/Source/WTF/wtf/DataLog.cpp
@@ -34,16 +34,29 @@
 #include <wtf/ProcessID.h>
 #include <mutex>
 
+// Setting DATA_LOG_TO_FILE to 1 will cause logs to be sent to the filename
+// specified in the WTF_DATA_LOG_FILENAME envvar.
 #define DATA_LOG_TO_FILE 0
-
-// Set to 1 to use the temp directory from confstr instead of hardcoded directory.
-// The last component of DATA_LOG_FILENAME will still be used.
+// Alternatively, setting this to 1 will override the above settings and use
+// the temp directory from confstr instead of the hardcoded directory.
 #define DATA_LOG_TO_DARWIN_TEMP_DIR 0
 
-// Uncomment to force logging to the given file regardless of what the environment variable says.
+// Setting DATA_LOG_TO_FILE_IGNORE_ENVVAR to 1 will cause both data-log options
+// above to always use the fallback filename.
+#define DATA_LOG_IGNORE_ENV_VAR 0
+
+static_assert(!(DATA_LOG_TO_FILE && DATA_LOG_TO_DARWIN_TEMP_DIR), "Set at most one data-log file target");
+#if OS(WINDOWS)
+static_assert(!DATA_LOG_TO_DARWIN_TEMP_DIR, "Cannot log to Darwin temp dir on Windows");
+#endif
+
 // Note that we will append ".<pid>.txt" where <pid> is the PID.
-// This path won't work on Windows, make sure to change to something like C:\\Users\\<more path>\\log.txt.
-#define DATA_LOG_FILENAME "/tmp/WTFLog"
+#define DATA_LOG_DEFAULT_BASENAME "WTFLog"
+#if OS(WINDOWS)
+#define DATA_LOG_DEFAULT_PATH "%localappdata%\\Temp\\"
+#else
+#define DATA_LOG_DEFAULT_PATH "/tmp/"
+#endif
 
 namespace WTF {
 
@@ -60,15 +73,14 @@ static void initializeLogFileOnce()
     if (s_file)
         return;
 
-#if DATA_LOG_TO_FILE
+#if DATA_LOG_TO_FILE || DATA_LOG_TO_DARWIN_TEMP_DIR
 #if DATA_LOG_TO_DARWIN_TEMP_DIR
     char filenameBuffer[maxPathLength + 1];
-#if defined(DATA_LOG_FILENAME)
-    const char* logBasename = strrchr(DATA_LOG_FILENAME, '/');
+    const char* logBasename = DATA_LOG_DEFAULT_BASENAME;
+#if !DATA_LOG_IGNORE_ENV_VAR
+    logBasename = getenv("WTF_DATA_LOG_FILENAME");
     if (!logBasename)
-        logBasename = (char*)DATA_LOG_FILENAME;
-#else
-    const char* logBasename = "WTFLog";
+        logBasename = DATA_LOG_DEFAULT_BASENAME;
 #endif
 
     bool success = confstr(_CS_DARWIN_USER_TEMP_DIR, filenameBuffer, sizeof(filenameBuffer));
@@ -85,18 +97,22 @@ static void initializeLogFileOnce()
             filename = filenameBuffer;
         }
     }
-#elif defined(DATA_LOG_FILENAME)
-    filename = DATA_LOG_FILENAME;
-#else
+#elif DATA_LOG_TO_FILE // !DATA_LOG_TO_DARWIN_TEMP_DIR
+    [[maybe_unused]] static constexpr const char* fallbackFilepath = DATA_LOG_DEFAULT_PATH DATA_LOG_DEFAULT_BASENAME;
+    filename = fallbackFilepath;
+#if !DATA_LOG_IGNORE_ENV_VAR
     filename = getenv("WTF_DATA_LOG_FILENAME");
+    if (!filename)
+        filename = fallbackFilepath;
 #endif
+#endif // DATA_LOG_TO_FILE
     char actualFilename[maxPathLength + 1];
 
     if (filename && !strstr(filename, "%pid")) {
         snprintf(actualFilename, sizeof(actualFilename), "%s.%%pid.txt", filename);
         filename = actualFilename;
     }
-#endif // DATA_LOG_TO_FILE
+#endif // DATA_LOG_TO_FILE || DATA_LOG_TO_DARWIN_TEMP_DIR
 
     setDataFile(filename);
 }


### PR DESCRIPTION
#### 183b8fe2f0c1a1cdd7d766ff2933029a64fb6c81
<pre>
Fix WTF handling for logging to a file in DataLog.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=274855">https://bugs.webkit.org/show_bug.cgi?id=274855</a>
<a href="https://rdar.apple.com/128959048">rdar://128959048</a>

Reviewed by Mark Lam.

In addition to the small (char*) -&gt; (const char*) fix, this reorganizes
things so that the two log options are independent (w/o depending on or
overriding one another), the env-var path works for both, and now the
default path should work on Windows.

* Source/WTF/wtf/DataLog.cpp:

Canonical link: <a href="https://commits.webkit.org/279552@main">https://commits.webkit.org/279552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67fad3129657884ad47734792df2d1fa49ff16e8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6238 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57002 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4447 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4288 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43516 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2908 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55818 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31311 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46452 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24651 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28134 "Found 59 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html, imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html, imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html, imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3772 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2602 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/47082 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58596 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/53265 "Found 1 new JSC stress test failure: stress/scoped-arguments-table-should-be-tolerant-for-oom.js.bytecode-cache (failure)") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28887 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4007 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50924 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30084 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46612 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50268 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31018 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65537 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7958 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29863 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12487 "Passed tests") | 
<!--EWS-Status-Bubble-End-->