### PR TITLE
Drop unnecessary createUnarchiver() overload

### DIFF
--- a/Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm
@@ -73,17 +73,12 @@ static NSEventModifierFlags currentModifierFlags(id self, SEL _cmd)
 }
 #endif
 
-static RetainPtr<NSKeyedUnarchiver> createUnarchiver(const unsigned char* bytes, NSUInteger length)
+static RetainPtr<NSKeyedUnarchiver> createUnarchiver(std::span<const uint8_t> span)
 {
-    auto data = adoptNS([[NSData alloc] initWithBytesNoCopy:const_cast<unsigned char*>(bytes) length:length freeWhenDone:NO]);
-    auto unarchiver = adoptNS([[NSKeyedUnarchiver alloc] initForReadingFromData:data.get() error:nullptr]);
+    RetainPtr data = adoptNS([[NSData alloc] initWithBytesNoCopy:const_cast<uint8_t*>(span.data()) length:span.size() freeWhenDone:NO]);
+    RetainPtr unarchiver = adoptNS([[NSKeyedUnarchiver alloc] initForReadingFromData:data.get() error:nullptr]);
     unarchiver.get().decodingFailurePolicy = NSDecodingFailurePolicyRaiseException;
     return unarchiver;
-}
-
-static RetainPtr<NSKeyedUnarchiver> createUnarchiver(std::span<const uint8_t> data)
-{
-    return createUnarchiver(data.data(), data.size());
 }
 
 static RetainPtr<NSKeyedUnarchiver> createUnarchiver(const API::Data& data)


### PR DESCRIPTION
#### 65727165b38b3a930ed9a73bec5abdd79be26ad7
<pre>
Drop unnecessary createUnarchiver() overload
<a href="https://bugs.webkit.org/show_bug.cgi?id=274857">https://bugs.webkit.org/show_bug.cgi?id=274857</a>

Reviewed by Per Arne Vollan.

Drop unnecessary createUnarchiver() overload as it is no longer used.

* Source/WebKit/WebProcess/InjectedBundle/mac/InjectedBundleMac.mm:
(WebKit::createUnarchiver):

Canonical link: <a href="https://commits.webkit.org/279485@main">https://commits.webkit.org/279485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98780444f7a4c3778ae8e7708ec750ec8eaf6de1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56857 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4303 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40409 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4127 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43432 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2823 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55675 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31148 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46306 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24562 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27999 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2459 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58454 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28735 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3854 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50839 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-17-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46479 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50176 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30874 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7907 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29713 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->