### PR TITLE
[WPE] Unreviewed, fix build error after 279501@main

### DIFF
--- a/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionLibWPE.cpp
+++ b/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionLibWPE.cpp
@@ -35,7 +35,7 @@ namespace WebKit {
 using namespace WebCore;
 
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
-static uint32_t modifiersToEventState(OptionSet<WebEventModifier> modifiers)
+static uint32_t libWPEModifiersToEventState(OptionSet<WebEventModifier> modifiers)
 {
     uint32_t state = 0;
     if (modifiers.contains(WebEventModifier::ControlKey))
@@ -100,7 +100,7 @@ void platformSimulateMouseInteractionLibWPE(WebPageProxy& page, MouseInteraction
 
     unsigned wpeButton = mouseButtonToWPEButton(button);
     auto modifier = stateModifierForWPEButton(wpeButton);
-    uint32_t state = modifiersToEventState(keyModifiers) | currentModifiers;
+    uint32_t state = libWPEModifiersToEventState(keyModifiers) | currentModifiers;
 
     switch (interaction) {
     case MouseInteraction::Move:

--- a/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp
+++ b/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp
@@ -97,7 +97,7 @@ static uint32_t modifiersToEventState(OptionSet<WebEventModifier> modifiers)
     return state;
 }
 
-static unsigned mouseButtonToWPEButton(MouseButton button)
+static unsigned libWPEMouseButtonToWPEButton(MouseButton button)
 {
     switch (button) {
     case MouseButton::None:
@@ -111,7 +111,7 @@ static unsigned mouseButtonToWPEButton(MouseButton button)
     return 1;
 }
 
-static unsigned stateModifierForWPEButton(unsigned button)
+static unsigned libWPEStateModifierForWPEButton(unsigned button)
 {
     uint32_t state = 0;
 
@@ -152,7 +152,7 @@ static WebCore::IntPoint deviceScaleLocationInView(WebPageProxy& page, const Web
 static void doMouseEvent(WebPageProxy& page, const WebCore::IntPoint& location, unsigned button, bool isPressed, uint32_t modifiers)
 {
     auto* view = page.wpeView();
-    auto buttonModifiers =  stateModifierForWPEButton(button);
+    auto buttonModifiers =  libWPEStateModifierForWPEButton(button);
     if (isPressed)
         modifiers |= buttonModifiers;
     else
@@ -182,8 +182,8 @@ void WebAutomationSession::platformSimulateMouseInteraction(WebPageProxy& page, 
     }
 
 #if ENABLE(WPE_PLATFORM)
-    unsigned wpeButton = mouseButtonToWPEButton(button);
-    auto modifier = stateModifierForWPEButton(wpeButton);
+    unsigned wpeButton = libWPEMouseButtonToWPEButton(button);
+    auto modifier = libWPEStateModifierForWPEButton(wpeButton);
     uint32_t state = modifiersToEventState(keyModifiers) | m_currentModifiers;
 
     switch (interaction) {


### PR DESCRIPTION
#### 5ca7f83342d31c77a802fe0b525f005a82e38732
<pre>
[WPE] Unreviewed, fix build error after 279501@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=273750">https://bugs.webkit.org/show_bug.cgi?id=273750</a>

In the case unified sources group files &apos;WebAutomationSessionLibWPE.cpp&apos;
and &apos;WebAutomationSessionWPE.cpp&apos; together, because there are several
static functions in these files defined with the same name, a duplicate
symbol build error will happen.

Rename function names to avoid collisions.

* Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionLibWPE.cpp:
(WebKit::libWPEModifiersToEventState):
(WebKit::platformSimulateMouseInteractionLibWPE):
(WebKit::modifiersToEventState): Deleted.
* Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp:
(WebKit::libWPEMouseButtonToWPEButton):
(WebKit::libWPEStateModifierForWPEButton):
(WebKit::doMouseEvent):
(WebKit::WebAutomationSession::platformSimulateMouseInteraction):
(WebKit::mouseButtonToWPEButton): Deleted.
(WebKit::stateModifierForWPEButton): Deleted.

Canonical link: <a href="https://commits.webkit.org/279538@main">https://commits.webkit.org/279538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/198e8047d4cd37a8b1afe8fe3952a2b8ab28a769

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53754 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57034 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4479 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4326 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/2930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55853 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/46483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/24671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/28162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2634 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/3985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58629 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/28921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/4036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/50949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/30116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/46641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/31051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7944 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/29895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->