### PR TITLE
[macOS] Safari flashes a page background colored bar with top content inset dimensions in footer when window resizing

### DIFF
--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2470,11 +2470,7 @@ void RenderLayerCompositor::frameViewDidChangeSize()
         updateOverflowControlsLayers();
 
 #if HAVE(RUBBER_BANDING)
-        if (m_layerForOverhangAreas) {
-            auto& frameView = m_renderView.frameView();
-            m_layerForOverhangAreas->setSize(frameView.frameRect().size());
-            m_layerForOverhangAreas->setPosition(FloatPoint(0, frameView.topContentInset()));
-        }
+        updateSizeAndPositionForOverhangAreaLayer();
 #endif
     }
 }
@@ -4481,6 +4477,21 @@ void RenderLayerCompositor::rootBackgroundColorOrTransparencyChanged()
     rootLayerConfigurationChanged();
 }
 
+#if HAVE(RUBBER_BANDING)
+void RenderLayerCompositor::updateSizeAndPositionForOverhangAreaLayer()
+{
+    if (!m_layerForOverhangAreas)
+        return;
+
+    float topContentInset = m_renderView.frameView().topContentInset();
+    IntSize overhangAreaSize = m_renderView.frameView().frameRect().size();
+    overhangAreaSize.contract(0, topContentInset);
+    overhangAreaSize.clampNegativeToZero();
+    m_layerForOverhangAreas->setSize(overhangAreaSize);
+    m_layerForOverhangAreas->setPosition({ 0, topContentInset });
+}
+#endif
+
 void RenderLayerCompositor::updateOverflowControlsLayers()
 {
 #if HAVE(RUBBER_BANDING)
@@ -4490,11 +4501,7 @@ void RenderLayerCompositor::updateOverflowControlsLayers()
             m_layerForOverhangAreas->setName(MAKE_STATIC_STRING_IMPL("overhang areas"));
             m_layerForOverhangAreas->setDrawsContent(false);
 
-            float topContentInset = m_renderView.frameView().topContentInset();
-            IntSize overhangAreaSize = m_renderView.frameView().frameRect().size();
-            overhangAreaSize.setHeight(overhangAreaSize.height() - topContentInset);
-            m_layerForOverhangAreas->setSize(overhangAreaSize);
-            m_layerForOverhangAreas->setPosition(FloatPoint(0, topContentInset));
+            updateSizeAndPositionForOverhangAreaLayer();
             m_layerForOverhangAreas->setAnchorPoint(FloatPoint3D());
             updateLayerForOverhangAreasBackgroundColor();
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -352,6 +352,7 @@ public:
     GraphicsLayer* updateLayerForFooter(bool wantsLayer);
 
     void updateLayerForOverhangAreasBackgroundColor();
+    void updateSizeAndPositionForOverhangAreaLayer();
 #endif // HAVE(RUBBER_BANDING)
 
     // FIXME: make the coordinated/async terminology consistent.


### PR DESCRIPTION
#### 071943e457d9e93f456b8a8ee24a016e0143cb1c
<pre>
[macOS] Safari flashes a page background colored bar with top content inset dimensions in footer when window resizing
<a href="https://bugs.webkit.org/show_bug.cgi?id=274831">https://bugs.webkit.org/show_bug.cgi?id=274831</a>
<a href="https://rdar.apple.com/128940179">rdar://128940179</a>

Reviewed by Simon Fraser.

Previously, on a FrameView resize, RenderLayerCompositor was sizing its
overhang area layer incorrectly since it did not account for the top
content offset. This is incorrect because the layer itself was
positioned vertically at the top content offset, so with the inflated
size, we always had a page background colored bar hanging at the bottom
of the frame, which was easily perceptible when snap resizing a Safari
window, for example.

This patch fixes said issue by introducing a reusable utility method
RenderLayerCompositor::updateSizeAndPositionForOverhangAreaLayer() that
is used both during layer creation and any later updates (such as when a
frame view&apos;s size changes). We make sure to size the layer (and
position it) correctly in this method, accounting for the top content
offset.

* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::frameViewDidChangeSize):
(WebCore::RenderLayerCompositor::updateSizeAndPositionForOverhangAreaLayer):
(WebCore::RenderLayerCompositor::updateOverflowControlsLayers):
* Source/WebCore/rendering/RenderLayerCompositor.h:

Canonical link: <a href="https://commits.webkit.org/279562@main">https://commits.webkit.org/279562@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/baedc3650f28d922f6951ca3b4fa1288651ffbd3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53819 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6342 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57097 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4542 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56123 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40681 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4401 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43579 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2978 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55917 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46547 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24718 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28225 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3857 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2697 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4048 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58692 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28987 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50990 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30180 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46693 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11715 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31117 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/29960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->