### PR TITLE
[Remote Inspection] Refactor some code for copying rendered text from selected elements

### DIFF
--- a/Source/WebCore/page/ElementTargetingTypes.h
+++ b/Source/WebCore/page/ElementTargetingTypes.h
@@ -69,6 +69,7 @@ struct TargetedElementInfo {
     bool isPseudoElement { false };
     bool isInShadowTree { false };
     bool isInVisibilityAdjustmentSubtree { false };
+    bool hasLargeReplacedDescendant { false };
     bool hasAudibleMedia { false };
 };
 

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -52,6 +52,7 @@
 #include "TextIterator.h"
 #include "WritingMode.h"
 #include <unicode/uchar.h>
+#include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 namespace TextExtraction {
@@ -453,8 +454,9 @@ Item extractItem(std::optional<WebCore::FloatRect>&& collectionRectInRootView, P
     return root;
 }
 
-struct StringsAndBlockOffset {
-    Vector<String> strings;
+using Token = std::variant<String, IntSize>;
+struct TokenAndBlockOffset {
+    Vector<Token> tokens;
     int offset { 0 };
 };
 
@@ -467,15 +469,15 @@ static IntSize reducePrecision(FloatSize size)
     };
 }
 
-static void extractRenderedText(Vector<StringsAndBlockOffset>& stringsAndOffsets, ContainerNode& node, BlockFlowDirection direction, OnlyIncludeTextContent onlyIncludeTextContent)
+static void extractRenderedTokens(Vector<TokenAndBlockOffset>& tokensAndOffsets, ContainerNode& node, BlockFlowDirection direction)
 {
     CheckedPtr renderer = node.renderer();
     if (!renderer)
         return;
 
-    auto appendStrings = [&](Vector<String>&& strings, IntRect bounds) mutable {
+    auto appendTokens = [&](Vector<Token>&& tokens, IntRect bounds) mutable {
         static constexpr auto minPixelDistanceForNearbyText = 5;
-        if (strings.isEmpty() || bounds.width() <= minPixelDistanceForNearbyText || bounds.height() <= minPixelDistanceForNearbyText)
+        if (tokens.isEmpty() || bounds.width() <= minPixelDistanceForNearbyText || bounds.height() <= minPixelDistanceForNearbyText)
             return;
 
         auto offset = [&] {
@@ -493,21 +495,21 @@ static void extractRenderedText(Vector<StringsAndBlockOffset>& stringsAndOffsets
             return 0;
         }();
 
-        auto foundIndex = stringsAndOffsets.reverseFindIf([&](auto& item) {
+        auto foundIndex = tokensAndOffsets.reverseFindIf([&](auto& item) {
             return std::abs(offset - item.offset) <= minPixelDistanceForNearbyText;
         });
 
         if (foundIndex == notFound) {
-            stringsAndOffsets.append({ WTFMove(strings), offset });
+            tokensAndOffsets.append({ WTFMove(tokens), offset });
             return;
         }
 
-        stringsAndOffsets[foundIndex].strings.appendVector(WTFMove(strings));
+        tokensAndOffsets[foundIndex].tokens.appendVector(WTFMove(tokens));
     };
 
     if (CheckedPtr frameRenderer = dynamicDowncast<RenderIFrame>(*renderer)) {
         if (auto contentDocument = frameRenderer->iframeElement().protectedContentDocument())
-            extractRenderedText(stringsAndOffsets, *contentDocument, direction, onlyIncludeTextContent);
+            extractRenderedTokens(tokensAndOffsets, *contentDocument, direction);
         return;
     }
 
@@ -518,11 +520,10 @@ static void extractRenderedText(Vector<StringsAndBlockOffset>& stringsAndOffsets
 
         auto absoluteRect = renderer.absoluteBoundingBoxRect();
         auto roundedSize = reducePrecision(frameView->absoluteToDocumentRect(absoluteRect).size());
-        appendStrings({ makeString('{', roundedSize.width(), ',', roundedSize.height(), '}') }, frameView->contentsToRootView(absoluteRect));
+        appendTokens({ { roundedSize } }, frameView->contentsToRootView(absoluteRect));
     };
 
-    if (onlyIncludeTextContent == OnlyIncludeTextContent::No)
-        appendReplacedContentOrBackgroundImage(*renderer);
+    appendReplacedContentOrBackgroundImage(*renderer);
 
     for (auto& descendant : descendantsOfType<RenderObject>(*renderer)) {
         if (descendant.style().usedVisibility() == Visibility::Hidden)
@@ -535,38 +536,40 @@ static void extractRenderedText(Vector<StringsAndBlockOffset>& stringsAndOffsets
             continue;
 
         if (CheckedPtr textRenderer = dynamicDowncast<RenderText>(descendant); textRenderer && textRenderer->hasRenderedText()) {
-            Vector<String> strings;
+            Vector<Token> tokens;
             for (auto token : textRenderer->text().simplifyWhiteSpace(isASCIIWhitespace).split(' ')) {
                 auto candidate = token.removeCharacters([](UChar character) {
                     return !u_isalpha(character) && !u_isdigit(character);
                 });
                 if (!candidate.isEmpty())
-                    strings.append(WTFMove(candidate));
+                    tokens.append({ WTFMove(candidate) });
             }
-            appendStrings(WTFMove(strings), frameView->contentsToRootView(descendant.absoluteBoundingBoxRect()));
+            appendTokens(WTFMove(tokens), frameView->contentsToRootView(descendant.absoluteBoundingBoxRect()));
             continue;
         }
 
         if (CheckedPtr frameRenderer = dynamicDowncast<RenderIFrame>(descendant)) {
             if (auto contentDocument = frameRenderer->iframeElement().protectedContentDocument())
-                extractRenderedText(stringsAndOffsets, *contentDocument, direction, onlyIncludeTextContent);
+                extractRenderedTokens(tokensAndOffsets, *contentDocument, direction);
             continue;
         }
 
-        if (onlyIncludeTextContent == OnlyIncludeTextContent::No)
-            appendReplacedContentOrBackgroundImage(descendant);
+        appendReplacedContentOrBackgroundImage(descendant);
     }
 }
 
-String extractRenderedText(Element& element, OnlyIncludeTextContent onlyIncludeTextContent)
+RenderedText extractRenderedText(Element& element)
 {
-    if (!element.renderer())
-        return emptyString();
+    CheckedPtr renderer = element.renderer();
+    if (!renderer)
+        return { };
 
-    auto direction = element.renderer()->style().blockFlowDirection();
+    RefPtr frameView = renderer->view().protectedFrameView();
+    auto direction = renderer->style().blockFlowDirection();
+    auto elementRectInDocument = frameView->absoluteToDocumentRect(renderer->absoluteBoundingBoxRect());
 
-    Vector<StringsAndBlockOffset> stringsAndOffsets;
-    extractRenderedText(stringsAndOffsets, element, direction, onlyIncludeTextContent);
+    Vector<TokenAndBlockOffset> allTokensAndOffsets;
+    extractRenderedTokens(allTokensAndOffsets, element, direction);
 
     bool ascendingOrder = [&] {
         switch (direction) {
@@ -581,15 +584,34 @@ String extractRenderedText(Element& element, OnlyIncludeTextContent onlyIncludeT
         return true;
     }();
 
-    std::sort(stringsAndOffsets.begin(), stringsAndOffsets.end(), [&](auto& a, auto& b) {
+    std::sort(allTokensAndOffsets.begin(), allTokensAndOffsets.end(), [&](auto& a, auto& b) {
         return ascendingOrder ? a.offset < b.offset : a.offset > b.offset;
     });
 
-    auto flattenedStrings = stringsAndOffsets.map([](auto& item) {
-        return makeStringByJoining(item.strings, " "_s);
-    });
+    bool hasLargeReplacedDescendant = false;
+    StringBuilder textWithReplacedContent;
+    StringBuilder textWithoutReplacedContent;
+    auto appendText = [](StringBuilder& builder, const String& string) {
+        if (!builder.isEmpty())
+            builder.append(' ');
+        builder.append(string);
+    };
 
-    return makeStringByJoining(flattenedStrings, " "_s);
+    for (auto& [tokens, offset] : allTokensAndOffsets) {
+        for (auto& token : tokens) {
+            switchOn(token, [&](const String& text) {
+                appendText(textWithReplacedContent, text);
+                appendText(textWithoutReplacedContent, text);
+            }, [&](const IntSize& size) {
+                constexpr auto ratioToConsiderLengthAsLarge = 0.9;
+                if (size.width() > ratioToConsiderLengthAsLarge * elementRectInDocument.width() && size.height() > ratioToConsiderLengthAsLarge * elementRectInDocument.height())
+                    hasLargeReplacedDescendant = true;
+                appendText(textWithReplacedContent, makeString('{', size.width(), ',', size.height(), '}'));
+            });
+        }
+    }
+
+    return { textWithReplacedContent.toString(), textWithoutReplacedContent.toString(), hasLargeReplacedDescendant };
 }
 
 } // namespace TextExtractor

--- a/Source/WebCore/page/text-extraction/TextExtraction.h
+++ b/Source/WebCore/page/text-extraction/TextExtraction.h
@@ -37,11 +37,15 @@ enum class ExceptionCode : uint8_t;
 
 namespace TextExtraction {
 
-enum class OnlyIncludeTextContent : bool { No, Yes };
-
 WEBCORE_EXPORT Item extractItem(std::optional<WebCore::FloatRect>&& collectionRectInRootView, Page&);
 
-String extractRenderedText(Element&, OnlyIncludeTextContent);
+struct RenderedText {
+    String textWithReplacedContent;
+    String textWithoutReplacedContent;
+    bool hasLargeReplacedDescendant { false };
+};
+
+RenderedText extractRenderedText(Element&);
 
 } // namespace TextExtraction
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -921,6 +921,7 @@ header: <WebCore/ElementTargetingTypes.h>
     bool isPseudoElement
     bool isInShadowTree
     bool isInVisibilityAdjustmentSubtree
+    bool hasLargeReplacedDescendant
     bool hasAudibleMedia
 };
 

--- a/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/APITargetedElementInfo.h
@@ -67,6 +67,7 @@ public:
     bool isPseudoElement() const { return m_info.isPseudoElement; }
     bool isInShadowTree() const { return m_info.isInShadowTree; }
     bool isInVisibilityAdjustmentSubtree() const { return m_info.isInVisibilityAdjustmentSubtree; }
+    bool hasLargeReplacedDescendant() const { return m_info.hasLargeReplacedDescendant; }
     bool hasAudibleMedia() const { return m_info.hasAudibleMedia; }
 
     const HashSet<WTF::URL>& mediaAndLinkURLs() const { return m_info.mediaAndLinkURLs; }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h
@@ -47,6 +47,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 @property (nonatomic, readonly, getter=isPseudoElement) BOOL pseudoElement;
 @property (nonatomic, readonly, getter=isInShadowTree) BOOL inShadowTree;
 @property (nonatomic, readonly, getter=isInVisibilityAdjustmentSubtree) BOOL inVisibilityAdjustmentSubtree;
+@property (nonatomic, readonly) BOOL hasLargeReplacedDescendant;
 @property (nonatomic, readonly) BOOL hasAudibleMedia;
 @property (nonatomic, readonly) NSSet<NSURL *> *mediaAndLinkURLs;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
@@ -159,6 +159,11 @@
     return _info->isInVisibilityAdjustmentSubtree();
 }
 
+- (BOOL)hasLargeReplacedDescendant
+{
+    return _info->hasLargeReplacedDescendant();
+}
+
 - (NSSet<NSURL *> *)mediaAndLinkURLs
 {
     RetainPtr result = adoptNS([NSMutableSet<NSURL *> new]);

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1262,6 +1262,7 @@
 		F4C2AB221DD6D95E00E06D5B /* enormous-video-with-sound.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4C2AB211DD6D94100E06D5B /* enormous-video-with-sound.html */; };
 		F4C8797F2059D8D3009CD00B /* ScrollViewInsetTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4C8797E2059D8D3009CD00B /* ScrollViewInsetTests.mm */; };
 		F4CB8A7D2856462B0017ECD3 /* TestPDFHostViewController.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4CB8A7C285644FB0017ECD3 /* TestPDFHostViewController.mm */; };
+		F4CC8F4D2C0A759D00D7E76E /* element-targeting-9.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4CC8F452C0A74BA00D7E76E /* element-targeting-9.html */; };
 		F4CD74C620FDACFA00DE3794 /* text-with-async-script.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4CD74C520FDACF500DE3794 /* text-with-async-script.html */; };
 		F4CDF3D227E97C7E00191928 /* SpellCheckerDocumentTag.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4CDF3D127E97C7E00191928 /* SpellCheckerDocumentTag.mm */; };
 		F4CEF1572A1030A400A370BE /* editable-body-mixed-text.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = F4CEF1562A102F4E00A370BE /* editable-body-mixed-text.html */; };
