### PR TITLE
[Navigation] Add fully active document check to the "perform shared checks" algorithm

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-detach-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-detach-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL event.intercept() throws if used on an event from a detached iframe assert_throws_dom: function "() => e.intercept()" did not throw
+PASS event.intercept() throws if used on an event from a detached iframe
 

--- a/Source/WebCore/page/NavigateEvent.cpp
+++ b/Source/WebCore/page/NavigateEvent.cpp
@@ -62,8 +62,11 @@ Ref<NavigateEvent> NavigateEvent::create(const AtomString& type, const NavigateE
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigateevent-perform-shared-checks
-ExceptionOr<void> NavigateEvent::sharedChecks()
+ExceptionOr<void> NavigateEvent::sharedChecks(Document& document)
 {
+    if (!document.isFullyActive())
+        return Exception { ExceptionCode::InvalidStateError, "Document is not fully active"_s };
+
     if (!isTrusted())
         return Exception { ExceptionCode::SecurityError, "Event is not trusted"_s };
 
@@ -74,9 +77,9 @@ ExceptionOr<void> NavigateEvent::sharedChecks()
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-intercept
-ExceptionOr<void> NavigateEvent::intercept(NavigationInterceptOptions&& options)
+ExceptionOr<void> NavigateEvent::intercept(Document& document, NavigationInterceptOptions&& options)
 {
-    if (auto checkResult = sharedChecks(); checkResult.hasException())
+    if (auto checkResult = sharedChecks(document); checkResult.hasException())
         return checkResult;
 
     if (!canIntercept())
@@ -106,9 +109,9 @@ ExceptionOr<void> NavigateEvent::intercept(NavigationInterceptOptions&& options)
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-scroll
-ExceptionOr<void> NavigateEvent::scroll()
+ExceptionOr<void> NavigateEvent::scroll(Document& document)
 {
-    auto checkResult = sharedChecks();
+    auto checkResult = sharedChecks(document);
     if (checkResult.hasException())
         return checkResult;
 

--- a/Source/WebCore/page/NavigateEvent.h
+++ b/Source/WebCore/page/NavigateEvent.h
@@ -90,8 +90,8 @@ public:
     String downloadRequest() { return m_downloadRequest; };
     JSC::JSValue info() { return m_info; };
 
-    ExceptionOr<void> intercept(NavigationInterceptOptions&&);
-    ExceptionOr<void> scroll();
+    ExceptionOr<void> intercept(Document&, NavigationInterceptOptions&&);
+    ExceptionOr<void> scroll(Document&);
 
     bool wasIntercepted() const { return m_interceptionState.has_value(); };
     void setCanIntercept(bool canIntercept) { m_canIntercept = canIntercept; };
@@ -104,7 +104,7 @@ public:
 private:
     NavigateEvent(const AtomString& type, const Init&, AbortController*);
 
-    ExceptionOr<void> sharedChecks();
+    ExceptionOr<void> sharedChecks(Document&);
 
     NavigationNavigationType m_navigationType;
     RefPtr<NavigationDestination> m_destination;

--- a/Source/WebCore/page/NavigateEvent.idl
+++ b/Source/WebCore/page/NavigateEvent.idl
@@ -15,8 +15,8 @@
   readonly attribute any info;
   [EnabledBySetting=UAVisualTransitionDetectionEnabled] readonly attribute boolean hasUAVisualTransition;
 
-  undefined intercept(optional NavigationInterceptOptions options = {});
-  undefined scroll();
+  [CallWith=RelevantDocument] undefined intercept(optional NavigationInterceptOptions options = {});
+  [CallWith=RelevantDocument] undefined scroll();
 };
 
 dictionary NavigateEventInit : EventInit {


### PR DESCRIPTION
#### b50dcf22f189f2c47da11c0929f1204ba6ecac1f
<pre>
[Navigation] Add fully active document check to the &quot;perform shared checks&quot; algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=274890">https://bugs.webkit.org/show_bug.cgi?id=274890</a>

Reviewed by Alex Christensen.

Add fully active document check to the &quot;perform shared checks&quot; algorithm [1].

[1] <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigateevent-perform-shared-checks">https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigateevent-perform-shared-checks</a>

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-detach-expected.txt:
* Source/WebCore/page/NavigateEvent.cpp:
(WebCore::NavigateEvent::sharedChecks):
(WebCore::NavigateEvent::intercept):
(WebCore::NavigateEvent::scroll):
* Source/WebCore/page/NavigateEvent.h:
* Source/WebCore/page/NavigateEvent.idl:

Canonical link: <a href="https://commits.webkit.org/279613@main">https://commits.webkit.org/279613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/792ed995f2dcf03020d1253684919bf8cbf05a15

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56981 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4426 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56004 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40556 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4263 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43503 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2893 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31302 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46431 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24638 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28110 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3750 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2581 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49845 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3930 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58575 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28865 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3976 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50909 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30063 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46593 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50254 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11760 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30996 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29840 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->