### PR TITLE
Avoid extra lookup for text runs in GlyphDisplayListCache

### DIFF
--- a/Source/WebCore/rendering/GlyphDisplayListCache.cpp
+++ b/Source/WebCore/rendering/GlyphDisplayListCache.cpp
@@ -80,7 +80,6 @@ GlyphDisplayListCache& GlyphDisplayListCache::singleton()
 void GlyphDisplayListCache::clear()
 {
     m_entriesForLayoutRun.clear();
-    m_entriesForFrequentlyPaintedLayoutRun.clear();
     m_entries.clear();
 }
 
@@ -118,10 +117,7 @@ DisplayList::DisplayList* GlyphDisplayListCache::getDisplayList(const LayoutRun&
         Ref entry { iterator->get() };
         auto* result = &entry->displayList();
         const_cast<LayoutRun&>(run).setIsInGlyphDisplayListCache();
-        if (isFrequentlyPainted)
-            m_entriesForFrequentlyPaintedLayoutRun.add(&run, WTFMove(entry));
-        else
-            m_entriesForLayoutRun.add(&run, WTFMove(entry));
+        m_entriesForLayoutRun.add(&run, WTFMove(entry));
         return result;
     }
 
@@ -131,10 +127,7 @@ DisplayList::DisplayList* GlyphDisplayListCache::getDisplayList(const LayoutRun&
         if (canShareDisplayList(*result))
             m_entries.add(entry.get());
         const_cast<LayoutRun&>(run).setIsInGlyphDisplayListCache();
-        if (isFrequentlyPainted)
-            m_entriesForFrequentlyPaintedLayoutRun.add(&run, WTFMove(entry));
-        else
-            m_entriesForLayoutRun.add(&run, WTFMove(entry));
+        m_entriesForLayoutRun.add(&run, WTFMove(entry));
         return result;
     }
 
@@ -158,8 +151,6 @@ DisplayList::DisplayList* GlyphDisplayListCache::getIfExistsImpl(const LayoutRun
         return nullptr;
     if (auto entry = m_entriesForLayoutRun.get(&run))
         return &entry->displayList();
-    if (auto entry = m_entriesForFrequentlyPaintedLayoutRun.get(&run))
-        return &entry->displayList();
     return nullptr;
 }
 
@@ -176,7 +167,6 @@ DisplayList::DisplayList* GlyphDisplayListCache::getIfExists(const InlineDisplay
 void GlyphDisplayListCache::remove(const void* run)
 {
     m_entriesForLayoutRun.remove(run);
-    m_entriesForFrequentlyPaintedLayoutRun.remove(run);
 }
 
 bool GlyphDisplayListCache::canShareDisplayList(const DisplayList::DisplayList& displayList)

--- a/Source/WebCore/rendering/GlyphDisplayListCache.h
+++ b/Source/WebCore/rendering/GlyphDisplayListCache.h
@@ -132,7 +132,6 @@ private:
     void remove(const void* run);
 
     HashMap<const void*, Ref<GlyphDisplayListCacheEntry>> m_entriesForLayoutRun;
-    HashMap<const void*, Ref<GlyphDisplayListCacheEntry>> m_entriesForFrequentlyPaintedLayoutRun;
     HashSet<SingleThreadWeakRef<GlyphDisplayListCacheEntry>> m_entries;
     bool m_forceUseGlyphDisplayListForTesting { false };
 };


### PR DESCRIPTION
#### 0a66846d340160d3277d39f5f24b7d91bb92845d
<pre>
Avoid extra lookup for text runs in GlyphDisplayListCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=274960">https://bugs.webkit.org/show_bug.cgi?id=274960</a>
<a href="https://rdar.apple.com/129057676">rdar://129057676</a>

Reviewed by Simon Fraser.

Simplify glyph cache by removing extra hash map separating frequently
painted text runs and infrequently painted text runs.

Limits before:
- Frequent: unlimited
- Infrequent: 2048

Limits after:
- Frequent: unlimited
- Infrequent: 2048 - count of frequent

Avoids extra hash lookup per query.
Avoids extra hash lookup per removal.

* Source/WebCore/rendering/GlyphDisplayListCache.cpp:
(WebCore::GlyphDisplayListCache::clear):
(WebCore::GlyphDisplayListCache::getDisplayList):
(WebCore::GlyphDisplayListCache::getIfExistsImpl):
(WebCore::GlyphDisplayListCache::remove):
* Source/WebCore/rendering/GlyphDisplayListCache.h:

Canonical link: <a href="https://commits.webkit.org/279641@main">https://commits.webkit.org/279641@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18dbc6613246ac603d9ac4ae84ddd97ebaf116cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53862 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6385 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57141 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4585 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56166 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40733 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43612 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3012 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31466 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46592 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24752 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28269 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3903 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2740 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49957 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58735 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29033 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4200 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51024 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30226 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46735 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50361 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11781 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31162 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30003 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->