### PR TITLE
[WPE GTK Debug] API test `TestWebCore.MIMETypeRegistry.ExtensionsForMIMEType` is a constant crash

### DIFF
--- a/Source/WebCore/platform/xdg/MIMETypeRegistryXdg.cpp
+++ b/Source/WebCore/platform/xdg/MIMETypeRegistryXdg.cpp
@@ -29,6 +29,7 @@
 #define XDG_PREFIX _wk_xdg
 #include "xdgmime.h"
 
+#define MAX_EXTENSION_COUNT 10
 namespace WebCore {
 
 String MIMETypeRegistry::mimeTypeForExtension(StringView string)
@@ -69,10 +70,19 @@ String MIMETypeRegistry::preferredExtensionForMIMEType(const String& mimeType)
     return returnValue;
 }
 
-Vector<String> MIMETypeRegistry::extensionsForMIMEType(const String&)
+Vector<String> MIMETypeRegistry::extensionsForMIMEType(const String& mimeType)
 {
-    ASSERT_NOT_IMPLEMENTED_YET();
-    return { };
+    if (mimeType.isEmpty())
+        return { };
+
+    Vector<String> returnValue;
+    char* extensions[MAX_EXTENSION_COUNT];
+    int n = xdg_mime_get_simple_globs(mimeType.utf8().data(), extensions, MAX_EXTENSION_COUNT);
+    for (int i = 0; i < n; ++i) {
+        returnValue.append(String::fromUTF8(extensions[i]));
+        free(extensions[i]);
+    }
+    return returnValue;
 }
 
 }


### PR DESCRIPTION
#### 1748da27016550439ffc0c2027dc9e92938668e0
<pre>
[WPE GTK Debug] API test `TestWebCore.MIMETypeRegistry.ExtensionsForMIMEType` is a constant crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=274959">https://bugs.webkit.org/show_bug.cgi?id=274959</a>

Reviewed by Carlos Garcia Campos.

This patch implements `MIMETypeRegistry::extensionsForMIMEType`
on Linux by using `xdg_mime_get_simple_globs()`.

* Source/WebCore/platform/xdg/MIMETypeRegistryXdg.cpp:
(WebCore::MIMETypeRegistry::extensionsForMIMEType):

Canonical link: <a href="https://commits.webkit.org/279575@main">https://commits.webkit.org/279575@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ef8e0fb1d4c7acec27e13e71ec576aa406fac7f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33224 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57134 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4579 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40722 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4450 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43609 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3007 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55954 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31431 "Found 1 new test failure: compositing/overflow/image-load-overflow-scrollbars.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46589 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24749 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/28261 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3900 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2734 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/49952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4102 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58729 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29026 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4158 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51021 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30218 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46732 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50358 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11727 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31154 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/29997 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->