### PR TITLE
[SHA1] Add fast path when adding UTF8 bytes from a String that only contains ASCII

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlockHash.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlockHash.cpp
@@ -53,7 +53,7 @@ CodeBlockHash::CodeBlockHash(const SourceCode& sourceCode, CodeSpecializationKin
     ASSERT(sourceCode.length() >= 0);
     constexpr unsigned maxSourceCodeLengthToHash = 500 * MB;
     if (static_cast<unsigned>(sourceCode.length()) < maxSourceCodeLengthToHash)
-        sha1.addBytes(sourceCode.toUTF8());
+        sha1.addUTF8Bytes(sourceCode.view());
     else {
         // Just hash with the length and samples of the source string instead.
         StringView str = sourceCode.provider()->source();

--- a/Source/JavaScriptCore/bytecode/ParseHash.cpp
+++ b/Source/JavaScriptCore/bytecode/ParseHash.cpp
@@ -34,7 +34,7 @@ namespace JSC {
 ParseHash::ParseHash(const SourceCode& sourceCode)
 {
     SHA1 sha1;
-    sha1.addBytes(sourceCode.toUTF8());
+    sha1.addUTF8Bytes(sourceCode.view());
     SHA1::Digest digest;
     sha1.computeHash(digest);
     unsigned hash = digest[0] | (digest[1] << 8) | (digest[2] << 16) | (digest[3] << 24);

--- a/Source/WTF/wtf/SHA1.h
+++ b/Source/WTF/wtf/SHA1.h
@@ -38,6 +38,14 @@
 #include <CommonCrypto/CommonDigest.h>
 #endif
 
+#ifdef __OBJC__
+#include <objc/objc.h>
+#endif
+
+#if USE(CF)
+typedef const struct __CFString * CFStringRef;
+#endif
+
 // On Cocoa platforms, CoreUtils.h has a SHA1() macro that sometimes get included above here.
 #ifdef SHA1
 #undef SHA1
@@ -61,6 +69,15 @@ public:
     {
         addBytes(input.span());
     }
+
+    WTF_EXPORT_PRIVATE void addUTF8Bytes(StringView);
+
+#if USE(CF)
+    WTF_EXPORT_PRIVATE void addUTF8Bytes(CFStringRef);
+#ifdef __OBJC__
+    void addUTF8Bytes(NSString *string) { addUTF8Bytes((__bridge CFStringRef)string); }
+#endif
+#endif
 
     // Size of the SHA1 hash
     WTF_EXPORT_PRIVATE static constexpr size_t hashSize = 20;

--- a/Source/WebCore/inspector/DOMPatchSupport.cpp
+++ b/Source/WebCore/inspector/DOMPatchSupport.cpp
@@ -398,7 +398,7 @@ ExceptionOr<void> DOMPatchSupport::innerPatchChildren(ContainerNode& parentNode,
 
 static void addStringToSHA1(SHA1& sha1, const String& string)
 {
-    sha1.addBytes(string.utf8().span());
+    sha1.addUTF8Bytes(string);
 }
 
 std::unique_ptr<DOMPatchSupport::Digest> DOMPatchSupport::createDigest(Node& node, UnusedNodesMap* unusedNodesMap)

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp
@@ -154,14 +154,7 @@ static void addStringToSHA1(SHA1& sha1, const String& string)
     if (string.isEmpty())
         return;
 
-    if (string.is8Bit() && string.containsOnlyASCII()) {
-        const uint8_t nullByte = 0;
-        sha1.addBytes(string.span8());
-        sha1.addBytes(std::span { &nullByte, 1 });
-        return;
-    }
-
-    sha1.addBytes(string.utf8());
+    sha1.addUTF8Bytes(string);
 }
 
 String RealtimeMediaSourceCenter::hashStringWithSalt(const String& id, const String& hashSalt)

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheKey.cpp
@@ -86,14 +86,7 @@ static void hashString(SHA1& sha1, const String& string)
     if (string.isNull())
         return;
 
-    if (string.is8Bit() && string.containsOnlyASCII()) {
-        const uint8_t nullByte = 0;
-        sha1.addBytes(string.span8());
-        sha1.addBytes(std::span { &nullByte, 1 });
-        return;
-    }
-
-    sha1.addBytes(string.utf8());
+    sha1.addUTF8Bytes(string);
 }
 
 Key::HashType Key::computeHash(const Salt& salt) const

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h
@@ -108,8 +108,7 @@ public:
     size_t approximateSize() const;
 
     // Incrementing this number will delete all existing cache content for everyone. Do you really need to do it?
-    // FIXME: When this is incremented, remove LegacyCertificateInfoType.
-    static const unsigned version = 16;
+    static const unsigned version = 17;
 
     String basePathIsolatedCopy() const;
     String versionPath() const;

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -4267,7 +4267,7 @@ bool WebExtensionContext::hasContentModificationRules()
 static NSString *computeStringHashForContentBlockerRules(NSString *rules)
 {
     SHA1 sha1;
-    sha1.addBytes(String(rules).span8());
+    sha1.addUTF8Bytes(rules);
 
     SHA1::Digest digest;
     sha1.computeHash(digest);


### PR DESCRIPTION
#### 484500b2c078b29f80e12b8130c3f95ca698e2d3
<pre>
[SHA1] Add fast path when adding UTF8 bytes from a String that only contains ASCII
<a href="https://bugs.webkit.org/show_bug.cgi?id=274873">https://bugs.webkit.org/show_bug.cgi?id=274873</a>

Reviewed by Darin Adler and Timothy Hatcher.

Add fast path when adding UTF8 bytes from a String that only contains ASCII.
Also fix a bug in our HTTP disk cache hashing function where there was already
a fast path and this fast path was hashing the null terminator, where was the
slow path wasn&apos;t. Align both code paths so that we never hash the null
terminator and bump the HTTP cache version since this change is not backward
compatible.

* Source/JavaScriptCore/bytecode/CodeBlockHash.cpp:
(JSC::CodeBlockHash::CodeBlockHash):
* Source/JavaScriptCore/bytecode/ParseHash.cpp:
(JSC::ParseHash::ParseHash):
* Source/WTF/wtf/SHA1.cpp:
(WTF::SHA1::addUTF8Bytes):
* Source/WTF/wtf/SHA1.h:
(WTF::SHA1::addUTF8Bytes):
* Source/WebCore/inspector/DOMPatchSupport.cpp:
(WebCore::addStringToSHA1):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCenter.cpp:
(WebCore::addStringToSHA1):
* Source/WebKit/NetworkProcess/cache/NetworkCacheKey.cpp:
(WebKit::NetworkCache::hashString):
* Source/WebKit/NetworkProcess/cache/NetworkCacheStorage.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::computeStringHashForContentBlockerRules):

Canonical link: <a href="https://commits.webkit.org/279513@main">https://commits.webkit.org/279513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c7d2bfddca02be2f11151123b165af3528ccf8c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53651 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33012 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56932 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4377 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4197 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43468 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2858 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55748 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31246 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46382 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24602 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28061 "Found 1 new test failure: imported/w3c/web-platform-tests/html/dom/idlharness.https.html?exclude=(Document|Window|HTML.*) (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3705 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2532 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/47012 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3880 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58526 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/53163 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28813 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3917 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50875 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30013 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46549 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50222 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30952 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65467 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7924 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29790 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12475 "Passed tests") | 
<!--EWS-Status-Bubble-End-->