### PR TITLE
[WPE][GTK] g_variant_builder_add_value: assertion 'GVSB(builder)->offset < GVSB(builder)->max_items' failed when encoding session state

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewSessionState.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewSessionState.cpp
@@ -125,8 +125,8 @@ static inline void encodeHTTPBody(GVariantBuilder* sessionBuilder, const HTTPBod
     g_variant_builder_open(sessionBuilder, G_VARIANT_TYPE("(sa" HTTP_BODY_ELEMENT_TYPE_STRING_V1 ")"));
     g_variant_builder_add(sessionBuilder, "s", httpBody.contentType.utf8().data());
     g_variant_builder_open(sessionBuilder, G_VARIANT_TYPE("a" HTTP_BODY_ELEMENT_TYPE_STRING_V1));
-    g_variant_builder_open(sessionBuilder, G_VARIANT_TYPE(HTTP_BODY_ELEMENT_TYPE_STRING_V1));
     for (const auto& element : httpBody.elements) {
+        g_variant_builder_open(sessionBuilder, G_VARIANT_TYPE(HTTP_BODY_ELEMENT_TYPE_STRING_V1));
         g_variant_builder_add(sessionBuilder, "u", toHTMLBodyElementType(element.data.index()));
 
         g_variant_builder_open(sessionBuilder, G_VARIANT_TYPE("ay"));
@@ -159,8 +159,9 @@ static inline void encodeHTTPBody(GVariantBuilder* sessionBuilder, const HTTPBod
             g_variant_builder_add(sessionBuilder, "s", blobURLString->utf8().data());
         else
             g_variant_builder_add(sessionBuilder, "s", "");
+
+        g_variant_builder_close(sessionBuilder);
     }
-    g_variant_builder_close(sessionBuilder);
     g_variant_builder_close(sessionBuilder);
     g_variant_builder_close(sessionBuilder);
 }


### PR DESCRIPTION
#### 86fbb6c7dafe2bb7bb60e991ad84df6a5a9afe4f
<pre>
[WPE][GTK] g_variant_builder_add_value: assertion &apos;GVSB(builder)-&gt;offset &lt; GVSB(builder)-&gt;max_items&apos; failed when encoding session state
<a href="https://bugs.webkit.org/show_bug.cgi?id=274964">https://bugs.webkit.org/show_bug.cgi?id=274964</a>

Reviewed by Carlos Garcia Campos.

When we encode the array of HTTP body elements, we have the open and
close calls in the wrong place, such that it breaks if there are ever
more than just one element.

We could probably add a test for this, but it&apos;s not too likely to
regress, and I didn&apos;t want to spend too long trying to work on that.

* Source/WebKit/UIProcess/API/glib/WebKitWebViewSessionState.cpp:
(encodeHTTPBody):

Canonical link: <a href="https://commits.webkit.org/279649@main">https://commits.webkit.org/279649@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68312b9f3cc2826b42629002d0658084f54f4126

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6414 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57165 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4610 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4526 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43639 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3036 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55983 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31474 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46612 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24773 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28305 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2763 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49970 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58758 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29059 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4242 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51053 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30251 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50385 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11787 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31197 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30028 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->