@@ -1647,6 +1648,7 @@
 				F41289A92BCC97E700D6E0E7 /* element-targeting-6.html in Copy Resources */,
 				F405F8AD2BD1D4DC0020E6AB /* element-targeting-7.html in Copy Resources */,
 				F44CD9D12BD6ABFD0080A6C7 /* element-targeting-8.html in Copy Resources */,
+				F4CC8F4D2C0A759D00D7E76E /* element-targeting-9.html in Copy Resources */,
 				51C8E1A91F27F49600BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist in Copy Resources */,
 				49D902B328209B3300E2C3B8 /* emptyTable.html in Copy Resources */,
 				A14AAB651E78DC5400C1ADC2 /* encrypted.pdf in Copy Resources */,
@@ -3675,6 +3677,7 @@
 		F4C8797E2059D8D3009CD00B /* ScrollViewInsetTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ScrollViewInsetTests.mm; sourceTree = "<group>"; };
 		F4CB8A7B2856447F0017ECD3 /* TestPDFHostViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestPDFHostViewController.h; sourceTree = "<group>"; };
 		F4CB8A7C285644FB0017ECD3 /* TestPDFHostViewController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TestPDFHostViewController.mm; sourceTree = "<group>"; };
+		F4CC8F452C0A74BA00D7E76E /* element-targeting-9.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "element-targeting-9.html"; sourceTree = "<group>"; };
 		F4CD74C520FDACF500DE3794 /* text-with-async-script.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "text-with-async-script.html"; sourceTree = "<group>"; };
 		F4CD74C720FDB49600DE3794 /* TestURLSchemeHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestURLSchemeHandler.h; sourceTree = "<group>"; };
 		F4CD74C820FDB49600DE3794 /* TestURLSchemeHandler.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TestURLSchemeHandler.mm; sourceTree = "<group>"; };
@@ -4885,6 +4888,7 @@
 				F41289A12BCC97DA00D6E0E7 /* element-targeting-6.html */,
 				F405F8A42BD1D1B90020E6AB /* element-targeting-7.html */,
 				F44CD9C92BD6ABF00080A6C7 /* element-targeting-8.html */,
