### PR TITLE
[GTK] UI process crash in gtk_accessible_update_children

### DIFF
--- a/Source/WebKit/UIProcess/gtk/WebDataListSuggestionsDropdownGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebDataListSuggestionsDropdownGtk.cpp
@@ -250,6 +250,7 @@ void WebDataListSuggestionsDropdownGtk::handleKeydownWithIdentifier(const String
 void WebDataListSuggestionsDropdownGtk::close()
 {
     gtk_widget_hide(m_popup);
+    WebDataListSuggestionsDropdown::close();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
@@ -138,7 +138,7 @@ void WebDataListSuggestionsDropdownIOS::close()
 {
     [m_suggestionsControl invalidate];
     m_suggestionsControl = nil;
-    m_page->didCloseSuggestions();
+    WebDataListSuggestionsDropdown::close();
 }
 
 void WebDataListSuggestionsDropdownIOS::didSelectOption(const String& selectedOption)


### PR DESCRIPTION
#### 34f75014ef7332cc8060d161bfd31e12a6ba49ca
<pre>
[GTK] UI process crash in gtk_accessible_update_children
<a href="https://bugs.webkit.org/show_bug.cgi?id=274927">https://bugs.webkit.org/show_bug.cgi?id=274927</a>

Reviewed by Carlos Garcia Campos.

We are failing to unparent the WebDataListSuggestionsDropdownGtk from
the WebKitWebView before finalizing the web view. WebPageProxy calls
WebDataListSuggestionsDropdown::close, but doesn&apos;t drop its ref until
WebPageProxy::didCloseSuggestions is called. That happens in
WebDataListSuggestionsDropdown::close, but the GTK implementation fails
to chain up. Oops.

I checked the color chooser and date/time picker widgets, which are
implemented similarly, but didn&apos;t find any similar problem. I did notice
that iOS also fails to chain up. It doesn&apos;t have this bug since it does
the same work in the subclass instead, but it&apos;s surely safest to chain
up here to be robust to future changes. Developers tend to get surprised
when virtual function do not chain up.

* Source/WebKit/UIProcess/gtk/WebDataListSuggestionsDropdownGtk.cpp:
(WebKit::WebDataListSuggestionsDropdownGtk::close):
* Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm:
(WebKit::WebDataListSuggestionsDropdownIOS::close):

Canonical link: <a href="https://commits.webkit.org/279571@main">https://commits.webkit.org/279571@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad421457446b99bf581bc3667ebcaa5506268f40

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53788 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33156 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6306 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57068 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4513 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40649 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43555 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2952 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55887 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31377 "Found 2 new test failures: compositing/overflow/clipping-ancestor-with-accelerated-scrolling-ancestor.html, compositing/rtl/rtl-relative.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46521 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24691 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28202 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2668 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49894 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4027 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58663 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28955 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4092 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50968 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30151 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46674 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50309 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11725 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31090 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29931 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->