### PR TITLE
[UnifiedPDF] Data detector borders are unstable during zoom

### DIFF
--- a/Source/WebCore/platform/mac/DataDetectorHighlight.h
+++ b/Source/WebCore/platform/mac/DataDetectorHighlight.h
@@ -98,6 +98,7 @@ public:
 
     WEBCORE_EXPORT void fadeIn();
     WEBCORE_EXPORT void fadeOut();
+    WEBCORE_EXPORT void dismissImmediately();
 
     WEBCORE_EXPORT void setHighlight(DDHighlightRef);
 

--- a/Source/WebCore/platform/mac/DataDetectorHighlight.mm
+++ b/Source/WebCore/platform/mac/DataDetectorHighlight.mm
@@ -196,6 +196,17 @@ void DataDetectorHighlight::fadeAnimationTimerFired()
     }
 }
 
+void DataDetectorHighlight::dismissImmediately()
+{
+    layer().setOpacity(0);
+
+    if (m_fadeAnimationTimer.isActive())
+        m_fadeAnimationTimer.stop();
+
+    m_fadeAnimationState = FadeAnimationState::NotAnimating;
+    didFinishFadeOutAnimation();
+}
+
 void DataDetectorHighlight::fadeIn()
 {
     if (m_fadeAnimationState == FadeAnimationState::FadingIn && m_fadeAnimationTimer.isActive())

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.h
@@ -68,6 +68,7 @@ public:
     enum class ShouldUpdatePlatformHighlightData : bool { No, Yes };
     enum class ActiveHighlightChanged : bool { No, Yes };
     void didInvalidateHighlightOverlayRects(std::optional<PDFDocumentLayout::PageIndex> = { }, ShouldUpdatePlatformHighlightData = ShouldUpdatePlatformHighlightData::Yes, ActiveHighlightChanged = ActiveHighlightChanged::No);
+    void hideActiveHighlightOverlay();
 
 private:
     // PageOverlayClient

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
@@ -247,6 +247,12 @@ void PDFDataDetectorOverlayController::updatePlatformHighlightData(PDFDocumentLa
     });
 }
 
+void PDFDataDetectorOverlayController::hideActiveHighlightOverlay()
+{
+    if (RefPtr activeHighlight = m_activeDataDetectorItemWithHighlight.second)
+        activeHighlight->dismissImmediately();
+}
+
 void PDFDataDetectorOverlayController::didInvalidateHighlightOverlayRects(std::optional<PDFDocumentLayout::PageIndex> pageIndex, ShouldUpdatePlatformHighlightData shouldUpdatePlatformHighlightData, ActiveHighlightChanged activeHighlightChanged)
 {
     // Regardless of what we repaint, we don't need the stale data after this.
@@ -254,11 +260,15 @@ void PDFDataDetectorOverlayController::didInvalidateHighlightOverlayRects(std::o
         m_staleDataDetectorItemWithHighlight = { { }, { } };
     });
 
+    RefPtr plugin = protectedPlugin();
+    if (!plugin)
+        return;
+
     auto [previousDataDetectorItem, previousActiveHighlight] = m_staleDataDetectorItemWithHighlight;
     auto [activeDataDetectorItem, activeHighlight] = m_activeDataDetectorItemWithHighlight;
 
     bool shouldUpdateHighlights = activeHighlightChanged == ActiveHighlightChanged::Yes || activeHighlight || previousActiveHighlight;
-    if (!shouldUpdateHighlights)
+    if (!shouldUpdateHighlights || !plugin->canShowDataDetectorHighlightOverlays())
         return;
 
     if (shouldUpdatePlatformHighlightData == ShouldUpdatePlatformHighlightData::No)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -157,6 +157,8 @@ public:
     void uninstallDataDetectorOverlay(WebCore::PageOverlay&);
 
     void handleClickForDataDetectionResult(const WebCore::DataDetectorElementInfo&, const WebCore::IntPoint&);
+
+    bool canShowDataDetectorHighlightOverlays() const;
 #endif
 
     void scheduleRenderingUpdate(OptionSet<WebCore::RenderingUpdateStep> = WebCore::RenderingUpdateStep::LayerFlush);

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -321,6 +321,11 @@ void UnifiedPDFPlugin::handleClickForDataDetectionResult(const DataDetectorEleme
     page->chrome().client().handleClickForDataDetectionResult(dataDetectorElementInfo, clickPointInPluginSpace);
 }
 
