### PR TITLE
REGRESSION(279321@main): js/dom/missing-exception-check-in-convertVariadicArguments.html is crashing : Unchecked exception detected at JSC::VM::verifyExceptionCheckNeedIsSatisfied : ASSERTION FAILED: !m_needExceptionCheck

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7316,6 +7316,4 @@ webkit.org/b/271916 media/track/track-in-band-layout.html [ Failure ]
 
 webkit.org/b/274766 [ Debug ] http/wpt/webauthn/public-key-credential-get-success-u2f.https.html [ Failure ]
 
-webkit.org/b/274732 [ Debug ] js/dom/missing-exception-check-in-convertVariadicArguments.html [ Skip ]
-
 webkit.org/b/274925 [ Debug ] ipc/dirty-region-overflow.html [ Skip ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2530,5 +2530,3 @@ webkit.org/b/273308 http/tests/media/media-source/mediasource-rvfc.html [ Timeou
 # webkit.org/b/274475 REGRESSION (278960@main?): [ MacOS iOS ] 8X imported/w3c/web-platform-t ests/navigation-api are consistently failing and 1 is crashing
 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-navigations-in-multiple-windows.html [ Failure ]
 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-location-replace-cross-origin.html [ Failure ]
-
-webkit.org/b/274732 [ Debug ] js/dom/missing-exception-check-in-convertVariadicArguments.html [ Skip ]

--- a/Source/WebCore/bindings/js/JSDOMConvertAny.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertAny.h
@@ -70,14 +70,7 @@ template<> struct VariadicConverter<IDLAny> {
 
     static std::optional<Item> convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
     {
-        auto& vm = JSC::getVM(&lexicalGlobalObject);
-        auto scope = DECLARE_THROW_SCOPE(vm);
-
-        auto result = WebCore::convert<IDLAny>(lexicalGlobalObject, value);
-        if (UNLIKELY(result.hasException(scope)))
-            return std::nullopt;
-
-        return Item { JSC::getVM(&lexicalGlobalObject), result.releaseReturnValue() };
+        return Item { JSC::getVM(&lexicalGlobalObject), value };
     }
 };
 


### PR DESCRIPTION
#### dc54b6a653e308433ca5861898c0b19830f17347
<pre>
REGRESSION(279321@main): js/dom/missing-exception-check-in-convertVariadicArguments.html is crashing : Unchecked exception detected at JSC::VM::verifyExceptionCheckNeedIsSatisfied : ASSERTION FAILED: !m_needExceptionCheck
<a href="https://bugs.webkit.org/show_bug.cgi?id=274732">https://bugs.webkit.org/show_bug.cgi?id=274732</a>

Reviewed by Mark Lam.

Placate the exception checking mechanism by ensure we check for each
conversion in the variadic converter loop.

Also remove unnecessary checks in IDLAny converter.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
    - Re-enable tests.

* Source/WebCore/bindings/js/JSDOMConvertAny.h:
(WebCore::VariadicConverter&lt;IDLAny&gt;::convert):
    - Remove unneeded checks.

* Source/WebCore/bindings/js/JSDOMConvertVariadic.h:
(WebCore::convertVariadicArguments):
    - Add checks for each loop.

Canonical link: <a href="https://commits.webkit.org/279617@main">https://commits.webkit.org/279617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4759c605cde49234a33e0fab565c2a2360ce176c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33368 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57272 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4721 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56298 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4612 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43718 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3118 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56093 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31584 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46722 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24859 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28413 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4044 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2870 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50075 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4244 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58866 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29174 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4332 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51133 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30362 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46852 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50475 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11762 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31315 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30139 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->