### PR TITLE
[JSC] `fractionalDigits` of `Intl.DurationFormat` should be treated as at most 9 digits if it is omitted

### DIFF
--- a/JSTests/stress/intl-durationformat-digital.js
+++ b/JSTests/stress/intl-durationformat-digital.js
@@ -16,7 +16,7 @@ if (Intl.DurationFormat) {
             style: 'digital'
         });
         shouldBeOneOf(fmt.format({ years: 1, months: 2, weeks: 3, days: 4, hours: 10, minutes: 34, seconds: 33, milliseconds: 32 }), [
-            `1 yr, 2 mths, 3 wks, 4 days, 10.34.33`,
+            `1 yr, 2 mths, 3 wks, 4 days, 10.34.33,032`,
         ]);
     }
     {
@@ -24,7 +24,7 @@ if (Intl.DurationFormat) {
             style: 'digital'
         });
         shouldBeOneOf(fmt.format({ years: 1, months: 2, weeks: 3, days: 4, hours: 10, minutes: 34, seconds: 33, milliseconds: 32 }), [
-            `1 yr, 2 mths, 3 wks, 4 days, 10.34.33`,
+            `1 yr, 2 mths, 3 wks, 4 days, 10.34.33,032`,
         ]);
     }
     {
@@ -32,7 +32,7 @@ if (Intl.DurationFormat) {
             style: 'digital'
         });
         shouldBeOneOf(fmt.format({ years: 1, months: 2, weeks: 3, days: 4, hours: 10, minutes: 34, seconds: 33, milliseconds: 32 }), [
-            `一 yr, 二 mths, 三 wks, 四 days, 一〇:三四:三三`,
+            `一 yr, 二 mths, 三 wks, 四 days, 一〇:三四:三三,〇三二`,
         ]);
     }
     {
@@ -40,7 +40,7 @@ if (Intl.DurationFormat) {
             style: 'digital'
         });
         shouldBeOneOf(fmt.format({ years: 1, months: 2, weeks: 3, days: 4, hours: 10, minutes: 34, seconds: 33, milliseconds: 32 }), [
-            `1 yr, 2 mths, 3 wks, 4 days, 10:34:33`,
+            `1 yr, 2 mths, 3 wks, 4 days, 10:34:33.032`,
         ]);
     }
     {
@@ -48,7 +48,7 @@ if (Intl.DurationFormat) {
             style: 'digital'
         });
         shouldBeOneOf(fmt.format({ years: 1, months: 2, weeks: 3, days: 4, hours: 10, minutes: 34, seconds: 33, milliseconds: 32 }), [
-            `1 yr, 2 mths, 3 wks, 4 days, 10:34:33`,
+            `1 yr, 2 mths, 3 wks, 4 days, 10:34:33.032`,
         ]);
     }
     {
@@ -114,7 +114,7 @@ if (Intl.DurationFormat) {
         });
 
         shouldBeOneOf(fmt.format({ hours: 10, minutes: 10, milliseconds: 32}), [
-            `10:10:00`,
+            `10:10:00.032`,
         ]);
     }
     {

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1026,9 +1026,6 @@ test/intl402/DateTimeFormat/timezone-legacy-non-iana.js:
 test/intl402/DateTimeFormat/timezone-not-canonicalized.js:
   default: 'Test262Error: Expected SameValue(«Asia/Calcutta», «Asia/Kolkata») to be true'
   strict mode: 'Test262Error: Expected SameValue(«Asia/Calcutta», «Asia/Kolkata») to be true'
-test/intl402/DurationFormat/prototype/format/fractions-of-subsecond-units-en.js:
-  default: 'Test262Error: DurationFormat output when microseconds first "numeric" unit Expected SameValue(«3 sec, 444 ms», «3 sec, 444.055006 ms») to be true'
-  strict mode: 'Test262Error: DurationFormat output when microseconds first "numeric" unit Expected SameValue(«3 sec, 444 ms», «3 sec, 444.055006 ms») to be true'
 test/intl402/DurationFormat/prototype/format/negative-duration-style-default-en.js:
   default: 'Test262Error: DurationFormat format output using default style option Expected SameValue(«-1 yr, -2 mths, -3 wks, -3 days, -4 hr, -5 min, -6 sec, -7 ms, -8 μs, -9 ns», «-1 yr, 2 mths, 3 wks, 3 days, 4 hr, 5 min, 6 sec, 7 ms, 8 μs, 9 ns») to be true'
   strict mode: 'Test262Error: DurationFormat format output using default style option Expected SameValue(«-1 yr, -2 mths, -3 wks, -3 days, -4 hr, -5 min, -6 sec, -7 ms, -8 μs, -9 ns», «-1 yr, 2 mths, 3 wks, 3 days, 4 hr, 5 min, 6 sec, 7 ms, 8 μs, 9 ns») to be true'
@@ -1051,8 +1048,8 @@ test/intl402/DurationFormat/prototype/format/negative-duration-with-leading-zero
   default: 'Test262Error: DurationFormat format output using short style option Expected SameValue(«0 hr, -1 sec», «-0 hr, 1 sec») to be true'
   strict mode: 'Test262Error: DurationFormat format output using short style option Expected SameValue(«0 hr, -1 sec», «-0 hr, 1 sec») to be true'
 test/intl402/DurationFormat/prototype/format/negative-durationstyle-digital-en.js:
-  default: 'Test262Error: DurationFormat format output using digital style option Expected SameValue(«-1 yr, -2 mths, -3 wks, -3 days, -4:-05:-06», «-1 yr, 2 mths, 3 wks, 3 days, 4:05:06.007008009») to be true'
-  strict mode: 'Test262Error: DurationFormat format output using digital style option Expected SameValue(«-1 yr, -2 mths, -3 wks, -3 days, -4:-05:-06», «-1 yr, 2 mths, 3 wks, 3 days, 4:05:06.007008009») to be true'
+  default: 'Test262Error: DurationFormat format output using digital style option Expected SameValue(«-1 yr, -2 mths, -3 wks, -3 days, -4:-05:-06.007008009», «-1 yr, 2 mths, 3 wks, 3 days, 4:05:06.007008009») to be true'
+  strict mode: 'Test262Error: DurationFormat format output using digital style option Expected SameValue(«-1 yr, -2 mths, -3 wks, -3 days, -4:-05:-06.007008009», «-1 yr, 2 mths, 3 wks, 3 days, 4:05:06.007008009») to be true'
 test/intl402/DurationFormat/prototype/format/negative-durationstyle-long-en.js:
   default: 'Test262Error: DurationFormat format output using long style option Expected SameValue(«-1 year, -2 months, -3 weeks, -3 days, -4 hours, -5 minutes, -6 seconds, -7 milliseconds, -8 microseconds, -9 nanoseconds», «-1 year, 2 months, 3 weeks, 3 days, 4 hours, 5 minutes, 6 seconds, 7 milliseconds, 8 microseconds, 9 nanoseconds») to be true'
   strict mode: 'Test262Error: DurationFormat format output using long style option Expected SameValue(«-1 year, -2 months, -3 weeks, -3 days, -4 hours, -5 minutes, -6 seconds, -7 milliseconds, -8 microseconds, -9 nanoseconds», «-1 year, 2 months, 3 weeks, 3 days, 4 hours, 5 minutes, 6 seconds, 7 milliseconds, 8 microseconds, 9 nanoseconds») to be true'
@@ -1069,23 +1066,14 @@ test/intl402/DurationFormat/prototype/format/numeric-hour-with-zero-minutes-and-
   default: 'Test262Error: Duration is {"hours":0,"minutes":0,"seconds":1} Expected SameValue(«0, 01», «0:00:01») to be true'
   strict mode: 'Test262Error: Duration is {"hours":0,"minutes":0,"seconds":1} Expected SameValue(«0, 01», «0:00:01») to be true'
 test/intl402/DurationFormat/prototype/format/precision-exact-mathematical-values.js:
-  default: 'Test262Error: Duration is {"seconds":10000000,"nanoseconds":1} Expected SameValue(«0:00:10,000,000», «0:00:10,000,000.000000001») to be true'
-  strict mode: 'Test262Error: Duration is {"seconds":10000000,"nanoseconds":1} Expected SameValue(«0:00:10,000,000», «0:00:10,000,000.000000001») to be true'
-test/intl402/DurationFormat/prototype/format/style-digital-en.js:
-  default: 'Test262Error: Assert DurationFormat format output using digital style option Expected SameValue(«1 yr, 2 mths, 3 wks, 3 days, 4:05:06», «1 yr, 2 mths, 3 wks, 3 days, 4:05:06.007008009») to be true'
-  strict mode: 'Test262Error: Assert DurationFormat format output using digital style option Expected SameValue(«1 yr, 2 mths, 3 wks, 3 days, 4:05:06», «1 yr, 2 mths, 3 wks, 3 days, 4:05:06.007008009») to be true'
-test/intl402/DurationFormat/prototype/format/style-digital-fractionalDigits-undefined-en.js:
-  default: 'Test262Error: format output with nanosecond digits and fractionalDigits: undefined using digital style option Expected SameValue(«1:22:33», «1:22:33.111222333») to be true'
-  strict mode: 'Test262Error: format output with nanosecond digits and fractionalDigits: undefined using digital style option Expected SameValue(«1:22:33», «1:22:33.111222333») to be true'
-test/intl402/DurationFormat/prototype/formatToParts/formatToParts-style-digital-en.js:
-  default: 'Test262Error: Using style : digital: length Expected SameValue(«5», «7») to be true'
-  strict mode: 'Test262Error: Using style : digital: length Expected SameValue(«5», «7») to be true'
+  default: 'Test262Error: Duration is {"seconds":10000000,"nanoseconds":1} Expected SameValue(«0:00:10,000,000.000000002», «0:00:10,000,000.000000001») to be true'
+  strict mode: 'Test262Error: Duration is {"seconds":10000000,"nanoseconds":1} Expected SameValue(«0:00:10,000,000.000000002», «0:00:10,000,000.000000001») to be true'
 test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-default-en.js:
   default: 'Test262Error: Using style : default: length Expected SameValue(«49», «40») to be true'
   strict mode: 'Test262Error: Using style : default: length Expected SameValue(«49», «40») to be true'
 test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-digital-en.js:
-  default: 'Test262Error: Using style : digital: length Expected SameValue(«28», «24») to be true'
-  strict mode: 'Test262Error: Using style : digital: length Expected SameValue(«28», «24») to be true'
+  default: 'Test262Error: Using style : digital: length Expected SameValue(«30», «24») to be true'
+  strict mode: 'Test262Error: Using style : digital: length Expected SameValue(«30», «24») to be true'
 test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-long-en.js:
   default: 'Test262Error: Using style : long: length Expected SameValue(«49», «40») to be true'
   strict mode: 'Test262Error: Using style : long: length Expected SameValue(«49», «40») to be true'

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.cpp
@@ -366,9 +366,13 @@ static Vector<Element> collectElements(JSGlobalObject* globalObject, const IntlD
                 // https://github.com/unicode-org/icu/blob/master/docs/userguide/format_parse/numbers/skeletons.md#fraction-precision
                 skeletonBuilder.append(" ."_s);
 
-                unsigned fractionalDigits = durationFormat->fractionalDigits() == fractionalDigitsUndefinedValue ? 0 : durationFormat->fractionalDigits();
-                for (unsigned i = 0; i < fractionalDigits; ++i)
-                    skeletonBuilder.append('0');
+                unsigned fractionalDigits = durationFormat->fractionalDigits();
+                if (fractionalDigits == fractionalDigitsUndefinedValue)
+                    skeletonBuilder.append("#########"_s);
+                else {
+                    for (unsigned i = 0; i < fractionalDigits; ++i)
+                        skeletonBuilder.append('0');
+                }
                 done = true;
             }
             break;


### PR DESCRIPTION
#### d0e99dfc02abd030c519c3e459f087e842405338
<pre>
[JSC] `fractionalDigits` of `Intl.DurationFormat` should be treated as at most 9 digits if it is omitted
<a href="https://bugs.webkit.org/show_bug.cgi?id=274974">https://bugs.webkit.org/show_bug.cgi?id=274974</a>

Reviewed by Yusuke Suzuki.

According to the spec[1], if the `fractionalDigits` option of `Intl.DurationFormat` is omitted, it
should be treated as at most 9 digits. However, in the current JSC, it is treated as exact 0 digits.

The README of the proposal repository[2] states the following:
&gt; If this option is omitted, only nonzero decimals will be displayed and trailing zeroes will be omitted.

This patch changes to treat it as at most 9 digits, using the ICU&apos;s Fraction Precision notation[3].

[1]: <a href="https://tc39.es/proposal-intl-duration-format/#sec-partitiondurationformatpattern">https://tc39.es/proposal-intl-duration-format/#sec-partitiondurationformatpattern</a> ( 4.f.ii.1.b )
[2]: <a href="https://github.com/tc39/proposal-intl-duration-format#parameters">https://github.com/tc39/proposal-intl-duration-format#parameters</a>
[3]: <a href="https://github.com/unicode-org/icu/blob/main/docs/userguide/format_parse/numbers/skeletons.md#fraction-precision">https://github.com/unicode-org/icu/blob/main/docs/userguide/format_parse/numbers/skeletons.md#fraction-precision</a>

* JSTests/stress/intl-durationformat-digital.js:
(Intl.DurationFormat.shouldBeOneOf.fmt.format):
(Intl.DurationFormat.shouldBeOneOf):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/IntlDurationFormat.cpp:
(JSC::collectElements):

Canonical link: <a href="https://commits.webkit.org/279632@main">https://commits.webkit.org/279632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7da8c7278f6965fe404a9371bb0c98ef92af0a6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53894 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57174 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4630 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43642 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3050 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55992 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31486 "Found 2 new test failures: compositing/overflow/clipping-ancestor-with-accelerated-scrolling-ancestor.html, compositing/patterns/direct-pattern-compositing-add-text.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46625 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24777 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28317 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3944 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2772 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/47253 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49979 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4145 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58767 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/53405 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29068 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4216 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51058 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30260 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46765 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50391 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31206 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65708 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8004 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30037 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12505 "Passed tests") | 
<!--EWS-Status-Bubble-End-->