### PR TITLE
WebCore::XPath::Parser::Token contains uninitialized fields after construction

### DIFF
--- a/Source/WebCore/xml/XPathParser.cpp
+++ b/Source/WebCore/xml/XPathParser.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2005 Maksim Orlovich <maksim@kde.org>
- * Copyright (C) 2006, 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2019 Google Inc. All rights reserved.
  * Copyright (C) 2007 Alexey Proskuryakov <ap@webkit.org>
  *
@@ -47,16 +47,22 @@ namespace XPath {
 
 struct Parser::Token {
     int type;
-    String string;
-    Step::Axis axis;
-    NumericOp::Opcode numericOpcode;
-    EqTestOp::Opcode equalityTestOpcode;
+    using TokenValue = std::variant<String, Step::Axis, NumericOp::Opcode, EqTestOp::Opcode>;
+    TokenValue value;
 
-    Token(int type) : type(type) { }
-    Token(int type, const String& string) : type(type), string(string) { }
-    Token(int type, Step::Axis axis) : type(type), axis(axis) { }
-    Token(int type, NumericOp::Opcode opcode) : type(type), numericOpcode(opcode) { }
-    Token(int type, EqTestOp::Opcode opcode) : type(type), equalityTestOpcode(opcode) { }
+    Token() = delete;
+
+    Token(int type)
+        : type(type)
+    { }
+    Token(int type, TokenValue&& value)
+        : type(type), value(WTFMove(value))
+    { }
+
+    String& string() { return std::get<String>(value); }
+    Step::Axis axis() const { return std::get<Step::Axis>(value); }
+    NumericOp::Opcode numericOpcode() const { return std::get<NumericOp::Opcode>(value); }
+    EqTestOp::Opcode equalityTestOpcode() const { return std::get<EqTestOp::Opcode>(value); }
 };
 
 enum XMLCat { NameStart, NameCont, NotPartOfName };
@@ -409,14 +415,14 @@ int Parser::lex(YYSTYPE& yylval)
 
     switch (token.type) {
     case AXISNAME:
-        yylval.axis = token.axis;
+        yylval.axis = token.axis();
         break;
     case MULOP:
-        yylval.numericOpcode = token.numericOpcode;
+        yylval.numericOpcode = token.numericOpcode();
         break;
     case RELOP:
     case EQOP:
-        yylval.equalityTestOpcode = token.equalityTestOpcode;
+        yylval.equalityTestOpcode = token.equalityTestOpcode();
         break;
     case NODETYPE:
     case FUNCTIONNAME:
@@ -424,7 +430,7 @@ int Parser::lex(YYSTYPE& yylval)
     case VARIABLEREFERENCE:
     case NUMBER:
     case NAMETEST:
-        yylval.string = token.string.releaseImpl().leakRef();
+        yylval.string = token.string().releaseImpl().leakRef();
         break;
     }
 
@@ -465,4 +471,5 @@ ExceptionOr<std::unique_ptr<Expression>> Parser::parseStatement(const String& st
     return WTFMove(parser.m_result);
 }
 
-} }
+} // namespace XPath
+} // namespace WebCore


### PR DESCRIPTION
#### ff290911a4c8c24e3863c1b6f38d3da07b3fcf5b
<pre>
WebCore::XPath::Parser::Token contains uninitialized fields after construction
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=274872">https://bugs.webkit.org/show_bug.cgi?id=274872</a>&gt;
&lt;<a href="https://rdar.apple.com/128972339">rdar://128972339</a>&gt;

Reviewed by Chris Dumez.

Merge individual token values into a std::variant&lt;&gt; type named
TokenValue to make sure their initialized state and value are tracked
properly.

* Source/WebCore/xml/XPathParser.cpp:
(WebCore::XPath::Parser::Token::TokenValue): Add.
- Declare std::variant type to hold one of four possible values.
(WebCore::XPath::Parser::Token::Token):
- Replace four instance variables with TokenValue variable.
- Delete default constructor since it is unused.
- Condense constructors taking different value arguments into a single
  constructor taking a TokenValue (std::variant) r-value.
(WebCore::XPath::Parser::Token::string): Add.
(WebCore::XPath::Parser::Token::axis): Add.
(WebCore::XPath::Parser::Token::numericOpcode): Add.
(WebCore::XPath::Parser::Token::equalityTestOpcode): Add.
- Add getter methods to read `value` instance variable.
(WebCore::XPath::Parser::lex):
- Update to use getter methods.

Canonical link: <a href="https://commits.webkit.org/279493@main">https://commits.webkit.org/279493@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50ced5b0e84198a82a0e44cf7d19413fc235b423

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/32998 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56917 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4363 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55940 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4178 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43455 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2849 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55734 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46370 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/24590 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/28042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3687 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2518 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58512 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28799 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3892 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/29999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46534 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/30930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7910 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29776 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->