### PR TITLE
[UnifiedPDF] Form annotations get stuck permanently on the document when navigating while an annotation is focused

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h
@@ -87,7 +87,7 @@ public:
     virtual ~PDFPlugin();
 
     void paintControlForLayerInContext(CALayer *, CGContextRef);
-    void setActiveAnnotation(RetainPtr<PDFAnnotation>&&) final;
+    void setActiveAnnotation(SetActiveAnnotationParams&&) final;
 
     void notifyContentScaleFactorChanged(CGFloat scaleFactor);
     void notifyDisplayModeChanged(int);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -457,7 +457,7 @@ static WebCore::Cursor::Type toWebCoreCursorType(PDFLayerControllerCursorType cu
 
 - (void)pdfLayerController:(PDFLayerController *)pdfLayerController didChangeActiveAnnotation:(PDFAnnotation *)annotation
 {
-    _pdfPlugin->setActiveAnnotation(annotation);
+    _pdfPlugin->setActiveAnnotation({ annotation });
 }
 
 - (void)pdfLayerController:(PDFLayerController *)pdfLayerController didChangeContentScaleFactor:(CGFloat)scaleFactor
@@ -1194,10 +1194,10 @@ void PDFPlugin::invalidateScrollCornerRect(const IntRect& rect)
     [m_scrollCornerLayer setNeedsDisplay];
 }
 
-void PDFPlugin::setActiveAnnotation(RetainPtr<PDFAnnotation>&& annotation)
+void PDFPlugin::setActiveAnnotation(SetActiveAnnotationParams&& setActiveAnnotationParams)
 {
     // This may be called off the main thread if VoiceOver is running, thus dispatch to the main runloop since it involves main thread only objects.
-    callOnMainRunLoopAndWait([annotation = WTFMove(annotation), this] {
+    callOnMainRunLoopAndWait([annotation = WTFMove(setActiveAnnotationParams.annotation), this] {
         if (!supportsForms())
             return;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
@@ -119,7 +119,7 @@ void PDFPluginAnnotation::updateGeometry()
 bool PDFPluginAnnotation::handleEvent(Event& event)
 {
     if (event.type() == eventNames().blurEvent || event.type() == eventNames().changeEvent) {
-        m_plugin->setActiveAnnotation(0);
+        m_plugin->setActiveAnnotation({ nullptr });
         return true;
     }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -228,7 +228,15 @@ public:
     PDFPluginAnnotation* activeAnnotation() const { return m_activeAnnotation.get(); }
     RefPtr<PDFPluginAnnotation> protectedActiveAnnotation() const;
 #endif
-    virtual void setActiveAnnotation(RetainPtr<PDFAnnotation>&&) = 0;
+
+    enum class IsInPluginCleanup : bool { No, Yes };
+
+    struct SetActiveAnnotationParams {
+        RetainPtr<PDFAnnotation> annotation;
+        IsInPluginCleanup isInPluginCleanup { IsInPluginCleanup::No };
+    };
+
+    virtual void setActiveAnnotation(SetActiveAnnotationParams&&) = 0;
     void didMutatePDFDocument() { m_pdfDocumentWasMutated = true; }
 
     virtual CGRect pluginBoundsForAnnotation(RetainPtr<PDFAnnotation>&) const = 0;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -125,7 +125,7 @@ public:
     WebCore::FrameView* mainFrameView() const;
 
     CGRect pluginBoundsForAnnotation(RetainPtr<PDFAnnotation>&) const final;
-    void setActiveAnnotation(RetainPtr<PDFAnnotation>&&) final;
+    void setActiveAnnotation(SetActiveAnnotationParams&&) final;
     void focusNextAnnotation() final;
     void focusPreviousAnnotation() final;
 #if PLATFORM(MAC)


### PR DESCRIPTION
#### 3cecef4425a0713947e7774132427d2d9bb7193d
<pre>
[UnifiedPDF] Form annotations get stuck permanently on the document when navigating while an annotation is focused
<a href="https://bugs.webkit.org/show_bug.cgi?id=274867">https://bugs.webkit.org/show_bug.cgi?id=274867</a>
<a href="https://rdar.apple.com/128912717">rdar://128912717</a>

Reviewed by Simon Fraser.

When an annotation is focused and we navigate away, nothing ensures that
the active annotation is cleaned up appropriately and the queued async
task to call Node::remove() on the annotation element gets dropped.

This means that on a reload, the Node corresponding to the previous
active annotation is still hanging around, and now with no way to
actually detach it.

This patch fixes said issue by ensuring we do eager cleanup for any
active annotation when the PDF plugin is torn down.Note that we now
provide additional context to setActiveAnnotation() because when the
navigation has started, and the plugin is being torn down,
PDFPluginBase::isFullFramePlugin() returns false, expectedly so. We do
not want to consult this during cleanup.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(-[WKPDFLayerControllerDelegate pdfLayerController:didChangeActiveAnnotation:]):
(WebKit::PDFPlugin::setActiveAnnotation):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm:
(WebKit::PDFPluginAnnotation::handleEvent):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::teardown):
(WebKit::UnifiedPDFPlugin::handleMouseEvent):
(WebKit::UnifiedPDFPlugin::focusNextAnnotation):
(WebKit::UnifiedPDFPlugin::focusPreviousAnnotation):
(WebKit::UnifiedPDFPlugin::setActiveAnnotation):

Canonical link: <a href="https://commits.webkit.org/279537@main">https://commits.webkit.org/279537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9adb4f10d39b762d4797940561b6bcdcc4b35602

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57005 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4450 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40580 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4292 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43519 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2911 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55821 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46456 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24654 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28140 "Found 59 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html, imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html, imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html, imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html, imported/w3c/web-platform-tests/FileAPI/file/File-constructor-endings.html ... (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2605 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3958 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58599 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28892 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4005 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50927 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30087 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46617 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11704 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31021 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/29866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->