### PR TITLE
http/tests/inspector/network/copy-as-fetch.html should ignore the Priority header

### DIFF
--- a/LayoutTests/http/tests/inspector/network/copy-as-fetch.html
+++ b/LayoutTests/http/tests/inspector/network/copy-as-fetch.html
@@ -92,6 +92,7 @@ function test()
 
                 // Strip inconsistent headers.
                 fetchCode = fetchCode.replace(/\s+"Accept-Language": ".+?",\n/, "\n");
+                fetchCode = fetchCode.replace(/\s+"Priority": ".+?",\n/, "\n");
                 fetchCode = fetchCode.replace(/("User-Agent": )(".+?")(,?\n)/, "$1<filtered>$3");
 
                 InspectorTest.log(fetchCode);


### PR DESCRIPTION
#### 836ca314b9b56061fd66df423fe0d6b5d33f1212
<pre>
http/tests/inspector/network/copy-as-fetch.html should ignore the Priority header
<a href="https://bugs.webkit.org/show_bug.cgi?id=274940">https://bugs.webkit.org/show_bug.cgi?id=274940</a>

Reviewed by Alexey Proskuryakov.

Priority request header field is added by the new HTTP stack but not the CFNetwork stack.

* LayoutTests/http/tests/inspector/network/copy-as-fetch.html:

Canonical link: <a href="https://commits.webkit.org/279677@main">https://commits.webkit.org/279677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6422e1c7a30bed88ae4fc6316ca4c8575f3ee23

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53806 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6329 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57085 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4530 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4385 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43570 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2966 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55904 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46539 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24709 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28217 "Found 59 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html, imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html, imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html, imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html, imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html, imported/w3c/web-platform-tests/FileAPI/file/File-constructor-endings.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3849 "9 flakes 1 failures") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2685 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49968 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4040 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58680 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/28975 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4099 "13 flakes 4 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/50980 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30168 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46685 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50322 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11794 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31105 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29948 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->