### PR TITLE
WebCore::XPath::Value has uninitialized fields after construction

### DIFF
--- a/Source/WebCore/xml/XPathFunctions.cpp
+++ b/Source/WebCore/xml/XPathFunctions.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2005 Frerich Raabe <raabe@kde.org>
- * Copyright (C) 2006, 2009, 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2019 Google Inc. All rights reserved.
  * Copyright (C) 2007 Alexey Proskuryakov <ap@webkit.org>
  *
@@ -68,157 +68,157 @@ private:
 
 class FunLast final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::NumberValue; }
+    Value::Type resultType() const override { return Value::Type::Number; }
 public:
     FunLast() { setIsContextSizeSensitive(true); }
 };
 
 class FunPosition final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::NumberValue; }
+    Value::Type resultType() const override { return Value::Type::Number; }
 public:
     FunPosition() { setIsContextPositionSensitive(true); }
 };
 
 class FunCount final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::NumberValue; }
+    Value::Type resultType() const override { return Value::Type::Number; }
 };
 
 class FunId final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::NodeSetValue; }
+    Value::Type resultType() const override { return Value::Type::NodeSet; }
 };
 
 class FunLocalName final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::StringValue; }
+    Value::Type resultType() const override { return Value::Type::String; }
 public:
     FunLocalName() { setIsContextNodeSensitive(true); } // local-name() with no arguments uses context node. 
 };
 
 class FunNamespaceURI final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::StringValue; }
+    Value::Type resultType() const override { return Value::Type::String; }
 public:
     FunNamespaceURI() { setIsContextNodeSensitive(true); } // namespace-uri() with no arguments uses context node. 
 };
 
 class FunName final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::StringValue; }
+    Value::Type resultType() const override { return Value::Type::String; }
 public:
     FunName() { setIsContextNodeSensitive(true); } // name() with no arguments uses context node. 
 };
 
 class FunString final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::StringValue; }
+    Value::Type resultType() const override { return Value::Type::String; }
 public:
     FunString() { setIsContextNodeSensitive(true); } // string() with no arguments uses context node. 
 };
 
 class FunConcat final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::StringValue; }
+    Value::Type resultType() const override { return Value::Type::String; }
 };
 
 class FunStartsWith final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::BooleanValue; }
+    Value::Type resultType() const override { return Value::Type::Boolean; }
 };
 
 class FunContains final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::BooleanValue; }
+    Value::Type resultType() const override { return Value::Type::Boolean; }
 };
 
 class FunSubstringBefore final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::StringValue; }
+    Value::Type resultType() const override { return Value::Type::String; }
 };
 
 class FunSubstringAfter final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::StringValue; }
+    Value::Type resultType() const override { return Value::Type::String; }
 };
 
 class FunSubstring final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::StringValue; }
+    Value::Type resultType() const override { return Value::Type::String; }
 };
 
 class FunStringLength final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::NumberValue; }
+    Value::Type resultType() const override { return Value::Type::Number; }
 public:
     FunStringLength() { setIsContextNodeSensitive(true); } // string-length() with no arguments uses context node. 
 };
 
 class FunNormalizeSpace final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::StringValue; }
+    Value::Type resultType() const override { return Value::Type::String; }
 public:
     FunNormalizeSpace() { setIsContextNodeSensitive(true); } // normalize-space() with no arguments uses context node. 
 };
 
 class FunTranslate final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::StringValue; }
+    Value::Type resultType() const override { return Value::Type::String; }
 };
 
 class FunBoolean final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::BooleanValue; }
+    Value::Type resultType() const override { return Value::Type::Boolean; }
 };
 
 class FunNot : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::BooleanValue; }
+    Value::Type resultType() const override { return Value::Type::Boolean; }
 };
 
 class FunTrue final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::BooleanValue; }
+    Value::Type resultType() const override { return Value::Type::Boolean; }
 };
 
 class FunFalse final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::BooleanValue; }
+    Value::Type resultType() const override { return Value::Type::Boolean; }
 };
 
 class FunLang final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::BooleanValue; }
+    Value::Type resultType() const override { return Value::Type::Boolean; }
 public:
     FunLang() { setIsContextNodeSensitive(true); } // lang() always works on context node. 
 };
 
 class FunNumber final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::NumberValue; }
