### PR TITLE
Avoid WeakPtr indirection in GlyphDisplayListCache

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h
@@ -159,8 +159,8 @@ struct Box {
     void setIsFirstForLayoutBox(bool isFirstBox) { m_isFirstForLayoutBox = isFirstBox; }
     void setIsLastForLayoutBox(bool isLastBox) { m_isLastForLayoutBox = isLastBox; }
 
-    bool isInGlyphDisplayListCache() const { return m_isInGlyphDisplayListCache; }
-    void setIsInGlyphDisplayListCache() { m_isInGlyphDisplayListCache = true; }
+    bool isInGlyphDisplayListCache() const { return m_maybeInGlyphDisplayListCache; }
+    void setIsInGlyphDisplayListCache() { m_maybeInGlyphDisplayListCache = true; }
     void removeFromGlyphDisplayListCache();
 
 private:
@@ -180,7 +180,7 @@ private:
     bool m_isFirstForLayoutBox : 1 { false };
     bool m_isLastForLayoutBox : 1 { false };
     bool m_isFullyTruncated : 1 { false };
-    bool m_isInGlyphDisplayListCache : 1 { false };
+    bool m_maybeInGlyphDisplayListCache : 1 { false }; // Maybe, because after move it is not.
 
     Text m_text;
 };
@@ -204,7 +204,7 @@ inline Box::Box(size_t lineIndex, Type type, const Layout::Box& layoutBox, UBiDi
 
 inline Box::~Box()
 {
-    if (m_isInGlyphDisplayListCache)
+    if (m_maybeInGlyphDisplayListCache)
         removeBoxFromGlyphDisplayListCache(*this);
 }
 
@@ -295,9 +295,9 @@ inline void Box::setRect(const FloatRect& rect, const FloatRect& inkOverflow)
 
 inline void Box::removeFromGlyphDisplayListCache()
 {
-    if (m_isInGlyphDisplayListCache) {
+    if (m_maybeInGlyphDisplayListCache) {
         removeBoxFromGlyphDisplayListCache(*this);
-        m_isInGlyphDisplayListCache = false;
+        m_maybeInGlyphDisplayListCache = false;
     }
 }
 

--- a/Source/WebCore/rendering/GlyphDisplayListCache.cpp
+++ b/Source/WebCore/rendering/GlyphDisplayListCache.cpp
@@ -52,9 +52,8 @@ struct GlyphDisplayListCacheKeyTranslator {
         return computeHash(key);
     }
 
-    static bool equal(const SingleThreadWeakRef<GlyphDisplayListCacheEntry>& entryRef, const GlyphDisplayListCacheKey& key)
+    static bool equal(const GlyphDisplayListCacheEntry& entry, const GlyphDisplayListCacheKey& key)
     {
-        auto& entry = entryRef.get();
         return entry.m_textRun == key.textRun
             && entry.m_scaleFactor == key.context.scaleFactor()
             && entry.m_fontCascadeGeneration == key.font.generation()
@@ -106,7 +105,7 @@ DisplayList::DisplayList* GlyphDisplayListCache::getDisplayList(const LayoutRun&
     }
 
     if (auto iterator = m_entries.find<GlyphDisplayListCacheKeyTranslator>(GlyphDisplayListCacheKey { textRun, font, context }); iterator != m_entries.end()) {
-        Ref entry { iterator->get() };
+        Ref entry  = *iterator;
         auto* result = &entry->displayList();
         const_cast<LayoutRun&>(run).setIsInGlyphDisplayListCache();
         if (isFrequentlyPainted)
@@ -166,8 +165,17 @@ DisplayList::DisplayList* GlyphDisplayListCache::getIfExists(const InlineDisplay
 
 void GlyphDisplayListCache::remove(const void* run)
 {
-    m_entriesForLayoutRun.remove(run);
-    m_entriesForFrequentlyPaintedLayoutRun.remove(run);
+    RefPtr entry = m_entriesForLayoutRun.take(run);
+    ASSERT(!entry || !m_entriesForFrequentlyPaintedLayoutRun.contains(run));
+    if (!entry)
+        entry = m_entriesForFrequentlyPaintedLayoutRun.take(run);
+    // Entry is not found if the caller trying to remove a text run that inherits the "is in glyph cache"
+    // via move or copy constructor.
+    if (entry && entry->refCount() == 2) {
+        // One ref is in entry, the other is in m_entries.
+        bool didRemove = m_entries.remove(*entry);
+        ASSERT_UNUSED(didRemove, didRemove);
+    }
 }
 
 bool GlyphDisplayListCache::canShareDisplayList(const DisplayList::DisplayList& displayList)
@@ -184,11 +192,6 @@ bool GlyphDisplayListCache::canShareDisplayList(const DisplayList::DisplayList& 
             return false;
     }
     return true;
-}
-
-GlyphDisplayListCacheEntry::~GlyphDisplayListCacheEntry()
-{
-    GlyphDisplayListCache::singleton().m_entries.remove(this);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### f2181795430b67608412c9601369e1bbbe6eeb7d
<pre>
Avoid WeakPtr indirection in GlyphDisplayListCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=274962">https://bugs.webkit.org/show_bug.cgi?id=274962</a>
<a href="https://rdar.apple.com/129058727">rdar://129058727</a>

Reviewed by NOBODY (OOPS!).

GlyphDisplayListCacheEntry would be stored in the shared entry list
as a weak pointer, just to match the WebKit rule to avoid storing a raw
pointer. The list would be maintained in the entry destructor, so it
the weakptr would guaranteed to be engaged.

Using WeakPtr causes needless indirection, just to fulfill the policy.

Fulfill the policy by using Ref&lt;&gt; instead, and maintain the list
during removal. When the entry refcount is 2, we know it&apos;s time to
maintain the list.

* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h:
(WebCore::InlineDisplay::Box::isInGlyphDisplayListCache const):
(WebCore::InlineDisplay::Box::setIsInGlyphDisplayListCache):
(WebCore::InlineDisplay::Box::~Box):
(WebCore::InlineDisplay::Box::removeFromGlyphDisplayListCache):
* Source/WebCore/rendering/GlyphDisplayListCache.cpp:
(WebCore::GlyphDisplayListCacheKeyTranslator::equal):
(WebCore::GlyphDisplayListCache::getDisplayList):
(WebCore::GlyphDisplayListCache::remove):
(WebCore::GlyphDisplayListCacheEntry::~GlyphDisplayListCacheEntry): Deleted.
* Source/WebCore/rendering/GlyphDisplayListCache.h:
(WebCore::GlyphDisplayListCacheEntryHash::hash):
(WebCore::GlyphDisplayListCacheEntryHash::equal):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2181795430b67608412c9601369e1bbbe6eeb7d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33233 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57144 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4588 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56169 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43616 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3014 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31458 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46595 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24756 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28272 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3907 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2743 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49959 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4104 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58738 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29036 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4171 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51027 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30229 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46738 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50364 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31165 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30006 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->