### PR TITLE
Invalidate process object in XPC connection termination watchdog

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -1265,10 +1265,14 @@ void Connection::enqueueIncomingMessage(UniqueRef<Decoder> incomingMessage)
             return;
 
         if (isIncomingMessagesThrottlingEnabled() && m_incomingMessages.size() >= maxPendingIncomingMessagesKillingThreshold) {
-            if (kill()) {
-                RELEASE_LOG_FAULT(IPC, "%p - Connection::enqueueIncomingMessage: Over %zu incoming messages have been queued without the main thread processing them, killing the connection as the remote process seems to be misbehaving", this, maxPendingIncomingMessagesKillingThreshold);
-                m_incomingMessages.clear();
-            }
+            dispatchToClient([protectedThis = Ref { *this }] {
+                if (!protectedThis->m_client)
+                    return;
+                protectedThis->m_client->requestRemoteProcessTermination();
+                RELEASE_LOG_FAULT(IPC, "%p - Connection::enqueueIncomingMessage: Over %zu incoming messages have been queued without the main thread processing them, terminating the remote process as it seems to be misbehaving", protectedThis.ptr(), maxPendingIncomingMessagesKillingThreshold);
+                Locker lock { protectedThis->m_incomingMessagesLock };
+                protectedThis->m_incomingMessages.clear();
+            });
             return;
         }
 #endif

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -218,6 +218,7 @@ public:
     public:
         virtual void didClose(Connection&) = 0;
         virtual void didReceiveInvalidMessage(Connection&, MessageName) = 0;
+        virtual void requestRemoteProcessTermination() { }
 
     protected:
         virtual ~Client() { }
@@ -424,7 +425,7 @@ public:
 
     Identifier identifier() const;
 
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) && !USE(EXTENSIONKIT)
     bool kill();
 #endif
 

--- a/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
@@ -591,6 +591,7 @@ std::optional<audit_token_t> Connection::getAuditToken()
     return WTFMove(auditToken);
 }
 
+#if !USE(EXTENSIONKIT)
 bool Connection::kill()
 {
     if (m_xpcConnection) {
@@ -598,9 +599,9 @@ bool Connection::kill()
         m_wasKilled = true;
         return true;
     }
-
     return false;
 }
+#endif
 
 pid_t Connection::remoteProcessID() const
 {

--- a/Source/WebKit/Platform/cocoa/XPCUtilities.h
+++ b/Source/WebKit/Platform/cocoa/XPCUtilities.h
@@ -35,7 +35,10 @@ enum class ReasonCode : uint64_t {
     ConnectionKilled,
 };
 
+#if !USE(EXTENSIONKIT)
 void terminateWithReason(xpc_connection_t, ReasonCode, const char* reason);
+#endif
+
 void handleXPCExitMessage(xpc_object_t);
 
 }

