### PR TITLE
Fix same-site cookie quirk for bing.com

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3352,7 +3352,7 @@ void FrameLoader::addSameSiteInfoToRequestIfNeeded(ResourceRequest& request, con
         request.setIsSameSite(true);
         return;
     }
-    if (initiator->quirks().needsLaxSameSiteCookieQuirk()) {
+    if (initiator->quirks().needsLaxSameSiteCookieQuirk(request.url())) {
         request.setIsSameSite(true);
         return;
     }

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1863,21 +1863,13 @@ bool Quirks::needsRelaxedCorsMixedContentCheckQuirk() const
 }
 
 // rdar://127398734
-bool Quirks::needsLaxSameSiteCookieQuirk() const
+bool Quirks::needsLaxSameSiteCookieQuirk(const URL& requestURL) const
 {
     if (!needsQuirks())
         return false;
 
-    if (m_needsLaxSameSiteCookieQuirk)
-        return *m_needsLaxSameSiteCookieQuirk;
-
-    m_needsLaxSameSiteCookieQuirk = false;
-
     auto url = m_document->url();
-    if (url.protocolIs("https"_s) && url.host() == "www.bing.com"_s)
-        m_needsLaxSameSiteCookieQuirk = true;
-
-    return *m_needsLaxSameSiteCookieQuirk;
+    return url.protocolIs("https"_s) && url.host() == "login.microsoftonline.com"_s && requestURL.protocolIs("https"_s) && requestURL.host() == "www.bing.com"_s;
 }
 
 }

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -191,7 +191,7 @@ public:
 
     bool needsGetElementsByNameQuirk() const;
     bool needsRelaxedCorsMixedContentCheckQuirk() const;
-    bool needsLaxSameSiteCookieQuirk() const;
+    bool needsLaxSameSiteCookieQuirk(const URL&) const;
 
 private:
     bool needsQuirks() const;
@@ -265,7 +265,6 @@ private:
     mutable std::optional<bool> m_shouldDisableElementFullscreen;
     mutable std::optional<bool> m_shouldIgnorePlaysInlineRequirementQuirk;
     mutable std::optional<bool> m_needsRelaxedCorsMixedContentCheckQuirk;
-    mutable std::optional<bool> m_needsLaxSameSiteCookieQuirk;
 
     Vector<RegistrableDomain> m_subFrameDomainsForStorageAccessQuirk;
 };


### PR DESCRIPTION
#### 2456802a5836d6d646d2b68d311e7ec192819922
<pre>
Fix same-site cookie quirk for bing.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=274985">https://bugs.webkit.org/show_bug.cgi?id=274985</a>
<a href="https://rdar.apple.com/128956265">rdar://128956265</a>

Reviewed by Pascoe.

The original quirk only looked at the current document&apos;s URL. This was
insufficient because we need the quirk to apply on a cross-site from
<a href="https://login.microsoftonline.com">https://login.microsoftonline.com</a> to <a href="https://www.bing.com.">https://www.bing.com.</a> Now this quirk
checks both the current document and the request URLs.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::addSameSiteInfoToRequestIfNeeded):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsLaxSameSiteCookieQuirk const):
* Source/WebCore/page/Quirks.h:

Canonical link: <a href="https://commits.webkit.org/279675@main">https://commits.webkit.org/279675@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac73602afe9901a4f7a3f2f2caf3c17808561f19

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33281 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6443 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57190 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4636 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56214 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4516 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43653 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3060 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31497 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46636 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24790 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28329 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/3955 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2788 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/49990 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4156 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58783 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29085 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4234 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51071 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30277 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46776 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50405 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31223 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8022 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30053 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->