### PR TITLE
WebGLProgram::isUsingVertexAttrib0 is unused

### DIFF
--- a/Source/WebCore/html/canvas/WebGLProgram.cpp
+++ b/Source/WebCore/html/canvas/WebGLProgram.cpp
@@ -110,30 +110,6 @@ void WebGLProgram::deleteObjectImpl(const AbstractLocker& locker, GraphicsContex
     }
 }
 
-unsigned WebGLProgram::numActiveAttribLocations()
-{
-    cacheInfoIfNeeded();
-    return m_activeAttribLocations.size();
-}
-
-GCGLint WebGLProgram::getActiveAttribLocation(GCGLuint index)
-{
-    cacheInfoIfNeeded();
-    if (index >= numActiveAttribLocations())
-        return -1;
-    return m_activeAttribLocations[index];
-}
-
-bool WebGLProgram::isUsingVertexAttrib0()
-{
-    cacheInfoIfNeeded();
-    for (unsigned ii = 0; ii < numActiveAttribLocations(); ++ii) {
-        if (!getActiveAttribLocation(ii))
-            return true;
-    }
-    return false;
-}
-
 bool WebGLProgram::getLinkStatus()
 {
     cacheInfoIfNeeded();
@@ -204,19 +180,6 @@ void WebGLProgram::addMembersToOpaqueRoots(const AbstractLocker&, JSC::AbstractS
     addWebCoreOpaqueRoot(visitor, m_fragmentShader.get());
 }
 
-void WebGLProgram::cacheActiveAttribLocations(GraphicsContextGL* context3d)
-{
-    m_activeAttribLocations.clear();
-
-    GCGLint numAttribs = context3d->getProgrami(object(), GraphicsContextGL::ACTIVE_ATTRIBUTES);
-    m_activeAttribLocations.resize(static_cast<size_t>(numAttribs));
-    for (int i = 0; i < numAttribs; ++i) {
-        GraphicsContextGLActiveInfo info;
-        context3d->getActiveAttrib(object(), i, info);
-        m_activeAttribLocations[i] = context3d->getAttribLocation(object(), info.name);
-    }
-}
-
 void WebGLProgram::cacheInfoIfNeeded()
 {
     if (m_infoValid)
@@ -231,7 +194,6 @@ void WebGLProgram::cacheInfoIfNeeded()
     GCGLint linkStatus = context->getProgrami(object(), GraphicsContextGL::LINK_STATUS);
     m_linkStatus = linkStatus;
     if (m_linkStatus) {
-        cacheActiveAttribLocations(context.get());
         m_requiredTransformFeedbackBufferCount = m_requiredTransformFeedbackBufferCountAfterNextLink;
     }
     m_infoValid = true;

--- a/Source/WebCore/html/canvas/WebGLProgram.h
+++ b/Source/WebCore/html/canvas/WebGLProgram.h
@@ -58,11 +58,6 @@ public:
 
     void contextDestroyed() final;
 
-    unsigned numActiveAttribLocations();
-    GCGLint getActiveAttribLocation(GCGLuint index);
-
-    bool isUsingVertexAttrib0();
-
     bool getLinkStatus();
 
     unsigned getLinkCount() const { return m_linkCount; }
@@ -97,12 +92,9 @@ private:
 
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) override;
 
-    void cacheActiveAttribLocations(GraphicsContextGL*);
     void cacheInfoIfNeeded();
 
     static Lock s_instancesLock;
-
-    Vector<GCGLint> m_activeAttribLocations;
 
     GCGLint m_linkStatus { 0 };
 


### PR DESCRIPTION
#### 195db9947d9f6e4b26b1c636f15480c5a1694672
<pre>
WebGLProgram::isUsingVertexAttrib0 is unused
<a href="https://bugs.webkit.org/show_bug.cgi?id=274774">https://bugs.webkit.org/show_bug.cgi?id=274774</a>

Reviewed by Kimmo Kinnunen.

Removed unused code.

* Source/WebCore/html/canvas/WebGLProgram.cpp:
(WebCore::WebGLProgram::cacheInfoIfNeeded):
(WebCore::WebGLProgram::numActiveAttribLocations): Deleted.
(WebCore::WebGLProgram::getActiveAttribLocation): Deleted.
(WebCore::WebGLProgram::isUsingVertexAttrib0): Deleted.
(WebCore::WebGLProgram::cacheActiveAttribLocations): Deleted.
* Source/WebCore/html/canvas/WebGLProgram.h:

Canonical link: <a href="https://commits.webkit.org/279583@main">https://commits.webkit.org/279583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cb9fef7bec4da83440d1c6153034100fb1b54a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57128 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4573 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56154 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40715 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4441 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43605 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3001 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31433 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46583 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24745 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28254 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3894 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2728 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4086 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58723 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4150 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51018 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30212 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46726 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50355 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11740 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31148 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29991 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->