### PR TITLE
[JSC] Fix Atomics.waitAsync by using weak references in JSC::DeferredWorkTimer

### DIFF
--- a/Source/JavaScriptCore/heap/WeakInlines.h
+++ b/Source/JavaScriptCore/heap/WeakInlines.h
@@ -126,6 +126,16 @@ template <typename T> inline bool operator==(const Weak<T>& lhs, const Weak<T>& 
     return lhs.get() == rhs.get();
 }
 
+template<typename T> inline bool operator==(const Weak<T>& lhs, const T* rhs)
+{
+    return lhs.get() == rhs;
+}
+
+template<typename T> inline bool operator==(const T* lhs, const Weak<T>& rhs)
+{
+    return lhs == rhs.get();
+}
+
 // This function helps avoid modifying a weak table while holding an iterator into it. (Object allocation
 // can run a finalizer that modifies the table. We avoid that by requiring a pre-constructed object as our value.)
 template<typename Map, typename Key, typename Value> inline void weakAdd(Map& map, const Key& key, Value&& value)

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
@@ -155,7 +155,7 @@ void ArrayBufferContents::makeShared()
 
 SharedArrayBufferContents::~SharedArrayBufferContents()
 {
-    WaiterListManager::singleton().unregisterSharedArrayBuffer(bitwise_cast<uint8_t*>(data()), m_sizeInBytes);
+    WaiterListManager::singleton().unregister(bitwise_cast<uint8_t*>(data()), m_sizeInBytes);
     if (m_destructor) {
         // FIXME: we shouldn't use getUnsafe here https://bugs.webkit.org/show_bug.cgi?id=197698
         m_destructor->run(m_data.getUnsafe());

--- a/Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp
+++ b/Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp
@@ -26,9 +26,9 @@
 #include "config.h"
 #include "DeferredWorkTimer.h"
 
+#include "CatchScope.h"
 #include "GlobalObjectMethodTable.h"
-#include "JSPromise.h"
-#include "StrongInlines.h"
+#include "JSGlobalObject.h"
 #include "VM.h"
 #include <wtf/RunLoop.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -41,10 +41,17 @@ namespace DeferredWorkTimerInternal {
 static constexpr bool verbose = false;
 }
 
-inline DeferredWorkTimer::TicketData::TicketData(VM& vm, JSObject* scriptExecutionOwner, Vector<Strong<JSCell>>&& dependencies)
+inline DeferredWorkTimer::TicketData::TicketData(JSGlobalObject* globalObject, JSObject* scriptExecutionOwner, Vector<Weak<JSCell>>&& dependencies)
     : dependencies(WTFMove(dependencies))
-    , scriptExecutionOwner(vm, scriptExecutionOwner)
+    , scriptExecutionOwner(scriptExecutionOwner)
+    , globalObject(globalObject)
 {
+    globalObject->addObjectsForTicket(this, scriptExecutionOwner, this->dependencies);
+}
+
+inline DeferredWorkTimer::TicketData::~TicketData()
+{
+    clearGlobalObject();
 }
 
 inline VM& DeferredWorkTimer::TicketData::vm()
@@ -53,12 +60,21 @@ inline VM& DeferredWorkTimer::TicketData::vm()
     return target()->vm();
 }
 
+void DeferredWorkTimer::TicketData::clearGlobalObject()
+{
+    if (!globalObject)
+        return;
+
+    globalObject->removeObjectsForTicket(this);
+    globalObject.clear();
+}
+
 inline void DeferredWorkTimer::TicketData::cancel()
 {
     scriptExecutionOwner.clear();
     dependencies.clear();
+    clearGlobalObject();
 }
-
 
 DeferredWorkTimer::DeferredWorkTimer(VM& vm)
     : Base(vm)
@@ -92,7 +108,7 @@ void DeferredWorkTimer::doWork(VM& vm)
 
         // We shouldn't access the TicketData to get this globalObject until
         // after we confirm that the ticket is still valid (which we did above).
