### PR TITLE
[UnifiedPDF] Keep page previews around more aggressively

### DIFF
--- a/Source/WebCore/html/PluginDocument.cpp
+++ b/Source/WebCore/html/PluginDocument.cpp
@@ -192,4 +192,10 @@ void PluginDocument::detachFromPluginElement()
     m_pluginElement = nullptr;
 }
 
+void PluginDocument::releaseMemory()
+{
+    if (RefPtr pluginView = pluginWidget())
+        pluginView->releaseMemory();
+}
+
 }

--- a/Source/WebCore/html/PluginDocument.h
+++ b/Source/WebCore/html/PluginDocument.h
@@ -48,6 +48,8 @@ public:
     void detachFromPluginElement();
     bool shouldLoadPluginManually() const { return m_shouldLoadPluginManually; }
 
+    void releaseMemory();
+
 private:
     PluginDocument(LocalFrame&, const URL&);
 

--- a/Source/WebCore/page/MemoryRelease.cpp
+++ b/Source/WebCore/page/MemoryRelease.cpp
@@ -50,6 +50,7 @@
 #include "MemoryCache.h"
 #include "Page.h"
 #include "PerformanceLogging.h"
+#include "PluginDocument.h"
 #include "RenderTheme.h"
 #include "RenderView.h"
 #include "SVGPathElement.h"
@@ -131,6 +132,9 @@ static void releaseCriticalMemory(Synchronous synchronous, MaintainBackForwardCa
         if (RefPtr fontSelector = document->fontSelectorIfExists())
             fontSelector->emptyCaches();
         document->cachedResourceLoader().garbageCollectDocumentResources();
+
+        if (RefPtr pluginDocument = dynamicDowncast<PluginDocument>(document))
+            pluginDocument->releaseMemory();
     }
 
     if (synchronous == Synchronous::Yes)

--- a/Source/WebCore/plugins/PluginViewBase.h
+++ b/Source/WebCore/plugins/PluginViewBase.h
@@ -77,6 +77,8 @@ public:
     virtual void setPDFDisplayModeForTesting(const String&) { };
     virtual Vector<FloatRect> pdfAnnotationRectsForTesting() const { return { }; }
 
+    virtual void releaseMemory() { }
+
 protected:
     explicit PluginViewBase(PlatformWidget widget = 0) : Widget(widget) { }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -184,6 +184,7 @@ public:
     id accessibilityAssociatedPluginParentForElement(WebCore::Element*) const;
 
     bool isBeingDestroyed() const { return m_isBeingDestroyed; }
+    virtual void releaseMemory() { }
 
     bool isFullFramePlugin() const;
     WebCore::IntSize size() const { return m_size; }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
@@ -103,6 +103,8 @@ public:
     void setupWithLayer(WebCore::GraphicsLayer&);
     void teardown();
 
+    void releaseMemory();
+
     bool paintTilesForPage(WebCore::GraphicsContext&, float documentScale, const WebCore::FloatRect& clipRect, const WebCore::FloatRect& pageBoundsInPaintingCoordinates, PDFDocumentLayout::PageIndex);
     void paintPagePreview(WebCore::GraphicsContext&, const WebCore::FloatRect& clipRect, const WebCore::FloatRect& pageBoundsInPaintingCoordinates, PDFDocumentLayout::PageIndex);
 
@@ -165,6 +167,7 @@ private:
 
     void paintPagePreviewOnWorkQueue(RetainPtr<PDFDocument>&&, const PagePreviewRequest&);
     void didCompletePagePreviewRender(RefPtr<WebCore::ImageBuffer>&&, const PagePreviewRequest&);
+    void removePagePreviewsOutsideCoverageRect(const WebCore::FloatRect&);
 
     void paintPDFPageIntoBuffer(RetainPtr<PDFDocument>&&, Ref<WebCore::ImageBuffer>, PDFDocumentLayout::PageIndex, const WebCore::FloatRect& pageBounds);
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -145,6 +145,8 @@ public:
 
     float documentFittingScale() const { return m_documentLayout.scale(); }
 
+    bool shouldCachePagePreviews() const;
+
 #if PLATFORM(MAC)
     WebCore::FloatRect convertFromPDFPageToScreenForAccessibility(const WebCore::FloatRect&, PDFDocumentLayout::PageIndex) const;
     void accessibilityScrollToPage(PDFDocumentLayout::PageIndex);
