### PR TITLE
[WebXR] Avoid re-allocation of metal textures for every frame

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -376,6 +376,9 @@ void WebXRSession::shutdown(InitiatedBySystem initiatedBySystem)
 
 void WebXRSession::didCompleteShutdown()
 {
+    if (isImmersive(m_mode) && m_activeRenderState && m_activeRenderState->baseLayer())
+        m_activeRenderState->baseLayer()->sessionEnded();
+
     if (auto device = m_device.get())
         device->setTrackingAndRenderingClient(nullptr);
 

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
@@ -269,6 +269,13 @@ HTMLCanvasElement* WebXRWebGLLayer::canvas() const
     });
 }
 
+void WebXRWebGLLayer::sessionEnded()
+{
+#if PLATFORM(COCOA)
+    if (m_framebuffer)
+        m_framebuffer->releaseAllDisplayAttachments();
+#endif
+}
 
 void WebXRWebGLLayer::startFrame(const PlatformXR::FrameData& data)
 {

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.h
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.h
@@ -82,6 +82,8 @@ public:
 
     HTMLCanvasElement* canvas() const;
 
+    void sessionEnded();
+
     // WebXRLayer
     void startFrame(const PlatformXR::FrameData&) final;
     PlatformXR::Device::Layer endFrame() final;

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -278,14 +278,20 @@ struct FrameData {
         MachSendRight handle;
         bool isSharedTexture;
     };
+
+    struct ExternalTextureData {
+        size_t reusableTextureIndex = 0;
+        ExternalTexture colorTexture = { MachSendRight(), false };
+        ExternalTexture depthStencilBuffer = { MachSendRight(), false };
+    };
 #endif
 
     struct LayerData {
+        WTF_MAKE_STRUCT_FAST_ALLOCATED;
 #if PLATFORM(COCOA)
         std::optional<LayerSetupData> layerSetup = { std::nullopt };
         uint64_t renderingFrameIndex { 0 };
-        ExternalTexture colorTexture = { MachSendRight(), false };
-        ExternalTexture depthStencilBuffer = { MachSendRight(), false };
+        std::optional<ExternalTextureData> textureData;
 #else
         WebCore::IntSize framebufferSize;
         PlatformGLObject opaqueTexture { 0 };
@@ -335,7 +341,7 @@ struct FrameData {
     std::optional<Pose> floorTransform;
     StageParameters stageParameters;
     Vector<View> views;
-    HashMap<LayerHandle, LayerData> layers;
+    HashMap<LayerHandle, UniqueRef<LayerData>> layers;
     Vector<InputSource> inputSources;
 
     FrameData copy() const;

--- a/Source/WebCore/platform/xr/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebCore/platform/xr/openxr/PlatformXROpenXR.cpp
@@ -232,8 +232,10 @@ void OpenXRDevice::requestFrame(RequestFrameCallback&& callback)
 
             for (auto& layer : m_layers) {
                 auto layerData = layer.value->startFrame();
-                if (layerData)
-                    frameData.layers.add(layer.key, *layerData);
+                if (layerData) {
+                    auto layerDataRef = makeUniqueRef<PlatformXR::FrameData::LayerData>(*layerData);
+                    frameData.layers.add(layer.key, WTFMove(layerDataRef));
+                }
             }
 
             if (m_input)

--- a/Source/WebCore/testing/WebFakeXRDevice.cpp
+++ b/Source/WebCore/testing/WebFakeXRDevice.cpp
@@ -35,6 +35,7 @@
 #include "WebFakeXRInputController.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/MathExtras.h>
+#include <wtf/UniqueRef.h>
 
 namespace WebCore {
 
@@ -161,15 +162,16 @@ void SimulatedXRDevice::frameTimerFired()
 #if PLATFORM(COCOA)
         PlatformXR::FrameData::LayerSetupData layerSetupData;
         layerSetupData.physicalSize[0] = { static_cast<uint16_t>(layer.value.width()), static_cast<uint16_t>(layer.value.height()) };
-        data.layers.add(layer.key, PlatformXR::FrameData::LayerData {
+        auto layerData = makeUniqueRef<PlatformXR::FrameData::LayerData>(PlatformXR::FrameData::LayerData {
             .layerSetup = layerSetupData,
-            .colorTexture = { MachSendRight(), false }
         });
+        data.layers.add(layer.key, WTFMove(layerData));
 #else
-        data.layers.add(layer.key, PlatformXR::FrameData::LayerData {
+        auto layerData = makeUniqueRef<PlatformXR::FrameData::LayerData>(PlatformXR::FrameData::LayerData {
             .framebufferSize = IntSize(0, 0),
             .opaqueTexture = layer.value
         });
+        data.layers.add(layer.key, WTFMove(layerData));
 #endif
     }
 

--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -118,14 +118,19 @@ enum class PlatformXR::XRTargetRayMode : uint8_t {
     MachSendRight handle;
     bool isSharedTexture;
 };
+
+[Nested, RValue] struct PlatformXR::FrameData::ExternalTextureData {
+    size_t reusableTextureIndex;
+    PlatformXR::FrameData::ExternalTexture colorTexture;
+    PlatformXR::FrameData::ExternalTexture depthStencilBuffer;
+};
 #endif
 
 [Nested, RValue] struct PlatformXR::FrameData::LayerData {
 #if PLATFORM(COCOA)
     std::optional<PlatformXR::FrameData::LayerSetupData> layerSetup;
     uint64_t renderingFrameIndex;
-    PlatformXR::FrameData::ExternalTexture colorTexture;
-    PlatformXR::FrameData::ExternalTexture depthStencilBuffer;
+    std::optional<PlatformXR::FrameData::ExternalTextureData> textureData;
 #else
     WebCore::IntSize framebufferSize;
     PlatformGLObject opaqueTexture;
@@ -181,7 +186,7 @@ header: <WebCore/PlatformXR.h>
     std::optional<PlatformXR::FrameData::Pose> floorTransform;
     PlatformXR::FrameData::StageParameters stageParameters;
     Vector<PlatformXR::FrameData::View> views;
-    HashMap<PlatformXR::LayerHandle, PlatformXR::FrameData::LayerData> layers;
+    HashMap<PlatformXR::LayerHandle, UniqueRef<PlatformXR::FrameData::LayerData>> layers;
     Vector<PlatformXR::FrameData::InputSource> inputSources;
 };
 


### PR DESCRIPTION
#### 32a1e991f51741f6d02c5025fd3773ffcd9302c6
<pre>
[WebXR] Avoid re-allocation of metal textures for every frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=274882">https://bugs.webkit.org/show_bug.cgi?id=274882</a>
<a href="https://rdar.apple.com/128010992">rdar://128010992</a>

Reviewed by Dan Glastonbury and Mike Wyrzykowski.

Before this code change, metal texture handles are passed in
the frame data for every frame render, and we&apos;d allocate a metal
texture from this handle (and later deallocate it) for each frame.

With this change, we allow textures to be reused. PlatformXRSystem
can send back a reusable index along with the texture handle, and
WebXROpaqueFramebuffer caches the allocated texture with that index.
When this same texture can be reused in a future frame, PlatformXRSystem
will send back that index in the frame data with a null texture handle
as a signal that the last texture stored at that index should be used.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h:
(WebCore::WebXRExternalRenderbuffer::operator bool const):
(WebCore::WebXRAttachmentSet::operator bool const):
* Source/WebCore/Modules/webxr/WebXROpaqueFramebufferCocoa.cpp:
(WebCore::WebXROpaqueFramebuffer::~WebXROpaqueFramebuffer):
The cleanup of the display attachments is now handled in releaseAllDisplayAttachments().
(WebCore::WebXROpaqueFramebuffer::startFrame):
Call the new helper method bindCompositorTexturesForDisplay() that will
reuse a cached texture if possible.
(WebCore::WebXROpaqueFramebuffer::endFrame):
We no longer need to deallocate the texture after each frame render.
(WebCore::WebXROpaqueFramebuffer::releaseAllDisplayAttachments):
Release all the cached display attachments.
(WebCore::WebXROpaqueFramebuffer::blitShared):
(WebCore::WebXROpaqueFramebuffer::blitSharedToLayered):
(WebCore::WebXROpaqueFramebuffer::reusableDisplayAttachments const):
If texture handle is null, return the texture cached at the reusableTextureIndex.
(WebCore::WebXROpaqueFramebuffer::bindCompositorTexturesForDisplay):
First, ensure the m_displayAttachmentsSets vector is large enough to store
the set of display attachments used for this frame render. If there&apos;s no
layerData.textureData, which is the case when we run layout tests, create a
temporary renderbuffer to be used as the display color buffer. Otherwise,
check if we can reuse a previously created texture. If reuse is not possible,
create new textures with the handles passed in the frame data.
(WebCore::WebXROpaqueFramebuffer::releaseDisplayAttachmentsAtIndex):
Helper method to clean up the display attachments, refactored from old code.
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::didCompleteShutdown):
* Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp:
(WebCore::WebXRWebGLLayer::sessionEnded):
Clean up any cached display attachments.
* Source/WebCore/Modules/webxr/WebXRWebGLLayer.h:
* Source/WebCore/platform/xr/PlatformXR.h:
Introduce ExternalTextureData that packages up all the texture info
along with the reusable index.
Store LayerData with UniqueRef so we don&apos;t have to worry about its
size getting too large to be hashable.
* Source/WebCore/platform/xr/openxr/PlatformXROpenXR.cpp:
(PlatformXR::OpenXRDevice::requestFrame):
* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::SimulatedXRDevice::frameTimerFired):
Don&apos;t pass any textureData from the fake device so a temporary
renderbuffer will be used for the color display buffer.
* Source/WebKit/Shared/XR/PlatformXR.serialization.in:
* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm:
(WebKit::ARKitCoordinator::renderLoop):

Canonical link: <a href="https://commits.webkit.org/279523@main">https://commits.webkit.org/279523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cb050bbbe065f095b3ed1c1f9a58e9fa0b3f24d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33038 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6189 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56954 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4399 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55977 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40522 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4231 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43483 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2870 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31263 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46406 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24618 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28082 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3727 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2554 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3905 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58548 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28836 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3945 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50888 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30036 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46570 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50233 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11703 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30968 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29812 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->