-        auto globalObject = ticket->target()->structure()->globalObject();
+        auto globalObject = ticket->target()->globalObject();
         switch (globalObject->globalObjectMethodTable()->scriptExecutionStatus(globalObject, ticket->scriptExecutionOwner.get())) {
         case ScriptExecutionStatus::Suspended:
             suspendedTasks.append(std::make_tuple(ticket, WTFMove(task)));
@@ -105,7 +121,7 @@ void DeferredWorkTimer::doWork(VM& vm)
         }
 
         // Remove ticket from m_pendingTickets since we are going to run it.
-        // But we want to keep ticketData while running task since it ensures dependencies are strongly held.
+        // But we want to keep ticketData while running task since its globalObject ensures dependencies are strongly held.
         std::unique_ptr<TicketData> ticketData = m_pendingTickets.take(pendingTicket);
 
         // Allow tasks we are about to run to schedule work.
@@ -155,17 +171,17 @@ void DeferredWorkTimer::runRunLoop()
         RunLoop::run();
 }
 
-DeferredWorkTimer::Ticket DeferredWorkTimer::addPendingWork(VM& vm, JSObject* target, Vector<Strong<JSCell>>&& dependencies)
+DeferredWorkTimer::Ticket DeferredWorkTimer::addPendingWork(VM& vm, JSObject* target, Vector<Weak<JSCell>>&& dependencies)
 {
-    ASSERT(vm.currentThreadIsHoldingAPILock() || (Thread::mayBeGCThread() && vm.heap.worldIsStopped()));
+    ASSERT_UNUSED(vm, vm.currentThreadIsHoldingAPILock() || (Thread::mayBeGCThread() && vm.heap.worldIsStopped()));
     for (unsigned i = 0; i < dependencies.size(); ++i)
-        ASSERT(dependencies[i].get() != target);
+        ASSERT(dependencies[i].get() != target && dependencies[i].get());
 
     auto* globalObject = target->globalObject();
     JSObject* scriptExecutionOwner = globalObject->globalObjectMethodTable()->currentScriptExecutionOwner(globalObject);
-    dependencies.append(Strong<JSCell>(vm, target));
+    dependencies.append(Weak<JSCell>(target));
 
-    auto ticketData = makeUnique<TicketData>(vm, scriptExecutionOwner, WTFMove(dependencies));
+    auto ticketData = makeUnique<TicketData>(globalObject, scriptExecutionOwner, WTFMove(dependencies));
     Ticket ticket = ticketData.get();
 
     dataLogLnIf(DeferredWorkTimerInternal::verbose, "Adding new pending ticket: ", RawPointer(ticket));
@@ -184,7 +200,7 @@ bool DeferredWorkTimer::hasPendingWork(Ticket ticket)
     return true;
 }
 
-bool DeferredWorkTimer::hasDependancyInPendingWork(Ticket ticket, JSCell* dependency)
+bool DeferredWorkTimer::hasDependencyInPendingWork(Ticket ticket, JSCell* dependency)
 {
     auto result = m_pendingTickets.find(ticket);
     if (result == m_pendingTickets.end() || ticket->isCancelled())
@@ -214,6 +230,18 @@ bool DeferredWorkTimer::cancelPendingWork(Ticket ticket)
     }
 
     return result;
+}
+
+void DeferredWorkTimer::cancelPendingWorkSafe(JSGlobalObject* globalObject)
+{
+    Locker locker { m_taskLock };
+    for (auto ticket : globalObject->m_objectsForTicket->keys()) {
+        if (!ticket->isCancelled())
+            cancelPendingWork(ticket);
+        m_tasks.append(std::make_tuple(ticket, [](DeferredWorkTimer::Ticket) mutable { }));
+    }
+    if (!isScheduled() && !m_currentlyRunningTask)
+        setTimeUntilFire(0_s);
 }
 
 void DeferredWorkTimer::didResumeScriptExecutionOwner()

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "DeferredWorkTimer.h"
 #include "JSSegmentedVariableObject.h"
 #include "LazyClassStructure.h"
 #include "RegExpGlobalData.h"
@@ -504,6 +505,11 @@ public:
     FOR_EACH_TYPED_ARRAY_TYPE(DECLARE_TYPED_ARRAY_TYPE_WATCHPOINT)
 #undef DECLARE_TYPED_ARRAY_TYPE_WATCHPOINT
     Vector<std::unique_ptr<ObjectAdaptiveStructureWatchpoint>> m_missWatchpoints;
