### PR TITLE
Request attachment icon again if needed

### DIFF
--- a/LayoutTests/fast/attachment/attachment-icon-update-after-type-change-expected.html
+++ b/LayoutTests/fast/attachment/attachment-icon-update-after-type-change-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
+<html class="reftest-wait">
+<body>
+<attachment title=" " type="image/jpeg"></attachment>
+<script src="resources/attachment-test-utils.js"></script>
+<script>
+takeExpectedScreenshotWhenAttachmentsSettled();
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/attachment/attachment-icon-update-after-type-change.html
+++ b/LayoutTests/fast/attachment/attachment-icon-update-after-type-change.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true ] -->
+<html class="reftest-wait">
+<body>
+<attachment title=" " type="text/plain"></attachment>
+<script src="resources/attachment-test-utils.js"></script>
+<script>
+(() => {
+    const attachments = [...document.getElementsByTagName("attachment")];
+    console.assert(attachments.length == 1);
+    if (attachments.length != 1)
+        return takeScreenshot();
+    let attachment = attachments[0];
+
+    let events = [];
+
+    let timeoutId;
+
+    const onFailure = () => {
+        clearTimeout(timeoutId);
+        attachment.insertAdjacentText("afterend", "<- (actual) events = [" + events.join() + "]");
+        takeScreenshot();
+    };
+
+    timeoutId = setTimeout(() => { events.push("timeout"); onFailure(); }, 5000);
+
+    for (const event of ["beforeload", "loadingerror", "loadeddata", "error", "load"])
+        attachment.addEventListener(event, () => { events.push(event); });
+
+    attachment.addEventListener("loadingerror", () => {
+        events.push("loadingerror");
+        onFailure();
+    }, { once: true });
+
+    let loadState = 0;
+    attachment.addEventListener("load", () => {
+        if (loadState == 0) {
+            loadState = 1;
+            requestAnimationFrame(() => requestAnimationFrame(() => {
+                loadState = 2;
+                attachment.setAttribute("type", "image/jpeg");
+            }));
+        } else if (loadState == 2) {
+            requestAnimationFrame(() => requestAnimationFrame(takeScreenshot));
+        }
+    });
+})();
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/attachment/resources/attachment-test-utils.js
+++ b/LayoutTests/fast/attachment/resources/attachment-test-utils.js
@@ -1,24 +1,28 @@
-function takeScreenshotWhenAttachmentsSettled() {
+function takeScreenshot() {
+    document.documentElement.classList.remove("reftest-wait");
+}
+
+function takeScreenshotWhenAttachmentsSettled(message) {
     console.assert(document.documentElement.classList.contains("reftest-wait"));
 
     const attachments = [...document.getElementsByTagName("attachment")];
     console.assert(attachments.length);
     if (!attachments.length)
-        return document.documentElement.classList.remove("reftest-wait");
+        return takeScreenshot();
 
     const states = new Map(attachments.map(a => [a, []]));
 
     const onFailure = () => {
         for (const [attachment, events] of states)
             attachment.insertAdjacentText("afterend", "<- (" + message + ") - events = [" + events.join() + "]");
-        document.documentElement.classList.remove("reftest-wait");
+        takeScreenshot();
     };
 
     const timeoutId = setTimeout(onFailure, 5000);
 
     const onSuccess = () => {
         clearTimeout(timeoutId);
-        document.documentElement.classList.remove("reftest-wait");
+        takeScreenshot();
     };
 
     const promises = attachments.map((attachment) => new Promise((resolve, reject) => {

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1936,6 +1936,7 @@ imported/w3c/web-platform-tests/html/rendering/replaced-elements/embedded-conten
 
 # "reftest-wait" blocks attachment rendering.
 webkit.org/b/263367 fast/attachment/attachment-icon-from-file-extension.html [ Skip ]
+webkit.org/b/263367 fast/attachment/attachment-icon-update-after-type-change.html [ Skip ]
 webkit.org/b/263367 fast/attachment/attachment-uti.html [ Skip ]
 webkit.org/b/265962 fast/attachment/attachment-folder-icon.html [ Skip ]
 webkit.org/b/265962 fast/attachment/attachment-type-attribute.html [ Skip ]

--- a/Source/WebCore/html/HTMLAttachmentElement.h
+++ b/Source/WebCore/html/HTMLAttachmentElement.h
@@ -83,7 +83,7 @@ public:
     String attachmentPath() const;
     RefPtr<Image> thumbnail() const { return m_thumbnail; }
     RefPtr<Image> icon() const { return m_icon; }
-    void requestIconWithSize(const FloatSize&);
+    void requestIconIfNeededWithSize(const FloatSize&);
     void requestWideLayoutIconIfNeeded();
     FloatSize iconSize() const { return m_iconSize; }
     void invalidateRendering();
@@ -110,7 +110,7 @@ private:
     void updateSaveButton(bool);
     void updateImage();
 
-    void setNeedsWideLayoutIconRequest();
+    void setNeedsIconRequest();
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     bool shouldSelectOnMouseDown() final {
@@ -152,7 +152,7 @@ private:
     RefPtr<HTMLElement> m_saveButton;
     mutable RefPtr<DOMRectReadOnly> m_saveButtonClientRect;
 
-    bool m_needsWideLayoutIconRequest { false };
+    bool m_needsIconRequest { true };
 
 #if ENABLE(SERVICE_CONTROLS)
     bool m_isImageMenuEnabled { false };

--- a/Source/WebCore/rendering/AttachmentLayout.mm
+++ b/Source/WebCore/rendering/AttachmentLayout.mm
@@ -282,10 +282,9 @@ AttachmentLayout::AttachmentLayout(const RenderAttachment& attachment, Attachmen
     }
 
     if (action.isEmpty() && !hasProgress) {
+        attachment.attachmentElement().requestIconIfNeededWithSize(FloatSize());
         FloatSize iconSize = attachment.attachmentElement().iconSize();
         icon = attachment.attachmentElement().icon();
-        if (!icon)
-            attachment.attachmentElement().requestIconWithSize(FloatSize());
         thumbnailIcon = attachment.attachmentElement().thumbnail();
         if (thumbnailIcon)
             iconSize = largestRectWithAspectRatioInsideRect(thumbnailIcon->size().aspectRatio(), FloatRect(0, 0, attachmentIconSize, attachmentIconSize)).size();

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -1330,11 +1330,10 @@ static void paintAttachmentIcon(const RenderAttachment& attachment, GraphicsCont
     if (context.paintingDisabled())
         return;
 
+    attachment.attachmentElement().requestIconIfNeededWithSize(layout.iconRect.size());
     auto icon = attachment.attachmentElement().icon();
-    if (!icon) {
-        attachment.attachmentElement().requestIconWithSize(layout.iconRect.size());
+    if (!icon)
         return;
-    }
     
     if (!shouldDrawIcon(attachment.attachmentElement().attachmentTitleForDisplay()))
         return;


### PR DESCRIPTION
#### 8852bc5adfdbc818376a780dc93ffac266e2e268
<pre>
Request attachment icon again if needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=274951">https://bugs.webkit.org/show_bug.cgi?id=274951</a>
<a href="https://rdar.apple.com/128175175">rdar://128175175</a>

Reviewed by Aditya Keerthi.

The attachment icon was only requested once, during the first
layout&amp;painting.
But if the title and/or type attributes are changed, the icon
should be requested again to match these attributes.

In particular, this fixes an issue when sharing a document from
Keynote or other iWork app, where the attachment is initially
created with a generic &quot;application/octet-stream&quot; type, and later
updated to the proper type like &quot;com.apple.iwork.keynote.sffkey&quot;.

* LayoutTests/fast/attachment/attachment-icon-update-after-type-change-expected.html: Added.
* LayoutTests/fast/attachment/attachment-icon-update-after-type-change.html: Added.
* LayoutTests/fast/attachment/resources/attachment-test-utils.js:
(takeScreenshot):
(takeScreenshotWhenAttachmentsSettled):
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::ensureWideLayoutShadowTree):
(WebCore::HTMLAttachmentElement::setFile):
(WebCore::HTMLAttachmentElement::attributeChanged):
(WebCore::HTMLAttachmentElement::updateAttributes):
(WebCore::HTMLAttachmentElement::setNeedsIconRequest):
(WebCore::HTMLAttachmentElement::requestWideLayoutIconIfNeeded):
(WebCore::HTMLAttachmentElement::requestIconIfNeededWithSize):
(WebCore::HTMLAttachmentElement::setNeedsWideLayoutIconRequest): Deleted.
(WebCore::HTMLAttachmentElement::requestIconWithSize): Deleted.
* Source/WebCore/html/HTMLAttachmentElement.h:
* Source/WebCore/rendering/AttachmentLayout.mm:
(WebCore::AttachmentLayout::AttachmentLayout):
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::paintAttachmentIcon):

Canonical link: <a href="https://commits.webkit.org/279620@main">https://commits.webkit.org/279620@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8ca58f1bf0e57195636dac30dbcc8544327accb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57227 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4673 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56251 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40827 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4564 "Failed to checkout and rebase branch from PR 29371") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43680 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3082 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56046 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31531 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46673 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24821 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28364 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3992 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2825 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50011 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58820 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29124 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/4564 "Failed to checkout and rebase branch from PR 29371") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51096 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30316 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46811 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50434 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11764 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31267 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30091 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->