### PR TITLE
Update canUseFastRenderer() in WebKitNSStringExtras to use std::span

### DIFF
--- a/Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm
@@ -46,11 +46,11 @@ using namespace WebCore;
 
 #if PLATFORM(MAC)
 
-static bool canUseFastRenderer(const UniChar* buffer, unsigned length)
+static bool canUseFastRenderer(std::span<const UniChar> buffer)
 {
-    for (unsigned i = 0; i < length; i++) {
-        if (!isLatin1(buffer[i])) {
-            auto direction = u_charDirection(buffer[i]);
+    for (auto character : buffer) {
+        if (!isLatin1(character)) {
+            auto direction = u_charDirection(character);
             if (direction == U_RIGHT_TO_LEFT || (direction > U_OTHER_NEUTRAL && direction != U_DIR_NON_SPACING_MARK && direction != U_BOUNDARY_NEUTRAL))
                 return false;
         }
@@ -67,9 +67,9 @@ static bool canUseFastRenderer(const UniChar* buffer, unsigned length)
     Vector<UniChar, 2048> buffer(length);
     [self getCharacters:buffer.data()];
 
-    if (canUseFastRenderer(buffer.data(), length)) {
+    if (canUseFastRenderer(buffer)) {
         FontCascade webCoreFont(FontPlatformData((__bridge CTFontRef)font, [font pointSize]));
-        TextRun run(StringView(std::span { reinterpret_cast<const UChar*>(buffer.data()), length }));
+        TextRun run(StringView(spanReinterpretCast<const UChar>(std::span { buffer })));
 
         // The following is a half-assed attempt to match AppKit's rounding rules for drawAtPoint.
         // If you change it, be sure to test all the text drawn this way in Safari, including
@@ -107,9 +107,9 @@ static bool canUseFastRenderer(const UniChar* buffer, unsigned length)
     Vector<UniChar, 2048> buffer(length);
     [self getCharacters:buffer.data()];
 
-    if (canUseFastRenderer(buffer.data(), length)) {
+    if (canUseFastRenderer(buffer)) {
         FontCascade webCoreFont(FontPlatformData((__bridge CTFontRef)font, [font pointSize]));
-        TextRun run(StringView(std::span { reinterpret_cast<const UChar*>(buffer.data()), length }));
+        TextRun run(StringView(spanReinterpretCast<const UChar>(std::span { buffer })));
         return webCoreFont.width(run);
     }
 


### PR DESCRIPTION
#### 8e2703a62c3ac7282b9f96744a53646a89b59c9a
<pre>
Update canUseFastRenderer() in WebKitNSStringExtras to use std::span
<a href="https://bugs.webkit.org/show_bug.cgi?id=274923">https://bugs.webkit.org/show_bug.cgi?id=274923</a>

Reviewed by Brent Fulgham.

* Source/WebKitLegacy/mac/Misc/WebKitNSStringExtras.mm:
(canUseFastRenderer):
(-[NSString _web_drawAtPoint:font:textColor:]):
(-[NSString _web_widthWithFont:]):

Canonical link: <a href="https://commits.webkit.org/279551@main">https://commits.webkit.org/279551@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91bc45ff1af80aa794eeceee1099e5eb8f7f0815

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53766 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6284 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57046 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4491 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4340 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43540 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2936 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55865 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46491 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24676 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28169 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3808 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2646 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/3993 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58641 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28933 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4047 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50952 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/30128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46649 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31063 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7955 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/29908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->