+				F4CC8F452C0A74BA00D7E76E /* element-targeting-9.html */,
 				51C8E1A81F27F47300BF731B /* EmptyGrandfatheredResourceLoadStatistics.plist */,
 				F4C2AB211DD6D94100E06D5B /* enormous-video-with-sound.html */,
 				F407FE381F1D0DE60017CF25 /* enormous.svg */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm
@@ -562,6 +562,8 @@ TEST(ElementTargeting, ReplacedRendererSizeIgnoresPageScaleAndZoom)
     [webView waitForNextPresentationUpdate];
     RetainPtr targetAfterScaling = [[webView targetedElementInfoAt:CGPointMake(100, 100)] firstObject];
     EXPECT_WK_STREQ([targetBeforeScaling renderedText], [targetAfterScaling renderedText]);
+    EXPECT_FALSE([targetBeforeScaling hasLargeReplacedDescendant]);
+    EXPECT_FALSE([targetAfterScaling hasLargeReplacedDescendant]);
 }
 
 TEST(ElementTargeting, RequestTargetedElementsBySearchableText)
@@ -601,14 +603,15 @@ TEST(ElementTargeting, AdjustVisibilityAfterRecreatingElement)
     Util::run(&didAdjustment);
 }
 
-TEST(ElementTargeting, TargetedElementScreenReaderText)
+TEST(ElementTargeting, TargetedElementWithLargeImage)
 {
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
-    [webView synchronouslyLoadTestPageNamed:@"element-targeting-7"];
-    RetainPtr element = [[webView targetedElementInfoAt:CGPointMake(100, 100)] firstObject];
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 480, 600)]);
+    [webView synchronouslyLoadTestPageNamed:@"element-targeting-9"];
+    RetainPtr element = [[webView targetedElementInfoAt:CGPointMake(80, 80)] firstObject];
 
