### PR TITLE
Fix incorrectly positioned block element inside list-style-position:inside item

### DIFF
--- a/LayoutTests/css2.1/20110323/list-style-position-005.htm
+++ b/LayoutTests/css2.1/20110323/list-style-position-005.htm
@@ -1,0 +1,32 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html>
+ <head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>CSS Test: Marker box position (inside principal box) - block box in normal flow (as child of principal box)</title>
+  <link rel="author" title="James Hopkins" href="http://idreamincode.co.uk/css21testsuite">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/visuren.html#block-boxes">
+  <meta name="flags" content="">
+  <meta name="assert" content="Since a marker box is the first inline element in the principal box when 'list-style-position:inside', the following block box (in normal flow) must create a new stacking context below the marker box">
+  <style type="text/css">
+  #test{
+  background:lime;
+  color:lime;
+  display:list-item;
+  font-size:85px;
+  list-style-position:inside;
+  }
+  #test div{
+  background:blue;
+  display:block;
+  }
+  </style>
+ </head>
+
+ <body>
+  <p>To pass, there <strong>must</strong> be a green bar stacked on top of a blue bar.</p>
+  <div id="test">
+   <div>&nbsp;</div>
+  </div>
+ </body>
+</html>

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
@@ -1,7 +1,8 @@
 /**
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003-2006, 2010, 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2016 Google Inc. All rights reserved.
  * Copyright (C) 2006 Andrew Wellington (proton@wiretapped.net)
  *
  * This library is free software; you can redistribute it and/or
@@ -108,7 +109,7 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
     }
 
     RenderElement* currentParent = markerRenderer->parent();
-    RenderBlock* newParent = getParentOfFirstLineBox(listItemRenderer, *markerRenderer);
+    RenderBlock* newParent = markerRenderer->isInside() ? &listItemRenderer : getParentOfFirstLineBox(listItemRenderer, *markerRenderer);
     if (!newParent) {
         // If the marker is currently contained inside an anonymous box,
         // then we are the only item in that anonymous box (since no line box


### PR DESCRIPTION
<pre>
Fix incorrectly positioned block element inside list-style-position:inside item
<a href="https://bugs.webkit.org/show_bug.cgi?id=245929">https://bugs.webkit.org/show_bug.cgi?id=245929</a>
rdar://problem/100933527

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://chromium.googlesource.com/chromium/src/+/36d85fd5ae96048efcef076a209655ddf2bd02fe">https://chromium.googlesource.com/chromium/src/+/36d85fd5ae96048efcef076a209655ddf2bd02fe</a>

This patch aligns WebKit with Gecko / Firefox and
Blink / Chromium.

This fixes the interop issue with incorrectly positioned
block element inside of list item (list-style-position: inline).

CSSWG: <a href="https://lists.w3.org/Archives/Public/www-style/2015Mar/0163.html">https://lists.w3.org/Archives/Public/www-style/2015Mar/0163.html</a>

Details:
list-style-position:inside makes the ::marker pseudo an ordinary
position:static element that needs to be wrapped in an anonymous
block before the block element.
This patch changes the current behaviour where we try to position
the marker as the first inline child of the block.

* Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp:
(WebCore::RenderTreeBuilder::List::updateItemMarker):
* LayoutTests/css2.1/20110323/list-style-position-005.htm: Add Test Case
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5e7b700c0de05fe71407292c19ffe14a211dfa0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33241 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57151 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4595 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56176 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4469 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43627 "Found 3 new test failures: css2.1/20110323/list-style-position-005.htm, fast/lists/inline-before-content-after-list-marker.html, imported/w3c/web-platform-tests/css/css-lists/change-list-style-position-002.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3028 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55970 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31468 "Found 1 new test failure: css2.1/20110323/list-style-position-005.htm (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46606 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24760 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28291 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-lists/change-list-style-position-002.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3921 "Found 4 new test failures: css2.1/20110323/list-style-position-005.htm, fast/lists/inline-before-content-after-list-marker.html, fast/repaint/list-marker.html, imported/w3c/web-platform-tests/css/css-lists/change-list-style-position-002.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2750 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49960 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4122 "Found 5 new test failures: css2.1/20110323/list-style-position-005.htm, fast/lists/inline-before-content-after-list-marker.html, fast/repaint/list-marker.html, imported/w3c/web-platform-tests/css/css-lists/change-list-style-position-002.html, media/video-playsinline.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58745 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29043 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4201 "Found 4 new test failures: css2.1/20110323/list-style-position-005.htm, fast/lists/inline-before-content-after-list-marker.html, fast/repaint/list-marker.html, imported/w3c/web-platform-tests/css/css-lists/change-list-style-position-002.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51043 "Found 4 new test failures: css2.1/20110323/list-style-position-005.htm, fast/lists/inline-before-content-after-list-marker.html, fast/repaint/list-marker.html, imported/w3c/web-platform-tests/css/css-lists/change-list-style-position-002.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30238 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46742 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50386 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31183 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30015 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->