### PR TITLE
Adopt smart pointers to glib related code

### DIFF
--- a/Source/JavaScriptCore/API/glib/JSCException.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCException.cpp
@@ -63,7 +63,7 @@ GRefPtr<JSCException> jscExceptionCreate(JSCContext* context, JSValueRef jsExcep
     GRefPtr<JSCException> exception = adoptGRef(JSC_EXCEPTION(g_object_new(JSC_TYPE_EXCEPTION, nullptr)));
     auto* jsContext = jscContextGetJSContext(context);
     JSC::JSGlobalObject* globalObject = toJS(jsContext);
-    JSC::VM& vm = globalObject->vm();
+    Ref vm = globalObject->vm();
     JSC::JSLockHolder locker(vm);
     exception->priv->jsException.set(vm, toJS(JSValueToObject(jsContext, jsException, nullptr)));
     // The context has a strong reference to the exception, so we can't ref the context. We use a weak

--- a/Source/JavaScriptCore/API/glib/JSCWeakValue.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCWeakValue.cpp
@@ -188,11 +188,11 @@ JSCValue* jsc_weak_value_get_value(JSCWeakValue* weakValue)
 
     JSCWeakValuePrivate* priv = weakValue->priv;
     WTF::Locker<JSC::JSLock> locker(priv->lock.get());
-    JSC::VM* vm = priv->lock->vm();
+    RefPtr vm = priv->lock->vm();
     if (!vm)
         return nullptr;
 
-    JSC::JSLockHolder apiLocker(vm);
+    JSC::JSLockHolder apiLocker(vm.get());
     if (!priv->globalObject || priv->weakValueRef.isClear())
         return nullptr;
 

--- a/Source/JavaScriptCore/API/glib/JSCWrapperMap.cpp
+++ b/Source/JavaScriptCore/API/glib/JSCWrapperMap.cpp
@@ -66,9 +66,9 @@ void WrapperMap::unwrap(JSValueRef jsValue)
 
 void WrapperMap::registerClass(JSCClass* jscClass)
 {
-    auto* jsClass = jscClassGetJSClass(jscClass);
-    ASSERT(!m_classMap.contains(jsClass));
-    m_classMap.set(jsClass, jscClass);
+    RefPtr jsClass = jscClassGetJSClass(jscClass);
+    ASSERT(!m_classMap.contains(jsClass.get()));
+    m_classMap.set(jsClass.get(), jscClass);
 }
 
 JSCClass* WrapperMap::registeredClass(JSClassRef jsClass) const
@@ -80,7 +80,7 @@ JSObject* WrapperMap::createJSWrapper(JSGlobalContextRef jsContext, JSClassRef j
 {
     ASSERT(toJSGlobalObject(jsContext)->wrapperMap() == this);
     JSGlobalObject* globalObject = toJS(jsContext);
-    VM& vm = globalObject->vm();
+    Ref vm = globalObject->vm();
     JSLockHolder locker(vm);
     auto* object = JSC::JSCallbackObject<JSC::JSAPIWrapperObject>::create(globalObject, globalObject->glibWrapperObjectStructure(), jsClass, nullptr);
     if (wrappedObject) {

--- a/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp
+++ b/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp
@@ -301,7 +301,7 @@ void RemoteInspector::setup(TargetID targetIdentifier)
 
 void RemoteInspector::sendMessageToTarget(TargetID targetIdentifier, const char* message)
 {
-    if (auto connectionToTarget = m_targetConnectionMap.get(targetIdentifier))
+    if (RefPtr connectionToTarget = m_targetConnectionMap.get(targetIdentifier))
         connectionToTarget->sendMessageToTarget(String::fromUTF8(message));
 }
 

--- a/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.cpp
+++ b/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.cpp
@@ -228,7 +228,7 @@ void RemoteInspectorServer::setTargetList(SocketConnection& remoteInspectorConne
     gboolean remoteAutomationEnabled;
     GRefPtr<GVariant> targetList;
     g_variant_get(parameters, "(@a(tsssb)b)", &targetList.outPtr(), &remoteAutomationEnabled);
-    SocketConnection* clientConnection = remoteAutomationEnabled && m_automationConnection ? m_automationConnection : m_clientConnection;
+    RefPtr clientConnection = remoteAutomationEnabled && m_automationConnection ? m_automationConnection : m_clientConnection;
     if (!clientConnection)
         return;
 
@@ -248,7 +248,7 @@ GVariant* RemoteInspectorServer::setupInspectorClient(SocketConnection& clientCo
         backendCommands = g_variant_new_bytestring("");
 
     // Ask all remote inspectors to push their target lists to notify the new client.
-    for (auto* remoteInspectorConnection : m_remoteInspectorConnectionToIDMap.keys())
+    for (RefPtr remoteInspectorConnection : m_remoteInspectorConnectionToIDMap.keys())
         remoteInspectorConnection->sendMessage("GetTargetList", nullptr);
 
     return backendCommands;
@@ -298,7 +298,7 @@ void RemoteInspectorServer::connectionDidClose(SocketConnection& clientConnectio
         m_idToRemoteInspectorConnectionMap.remove(connectionID);
         // Send an empty target list to the clients.
         Vector<SocketConnection*> clientConnections = { m_automationConnection, m_clientConnection };
-        for (auto* connection : clientConnections) {
+        for (RefPtr connection : clientConnections) {
             if (!connection)
                 continue;
             connection->sendMessage("SetTargetList", g_variant_new("(t@a(tsssb))", connectionID, g_variant_new_array(G_VARIANT_TYPE("(tsssb)"), nullptr, 0)));
@@ -329,7 +329,7 @@ void RemoteInspectorServer::sendMessageToFrontend(SocketConnection& remoteInspec
     if (!m_automationTargets.contains(connectionTargetPair) && !m_inspectionTargets.contains(connectionTargetPair))
         return;
 
-    SocketConnection* clientConnection = m_inspectionTargets.contains(connectionTargetPair) ? m_clientConnection : m_automationConnection;
+    RefPtr clientConnection = m_inspectionTargets.contains(connectionTargetPair) ? m_clientConnection : m_automationConnection;
     ASSERT(clientConnection);
     clientConnection->sendMessage("SendMessageToFrontend", g_variant_new("(tt&s)", connectionID, targetID, message));
 }

--- a/Source/WTF/wtf/glib/RunLoopGLib.cpp
+++ b/Source/WTF/wtf/glib/RunLoopGLib.cpp
@@ -96,13 +96,13 @@ RunLoop::~RunLoop()
 
 void RunLoop::run()
 {
-    RunLoop& runLoop = RunLoop::current();
-    GMainContext* mainContext = runLoop.m_mainContext.get();
+    Ref runLoop = RunLoop::current();
+    GMainContext* mainContext = runLoop->m_mainContext.get();
 
     // The innermost main loop should always be there.
-    ASSERT(!runLoop.m_mainLoops.isEmpty());
+    ASSERT(!runLoop->m_mainLoops.isEmpty());
 
-    GMainLoop* innermostLoop = runLoop.m_mainLoops[0].get();
+    GMainLoop* innermostLoop = runLoop->m_mainLoops[0].get();
     if (!g_main_loop_is_running(innermostLoop)) {
         g_main_context_push_thread_default(mainContext);
         g_main_loop_run(innermostLoop);
@@ -112,13 +112,13 @@ void RunLoop::run()
 
     // Create and run a nested loop if the innermost one was already running.
     GMainLoop* nestedMainLoop = g_main_loop_new(mainContext, FALSE);
-    runLoop.m_mainLoops.append(adoptGRef(nestedMainLoop));
+    runLoop->m_mainLoops.append(adoptGRef(nestedMainLoop));
 
     g_main_context_push_thread_default(mainContext);
     g_main_loop_run(nestedMainLoop);
     g_main_context_pop_thread_default(mainContext);
 
-    runLoop.m_mainLoops.removeLast();
+    runLoop->m_mainLoops.removeLast();
 }
 
 void RunLoop::stop()

--- a/Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp
@@ -385,11 +385,11 @@ WebKitAutomationSession* webkitAutomationSessionCreate(WebKitWebContext* webCont
                 settings.defaultProxyURL = capabilities.proxy->autoconfigURL->utf8();
             if (!settings.isEmpty()) {
 #if ENABLE(2022_GLIB_API)
-                auto& dataStore = webkitWebsiteDataManagerGetDataStore(webkit_network_session_get_website_data_manager(networkSession));
+                Ref dataStore = webkitWebsiteDataManagerGetDataStore(webkit_network_session_get_website_data_manager(networkSession));
 #else
-                auto& dataStore = webkitWebsiteDataManagerGetDataStore(webkit_web_context_get_website_data_manager(webContext));
+                Ref dataStore = webkitWebsiteDataManagerGetDataStore(webkit_web_context_get_website_data_manager(webContext));
 #endif
-                dataStore.setNetworkProxySettings(WTFMove(settings));
+                dataStore->setNetworkProxySettings(WTFMove(settings));
             }
         } else {
             WebKitNetworkProxySettings* proxySettings = nullptr;

--- a/Source/WebKit/UIProcess/API/glib/WebKitBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitBackForwardList.cpp
@@ -113,8 +113,8 @@ static GList* webkitBackForwardListCreateList(WebKitBackForwardList* list, API::
 
     GList* returnValue = 0;
     for (size_t i = 0; i < backForwardItems->size(); ++i) {
-        WebBackForwardListItem* webItem = static_cast<WebBackForwardListItem*>(backForwardItems->at(i));
-        returnValue = g_list_prepend(returnValue, webkitBackForwardListGetOrCreateItem(list, webItem));
+        RefPtr webItem = static_cast<WebBackForwardListItem*>(backForwardItems->at(i));
+        returnValue = g_list_prepend(returnValue, webkitBackForwardListGetOrCreateItem(list, webItem.get()));
     }
 
     return returnValue;

--- a/Source/WebKit/UIProcess/API/glib/WebKitCookieManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitCookieManager.cpp
@@ -196,8 +196,8 @@ void webkit_cookie_manager_set_persistent_storage(WebKitCookieManager* manager, 
     if (sessionID.isEphemeral())
         return;
 
-    auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(manager->priv->dataManager);
-    websiteDataStore.setCookiePersistentStorage(String::fromUTF8(filename), toSoupCookiePersistentStorageType(storage));
+    Ref websiteDataStore = webkitWebsiteDataManagerGetDataStore(manager->priv->dataManager);
+    websiteDataStore->setCookiePersistentStorage(String::fromUTF8(filename), toSoupCookiePersistentStorageType(storage));
 }
 
 /**
@@ -216,8 +216,8 @@ void webkit_cookie_manager_set_accept_policy(WebKitCookieManager* manager, WebKi
 {
     g_return_if_fail(WEBKIT_IS_COOKIE_MANAGER(manager));
 
-    auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(manager->priv->dataManager);
-    websiteDataStore.setHTTPCookieAcceptPolicy(toHTTPCookieAcceptPolicy(policy));
+    Ref websiteDataStore = webkitWebsiteDataManagerGetDataStore(manager->priv->dataManager);
+    websiteDataStore->setHTTPCookieAcceptPolicy(toHTTPCookieAcceptPolicy(policy));
 }
 
 /**

--- a/Source/WebKit/UIProcess/API/glib/WebKitFileChooserRequest.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFileChooserRequest.cpp
@@ -223,7 +223,7 @@ const gchar* const* webkit_file_chooser_request_get_mime_types(WebKitFileChooser
 
     request->priv->mimeTypes = adoptGRef(g_ptr_array_new_with_free_func(g_free));
     for (size_t i = 0; i < numOfMimeTypes; ++i) {
-        API::String* webMimeType = static_cast<API::String*>(mimeTypes->at(i));
+        RefPtr webMimeType = static_cast<API::String*>(mimeTypes->at(i));
         String mimeTypeString = webMimeType->string();
         if (mimeTypeString.isEmpty())
             continue;
@@ -363,7 +363,7 @@ const gchar* const* webkit_file_chooser_request_get_selected_files(WebKitFileCho
 
     request->priv->selectedFiles = adoptGRef(g_ptr_array_new_with_free_func(g_free));
     for (size_t i = 0; i < numOfFiles; ++i) {
-        API::String* webFileName = static_cast<API::String*>(selectedFileNames->at(i));
+        RefPtr webFileName = static_cast<API::String*>(selectedFileNames->at(i));
         if (webFileName->stringView().isEmpty())
             continue;
         CString filename = FileSystem::fileSystemRepresentation(webFileName->string());

--- a/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp
@@ -359,8 +359,8 @@ void webkit_network_session_set_itp_enabled(WebKitNetworkSession* session, gbool
 {
     g_return_if_fail(WEBKIT_IS_NETWORK_SESSION(session));
 
-    auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
-    websiteDataStore.setTrackingPreventionEnabled(enabled);
+    Ref websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
+    websiteDataStore->setTrackingPreventionEnabled(enabled);
 }
 
 /**
@@ -377,8 +377,8 @@ gboolean webkit_network_session_get_itp_enabled(WebKitNetworkSession* session)
 {
     g_return_val_if_fail(WEBKIT_IS_NETWORK_SESSION(session), FALSE);
 
-    auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
-    return websiteDataStore.trackingPreventionEnabled();
+    Ref websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
+    return websiteDataStore->trackingPreventionEnabled();
 }
 
 /**
@@ -398,8 +398,8 @@ void webkit_network_session_set_persistent_credential_storage_enabled(WebKitNetw
 {
     g_return_if_fail(WEBKIT_IS_NETWORK_SESSION(session));
 
-    auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
-    websiteDataStore.setPersistentCredentialStorageEnabled(enabled);
+    Ref websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
+    websiteDataStore->setPersistentCredentialStorageEnabled(enabled);
 }
 
 /**
@@ -418,8 +418,8 @@ gboolean webkit_network_session_get_persistent_credential_storage_enabled(WebKit
 {
     g_return_val_if_fail(WEBKIT_IS_NETWORK_SESSION(session), FALSE);
 
-    auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
-    return websiteDataStore.persistentCredentialStorageEnabled();
+    Ref websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
+    return websiteDataStore->persistentCredentialStorageEnabled();
 }
 
 /**
@@ -439,8 +439,8 @@ void webkit_network_session_set_tls_errors_policy(WebKitNetworkSession* session,
         return;
 
     session->priv->tlsErrorsPolicy = policy;
-    auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
-    websiteDataStore.setIgnoreTLSErrors(policy == WEBKIT_TLS_ERRORS_POLICY_IGNORE);
+    Ref websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
+    websiteDataStore->setIgnoreTLSErrors(policy == WEBKIT_TLS_ERRORS_POLICY_IGNORE);
 }
 
 /**
@@ -480,8 +480,8 @@ void webkit_network_session_allow_tls_certificate_for_host(WebKitNetworkSession*
     g_return_if_fail(host);
 
     auto certificateInfo = WebCore::CertificateInfo(certificate, static_cast<GTlsCertificateFlags>(0));
-    auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
-    websiteDataStore.allowSpecificHTTPSCertificateForHost(certificateInfo, String::fromUTF8(host));
+    Ref websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
+    websiteDataStore->allowSpecificHTTPSCertificateForHost(certificateInfo, String::fromUTF8(host));
 }
 
 /**
@@ -507,13 +507,13 @@ void webkit_network_session_set_proxy_settings(WebKitNetworkSession* session, We
     g_return_if_fail(WEBKIT_IS_NETWORK_SESSION(session));
     g_return_if_fail((proxyMode != WEBKIT_NETWORK_PROXY_MODE_CUSTOM && !proxySettings) || (proxyMode == WEBKIT_NETWORK_PROXY_MODE_CUSTOM && proxySettings));
 
-    auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
+    Ref websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
     switch (proxyMode) {
     case WEBKIT_NETWORK_PROXY_MODE_DEFAULT:
-        websiteDataStore.setNetworkProxySettings({ });
+        websiteDataStore->setNetworkProxySettings({ });
         break;
     case WEBKIT_NETWORK_PROXY_MODE_NO_PROXY:
-        websiteDataStore.setNetworkProxySettings(WebCore::SoupNetworkProxySettings(WebCore::SoupNetworkProxySettings::Mode::NoProxy));
+        websiteDataStore->setNetworkProxySettings(WebCore::SoupNetworkProxySettings(WebCore::SoupNetworkProxySettings::Mode::NoProxy));
         break;
     case WEBKIT_NETWORK_PROXY_MODE_CUSTOM:
         auto settings = webkitNetworkProxySettingsGetNetworkProxySettings(proxySettings);
@@ -521,7 +521,7 @@ void webkit_network_session_set_proxy_settings(WebKitNetworkSession* session, We
             g_warning("Invalid attempt to set custom network proxy settings with an empty WebKitNetworkProxySettings. Use "
                 "WEBKIT_NETWORK_PROXY_MODE_NO_PROXY to not use any proxy or WEBKIT_NETWORK_PROXY_MODE_DEFAULT to use the default system settings");
         } else
-            websiteDataStore.setNetworkProxySettings(WTFMove(settings));
+            websiteDataStore->setNetworkProxySettings(WTFMove(settings));
         break;
     }
 }
@@ -572,9 +572,9 @@ void webkit_network_session_get_itp_summary(WebKitNetworkSession* session, GCanc
 {
     g_return_if_fail(WEBKIT_IS_NETWORK_SESSION(session));
 
-    auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
+    Ref websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
     GRefPtr<GTask> task = adoptGRef(g_task_new(session, cancellable, callback, userData));
-    websiteDataStore.getResourceLoadStatisticsDataSummary([task = WTFMove(task)](Vector<ITPThirdPartyData>&& thirdPartyList) {
+    websiteDataStore->getResourceLoadStatisticsDataSummary([task = WTFMove(task)](Vector<ITPThirdPartyData>&& thirdPartyList) {
         GList* result = nullptr;
         while (!thirdPartyList.isEmpty())
             result = g_list_prepend(result, webkitITPThirdPartyCreate(thirdPartyList.takeLast()));
@@ -622,8 +622,8 @@ void webkit_network_session_prefetch_dns(WebKitNetworkSession* session, const ch
     g_return_if_fail(hostname);
 
     if (session->priv->dnsPrefetchedHosts.add(String::fromUTF8(hostname)).isNewEntry) {
-        auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
-        websiteDataStore.networkProcess().send(Messages::NetworkProcess::PrefetchDNS(String::fromUTF8(hostname)), 0);
+        Ref websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
+        websiteDataStore->networkProcess().send(Messages::NetworkProcess::PrefetchDNS(String::fromUTF8(hostname)), 0);
     }
     session->priv->dnsPrefetchHystereris.impulse();
 }
@@ -650,8 +650,8 @@ WebKitDownload* webkit_network_session_download_uri(WebKitNetworkSession* sessio
     g_return_val_if_fail(uri, nullptr);
 
     WebCore::ResourceRequest request(String::fromUTF8(uri));
-    auto& websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
-    auto downloadProxy = websiteDataStore.createDownloadProxy(adoptRef(*new API::DownloadClient), request, nullptr, { });
+    Ref websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
+    auto downloadProxy = websiteDataStore->createDownloadProxy(adoptRef(*new API::DownloadClient), request, nullptr, { });
     auto download = webkitDownloadCreate(downloadProxy);
     downloadProxy->setDidStartCallback([session = GRefPtr<WebKitNetworkSession> { session }, download = download.get()](auto* downloadProxy) {
         if (!downloadProxy)
@@ -660,7 +660,7 @@ WebKitDownload* webkit_network_session_download_uri(WebKitNetworkSession* sessio
         webkitDownloadStarted(download);
         webkitNetworkSessionDownloadStarted(session.get(), download);
     });
-    websiteDataStore.download(downloadProxy, { });
+    websiteDataStore->download(downloadProxy, { });
     return download.leakRef();
 }
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -397,8 +397,8 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
     auto displayObject = JSON::Object::create();
     startTable("Display Information"_s);
 
-    auto& page = webkitURISchemeRequestGetWebPage(request);
-    auto displayID = page.displayID();
+    Ref page = webkitURISchemeRequestGetWebPage(request);
+    auto displayID = page->displayID();
     addTableRow(displayObject, "Identifier"_s, String::number(displayID.value_or(0)));
 
 #if PLATFORM(GTK)
@@ -429,7 +429,7 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
 #endif
 
     if (displayID) {
-        if (auto* displayLink = page.configuration().processPool().displayLinks().existingDisplayLinkForDisplay(*displayID)) {
+        if (auto* displayLink = page->configuration().processPool().displayLinks().existingDisplayLinkForDisplay(*displayID)) {
             auto& vblankMonitor = displayLink->vblankMonitor();
             addTableRow(displayObject, "VBlank type"_s, vblankMonitor.type() == DisplayVBlankMonitor::Type::Timer ? "Timer"_s : "DRM"_s);
             addTableRow(displayObject, "VBlank refresh rate"_s, makeString(vblankMonitor.refreshRate(), "Hz"_s));

--- a/Source/WebKit/UIProcess/API/glib/WebKitSecurityManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSecurityManager.cpp
@@ -70,7 +70,7 @@ WebKitSecurityManager* webkitSecurityManagerCreate(WebKitWebContext* webContext)
 static void registerSecurityPolicyForURIScheme(WebKitSecurityManager* manager, const char* scheme, SecurityPolicy policy)
 {
     String urlScheme = String::fromUTF8(scheme);
-    auto& processPool = webkitWebContextGetProcessPool(manager->priv->webContext);
+    Ref processPool = webkitWebContextGetProcessPool(manager->priv->webContext);
 
     // We keep the WebCore::LegacySchemeRegistry of the UI process in sync with the
     // web process one, so that we can return the SecurityPolicy for
@@ -78,27 +78,27 @@ static void registerSecurityPolicyForURIScheme(WebKitSecurityManager* manager, c
     switch (policy) {
     case SecurityPolicyLocal:
         WebCore::LegacySchemeRegistry::registerURLSchemeAsLocal(urlScheme);
-        processPool.registerURLSchemeAsLocal(urlScheme);
+        processPool->registerURLSchemeAsLocal(urlScheme);
         break;
     case SecurityPolicyNoAccess:
         WebCore::LegacySchemeRegistry::registerURLSchemeAsNoAccess(urlScheme);
-        processPool.registerURLSchemeAsNoAccess(urlScheme);
+        processPool->registerURLSchemeAsNoAccess(urlScheme);
         break;
     case SecurityPolicyDisplayIsolated:
         WebCore::LegacySchemeRegistry::registerURLSchemeAsDisplayIsolated(urlScheme);
-        processPool.registerURLSchemeAsDisplayIsolated(urlScheme);
+        processPool->registerURLSchemeAsDisplayIsolated(urlScheme);
         break;
     case SecurityPolicySecure:
         WebCore::LegacySchemeRegistry::registerURLSchemeAsSecure(urlScheme);
-        processPool.registerURLSchemeAsSecure(urlScheme);
+        processPool->registerURLSchemeAsSecure(urlScheme);
         break;
     case SecurityPolicyCORSEnabled:
         WebCore::LegacySchemeRegistry::registerURLSchemeAsCORSEnabled(urlScheme);
-        processPool.registerURLSchemeAsCORSEnabled(urlScheme);
+        processPool->registerURLSchemeAsCORSEnabled(urlScheme);
         break;
     case SecurityPolicyEmptyDocument:
         WebCore::LegacySchemeRegistry::registerURLSchemeAsEmptyDocument(urlScheme);
-        processPool.registerURLSchemeAsEmptyDocument(urlScheme);
+        processPool->registerURLSchemeAsEmptyDocument(urlScheme);
         break;
     }
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -190,7 +190,7 @@ static void webKitSettingsConstructed(GObject* object)
     G_OBJECT_CLASS(webkit_settings_parent_class)->constructed(object);
 
     WebKitSettings* settings = WEBKIT_SETTINGS(object);
-    WebPreferences* prefs = settings->priv->preferences.get();
+    RefPtr prefs = settings->priv->preferences.get();
     prefs->setShouldRespectImageOrientation(true);
 
 #if ENABLE(MEDIA_STREAM)

--- a/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp
@@ -257,9 +257,9 @@ private:
 #elif PLATFORM(WPE)
         // FIXME: I guess this is actually the view size in WPE. We need more refactoring here.
         WebCore::FloatRect rect;
-        auto& page = webkitWebViewGetPage(m_webView);
-        if (page.drawingArea())
-            rect.setSize(page.drawingArea()->size());
+        Ref page = webkitWebViewGetPage(m_webView);
+        if (page->drawingArea())
+            rect.setSize(page->drawingArea()->size());
         completionHandler(WTFMove(rect));
 #endif
     }

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
@@ -2032,13 +2032,13 @@ WebProcessPool& webkitWebContextGetProcessPool(WebKitWebContext* context)
 
 void webkitWebContextWebViewCreated(WebKitWebContext* context, WebKitWebView* webView)
 {
-    auto& page = webkitWebViewGetPage(webView);
+    Ref page = webkitWebViewGetPage(webView);
     for (auto& it : context->priv->uriSchemeHandlers) {
         Ref<WebURLSchemeHandler> handler(*it.value);
-        page.setURLSchemeHandlerForScheme(WTFMove(handler), it.key);
+        page->setURLSchemeHandlerForScheme(WTFMove(handler), it.key);
     }
 
-    context->priv->webViews.set(page.identifier(), webView);
+    context->priv->webViews.set(page->identifier(), webView);
 }
 
 void webkitWebContextWebViewDestroyed(WebKitWebContext* context, WebKitWebView* webView)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebResourceLoadManager.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebResourceLoadManager.cpp
@@ -43,7 +43,7 @@ WebKitWebResourceLoadManager::~WebKitWebResourceLoadManager()
 
 void WebKitWebResourceLoadManager::didInitiateLoad(ResourceLoaderIdentifier resourceID, FrameIdentifier frameID, ResourceRequest&& request)
 {
-    auto* frame = WebFrameProxy::webFrame(frameID);
+    RefPtr frame = WebFrameProxy::webFrame(frameID);
     if (!frame)
         return;
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -617,11 +617,11 @@ static void allowModalDialogsChanged(WebKitSettings* settings, GParamSpec*, WebK
 
 static void zoomTextOnlyChanged(WebKitSettings* settings, GParamSpec*, WebKitWebView* webView)
 {
-    auto& page = getPage(webView);
+    Ref page = getPage(webView);
     gboolean zoomTextOnly = webkit_settings_get_zoom_text_only(settings);
-    gdouble pageZoomLevel = zoomTextOnly ? 1 : page.textZoomFactor();
-    gdouble textZoomLevel = zoomTextOnly ? page.pageZoomFactor() : 1;
-    page.setPageAndTextZoomFactors(pageZoomLevel, textZoomLevel);
+    gdouble pageZoomLevel = zoomTextOnly ? 1 : page->textZoomFactor();
+    gdouble textZoomLevel = zoomTextOnly ? page->pageZoomFactor() : 1;
+    page->setPageAndTextZoomFactors(pageZoomLevel, textZoomLevel);
 }
 
 static void userAgentChanged(WebKitSettings* settings, GParamSpec*, WebKitWebView* webView)
@@ -740,11 +740,11 @@ static void webkitWebViewUpdateSettings(WebKitWebView* webView)
     if (!webkitWebViewIsConstructed(webView))
         return;
 
-    auto& page = getPage(webView);
+    Ref page = getPage(webView);
     WebKitSettings* settings = webView->priv->settings.get();
-    page.setPreferences(*webkitSettingsGetPreferences(settings));
-    page.setCanRunModal(webkit_settings_get_allow_modal_dialogs(settings));
-    page.setCustomUserAgent(String::fromUTF8(webkit_settings_get_user_agent(settings)));
+    page->setPreferences(*webkitSettingsGetPreferences(settings));
+    page->setCanRunModal(webkit_settings_get_allow_modal_dialogs(settings));
+    page->setCustomUserAgent(String::fromUTF8(webkit_settings_get_user_agent(settings)));
 #if PLATFORM(GTK)
     enableBackForwardNavigationGesturesChanged(settings, nullptr, webView);
 #endif
@@ -3957,11 +3957,11 @@ void webkit_web_view_set_zoom_level(WebKitWebView* webView, gdouble zoomLevel)
     const double pageScale = 1.0;
 #endif
 
-    auto& page = getPage(webView);
+    Ref page = getPage(webView);
     if (webkit_settings_get_zoom_text_only(webView->priv->settings.get()))
-        page.setTextZoomFactor(zoomLevel);
+        page->setTextZoomFactor(zoomLevel);
     else
-        page.setPageZoomFactor(zoomLevel * pageScale);
+        page->setPageZoomFactor(zoomLevel * pageScale);
     g_object_notify_by_pspec(G_OBJECT(webView), sObjProperties[PROP_ZOOM_LEVEL]);
 }
 
@@ -3986,9 +3986,9 @@ gdouble webkit_web_view_get_zoom_level(WebKitWebView* webView)
     const double pageScale = 1.0;
 #endif
 
-    auto& page = getPage(webView);
+    Ref page = getPage(webView);
     gboolean zoomTextOnly = webkit_settings_get_zoom_text_only(webView->priv->settings.get());
-    return zoomTextOnly ? page.textZoomFactor() : page.pageZoomFactor() / pageScale;
+    return zoomTextOnly ? page->textZoomFactor() : page->pageZoomFactor() / pageScale;
 }
 
 /**
@@ -4886,8 +4886,8 @@ WebKitDownload* webkit_web_view_download_uri(WebKitWebView* webView, const char*
     g_return_val_if_fail(WEBKIT_IS_WEB_VIEW(webView), nullptr);
     g_return_val_if_fail(uri, nullptr);
 
-    auto& page = getPage(webView);
-    auto downloadProxy = page.configuration().processPool().download(page.websiteDataStore(), &page, ResourceRequest { String::fromUTF8(uri) });
+    Ref page = getPage(webView);
+    auto downloadProxy = page->configuration().processPool().download(page->websiteDataStore(), page.ptr(), ResourceRequest { String::fromUTF8(uri) });
     auto download = webkitDownloadCreate(downloadProxy, webView);
 #if ENABLE(2022_GLIB_API)
     downloadProxy->setDidStartCallback([session = GRefPtr<WebKitNetworkSession> { webView->priv->networkSession }, download = download.get()](auto* downloadProxy) {
@@ -4938,7 +4938,7 @@ gboolean webkit_web_view_get_tls_info(WebKitWebView* webView, GTlsCertificate** 
 {
     g_return_val_if_fail(WEBKIT_IS_WEB_VIEW(webView), FALSE);
 
-    WebFrameProxy* mainFrame = getPage(webView).mainFrame();
+    RefPtr mainFrame = getPage(webView).mainFrame();
     if (!mainFrame)
         return FALSE;
 
@@ -5246,9 +5246,9 @@ void webkit_web_view_send_message_to_page(WebKitWebView* webView, WebKitUserMess
 
     // We sink the reference in case of being floating.
     GRefPtr<WebKitUserMessage> adoptedMessage = message;
-    auto& page = getPage(webView);
+    Ref page = getPage(webView);
     if (!callback) {
-        page.ensureRunningProcess().send(Messages::WebPage::SendMessageToWebProcessExtension(webkitUserMessageGetMessage(message)), page.webPageID().toUInt64());
+        page->ensureRunningProcess().send(Messages::WebPage::SendMessageToWebProcessExtension(webkitUserMessageGetMessage(message)), page->webPageID().toUInt64());
         return;
     }
 
@@ -5266,8 +5266,8 @@ void webkit_web_view_send_message_to_page(WebKitWebView* webView, WebKitUserMess
             break;
         }
     };
-    page.ensureRunningProcess().sendWithAsyncReply(Messages::WebPage::SendMessageToWebProcessExtensionWithReply(webkitUserMessageGetMessage(message)),
-        WTFMove(completionHandler), page.webPageID().toUInt64());
+    page->ensureRunningProcess().sendWithAsyncReply(Messages::WebPage::SendMessageToWebProcessExtensionWithReply(webkitUserMessageGetMessage(message)),
+        WTFMove(completionHandler), page->webPageID().toUInt64());
 }
 
 /**
@@ -5415,12 +5415,12 @@ void webkit_web_view_terminate_web_process(WebKitWebView* webView)
 {
     g_return_if_fail(WEBKIT_IS_WEB_VIEW(webView));
 
-    auto& page = getPage(webView);
+    Ref page = getPage(webView);
 
-    Ref protectedProcessProxy(page.legacyMainFrameProcess());
+    Ref protectedProcessProxy(page->legacyMainFrameProcess());
     protectedProcessProxy->requestTermination(WebKit::ProcessTerminationReason::RequestedByClient);
 
-    if (auto* provisionalPageProxy = page.provisionalPageProxy()) {
+    if (auto* provisionalPageProxy = page->provisionalPageProxy()) {
         Ref protectedProcessProxy(provisionalPageProxy->process());
         protectedProcessProxy->requestTermination(WebKit::ProcessTerminationReason::RequestedByClient);
     }
@@ -5465,12 +5465,12 @@ void webkit_web_view_set_cors_allowlist(WebKitWebView* webView, const gchar* con
 
 static void webkitWebViewConfigureMediaCapture(WebKitWebView* webView, WebCore::MediaProducerMediaCaptureKind captureKind, WebKitMediaCaptureState captureState)
 {
-    auto& page = getPage(webView);
-    auto mutedState = page.mutedStateFlags();
+    Ref page = getPage(webView);
+    auto mutedState = page->mutedStateFlags();
 
     switch (captureState) {
     case WEBKIT_MEDIA_CAPTURE_STATE_NONE:
-        page.stopMediaCapture(captureKind, [webView, captureKind] {
+        page->stopMediaCapture(captureKind, [webView, captureKind] {
             switch (captureKind) {
             case WebCore::MediaProducerMediaCaptureKind::Microphone:
                 g_object_notify_by_pspec(G_OBJECT(webView), sObjProperties[PROP_MICROPHONE_CAPTURE_STATE]);
@@ -5503,7 +5503,7 @@ static void webkitWebViewConfigureMediaCapture(WebKitWebView* webView, WebCore::
             ASSERT_NOT_REACHED();
             return;
         }
-        page.setMuted(mutedState);
+        page->setMuted(mutedState);
         break;
     case WEBKIT_MEDIA_CAPTURE_STATE_MUTED:
         switch (captureKind) {
@@ -5521,7 +5521,7 @@ static void webkitWebViewConfigureMediaCapture(WebKitWebView* webView, WebCore::
             ASSERT_NOT_REACHED();
             return;
         }
-        page.setMuted(mutedState);
+        page->setMuted(mutedState);
         break;
     }
 }

--- a/Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp
@@ -44,7 +44,7 @@ void WebProcessProxy::platformGetLaunchOptions(ProcessLauncher::LaunchOptions& l
     if (m_processPool->sandboxEnabled()) {
         // Prewarmed processes don't have a WebsiteDataStore yet, so use the primary WebsiteDataStore from the WebProcessPool.
         // The process won't be used if current WebsiteDataStore is different than the WebProcessPool primary one.
-        WebsiteDataStore* dataStore = isPrewarmed() ? WebsiteDataStore::defaultDataStore().ptr() : websiteDataStore();
+        RefPtr dataStore = isPrewarmed() ? WebsiteDataStore::defaultDataStore().ptr() : websiteDataStore();
 
         ASSERT(dataStore);
         launchOptions.extraInitializationData.set("mediaKeysDirectory"_s, dataStore->resolvedDirectories().mediaKeysStorageDirectory);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp
@@ -66,7 +66,7 @@ static void webkit_frame_class_init(WebKitFrameClass*)
 
 static CString getURL(WebFrame* webFrame)
 {
-    auto* documentLoader = webFrame->coreLocalFrame()->loader().provisionalDocumentLoader();
+    RefPtr documentLoader = webFrame->coreLocalFrame()->loader().provisionalDocumentLoader();
     if (!documentLoader)
         documentLoader = webFrame->coreLocalFrame()->loader().documentLoader();
 
@@ -102,8 +102,8 @@ GRefPtr<JSCValue> webkitFrameGetJSCValueForElementInWorld(WebKitFrame* frame, El
 
 Vector<GRefPtr<JSCValue>> webkitFrameGetJSCValuesForElementsInWorld(WebKitFrame* frame, const Vector<RefPtr<Element>>& elements, WebKitScriptWorld* world)
 {
-    auto* wkWorld = webkitScriptWorldGetInjectedBundleScriptWorld(world);
-    auto jsContext = jscContextGetOrCreate(frame->priv->webFrame->jsContextForWorld(wkWorld));
+    RefPtr wkWorld = webkitScriptWorldGetInjectedBundleScriptWorld(world);
+    auto jsContext = jscContextGetOrCreate(frame->priv->webFrame->jsContextForWorld(wkWorld.get()));
     auto* globalObject = frame->priv->webFrame->coreLocalFrame()->script().globalObject(wkWorld->coreWorld());
     return elements.map([&jsContext, globalObject](auto& element) -> GRefPtr<JSCValue> {
         JSValueRef jsValue = nullptr;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebFormManager.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebFormManager.cpp
@@ -192,7 +192,7 @@ gboolean webkit_web_form_manager_input_element_is_user_edited(JSCValue* element)
     g_return_val_if_fail(JSC_IS_VALUE(element), FALSE);
     g_return_val_if_fail(jsc_value_is_object(element), FALSE);
 
-    auto* node = nodeForJSCValue(element);
+    RefPtr node = nodeForJSCValue(element);
     if (RefPtr input = dynamicDowncast<HTMLInputElement>(node))
         return input->lastChangeWasUserEdit();
 
@@ -218,7 +218,7 @@ void webkit_web_form_manager_input_element_auto_fill(JSCValue* element, const ch
     g_return_if_fail(JSC_IS_VALUE(element));
     g_return_if_fail(jsc_value_is_object(element));
 
-    auto* node = nodeForJSCValue(element);
+    RefPtr node = nodeForJSCValue(element);
     RefPtr input = dynamicDowncast<HTMLInputElement>(node);
     if (!input)
         return;
@@ -243,7 +243,7 @@ gboolean webkit_web_form_manager_input_element_is_auto_filled(JSCValue* element)
     g_return_val_if_fail(JSC_IS_VALUE(element), FALSE);
     g_return_val_if_fail(jsc_value_is_object(element), FALSE);
 
-    auto* node = nodeForJSCValue(element);
+    RefPtr node = nodeForJSCValue(element);
     RefPtr input = dynamicDowncast<HTMLInputElement>(node);
     return input && input->isAutoFilled();
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.cpp
@@ -414,14 +414,14 @@ JSCValue* webkit_web_hit_test_result_get_js_node(WebKitWebHitTestResult* webHitT
     if (!webHitTestResult->priv->node)
         return nullptr;
 
-    auto* frame = webHitTestResult->priv->node->document().frame();
+    RefPtr frame = webHitTestResult->priv->node->document().frame();
     if (!frame)
         return nullptr;
 
     if (!world)
         world = webkit_script_world_get_default();
 
-    auto* wkWorld = webkitScriptWorldGetInjectedBundleScriptWorld(world);
+    RefPtr wkWorld = webkitScriptWorldGetInjectedBundleScriptWorld(world);
     auto* globalObject = frame->script().globalObject(wkWorld->coreWorld());
     auto jsContext = jscContextGetOrCreate(toGlobalRef(globalObject));
     JSValueRef jsValue = nullptr;

--- a/Source/WebKit/WebProcess/WebCoreSupport/glib/WebEditorClientGLib.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/glib/WebEditorClientGLib.cpp
@@ -43,7 +43,7 @@ void WebEditorClient::didDispatchInputMethodKeydown(KeyboardEvent& event)
 {
     auto* platformEvent = event.underlyingPlatformEvent();
     ASSERT(event.target());
-    auto* frame = downcast<Node>(event.target())->document().frame();
+    RefPtr frame = downcast<Node>(event.target())->document().frame();
     ASSERT(frame);
 
     if (const auto& underlines = platformEvent->preeditUnderlines()) {

--- a/Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp
+++ b/Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp
@@ -61,7 +61,7 @@ void WebPage::platformInitialize(const WebPageCreationParameters&)
     // entry point to the Web process, and send a message to the UI
     // process to connect the two worlds through the accessibility
     // object there specifically placed for that purpose (the socket).
-    if (auto* page = corePage()) {
+    if (RefPtr page = corePage()) {
         m_accessibilityRootObject = AccessibilityRootAtspi::create(*page);
         m_accessibilityRootObject->registerObject([&](const String& plugID) {
             if (!plugID.isEmpty())


### PR DESCRIPTION
#### fa36680627bf7c079a0d1f1b88b171889342af25
<pre>
Adopt smart pointers to glib related code
<a href="https://bugs.webkit.org/show_bug.cgi?id=274898">https://bugs.webkit.org/show_bug.cgi?id=274898</a>

Reviewed by Carlos Garcia Campos.

This patch changes glib related code in WebKit to
use smart pointers

* Source/JavaScriptCore/API/glib/JSCClass.cpp:
(getProperty):
(setProperty):
(hasProperty):
(deleteProperty):
(getPropertyNames):
(jscClassCreate):
(jscClassCreateConstructor):
(jscClassAddMethod):
* Source/JavaScriptCore/API/glib/JSCContext.cpp:
(jscContextPushCallback):
(jscContextPopCallback):
(jscContextGarbageCollect):
(jsc_context_evaluate_in_object):
(jsc_context_check_syntax):
* Source/JavaScriptCore/API/glib/JSCException.cpp:
(jscExceptionCreate):
* Source/JavaScriptCore/API/glib/JSCValue.cpp:
(jsc_value_object_enumerate_properties):
(jsc_value_object_define_property_data):
(jscValueObjectDefinePropertyAccessor):
(jscValueFunctionCreate):
(jsc_value_is_array_buffer):
(jsc_value_typed_array_get_type):
* Source/JavaScriptCore/API/glib/JSCWeakValue.cpp:
(jsc_weak_value_get_value):
* Source/JavaScriptCore/API/glib/JSCWrapperMap.cpp:
(JSC::WrapperMap::registerClass):
(JSC::WrapperMap::createJSWrapper):
* Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp:
(Inspector::RemoteInspector::sendMessageToTarget):
* Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorServer.cpp:
(Inspector::RemoteInspectorServer::setTargetList):
(Inspector::RemoteInspectorServer::setupInspectorClient):
(Inspector::RemoteInspectorServer::connectionDidClose):
(Inspector::RemoteInspectorServer::sendMessageToFrontend):
* Source/WTF/wtf/glib/RunLoopGLib.cpp:
(WTF::RunLoop::run):
* Source/WebKit/UIProcess/API/glib/WebKitAutomationSession.cpp:
(webkitAutomationSessionCreate):
* Source/WebKit/UIProcess/API/glib/WebKitBackForwardList.cpp:
(webkitBackForwardListCreateList):
* Source/WebKit/UIProcess/API/glib/WebKitCookieManager.cpp:
(webkit_cookie_manager_set_persistent_storage):
(webkit_cookie_manager_set_accept_policy):
* Source/WebKit/UIProcess/API/glib/WebKitFileChooserRequest.cpp:
(webkit_file_chooser_request_get_mime_types):
(webkit_file_chooser_request_get_selected_files):
* Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp:
(webkit_network_session_set_itp_enabled):
(webkit_network_session_get_itp_enabled):
(webkit_network_session_set_persistent_credential_storage_enabled):
(webkit_network_session_get_persistent_credential_storage_enabled):
(webkit_network_session_set_tls_errors_policy):
(webkit_network_session_allow_tls_certificate_for_host):
(webkit_network_session_set_proxy_settings):
(webkit_network_session_get_itp_summary):
(webkit_network_session_prefetch_dns):
(webkit_network_session_download_uri):
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::WebKitProtocolHandler::handleGPU):
* Source/WebKit/UIProcess/API/glib/WebKitSecurityManager.cpp:
(registerSecurityPolicyForURIScheme):
* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
(webKitSettingsConstructed):
* Source/WebKit/UIProcess/API/glib/WebKitUIClient.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp:
* Source/WebKit/UIProcess/API/glib/WebKitWebResourceLoadManager.cpp:
(WebKit::WebKitWebResourceLoadManager::didInitiateLoad):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(zoomTextOnlyChanged):
(webkitWebViewUpdateSettings):
(webkit_web_view_set_zoom_level):
(webkit_web_view_get_zoom_level):
* Source/WebKit/UIProcess/glib/WebProcessProxyGLib.cpp:
(WebKit::WebProcessProxy::platformGetLaunchOptions):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp:
(getURL):
(webkitFrameGetJSCValuesForElementsInWorld):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebFormManager.cpp:
(webkit_web_form_manager_input_element_is_user_edited):
(webkit_web_form_manager_input_element_auto_fill):
(webkit_web_form_manager_input_element_is_auto_filled):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebHitTestResult.cpp:
(webkit_web_hit_test_result_get_js_node):
* Source/WebKit/WebProcess/WebCoreSupport/glib/WebEditorClientGLib.cpp:
(WebKit::WebEditorClient::didDispatchInputMethodKeydown):
* Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp:
(WebKit::WebPage::platformInitialize):

Canonical link: <a href="https://commits.webkit.org/280015@main">https://commits.webkit.org/280015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6757505bb30473a65782ce1bf2bdd4a7421792b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55071 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58353 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5803 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5842 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44587 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3963 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32613 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47712 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25711 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29393 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5059 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3947 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/48446 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51462 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5294 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59943 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/54576 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30350 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5460 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52017 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31474 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47780 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51470 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12298 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32500 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/66872 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31264 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12747 "Passed tests") | 
<!--EWS-Status-Bubble-End-->