### PR TITLE
DOMMatrix.inverse() returns NaN matrix for small but normal values

### DIFF
--- a/LayoutTests/fast/css/matrix-small-values-inverse-expected.txt
+++ b/LayoutTests/fast/css/matrix-small-values-inverse-expected.txt
@@ -1,0 +1,21 @@
+DOMMatrix.invers() should not return NaN for small but normal values.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS matrixInverse.a is not NaN
+PASS matrixInverse.b is not NaN
+PASS matrixInverse.c is not NaN
+PASS matrixInverse.d is not NaN
+PASS matrixInverse.e is not NaN
+PASS matrixInverse.f is not NaN
+PASS Math.abs(matrixInverse.a - svgMatrixInverse.a) < 0.0000001 is true
+PASS Math.abs(matrixInverse.b - svgMatrixInverse.b) < 0.0000001 is true
+PASS Math.abs(matrixInverse.c - svgMatrixInverse.c) < 0.0000001 is true
+PASS Math.abs(matrixInverse.d - svgMatrixInverse.d) < 0.0000001 is true
+PASS Math.abs(matrixInverse.e - svgMatrixInverse.e) < 0.0000001 is true
+PASS Math.abs(matrixInverse.f - svgMatrixInverse.f) < 0.0000001 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/matrix-small-values-inverse.html
+++ b/LayoutTests/fast/css/matrix-small-values-inverse.html
@@ -1,0 +1,33 @@
+<script src="../../resources/js-test.js"></script>
+<body>
+    <script>
+        description("DOMMatrix.invers() should not return NaN for small but normal values.");
+
+        const matrix = new DOMMatrix([9.780006597705043e-07, 3.532646825298159e-07, -2.528174268419108e-07, 1.326003454762908e-06, 42.05985792398261, -76.82054904789567]);
+        const svgMatrix = document.createElementNS('http://www.w3.org/2000/svg', 'svg').createSVGMatrix();
+
+        svgMatrix.a = matrix.a;
+        svgMatrix.b = matrix.b;
+        svgMatrix.c = matrix.c;
+        svgMatrix.d = matrix.d;
+        svgMatrix.e = matrix.e;
+        svgMatrix.f = matrix.f;
+
+        const matrixInverse = matrix.inverse();
+        const svgMatrixInverse = svgMatrix.inverse();
+
+        shouldNotBe("matrixInverse.a", "NaN");
+        shouldNotBe("matrixInverse.b", "NaN");
+        shouldNotBe("matrixInverse.c", "NaN");
+        shouldNotBe("matrixInverse.d", "NaN");
+        shouldNotBe("matrixInverse.e", "NaN");
+        shouldNotBe("matrixInverse.f", "NaN");
+
+        shouldBeTrue("Math.abs(matrixInverse.a - svgMatrixInverse.a) < 0.0000001");
+        shouldBeTrue("Math.abs(matrixInverse.b - svgMatrixInverse.b) < 0.0000001");
+        shouldBeTrue("Math.abs(matrixInverse.c - svgMatrixInverse.c) < 0.0000001");
+        shouldBeTrue("Math.abs(matrixInverse.d - svgMatrixInverse.d) < 0.0000001");
+        shouldBeTrue("Math.abs(matrixInverse.e - svgMatrixInverse.e) < 0.0000001");
+        shouldBeTrue("Math.abs(matrixInverse.f - svgMatrixInverse.f) < 0.0000001");
+    </script>
+</body>

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
@@ -69,8 +69,6 @@ namespace WebCore {
 typedef double Vector4[4];
 typedef double Vector3[3];
 
-const double SMALL_NUMBER = 1.e-8;
-
 const TransformationMatrix TransformationMatrix::identity { };
 
 // inverse(original_matrix, inverse_matrix)
@@ -212,16 +210,15 @@ static bool inverse(const TransformationMatrix::Matrix4& matrix, TransformationM
     // Calculate the 4x4 determinant
     // If the determinant is zero,
     // then the inverse matrix is not unique.
-    double det = determinant4x4(matrix);
-
-    if (std::abs(det) < SMALL_NUMBER)
+    double determinant = determinant4x4(matrix);
+    if (!std::isnormal(determinant))
         return false;
 
     // Scale the adjoint matrix to get the inverse
 
     for (int i = 0; i < 4; i++)
         for (int j = 0; j < 4; j++)
-            result[i][j] = result[i][j] / det;
+            result[i][j] = result[i][j] / determinant;
 
     return true;
 }
@@ -1576,7 +1573,7 @@ bool TransformationMatrix::isInvertible() const
     if (type == Type::IdentityOrTranslation)
         return true;
 
-    return std::abs(type == Type::Affine ? (m11() * m22() - m12() * m21()) : WebCore::determinant4x4(m_matrix)) >= SMALL_NUMBER;
+    return std::isnormal(type == Type::Affine ? (m11() * m22() - m12() * m21()) : WebCore::determinant4x4(m_matrix));
 }
 
 std::optional<TransformationMatrix> TransformationMatrix::inverse() const
@@ -1602,7 +1599,7 @@ std::optional<TransformationMatrix> TransformationMatrix::inverse() const
         double e = m41();
         double f = m42();
         double determinant = a * d - b * c;
-        if (std::abs(determinant) < SMALL_NUMBER)
+        if (!std::isnormal(determinant))
             return std::nullopt;
 
         double inverseDeterminant = 1 / determinant;
@@ -1919,7 +1916,7 @@ bool TransformationMatrix::isBackFaceVisible() const
     double determinant = WebCore::determinant4x4(m_matrix);
 
     // If the matrix is not invertible, then we assume its backface is not visible.
-    if (std::abs(determinant) < SMALL_NUMBER)
+    if (!std::isnormal(determinant))
         return false;
 
     double cofactor33 = determinant3x3(m11(), m12(), m14(), m21(), m22(), m24(), m41(), m42(), m44());


### PR DESCRIPTION
#### 1f6b653b2343f60efb7261d8c1502f2fd427cfa6
<pre>
DOMMatrix.inverse() returns NaN matrix for small but normal values
<a href="https://bugs.webkit.org/show_bug.cgi?id=274834">https://bugs.webkit.org/show_bug.cgi?id=274834</a>
<a href="https://rdar.apple.com/128960283">rdar://128960283</a>

Reviewed by Kimmo Kinnunen.

Use std::isnormal(determinant) to check if DOMMatrix (or TransformationMatrix)
isInvertible(). This will replace checking the determinant is less than a defined
SMALL_NUMBER.

* LayoutTests/fast/css/matrix-small-values-inverse-expected.txt: Added.
* LayoutTests/fast/css/matrix-small-values-inverse.html: Added.
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp:
(WebCore::inverse):
(WebCore::TransformationMatrix::isInvertible const):
(WebCore::TransformationMatrix::inverse const):
(WebCore::TransformationMatrix::isBackFaceVisible const):

Canonical link: <a href="https://commits.webkit.org/279588@main">https://commits.webkit.org/279588@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c8121871e79d0d8b7055ec61a95ce52302cd8e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53581 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56861 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4307 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55887 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40413 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4110 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43436 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2824 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55679 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31160 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46310 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24571 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/27984 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Running apply-patch; Checked out pull request; Passed layout tests; Running layout-tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3629 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2463 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49744 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3802 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58458 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28740 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3825 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; Running layout-tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50841 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29946 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46482 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50179 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11744 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30878 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29719 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->