### PR TITLE
[CMake][GLib] Propagate unified build setting to make-dist script

### DIFF
--- a/Source/cmake/WebKitDist.cmake
+++ b/Source/cmake/WebKitDist.cmake
@@ -1,10 +1,15 @@
-macro(WEBKIT_DECLARE_DIST_TARGETS _port _tarball_prefix _manifest)
+function(WEBKIT_DECLARE_DIST_TARGETS _port _tarball_prefix _manifest)
     find_package(Xz REQUIRED)
 
     configure_file(
         ${_manifest}
         ${CMAKE_BINARY_DIR}/manifest.txt
     )
+
+    set(make_dist_unified_flag "")
+    if (ENABLE_UNIFIED_BUILDS)
+        set(make_dist_unified_flag "--unified")
+    endif ()
 
     add_custom_target(distcheck
         COMMENT "Checking release tarball: ${_tarball_prefix}-${PROJECT_VERSION}.tar"
@@ -17,6 +22,7 @@ macro(WEBKIT_DECLARE_DIST_TARGETS _port _tarball_prefix _manifest)
                 --source-dir=${CMAKE_SOURCE_DIR}
                 --build-dir=${CMAKE_BINARY_DIR}
                 --version=${PROJECT_VERSION}
+                ${make_dist_unified_flag}
                 ${CMAKE_BINARY_DIR}/manifest.txt
         COMMAND ${XZ_EXECUTABLE} -evfQ
                 ${CMAKE_BINARY_DIR}/${_tarball_prefix}-${PROJECT_VERSION}.tar
@@ -45,4 +51,4 @@ macro(WEBKIT_DECLARE_DIST_TARGETS _port _tarball_prefix _manifest)
         DEPENDS WebKit
         DEPENDS doc-all
     )
-endmacro()
+endfunction()


### PR DESCRIPTION
#### 5dfbc67f91ea412829e4f77603be555dd0e6568f
<pre>
[CMake][GLib] Propagate unified build setting to make-dist script
<a href="https://bugs.webkit.org/show_bug.cgi?id=274894">https://bugs.webkit.org/show_bug.cgi?id=274894</a>

Reviewed by Carlos Garcia Campos.

 Pass --unified to make-dist if ENABLE_UNIFIED_BUILDS has been enabled.

 While at it, change the WEBKIT_DECLARE_DIST_TARGETS() macro to be a
 function: it does not modify the caller environment in any way so there
 is no reason for it to be a macro. This makes it easier to have a new
 local variable that does not pollute the scope of the caller.

* Source/cmake/WebKitDist.cmake:

Canonical link: <a href="https://commits.webkit.org/279509@main">https://commits.webkit.org/279509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90c5667b20359dd5ff723ace41cc495b980d26e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53690 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56971 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4416 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40543 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4248 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2881 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55787 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46422 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/24628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/28100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2571 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/47050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58565 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/53202 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28853 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/3961 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50899 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30053 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46585 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30985 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65506 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7920 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29830 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12481 "Passed tests") | 
<!--EWS-Status-Bubble-End-->