+    Value::Type resultType() const override { return Value::Type::Number; }
 public:
     FunNumber() { setIsContextNodeSensitive(true); } // number() with no arguments uses context node. 
 };
 
 class FunSum final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::NumberValue; }
+    Value::Type resultType() const override { return Value::Type::Number; }
 };
 
 class FunFloor final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::NumberValue; }
+    Value::Type resultType() const override { return Value::Type::Number; }
 };
 
 class FunCeiling final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::NumberValue; }
+    Value::Type resultType() const override { return Value::Type::Number; }
 };
 
 class FunRound final : public Function {
     Value evaluate() const override;
-    Value::Type resultType() const override { return Value::NumberValue; }
+    Value::Type resultType() const override { return Value::Type::Number; }
 public:
     static double round(double);
 };
@@ -784,5 +784,5 @@ std::unique_ptr<Function> Function::create(const String& name, Vector<std::uniqu
     return function;
 }
 
-}
-}
+} // namespace XPath
+} // namespace WebCore

--- a/Source/WebCore/xml/XPathPath.h
+++ b/Source/WebCore/xml/XPathPath.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2005 Frerich Raabe <raabe@kde.org>
- * Copyright (C) 2006, 2009, 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,52 +29,52 @@
 #include "XPathExpressionNode.h"
 
 namespace WebCore {
-    namespace XPath {
+namespace XPath {
 
-        class Step;
+class Step;
 
-        class Filter final : public Expression {
-        public:
-            Filter(std::unique_ptr<Expression>, Vector<std::unique_ptr<Expression>> predicates);
+class Filter final : public Expression {
+public:
+    Filter(std::unique_ptr<Expression>, Vector<std::unique_ptr<Expression>> predicates);
 
-        private:
-            Value evaluate() const override;
-            Value::Type resultType() const override { return Value::NodeSetValue; }
+private:
+    Value evaluate() const override;
+    Value::Type resultType() const override { return Value::Type::NodeSet; }
 
-            std::unique_ptr<Expression> m_expression;
-            Vector<std::unique_ptr<Expression>> m_predicates;
-        };
+    std::unique_ptr<Expression> m_expression;
+    Vector<std::unique_ptr<Expression>> m_predicates;
+};
 
-        class LocationPath final : public Expression {
-        public:
-            LocationPath();
+class LocationPath final : public Expression {
+public:
+    LocationPath();
 
-            void setAbsolute() { m_isAbsolute = true; setIsContextNodeSensitive(false); }
+    void setAbsolute() { m_isAbsolute = true; setIsContextNodeSensitive(false); }
 
-            void evaluate(NodeSet& nodes) const; // nodes is an input/output parameter
+    void evaluate(NodeSet& nodes) const; // nodes is an input/output parameter
 
-            void appendStep(std::unique_ptr<Step>);
-            void prependStep(std::unique_ptr<Step>);
+    void appendStep(std::unique_ptr<Step>);
+    void prependStep(std::unique_ptr<Step>);
 
-        private:
-            Value evaluate() const override;
-            Value::Type resultType() const override { return Value::NodeSetValue; }
+private:
+    Value evaluate() const override;
+    Value::Type resultType() const override { return Value::Type::NodeSet; }
 
-            Vector<std::unique_ptr<Step>> m_steps;
-            bool m_isAbsolute;
-        };
+    Vector<std::unique_ptr<Step>> m_steps;
+    bool m_isAbsolute;
+};
 
-        class Path final : public Expression {
-        public:
-            Path(std::unique_ptr<Expression> filter, std::unique_ptr<LocationPath>);
+class Path final : public Expression {
+public:
+    Path(std::unique_ptr<Expression> filter, std::unique_ptr<LocationPath>);
 
-        private:
-            Value evaluate() const override;
-            Value::Type resultType() const override { return Value::NodeSetValue; }
+private:
+    Value evaluate() const override;
+    Value::Type resultType() const override { return Value::Type::NodeSet; }
 
-            std::unique_ptr<Expression> m_filter;
-            std::unique_ptr<LocationPath> m_path;
-        };
+    std::unique_ptr<Expression> m_filter;
+    std::unique_ptr<LocationPath> m_path;
+};
 
-    } // namespace XPath
+} // namespace XPath
 } // namespace WebCore