-    EXPECT_TRUE([[element renderedText] containsString:@"{200,100}"]);
-    EXPECT_FALSE([[element screenReaderText] containsString:@"{200,100}"]);
+    EXPECT_WK_STREQ("{480,150}", [element renderedText]);
+    EXPECT_EQ([[element screenReaderText] length], 0U);
+    EXPECT_TRUE([element hasLargeReplacedDescendant]);
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-9.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-9.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+html, body {
+    margin: 0;
+}
+
+p {
+    font-size: 16px;
+    font-family: system-ui;
+    line-height: 2em;
+}
+
+img {
+    width: 100%;
+    height: 150px;
+    object-fit: cover;
+}
+</style>
+</head>
+<body>
+    <div>
+        <img src="sunset-in-cupertino-200px.png" />
+    </div>
+    <p>Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo. You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them. Because they change things. They push the human race forward. And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world, are the ones who do.</p>
+</body>
+</html>


### PR DESCRIPTION
#### f2b8d72e13c34c2d1c00d57ee729628a29dd440d
<pre>
[Remote Inspection] Refactor some code for copying rendered text from selected elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=274995">https://bugs.webkit.org/show_bug.cgi?id=274995</a>
<a href="https://rdar.apple.com/129079086">rdar://129079086</a>

Reviewed by Richard Robinson.