@@ -279,6 +281,8 @@ private:
     RefPtr<WebCore::FragmentedSharedBuffer> liveResourceData() const override;
 
     NSData *liveData() const override;
+
+    void releaseMemory() override;
 
     bool wantsWheelEvents() const override { return false; }
     bool handleMouseEvent(const WebMouseEvent&) override;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1566,6 +1566,12 @@ NSData *UnifiedPDFPlugin::liveData() const
     return originalData();
 }
 
+void UnifiedPDFPlugin::releaseMemory()
+{
+    if (RefPtr asyncRenderer = asyncRendererIfExists())
+        asyncRenderer->releaseMemory();
+}
+
 void UnifiedPDFPlugin::didChangeScrollOffset()
 {
     if (this->currentScrollType() == ScrollType::User)
@@ -1737,6 +1743,12 @@ DelegatedScrollingMode UnifiedPDFPlugin::scrollingMode() const
 bool UnifiedPDFPlugin::isFullMainFramePlugin() const
 {
     return m_frame->isMainFrame() && isFullFramePlugin();
+}
+
+bool UnifiedPDFPlugin::shouldCachePagePreviews() const
+{
+    // Only main frame plugins are hooked up to releaseMemory().
+    return isFullFramePlugin();
 }
 
 OptionSet<TiledBackingScrollability> UnifiedPDFPlugin::computeScrollability() const

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -979,6 +979,11 @@ bool PluginView::isBeingDestroyed() const
     return protectedPlugin()->isBeingDestroyed();
 }
 
+void PluginView::releaseMemory()
+{
+    protectedPlugin()->releaseMemory();
+}
+
 RetainPtr<PDFDocument> PluginView::pdfDocumentForPrinting() const
 {
     return protectedPlugin()->pdfDocument();

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -177,6 +177,8 @@ private:
     bool transformsAffectFrameRect() final;
     void clipRectChanged() final;
 
+    void releaseMemory() final;
+
     RefPtr<WebPage> protectedWebPage() const;
 
     Ref<WebCore::HTMLPlugInElement> m_pluginElement;


### PR DESCRIPTION
#### a5473c4f0084ecfaba9cb8a09b2ea86d6e95a820
<pre>
[UnifiedPDF] Keep page previews around more aggressively
<a href="https://bugs.webkit.org/show_bug.cgi?id=273958">https://bugs.webkit.org/show_bug.cgi?id=273958</a>
<a href="https://rdar.apple.com/127820531">rdar://127820531</a>

Reviewed by Abrar Rahman Protyasha.

Page previews are used to show a lower-resolution of the PDF page before we render
high-resolution tiles. They help reduce apparent flashiness when scrolling and zooming.

We currently only retain page previews for pages in the visible area (based on
TiledBacking&apos;s `coverageRect`). However, this causes us to throw away and re-render
page previews frequently when scrolling and zooming.

Instead, retain all the page previews, for full-page plugins, and rely on a memory
warning to release those outside the visible area. They are released via a
`releaseMemory()` call that is plumbed through from `releaseCriticalMemory()`.
Doing this only for full-frame plugins avoids the need to traverse the DOM to find
all the PDFPlugin instances.

* Source/WebCore/html/PluginDocument.cpp:
(WebCore::PluginDocument::releaseMemory):
* Source/WebCore/html/PluginDocument.h:
* Source/WebCore/page/MemoryRelease.cpp:
(WebCore::releaseCriticalMemory):
* Source/WebCore/plugins/PluginViewBase.h:
(WebCore::PluginViewBase::releaseMemory):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::releaseMemory):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.mm:
(WebKit::AsyncPDFRenderer::releaseMemory):
(WebKit::AsyncPDFRenderer::removePreviewForPage):
(WebKit::AsyncPDFRenderer::coverageRectDidChange):
(WebKit::AsyncPDFRenderer::removePagePreviewsOutsideCoverageRect):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::releaseMemory):
(WebKit::UnifiedPDFPlugin::shouldCachePagePreviews const):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::releaseMemory):
* Source/WebKit/WebProcess/Plugins/PluginView.h:

Canonical link: <a href="https://commits.webkit.org/279522@main">https://commits.webkit.org/279522@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/190716ad15e5981a718c342ffa318619e8bf066c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53665 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6181 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56946 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4391 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55969 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4215 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43476 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2865 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55762 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31271 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46395 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24613 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28097 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3715 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2546 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3893 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58540 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28828 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3929 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50882 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30027 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46560 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50226 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11702 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30960 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29804 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->