### PR TITLE
Many subclasses of WebCore::RTCStatsReport::Stats fail to initialize timestamp field

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCStatsReport.h
+++ b/Source/WebCore/Modules/mediastream/RTCStatsReport.h
@@ -61,7 +61,7 @@ public:
         Certificate,
     };
     struct Stats {
-        double timestamp;
+        double timestamp { 0 };
         Type type;
         String id;
     };


### PR DESCRIPTION
#### 44d522f49fae6a236652c8ac5f8b2aec9d0f67dc
<pre>
Many subclasses of WebCore::RTCStatsReport::Stats fail to initialize timestamp field
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=274976">https://bugs.webkit.org/show_bug.cgi?id=274976</a>&gt;
&lt;<a href="https://rdar.apple.com/129071458">rdar://129071458</a>&gt;

Reviewed by Youenn Fablet.

* Source/WebCore/Modules/mediastream/RTCStatsReport.h:
(WebCore::RTCStatsReport::Stats::timestamp):
- Add default initializer.

Canonical link: <a href="https://commits.webkit.org/279660@main">https://commits.webkit.org/279660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6fb91a56ce3b2c951a063cc7503865b97b369fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57177 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4622 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56201 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4498 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43644 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3044 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55995 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31485 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46622 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24780 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28316 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3942 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2775 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49978 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4140 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58770 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29071 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4221 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51060 "Found 1 new test failure: imported/w3c/web-platform-tests/webcodecs/audioDecoder-codec-specific.https.any.worker.html?mp4_aac (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46763 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50393 "Found 3 new API test failures: /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31209 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8014 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30040 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->