### PR TITLE
[view-transitions] Back icon jiggles while animating on https://codepen.io/bramus/full/mdowgYX.

### DIFF
--- a/LayoutTests/fast/css/view-transitions-scrolling-position-fixed-expected.html
+++ b/LayoutTests/fast/css/view-transitions-scrolling-position-fixed-expected.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>View transitions: computed transform for position fixed elements doesn't include scroll pos (ref)</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<style>
+.box {
+  background: lightblue;
+  width: 100px;
+  height: 100px;
+  position: fixed;
+}
+</style>
+<div class=box></div>
+<div style="height: 1000px;"></div>
+<script>
+  addEventListener("scroll", () => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        document.documentElement.classList.remove("reftest-wait");
+      });
+    });
+  }, { once: true, capture: true });
+  document.documentElement.scrollTop = 500;
+</script>
+</html>

--- a/LayoutTests/fast/css/view-transitions-scrolling-position-fixed.html
+++ b/LayoutTests/fast/css/view-transitions-scrolling-position-fixed.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: computed transform for position fixed elements doesn't include scroll pos</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<link rel="author" title="Matt Woodrow" href="mailto:mattwoodrow@apple.com">
+<script src="../../resources/ui-helper.js"></script>
+<style>
+.box {
+  background: lightblue;
+  width: 100px;
+  height: 100px;
+  position: fixed;
+}
+
+/* We're verifying what we capture, so just display the new contents for 5 minutes.  */
+html::view-transition-group(*) { animation-duration: 300s; }
+html::view-transition-new(*) { animation: unset; opacity: 1; }
+html::view-transition-old(*) { animation: unset; opacity: 0; }
+</style>
+<div class=box></div>
+<div style="height: 1000px;"></div>
+<script>
+if (window.testRunner) {
+  testRunner.waitUntilDone();
+  if (testRunner.dontForceRepaint)
+    testRunner.dontForceRepaint();
+  if (window.internals)
+    internals.setUsesOverlayScrollbars(true);
+}
+
+async function runTest() {
+
+  await document.startViewTransition(() => {}).ready;
+
+  await UIHelper.renderingUpdate();
+  await UIHelper.renderingUpdate();
+
+  /* Scroll the doc, position:fixed content inside the snapshot should not move */
+  document.documentElement.scrollTop = 500;
+
+  await UIHelper.renderingUpdate();
+  await UIHelper.renderingUpdate();
+
+  if (window.testRunner)
+    testRunner.notifyDone();
+}
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>

