### PR TITLE
Validate the attributes CFDictionaryRef when decoding FontPlatformData classes

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h
@@ -159,13 +159,19 @@ CGFloat CTFontGetAccessibilityBoldWeightOfWeight(CGFloat);
 
 extern const CFStringRef kCTFontCSSWeightAttribute;
 extern const CFStringRef kCTFontCSSWidthAttribute;
+extern const CFStringRef kCTFontDescriptorLanguageAttribute;
 extern const CFStringRef kCTFontDescriptorTextStyleAttribute;
-extern const CFStringRef kCTFontUIFontDesignTrait;
+extern const CFStringRef kCTFontGradeTrait;
+extern const CFStringRef kCTFontIgnoreLegibilityWeightAttribute;
+extern const CFStringRef kCTFontSizeCategoryAttribute;
+extern const CFStringRef kCTFontTrackAttribute;
+extern const CFStringRef kCTFontUnscaledTrackingAttribute;
 
 extern const CFStringRef kCTFontUIFontDesignDefault;
-extern const CFStringRef kCTFontUIFontDesignSerif;
 extern const CFStringRef kCTFontUIFontDesignMonospaced;
 extern const CFStringRef kCTFontUIFontDesignRounded;
+extern const CFStringRef kCTFontUIFontDesignSerif;
+extern const CFStringRef kCTFontUIFontDesignTrait;
 
 extern const CFStringRef kCTFontPaletteAttribute;
 extern const CFStringRef kCTFontPaletteColorsAttribute;

--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -142,9 +142,67 @@ struct FontPlatformDataAttributes {
 };
 
 #if USE(CORE_TEXT)
+
+// FIXME: Some of these structures have std::optional<RetainPtr<>> which seems weird,
+// but generated encode/decode of RetainPtrs doesn't currently handle null values very well.
+// Once it does, remove the std::optional redirect.
+struct FontPlatformSerializedTraits {
+    static std::optional<FontPlatformSerializedTraits> fromCF(CFDictionaryRef);
+    RetainPtr<CFDictionaryRef> toCFDictionary() const;
+
+    String uiFontDesign;
+    std::optional<RetainPtr<CFNumberRef>> weight;
+    std::optional<RetainPtr<CFNumberRef>> width;
+    std::optional<RetainPtr<CFNumberRef>> symbolic;
+    std::optional<RetainPtr<CFNumberRef>> grade;
+};
+
+struct FontPlatformOpticalSize {
+    static std::optional<FontPlatformOpticalSize> fromCF(CFTypeRef);
+    RetainPtr<CFTypeRef> toCF() const;
+    std::variant<RetainPtr<CFNumberRef>, String> opticalSize;
+};
+
+struct FontPlatformSerializedAttributes {
+    static std::optional<FontPlatformSerializedAttributes> fromCF(CFDictionaryRef);
+    RetainPtr<CFDictionaryRef> toCFDictionary() const;
+
+    String fontName;
+    String descriptorLanguage;
+    String descriptorTextStyle;
+
+    std::optional<RetainPtr<CFDataRef>> matrix;
+
+    std::optional<RetainPtr<CFBooleanRef>> ignoreLegibilityWeight;
+
+    std::optional<RetainPtr<CFNumberRef>> baselineAdjust;
+    std::optional<RetainPtr<CFNumberRef>> fallbackOption;
+    std::optional<RetainPtr<CFNumberRef>> fixedAdvance;
+    std::optional<RetainPtr<CFNumberRef>> orientation;
+    std::optional<RetainPtr<CFNumberRef>> palette;
+    std::optional<RetainPtr<CFNumberRef>> size;
+    std::optional<RetainPtr<CFNumberRef>> sizeCategory;
+    std::optional<RetainPtr<CFNumberRef>> track;
+    std::optional<RetainPtr<CFNumberRef>> unscaledTracking;
+
+    std::optional<Vector<std::pair<RetainPtr<CFNumberRef>, RetainPtr<CGColorRef>>>> paletteColors;
+    std::optional<Vector<std::pair<RetainPtr<CFNumberRef>, RetainPtr<CFNumberRef>>>> variations;
+
+    std::optional<FontPlatformOpticalSize> opticalSize;
+    std::optional<FontPlatformSerializedTraits> traits;
+
+    // FIXME: featureSettings is an array of CFDictionaries whose layouts are highly variable
+    std::optional<RetainPtr<CFArrayRef>> featureSettings;
+
+#if HAVE(ADDITIONAL_FONT_PLATFORM_SERIALIZED_ATTRIBUTES)
+    std::optional<RetainPtr<CFNumberRef>> additionalNumber;
+    static CFStringRef additionalFontPlatformSerializedAttributesNumberDictionaryKey();
+#endif
+};
+
 struct FontPlatformSerializedCreationData {
     Vector<uint8_t> fontFaceData;
-    RetainPtr<CFDictionaryRef> attributes;
+    std::optional<FontPlatformSerializedAttributes> attributes;
     String itemInCollection;
 };
 
@@ -152,7 +210,7 @@ struct FontPlatformSerializedData {
     CTFontDescriptorOptions options { 0 }; // <rdar://121670125>
     RetainPtr<CFStringRef> referenceURL;
     RetainPtr<CFStringRef> postScriptName;
-    RetainPtr<CFDictionaryRef> attributes;
+    std::optional<FontPlatformSerializedAttributes> attributes;
 };
 #endif
 

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -23,19 +23,64 @@
 headers: "ArgumentCodersCocoa.h"
 
 #if USE(CORE_TEXT)
