### PR TITLE
[WebGPU] RGB external textures read RRG channels instead of RGB

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2144,6 +2144,7 @@ fast/webgpu/regression [ Pass ]
 [ Release ] fast/webgpu/fuzz-128396311.html [ Pass Failure Timeout ]
 [ Debug ] fast/webgpu/fuzz-274622.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-274622.html [ Pass Failure Timeout ]
+fast/webgpu/regression/repro_274977.html [ Pass Failure ]
 
 # Imported W3C HTML/DOM ref tests that are failing.
 imported/w3c/web-platform-tests/html/dom/elements/global-attributes/dir_auto-textarea-script-N-between-Rs.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/webgpu/regression/repro_274977-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_274977-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: no validation error
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_274977.html
+++ b/LayoutTests/fast/webgpu/regression/repro_274977.html
@@ -1,0 +1,80 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  const format = 'bgra8unorm';
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let videoFrame = new VideoFrame(new ArrayBuffer(4), {
+      codedWidth: 1, codedHeight: 1,
+      format: 'BGRA',
+      timestamp: 0,
+    });
+    let externalTexture0 = device.importExternalTexture({source: videoFrame});
+    let vertexesF32 = new Float32Array([1, -1, 1, 1, -1, 1, 1, 1, -1, -1, 1, 1, 1, -1, 1, 1, 1, 1, 1, 1, -1, 1, 1, 1]);
+    let vertexBuffer = device.createBuffer({size: vertexesF32.byteLength, usage: GPUBufferUsage.VERTEX, mappedAtCreation: true});
+    new Float32Array(vertexBuffer.getMappedRange()).set(vertexesF32);
+    vertexBuffer.unmap();
+
+    let vertexShader = `
+@vertex
+fn v(@location(0) position : vec4f) -> @builtin(position) vec4f {
+  return position;
+}
+
+@group(0) @binding(1) var et: texture_external;
+
+@fragment
+fn f() -> @location(0) vec4f {
+  return textureLoad(et, vec2());
+}
+`;
+    let bindGroupLayout = device.createBindGroupLayout({
+      entries: [{binding: 1, externalTexture: {}, texture: {}, visibility: GPUShaderStage.FRAGMENT}],
+    });
+    let module = device.createShaderModule({code: vertexShader});
+    let pipeline = device.createRenderPipeline({
+      layout: device.createPipelineLayout({bindGroupLayouts: [bindGroupLayout]}),
+      vertex: {
+        module,
+        buffers: [{arrayStride: 16, attributes: [{shaderLocation: 0, offset: 0, format: 'float32x4'}]}],
+      },
+      fragment: {module, targets: [{format}]},
+    });
+
+    let textureBindGroup = device.createBindGroup({
+      layout: bindGroupLayout,
+      entries: [{binding: 1, resource: externalTexture0}],
+    });
+
+    let renderPassDescriptor = {
+      colorAttachments: [{
+        view: device.createTexture({format, size: [1], usage: GPUTextureUsage.RENDER_ATTACHMENT}).createView(),
+        clearValue: [0.5, 0.5, 0.5, 1],
+        loadOp: 'clear', storeOp: 'store',
+      }],
+    };
+
+    let commandEncoder = device.createCommandEncoder();
+    let passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+
+    passEncoder.setPipeline(pipeline);
+    passEncoder.setBindGroup(0, textureBindGroup);
+    passEncoder.setVertexBuffer(0, vertexBuffer);
+    passEncoder.draw(6);
+    passEncoder.end();
+    device.queue.submit([commandEncoder.finish()]);
+
+    await device.queue.onSubmittedWorkDone();
+    let error = await device.popErrorScope();
+    if (error) {
+      log(error.message);
+    } else {
+      log('no validation error');
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>


### PR DESCRIPTION
#### ca50fe80d4cf47c03f1fc36603a1b604c0bf1322
<pre>
[WebGPU] RGB external textures read RRG channels instead of RGB
<a href="https://bugs.webkit.org/show_bug.cgi?id=274977">https://bugs.webkit.org/show_bug.cgi?id=274977</a>
&lt;radar://129054259&gt;

Reviewed by Tadeu Zagallo.

Fix an issue where single planar external textures attempted to read
from a null texture and instead of reading RGB we would read RRG or ARR.

* LayoutTests/fast/webgpu/regression/repro_274977-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_274977.html: Added.
* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::metalPixelFormat):
(WebGPU::Device::createExternalTextureFromPixelBuffer const):

Canonical link: <a href="https://commits.webkit.org/279681@main">https://commits.webkit.org/279681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00afb7075bb2600021fe9a30a3f95b3529c6f403

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54142 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57418 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4866 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43850 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3248 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56238 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46877 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24995 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/28585 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4196 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3015 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59011 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29341 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4506 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51268 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30516 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46991 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50628 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11799 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31483 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30297 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->