### PR TITLE
[WebGPU] Replace asynchronous .requestAdapterInfo() with synchronous .info

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
@@ -126,4 +126,9 @@ void GPUAdapter::requestAdapterInfo(const std::optional<Vector<String>>&, Reques
     promise.resolve(GPUAdapterInfo::create(name()));
 }
 
+Ref<GPUAdapterInfo> GPUAdapter::info()
+{
+    return GPUAdapterInfo::create(name());
+}
+
 }

--- a/Source/WebCore/Modules/WebGPU/GPUAdapter.h
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapter.h
@@ -57,6 +57,7 @@ public:
 
     using RequestAdapterInfoPromise = DOMPromiseDeferred<IDLInterface<GPUAdapterInfo>>;
     void requestAdapterInfo(const std::optional<Vector<String>>&, RequestAdapterInfoPromise&&);
+    Ref<GPUAdapterInfo> info();
 
     WebGPU::Adapter& backing() { return m_backing; }
     const WebGPU::Adapter& backing() const { return m_backing; }

--- a/Source/WebCore/Modules/WebGPU/GPUAdapter.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapter.idl
@@ -35,6 +35,7 @@ interface GPUAdapter {
     [SameObject] readonly attribute GPUSupportedFeatures features;
     [SameObject] readonly attribute GPUSupportedLimits limits;
     readonly attribute boolean isFallbackAdapter;
+    [SameObject] readonly attribute GPUAdapterInfo info;
 
     [CallWith=CurrentScriptExecutionContext] Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor);
     Promise<GPUAdapterInfo> requestAdapterInfo(optional sequence<DOMString> unmaskHints = []);


### PR DESCRIPTION
#### 2228e1db0bd91bd4dac15c25dc4bbbaddd482485
<pre>
[WebGPU] Replace asynchronous .requestAdapterInfo() with synchronous .info
<a href="https://bugs.webkit.org/show_bug.cgi?id=274797">https://bugs.webkit.org/show_bug.cgi?id=274797</a>
&lt;radar://128896785&gt;

Reviewed by Dan Glastonbury.

Per recent spec change, requestAdapterInfo has become a synchronous info
call.

Our implementation already resolved the promise synchronously, so the impact
is minimal.

Reland keeping both implementations as removing the old version regresses
some websites.

* Source/WebCore/Modules/WebGPU/GPUAdapter.cpp:
(WebCore::GPUAdapter::info):
* Source/WebCore/Modules/WebGPU/GPUAdapter.h:
* Source/WebCore/Modules/WebGPU/GPUAdapter.idl:

Canonical link: <a href="https://commits.webkit.org/279516@main">https://commits.webkit.org/279516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf38417fb5003b9c687ef703e8cc2843ab83a6cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33027 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56944 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4389 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55967 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40510 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43480 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2864 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55760 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31244 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46399 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24615 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28070 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3719 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2544 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58538 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28826 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3938 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50881 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30025 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46564 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50224 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/document/load-events (failure)") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/11699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30958 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7929 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29802 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->