+
+    void addObjectsForTicket(DeferredWorkTimer::Ticket, JSObject* scriptExecutionOwner, FixedVector<Weak<JSCell>>& dependencies);
+    void removeObjectsForTicket(DeferredWorkTimer::Ticket);
+    void clearObjectsForTicket();
+    std::unique_ptr<HashMap<DeferredWorkTimer::Ticket, FixedVector<WriteBarrier<JSCell>>>> m_objectsForTicket;
 
     inline std::unique_ptr<ObjectAdaptiveStructureWatchpoint>& typedArrayConstructorSpeciesAbsenceWatchpoint(TypedArrayType);
     inline std::unique_ptr<ObjectAdaptiveStructureWatchpoint>& typedArrayPrototypeSymbolIteratorAbsenceWatchpoint(TypedArrayType);

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -451,7 +451,7 @@ VM::~VM()
     Locker destructionLocker { s_destructionLock.read() };
 
     if (Options::useAtomicsWaitAsync() && vmType == Default)
-        WaiterListManager::singleton().unregisterVM(this);
+        WaiterListManager::singleton().unregister(this);
 
     Gigacage::removePrimitiveDisableCallback(primitiveGigacageDisabledCallback, this);
     deferredWorkTimer->stopRunningTasks();

--- a/Source/JavaScriptCore/runtime/WaiterListManager.cpp
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include "WaiterListManager.h"
 
-#include "JSCInlines.h"
 #include "JSGlobalObject.h"
 #include "JSLock.h"
 #include "ObjectConstructor.h"
@@ -44,6 +43,37 @@ static constexpr bool verbose = false;
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Waiter);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WaiterList);
 
+Waiter::Waiter(VM* vm)
+    : m_vm(vm)
+    , m_isAsync(false)
+{
+}
+
+Waiter::Waiter(JSPromise* promise)
+    : m_vm(&promise->vm())
+    , m_ticket(m_vm->deferredWorkTimer->addPendingWork(*m_vm, promise, { }))
+    , m_isAsync(true)
+{
+}
+
+Waiter::~Waiter()
+{
+    if (m_ticket) {
+        ASSERT(m_ticket->isCancelled());
+        scheduleWorkAndClearTicket([](DeferredWorkTimer::Ticket) mutable { });
+    }
+}
+
+void Waiter::scheduleWorkAndClearTicket(DeferredWorkTimer::Task&& task)
+{
+    ASSERT(m_isAsync && m_vm && !isOnList());
+    // If the ticket is already be removed from the the pending tickets, then do nothing here.
+    if (!m_ticket)
+        return;
+    auto ticket = std::exchange(m_ticket, nullptr);
+    m_vm->deferredWorkTimer->scheduleWorkSoon(ticket, WTFMove(task));
+}
+
 WaiterListManager& WaiterListManager::singleton()
 {
     static LazyNeverDestroyed<WaiterListManager> manager;
@@ -57,6 +87,8 @@ WaiterListManager& WaiterListManager::singleton()
 template <typename ValueType>
 WaiterListManager::WaitSyncResult WaiterListManager::waitSyncImpl(VM& vm, ValueType* ptr, ValueType expectedValue, Seconds timeout)
 {
+    dataLogLnIf(WaiterListsManagerInternal::verbose, "<WaiterListManager> <Thread:", Thread::current(), "> waitSyncImpl starts totalWaiterCount=", totalWaiterCount());
+
     Ref<Waiter> syncWaiter = vm.syncWaiter();
     Ref<WaiterList> list = findOrCreateList(ptr);
     MonotonicTime time = MonotonicTime::timePointFromNow(timeout);
@@ -67,7 +99,7 @@ WaiterListManager::WaitSyncResult WaiterListManager::waitSyncImpl(VM& vm, ValueT
             return WaitSyncResult::NotEqual;
 
         list->addLast(listLocker, syncWaiter);
-        dataLogLnIf(WaiterListsManagerInternal::verbose, "WaiterListManager added a new SyncWaiter ", RawPointer(&syncWaiter), " to a waiterList for ptr ", RawPointer(ptr));
+        dataLogLnIf(WaiterListsManagerInternal::verbose, "<WaiterListManager> <Thread:", Thread::current(), "> added a new SyncWaiter=", syncWaiter.get(), " to a waiterList for ptr ", RawPointer(ptr));
 
         while (syncWaiter->vm() && time.now() < time)
             syncWaiter->condition().waitUntil(list->lock, time.approximateWallTime());
@@ -88,6 +120,8 @@ WaiterListManager::WaitSyncResult WaiterListManager::waitSyncImpl(VM& vm, ValueT
 template <typename ValueType>
 JSValue WaiterListManager::waitAsyncImpl(JSGlobalObject* globalObject, VM& vm, ValueType* ptr, ValueType expectedValue, Seconds timeout)
 {
+    dataLogLnIf(WaiterListsManagerInternal::verbose, "<WaiterListManager> <Thread:", Thread::current(), "> waitAsyncImpl starts totalWaiterCount=", totalWaiterCount());
+
     JSObject* object = constructEmptyObject(globalObject);
 
     bool isAsync = false;
@@ -113,9 +147,9 @@ JSValue WaiterListManager::waitAsyncImpl(JSGlobalObject* globalObject, VM& vm, V
                     timeoutAsyncWaiter(ptr, WTFMove(waiter));
                 });
                 waiter->setTimer(listLocker, WTFMove(timer));
-                dataLogLnIf(WaiterListsManagerInternal::verbose, "WaiterListManager added a new AsyncWaiter ", RawPointer(waiter.ptr()), " to a waiterList for ptr ", RawPointer(ptr));
             }
 
+            dataLogLnIf(WaiterListsManagerInternal::verbose, "<WaiterListManager> <Thread:", Thread::current(), "> added a new AsyncWaiter=", *waiter.ptr(), " to a waiterList for ptr ", RawPointer(ptr));
             value = promise;
         }
     }
@@ -188,29 +222,26 @@ unsigned WaiterListManager::notifyWaiter(void* ptr, unsigned count)
         }
     }
 
