### PR TITLE
WebGLRenderingContextBase::validateBlendEquation is redundant

### DIFF
--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -3229,21 +3229,6 @@ WebGLAny WebGL2RenderingContext::getParameter(GCGLenum pname)
     }
 }
 
-bool WebGL2RenderingContext::validateBlendEquation(ASCIILiteral functionName, GCGLenum mode)
-{
-    switch (mode) {
-    case GraphicsContextGL::FUNC_ADD:
-    case GraphicsContextGL::FUNC_SUBTRACT:
-    case GraphicsContextGL::FUNC_REVERSE_SUBTRACT:
-    case GraphicsContextGL::MIN:
-    case GraphicsContextGL::MAX:
-        return true;
-    default:
-        synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid mode"_s);
-        return false;
-    }
-}
-
 bool WebGL2RenderingContext::validateCapability(ASCIILiteral functionName, GCGLenum cap)
 {
     switch (cap) {

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -280,7 +280,6 @@ private:
     bool validateAndCacheBufferBinding(const AbstractLocker&, ASCIILiteral functionName, GCGLenum target, WebGLBuffer*) final;
     GCGLint maxDrawBuffers() final;
     GCGLint maxColorAttachments() final;
-    bool validateBlendEquation(ASCIILiteral functionName, GCGLenum mode) final;
     bool validateCapability(ASCIILiteral functionName, GCGLenum cap) final;
     template<typename T, typename TypedArrayType>
     std::optional<std::span<const T>> validateClearBuffer(ASCIILiteral functionName, GCGLenum buffer, TypedList<TypedArrayType, T>& values, GCGLuint srcOffset);

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.cpp
@@ -342,26 +342,6 @@ GCGLint WebGLRenderingContext::maxColorAttachments()
     return m_maxColorAttachments;
 }
 
-bool WebGLRenderingContext::validateBlendEquation(ASCIILiteral functionName, GCGLenum mode)
-{
-    switch (mode) {
-    case GraphicsContextGL::FUNC_ADD:
-    case GraphicsContextGL::FUNC_SUBTRACT:
-    case GraphicsContextGL::FUNC_REVERSE_SUBTRACT:
-    case GraphicsContextGL::MIN_EXT:
-    case GraphicsContextGL::MAX_EXT:
-        if ((mode == GraphicsContextGL::MIN_EXT || mode == GraphicsContextGL::MAX_EXT) && !m_extBlendMinMax) {
-            synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid mode"_s);
-            return false;
-        }
-        return true;
-        break;
-    default:
-        synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid mode"_s);
-        return false;
-    }
-}
-
 void WebGLRenderingContext::addMembersToOpaqueRoots(JSC::AbstractSlotVisitor& visitor)
 {
     WebGLRenderingContextBase::addMembersToOpaqueRoots(visitor);

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.h
@@ -53,7 +53,6 @@ public:
     GCGLint maxDrawBuffers() final;
     GCGLint maxColorAttachments() final;
     void initializeDefaultObjects() final;
-    bool validateBlendEquation(ASCIILiteral functionName, GCGLenum mode) final;
 
     void addMembersToOpaqueRoots(JSC::AbstractSlotVisitor&) final;
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -1094,14 +1094,14 @@ void WebGLRenderingContextBase::blendColor(GCGLfloat red, GCGLfloat green, GCGLf
 
 void WebGLRenderingContextBase::blendEquation(GCGLenum mode)
 {
-    if (isContextLost() || !validateBlendEquation("blendEquation"_s, mode))
+    if (isContextLost())
         return;
     m_context->blendEquation(mode);
 }
 
 void WebGLRenderingContextBase::blendEquationSeparate(GCGLenum modeRGB, GCGLenum modeAlpha)
 {
-    if (isContextLost() || !validateBlendEquation("blendEquation"_s, modeRGB) || !validateBlendEquation("blendEquation"_s, modeAlpha))
+    if (isContextLost())
         return;
     m_context->blendEquationSeparate(modeRGB, modeAlpha);
 }

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -976,9 +976,6 @@ protected:
     // Generate GL error if parameters are illegal.
     bool validateFramebufferFuncParameters(ASCIILiteral functionName, GCGLenum target, GCGLenum attachment);
 
-    // Helper function to validate blend equation mode.
-    virtual bool validateBlendEquation(ASCIILiteral functionName, GCGLenum) = 0;
-
     // Helper function to validate a GL capability.
     virtual bool validateCapability(ASCIILiteral functionName, GCGLenum);
 


### PR DESCRIPTION
#### 44b3ed42e30a88b4698f03e39cfaf266a5f3bee3
<pre>
WebGLRenderingContextBase::validateBlendEquation is redundant
<a href="https://bugs.webkit.org/show_bug.cgi?id=274983">https://bugs.webkit.org/show_bug.cgi?id=274983</a>

Reviewed by Kimmo Kinnunen.

Removed redundant code.

* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::validateBlendEquation): Deleted.
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContext.cpp:
(WebCore::WebGLRenderingContext::validateBlendEquation): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::blendEquation):
(WebCore::WebGLRenderingContextBase::blendEquationSeparate):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:

Canonical link: <a href="https://commits.webkit.org/279637@main">https://commits.webkit.org/279637@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fdcde0b081dc260521ca63e6b7b3d4aec8507c5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6442 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57189 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4635 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56213 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40786 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4521 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43654 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3055 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31505 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46637 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24791 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28327 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3956 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2787 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49988 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4157 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58782 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4254 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51070 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30276 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46777 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50404 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11778 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31222 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30052 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->