### PR TITLE
WebCore::ScopedInspectorShaderProgramHighlight constructor does not initialize struct m_savedBlend

### DIFF
--- a/Source/WebCore/html/canvas/WebGLUtilities.h
+++ b/Source/WebCore/html/canvas/WebGLUtilities.h
@@ -53,14 +53,14 @@ private:
     void hideHighlight();
 
     struct {
-        GCGLfloat color[4];
-        GCGLenum equationRGB;
-        GCGLenum equationAlpha;
-        GCGLenum srcRGB;
-        GCGLenum dstRGB;
-        GCGLenum srcAlpha;
-        GCGLenum dstAlpha;
-        GCGLboolean enabled;
+        GCGLfloat color[4] { 0, 0, 0, 0 };
+        GCGLenum equationRGB { GraphicsContextGL::NONE };
+        GCGLenum equationAlpha { GraphicsContextGL::NONE };
+        GCGLenum srcRGB { GraphicsContextGL::ONE };
+        GCGLenum dstRGB { GraphicsContextGL::ZERO };
+        GCGLenum srcAlpha { GraphicsContextGL::ONE };
+        GCGLenum dstAlpha { GraphicsContextGL::ZERO };
+        GCGLboolean enabled { false };
     } m_savedBlend;
 
     WebGLRenderingContextBase* const m_context;


### PR DESCRIPTION
#### e39e0c613f32314d1779a80cf520865827c19646
<pre>
WebCore::ScopedInspectorShaderProgramHighlight constructor does not initialize struct m_savedBlend
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=274858">https://bugs.webkit.org/show_bug.cgi?id=274858</a>&gt;
&lt;<a href="https://rdar.apple.com/128962006">rdar://128962006</a>&gt;

Reviewed by Dan Glastonbury.

* Source/WebCore/html/canvas/WebGLUtilities.h:
(WebCore::ScopedInspectorShaderProgramHighlight::m_savedBlend):
- Add default initializers.

Canonical link: <a href="https://commits.webkit.org/279549@main">https://commits.webkit.org/279549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db20916eac37b75c321da8166f9f28aded32149d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6224 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56988 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4433 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56011 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4271 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43510 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2901 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55804 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46440 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24645 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28116 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3759 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2588 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58582 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28872 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3987 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50915 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30070 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46602 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50260 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31003 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7953 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29847 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->