+
 header: <WebCore/FontPlatformData.h>
+
+[CustomHeader] struct WebCore::FontPlatformSerializedTraits {
+    String uiFontDesign;
+    std::optional<RetainPtr<CFNumberRef>> weight;
+    std::optional<RetainPtr<CFNumberRef>> width;
+    std::optional<RetainPtr<CFNumberRef>> symbolic;
+    std::optional<RetainPtr<CFNumberRef>> grade;
+};
+
+[CustomHeader] struct WebCore::FontPlatformOpticalSize {
+    std::variant<RetainPtr<CFNumberRef>, String> opticalSize;
+};
+
+[CustomHeader] struct WebCore::FontPlatformSerializedAttributes {
+    String fontName;
+    String descriptorLanguage;
+    String descriptorTextStyle;
+
+    std::optional<RetainPtr<CFDataRef>> matrix;
+
+    std::optional<RetainPtr<CFBooleanRef>> ignoreLegibilityWeight;
+
+    std::optional<RetainPtr<CFNumberRef>> baselineAdjust;
+    std::optional<RetainPtr<CFNumberRef>> fallbackOption;
+    std::optional<RetainPtr<CFNumberRef>> fixedAdvance;
+    std::optional<RetainPtr<CFNumberRef>> orientation;
+    std::optional<RetainPtr<CFNumberRef>> palette;
+    std::optional<RetainPtr<CFNumberRef>> size;
+    std::optional<RetainPtr<CFNumberRef>> sizeCategory;
+    std::optional<RetainPtr<CFNumberRef>> track;
+    std::optional<RetainPtr<CFNumberRef>> unscaledTracking;
+
+    std::optional<Vector<std::pair<RetainPtr<CFNumberRef>, RetainPtr<CGColorRef>>>> paletteColors;
+    std::optional<Vector<std::pair<RetainPtr<CFNumberRef>, RetainPtr<CFNumberRef>>>> variations;
+
+    std::optional<WebCore::FontPlatformOpticalSize> opticalSize;
+    std::optional<WebCore::FontPlatformSerializedTraits> traits;
+
+    std::optional<RetainPtr<CFArrayRef>> featureSettings;
+
+#if HAVE(ADDITIONAL_FONT_PLATFORM_SERIALIZED_ATTRIBUTES)
+    std::optional<RetainPtr<CFNumberRef>> additionalNumber;
+#endif
+};
+
 [CustomHeader] struct WebCore::FontPlatformSerializedCreationData {
     Vector<uint8_t> fontFaceData;
-    RetainPtr<CFDictionaryRef> attributes;
+    std::optional<WebCore::FontPlatformSerializedAttributes> attributes;
     String itemInCollection;
 };
 
-header: <WebCore/FontPlatformData.h>
 [CustomHeader] struct WebCore::FontPlatformSerializedData {
     CTFontDescriptorOptions options;
     RetainPtr<CFStringRef> referenceURL;
     RetainPtr<CFStringRef> postScriptName;
-    RetainPtr<CFDictionaryRef> attributes;
+    std::optional<WebCore::FontPlatformSerializedAttributes> attributes;
 };
 
 header: <WebCore/FontCustomPlatformData.h>
@@ -44,7 +89,7 @@ header: <WebCore/FontCustomPlatformData.h>
     String itemInCollection;
     WebCore::RenderingResourceIdentifier renderingResourceIdentifier;
 };
-#endif
+#endif // USE(CORE_TEXT)
 
 #if ENABLE(CONTENT_FILTERING)
 class WebCore::ContentFilterUnblockHandler {


### PR DESCRIPTION
#### ec419da7f4621af0ce69a9cce5e4eed57d8df190
<pre>
Validate the attributes CFDictionaryRef when decoding FontPlatformData classes
<a href="https://rdar.apple.com/125475043">rdar://125475043</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=274933">https://bugs.webkit.org/show_bug.cgi?id=274933</a>

Reviewed by Alex Christensen.

This is the first dive into the expected key/values in the FontPlatformData attributes dictionary.
Like other IPC validation we&apos;ve done, it&apos;s more robust (while being less flexible) to rely on structs
that pull out values for serialization an deserialization.

* Source/WebCore/PAL/pal/spi/cf/CoreTextSPI.h:
* Source/WebCore/platform/graphics/FontPlatformData.h:
* Source/WebCore/platform/graphics/coretext/FontPlatformDataCoreText.cpp:
(WebCore::FontPlatformData::fromIPCData):
(WebCore::FontPlatformData::toIPCData const):
(WebCore::FontPlatformSerializedAttributes::fromCF):
(WebCore::FontPlatformSerializedAttributes::toCFDictionary const):
(WebCore::FontPlatformSerializedTraits::fromCF):
(WebCore::FontPlatformSerializedTraits::toCFDictionary const):
(WebCore::FontPlatformOpticalSize::fromCF):
(WebCore::FontPlatformOpticalSize::toCF const):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:

Canonical link: <a href="https://commits.webkit.org/279743@main">https://commits.webkit.org/279743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb3686fc3a2ddcaefe41df99dfc560336a6745db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33684 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57588 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5026 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56594 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4985 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43981 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3347 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56387 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31889 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25116 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/28702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4347 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/3168 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59160 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29506 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/4694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51397 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/30672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47115 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50752 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11857 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/31645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30454 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->