--- a/Source/WebCore/animation/CSSTransition.cpp
+++ b/Source/WebCore/animation/CSSTransition.cpp
@@ -61,10 +61,11 @@ CSSTransition::CSSTransition(const Styleable& styleable, const AnimatableCSSProp
 {
 }
 
-void CSSTransition::resolve(RenderStyle& targetStyle, const Style::ResolutionContext& resolutionContext, std::optional<Seconds> startTime)
+OptionSet<AnimationImpact> CSSTransition::resolve(RenderStyle& targetStyle, const Style::ResolutionContext& resolutionContext, std::optional<Seconds> startTime)
 {
-    StyleOriginatedAnimation::resolve(targetStyle, resolutionContext, startTime);
+    auto impact = StyleOriginatedAnimation::resolve(targetStyle, resolutionContext, startTime);
     m_currentStyle = RenderStyle::clonePtr(targetStyle);
+    return impact;
 }
 
 void CSSTransition::animationDidFinish()

--- a/Source/WebCore/animation/CSSTransition.h
+++ b/Source/WebCore/animation/CSSTransition.h
@@ -58,7 +58,7 @@ private:
     CSSTransition(const Styleable&, const AnimatableCSSProperty&, MonotonicTime generationTime, const Animation&, const RenderStyle& oldStyle, const RenderStyle& targetStyle, const RenderStyle& reversingAdjustedStartStyle, double);
     void setTimingProperties(Seconds delay, Seconds duration);
     Ref<StyleOriginatedAnimationEvent> createEvent(const AtomString& eventType, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>&) final;
-    void resolve(RenderStyle& targetStyle, const Style::ResolutionContext&, std::optional<Seconds>) final;
+    OptionSet<AnimationImpact> resolve(RenderStyle& targetStyle, const Style::ResolutionContext&, std::optional<Seconds>) final;
     void animationDidFinish() final;
     bool isCSSTransition() const final { return true; }
 

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -130,7 +130,7 @@ public:
     void setBindingsComposite(CompositeOperation);
 
     void getAnimatedStyle(std::unique_ptr<RenderStyle>& animatedStyle);
-    void apply(RenderStyle& targetStyle, const Style::ResolutionContext&, std::optional<Seconds> = std::nullopt);
+    OptionSet<AnimationImpact> apply(RenderStyle& targetStyle, const Style::ResolutionContext&, std::optional<Seconds> = std::nullopt);
     void invalidate();
 
     void animationTimingDidChange();

--- a/Source/WebCore/animation/KeyframeEffectStack.cpp
+++ b/Source/WebCore/animation/KeyframeEffectStack.cpp
@@ -172,7 +172,7 @@ OptionSet<AnimationImpact> KeyframeEffectStack::applyKeyframeEffects(RenderStyle
 
         ASSERT(effect->animation());
         auto* animation = effect->animation();
-        animation->resolve(targetStyle, resolutionContext);
+        impact.add(animation->resolve(targetStyle, resolutionContext));
 
         if (effect->isRunningAccelerated() || effect->isAboutToRunAccelerated())
             impact.add(AnimationImpact::RequiresRecomposite);

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1379,14 +1379,15 @@ void WebAnimation::tick()
         m_effect->animationDidTick();
 }
 
-void WebAnimation::resolve(RenderStyle& targetStyle, const Style::ResolutionContext& resolutionContext, std::optional<Seconds> startTime)
+OptionSet<AnimationImpact> WebAnimation::resolve(RenderStyle& targetStyle, const Style::ResolutionContext& resolutionContext, std::optional<Seconds> startTime)
 {
     if (!m_shouldSkipUpdatingFinishedStateWhenResolving)
         updateFinishedState(DidSeek::No, SynchronouslyNotify::No);
     m_shouldSkipUpdatingFinishedStateWhenResolving = false;
 
     if (auto keyframeEffect = dynamicDowncast<KeyframeEffect>(m_effect.get()))
-        keyframeEffect->apply(targetStyle, resolutionContext, startTime);
+        return keyframeEffect->apply(targetStyle, resolutionContext, startTime);
+    return { };
 }
 
 void WebAnimation::setSuspended(bool isSuspended)

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -135,7 +135,7 @@ public:
     bool needsTick() const;
     virtual void tick();
     WEBCORE_EXPORT Seconds timeToNextTick() const;
-    virtual void resolve(RenderStyle& targetStyle, const Style::ResolutionContext&, std::optional<Seconds> = std::nullopt);
+    virtual OptionSet<AnimationImpact> resolve(RenderStyle& targetStyle, const Style::ResolutionContext&, std::optional<Seconds> = std::nullopt);
     void effectTargetDidChange(const std::optional<const Styleable>& previousTarget, const std::optional<const Styleable>& newTarget);
     void acceleratedStateDidChange();
     void willChangeRenderer();

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -722,7 +722,7 @@ ExceptionOr<void> ViewTransition::updatePseudoElementStyles()
                     if (RefPtr frame = document()->frame(); !viewTransitionCapture->canUseExistingLayers()) {
                         image = snapshotElementVisualOverflowClippedToViewport(*frame, *renderer, overflowRect);
                         changed = true;
-                    } else if (CheckedPtr layer = renderer->layer())
+                    } else if (CheckedPtr layer = renderer->isDocumentElementRenderer() ? renderer->view().layer() : renderer->layer())
                         layer->setNeedsCompositingGeometryUpdate();
                     viewTransitionCapture->setImage(image);
                 }


### PR DESCRIPTION
#### e6a8ede67b0919c59b9bef1c1368c8869c1f14b7
<pre>
[view-transitions] Back icon jiggles while animating on <a href="https://codepen.io/bramus/full/mdowgYX.">https://codepen.io/bramus/full/mdowgYX.</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=274606">https://bugs.webkit.org/show_bug.cgi?id=274606</a>
&lt;<a href="https://rdar.apple.com/128627261">rdar://128627261</a>&gt;

Reviewed by Antoine Quint.

If the view transition is capturing the root element, then we reparent the GraphicsLayer for
the RenderView instead. Make sure we request a geometry update on the right RenderLayer to
account for this.

New non-WPT test added, since this requires overlay scrollbars to be enabled to reproduce (otherwise
the scrollbar move requests a geometry update on the RenderView as well and hides the bug).

This also exposed a bug where the transition from &apos;active&apos; to &apos;after&apos; state of the view transition
animations wasn&apos;t invalidating layer composition, but does affect compositing decisions.

The original testcase still isn&apos;t perfect with these changes, since async scrolling still
incorrectly accounts for the view transition overlays. That will be fixed by bug 273612.

* LayoutTests/fast/css/view-transitions-scrolling-position-fixed-expected.html: Added.
* LayoutTests/fast/css/view-transitions-scrolling-position-fixed.html: Added.
* Source/WebCore/animation/CSSTransition.cpp:
(WebCore::CSSTransition::resolve):
* Source/WebCore/animation/CSSTransition.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::apply):
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/KeyframeEffectStack.cpp:
(WebCore::KeyframeEffectStack::applyKeyframeEffects):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::resolve):
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::updatePseudoElementStyles):

Canonical link: <a href="https://commits.webkit.org/279674@main">https://commits.webkit.org/279674@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e0ba3d0874fd8173f941539d159bc6f07c15a6a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33330 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6489 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57236 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4683 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56261 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40837 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4569 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43690 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3088 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56055 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31537 "Found 3 new test failures: animations/3d/change-transform-in-end-event.html, compositing/culling/clear-fixed-iframe.html, compositing/overflow/nested-scrolling.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46678 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24831 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28376 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4000 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2834 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50021 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4203 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58829 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29135 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4281 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51105 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30325 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46815 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50440 "3 api tests failed or timed out") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11797 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31276 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30100 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->