### PR TITLE
REGRESSION(2.45.1/2.45.2): [GTK] UI process crash in Nicosia::AcceleratedBuffer::~AcceleratedBuffer: Couldn't find current GLX or EGL context

### DIFF
--- a/Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp
@@ -33,6 +33,7 @@
 
 #if USE(SKIA)
 #include "FontRenderOptions.h"
+#include "GLContext.h"
 #include "GLFence.h"
 #include "PlatformDisplay.h"
 #include <skia/core/SkCanvas.h>
@@ -43,6 +44,7 @@
 #include <skia/gpu/ganesh/SkSurfaceGanesh.h>
 #include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
 #include <skia/gpu/ganesh/gl/GrGLDirectContext.h>
+#include <wtf/MainThread.h>
 
 #if USE(LIBEPOXY)
 #include <epoxy/gl.h>
@@ -142,7 +144,14 @@ AcceleratedBuffer::AcceleratedBuffer(sk_sp<SkSurface>&& surface, Flags flags)
     m_surface = WTFMove(surface);
 }
 
-AcceleratedBuffer::~AcceleratedBuffer() = default;
+AcceleratedBuffer::~AcceleratedBuffer()
+{
+    ensureOnMainThread([surface = WTFMove(m_surface), fence = WTFMove(m_fence)]() mutable {
+        PlatformDisplay::sharedDisplayForCompositing().skiaGLContext()->makeContextCurrent();
+        fence = nullptr;
+        surface = nullptr;
+    });
+}
 
 WebCore::IntSize AcceleratedBuffer::size() const
 {

--- a/Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp
@@ -45,16 +45,7 @@ SkiaAcceleratedBufferPool::SkiaAcceleratedBufferPool()
 {
 }
 
-SkiaAcceleratedBufferPool::~SkiaAcceleratedBufferPool()
-{
-    if (m_buffers.isEmpty())
-        return;
-
-    if (!PlatformDisplay::sharedDisplayForCompositing().skiaGLContext()->makeContextCurrent())
-        return;
-
-    m_buffers.clear();
-}
+SkiaAcceleratedBufferPool::~SkiaAcceleratedBufferPool() = default;
 
 RefPtr<Nicosia::Buffer> SkiaAcceleratedBufferPool::acquireBuffer(const IntSize& size, bool supportsAlpha)
 {
@@ -106,11 +97,9 @@ void SkiaAcceleratedBufferPool::releaseUnusedBuffersTimerFired()
     static const Seconds releaseUnusedSecondsTolerance { 3_s };
     MonotonicTime minUsedTime = MonotonicTime::now() - releaseUnusedSecondsTolerance;
 
-    if (PlatformDisplay::sharedDisplayForCompositing().skiaGLContext()->makeContextCurrent()) {
-        m_buffers.removeAllMatching([&minUsedTime](const Entry& entry) {
-            return entry.canBeReleased(minUsedTime);
-        });
-    }
+    m_buffers.removeAllMatching([&minUsedTime](const Entry& entry) {
+        return entry.canBeReleased(minUsedTime);
+    });
 
     if (!m_buffers.isEmpty())
         scheduleReleaseUnusedBuffers();


### PR DESCRIPTION
#### a04bd30787a23ce52d90bba8c0acb4f4cd5ab5d5
<pre>
REGRESSION(2.45.1/2.45.2): [GTK] UI process crash in Nicosia::AcceleratedBuffer::~AcceleratedBuffer: Couldn&apos;t find current GLX or EGL context
<a href="https://bugs.webkit.org/show_bug.cgi?id=274389">https://bugs.webkit.org/show_bug.cgi?id=274389</a>

Reviewed by Miguel Gomez.

The problem is that the scrolling thread is invalidated when the page is
destroyed after the SkiaAcceleratedBufferPool is destroyed. So, the
CompositeLayers of the scroling tree nodes can have a reference of a
Nicosia::AcceleratedBuffer that is destroyed in the async scrolling thread
with no current GL context. In SkiaAcceleratedBufferPool we make sure to
make the skia GL context current before destroying the buffers, but
buffers are only destroyed there if it&apos;s the last reference. We should make
sure that Nicosia::AcceleratedBuffer GL recources are freed in the main
thread with the skia GL context current on destruction.

* Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp:
(Nicosia::AcceleratedBuffer::~AcceleratedBuffer):
* Source/WebCore/platform/graphics/skia/SkiaAcceleratedBufferPool.cpp:
(WebCore::SkiaAcceleratedBufferPool::releaseUnusedBuffersTimerFired):
(WebCore::SkiaAcceleratedBufferPool::~SkiaAcceleratedBufferPool): Deleted.

Canonical link: <a href="https://commits.webkit.org/279507@main">https://commits.webkit.org/279507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1975bd64752ac9fa4d059cf82ff7cc42a38aa003

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56948 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4393 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55971 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4217 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43477 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2866 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55764 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31249 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46396 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24611 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/28076 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3716 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2548 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3894 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58542 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28830 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3931 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50883 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30029 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46561 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30962 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7918 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29806 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->