--- a/Source/WebCore/xml/XPathPredicate.cpp
+++ b/Source/WebCore/xml/XPathPredicate.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2005 Frerich Raabe <raabe@kde.org>
- * Copyright (C) 2006, 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2007 Alexey Proskuryakov <ap@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -297,8 +297,8 @@ bool evaluatePredicate(const Expression& expression)
 
 bool predicateIsContextPositionSensitive(const Expression& expression)
 {
-    return expression.isContextPositionSensitive() || expression.resultType() == Value::NumberValue;
+    return expression.isContextPositionSensitive() || expression.resultType() == Value::Type::Number;
 }
 
-}
-}
+} // namespace XPath
+} // namespace WebCore

--- a/Source/WebCore/xml/XPathPredicate.h
+++ b/Source/WebCore/xml/XPathPredicate.h
@@ -1,6 +1,6 @@
 /*
  * Copyright 2005 Frerich Raabe <raabe@kde.org>
- * Copyright (C) 2006, 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,88 +29,88 @@
 #include "XPathExpressionNode.h"
 
 namespace WebCore {
-    namespace XPath {
-        
-        class Number final : public Expression {
-        public:
-            explicit Number(double);
+namespace XPath {
 
-        private:
-            Value evaluate() const override;
-            Value::Type resultType() const override { return Value::NumberValue; }
+class Number final : public Expression {
+public:
+    explicit Number(double);
 
-            Value m_value;
-        };
+private:
+    Value evaluate() const override;
+    Value::Type resultType() const override { return Value::Type::Number; }
 
-        class StringExpression final : public Expression {
-        public:
-            explicit StringExpression(String&&);
+    Value m_value;
+};
 
-        private:
-            Value evaluate() const override;
-            Value::Type resultType() const override { return Value::StringValue; }
+class StringExpression final : public Expression {
+public:
+    explicit StringExpression(String&&);
 
-            Value m_value;
-        };
+private:
+    Value evaluate() const override;
+    Value::Type resultType() const override { return Value::Type::String; }
 
-        class Negative final : public Expression {
-        public:
-            explicit Negative(std::unique_ptr<Expression>);
+    Value m_value;
+};
 
-        private:
-            Value evaluate() const override;
-            Value::Type resultType() const override { return Value::NumberValue; }
-        };
+class Negative final : public Expression {
+public:
+    explicit Negative(std::unique_ptr<Expression>);
 
-        class NumericOp final : public Expression {
-        public:
-            enum Opcode { OP_Add, OP_Sub, OP_Mul, OP_Div, OP_Mod };
-            NumericOp(Opcode, std::unique_ptr<Expression> lhs, std::unique_ptr<Expression> rhs);
+private:
+    Value evaluate() const override;
+    Value::Type resultType() const override { return Value::Type::Number; }
+};
 
-        private:
-            Value evaluate() const override;
-            Value::Type resultType() const override { return Value::NumberValue; }
+class NumericOp final : public Expression {
+public:
+    enum Opcode { OP_Add, OP_Sub, OP_Mul, OP_Div, OP_Mod };
+    NumericOp(Opcode, std::unique_ptr<Expression> lhs, std::unique_ptr<Expression> rhs);
 
-            Opcode m_opcode;
-        };
+private:
+    Value evaluate() const override;
+    Value::Type resultType() const override { return Value::Type::Number; }
 
-        class EqTestOp final : public Expression {
-        public:
-            enum Opcode { OP_EQ, OP_NE, OP_GT, OP_LT, OP_GE, OP_LE };
-            EqTestOp(Opcode, std::unique_ptr<Expression> lhs, std::unique_ptr<Expression> rhs);
-            Value evaluate() const override;
+    Opcode m_opcode;
+};
 
-        private:
-            Value::Type resultType() const override { return Value::BooleanValue; }
-            bool compare(const Value&, const Value&) const;
+class EqTestOp final : public Expression {
+public:
+    enum Opcode { OP_EQ, OP_NE, OP_GT, OP_LT, OP_GE, OP_LE };
+    EqTestOp(Opcode, std::unique_ptr<Expression> lhs, std::unique_ptr<Expression> rhs);
+    Value evaluate() const override;
 
-            Opcode m_opcode;
-        };
+private:
+    Value::Type resultType() const override { return Value::Type::Boolean; }
+    bool compare(const Value&, const Value&) const;
 
-        class LogicalOp final : public Expression {
-        public:
-            enum Opcode { OP_And, OP_Or };
-            LogicalOp(Opcode, std::unique_ptr<Expression> lhs, std::unique_ptr<Expression> rhs);
+    Opcode m_opcode;
+};
 
-        private:
-            Value::Type resultType() const override { return Value::BooleanValue; }
-            bool shortCircuitOn() const;
-            Value evaluate() const override;
+class LogicalOp final : public Expression {
+public:
+    enum Opcode { OP_And, OP_Or };
+    LogicalOp(Opcode, std::unique_ptr<Expression> lhs, std::unique_ptr<Expression> rhs);
 
-            Opcode m_opcode;
-        };
+private:
+    Value::Type resultType() const override { return Value::Type::Boolean; }
+    bool shortCircuitOn() const;
+    Value evaluate() const override;
 
-        class Union final : public Expression {
-        public:
-            Union(std::unique_ptr<Expression>, std::unique_ptr<Expression>);
+    Opcode m_opcode;
+};
 
-        private:
-            Value evaluate() const override;
-            Value::Type resultType() const override { return Value::NodeSetValue; }
-        };
+class Union final : public Expression {
+public:
+    Union(std::unique_ptr<Expression>, std::unique_ptr<Expression>);
 
-        bool evaluatePredicate(const Expression&);
-        bool predicateIsContextPositionSensitive(const Expression&);
+private:
+    Value evaluate() const override;
+    Value::Type resultType() const override { return Value::Type::NodeSet; }
+};
 
-    } // namespace XPath
+bool evaluatePredicate(const Expression&);
+bool predicateIsContextPositionSensitive(const Expression&);
+
+} // namespace XPath
 } // namespace WebCore

--- a/Source/WebCore/xml/XPathResult.cpp
+++ b/Source/WebCore/xml/XPathResult.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2005 Frerich Raabe <raabe@kde.org>
- * Copyright (C) 2006, 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,22 +36,22 @@ XPathResult::XPathResult(Document& document, const XPath::Value& value)
     : m_value(value)
 {
     switch (m_value.type()) {
-        case XPath::Value::BooleanValue:
-            m_resultType = BOOLEAN_TYPE;
-            return;
-        case XPath::Value::NumberValue:
-            m_resultType = NUMBER_TYPE;
-            return;
-        case XPath::Value::StringValue:
-            m_resultType = STRING_TYPE;
-            return;
-        case XPath::Value::NodeSetValue:
-            m_resultType = UNORDERED_NODE_ITERATOR_TYPE;
-            m_nodeSetPosition = 0;
-            m_nodeSet = m_value.toNodeSet();
-            m_document = &document;
-            m_domTreeVersion = document.domTreeVersion();
-            return;
+    case XPath::Value::Type::Boolean:
+        m_resultType = BOOLEAN_TYPE;
+        return;
+    case XPath::Value::Type::Number:
+        m_resultType = NUMBER_TYPE;
+        return;
+    case XPath::Value::Type::String:
+        m_resultType = STRING_TYPE;
+        return;
+    case XPath::Value::Type::NodeSet:
+        m_resultType = UNORDERED_NODE_ITERATOR_TYPE;
+        m_nodeSetPosition = 0;
+        m_nodeSet = m_value.toNodeSet();
+        m_document = &document;
+        m_domTreeVersion = document.domTreeVersion();
+        return;
     }
     ASSERT_NOT_REACHED();
 }
@@ -180,4 +180,4 @@ ExceptionOr<Node*> XPathResult::snapshotItem(unsigned index)
     return nodes[index];
 }
 
-}
+} // namespace WebCore

--- a/Source/WebCore/xml/XPathValue.cpp
+++ b/Source/WebCore/xml/XPathValue.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2005 Frerich Raabe <raabe@kde.org>
- * Copyright (C) 2006, 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -59,21 +59,21 @@ NodeSet& Value::modifiableNodeSet()
     if (!m_data)
         m_data = Data::create();
 
-    m_type = NodeSetValue;
+    m_type = Type::NodeSet;
     return m_data->nodeSet;
 }
 
 bool Value::toBoolean() const
 {
     switch (m_type) {
-        case NodeSetValue:
-            return !m_data->nodeSet.isEmpty();
-        case BooleanValue:
-            return m_bool;
-        case NumberValue:
-            return m_number && !std::isnan(m_number);
-        case StringValue:
-            return !m_data->string.isEmpty();
+    case Type::NodeSet:
+        return !m_data->nodeSet.isEmpty();
+    case Type::Boolean:
+        return m_bool;
+    case Type::Number:
+        return m_number && !std::isnan(m_number);
+    case Type::String:
+        return !m_data->string.isEmpty();
     }
     ASSERT_NOT_REACHED();
     return false;
@@ -82,29 +82,29 @@ bool Value::toBoolean() const
 double Value::toNumber() const
 {
     switch (m_type) {
-        case NodeSetValue:
-            return Value(toString()).toNumber();
-        case NumberValue:
-            return m_number;
-        case StringValue: {
-            const String& str = m_data->string.simplifyWhiteSpace(deprecatedIsSpaceOrNewline);
+    case Type::NodeSet:
+        return Value(toString()).toNumber();
+    case Type::Number:
+        return m_number;
+    case Type::String: {
+        const String& str = m_data->string.simplifyWhiteSpace(deprecatedIsSpaceOrNewline);
 
-            // String::toDouble() supports exponential notation, which is not allowed in XPath.
-            unsigned len = str.length();
-            for (unsigned i = 0; i < len; ++i) {
-                UChar c = str[i];
-                if (!isASCIIDigit(c) && c != '.'  && c != '-')
-                    return std::numeric_limits<double>::quiet_NaN();
-            }
-
-            bool canConvert;
-            double value = str.toDouble(&canConvert);
-            if (canConvert)
-                return value;
-            return std::numeric_limits<double>::quiet_NaN();
+        // String::toDouble() supports exponential notation, which is not allowed in XPath.
+        unsigned len = str.length();
+        for (unsigned i = 0; i < len; ++i) {
+            UChar c = str[i];
+            if (!isASCIIDigit(c) && c != '.'  && c != '-')
+                return std::numeric_limits<double>::quiet_NaN();
         }
-        case BooleanValue:
-            return m_bool;
+
+        bool canConvert;
+        double value = str.toDouble(&canConvert);
+        if (canConvert)
+            return value;
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    case Type::Boolean:
+        return m_bool;
     }
 
     ASSERT_NOT_REACHED();
@@ -114,27 +114,27 @@ double Value::toNumber() const
 String Value::toString() const
 {
     switch (m_type) {
-        case NodeSetValue:
-            if (m_data->nodeSet.isEmpty())
-                return emptyString();
-            return stringValue(m_data->nodeSet.firstNode());
-        case StringValue:
-            return m_data->string;
-        case NumberValue:
-            if (std::isnan(m_number))
-                return "NaN"_s;
-            if (m_number == 0)
-                return "0"_s;
-            if (std::isinf(m_number))
-                return std::signbit(m_number) ? "-Infinity"_s : "Infinity"_s;
-            return String::number(m_number);
-        case BooleanValue:
-            return m_bool ? trueAtom() : falseAtom();
+    case Type::NodeSet:
+        if (m_data->nodeSet.isEmpty())
+            return emptyString();
+        return stringValue(m_data->nodeSet.firstNode());
+    case Type::String:
+        return m_data->string;
+    case Type::Number:
+        if (std::isnan(m_number))
+            return "NaN"_s;
+        if (!m_number)
+            return "0"_s;
+        if (std::isinf(m_number))
+            return std::signbit(m_number) ? "-Infinity"_s : "Infinity"_s;
+        return String::number(m_number);
+    case Type::Boolean:
+        return m_bool ? trueAtom() : falseAtom();
     }
 
     ASSERT_NOT_REACHED();
     return String();
 }
 
-}
-}
+} // namespace XPath
+} // namespace WebCore

--- a/Source/WebCore/xml/XPathVariableReference.h
+++ b/Source/WebCore/xml/XPathVariableReference.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2005 Frerich Raabe <raabe@kde.org>
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,17 +29,17 @@
 #include "XPathExpressionNode.h"
 
 namespace WebCore {
-    namespace XPath {
+namespace XPath {
 
-        // Variable references are not used with XPathEvaluator.
-        class VariableReference : public Expression {
-        public:
-            explicit VariableReference(const String& name);
-        private:
-            Value evaluate() const override;
-            Value::Type resultType() const override { ASSERT_NOT_REACHED(); return Value::NumberValue; }
-            String m_name;
-        };
+// Variable references are not used with XPathEvaluator.
+class VariableReference : public Expression {
+public:
+    explicit VariableReference(const String& name);
+private:
+    Value evaluate() const override;
+    Value::Type resultType() const override { ASSERT_NOT_REACHED(); return Value::Type::Number; }
+    String m_name;
+};
 
-    } // namespace XPath
+} // namespace XPath
 } // namespace WebCore


### PR DESCRIPTION
#### c4467fc5aed587478747535b46aedf0d08ad2995
<pre>
WebCore::XPath::Value has uninitialized fields after construction
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=274864">https://bugs.webkit.org/show_bug.cgi?id=274864</a>&gt;
&lt;<a href="https://rdar.apple.com/128966823">rdar://128966823</a>&gt;

Reviewed by Chris Dumez.

Fix in XPathValue.h is to set m_bool and m_double to default values when
constructing WebCore::XPath::Value objects.

Additional drive-by fixes that comprise most of the changes:
- Update WebCore::XPath::Value::Type to an enum class.
- Fix format of header files to remove unwanted whitespace.
- Add missing comments for closing namespace braces.
- Fix indentation of case statements in XPathValue.cpp.
- Fix formatting of constructors in XPathValue.h.

* Source/WebCore/xml/XPathFunctions.cpp:
* Source/WebCore/xml/XPathPath.h:
* Source/WebCore/xml/XPathPredicate.cpp:
(WebCore::XPath::predicateIsContextPositionSensitive):
* Source/WebCore/xml/XPathPredicate.h:
* Source/WebCore/xml/XPathResult.cpp:
(WebCore::XPathResult::XPathResult):
* Source/WebCore/xml/XPathValue.cpp:
(WebCore::XPath::Value::modifiableNodeSet):
(WebCore::XPath::Value::toBoolean const):
(WebCore::XPath::Value::toNumber const):
(WebCore::XPath::Value::toString const):
* Source/WebCore/xml/XPathValue.h:
(WebCore::XPath::Value):
- Initialize m_bool to false and m_double to 0 to fix the bug.
(WebCore::XPath::Value::Type):
- Change to enum class with size uint8_t.
- Remove redundant &quot;Value&quot; from the end of enum names.
(WebCore::XPath::Value::Value):
- Delete default constructor since it is unused.
(WebCore::XPath::Value::type const):
(WebCore::XPath::Value::isNodeSet const):
(WebCore::XPath::Value::isBoolean const):
(WebCore::XPath::Value::isNumber const):
(WebCore::XPath::Value::isString const):
(WebCore::XPath::Value::Data::create):
(WebCore::XPath::Value::Data::Data):
* Source/WebCore/xml/XPathVariableReference.h:

Canonical link: <a href="https://commits.webkit.org/279506@main">https://commits.webkit.org/279506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4ba0abd95dc9c7e56e9a473e4a2ba857f1dc312

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53632 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56912 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4358 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55935 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40472 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4171 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43450 "Found 19 new test failures: webgl/2.0.0/conformance/canvas/rapid-resizing.html, webgl/2.0.y/conformance2/textures/canvas/tex-3d-r11f_g11f_b10f-rgb-float.html, webgl/2.0.y/conformance2/textures/canvas/tex-3d-r11f_g11f_b10f-rgb-half_float.html, webgl/2.0.y/conformance2/textures/canvas/tex-3d-r8-red-unsigned_byte.html, webgl/2.0.y/conformance2/textures/canvas/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html, webgl/2.0.y/conformance2/textures/canvas/tex-3d-rgb9_e5-rgb-half_float.html, webgl/2.0.y/conformance2/textures/canvas/tex-3d-rgba16f-rgba-half_float.html, webgl/2.0.y/conformance2/textures/canvas/tex-3d-rgba32f-rgba-float.html, webgl/2.0.y/conformance2/textures/canvas/tex-3d-rgba8-rgba-unsigned_byte.html, webgl/2.0.y/conformance2/textures/canvas/tex-3d-srgb8-rgb-unsigned_byte.html ... (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2843 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55729 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46366 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24585 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28038 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3683 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2513 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58507 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28794 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3888 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50867 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/29994 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46528 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50207 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30925 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7917 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29771 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->