### PR TITLE
[view-transitions] Support page zoom

### DIFF
--- a/LayoutTests/fast/css/view-transitions-zoom-expected.html
+++ b/LayoutTests/fast/css/view-transitions-zoom-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: zoom</title>
+<style>
+.box {
+  color: red;
+  background: lightblue;
+  width: 200px;
+  height: 200px;
+  contain: paint;
+  position: absolute;
+}
+html {
+  background: lightpink;
+}
+#e1 { top: 40px; left: 40px;  }
+#e2 { top: 40px; left: 440px;  }
+</style>
+<div id=e1 class=box></div>
+<div id=e2 class=box></div>
+

--- a/LayoutTests/fast/css/view-transitions-zoom.html
+++ b/LayoutTests/fast/css/view-transitions-zoom.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<title>View transitions: zoom</title>
+<style>
+.box {
+  color: red;
+  background: lightblue;
+  width: 100px;
+  height: 100px;
+  contain: paint;
+  position: absolute;
+}
+#e1 { top: 20px; left: 20px; view-transition-name: e1; }
+/* We're verifying what we capture, so just display both captures for 5 minutes.  */
+html::view-transition-group(*) { animation-duration: 300s; }
+html::view-transition-new(*) { animation: unset; opacity: 1; }
+html::view-transition-old(*) { animation: unset; opacity: 1; left: 200px; }
+/* hide the root so we show transition background to ensure we're in a transition */
+html::view-transition-group(root) { animation: unset; opacity: 0; }
+html::view-transition { background: lightpink; }
+</style>
+<div id=e1 class=box></div>
+<script>
+if (window.testRunner)
+  testRunner.waitUntilDone();
+
+if (window.internals)
+  window.internals.setPageZoomFactor(2);
+
+async function runTest() {
+  await document.startViewTransition(() => { }).ready;
+
+  if (window.testRunner)
+    testRunner.notifyDone();
+}
+onload = () => requestAnimationFrame(() => requestAnimationFrame(runTest));
+</script>
+

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -176,6 +176,7 @@ private:
     void callUpdateCallback();
 
     ExceptionOr<void> updatePseudoElementStyles();
+    ExceptionOr<void> checkForViewportSizeChange();
 
     void clearViewTransition();
 
@@ -185,6 +186,7 @@ private:
     OrderedNamedElementsMap m_namedElements;
     ViewTransitionPhase m_phase { ViewTransitionPhase::PendingCapture };
     FloatSize m_initialLargeViewportSize;
+    float m_initialPageZoom;
 
     RefPtr<ViewTransitionUpdateCallback> m_updateCallback;
 

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
@@ -52,10 +52,20 @@ bool RenderViewTransitionCapture::setCapturedSize(const LayoutSize& size, const 
 {
     if (m_overflowRect == overflowRect && intrinsicSize() == size && m_layerToLayoutOffset == layerToLayoutOffset)
         return false;
+    m_imageIntrinsicSize = size;
     setIntrinsicSize(size);
     m_overflowRect = overflowRect;
     m_layerToLayoutOffset = layerToLayoutOffset;
     return true;
+}
+
+void RenderViewTransitionCapture::intrinsicSizeChanged()
+{
+    if (intrinsicSize() == m_imageIntrinsicSize)
+        return;
+    setIntrinsicSize(m_imageIntrinsicSize);
+    setPreferredLogicalWidthsDirty(true);
+    setNeedsLayout();
 }
 
 void RenderViewTransitionCapture::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOffset)

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.h
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.h
@@ -40,6 +40,7 @@ public:
     bool setCapturedSize(const LayoutSize&, const LayoutRect& overflowRect, const LayoutPoint& layerToLayoutOffset);
 
     void paintReplaced(PaintInfo&, const LayoutPoint& paintOffset) override;
+    void intrinsicSizeChanged() override;
 
     void layout() override;
 
@@ -70,6 +71,7 @@ private:
     // The overflow rect of the snapshot (replaced content), scaled and positioned
     // so that the intrinsic size of the image fits the replaced content rect.
     LayoutRect m_localOverflowRect;
+    LayoutSize m_imageIntrinsicSize;
     // Scale factor between the intrinsic size and the replaced content rect size.
     FloatSize m_scale;
 };


### PR DESCRIPTION
#### a6acaf9fffcc0e608491265f4ecc0905b9bc5b00
<pre>
[view-transitions] Support page zoom
<a href="https://bugs.webkit.org/show_bug.cgi?id=274533">https://bugs.webkit.org/show_bug.cgi?id=274533</a>
&lt;<a href="https://rdar.apple.com/128549362">rdar://128549362</a>&gt;

Reviewed by Tim Nguyen.

Fixes support for page zoom in 3 ways:

Includes checks for page zoom (and page scale) changing, and aborts an in-progress
view transition, as required by spec.

Cache the intrinsic size of the capture in RenderViewTransitionCapture, and listen
for the `intrinsicSizeChanged()` function. This gets called when RenderReplaced
overwrites the existing intrinsic size, and we need to write it again.
Setting an initial style on the renderer with zoom causes this to happen.

Don&apos;t apply the page scale to the captured snapshot, since it will already be
applied to the pseudo element tree that the snapshot renders into.

Adds a new test with zoom, which displays both the new and old captures
simultaneously to confirm they&apos;re both the right size.

* LayoutTests/fast/css/view-transitions-zoom-expected.html: Added.
* LayoutTests/fast/css/view-transitions-zoom.html: Added.
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::snapshotElementVisualOverflowClippedToViewport):
(WebCore::ViewTransition::captureOldState):
(WebCore::ViewTransition::checkForViewportSizeChange):
(WebCore::ViewTransition::activateViewTransition):
(WebCore::ViewTransition::handleTransitionFrame):
(WebCore::ViewTransition::copyElementBaseProperties):
* Source/WebCore/dom/ViewTransition.h:
* Source/WebCore/rendering/RenderViewTransitionCapture.cpp:
(WebCore::RenderViewTransitionCapture::setSize):
(WebCore::RenderViewTransitionCapture::intrinsicSizeChanged):
* Source/WebCore/rendering/RenderViewTransitionCapture.h:

Canonical link: <a href="https://commits.webkit.org/279860@main">https://commits.webkit.org/279860@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2141be03db9ed5544f01c638f426344a33895b1f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7343 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58046 "Hash 2141be03 for PR 29278 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5499 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57068 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5513 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/58046 "Hash 2141be03 for PR 29278 does not build (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3715 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56862 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32329 "Found 60 new test failures: accessibility/accessibility-node-reparent.html accessibility/ancestor-computation.html accessibility/announcement-notification.html accessibility/aria-braillelabel.html accessibility/aria-brailleroledescription.html accessibility/aria-checked-mixed-value.html accessibility/aria-current-state-changed-notification.html accessibility/aria-current.html accessibility/aria-describedby-on-input.html accessibility/aria-description.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47445 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/58046 "Hash 2141be03 for PR 29278 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29119 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4783 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3640 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59636 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30013 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5146 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51780 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31155 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47528 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51183 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12029 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32164 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30942 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->