### PR TITLE
Use "= default" for constructor and destructor in JSC code

### DIFF
--- a/Source/JavaScriptCore/API/ObjCCallbackFunction.mm
+++ b/Source/JavaScriptCore/API/ObjCCallbackFunction.mm
@@ -51,9 +51,7 @@ public:
     std::unique_ptr<CallbackArgument> m_next;
 };
 
-CallbackArgument::~CallbackArgument()
-{
-}
+CallbackArgument::~CallbackArgument() = default;
 
 class CallbackArgumentBoolean final : public CallbackArgument {
     void set(NSInvocation *invocation, NSInteger argumentNumber, JSContext *context, JSValueRef argument, JSValueRef*) final

--- a/Source/JavaScriptCore/b3/B3ArgumentRegValue.cpp
+++ b/Source/JavaScriptCore/b3/B3ArgumentRegValue.cpp
@@ -30,9 +30,7 @@
 
 namespace JSC { namespace B3 {
 
-ArgumentRegValue::~ArgumentRegValue()
-{
-}
+ArgumentRegValue::~ArgumentRegValue() = default;
 
 void ArgumentRegValue::dumpMeta(CommaPrinter& comma, PrintStream& out) const
 {

--- a/Source/JavaScriptCore/b3/B3AtomicValue.cpp
+++ b/Source/JavaScriptCore/b3/B3AtomicValue.cpp
@@ -31,9 +31,7 @@
 
 namespace JSC { namespace B3 {
 
-AtomicValue::~AtomicValue()
-{
-}
+AtomicValue::~AtomicValue() = default;
 
 void AtomicValue::dumpMeta(CommaPrinter& comma, PrintStream& out) const
 {

--- a/Source/JavaScriptCore/b3/B3BasicBlock.cpp
+++ b/Source/JavaScriptCore/b3/B3BasicBlock.cpp
@@ -47,9 +47,7 @@ BasicBlock::BasicBlock(unsigned index, double frequency)
 {
 }
 
-BasicBlock::~BasicBlock()
-{
-}
+BasicBlock::~BasicBlock() = default;
 
 void BasicBlock::append(Value* value)
 {

--- a/Source/JavaScriptCore/b3/B3BlockInsertionSet.cpp
+++ b/Source/JavaScriptCore/b3/B3BlockInsertionSet.cpp
@@ -40,7 +40,7 @@ BlockInsertionSet::BlockInsertionSet(Procedure &proc)
 {
 }
 
-BlockInsertionSet::~BlockInsertionSet() { }
+BlockInsertionSet::~BlockInsertionSet() = default;
 
 BasicBlock* BlockInsertionSet::splitForward(
     BasicBlock* block, unsigned& valueIndex, InsertionSet* insertionSet, double frequency)

--- a/Source/JavaScriptCore/b3/B3CCallValue.cpp
+++ b/Source/JavaScriptCore/b3/B3CCallValue.cpp
@@ -30,9 +30,7 @@
 
 namespace JSC { namespace B3 {
 
-CCallValue::~CCallValue()
-{
-}
+CCallValue::~CCallValue() = default;
 
 void CCallValue::appendArgs(const Vector<Value*>& args)
 {

--- a/Source/JavaScriptCore/b3/B3CheckSpecial.cpp
+++ b/Source/JavaScriptCore/b3/B3CheckSpecial.cpp
@@ -97,9 +97,7 @@ CheckSpecial::CheckSpecial(const CheckSpecial::Key& key)
 {
 }
 
-CheckSpecial::~CheckSpecial()
-{
-}
+CheckSpecial::~CheckSpecial() = default;
 
 Inst CheckSpecial::hiddenBranch(const Inst& inst) const
 {

--- a/Source/JavaScriptCore/b3/B3CheckValue.cpp
+++ b/Source/JavaScriptCore/b3/B3CheckValue.cpp
@@ -30,9 +30,7 @@
 
 namespace JSC { namespace B3 {
 
-CheckValue::~CheckValue()
-{
-}
+CheckValue::~CheckValue() = default;
 
 void CheckValue::convertToAdd()
 {

--- a/Source/JavaScriptCore/b3/B3Const32Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Const32Value.cpp
@@ -33,9 +33,7 @@
 
 namespace JSC { namespace B3 {
 
-Const32Value::~Const32Value()
-{
-}
+Const32Value::~Const32Value() = default;
 
 Value* Const32Value::negConstant(Procedure& proc) const
 {

--- a/Source/JavaScriptCore/b3/B3Const64Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Const64Value.cpp
@@ -33,9 +33,7 @@
 
 namespace JSC { namespace B3 {
 
-Const64Value::~Const64Value()
-{
-}
+Const64Value::~Const64Value() = default;
 
 Value* Const64Value::negConstant(Procedure& proc) const
 {

--- a/Source/JavaScriptCore/b3/B3ConstDoubleValue.cpp
+++ b/Source/JavaScriptCore/b3/B3ConstDoubleValue.cpp
@@ -34,9 +34,7 @@
 
 namespace JSC { namespace B3 {
 
-ConstDoubleValue::~ConstDoubleValue()
-{
-}
+ConstDoubleValue::~ConstDoubleValue() = default;
 
 Value* ConstDoubleValue::negConstant(Procedure& proc) const
 {

--- a/Source/JavaScriptCore/b3/B3ConstFloatValue.cpp
+++ b/Source/JavaScriptCore/b3/B3ConstFloatValue.cpp
@@ -34,9 +34,7 @@
 
 namespace JSC { namespace B3 {
 
-ConstFloatValue::~ConstFloatValue()
-{
-}
+ConstFloatValue::~ConstFloatValue() = default;
 
 Value* ConstFloatValue::negConstant(Procedure& proc) const
 {

--- a/Source/JavaScriptCore/b3/B3ExtractValue.cpp
+++ b/Source/JavaScriptCore/b3/B3ExtractValue.cpp
@@ -30,9 +30,7 @@
 
 namespace JSC { namespace B3 {
 
-ExtractValue::~ExtractValue()
-{
-}
+ExtractValue::~ExtractValue() = default;
 
 void ExtractValue::dumpMeta(CommaPrinter& comma, PrintStream& out) const
 {

--- a/Source/JavaScriptCore/b3/B3FenceValue.cpp
+++ b/Source/JavaScriptCore/b3/B3FenceValue.cpp
@@ -32,9 +32,7 @@
 
 namespace JSC { namespace B3 {
 
-FenceValue::~FenceValue()
-{
-}
+FenceValue::~FenceValue() = default;
 
 FenceValue::FenceValue(Origin origin, HeapRange read, HeapRange write)
     : Value(CheckedOpcode, Fence, Void, Zero, origin)

--- a/Source/JavaScriptCore/b3/B3MemoryValue.cpp
+++ b/Source/JavaScriptCore/b3/B3MemoryValue.cpp
@@ -33,9 +33,7 @@
 
 namespace JSC { namespace B3 {
 
-MemoryValue::~MemoryValue()
-{
-}
+MemoryValue::~MemoryValue() = default;
 
 bool MemoryValue::isLegalOffsetImpl(int64_t offset) const
 {

--- a/Source/JavaScriptCore/b3/B3PatchpointSpecial.cpp
+++ b/Source/JavaScriptCore/b3/B3PatchpointSpecial.cpp
@@ -41,13 +41,9 @@ namespace JSC { namespace B3 {
 using Arg = Air::Arg;
 using Inst = Air::Inst;
 
-PatchpointSpecial::PatchpointSpecial()
-{
-}
+PatchpointSpecial::PatchpointSpecial() = default;
 
-PatchpointSpecial::~PatchpointSpecial()
-{
-}
+PatchpointSpecial::~PatchpointSpecial() = default;
 
 void PatchpointSpecial::forEachArg(Inst& inst, const ScopedLambda<Inst::EachArgCallback>& callback)
 {

--- a/Source/JavaScriptCore/b3/B3PatchpointValue.cpp
+++ b/Source/JavaScriptCore/b3/B3PatchpointValue.cpp
@@ -30,9 +30,7 @@
 
 namespace JSC { namespace B3 {
 
-PatchpointValue::~PatchpointValue()
-{
-}
+PatchpointValue::~PatchpointValue() = default;
 
 void PatchpointValue::dumpMeta(CommaPrinter& comma, PrintStream& out) const
 {

--- a/Source/JavaScriptCore/b3/B3PhiChildren.cpp
+++ b/Source/JavaScriptCore/b3/B3PhiChildren.cpp
@@ -49,9 +49,7 @@ PhiChildren::PhiChildren(Procedure& proc)
     }
 }
 
-PhiChildren::~PhiChildren()
-{
-}
+PhiChildren::~PhiChildren() = default;
 
 } } // namespace JSC::B3
 

--- a/Source/JavaScriptCore/b3/B3Procedure.cpp
+++ b/Source/JavaScriptCore/b3/B3Procedure.cpp
@@ -60,9 +60,7 @@ Procedure::Procedure(bool usesSIMD)
     m_code->setNumEntrypoints(m_numEntrypoints);
 }
 
-Procedure::~Procedure()
-{
-}
+Procedure::~Procedure() = default;
 
 void Procedure::printOrigin(PrintStream& out, Origin origin) const
 {

--- a/Source/JavaScriptCore/b3/B3PureCSE.cpp
+++ b/Source/JavaScriptCore/b3/B3PureCSE.cpp
@@ -35,13 +35,9 @@
 
 namespace JSC { namespace B3 {
 
-PureCSE::PureCSE()
-{
-}
+PureCSE::PureCSE() = default;
 
-PureCSE::~PureCSE()
-{
-}
+PureCSE::~PureCSE() = default;
 
 void PureCSE::clear()
 {

--- a/Source/JavaScriptCore/b3/B3SSACalculator.cpp
+++ b/Source/JavaScriptCore/b3/B3SSACalculator.cpp
@@ -60,9 +60,7 @@ SSACalculator::SSACalculator(Procedure& proc)
 {
 }
 
-SSACalculator::~SSACalculator()
-{
-}
+SSACalculator::~SSACalculator() = default;
 
 void SSACalculator::reset()
 {

--- a/Source/JavaScriptCore/b3/B3SlotBaseValue.cpp
+++ b/Source/JavaScriptCore/b3/B3SlotBaseValue.cpp
@@ -32,9 +32,7 @@
 
 namespace JSC { namespace B3 {
 
-SlotBaseValue::~SlotBaseValue()
-{
-}
+SlotBaseValue::~SlotBaseValue() = default;
 
 void SlotBaseValue::dumpMeta(CommaPrinter& comma, PrintStream& out) const
 {

--- a/Source/JavaScriptCore/b3/B3StackmapSpecial.cpp
+++ b/Source/JavaScriptCore/b3/B3StackmapSpecial.cpp
@@ -41,13 +41,9 @@ using Arg = Air::Arg;
 using Inst = Air::Inst;
 using Tmp = Air::Tmp;
 
-StackmapSpecial::StackmapSpecial()
-{
-}
+StackmapSpecial::StackmapSpecial() = default;
 
-StackmapSpecial::~StackmapSpecial()
-{
-}
+StackmapSpecial::~StackmapSpecial() = default;
 
 void StackmapSpecial::reportUsedRegisters(Inst& inst, const RegisterSetBuilder& usedRegisters)
 {

--- a/Source/JavaScriptCore/b3/B3StackmapValue.cpp
+++ b/Source/JavaScriptCore/b3/B3StackmapValue.cpp
@@ -36,9 +36,7 @@ namespace B3StackmapValueInternal {
 constexpr bool dumpRegisters = false;
 }
 
-StackmapValue::~StackmapValue()
-{
-}
+StackmapValue::~StackmapValue() = default;
 
 void StackmapValue::append(Value* value, const ValueRep& rep)
 {

--- a/Source/JavaScriptCore/b3/B3SwitchValue.cpp
+++ b/Source/JavaScriptCore/b3/B3SwitchValue.cpp
@@ -34,9 +34,7 @@
 
 namespace JSC { namespace B3 {
 
-SwitchValue::~SwitchValue()
-{
-}
+SwitchValue::~SwitchValue() = default;
 
 BasicBlock* SwitchValue::fallThrough(const BasicBlock* owner)
 {

--- a/Source/JavaScriptCore/b3/B3UpsilonValue.cpp
+++ b/Source/JavaScriptCore/b3/B3UpsilonValue.cpp
@@ -30,9 +30,7 @@
 
 namespace JSC { namespace B3 {
 
-UpsilonValue::~UpsilonValue()
-{
-}
+UpsilonValue::~UpsilonValue() = default;
 
 void UpsilonValue::dumpMeta(CommaPrinter& comma, PrintStream& out) const
 {

--- a/Source/JavaScriptCore/b3/B3UseCounts.cpp
+++ b/Source/JavaScriptCore/b3/B3UseCounts.cpp
@@ -55,9 +55,7 @@ UseCounts::UseCounts(Procedure& procedure)
     }
 }
 
-UseCounts::~UseCounts()
-{
-}
+UseCounts::~UseCounts() = default;
 
 } } // namespace JSC::B3
 

--- a/Source/JavaScriptCore/b3/B3Variable.cpp
+++ b/Source/JavaScriptCore/b3/B3Variable.cpp
@@ -34,9 +34,7 @@ namespace JSC { namespace B3 {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Variable);
 
-Variable::~Variable()
-{
-}
+Variable::~Variable() = default;
 
 void Variable::dump(PrintStream& out) const
 {

--- a/Source/JavaScriptCore/b3/B3VariableLiveness.cpp
+++ b/Source/JavaScriptCore/b3/B3VariableLiveness.cpp
@@ -39,9 +39,7 @@ VariableLiveness::VariableLiveness(Procedure& proc)
     compute();
 }
 
-VariableLiveness::~VariableLiveness()
-{
-}
+VariableLiveness::~VariableLiveness() = default;
 
 } } // namespace JSC::B3
 

--- a/Source/JavaScriptCore/b3/B3VariableValue.cpp
+++ b/Source/JavaScriptCore/b3/B3VariableValue.cpp
@@ -33,9 +33,7 @@
 
 namespace JSC { namespace B3 {
 
-VariableValue::~VariableValue()
-{
-}
+VariableValue::~VariableValue() = default;
 
 void VariableValue::dumpMeta(CommaPrinter& comma, PrintStream& out) const
 {

--- a/Source/JavaScriptCore/b3/B3WasmAddressValue.cpp
+++ b/Source/JavaScriptCore/b3/B3WasmAddressValue.cpp
@@ -32,9 +32,7 @@
 
 namespace JSC { namespace B3 {
 
-WasmAddressValue::~WasmAddressValue()
-{
-}
+WasmAddressValue::~WasmAddressValue() = default;
 
 void WasmAddressValue::dumpMeta(CommaPrinter& comma, PrintStream& out) const
 {

--- a/Source/JavaScriptCore/b3/B3WasmBoundsCheckValue.cpp
+++ b/Source/JavaScriptCore/b3/B3WasmBoundsCheckValue.cpp
@@ -33,9 +33,7 @@
 
 namespace JSC { namespace B3 {
 
-WasmBoundsCheckValue::~WasmBoundsCheckValue()
-{
-}
+WasmBoundsCheckValue::~WasmBoundsCheckValue() = default;
 
 WasmBoundsCheckValue::WasmBoundsCheckValue(Origin origin, GPRReg pinnedSize, Value* ptr, unsigned offset)
     : Value(CheckedOpcode, WasmBoundsCheck, One, origin, ptr)

--- a/Source/JavaScriptCore/b3/air/AirBlockInsertionSet.cpp
+++ b/Source/JavaScriptCore/b3/air/AirBlockInsertionSet.cpp
@@ -38,9 +38,7 @@ BlockInsertionSet::BlockInsertionSet(Code &code)
 {
 }
 
-BlockInsertionSet::~BlockInsertionSet()
-{
-}
+BlockInsertionSet::~BlockInsertionSet() = default;
 
 } } } // namespace JSC::B3::Air
 

--- a/Source/JavaScriptCore/b3/air/AirCCallSpecial.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCCallSpecial.cpp
@@ -44,9 +44,7 @@ CCallSpecial::CCallSpecial(bool isSIMDContext)
     m_clobberedRegs.remove(FPRInfo::returnValueFPR);
 }
 
-CCallSpecial::~CCallSpecial()
-{
-}
+CCallSpecial::~CCallSpecial() = default;
 
 void CCallSpecial::forEachArg(Inst& inst, const ScopedLambda<Inst::EachArgCallback>& callback)
 {

--- a/Source/JavaScriptCore/b3/air/AirCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCode.cpp
@@ -122,9 +122,7 @@ Code::Code(Procedure& proc)
     m_pinnedRegs.add(MacroAssembler::framePointerRegister, IgnoreVectors);
 }
 
-Code::~Code()
-{
-}
+Code::~Code() = default;
 
 void Code::emitDefaultPrologue(CCallHelpers& jit)
 {

--- a/Source/JavaScriptCore/b3/air/AirPrintSpecial.cpp
+++ b/Source/JavaScriptCore/b3/air/AirPrintSpecial.cpp
@@ -41,9 +41,7 @@ PrintSpecial::PrintSpecial(Printer::PrintRecordList* list)
 {
 }
 
-PrintSpecial::~PrintSpecial()
-{
-}
+PrintSpecial::~PrintSpecial() = default;
 
 void PrintSpecial::forEachArg(Inst&, const ScopedLambda<Inst::EachArgCallback>&)
 {

--- a/Source/JavaScriptCore/b3/air/AirSpecial.cpp
+++ b/Source/JavaScriptCore/b3/air/AirSpecial.cpp
@@ -38,13 +38,9 @@ const char* const Special::dumpPrefix = "&";
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Special);
 
-Special::Special()
-{
-}
+Special::Special() = default;
 
-Special::~Special()
-{
-}
+Special::~Special() = default;
 
 CString Special::name() const
 {

--- a/Source/JavaScriptCore/b3/air/AirTmpWidth.cpp
+++ b/Source/JavaScriptCore/b3/air/AirTmpWidth.cpp
@@ -35,9 +35,7 @@
 
 namespace JSC { namespace B3 { namespace Air {
 
-TmpWidth::TmpWidth()
-{
-}
+TmpWidth::TmpWidth() = default;
 
 TmpWidth::TmpWidth(Code& code)
 {
@@ -45,9 +43,7 @@ TmpWidth::TmpWidth(Code& code)
     recompute<FP>(code);
 }
 
-TmpWidth::~TmpWidth()
-{
-}
+TmpWidth::~TmpWidth() = default;
 
 template <Bank bank>
 void TmpWidth::recompute(Code& code)

--- a/Source/JavaScriptCore/bytecode/CheckPrivateBrandVariant.cpp
+++ b/Source/JavaScriptCore/bytecode/CheckPrivateBrandVariant.cpp
@@ -36,7 +36,7 @@ CheckPrivateBrandVariant::CheckPrivateBrandVariant(CacheableIdentifier identifie
     , m_identifier(WTFMove(identifier))
 { }
 
-CheckPrivateBrandVariant::~CheckPrivateBrandVariant() { }
+CheckPrivateBrandVariant::~CheckPrivateBrandVariant() = default;
 
 bool CheckPrivateBrandVariant::attemptToMerge(const CheckPrivateBrandVariant& other)
 {

--- a/Source/JavaScriptCore/bytecode/DFGExitProfile.cpp
+++ b/Source/JavaScriptCore/bytecode/DFGExitProfile.cpp
@@ -38,8 +38,8 @@ void FrequentExitSite::dump(PrintStream& out) const
     out.print(m_bytecodeIndex, ": ", m_kind, "/", m_jitType, "/", m_inlineKind);
 }
 
-ExitProfile::ExitProfile() { }
-ExitProfile::~ExitProfile() { }
+ExitProfile::ExitProfile() = default;
+ExitProfile::~ExitProfile() = default;
 
 bool ExitProfile::add(CodeBlock* owner, const FrequentExitSite& site)
 {

--- a/Source/JavaScriptCore/bytecode/DeferredCompilationCallback.cpp
+++ b/Source/JavaScriptCore/bytecode/DeferredCompilationCallback.cpp
@@ -28,8 +28,8 @@
 
 namespace JSC {
 
-DeferredCompilationCallback::DeferredCompilationCallback() { }
-DeferredCompilationCallback::~DeferredCompilationCallback() { }
+DeferredCompilationCallback::DeferredCompilationCallback() = default;
+DeferredCompilationCallback::~DeferredCompilationCallback() = default;
 
 void DeferredCompilationCallback::compilationDidComplete(CodeBlock*, CodeBlock*, CompilationResult result)
 {

--- a/Source/JavaScriptCore/bytecode/DeleteByVariant.cpp
+++ b/Source/JavaScriptCore/bytecode/DeleteByVariant.cpp
@@ -44,7 +44,7 @@ DeleteByVariant::DeleteByVariant(CacheableIdentifier identifier, bool result, St
         ASSERT(newStructure);
 }
 
-DeleteByVariant::~DeleteByVariant() { }
+DeleteByVariant::~DeleteByVariant() = default;
 
 DeleteByVariant::DeleteByVariant(const DeleteByVariant& other)
 {

--- a/Source/JavaScriptCore/bytecode/GetByVariant.cpp
+++ b/Source/JavaScriptCore/bytecode/GetByVariant.cpp
@@ -50,7 +50,7 @@ GetByVariant::GetByVariant(CacheableIdentifier identifier, const StructureSet& s
         ASSERT(intrinsic() != NoIntrinsic);
 }
 
-GetByVariant::~GetByVariant() { }
+GetByVariant::~GetByVariant() = default;
 
 GetByVariant::GetByVariant(const GetByVariant& other)
     : GetByVariant(other.m_identifier)

--- a/Source/JavaScriptCore/bytecode/InlineCallFrameSet.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCallFrameSet.cpp
@@ -30,8 +30,8 @@
 
 namespace JSC {
 
-InlineCallFrameSet::InlineCallFrameSet() { }
-InlineCallFrameSet::~InlineCallFrameSet() { }
+InlineCallFrameSet::InlineCallFrameSet() = default;
+InlineCallFrameSet::~InlineCallFrameSet() = default;
 
 InlineCallFrame* InlineCallFrameSet::add()
 {

--- a/Source/JavaScriptCore/bytecode/SetPrivateBrandVariant.cpp
+++ b/Source/JavaScriptCore/bytecode/SetPrivateBrandVariant.cpp
@@ -37,7 +37,7 @@ SetPrivateBrandVariant::SetPrivateBrandVariant(CacheableIdentifier identifier, S
     , m_identifier(WTFMove(identifier))
 { }
 
-SetPrivateBrandVariant::~SetPrivateBrandVariant() { }
+SetPrivateBrandVariant::~SetPrivateBrandVariant() = default;
 
 bool SetPrivateBrandVariant::attemptToMerge(const SetPrivateBrandVariant& other)
 {

--- a/Source/JavaScriptCore/bytecode/TrackedReferences.cpp
+++ b/Source/JavaScriptCore/bytecode/TrackedReferences.cpp
@@ -31,13 +31,9 @@
 
 namespace JSC {
 
-TrackedReferences::TrackedReferences()
-{
-}
+TrackedReferences::TrackedReferences() = default;
 
-TrackedReferences::~TrackedReferences()
-{
-}
+TrackedReferences::~TrackedReferences() = default;
 
 void TrackedReferences::add(JSCell* cell)
 {

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -1133,9 +1133,7 @@ BytecodeGenerator::BytecodeGenerator(VM& vm, ModuleProgramNode* moduleProgramNod
     codeBlock->setModuleEnvironmentSymbolTableConstantRegisterOffset(constantSymbolTable->index());
 }
 
-BytecodeGenerator::~BytecodeGenerator()
-{
-}
+BytecodeGenerator::~BytecodeGenerator() = default;
 
 void BytecodeGenerator::initializeDefaultParameterValuesAndSetupFunctionScopeStack(
     FunctionParameters& parameters, bool isSimpleParameterList, FunctionNode* functionNode, SymbolTable* functionSymbolTable, 

--- a/Source/JavaScriptCore/debugger/Debugger.cpp
+++ b/Source/JavaScriptCore/debugger/Debugger.cpp
@@ -113,9 +113,7 @@ void Debugger::TemporarilyDisableExceptionBreakpoints::restore()
 }
 
 
-Debugger::ProfilingClient::~ProfilingClient()
-{
-}
+Debugger::ProfilingClient::~ProfilingClient() = default;
 
 Debugger::Debugger(VM& vm)
     : m_vm(vm)


### PR DESCRIPTION
#### f61dcc33e889168e8dc6fa25ce9478ca65786a45
<pre>
Use &quot;= default&quot; for constructor and destructor in JSC code

<a href="https://bugs.webkit.org/show_bug.cgi?id=274978">https://bugs.webkit.org/show_bug.cgi?id=274978</a>

Reviewed by Chris Dumez.

This extends our &quot;= default&quot; usage across constructor and destructor in JSC code.

* Source/JavaScriptCore/API/ObjCCallbackFunction.mm:
(CallbackArgument::~CallbackArgument):
* Source/JavaScriptCore/b3/B3ArgumentRegValue.cpp:
(JSC::B3::ArgumentRegValue::~ArgumentRegValue):
* Source/JavaScriptCore/b3/B3AtomicValue.cpp:
(JSC::B3::AtomicValue::~AtomicValue):
* Source/JavaScriptCore/b3/B3BasicBlock.cpp:
(JSC::B3::BasicBlock::~BasicBlock):
* Source/JavaScriptCore/b3/B3BlockInsertionSet.cpp:
(JSC::B3::BlockInsertionSet::~BlockInsertionSet):
* Source/JavaScriptCore/b3/B3CCallValue.cpp:
(JSC::B3::CCallValue::~CCallValue):
* Source/JavaScriptCore/b3/B3CheckSpecial.cpp:
(JSC::B3::CheckSpecial::~CheckSpecial):
* Source/JavaScriptCore/b3/B3CheckValue.cpp:
(JSC::B3::CheckValue::~CheckValue):
* Source/JavaScriptCore/b3/B3Const32Value.cpp:
(JSC::B3::Const32Value::~Const32Value):
* Source/JavaScriptCore/b3/B3Const64Value.cpp:
(JSC::B3::Const64Value::~Const64Value):
* Source/JavaScriptCore/b3/B3ConstDoubleValue.cpp:
(JSC::B3::ConstDoubleValue::~ConstDoubleValue):
* Source/JavaScriptCore/b3/B3ConstFloatValue.cpp:
(JSC::B3::ConstFloatValue::~ConstFloatValue):
* Source/JavaScriptCore/b3/B3ExtractValue.cpp:
(JSC::B3::ExtractValue::~ExtractValue):
* Source/JavaScriptCore/b3/B3FenceValue.cpp:
(JSC::B3::FenceValue::~FenceValue):
* Source/JavaScriptCore/b3/B3MemoryValue.cpp:
(JSC::B3::MemoryValue::~MemoryValue):
* Source/JavaScriptCore/b3/B3PatchpointSpecial.cpp:
(JSC::B3::PatchpointSpecial::PatchpointSpecial):
(JSC::B3::PatchpointSpecial::~PatchpointSpecial):
* Source/JavaScriptCore/b3/B3PatchpointValue.cpp:
(JSC::B3::PatchpointValue::~PatchpointValue):
* Source/JavaScriptCore/b3/B3PhiChildren.cpp:
(JSC::B3::PhiChildren::~PhiChildren):
* Source/JavaScriptCore/b3/B3Procedure.cpp:
(JSC::B3::Procedure::~Procedure):
* Source/JavaScriptCore/b3/B3PureCSE.cpp:
(JSC::B3::PureCSE::PureCSE):
(JSC::B3::PureCSE::~PureCSE):
* Source/JavaScriptCore/b3/B3SSACalculator.cpp:
(JSC::B3::SSACalculator::~SSACalculator):
* Source/JavaScriptCore/b3/B3SlotBaseValue.cpp:
(JSC::B3::SlotBaseValue::~SlotBaseValue):
* Source/JavaScriptCore/b3/B3StackmapSpecial.cpp:
(JSC::B3::StackmapSpecial::StackmapSpecial):
(JSC::B3::StackmapSpecial::~StackmapSpecial):
* Source/JavaScriptCore/b3/B3StackmapValue.cpp:
(JSC::B3::StackmapValue::~StackmapValue):
* Source/JavaScriptCore/b3/B3SwitchValue.cpp:
(JSC::B3::SwitchValue::~SwitchValue):
* Source/JavaScriptCore/b3/B3UpsilonValue.cpp:
(JSC::B3::UpsilonValue::~UpsilonValue):
* Source/JavaScriptCore/b3/B3UseCounts.cpp:
(JSC::B3::UseCounts::~UseCounts):
* Source/JavaScriptCore/b3/B3Variable.cpp:
(JSC::B3::Variable::~Variable):
* Source/JavaScriptCore/b3/B3VariableLiveness.cpp:
(JSC::B3::VariableLiveness::~VariableLiveness):
* Source/JavaScriptCore/b3/B3VariableValue.cpp:
(JSC::B3::VariableValue::~VariableValue):
* Source/JavaScriptCore/b3/B3WasmAddressValue.cpp:
(JSC::B3::WasmAddressValue::~WasmAddressValue):
* Source/JavaScriptCore/b3/B3WasmBoundsCheckValue.cpp:
(JSC::B3::WasmBoundsCheckValue::~WasmBoundsCheckValue):
* Source/JavaScriptCore/b3/air/AirBlockInsertionSet.cpp:
(JSC::B3::Air::BlockInsertionSet::~BlockInsertionSet):
* Source/JavaScriptCore/b3/air/AirCCallSpecial.cpp:
(JSC::B3::Air::CCallSpecial::~CCallSpecial):
* Source/JavaScriptCore/b3/air/AirCode.cpp:
(JSC::B3::Air::Code::~Code):
* Source/JavaScriptCore/b3/air/AirPrintSpecial.cpp:
(JSC::B3::Air::PrintSpecial::~PrintSpecial):
* Source/JavaScriptCore/b3/air/AirSpecial.cpp:
(JSC::B3::Air::Special::Special):
(JSC::B3::Air::Special::~Special):
* Source/JavaScriptCore/b3/air/AirTmpWidth.cpp:
(JSC::B3::Air::TmpWidth::~TmpWidth):
* Source/JavaScriptCore/bytecode/CheckPrivateBrandVariant.cpp:
(JSC::CheckPrivateBrandVariant::~CheckPrivateBrandVariant):
* Source/JavaScriptCore/bytecode/DFGExitProfile.cpp:
(JSC::DFG::ExitProfile::ExitProfile):
(JSC::DFG::ExitProfile::~ExitProfile):
* Source/JavaScriptCore/bytecode/DeferredCompilationCallback.cpp:
(JSC::DeferredCompilationCallback::DeferredCompilationCallback):
(JSC::DeferredCompilationCallback::~DeferredCompilationCallback):
* Source/JavaScriptCore/bytecode/DeleteByVariant.cpp:
(JSC::DeleteByVariant::~DeleteByVariant):
* Source/JavaScriptCore/bytecode/GetByVariant.cpp:
(JSC::GetByVariant::~GetByVariant):
* Source/JavaScriptCore/bytecode/InlineCallFrameSet.cpp:
(JSC::InlineCallFrameSet::InlineCallFrameSet):
(JSC::InlineCallFrameSet::~InlineCallFrameSet):
* Source/JavaScriptCore/bytecode/SetPrivateBrandVariant.cpp:
(JSC::SetPrivateBrandVariant::~SetPrivateBrandVariant):
* Source/JavaScriptCore/bytecode/TrackedReferences.cpp:
(JSC::TrackedReferences::TrackedReferences):
(JSC::TrackedReferences::~TrackedReferences):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::~BytecodeGenerator):
* Source/JavaScriptCore/debugger/Debugger.cpp:
(JSC::Debugger::ProfilingClient::~ProfilingClient):

Canonical link: <a href="https://commits.webkit.org/279604@main">https://commits.webkit.org/279604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6551b30a7a959343406f460e7ee9d39d346d536e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57180 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4625 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4502 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43646 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3048 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/55998 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31516 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46627 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24804 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28319 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3946 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2778 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/47260 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49983 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4147 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58773 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/53413 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29075 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4223 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51063 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30266 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46767 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50396 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11751 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31213 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65714 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30043 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12506 "Passed tests") | 
<!--EWS-Status-Bubble-End-->