### PR TITLE
[LFC] Introduce concept of primary layout state

### DIFF
--- a/Source/WebCore/layout/LayoutState.h
+++ b/Source/WebCore/layout/LayoutState.h
@@ -59,8 +59,13 @@ class LayoutState : public CanMakeWeakPtr<LayoutState> {
     WTF_MAKE_NONCOPYABLE(LayoutState);
     WTF_MAKE_ISO_ALLOCATED(LayoutState);
 public:
-    LayoutState(const Document&, const ElementBox& rootContainer);
+    // Primary layout state has a direct geometry cache in layout boxes.
+    enum class Type { Primary, Secondary };
+
+    LayoutState(const Document&, const ElementBox& rootContainer, Type);
     ~LayoutState();
+
+    Type type() const { return m_type; }
 
     void updateQuirksMode(const Document&);
 
@@ -102,6 +107,8 @@ private:
     void setQuirksMode(QuirksMode quirksMode) { m_quirksMode = quirksMode; }
     BoxGeometry& ensureGeometryForBoxSlow(const Box&);
 
+    const Type m_type;
+
     HashMap<const ElementBox*, std::unique_ptr<InlineContentCache>> m_inlineContentCaches;
 
     HashMap<const ElementBox*, std::unique_ptr<BlockFormattingState>> m_blockFormattingStates;
@@ -119,22 +126,31 @@ private:
 
 inline bool LayoutState::hasBoxGeometry(const Box& layoutBox) const
 {
-    if (layoutBox.cachedGeometryForLayoutState(*this))
-        return true;
+    if (LIKELY(m_type == Type::Primary))
+        return !!layoutBox.m_cachedGeometryForPrimaryLayoutState;
+
     return m_layoutBoxToBoxGeometry.contains(&layoutBox);
 }
 
 inline BoxGeometry& LayoutState::ensureGeometryForBox(const Box& layoutBox)
 {
-    if (auto* boxGeometry = layoutBox.cachedGeometryForLayoutState(*this))
-        return *boxGeometry;
+    if (LIKELY(m_type == Type::Primary)) {
+        if (auto* boxGeometry = layoutBox.m_cachedGeometryForPrimaryLayoutState.get()) {
+            ASSERT(layoutBox.m_primaryLayoutState == this);
+            return *boxGeometry;
+        }
+    }
     return ensureGeometryForBoxSlow(layoutBox);
 }
 
 inline const BoxGeometry& LayoutState::geometryForBox(const Box& layoutBox) const
 {
-    if (auto* boxGeometry = layoutBox.cachedGeometryForLayoutState(*this))
-        return *boxGeometry;
+    if (LIKELY(m_type == Type::Primary)) {
+        ASSERT(layoutBox.m_primaryLayoutState == this);
+        return *layoutBox.m_cachedGeometryForPrimaryLayoutState;
+    }
+
+    ASSERT(layoutBox.m_primaryLayoutState != this);
     ASSERT(m_layoutBoxToBoxGeometry.contains(&layoutBox));
     return *m_layoutBoxToBoxGeometry.get(&layoutBox);
 }
@@ -147,19 +163,6 @@ inline void LayoutState::registerFormattingContext(const FormattingContext& form
     m_formattingContextList.add(&formattingContext);
 }
 #endif
-
-// These Layout::Box function are here to allow inlining.
-inline bool Box::canCacheForLayoutState(const LayoutState& layoutState) const
-{
-    return !m_cachedLayoutState || m_cachedLayoutState.get() == &layoutState;
-}
-
-inline BoxGeometry* Box::cachedGeometryForLayoutState(const LayoutState& layoutState) const
-{
-    if (m_cachedLayoutState.get() != &layoutState)
-        return nullptr;
-    return m_cachedGeometryForLayoutState.get();
-}
 
 }
 }

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -495,13 +495,6 @@ const ElementBox* Box::associatedRubyAnnotationBox() const
     return dynamicDowncast<ElementBox>(next);
 }
 
