### PR TITLE
Avoid GraphicsContext calls during GlyphDisplayListCache shared entry lookup

### DIFF
--- a/Source/WebCore/rendering/GlyphDisplayListCache.cpp
+++ b/Source/WebCore/rendering/GlyphDisplayListCache.cpp
@@ -36,14 +36,23 @@
 namespace WebCore {
 
 struct GlyphDisplayListCacheKey {
+    GlyphDisplayListCacheKey(const TextRun& textRun, const FontCascade& font, const GraphicsContext& context)
+        : textRun(textRun)
+        , scaleFactor(context.scaleFactor())
+        , fontCascadeGeneration(font.generation())
+        , shouldSubpixelQuantizeFonts(context.shouldSubpixelQuantizeFonts())
+    {
+    }
+
     const TextRun& textRun;
-    const FontCascade& font;
-    GraphicsContext& context;
+    const FloatSize scaleFactor;
+    const unsigned fontCascadeGeneration;
+    const bool shouldSubpixelQuantizeFonts;
 };
 
 static void add(Hasher& hasher, const GlyphDisplayListCacheKey& key)
 {
-    add(hasher, key.textRun, key.context.scaleFactor().width(), key.context.scaleFactor().height(), key.font.generation(), key.context.shouldSubpixelQuantizeFonts());
+    add(hasher, key.textRun, key.scaleFactor.width(), key.scaleFactor.height(), key.fontCascadeGeneration, key.shouldSubpixelQuantizeFonts);
 }
 
 struct GlyphDisplayListCacheKeyTranslator {
@@ -56,9 +65,9 @@ struct GlyphDisplayListCacheKeyTranslator {
     {
         auto& entry = entryRef.get();
         return entry.m_textRun == key.textRun
-            && entry.m_scaleFactor == key.context.scaleFactor()
-            && entry.m_fontCascadeGeneration == key.font.generation()
-            && entry.m_shouldSubpixelQuantizeFont == key.context.shouldSubpixelQuantizeFonts();
+            && entry.m_scaleFactor == key.scaleFactor
+            && entry.m_fontCascadeGeneration == key.fontCascadeGeneration
+            && entry.m_shouldSubpixelQuantizeFont == key.shouldSubpixelQuantizeFonts;
     }
 };
 


### PR DESCRIPTION
#### c803b13eb47867ac7ff9deeb129b900c14cf15d8
<pre>
Avoid GraphicsContext calls during GlyphDisplayListCache shared entry lookup
<a href="https://bugs.webkit.org/show_bug.cgi?id=274958">https://bugs.webkit.org/show_bug.cgi?id=274958</a>
<a href="https://rdar.apple.com/129056751">rdar://129056751</a>

Reviewed by Simon Fraser.

Obtain the values needed for translation lookup key before lookup begins.

* Source/WebCore/rendering/GlyphDisplayListCache.cpp:
(WebCore::GlyphDisplayListCacheKey::GlyphDisplayListCacheKey):
(WebCore::add):
(WebCore::GlyphDisplayListCacheKeyTranslator::equal):

Canonical link: <a href="https://commits.webkit.org/279582@main">https://commits.webkit.org/279582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/055b3e7b1021817682b4a8a7d49a9a1a0de17b5e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33223 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57133 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4578 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56159 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4449 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43608 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3006 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55953 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31429 "Found 3 new test failures: animations/3d/change-transform-in-end-event.html, compositing/repaint/content-into-overflow.html, compositing/rtl/rtl-overflow-scrolling.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46588 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24748 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28259 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3899 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2733 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4091 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58728 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29025 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4162 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51020 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30217 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46731 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50357 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11737 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31153 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29996 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->