Refactor some code for extracting rendered text from targeted elements, and expose a new property to
indicate that a targeted element contains a large replaced renderer. See below for more details.

* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::targetedElementInfo):
(WebCore::ElementTargetingController::snapshotIgnoringVisibilityAdjustment):

Drive-by fix: use `snapshotFrameRect()` here, passing in an element rect in absolute coordinates
that respects transforms.

* Source/WebCore/page/ElementTargetingTypes.h:
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractRenderedTokens):

Refactor this logic to return both the &quot;rendered text&quot; representation with and without `{W,H}` at
once, along with a flag indicating whether any individual replaced renderer was large enough to fill
most of the targeted element (90% of the width and height). This is an improvement over the current
code, which performs the entire render tree traversal twice to compute both versions of rendered
text.

This refactoring allows us to instead collect a series of &quot;tokens&quot; (either a rounded size
representing a replaced renderer or background image, or a piece of rendered text) with a single
traversal, and then produce both versions of the string while iterating once over all the tokens.

(WebCore::TextExtraction::extractRenderedText):
* Source/WebCore/page/text-extraction/TextExtraction.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/APITargetedElementInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm:
(-[_WKTargetedElementInfo hasLargeReplacedDescendant]):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ElementTargetingTests.mm:
(TestWebKitAPI::TEST(ElementTargeting, ReplacedRendererSizeIgnoresPageScaleAndZoom)):
(TestWebKitAPI::TEST(ElementTargeting, TargetedElementWithLargeImage)):
(TestWebKitAPI::TEST(ElementTargeting, TargetedElementScreenReaderText)): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/element-targeting-9.html: Added.

Canonical link: <a href="https://commits.webkit.org/279606@main">https://commits.webkit.org/279606@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e85ac4c854e0ad1992f515866ddfde422d70ece0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53955 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57233 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4680 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56258 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4580 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43685 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3089 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56052 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24826 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28372 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4001 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2831 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4202 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58826 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/29131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/4293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51101 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30322 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46816 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50435 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11754 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31273 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/30097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->