### PR TITLE
 Adopt StringParsingBuffer & std::span in WGSL's Lexer

### DIFF
--- a/Source/WebGPU/WGSL/Lexer.h
+++ b/Source/WebGPU/WGSL/Lexer.h
@@ -27,6 +27,7 @@
 
 #include "Token.h"
 #include <wtf/ASCIICType.h>
+#include <wtf/text/StringParsingBuffer.h>
 #include <wtf/text/WTFString.h>
 
 namespace WGSL {
@@ -36,17 +37,15 @@ class Lexer {
 public:
     Lexer(const String& wgsl)
     {
-        if constexpr (std::is_same<T, LChar>::value) {
-            m_code = wgsl.span8().data();
-            m_codeEnd = m_code + wgsl.sizeInBytes();
-        } else {
+        if constexpr (std::is_same<T, LChar>::value)
+            m_code = wgsl.span8();
+        else {
             static_assert(std::is_same<T, UChar>::value, "The lexer expects its template parameter to be either LChar or UChar");
-            m_code = wgsl.span16().data();
+            m_code = wgsl.span16();
             ASSERT(!(wgsl.sizeInBytes() % 2));
-            m_codeEnd = m_code + wgsl.sizeInBytes() / 2;
         }
 
-        m_current = (m_code != m_codeEnd) ? *m_code : 0;
+        m_current = m_code.hasCharactersRemaining() ? m_code[0] : 0;
         m_currentPosition = { 1, 0, 0 };
     }
 
@@ -86,8 +85,7 @@ private:
     bool skipWhitespaceAndComments();
 
     T m_current;
-    const T* m_code;
-    const T* m_codeEnd;
+    StringParsingBuffer<T> m_code;
     SourcePosition m_currentPosition { 0, 0, 0 };
     SourcePosition m_tokenStartingPosition { 0, 0, 0 };
 };


### PR DESCRIPTION
#### 8bd834504598b8c53f71236d66d714b6a61b3281
<pre>
 Adopt StringParsingBuffer &amp; std::span in WGSL&apos;s Lexer
<a href="https://bugs.webkit.org/show_bug.cgi?id=274861">https://bugs.webkit.org/show_bug.cgi?id=274861</a>

Reviewed by Sam Weinig.

* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::isIdentifierStart):
(WGSL::isIdentifierContinue):
(WGSL::Lexer&lt;T&gt;::nextToken):
(WGSL::Lexer&lt;T&gt;::shift):
(WGSL::Lexer&lt;T&gt;::peek):
(WGSL::Lexer&lt;T&gt;::isAtEndOfFile const):
(WGSL::Lexer&lt;T&gt;::lexNumber):
* Source/WebGPU/WGSL/Lexer.h:
(WGSL::Lexer::Lexer):

Canonical link: <a href="https://commits.webkit.org/279533@main">https://commits.webkit.org/279533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4218c14413395048f0d7d8324e833b4250d7f11

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56986 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4431 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40561 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43509 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2898 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55802 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31289 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46438 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24644 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28115 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2586 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58580 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28870 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3983 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50919 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30068 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46600 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31001 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7942 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29845 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->