--- a/Source/WebKit/Platform/cocoa/XPCUtilities.mm
+++ b/Source/WebKit/Platform/cocoa/XPCUtilities.mm
@@ -36,6 +36,7 @@ namespace WebKit {
 static constexpr auto messageNameKey = "message-name"_s;
 static constexpr auto exitProcessMessage = "exit"_s;
 
+#if !USE(EXTENSIONKIT)
 void terminateWithReason(xpc_connection_t connection, ReasonCode, const char*)
 {
     // This could use ReasonSPI.h, but currently does not as the SPI is blocked by the sandbox.
@@ -52,6 +53,7 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     xpc_connection_kill(connection, SIGKILL);
 ALLOW_DEPRECATED_DECLARATIONS_END
 }
+#endif
 
 void handleXPCExitMessage(xpc_object_t event)
 {

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -186,7 +186,7 @@ void AuxiliaryProcessProxy::terminate()
 {
     RELEASE_LOG(Process, "AuxiliaryProcessProxy::terminate: PID=%d", processID());
 
-#if PLATFORM(COCOA)
+#if PLATFORM(COCOA) && !USE(EXTENSIONKIT)
     if (RefPtr connection = m_connection) {
         if (connection->kill())
             return;
@@ -577,6 +577,11 @@ void AuxiliaryProcessProxy::platformStartConnectionTerminationWatchdog()
 }
 
 #endif
+
+void AuxiliaryProcessProxy::requestRemoteProcessTermination()
+{
+    terminate();
+}
 
 #if PLATFORM(MAC) && USE(RUNNINGBOARD)
 void AuxiliaryProcessProxy::setRunningBoardThrottlingEnabled()

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -286,6 +286,9 @@ private:
     Vector<String> platformOverrideLanguages() const;
     void platformStartConnectionTerminationWatchdog();
 
+    // Connection::Client
+    void requestRemoteProcessTermination() final;
+
     ResponsivenessTimer m_responsivenessTimer;
     Vector<PendingMessage> m_pendingMessages;
     RefPtr<ProcessLauncher> m_processLauncher;

--- a/Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.h
+++ b/Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.h
@@ -38,6 +38,9 @@ namespace WebKit {
 
 class AuxiliaryProcessProxy;
 class ProcessAndUIAssertion;
+#if USE(EXTENSIONKIT)
+class ExtensionProcess;
+#endif
 
 // ConnectionTerminationWatchdog does two things:
 // 1) It sets a watchdog timer to kill the peered process.
@@ -51,9 +54,13 @@ private:
     XPCConnectionTerminationWatchdog(AuxiliaryProcessProxy&, Seconds interval);
     void watchdogTimerFired();
 
-    OSObjectPtr<xpc_connection_t> m_xpcConnection;
     RunLoop::Timer m_watchdogTimer;
     Ref<ProcessAndUIAssertion> m_assertion;
+#if USE(EXTENSIONKIT)
+    std::optional<ExtensionProcess> m_process;
+#else
+    OSObjectPtr<xpc_connection_t> m_xpcConnection;
+#endif
 };
 
 }

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -503,15 +503,13 @@ void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name)
 
 void ProcessLauncher::terminateProcess()
 {
-    if (m_isLaunching) {
-        terminateXPCConnection();
-        return;
-    }
+#if USE(EXTENSIONKIT)
+    if (m_process)
+        m_process->invalidate();
+#endif
 
-    if (!m_processID)
-        return;
+    terminateXPCConnection();
 
-    kill(m_processID, SIGKILL);
     m_processID = 0;
 }
 
@@ -532,7 +530,9 @@ void ProcessLauncher::terminateXPCConnection()
         return;
 
     xpc_connection_cancel(m_xpcConnection.get());
+#if !USE(EXTENSIONKIT)
     terminateWithReason(m_xpcConnection.get(), WebKit::ReasonCode::Invalidation, "ProcessLauncher::platformInvalidate");
+#endif
     m_xpcConnection = nullptr;
 }
 


### PR DESCRIPTION
#### a7a2ef1d4abaeff8ba9cc9faf8a7bc703e877bd3
<pre>
Invalidate process object in XPC connection termination watchdog
<a href="https://bugs.webkit.org/show_bug.cgi?id=273773">https://bugs.webkit.org/show_bug.cgi?id=273773</a>
<a href="https://rdar.apple.com/126373957">rdar://126373957</a>

Reviewed by Chris Dumez.

Invalidate process object instead of calling xpc_connection_kill. This will send a termination request
which will terminate the process. This termination approach is only available for WebKit process
extensions.

* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::Client::didRequestProcessTermination):
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
(IPC::Connection::kill):
* Source/WebKit/Platform/cocoa/XPCUtilities.h:
* Source/WebKit/Platform/cocoa/XPCUtilities.mm:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::terminate):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::requestRemoteProcessTermination):
* Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.h:
* Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.mm:
(WebKit::XPCConnectionTerminationWatchdog::watchdogTimerFired):
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::ProcessLauncher::terminateProcess):
(WebKit::ProcessLauncher::terminateXPCConnection):

Canonical link: <a href="https://commits.webkit.org/280261@main">https://commits.webkit.org/280261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0294900731a5769eac6744eedacf06249951d0a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6399 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57154 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4598 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4477 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43629 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3027 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31462 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46607 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24762 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28303 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2753 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50385 "Build was cancelled. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Running apply-patch; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4123 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58748 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4199 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51044 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50378 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8323 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29046 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30241 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31187 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30018 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->