### PR TITLE
Allow to easily convert IPC NativePromises

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1807,16 +1807,15 @@ void NetworkStorageManager::cacheStoragePutRecords(WebCore::DOMCacheIdentifier c
     cache->putRecords(WTFMove(records), WTFMove(callback));
 }
 
-void NetworkStorageManager::cacheStorageClearMemoryRepresentation(const WebCore::ClientOrigin& origin, CompletionHandler<void(std::optional<WebCore::DOMCacheEngine::Error>&&)>&& callback)
+void NetworkStorageManager::cacheStorageClearMemoryRepresentation(const WebCore::ClientOrigin& origin, CompletionHandler<void()>&& callback)
 {
     assertIsCurrent(workQueue());
 
     auto iterator = m_originStorageManagers.find(origin);
-    if (iterator == m_originStorageManagers.end())
-        return callback(std::nullopt);
+    if (iterator != m_originStorageManagers.end())
+        iterator->value->closeCacheStorageManager();
 
-    iterator->value->closeCacheStorageManager();
-    callback(std::nullopt);
+    callback();
 }
 
 void NetworkStorageManager::cacheStorageRepresentation(CompletionHandler<void(String&&)>&& callback)

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -224,7 +224,7 @@ private:
     void cacheStorageRetrieveRecords(WebCore::DOMCacheIdentifier, WebCore::RetrieveRecordsOptions&&, WebCore::DOMCacheEngine::CrossThreadRecordsCallback&&);
     void cacheStorageRemoveRecords(WebCore::DOMCacheIdentifier, WebCore::ResourceRequest&&, WebCore::CacheQueryOptions&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
     void cacheStoragePutRecords(WebCore::DOMCacheIdentifier, Vector<WebCore::DOMCacheEngine::CrossThreadRecord>&&, WebCore::DOMCacheEngine::RecordIdentifiersCallback&&);
-    void cacheStorageClearMemoryRepresentation(const WebCore::ClientOrigin&, CompletionHandler<void(std::optional<WebCore::DOMCacheEngine::Error>&&)>&&);
+    void cacheStorageClearMemoryRepresentation(const WebCore::ClientOrigin&, CompletionHandler<void()>&&);
     void cacheStorageRepresentation(CompletionHandler<void(String&&)>&&);
 
     void cloneSessionStorageNamespace(StorageNamespaceIdentifier, StorageNamespaceIdentifier);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -87,7 +87,7 @@
     CacheStorageRetrieveRecords(WebCore::DOMCacheIdentifier cacheIdentifier, struct WebCore::RetrieveRecordsOptions options) -> (WebCore::DOMCacheEngine::CrossThreadRecordsOrError result)
     CacheStorageRemoveRecords(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::ResourceRequest request, struct WebCore::CacheQueryOptions options) -> (WebCore::DOMCacheEngine::RecordIdentifiersOrError result)
     CacheStoragePutRecords(WebCore::DOMCacheIdentifier cacheIdentifier, Vector<WebCore::DOMCacheEngine::CrossThreadRecord> records) -> (WebCore::DOMCacheEngine::RecordIdentifiersOrError result)
-    CacheStorageClearMemoryRepresentation(struct WebCore::ClientOrigin origin) -> (std::optional<WebCore::DOMCacheEngine::Error> error)
+    CacheStorageClearMemoryRepresentation(struct WebCore::ClientOrigin origin) -> ()
     CacheStorageRepresentation() -> (String representation)
 
     ResetQuotaUpdatedBasedOnUsageForTesting(struct WebCore::ClientOrigin origin)

--- a/Source/WebKit/Platform/IPC/MessageSenderInlines.h
+++ b/Source/WebKit/Platform/IPC/MessageSenderInlines.h
@@ -172,7 +172,7 @@ template<typename MessageType> Ref<typename MessageType::Promise> inline Message
 {
     static_assert(!MessageType::isSync);
     if (RefPtr connection = messageSenderConnection())
-        return connection->sendWithPromisedReply(std::forward<MessageType>(message), destinationID, options);
+        return connection->sendWithPromisedReply<MessageType>(std::forward<MessageType>(message), destinationID, options);
     return MessageType::Promise::createAndReject(Error::NoMessageSenderConnection);
 }
 

--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h
@@ -52,6 +52,8 @@ public:
 private:
     explicit WebCacheStorageConnection(WebCacheStorageProvider&);
 
+    template<typename P> struct PromiseConverter;
+
     IPC::Connection& connection();
 
     // WebCore::CacheStorageConnection

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -684,7 +684,7 @@ template<typename Frame> int32_t LibWebRTCCodecs::encodeFrameInternal(Encoder& e
         return WEBRTC_VIDEO_CODEC_ERROR;
 
     SharedVideoFrame sharedVideoFrame { mediaTime, false, rotation, WTFMove(*buffer) };
-    encoder.connection->sendWithPromisedReply(Messages::LibWebRTCCodecsProxy::EncodeFrame { encoder.identifier, WTFMove(sharedVideoFrame), timestamp, duration, shouldEncodeAsKeyFrame }, 0)->whenSettled(workQueue(), [callback = WTFMove(callback)] (auto&& result) mutable {
+    encoder.connection->sendWithPromisedReply<Messages::LibWebRTCCodecsProxy::EncodeFrame>({ encoder.identifier, WTFMove(sharedVideoFrame), timestamp, duration, shouldEncodeAsKeyFrame })->whenSettled(workQueue(), [callback = WTFMove(callback)] (auto&& result) mutable {
         callback(result ? result.value() : false);
     });
     return WEBRTC_VIDEO_CODEC_OK;
@@ -709,7 +709,7 @@ void LibWebRTCCodecs::flushEncoder(Encoder& encoder, Function<void()>&& callback
         return;
     }
 
-    connection->sendWithPromisedReply(Messages::LibWebRTCCodecsProxy::FlushEncoder { encoder.identifier })->whenSettled(workQueue(), WTFMove(callback));
+    connection->sendWithPromisedReply<Messages::LibWebRTCCodecsProxy::FlushEncoder>(encoder.identifier)->whenSettled(workQueue(), WTFMove(callback));
 }
 
 void LibWebRTCCodecs::registerEncodeFrameCallback(Encoder& encoder, void* encodedImageCallback)

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h
@@ -91,6 +91,8 @@ public:
     void updateConnection();
 
 private:
+    template<typename P> struct PromiseConverter;
+
     WebCore::RealtimeMediaSourceIdentifier m_identifier;
     Ref<IPC::Connection> m_connection;
     WebCore::CaptureDevice m_device;

--- a/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
@@ -639,7 +639,7 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendWithPromisedReply)
     dispatchAndWait(runLoop, [&] {
         ASSERT_TRUE(openB());
         for (uint64_t i = 100u; i < 160u; ++i) {
-            b()->sendWithPromisedReply(MockTestMessageWithAsyncReply1 { }, i)->then(runLoop,
+            b()->sendWithPromisedReply<MockTestMessageWithAsyncReply1>({ }, i)->then(runLoop,
                 [&, j = i] (uint64_t value) {
                     if (!value)
                         WTFLogAlways("GOT: %llu", j);
@@ -658,6 +658,37 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendWithPromisedReply)
 
     for (uint64_t i = 100u; i < 160u; ++i)
         EXPECT_TRUE(replies.contains(i));
+    localReferenceBarrier();
+}
+
+struct PromiseConverter {
+    using Promise = NativePromise<String, uint64_t>;
+    static typename Promise::Result convertResult(uint64_t result) { return { "1"_s }; }
+    static typename Promise::RejectValueType convertError(IPC::Error error) { return 2; }
+};
+
+TEST_P(ConnectionRunLoopTest, SendWithConvertedPromisedReply)
+{
+    ASSERT_TRUE(openA());
+    aClient().setAsyncMessageHandler([&] (IPC::Decoder& decoder) -> bool {
+        auto listenerID = decoder.decode<uint64_t>();
+        auto encoder = makeUniqueRef<IPC::Encoder>(MockTestMessageWithAsyncReply1::asyncMessageReplyName(), *listenerID);
+        encoder.get() << decoder.destinationID();
+        a()->sendSyncReply(WTFMove(encoder));
+        return true;
+    });
+    HashSet<uint64_t> replies;
+
+    auto runLoop = createRunLoop(RUN_LOOP_NAME);
+    dispatchAndWait(runLoop, [&] {
+        ASSERT_TRUE(openB());
+        b()->sendWithPromisedReply<MockTestMessageWithAsyncReply1, PromiseConverter>({ }, 1)->then(runLoop, [] (String&& value) {
+            EXPECT_EQ(value, "1"_s);
+        }, [] (uint64_t error) {
+            EXPECT_EQ(error, 2u);
+        });
+    });
+
     localReferenceBarrier();
 }
 
@@ -680,7 +711,7 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendWithPromisedReplyOnDispatcher)
         dispatchAndWait(runLoop, [&] {
             ASSERT_TRUE(openB());
             for (uint64_t i = 100u; i < 160u; ++i) {
-                b()->sendWithPromisedReply(MockTestMessageWithAsyncReply1 { }, i)->whenSettled(awq.queue(), [&, j = i] (auto&& result) {
+                b()->sendWithPromisedReply<MockTestMessageWithAsyncReply1>({ }, i)->whenSettled(awq.queue(), [&, j = i] (auto&& result) {
                     EXPECT_TRUE(result);
                     auto value = *result;
                     if (!value)
@@ -719,7 +750,7 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendWithPromisedReplyOnMixAndMatchDispatche
         dispatchAndWait(runLoop, [&] {
             ASSERT_TRUE(openB());
             for (uint64_t i = 100u; i < 160u; ++i) {
-                b()->sendWithPromisedReply(MockTestMessageWithAsyncReply1 { }, i)->whenSettled(runLoop, [&, j = i] (auto&& result) {
+                b()->sendWithPromisedReply<MockTestMessageWithAsyncReply1>({ }, i)->whenSettled(runLoop, [&, j = i] (auto&& result) {
                     EXPECT_TRUE(result);
                     auto value = *result;
                     if (!value)
@@ -889,7 +920,7 @@ TEST_P(ConnectionRunLoopTest, RunLoopSendWithPromisedReplyOrder)
         ASSERT_TRUE(openB());
         for (uint64_t i = 0; i < counter; ++i) {
             if (!(i % 2)) {
-                b()->sendWithPromisedReply(MockTestMessageWithAsyncReply1 { }, 100)->whenSettled(runLoop, [&, i] (Promise::Result result) {
+                b()->sendWithPromisedReply<MockTestMessageWithAsyncReply1>({ }, 100)->whenSettled(runLoop, [&, i] (Promise::Result result) {
                     EXPECT_TRUE(result.has_value());
                     EXPECT_EQ(result.value(), i);
                     replies.append(i);

--- a/Tools/TestWebKitAPI/Tests/IPC/MessageSenderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/MessageSenderTests.cpp
@@ -99,7 +99,7 @@ TEST_P(MessageSenderTest, SendWithPromisedReplyAfterInvalidateCancelsAllAsyncRep
     // This works for IPC::Connection.
     bool done = false;
 
-    b()->sendWithPromisedReply(MockTestMessageWithAsyncReply1 { }, 100)->whenSettled(RunLoop::current(), [&] (MockTestMessageWithAsyncReply1::Promise::Result result) {
+    b()->sendWithPromisedReply<MockTestMessageWithAsyncReply1>({ }, 100)->whenSettled(RunLoop::current(), [&] (MockTestMessageWithAsyncReply1::Promise::Result result) {
         EXPECT_FALSE(result.has_value());
         EXPECT_EQ(result.error(), IPC::Error::InvalidConnection);
         done = true;
@@ -112,7 +112,7 @@ TEST_P(MessageSenderTest, SendWithPromisedReplyAfterInvalidateCancelsAllAsyncRep
     done = false;
     SimpleMessageSender sender { b() };
 
-    sender.sendWithPromisedReply(MockTestMessageWithAsyncReply1 { }, 100)->whenSettled(RunLoop::current(), [&] (MockTestMessageWithAsyncReply1::Promise::Result result) {
+    sender.sendWithPromisedReply<MockTestMessageWithAsyncReply1>({ }, 100)->whenSettled(RunLoop::current(), [&] (MockTestMessageWithAsyncReply1::Promise::Result result) {
         EXPECT_FALSE(result.has_value());
         EXPECT_EQ(result.error(), IPC::Error::InvalidConnection);
         done = true;
@@ -141,7 +141,7 @@ TEST_P(MessageSenderTest, SendAsyncWithErrorAsynchronousCallback)
         RunLoop::current().cycle();
 
     done = false;
-    b()->sendWithPromisedReply(MockTestMessageWithAsyncReply1 { }, 100)->whenSettled(RunLoop::current(), [&] (MockTestMessageWithAsyncReply1::Promise::Result result) {
+    b()->sendWithPromisedReply<MockTestMessageWithAsyncReply1>({ }, 100)->whenSettled(RunLoop::current(), [&] (MockTestMessageWithAsyncReply1::Promise::Result result) {
         EXPECT_FALSE(result.has_value());
         EXPECT_EQ(result.error(), IPC::Error::InvalidConnection);
         done = true;


### PR DESCRIPTION
#### b88d5c1970f976abeb9fe6d74e0433a922613818
<pre>
Allow to easily convert IPC NativePromises
<a href="https://bugs.webkit.org/show_bug.cgi?id=274957">https://bugs.webkit.org/show_bug.cgi?id=274957</a>
<a href="https://rdar.apple.com/129054558">rdar://129054558</a>

Reviewed by Jean-Yves Avenard.

We sometimes use NativePromise in WebCore code and end up creating IPC NativePromises.
But the types between the two may not always match, for instance due to the handling of IPC::Error.
We used to use settle to adapt but it is more convenient to be able to convert directly before resolving/rejecting the promise.

We use this in WebCacheStorageConnection that has Promises defined in WebCore::CacheStorageConnection.
We use this for RemoteRealtimeMediaSourceProxy which has promises defined in WebCore::RemoteRealtimeMediaSource.

We update NetworkStorageManager::cacheStorageClearMemoryRepresentation as it is not returning any error.
We use a void completion handler instead.

* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::cacheStorageClearMemoryRepresentation):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in:
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::PromiseConverter::convertResult):
(IPC::Connection::PromiseConverter::convertError):
(IPC::Connection::sendWithPromisedReply):
(IPC::Connection::makeAsyncReplyHandlerWithDispatcher):
* Source/WebKit/Platform/IPC/MessageSenderInlines.h:
(IPC::MessageSender::sendWithPromisedReply):
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp:
(WebKit::WebCacheStorageConnection::PromiseConverter::convertResult):
(WebKit::WebCacheStorageConnection::PromiseConverter::convertError):
(WebKit::WebCacheStorageConnection::open):
(WebKit::WebCacheStorageConnection::remove):
(WebKit::WebCacheStorageConnection::retrieveCaches):
(WebKit::WebCacheStorageConnection::retrieveRecords):
(WebKit::WebCacheStorageConnection::batchDeleteOperation):
(WebKit::WebCacheStorageConnection::batchPutOperation):
(WebKit::WebCacheStorageConnection::clearMemoryRepresentation):
(WebKit::WebCacheStorageConnection::engineRepresentation):
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::encodeFrameInternal):
(WebKit::LibWebRTCCodecs::flushEncoder):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp:
(WebKit::RemoteRealtimeMediaSourceProxy::PromiseConverter::convertResult):
(WebKit::RemoteRealtimeMediaSourceProxy::PromiseConverter::convertError):
(WebKit::RemoteRealtimeMediaSourceProxy::takePhoto):
(WebKit::RemoteRealtimeMediaSourceProxy::getPhotoCapabilities):
(WebKit::RemoteRealtimeMediaSourceProxy::getPhotoSettings):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h:
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::TEST_P):
* Tools/TestWebKitAPI/Tests/IPC/MessageSenderTests.cpp:
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/279647@main">https://commits.webkit.org/279647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d023034a6bc627f272963948f86f1ec01a86d1c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6612 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57354 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4803 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56382 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4696 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43792 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3189 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56175 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31693 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46814 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24934 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28511 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4130 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2952 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50216 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4333 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58948 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29271 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4434 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/51208 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30449 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50571 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11785 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31412 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30231 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->