### PR TITLE
libpas: Enable easier testing of PGM crashes

### DIFF
--- a/Source/WTF/wtf/FastMalloc.cpp
+++ b/Source/WTF/wtf/FastMalloc.cpp
@@ -870,6 +870,11 @@ void fastDisableScavenger()
     bmalloc::api::disableScavenger();
 }
 
+void forceEnablePGM()
+{
+    bmalloc::api::forceEnablePGM();
+}
+
 } // namespace WTF
 
 #endif // USE(SYSTEM_MALLOC)

--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -138,6 +138,8 @@ WTF_EXPORT_PRIVATE void fastEnableMiniMode();
 
 WTF_EXPORT_PRIVATE void fastDisableScavenger();
 
+WTF_EXPORT_PRIVATE void forceEnablePGM();
+
 class ForbidMallocUseForCurrentThreadScope {
 public:
 #if ASSERT_ENABLED

--- a/Source/bmalloc/bmalloc/bmalloc.cpp
+++ b/Source/bmalloc/bmalloc/bmalloc.cpp
@@ -33,6 +33,7 @@
 #if BENABLE(LIBPAS)
 #include "bmalloc_heap_config.h"
 #include "pas_page_sharing_pool.h"
+#include "pas_probabilistic_guard_malloc_allocator.h"
 #include "pas_scavenger.h"
 #include "pas_thread_local_cache.h"
 #endif
@@ -229,6 +230,13 @@ void disableScavenger()
 #if !BUSE(LIBPAS)
     if (!DebugHeap::tryGet())
         Scavenger::get()->disable();
+#endif
+}
+
+void forceEnablePGM()
+{
+#if BUSE(LIBPAS)
+    pas_probabilistic_guard_malloc_initialize_pgm_as_enabled();
 #endif
 }
 

--- a/Source/bmalloc/bmalloc/bmalloc.h
+++ b/Source/bmalloc/bmalloc/bmalloc.h
@@ -226,6 +226,7 @@ BEXPORT void enableMiniMode();
 
 // Used for debugging only.
 BEXPORT void disableScavenger();
+BEXPORT void forceEnablePGM();
 
 #if BENABLE(MALLOC_SIZE)
 inline size_t mallocSize(const void* object)

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c
@@ -290,6 +290,17 @@ void pas_probabilistic_guard_malloc_initialize_pgm(void)
     }
 }
 
+/*
+ * This function shall be called for testing PGM behavior, since PGM enablement will be non-deterministic otherwise.
+ */
+void pas_probabilistic_guard_malloc_initialize_pgm_as_enabled(void)
+{
+    pas_probabilistic_guard_malloc_is_initialized = true;
+    pas_probabilistic_guard_malloc_can_use = true;
+    pas_probabilistic_guard_malloc_random = 1;
+    pas_probabilistic_guard_malloc_counter = 0;
+}
+
 void pas_probabilistic_guard_malloc_debug_info(const void* key, const pas_pgm_storage* value, const char* operation)
 {
     printf("******************************************************\n"

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
@@ -127,6 +127,7 @@ static PAS_ALWAYS_INLINE bool pas_probabilistic_guard_malloc_should_call_pgm(voi
 }
 
 extern PAS_API void pas_probabilistic_guard_malloc_initialize_pgm(void);
+extern PAS_API void pas_probabilistic_guard_malloc_initialize_pgm_as_enabled(void);
 pas_large_map_entry pas_probabilistic_guard_malloc_return_as_large_map_entry(uintptr_t mem);
 
 PAS_END_EXTERN_C;


### PR DESCRIPTION
#### 0146f7f3441f8d788963818d223665fc231c74ff
<pre>
libpas: Enable easier testing of PGM crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=274863">https://bugs.webkit.org/show_bug.cgi?id=274863</a>

Reviewed by David Kilzer.

Add crash test scenarios to enable automated testing of PGM crashes in libpas for ReportCrash.
JavaScriptCore is required to perform testing for ReportCrash, so I added it to the jsc binary.

The new options available are:
./jsc --crash-vm=PGMOOBLowerGuardPage
./jsc --crash-vm=PGMOOBUpperGuardPage
./jsc --crash-vm=PGMUAF

* Source/JavaScriptCore/jsc.cpp:
(printUsageStatement):
(CommandLine::parseArguments):
* Source/WTF/wtf/FastMalloc.cpp:
(WTF::forceEnablePGM):
* Source/WTF/wtf/FastMalloc.h:
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
(pas_probabilistic_guard_malloc_initialize_pgm_as_enabled):
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h:

Canonical link: <a href="https://commits.webkit.org/280443@main">https://commits.webkit.org/280443@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3724b14d2ff4bc83108dbf1b10defd9e3d2e1775

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56591 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35918 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9064 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60205 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7032 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7223 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45843 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4922 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33791 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48842 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26704 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30551 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6174 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6035 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/49683 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52508 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61887 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/55832 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/503 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6549 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53101 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/504 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48901 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53092 "Found 3 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12533 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/434 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/77593 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31746 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12857 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32832 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33916 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32578 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->