### PR TITLE
Copying and pasting a `<picture>` element and some text, loses `<source>` elements

### DIFF
--- a/LayoutTests/editing/pasteboard/copy-picture-and-text-expected.txt
+++ b/LayoutTests/editing/pasteboard/copy-picture-and-text-expected.txt
@@ -1,0 +1,12 @@
+This tests that copying and pasting an image in a picture element and adjacent text, preserves the picture and source elements.
+| "Paste"
+| <picture>
+|   id="picture"
+|   <source>
+|     media="(min-width: 600px)"
+|     srcset="resources/apple.gif"
+|   <source>
+|     srcset="resources/mozilla.gif"
+|   <img>
+|     src=""
+| "After<#selection-caret>"

--- a/LayoutTests/editing/pasteboard/copy-picture-and-text.html
+++ b/LayoutTests/editing/pasteboard/copy-picture-and-text.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../editing.js"></script>
+<script src="../../resources/dump-as-markup.js"></script>
+<script>
+Markup.description("This tests that copying and pasting an image in a picture element and adjacent text, preserves the picture and source elements.");
+Markup.noAutoDump();
+
+function runTest()
+{
+    var picture = document.getElementById("picture");
+    execSetSelectionCommand(picture, 2, picture.nextSibling, 5);
+    execCopyCommand();
+
+    document.getElementById("paste-contenteditable").innerHTML = "Paste";
+    selection.setPosition(document.getElementById("paste-contenteditable").childNodes[0], 5);
+    execPasteCommand();
+    Markup.dump("paste-contenteditable");
+}
+
+window.onload = function()
+{
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    runTest();
+
+    Markup.notifyDone();
+};
+</script>
+</head>
+<body>
+<div id="copy-contenteditable" contenteditable>
+Test<picture id="picture"><source srcset="resources/apple.gif" media="(min-width: 600px)"/><source srcset="resources/mozilla.gif"/><img src=""></picture>After
+</div>
+
+<div id="paste-contenteditable" contentEditable="true"></div>
+</body>
+</html>

--- a/LayoutTests/platform/ios/editing/pasteboard/copy-picture-and-text-expected.txt
+++ b/LayoutTests/platform/ios/editing/pasteboard/copy-picture-and-text-expected.txt
@@ -1,0 +1,13 @@
+This tests that copying and pasting an image in a picture element and adjacent text, preserves the picture and source elements.
+| "Paste"
+| <picture>
+|   id="picture"
+|   <source>
+|     media="(min-width: 600px)"
+|     srcset="resources/apple.gif"
+|   <source>
+|     srcset="resources/mozilla.gif"
+|   " "
+|   <img>
+|     src=""
+| "After<#selection-caret>"

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -1027,7 +1027,7 @@ static String serializePreservingVisualAppearanceInternal(const Position& start,
 
     Position adjustedStart = start;
 
-    if (RefPtr pictureElement = dynamicDowncast<HTMLPictureElement>(specialCommonAncestor))
+    if (RefPtr pictureElement = enclosingElementWithTag(adjustedStart, pictureTag))
         adjustedStart = firstPositionInNode(pictureElement.get());
 
     if (annotate == AnnotateForInterchange::Yes && needInterchangeNewlineAfter(visibleStart)) {


### PR DESCRIPTION
#### aaaee1d25e29a6c1eb0c99ffdf0901418ad30424
<pre>
Copying and pasting a `&lt;picture&gt;` element and some text, loses `&lt;source&gt;` elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=274874">https://bugs.webkit.org/show_bug.cgi?id=274874</a>
<a href="https://rdar.apple.com/124625324">rdar://124625324</a>

Reviewed by Wenson Hsieh.

When selecting a `&lt;picture&gt;` element, visible positions are before/after the
contained `&lt;img&gt;`. Originally, this resulted in issues where simply copying and
pasting `&lt;picture&gt;` elements would drop other nodes (`&lt;source&gt;`).

276754@main fixed the issue when the selection being copied was contained to a
single `&lt;picture&gt;`, by consulting the highest common ancestor of the start and
end positions. However, in cases where the selection ends outside of the
`&lt;picture&gt;`, for example, including some text after the image, there is no
common ancestor. Consequently, `&lt;source&gt;` elements continue to be dropped in
that scenario.

Fix by generalizing the solution in 276754@main to always adjust the start
position for serialization if it is within a `&lt;picture&gt;` element. Add a test to
validate the fix.

* LayoutTests/editing/pasteboard/copy-picture-and-text-expected.txt: Added.
* LayoutTests/editing/pasteboard/copy-picture-and-text.html: Added.
* LayoutTests/platform/ios/editing/pasteboard/copy-picture-and-text-expected.txt: Added.

An iOS-specific expectation is necessary due to smart replace, which inserts an
additional space when pasting this content. The space before `&lt;img&gt;` exists
before and after this patch.

* Source/WebCore/editing/markup.cpp:
(WebCore::serializePreservingVisualAppearanceInternal):

Canonical link: <a href="https://commits.webkit.org/279597@main">https://commits.webkit.org/279597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b396b124a30ea8e3f4a089d7e532492a35a956d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53845 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33213 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57123 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4568 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56149 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40709 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4440 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43599 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2997 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31491 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46579 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24739 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28248 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3890 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2723 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49955 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4082 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58718 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4148 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51011 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30207 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46722 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50348 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11748 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31143 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29986 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->