+bool UnifiedPDFPlugin::canShowDataDetectorHighlightOverlays() const
+{
+    return !m_inMagnificationGesture;
+}
+
 void UnifiedPDFPlugin::didInvalidateDataDetectorHighlightOverlayRects()
 {
     auto lastKnownMousePositionInDocumentSpace = convertDown<FloatPoint>(CoordinateSpace::Plugin, CoordinateSpace::PDFDocumentLayout, lastKnownMousePositionInView());
@@ -1281,6 +1286,10 @@ float UnifiedPDFPlugin::deviceScaleFactor() const
 void UnifiedPDFPlugin::didBeginMagnificationGesture()
 {
     m_inMagnificationGesture = true;
+
+#if ENABLE(UNIFIED_PDF_DATA_DETECTION)
+    dataDetectorOverlayController().hideActiveHighlightOverlay();
+#endif
 }
 
 void UnifiedPDFPlugin::didEndMagnificationGesture()
@@ -1337,10 +1346,6 @@ void UnifiedPDFPlugin::setScaleFactor(double scale, std::optional<WebCore::IntPo
 #if PLATFORM(MAC)
     if (m_activeAnnotation)
         m_activeAnnotation->updateGeometry();
-#endif
-
-#if ENABLE(UNIFIED_PDF_DATA_DETECTION)
-    didInvalidateDataDetectorHighlightOverlayRects();
 #endif
 
     auto scrolledContentsPoint = roundedIntPoint(convertUp(CoordinateSpace::Contents, CoordinateSpace::ScrolledContents, FloatPoint { zoomContentsOrigin }));


### PR DESCRIPTION
#### 1f4e1577f355f4a93eb0f3c0a34e08459356654c
<pre>
[UnifiedPDF] Data detector borders are unstable during zoom
<a href="https://bugs.webkit.org/show_bug.cgi?id=274942">https://bugs.webkit.org/show_bug.cgi?id=274942</a>
<a href="https://rdar.apple.com/128865849">rdar://128865849</a>

Reviewed by Simon Fraser.

Any active data detector overlay is constantly repainted during a
magnification gesture because we used to call into
didInvalidateHighlightOverlayRects whenever we were in the plugin&apos;s
setScaleFactor method. This resulted in the overlay looking unstable and
a little jumpy when pinching in/out.

To deal with this, we follow the precedent set by ImageOverlayController
and dismiss any active highlight during a magnification gesture. In
addition, we disallow the DD overlay controller to present DD overlay
rects in general during a pinch zoom.

We achieve this by:

1. Introducing the canShowDataDetectorHighlightOverlays method on the
   plugin, which is consulted before highlight presentation.

2. Providing WebCore::DataDetectorHighlight instances the ability to be
   dismissed immediately, rather than just being faded out.

* Source/WebCore/platform/mac/DataDetectorHighlight.h:
* Source/WebCore/platform/mac/DataDetectorHighlight.mm:
(WebCore::DataDetectorHighlight::dismissImmediately):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm:
(WebKit::PDFDataDetectorOverlayController::hideActiveHighlightOverlay):
(WebKit::PDFDataDetectorOverlayController::didInvalidateHighlightOverlayRects):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::canShowDataDetectorHighlightOverlays const):
(WebKit::UnifiedPDFPlugin::didBeginMagnificationGesture):
(WebKit::UnifiedPDFPlugin::setScaleFactor):

Canonical link: <a href="https://commits.webkit.org/279581@main">https://commits.webkit.org/279581@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5bd05389d6e9401e0d119fc1afe258157c7c136f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57115 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4560 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56141 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4422 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43592 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/2991 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55935 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31413 "Found 3 new test failures: fast/events/ios/key-events-comprehensive/key-events-meta.html, fast/forms/form-submission-crash-4.html, webgl/pending/conformance2/glsl3/empty-shader-with-output.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46571 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24732 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3882 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2715 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58710 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29007 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4132 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51003 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30199 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46714 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50338 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11731 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31135 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29978 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->