### PR TITLE
Drop SharedMemory::data() in favor of span()

### DIFF
--- a/Source/WebCore/PlatformMac.cmake
+++ b/Source/WebCore/PlatformMac.cmake
@@ -219,7 +219,7 @@ list(APPEND WebCore_SOURCES
     platform/cocoa/RuntimeApplicationChecksCocoa.mm
     platform/cocoa/SearchPopupMenuCocoa.mm
     platform/cocoa/SharedBufferCocoa.mm
-    platform/cocoa/SharedMemoryCocoa.cpp
+    platform/cocoa/SharedMemoryCocoa.mm
     platform/cocoa/SystemBattery.mm
     platform/cocoa/SystemVersion.mm
     platform/cocoa/TelephoneNumberDetectorCocoa.cpp

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -314,7 +314,7 @@ platform/cocoa/RuntimeApplicationChecksCocoa.mm
 platform/cocoa/SearchPopupMenuCocoa.mm
 platform/cocoa/SerializedPlatformDataCueValue.mm @no-unify
 platform/cocoa/SharedBufferCocoa.mm
-platform/cocoa/SharedMemoryCocoa.cpp
+platform/cocoa/SharedMemoryCocoa.mm
 platform/cocoa/SystemVersion.mm
 platform/cocoa/TelephoneNumberDetectorCocoa.cpp
 platform/cocoa/TextRecognitionResultCocoa.mm

--- a/Source/WebCore/platform/ShareableResource.cpp
+++ b/Source/WebCore/platform/ShareableResource.cpp
@@ -102,7 +102,7 @@ auto ShareableResource::createHandle() -> std::optional<Handle>
 
 const uint8_t* ShareableResource::data() const
 {
-    return static_cast<const uint8_t*>(m_sharedMemory->data()) + m_offset;
+    return m_sharedMemory->span().subspan(m_offset).data();
 }
 
 unsigned ShareableResource::size() const

--- a/Source/WebCore/platform/SharedMemory.h
+++ b/Source/WebCore/platform/SharedMemory.h
@@ -42,6 +42,10 @@
 #include <wtf/MachSendRight.h>
 #endif
 
+#if PLATFORM(COCOA)
+OBJC_CLASS NSData;
+#endif
+
 namespace WebCore {
 
 class FragmentedSharedBuffer;
@@ -107,11 +111,6 @@ public:
     WEBCORE_EXPORT std::optional<Handle> createHandle(Protection);
 
     size_t size() const { return m_size; }
-    void* data() const
-    {
-        ASSERT(m_data);
-        return m_data;
-    }
 
     std::span<const uint8_t> span() const { return { static_cast<const uint8_t*>(m_data), m_size }; }
     std::span<uint8_t> mutableSpan() const { return { static_cast<uint8_t*>(m_data), m_size }; }
@@ -122,6 +121,7 @@ public:
 
 #if PLATFORM(COCOA)
     Protection protection() const { return m_protection; }
+    WEBCORE_EXPORT RetainPtr<NSData> toNSData() const;
 #endif
 
     WEBCORE_EXPORT Ref<WebCore::SharedBuffer> createSharedBuffer(size_t) const;

--- a/Source/WebCore/platform/cocoa/SharedMemoryCocoa.mm
+++ b/Source/WebCore/platform/cocoa/SharedMemoryCocoa.mm
@@ -23,22 +23,22 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "SharedMemory.h"
+#import "config.h"
+#import "SharedMemory.h"
 
-#include "Logging.h"
-#include "ProcessIdentity.h"
-#include "SharedBuffer.h"
-#include <mach/mach_error.h>
-#include <mach/mach_init.h>
-#include <mach/mach_port.h>
-#include <mach/vm_map.h>
-#include <wtf/MachSendRight.h>
-#include <wtf/RefPtr.h>
-#include <wtf/spi/cocoa/MachVMSPI.h>
+#import "Logging.h"
+#import "ProcessIdentity.h"
+#import "SharedBuffer.h"
+#import <mach/mach_error.h>
+#import <mach/mach_init.h>
+#import <mach/mach_port.h>
+#import <mach/vm_map.h>
+#import <wtf/MachSendRight.h>
+#import <wtf/RefPtr.h>
+#import <wtf/spi/cocoa/MachVMSPI.h>
 
 #if HAVE(MACH_MEMORY_ENTRY)
-#include <mach/memory_entry.h>
+#import <mach/memory_entry.h>
 #endif
 
 namespace WebCore {
@@ -226,6 +226,12 @@ WTF::MachSendRight SharedMemory::createSendRight(Protection protection) const
 
     ASSERT(m_data);
     return makeMemoryEntry(m_size, toVMAddress(m_data), protection, MACH_PORT_NULL);
+}
+
+RetainPtr<NSData> SharedMemory::toNSData() const
+{
+    auto span = this->span();
+    return adoptNS([[NSData alloc] initWithBytes:span.data() length:span.size()]);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ShareableBitmap.cpp
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.cpp
@@ -170,7 +170,7 @@ ShareableBitmap::ShareableBitmap(ShareableBitmapConfiguration configuration, Ref
 
 void* ShareableBitmap::data() const
 {
-    return m_sharedMemory->data();
+    return m_sharedMemory->mutableSpan().data();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
@@ -28,6 +28,7 @@
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA) && ENABLE(MEDIA_SOURCE)
 
+#import "CDMFairPlayStreaming.h"
 #import "CDMPrivateMediaSourceAVFObjC.h"
 #import "LegacyCDM.h"
 #import "Logging.h"

--- a/Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm
+++ b/Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm
@@ -35,6 +35,7 @@
 #include "PlatformScreen.h"
 #include <pal/spi/cg/CoreGraphicsSPI.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/spi/cocoa/IOSurfaceSPI.h>
 
 namespace WebCore {
@@ -151,7 +152,7 @@ RefPtr<ShareableBitmap> ShareableBitmap::createFromImagePixels(NativeImage& imag
     if (!sharedMemory)
         return nullptr;
 
-    memcpy(sharedMemory->data(), bytes, sizeInBytes);
+    memcpySpan(sharedMemory->mutableSpan(), std::span { bytes, static_cast<size_t>(sizeInBytes) });
 
     return adoptRef(new ShareableBitmap(configuration, sharedMemory.releaseNonNull()));
 }

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -36,6 +36,10 @@ OBJC_CLASS AVSampleBufferDisplayLayer;
 OBJC_PROTOCOL(WebSampleBufferVideoRendering);
 typedef struct opaqueCMSampleBuffer *CMSampleBufferRef;
 
+#if HAVE(AVSAMPLEBUFFERDISPLAYLAYER_COPYDISPLAYEDPIXELBUFFER)
+typedef struct __CVBuffer* CVPixelBufferRef;
+#endif
+
 namespace WebCore {
 
 class WebCoreDecompressionSession;

--- a/Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.h
+++ b/Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.h
@@ -26,7 +26,20 @@
 
 #if PLATFORM(MAC)
 
-namespace WebCore::SwitchMacUtilities {
+namespace WebCore {
+
+class FloatRect;
+class FloatSize;
+class GraphicsContext;
+class ImageBuffer;
+class IntSize;
+
+struct ControlStyle;
+
+template<typename> class RectEdges;
+using IntOutsets = RectEdges<int>;
+
+namespace SwitchMacUtilities {
 
 IntSize cellSize(NSControlSize);
 FloatSize visualCellSize(IntSize, const ControlStyle&);
@@ -40,6 +53,8 @@ FloatRect trackRectForBounds(const FloatRect&, const FloatSize&);
 void rotateContextForVerticalWritingMode(GraphicsContext&, const FloatRect&);
 RefPtr<ImageBuffer> trackMaskImage(GraphicsContext&, FloatSize, float, bool, NSString *);
 
-} // namespace WebCore::SwitchMacUtilities
+} // namespace SwitchMacUtilities
+
+} // namespace WebCore
 
 #endif // PLATFORM(MAC)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -307,7 +307,7 @@ void RemoteGraphicsContextGL::readPixelsSharedMemory(WebCore::IntRect rect, uint
 
     handle.setOwnershipOfMemory(m_sharedResourceCache->resourceOwner(), WebKit::MemoryLedger::Default);
     if (auto buffer = SharedMemory::map(WTFMove(handle), SharedMemory::Protection::ReadWrite))
-        readArea = m_context->readPixelsWithStatus(rect, format, type, std::span<uint8_t>(static_cast<uint8_t*>(buffer->data()), buffer->size()));
+        readArea = m_context->readPixelsWithStatus(rect, format, type, buffer->mutableSpan());
     else
         m_context->addError(GCGLErrorCode::InvalidOperation);
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp
@@ -33,6 +33,7 @@
 #include "RemoteRenderingBackend.h"
 #include "StreamConnectionWorkQueue.h"
 #include <WebCore/GraphicsContext.h>
+#include <wtf/StdLibExtras.h>
 
 #define MESSAGE_CHECK(assertion, message) do { \
     if (UNLIKELY(!(assertion))) { \
@@ -90,9 +91,9 @@ void RemoteImageBuffer::getPixelBuffer(WebCore::PixelBufferFormat destinationFor
     IntRect srcRect(srcPoint, srcSize);
     if (auto pixelBuffer = m_imageBuffer->getPixelBuffer(destinationFormat, srcRect)) {
         MESSAGE_CHECK(pixelBuffer->bytes().size() <= memory->size(), "Shmem for return of getPixelBuffer is too small"_s);
-        memcpy(memory->data(), pixelBuffer->bytes().data(), pixelBuffer->bytes().size());
+        memcpySpan(memory->mutableSpan().first(pixelBuffer->bytes().size()), pixelBuffer->bytes());
     } else
-        memset(memory->data(), 0, memory->size());
+        memsetSpan(memory->mutableSpan(), 0);
     completionHandler();
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp
@@ -142,7 +142,7 @@ private:
         static_assert(std::atomic<UInt32>::is_always_lock_free, "Shared memory atomic usage assumes lock free primitives are used");
         if (m_frameCount) {
             RELEASE_ASSERT(m_frameCount->size() == sizeof(std::atomic<uint32_t>));
-            WTF::atomicExchangeAdd(static_cast<uint32_t*>(m_frameCount->data()), numberOfFrames);
+            WTF::atomicExchangeAdd(reinterpret_cast<uint32_t*>(m_frameCount->mutableSpan().data()), numberOfFrames);
         }
     }
 

--- a/Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp
+++ b/Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp
@@ -50,7 +50,7 @@ StreamConnectionBuffer::Handle StreamConnectionBuffer::createHandle()
 
 std::span<uint8_t> StreamConnectionBuffer::headerForTesting()
 {
-    return { static_cast<uint8_t*>(m_sharedMemory->data()), headerSize() };
+    return m_sharedMemory->mutableSpan().first(headerSize());
 }
 
 std::span<uint8_t> StreamConnectionBuffer::dataForTesting()

--- a/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
@@ -110,7 +110,7 @@ public:
 
     Atomic<ClientOffset>& clientOffset() { return header().clientOffset; }
     Atomic<ServerOffset>& serverOffset() { return header().serverOffset; }
-    uint8_t* data() const { return static_cast<uint8_t*>(m_sharedMemory->data()) + headerSize(); }
+    uint8_t* data() const { return m_sharedMemory->mutableSpan().subspan(headerSize()).data(); }
     size_t dataSize() const { return m_dataSize; }
 
     static constexpr size_t maximumSize() { return std::min(static_cast<size_t>(ClientOffset::serverIsSleepingTag), static_cast<size_t>(ClientOffset::serverIsSleepingTag)) - 1; }
@@ -135,7 +135,7 @@ protected:
 
 #undef HEADER_POINTER_ALIGNMENT
 
-    Header& header() const { return *reinterpret_cast<Header*>(m_sharedMemory->data()); }
+    Header& header() const { return *reinterpret_cast<Header*>(m_sharedMemory->mutableSpan().data()); }
     static constexpr size_t headerSize() { return roundUpToMultipleOf<alignof(std::max_align_t)>(sizeof(Header)); }
 
     size_t m_dataSize { 0 };

--- a/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
+++ b/Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp
@@ -205,7 +205,7 @@ bool Connection::processMessage()
 
     uint8_t* messageBody = messageData;
     if (messageInfo.isBodyOutOfLine())
-        messageBody = reinterpret_cast<uint8_t*>(oolMessageBody->data());
+        messageBody = oolMessageBody->mutableSpan().data();
 
     auto decoder = Decoder::create({ messageBody, messageInfo.bodySize() }, WTFMove(attachments));
     ASSERT(decoder);

--- a/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp
+++ b/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp
@@ -83,7 +83,7 @@ std::optional<ProducerSharedCARingBuffer::Pair> ProducerSharedCARingBuffer::allo
     if (!handle)
         return std::nullopt;
 
-    new (NotNull, sharedMemory->data()) TimeBoundsBuffer;
+    new (NotNull, sharedMemory->mutableSpan().data()) TimeBoundsBuffer;
     std::unique_ptr<ProducerSharedCARingBuffer> result { new ProducerSharedCARingBuffer { bytesPerFrame, frameCount, numChannelStreams, sharedMemory.releaseNonNull() } };
     result->initialize();
     return Pair { WTFMove(result), { WTFMove(*handle), frameCount } };

--- a/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h
+++ b/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h
@@ -38,8 +38,8 @@ namespace WebKit {
 class SharedCARingBufferBase : public WebCore::CARingBuffer {
 protected:
     SharedCARingBufferBase(size_t bytesPerFrame, size_t frameCount, uint32_t numChannelStream, Ref<WebCore::SharedMemory>);
-    void* data() final { return static_cast<Byte*>(m_storage->data()) + sizeof(TimeBoundsBuffer); }
-    TimeBoundsBuffer& timeBoundsBuffer() final { return *reinterpret_cast<TimeBoundsBuffer*>(m_storage->data()); }
+    void* data() final { return byteCast<Byte>(m_storage->mutableSpan().data()) + sizeof(TimeBoundsBuffer); }
+    TimeBoundsBuffer& timeBoundsBuffer() final { return *reinterpret_cast<TimeBoundsBuffer*>(m_storage->mutableSpan().data()); }
 
     Ref<WebCore::SharedMemory> m_storage;
 };

--- a/Source/WebKit/Shared/IPCStreamTester.cpp
+++ b/Source/WebKit/Shared/IPCStreamTester.cpp
@@ -85,8 +85,8 @@ void IPCStreamTester::syncMessageReturningSharedMemory1(uint32_t byteCount, Comp
         auto handle = sharedMemory->createHandle(WebCore::SharedMemory::Protection::ReadOnly);
         if (!handle)
             return std::nullopt;
-        uint8_t* data = static_cast<uint8_t*>(sharedMemory->data());
-        for (size_t i = 0; i < sharedMemory->size(); ++i)
+        auto data = sharedMemory->mutableSpan();
+        for (size_t i = 0; i < data.size(); ++i)
             data[i] = i;
         return WTFMove(*handle);
     }();

--- a/Source/WebKit/Shared/SharedStringHashStore.cpp
+++ b/Source/WebKit/Shared/SharedStringHashStore.cpp
@@ -28,6 +28,7 @@
 
 #include <algorithm>
 #include <wtf/PageBlock.h>
+#include <wtf/StdLibExtras.h>
 
 namespace WebKit {
 
@@ -123,7 +124,7 @@ void SharedStringHashStore::resizeTable(unsigned newTableLength)
         return;
     }
 
-    memset(newTableMemory->data(), 0, newTableMemory->size());
+    memsetSpan(newTableMemory->mutableSpan(), 0);
 
     RefPtr<SharedMemory> currentTableMemory = m_table.sharedMemory();
     unsigned currentTableLength = m_tableLength;
@@ -135,7 +136,7 @@ void SharedStringHashStore::resizeTable(unsigned newTableLength)
         RELEASE_ASSERT(currentTableMemory->size() == (Checked<unsigned>(currentTableLength) * sizeof(SharedStringHash)).value());
 
         // Go through the current hash table and re-add all entries to the new hash table.
-        const SharedStringHash* currentSharedStringHashes = static_cast<const SharedStringHash*>(currentTableMemory->data());
+        auto* currentSharedStringHashes = reinterpret_cast<const SharedStringHash*>(currentTableMemory->span().data());
         for (unsigned i = 0; i < currentTableLength; ++i) {
             auto sharedStringHash = currentSharedStringHashes[i];
             if (!sharedStringHash)

--- a/Source/WebKit/Shared/SharedStringHashTable.cpp
+++ b/Source/WebKit/Shared/SharedStringHashTable.cpp
@@ -27,6 +27,7 @@
 #include "SharedStringHashTable.h"
 
 #include <WebCore/SharedMemory.h>
+#include <wtf/StdLibExtras.h>
 
 namespace WebKit {
 
@@ -68,7 +69,7 @@ void SharedStringHashTable::clear()
     if (!m_sharedMemory)
         return;
 
-    memset(m_sharedMemory->data(), 0, m_sharedMemory->size());
+    memsetSpan(m_sharedMemory->mutableSpan(), 0);
     setSharedMemory(nullptr);
 }
 

--- a/Source/WebKit/Shared/SharedStringHashTableReadOnly.cpp
+++ b/Source/WebKit/Shared/SharedStringHashTableReadOnly.cpp
@@ -65,7 +65,7 @@ void SharedStringHashTableReadOnly::setSharedMemory(RefPtr<SharedMemory>&& share
 
     if (m_sharedMemory) {
         ASSERT(!(m_sharedMemory->size() % sizeof(SharedStringHash)));
-        m_table = static_cast<SharedStringHash*>(m_sharedMemory->data());
+        m_table = reinterpret_cast<SharedStringHash*>(m_sharedMemory->mutableSpan().data());
         m_tableSize = m_sharedMemory->size() / sizeof(SharedStringHash);
         ASSERT(isPowerOf2(m_tableSize));
         m_tableSizeMask = m_tableSize - 1;

--- a/Source/WebKit/Shared/WebHitTestResultData.cpp
+++ b/Source/WebKit/Shared/WebHitTestResultData.cpp
@@ -246,7 +246,7 @@ IntRect WebHitTestResultData::elementBoundingBoxInWindowCoordinates(const WebCor
 std::optional<WebCore::SharedMemory::Handle> WebHitTestResultData::getImageSharedMemoryHandle() const
 {
     std::optional<WebCore::SharedMemory::Handle> imageHandle = std::nullopt;
-    if (imageSharedMemory && imageSharedMemory->data()) {
+    if (imageSharedMemory && !imageSharedMemory->span().empty()) {
         if (auto handle = imageSharedMemory->createHandle(WebCore::SharedMemory::Protection::ReadOnly))
             imageHandle = WTFMove(*handle);
     }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2766,10 +2766,9 @@ static RetainPtr<NSArray> wkTextManipulationErrors(NSArray<_WKTextManipulationIt
 #if ENABLE(APP_HIGHLIGHTS)
 static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, NSData *highlight)
 {
-    auto sharedMemory = WebCore::SharedMemory::allocate(highlight.length);
-    if (sharedMemory) {
-        [highlight getBytes:sharedMemory->data() length:highlight.length];
-        buffers.append(*sharedMemory);
+    if (auto sharedMemory = WebCore::SharedMemory::allocate(highlight.length)) {
+        [highlight getBytes:sharedMemory->mutableSpan().data() length:highlight.length];
+        buffers.append(sharedMemory.releaseNonNull());
     }
 }
 #endif

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -424,7 +424,7 @@ void WebContextMenuProxyMac::getShareMenuItem(CompletionHandler<void(NSMenuItem 
     }
 
     if (hitTestData.imageSharedMemory) {
-        if (auto image = adoptNS([[NSImage alloc] initWithData:[NSData dataWithBytes:(unsigned char*)hitTestData.imageSharedMemory->data() length:hitTestData.imageSharedMemory->size()]])) {
+        if (auto image = adoptNS([[NSImage alloc] initWithData:hitTestData.imageSharedMemory->toNSData().get()])) {
 #if HAVE(NSPREVIEWREPRESENTINGACTIVITYITEM)
             NSString *title = hitTestData.imageText;
             if (!title.length)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -47,6 +47,7 @@
 #include "WebProcess.h"
 #include <JavaScriptCore/TypedArrayInlines.h>
 #include <WebCore/FontCustomPlatformData.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/TextStream.h>
 
 #if HAVE(IOSURFACE)
@@ -256,7 +257,7 @@ bool RemoteRenderingBackendProxy::getPixelBufferForImageBuffer(RenderingResource
         if (!sendResult.succeeded())
             return false;
     }
-    memcpy(result.data(), m_getPixelBufferSharedMemory->data(), result.size());
+    memcpySpan(result, m_getPixelBufferSharedMemory->span().first(result.size()));
     return true;
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
@@ -73,7 +73,7 @@ RemoteAudioDestinationProxy::RemoteAudioDestinationProxy(AudioIOCallback& callba
 uint32_t RemoteAudioDestinationProxy::totalFrameCount() const
 {
     RELEASE_ASSERT(m_frameCount->size() == sizeof(std::atomic<uint32_t>));
-    return WTF::atomicLoad(static_cast<uint32_t*>(m_frameCount->data()));
+    return WTF::atomicLoad(reinterpret_cast<uint32_t*>(m_frameCount->mutableSpan().data()));
 }
 
 void RemoteAudioDestinationProxy::startRenderingThread()

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
@@ -143,7 +143,7 @@ std::optional<SharedVideoFrame::Buffer> SharedVideoFrameWriter::writeBuffer(CVPi
     if (!prepareWriting(info, newSemaphoreCallback, newMemoryCallback))
         return { };
 
-    if (!info.writePixelBuffer(pixelBuffer, static_cast<uint8_t*>(m_storage->data())))
+    if (!info.writePixelBuffer(pixelBuffer, m_storage->mutableSpan().data()))
         return { };
 
     scope.release();
@@ -170,7 +170,7 @@ std::optional<SharedVideoFrame::Buffer> SharedVideoFrameWriter::writeBuffer(webr
     if (!prepareWriting(info, newSemaphoreCallback, newMemoryCallback))
         return { };
 
-    if (!info.writeVideoFrameBuffer(frameBuffer, static_cast<uint8_t*>(m_storage->data())))
+    if (!info.writeVideoFrameBuffer(frameBuffer, m_storage->mutableSpan().data()))
         return { };
 
     scope.release();

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -65,6 +65,7 @@
 #include <WebCore/SharedMemory.h>
 #include <wtf/PageBlock.h>
 #include <wtf/Scope.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/StringConcatenate.h>
 
 namespace WebKit::IPCTestingAPI {
@@ -1637,7 +1638,7 @@ JSValueRef JSSharedMemory::writeBytes(JSContextRef context, JSObjectRef, JSObjec
         length = *lengthValue;
     }
 
-    memcpy(static_cast<uint8_t*>(jsSharedMemory->m_sharedMemory->data()) + offset, span.data(), length);
+    memcpySpan(jsSharedMemory->m_sharedMemory->mutableSpan().subspan(offset, length), span.first(length));
 
     return JSValueMakeUndefined(context);
 }


### PR DESCRIPTION
#### 78d8c59ed298b1c74189daf439a9104dbb7b2e2c
<pre>
Drop SharedMemory::data() in favor of span()
<a href="https://bugs.webkit.org/show_bug.cgi?id=274943">https://bugs.webkit.org/show_bug.cgi?id=274943</a>

Reviewed by Darin Adler.

* Source/WebCore/PlatformMac.cmake:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/ShareableResource.cpp:
(WebCore::ShareableResource::data const):
* Source/WebCore/platform/SharedMemory.cpp:
(WebCore::SharedMemory::copyBuffer):
(WebCore::SharedMemory::createSharedBuffer const):
* Source/WebCore/platform/SharedMemory.h:
(WebCore::SharedMemory::size const):
(WebCore::SharedMemory::data const): Deleted.
* Source/WebCore/platform/cocoa/SharedMemoryCocoa.mm: Renamed from Source/WebCore/platform/cocoa/SharedMemoryCocoa.cpp.
(WebCore::toVMMemoryLedger):
(WebCore::SharedMemoryHandle::takeOwnershipOfMemory const):
(WebCore::SharedMemoryHandle::setOwnershipOfMemory const):
(WebCore::toPointer):
(WebCore::toVMAddress):
(WebCore::SharedMemory::allocate):
(WebCore::machProtection):
(WebCore::makeMemoryEntry):
(WebCore::SharedMemory::wrapMap):
(WebCore::SharedMemory::map):
(WebCore::SharedMemory::~SharedMemory):
(WebCore::SharedMemory::createHandle):
(WebCore::SharedMemory::createSendRight const):
(WebCore::SharedMemory::toNSData const):
* Source/WebCore/platform/graphics/ShareableBitmap.cpp:
(WebCore::ShareableBitmap::data const):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm:
* Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm:
(WebCore::ShareableBitmap::createFromImagePixels):
* Source/WebCore/platform/graphics/mac/controls/SwitchMacUtilities.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::readPixelsSharedMemory):
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp:
(WebKit::RemoteImageBuffer::getPixelBuffer):
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp:
* Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp:
(IPC::StreamConnectionBuffer::headerForTesting):
* Source/WebKit/Platform/IPC/StreamConnectionBuffer.h:
(IPC::StreamConnectionBuffer::data const):
(IPC::StreamConnectionBuffer::header const):
* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp:
(WebKit::ProducerSharedCARingBuffer::allocate):
* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.h:
* Source/WebKit/Shared/IPCStreamTester.cpp:
(WebKit::IPCStreamTester::syncMessageReturningSharedMemory1):
* Source/WebKit/Shared/SharedStringHashStore.cpp:
(WebKit::SharedStringHashStore::resizeTable):
* Source/WebKit/Shared/SharedStringHashTable.cpp:
(WebKit::SharedStringHashTable::clear):
* Source/WebKit/Shared/SharedStringHashTableReadOnly.cpp:
(WebKit::SharedStringHashTableReadOnly::setSharedMemory):
* Source/WebKit/Shared/WebHitTestResultData.cpp:
(WebKit::WebHitTestResultData::getImageSharedMemoryHandle const):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(convertAndAddHighlight):
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::WebContextMenuProxyMac::getShareMenuItem):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::getPixelBufferForImageBuffer):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp:
(WebKit::RemoteAudioDestinationProxy::totalFrameCount const):
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp:
(WebKit::SharedVideoFrameWriter::writeBuffer):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSSharedMemory::writeBytes):

Canonical link: <a href="https://commits.webkit.org/279598@main">https://commits.webkit.org/279598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fd439500acdeac2396230bfed58b927bf508168

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53892 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33262 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57172 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4617 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40767 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4492 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43645 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3043 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31483 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46620 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24781 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28314 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3940 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2770 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49976 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4143 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58765 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4218 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51059 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30258 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46761 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50398 "Found 1 new API test failure: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/select-all/non-editable (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31204 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7983 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30035 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->