-    dataLogLnIf(WaiterListsManagerInternal::verbose, "WaiterListManager notified waiters (count ", notified, ") for ptr ", RawPointer(ptr));
+    dataLogLnIf(WaiterListsManagerInternal::verbose, "<WaiterListManager> <Thread:", Thread::current(), "> notified waiters (count ", notified, ") for ptr ", RawPointer(ptr));
     return notified;
 }
 
 void WaiterListManager::notifyWaiterImpl(const AbstractLocker& listLocker, Ref<Waiter>&& waiter, const ResolveResult resolveResult)
 {
+    ASSERT(!waiter->isOnList());
+
     if (waiter->isAsync()) {
-        VM& vm = *waiter->vm();
-        auto ticket = waiter->takeTicket(listLocker);
-        ASSERT(ticket);
-        vm.deferredWorkTimer->scheduleWorkSoon(ticket, [resolveResult](DeferredWorkTimer::Ticket ticket) {
+        waiter->scheduleWorkAndClearTicket([resolveResult](DeferredWorkTimer::Ticket ticket) {
             JSPromise* promise = jsCast<JSPromise*>(ticket->target());
             JSGlobalObject* globalObject = promise->globalObject();
+            ASSERT(ticket->globalObject == globalObject);
             VM& vm = promise->vm();
             JSValue result = resolveResult == ResolveResult::Ok ? vm.smallStrings.okString() : vm.smallStrings.timedOutString();
             promise->resolve(globalObject, result);
         });
 
-        // If waiter is an AsyncWaiter, we null out its ticket first to indicate that it's notified.
-        // Then, cancel its RunLoop timer if it's not timed-out.
-        if (resolveResult != ResolveResult::Timeout)
-            waiter->cancelTimer(listLocker);
-
+        // The AsyncWaiter's timer holds the waiter's reference. We must cancel it after the waiter done its job.
+        waiter->cancelTimer(listLocker);
         return;
     }
 
@@ -232,14 +263,27 @@ size_t WaiterListManager::waiterListSize(void* ptr)
     return size;
 }
 
+size_t WaiterListManager::totalWaiterCount()
+{
+    Locker waiterListsLocker { m_waiterListsLock };
+    size_t totalCount = 0;
+    for (auto& entry : m_waiterLists) {
+        Ref<WaiterList> list = entry.value;
+        Locker listLocker { list->lock };
+        totalCount += list->size();
+    }
+    return totalCount;
+}
+
 void WaiterListManager::cancelAsyncWaiter(const AbstractLocker& listLocker, Waiter* waiter)
 {
     ASSERT(waiter->isAsync());
-    waiter->vm()->deferredWorkTimer->scheduleWorkSoon(waiter->takeTicket(listLocker), [](DeferredWorkTimer::Ticket) mutable { });
+    auto ticket = waiter->ticket(listLocker);
+    waiter->vm()->deferredWorkTimer->cancelPendingWork(ticket);
     waiter->cancelTimer(listLocker);
 }
 
-void WaiterListManager::unregisterVM(VM* vm)
+void WaiterListManager::unregister(VM* vm)
 {
     Locker waiterListsLocker { m_waiterListsLock };
     for (auto& entry : m_waiterLists) {
@@ -247,18 +291,15 @@ void WaiterListManager::unregisterVM(VM* vm)
         Locker listLocker { list->lock };
         list->removeIf(listLocker, [&](Waiter* waiter) {
             if (waiter->vm() == vm) {
+                dataLogLnIf(WaiterListsManagerInternal::verbose,
+                    "<WaiterListManager> <Thread:", Thread::current(),
+                    "> unregister VM is cancelling waiter=", *waiter,
+                    " in WaiterList for ptr ", RawPointer(entry.key));
+
                 // If the vm is about destructing, then it shouldn't
                 // been blocked. That means we shouldn't find any SyncWaiter.
                 ASSERT(waiter->isAsync());
                 cancelAsyncWaiter(listLocker, waiter);
-
-                dataLogLnIf(WaiterListsManagerInternal::verbose,
-                    "WaiterListManager::unregisterVM ",
-                    (waiter->isAsync() ? " deleted AsyncWaiter " : " removed SyncWaiter "),
-                    RawPointer(waiter),
-                    " in WaiterList for ptr ",
-                    RawPointer(entry.key));
-
                 return true;
             }
             return false;
@@ -266,7 +307,31 @@ void WaiterListManager::unregisterVM(VM* vm)
     }
 }
 
-void WaiterListManager::unregisterSharedArrayBuffer(uint8_t* arrayPtr, size_t size)
+void WaiterListManager::unregister(JSGlobalObject* globalObject)
+{
+    Locker waiterListsLocker { m_waiterListsLock };
+    for (auto& entry : m_waiterLists) {
+        Ref<WaiterList> list = entry.value;
+        Locker listLocker { list->lock };
+        list->removeIf(listLocker, [&](Waiter* waiter) {
+            if (waiter->isAsync()) {
+                auto ticket = waiter->ticket(listLocker);
+                if (ticket->globalObject == globalObject) {
+                    dataLogLnIf(WaiterListsManagerInternal::verbose,
+                        "<WaiterListManager> <Thread:", Thread::current(),
+                        "> unregister JSGlobalObject is cancelling waiter=", *waiter,
+                        " in WaiterList for ptr ", RawPointer(entry.key));
+
+                    cancelAsyncWaiter(listLocker, waiter);
+                    return true;
+                }
+            }
+            return false;
+        });
+    }
+}
+
+void WaiterListManager::unregister(uint8_t* arrayPtr, size_t size)
 {
     Locker listLocker { m_waiterListsLock };
     m_waiterLists.removeIf([&](auto& entry) {
@@ -274,22 +339,27 @@ void WaiterListManager::unregisterSharedArrayBuffer(uint8_t* arrayPtr, size_t si
             Ref<WaiterList> list = entry.value;
             Locker listLocker { list->lock };
             list->removeIf(listLocker, [&](Waiter* waiter) {
+                dataLogLnIf(WaiterListsManagerInternal::verbose,
+                    "<WaiterListManager> <Thread:", Thread::current(),
+                    "> unregister SAB is cancelling waiter=", *waiter,
+                    " in WaiterList for ptr ", RawPointer(entry.key));
+
                 // If the SharedArrayBuffer is about destructing, then no VM is
                 // referencing the buffer. That means no blocking SyncWaiter
                 // on the buffer for any VM.
                 ASSERT(waiter->isAsync());
-                // If the AsyncWaiter has valid timer, then let it
-                // timeout. Otherwise un-task it.
+                // If the AsyncWaiter has a valid timer, then let it timeout. Otherwise un-task it.
+                // See example, waitasync-timeout-finite-gc.js.
+                //
+                // OK, let's say if the ticket has a valid timer and its globalObject is about being
+                // destructed later but before the timeout. Then, we cannot cancel the timer from
+                // `unregister(JSGlobalObject* globalObject)` since the waiter is already removed
+                // from the lists by this code. So, should we keep it in the list? No, in either
+                // case, we have to remove it since all lists associating to the SAB (about destructing)
+                // must be removed. This is because there may be a new SAB with a waiter at the same address.
+                // Therefore, we will let clearObjectsForTicket to handle this special case.
                 if (!waiter->hasTimer(listLocker))
                     cancelAsyncWaiter(listLocker, waiter);
-
-                dataLogLnIf(WaiterListsManagerInternal::verbose,
-                    "WaiterListManager::unregisterSharedArrayBuffer ",
-                    (waiter->isAsync() ? " deleted AsyncWaiter " : " removed SyncWaiter "),
-                    RawPointer(waiter),
-                    " in WaiterList for ptr ",
-                    RawPointer(entry.key));
-
                 return true;
             });
 
@@ -315,6 +385,28 @@ RefPtr<WaiterList> WaiterListManager::findList(void* ptr)
     if (it == m_waiterLists.end())
         return nullptr;
     return it->value.ptr();
+}
+
+void Waiter::dump(PrintStream& out) const
+{
+    out.print("[this=");
+    out.print(RawPointer(this));
+    out.print(", vm=", RawPointer(m_vm));
+    out.print(", isAsync=", m_isAsync);
+    if (!m_isAsync) {
+        out.print("]");
+        return;
+    }
+
+    out.print(", ticket=", RawPointer(m_ticket));
+    if (m_ticket) {
+        out.print(", m_ticket->globalObject=", RawPointer(m_ticket->globalObject.get()));
+        out.print(", m_ticket->target=", RawPointer(jsCast<JSObject*>(m_ticket->dependencies.last().get())));
+        out.print(", m_ticket->scriptExecutionOwner=", RawPointer(m_ticket->scriptExecutionOwner.get()));
+    }
+
+    out.print(", m_timer=", RawPointer(m_timer.get()));
+    out.print("]");
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/WaiterListManager.h
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.h
@@ -41,18 +41,9 @@ class Waiter final : public WTF::BasicRawSentinelNode<Waiter>, public ThreadSafe
     WTF_MAKE_TZONE_ALLOCATED(Waiter);
 
 public:
-    Waiter(VM* vm)
-        : m_vm(vm)
-        , m_isAsync(false)
-    {
-    }
-
-    Waiter(JSPromise* promise)
-        : m_vm(&promise->vm())
-        , m_ticket(m_vm->deferredWorkTimer->addPendingWork(*m_vm, promise, { }))
-        , m_isAsync(true)
-    {
-    }
+    Waiter(VM*);
+    Waiter(JSPromise*);
+    ~Waiter();
 
     bool isAsync() const
     {
@@ -86,11 +77,7 @@ public:
         return m_ticket;
     }
 
-    DeferredWorkTimer::Ticket takeTicket(const AbstractLocker&)
-    {
-        ASSERT(m_isAsync);
-        return std::exchange(m_ticket, nullptr);
-    }
+    void scheduleWorkAndClearTicket(DeferredWorkTimer::Task&&);
 
     void setTimer(const AbstractLocker&, Ref<RunLoop::DispatchTimer>&& timer)
     {
@@ -110,9 +97,11 @@ public:
         if (!m_timer)
             return;
         m_timer->stop();
+        // This releases the strong reference to the Waiter in the timer.
         m_timer = nullptr;
     }
 
+    void dump(PrintStream&) const;
 private:
     VM* m_vm { nullptr };
     DeferredWorkTimer::Ticket m_ticket { nullptr };
@@ -224,9 +213,11 @@ public:
 
     size_t waiterListSize(void* ptr);
 
-    void unregisterVM(VM*);
+    size_t totalWaiterCount();
 
-    void unregisterSharedArrayBuffer(uint8_t* arrayPtr, size_t);
+    void unregister(VM*);
+    void unregister(JSGlobalObject*);
+    void unregister(uint8_t* arrayPtr, size_t);
 
 private:
     template <typename ValueType>

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
@@ -47,14 +47,14 @@ StreamingCompiler::StreamingCompiler(VM& vm, CompilerMode compilerMode, JSGlobal
     , m_info(Wasm::ModuleInformation::create())
     , m_parser(m_info.get(), *this)
 {
-    Vector<Strong<JSCell>> dependencies;
-    dependencies.append(Strong<JSCell>(vm, globalObject));
+    Vector<Weak<JSCell>> dependencies;
+    dependencies.append(Weak<JSCell>(globalObject));
     if (importObject)
-        dependencies.append(Strong<JSCell>(vm, importObject));
+        dependencies.append(Weak<JSCell>(importObject));
     m_ticket = vm.deferredWorkTimer->addPendingWork(vm, promise, WTFMove(dependencies));
     ASSERT(vm.deferredWorkTimer->hasPendingWork(m_ticket));
-    ASSERT(vm.deferredWorkTimer->hasDependancyInPendingWork(m_ticket, globalObject));
-    ASSERT(!importObject || vm.deferredWorkTimer->hasDependancyInPendingWork(m_ticket, importObject));
+    ASSERT(vm.deferredWorkTimer->hasDependencyInPendingWork(m_ticket, globalObject));
+    ASSERT(!importObject || vm.deferredWorkTimer->hasDependencyInPendingWork(m_ticket, importObject));
 }
 
 StreamingCompiler::~StreamingCompiler()

--- a/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
@@ -145,8 +145,8 @@ void JSWebAssembly::webAssemblyModuleValidateAsync(JSGlobalObject* globalObject,
 {
     VM& vm = globalObject->vm();
 
-    Vector<Strong<JSCell>> dependencies;
-    dependencies.append(Strong<JSCell>(vm, globalObject));
+    Vector<Weak<JSCell>> dependencies;
+    dependencies.append(Weak<JSCell>(globalObject));
 
     auto ticket = vm.deferredWorkTimer->addPendingWork(vm, promise, WTFMove(dependencies));
     Wasm::Module::validateAsync(vm, WTFMove(source), createSharedTask<Wasm::Module::CallbackType>([ticket, promise, globalObject, &vm] (Wasm::Module::ValidationResult&& result) mutable {
@@ -185,9 +185,9 @@ static void instantiate(VM& vm, JSGlobalObject* globalObject, JSPromise* promise
         return;
     }
 
-    Vector<Strong<JSCell>> dependencies;
+    Vector<Weak<JSCell>> dependencies;
     // The instance keeps the module alive.
-    dependencies.append(Strong<JSCell>(vm, promise));
+    dependencies.append(Weak<JSCell>(promise));
 
     scope.release();
     auto ticket = vm.deferredWorkTimer->addPendingWork(vm, instance, WTFMove(dependencies));
@@ -239,9 +239,10 @@ static void compileAndInstantiate(VM& vm, JSGlobalObject* globalObject, JSPromis
     }
 
     JSCell* moduleKeyCell = identifierToJSValue(vm, moduleKey).asCell();
-    Vector<Strong<JSCell>> dependencies;
-    dependencies.append(Strong<JSCell>(vm, importObject));
-    dependencies.append(Strong<JSCell>(vm, moduleKeyCell));
+    Vector<Weak<JSCell>> dependencies;
+    if (importObject)
+        dependencies.append(Weak<JSCell>(importObject));
+    dependencies.append(Weak<JSCell>(moduleKeyCell));
     auto ticket = vm.deferredWorkTimer->addPendingWork(vm, promise, WTFMove(dependencies));
     Wasm::Module::validateAsync(vm, WTFMove(source), createSharedTask<Wasm::Module::CallbackType>([ticket, promise, importObject, moduleKeyCell, globalObject, resolveKind, creationMode, &vm] (Wasm::Module::ValidationResult&& result) mutable {
         vm.deferredWorkTimer->scheduleWorkSoon(ticket, [promise, importObject, moduleKeyCell, globalObject, result = WTFMove(result), resolveKind, creationMode, &vm](DeferredWorkTimer::Ticket) mutable {


### PR DESCRIPTION
#### 1e4577ba8de434bc8942b01baf6b1d65ba967ab1
<pre>
[JSC] Fix Atomics.waitAsync by using weak references in JSC::DeferredWorkTimer
<a href="https://bugs.webkit.org/show_bug.cgi?id=272896">https://bugs.webkit.org/show_bug.cgi?id=272896</a>
<a href="https://rdar.apple.com/126690921">rdar://126690921</a>

Reviewed by Yusuke Suzuki.

Previously, we introduced JSC::DeferredWorkTimer by keeping the task related
dependencies and environment alive with strong references. This works fine
until Atomics.waitAsync is introduced. Consider a scenario that an Atomics.waitAsync
registered in the main thread with infinity timeout is never be resolved in the
runtime. At some point, the corresponding JSGlobalObject is no longer needed.
But the JSGlobalObject cannot be collected due to the previous registered
Atomics.waitAsync&apos;s JSPromise is strongly referenced and queued in the
DeferredWorkTimer.

To fix this issue, we can transfer the liveness responsibility from the
DeferredWorkTimer::TicketData to the target&apos;s JSGlobalObject. And this is
how it works. Given the graph as shown below:

            VM &lt;----------------------------
            ^                              |
            |                              |
        JSGlobalObject_0      ----&gt; JSGlobalObject_n -----
            ^                 |            ^             |
            |                 |            |             |
SharedArrayBufferContents -----            | S           | S
            ^                              |             |
            |                       W      |             |
            Waiter ----&gt; TicketData -----&gt; Target &lt;------|
                            |                            |
                            |  W                         |
                            ------&gt; Dependencies &lt;--------

1. The JSGlobalObject_0 and JSGlobalObject_n may or may not be the same object,
   which is dependent on the VM.
2. The SharedArrayBufferContents is dependent on the multiple JSGlobalObjects.
3. The Waiter is dependent on the SharedArrayBufferContents.
4. The Waiter has a TicketData used to schedule a task to DeferredWorkTimer.
5. The TicketData replies on a Target and its corresponding Dependencies to complete the task.
6. The TicketData has weak references to the Target and Dependencies.
7. The Target&apos;s JSGlobalObject_n holds the strong references to the Target and Dependencies.

Then, we should do:
A. If JSGlobalObject_n is alive, then it should clear those strong references once the
   Waiter done the task.
B. If JSGlobalObject_n is dead, then it should clear the corresponding waiters first and
   then clear the other TicketDatas associating to it.

If no others are referencing JSGlobalObject_n and Target, GC would consider the strong reference
cycle in Target -&gt; JSGlobalObject_n -&gt; Target as dead status. Then, they are available
for recycling.

* Source/JavaScriptCore/heap/WeakInlines.h:
(JSC::operator==):
* Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp:
(JSC::DeferredWorkTimer::TicketData::TicketData):
(JSC::DeferredWorkTimer::addPendingWork):
* Source/JavaScriptCore/runtime/DeferredWorkTimer.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::visitChildrenImpl):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::addObjectsForDeferredTaskTimer):
* Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp:
(JSC::Wasm::StreamingCompiler::StreamingCompiler):
* Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp:
(JSC::JSWebAssembly::webAssemblyModuleValidateAsync):
(JSC::instantiate):
(JSC::compileAndInstantiate):

Canonical link: <a href="https://commits.webkit.org/279852@main">https://commits.webkit.org/279852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9209306fc8ffc8a97dd1d13654ed6dccf8735dad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57979 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5432 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41672 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5442 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44308 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3669 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56795 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32260 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47384 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25432 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29053 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4720 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3572 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/48065 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50788 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4933 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59569 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/54205 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29943 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5080 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51731 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31086 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47469 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51121 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12000 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32079 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/66502 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30872 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12674 "Passed tests") | 
<!--EWS-Status-Bubble-End-->