-void Box::setCachedGeometryForLayoutState(LayoutState& layoutState, std::unique_ptr<BoxGeometry> geometry) const
-{
-    ASSERT(!m_cachedLayoutState);
-    m_cachedLayoutState = layoutState;
-    m_cachedGeometryForLayoutState = WTFMove(geometry);
-}
-
 Box::RareDataMap& Box::rareDataMap()
 {
     static NeverDestroyed<RareDataMap> map;

--- a/Source/WebCore/layout/layouttree/LayoutBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutBox.h
@@ -191,10 +191,6 @@ public:
 
     const ElementBox* associatedRubyAnnotationBox() const;
 
-    bool canCacheForLayoutState(const LayoutState&) const;
-    BoxGeometry* cachedGeometryForLayoutState(const LayoutState&) const;
-    void setCachedGeometryForLayoutState(LayoutState&, std::unique_ptr<BoxGeometry>) const;
-
     RenderObject* rendererForIntegration() const { return m_renderer.get(); }
     void setRendererForIntegration(RenderObject* renderer) { m_renderer = renderer; }
 
@@ -205,6 +201,7 @@ protected:
 
 private:
     friend class ElementBox;
+    friend class LayoutState;
 
     class BoxRareData {
         WTF_MAKE_FAST_ALLOCATED;
@@ -244,9 +241,11 @@ private:
     std::unique_ptr<Box> m_nextSibling;
     CheckedPtr<Box> m_previousSibling;
 
-    // First LayoutState gets a direct cache.
-    mutable WeakPtr<LayoutState> m_cachedLayoutState;
-    mutable std::unique_ptr<BoxGeometry> m_cachedGeometryForLayoutState;
+    // Primary LayoutState gets a direct cache.
+#if ASSERT_ENABLED
+    mutable WeakPtr<LayoutState> m_primaryLayoutState;
+#endif
+    mutable std::unique_ptr<BoxGeometry> m_cachedGeometryForPrimaryLayoutState;
 
     CheckedPtr<RenderObject> m_renderer;
 };

--- a/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
@@ -578,7 +578,7 @@ void printLayoutTreeForLiveDocuments()
         // FIXME: Need to find a way to output geometry without layout context.
         auto& renderView = *document->renderView();
         auto layoutTree = TreeBuilder::buildLayoutTree(renderView);
-        auto layoutState = LayoutState { document, layoutTree->root() };
+        auto layoutState = LayoutState { document, layoutTree->root(), Layout::LayoutState::Type::Secondary };
 
         LayoutContext(layoutState).layout(renderView.size());
         showLayoutTree(downcast<InitialContainingBlock>(layoutState.root()), &layoutState);

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -79,7 +79,7 @@ RenderView::RenderView(Document& document, RenderStyle&& style)
     : RenderBlockFlow(Type::View, document, WTFMove(style))
     , m_frameView(*document.view())
     , m_initialContainingBlock(makeUniqueRef<Layout::InitialContainingBlock>(RenderStyle::clone(this->style())))
-    , m_layoutState(makeUniqueRef<Layout::LayoutState>(document, *m_initialContainingBlock))
+    , m_layoutState(makeUniqueRef<Layout::LayoutState>(document, *m_initialContainingBlock, Layout::LayoutState::Type::Primary))
     , m_selection(*this)
 {
     // FIXME: We should find a way to enforce this at compile time.


### PR DESCRIPTION
#### 8c82c6544856e727ced9aacc14b5936042918b1e
<pre>
[LFC] Introduce concept of primary layout state
<a href="https://bugs.webkit.org/show_bug.cgi?id=274895">https://bugs.webkit.org/show_bug.cgi?id=274895</a>
<a href="https://rdar.apple.com/problem/128999403">rdar://problem/128999403</a>

Reviewed by Alan Baradlay.

Geometry for the primary layout state gets a direct cache in layout boxes.
This way we can remove the layout state pointer from Layout::Box saving memory
and simplifying code.

* Source/WebCore/layout/LayoutState.cpp:
(WebCore::Layout::LayoutState::LayoutState):
(WebCore::Layout::LayoutState::ensureGeometryForBoxSlow):
* Source/WebCore/layout/LayoutState.h:
(WebCore::Layout::LayoutState::type const):
(WebCore::Layout::LayoutState::hasBoxGeometry const):
(WebCore::Layout::LayoutState::ensureGeometryForBox):
(WebCore::Layout::LayoutState::geometryForBox const):
(WebCore::Layout::Box::canCacheForLayoutState const): Deleted.
(WebCore::Layout::Box::cachedGeometryForLayoutState const): Deleted.
* Source/WebCore/layout/layouttree/LayoutBox.cpp:
(WebCore::Layout::Box::setCachedGeometryForLayoutState const): Deleted.
* Source/WebCore/layout/layouttree/LayoutBox.h:
* Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp:
(WebCore::Layout::printLayoutTreeForLiveDocuments):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::RenderView):

Canonical link: <a href="https://commits.webkit.org/279519@main">https://commits.webkit.org/279519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8e23b574fbbbcbcd80c4a4ad007405f22df812e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33061 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6211 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/56975 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4420 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/55998 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4260 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43498 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2886 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55791 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31280 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46428 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24633 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28105 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3747 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2575 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58569 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28859 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/3973 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50906 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46590 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11700 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/30990 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29834 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->