### PR TITLE
[WebGPU] out of bounds access in drawIndirect call

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_274994-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_274994-expected.txt
@@ -1,0 +1,7 @@
+CONSOLE MESSAGE: 0
+CONSOLE MESSAGE: no validation error
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_274994.html
+++ b/LayoutTests/fast/webgpu/regression/repro_274994.html
@@ -1,0 +1,84 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let earlierBuffer = device.createBuffer({size: 4, usage: GPUBufferUsage.UNIFORM, mappedAtCreation: true});
+    let earlierU32 = new Uint32Array(earlierBuffer.getMappedRange());
+    earlierU32[0] = 10101010;
+    earlierBuffer.unmap();
+    let vertexBuffer = device.createBuffer({size: 4, usage: GPUBufferUsage.VERTEX});
+    let code = `
+struct VertexOutput {
+  @builtin(position) position : vec4f,
+  @location(0) @interpolate(flat) something: u32,
+}
+
+@vertex
+fn v(@location(0) fromVertexBuffer: u32) -> VertexOutput {
+  var v = VertexOutput();
+  v.something = fromVertexBuffer;
+  return v;
+}
+
+@fragment
+fn f(@location(0) @interpolate(flat) something: u32) -> @location(0) u32 {
+  return something;
+}
+`;
+    let module = device.createShaderModule({code});
+
+    let pipeline = device.createRenderPipeline({
+      layout: device.createPipelineLayout({bindGroupLayouts: []}),
+      vertex: {
+        module,
+        buffers: [{
+          arrayStride: 256,
+          attributes: [{format: 'uint32', offset: 0, shaderLocation: 0}],
+        }],
+      },
+      fragment: {module, targets: [{format: 'r32uint'}]},
+      primitive: {topology: 'point-list'},
+    });
+
+    let texture = device.createTexture({format: 'r32uint', size: [1], usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC});
+    let renderPassDescriptor = {
+      colorAttachments: [{
+        view: texture.createView(),
+        clearValue: [0, 0, 0, 0],
+        loadOp: 'clear', storeOp: 'store',
+      }],
+    };
+    let indirectBuffer = device.createBuffer({usage: GPUBufferUsage.INDIRECT, size: 16, mappedAtCreation: true});
+    let indirectU32 = new Uint32Array(indirectBuffer.getMappedRange());
+    indirectU32[0] = 1;
+    indirectU32[1] = 1;
+    indirectU32[2] = 0xff_ff_ff_ff;
+    indirectBuffer.unmap();
+    let commandEncoder = device.createCommandEncoder();
+    let renderPassEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+    renderPassEncoder.setPipeline(pipeline);
+    renderPassEncoder.setVertexBuffer(0, vertexBuffer);
+    renderPassEncoder.drawIndirect(indirectBuffer, 0);
+    renderPassEncoder.end();
+    let outputBuffer = device.createBuffer({size: 4, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyTextureToBuffer({texture}, {buffer: outputBuffer}, {width: 1});
+    device.queue.submit([commandEncoder.finish()]);
+    await device.queue.onSubmittedWorkDone();
+    await outputBuffer.mapAsync(GPUMapMode.READ);
+    let outputU32 = new Uint32Array(outputBuffer.getMappedRange());
+    log(outputU32);
+    outputBuffer.unmap();
+    let error = await device.popErrorScope();
+    if (error) {
+      log('validation error');
+      log(error.message);
+    } else {
+      log('no validation error');
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/LayoutTests/fast/webgpu/regression/repro_274994b-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_274994b-expected.txt
@@ -1,0 +1,7 @@
+CONSOLE MESSAGE: 0
+CONSOLE MESSAGE: no validation error
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_274994b.html
+++ b/LayoutTests/fast/webgpu/regression/repro_274994b.html
@@ -1,0 +1,85 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let earlierBuffer = device.createBuffer({size: 4, usage: GPUBufferUsage.UNIFORM, mappedAtCreation: true});
+    let earlierU32 = new Uint32Array(earlierBuffer.getMappedRange());
+    earlierU32[0] = 10101010;
+    earlierBuffer.unmap();
+    let vertexBuffer = device.createBuffer({size: 4, usage: GPUBufferUsage.VERTEX});
+    let code = `
+struct VertexOutput {
+  @builtin(position) position : vec4f,
+  @location(0) @interpolate(flat) something: u32,
+}
+
+@vertex
+fn v(@location(0) fromVertexBuffer: u32) -> VertexOutput {
+  var v = VertexOutput();
+  v.something = fromVertexBuffer;
+  return v;
+}
+
+@fragment
+fn f(@location(0) @interpolate(flat) something: u32) -> @location(0) u32 {
+  return something;
+}
+`;
+    let module = device.createShaderModule({code});
+
+    let pipeline = device.createRenderPipeline({
+      layout: device.createPipelineLayout({bindGroupLayouts: []}),
+      vertex: {
+        module,
+        buffers: [{
+          arrayStride: 256,
+          stepMode: 'instance',
+          attributes: [{format: 'uint32', offset: 0, shaderLocation: 0}],
+        }],
+      },
+      fragment: {module, targets: [{format: 'r32uint'}]},
+      primitive: {topology: 'point-list'},
+    });
+
+    let texture = device.createTexture({format: 'r32uint', size: [1], usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC});
+    let renderPassDescriptor = {
+      colorAttachments: [{
+        view: texture.createView(),
+        clearValue: [0, 0, 0, 0],
+        loadOp: 'clear', storeOp: 'store',
+      }],
+    };
+    let indirectBuffer = device.createBuffer({usage: GPUBufferUsage.INDIRECT, size: 16, mappedAtCreation: true});
+    let indirectU32 = new Uint32Array(indirectBuffer.getMappedRange());
+    indirectU32[0] = 1;
+    indirectU32[1] = 1;
+    indirectU32[3] = 0xff_ff_ff_ff;
+    indirectBuffer.unmap();
+    let commandEncoder = device.createCommandEncoder();
+    let renderPassEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+    renderPassEncoder.setPipeline(pipeline);
+    renderPassEncoder.setVertexBuffer(0, vertexBuffer);
+    renderPassEncoder.drawIndirect(indirectBuffer, 0);
+    renderPassEncoder.end();
+    let outputBuffer = device.createBuffer({size: 4, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyTextureToBuffer({texture}, {buffer: outputBuffer}, {width: 1});
+    device.queue.submit([commandEncoder.finish()]);
+    await device.queue.onSubmittedWorkDone();
+    await outputBuffer.mapAsync(GPUMapMode.READ);
+    let outputU32 = new Uint32Array(outputBuffer.getMappedRange());
+    log(outputU32);
+    outputBuffer.unmap();
+    let error = await device.popErrorScope();
+    if (error) {
+      log('validation error');
+      log(error.message);
+    } else {
+      log('no validation error');
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/Source/WebGPU/WebGPU/BindableResource.h
+++ b/Source/WebGPU/WebGPU/BindableResource.h
@@ -76,6 +76,7 @@ struct BindableResources {
 struct IndexData {
     uint64_t renderCommand { 0 };
     uint32_t minVertexCount { UINT32_MAX };
+    uint32_t minInstanceCount { UINT32_MAX };
     uint64_t bufferGpuAddress { 0 };
     uint32_t indexCount { 0 };
     uint32_t instanceCount { 0 };

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -94,8 +94,8 @@ public:
     bool isDestroyed() const;
     void setCommandEncoder(CommandEncoder&, bool mayModifyBuffer = false) const;
     uint8_t* getBufferContents();
-    bool indirectBufferRequiresRecomputation(uint32_t baseIndex, uint32_t indexCount, uint32_t minVertexCount, MTLIndexType) const;
-    void indirectBufferRecomputed(uint32_t baseIndex, uint32_t indexCount, uint32_t minVertexCount, MTLIndexType);
+    bool indirectBufferRequiresRecomputation(uint32_t baseIndex, uint32_t indexCount, uint32_t minVertexCount, uint32_t minInstanceCount, MTLIndexType) const;
+    void indirectBufferRecomputed(uint32_t baseIndex, uint32_t indexCount, uint32_t minVertexCount, uint32_t minInstanceCount, MTLIndexType);
     void indirectBufferInvalidated();
 
 private:
@@ -127,6 +127,7 @@ private:
         uint32_t lastBaseIndex { 0 };
         uint32_t indexCount { 0 };
         uint32_t minVertexCount { 0 };
+        uint32_t minInstanceCount { 0 };
         MTLIndexType indexType { MTLIndexTypeUInt16 };
     } m_indirectCache;
 

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -410,25 +410,26 @@ id<MTLBuffer> Buffer::indirectIndexedBuffer() const
     return m_indirectIndexedBuffer;
 }
 
-bool Buffer::indirectBufferRequiresRecomputation(uint32_t baseIndex, uint32_t indexCount, uint32_t minVertexCount, MTLIndexType indexType) const
+bool Buffer::indirectBufferRequiresRecomputation(uint32_t baseIndex, uint32_t indexCount, uint32_t minVertexCount, uint32_t minInstanceCount, MTLIndexType indexType) const
 {
     auto rangeBegin = m_indirectCache.lastBaseIndex;
     auto rangeEnd = m_indirectCache.lastBaseIndex + m_indirectCache.indexCount;
     auto newRangeEnd = baseIndex + indexCount;
-    return baseIndex < rangeBegin || newRangeEnd > rangeEnd || minVertexCount > m_indirectCache.minVertexCount || m_indirectCache.indexType != indexType;
+    return baseIndex < rangeBegin || newRangeEnd > rangeEnd || minVertexCount > m_indirectCache.minVertexCount || minInstanceCount > m_indirectCache.minInstanceCount || m_indirectCache.indexType != indexType;
 }
 
-void Buffer::indirectBufferRecomputed(uint32_t baseIndex, uint32_t indexCount, uint32_t minVertexCount, MTLIndexType indexType)
+void Buffer::indirectBufferRecomputed(uint32_t baseIndex, uint32_t indexCount, uint32_t minVertexCount, uint32_t minInstanceCount, MTLIndexType indexType)
 {
     m_indirectCache.lastBaseIndex = baseIndex;
     m_indirectCache.indexCount = indexCount;
     m_indirectCache.minVertexCount = minVertexCount;
+    m_indirectCache.minInstanceCount = minInstanceCount;
     m_indirectCache.indexType = indexType;
 }
 
 void Buffer::indirectBufferInvalidated()
 {
-    indirectBufferRecomputed(0, 0, 0, MTLIndexTypeUInt16);
+    indirectBufferRecomputed(0, 0, 0, 0, MTLIndexTypeUInt16);
 }
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -107,7 +107,7 @@ public:
 
     static constexpr auto startIndexForFragmentDynamicOffsets = 3;
     static constexpr uint32_t defaultSampleMask = UINT32_MAX;
-    static constexpr uint32_t invalidVertexCount = UINT32_MAX;
+    static constexpr uint32_t invalidVertexInstanceCount = UINT32_MAX;
 
     bool validateDepthStencilState(bool depthReadOnly, bool stencilReadOnly) const;
     Device& device() const { return m_device; }
@@ -137,7 +137,7 @@ private:
     uint32_t maxBindGroupIndex() const;
     void recordCommand(WTF::Function<bool(void)>&&);
     void storeVertexBufferCountsForValidation(uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex, int32_t baseVertex, uint32_t firstInstance, MTLIndexType, NSUInteger indexBufferOffsetInBytes);
-    uint32_t computeMininumVertexCount() const;
+    std::pair<uint32_t, uint32_t> computeMininumVertexInstanceCount() const;
 
     const Ref<Device> m_device;
     WeakPtr<Buffer> m_indexBuffer;

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -102,10 +102,10 @@ public:
     static double quantizedDepthValue(double, WGPUTextureFormat);
     NSString* errorValidatingPipeline(const RenderPipeline&) const;
 
-    static std::pair<id<MTLBuffer>, uint64_t> clampIndirectIndexBufferToValidValues(Buffer*, const Buffer&, MTLIndexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, MTLPrimitiveType, Device&, uint32_t rasterSampleCount, id<MTLRenderCommandEncoder>);
-    static id<MTLBuffer> clampIndirectBufferToValidValues(const Buffer&, uint64_t indirectOffset, uint32_t minVertexCount, Device&, uint32_t rasterSampleCount, id<MTLRenderCommandEncoder>);
+    static std::pair<id<MTLBuffer>, uint64_t> clampIndirectIndexBufferToValidValues(Buffer*, const Buffer&, MTLIndexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, MTLPrimitiveType, Device&, uint32_t rasterSampleCount, id<MTLRenderCommandEncoder>);
+    static id<MTLBuffer> clampIndirectBufferToValidValues(const Buffer&, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount, Device&, uint32_t rasterSampleCount, id<MTLRenderCommandEncoder>);
     enum class IndexCall { Draw, IndirectDraw, Skip };
-    static IndexCall clampIndexBufferToValidValues(uint32_t indexCount, uint32_t instanceCount, int32_t baseVertex, uint32_t firstInstance, MTLIndexType, NSUInteger indexBufferOffsetInBytes, Buffer*, uint32_t minVertexCount, id<MTLRenderCommandEncoder>, Device&, uint32_t rasterSampleCount, MTLPrimitiveType);
+    static IndexCall clampIndexBufferToValidValues(uint32_t indexCount, uint32_t instanceCount, int32_t baseVertex, uint32_t firstInstance, MTLIndexType, NSUInteger indexBufferOffsetInBytes, Buffer*, uint32_t minVertexCount, uint32_t minInstanceCount, id<MTLRenderCommandEncoder>, Device&, uint32_t rasterSampleCount, MTLPrimitiveType);
 
 private:
     RenderPassEncoder(id<MTLRenderCommandEncoder>, const WGPURenderPassDescriptor&, NSUInteger, bool depthReadOnly, bool stencilReadOnly, CommandEncoder&, id<MTLBuffer>, uint64_t maxDrawCount, Device&);
@@ -127,9 +127,9 @@ private:
     void incrementDrawCount(uint32_t = 1);
     bool occlusionQueryIsDestroyed() const;
     IndexCall clampIndexBufferToValidValues(uint32_t indexCount, uint32_t instanceCount, int32_t baseVertex, uint32_t firstInstance, MTLIndexType, NSUInteger indexBufferOffsetInBytes);
-    uint32_t computeMininumVertexCount() const;
-    std::pair<id<MTLBuffer>, uint64_t> clampIndirectIndexBufferToValidValues(const Buffer&, MTLIndexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount);
-    id<MTLBuffer> clampIndirectBufferToValidValues(const Buffer&, uint64_t indirectOffset, uint32_t minVertexCount);
+    std::pair<uint32_t, uint32_t> computeMininumVertexInstanceCount() const;
+    std::pair<id<MTLBuffer>, uint64_t> clampIndirectIndexBufferToValidValues(const Buffer&, MTLIndexType, NSUInteger indexBufferOffsetInBytes, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount);
+    id<MTLBuffer> clampIndirectBufferToValidValues(const Buffer&, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount);
 
     id<MTLRenderCommandEncoder> m_renderCommandEncoder { nil };
 


### PR DESCRIPTION
#### bdc472fd3321132aaedd43a89572dfc21722697c
<pre>
[WebGPU] out of bounds access in drawIndirect call
<a href="https://bugs.webkit.org/show_bug.cgi?id=274994">https://bugs.webkit.org/show_bug.cgi?id=274994</a>
&lt;radar://129061487&gt;

Reviewed by Dan Glastonbury.

Instance counts were not being validated in indirect calls, leading to out of
bounds buffer accesses.

* LayoutTests/fast/webgpu/regression/repro_274994-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_274994.html: Added.
* LayoutTests/fast/webgpu/regression/repro_274994b-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_274994b.html: Added.
Add regression tests.

* Source/WebGPU/WebGPU/BindableResource.h:
* Source/WebGPU/WebGPU/Buffer.h:
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::indirectBufferRequiresRecomputation const):
(WebGPU::Buffer::indirectBufferRecomputed):
(WebGPU::Buffer::indirectBufferInvalidated):
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::copyIndexIndirectArgsPipeline):
* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::computeMininumVertexInstanceCount const):
(WebGPU::RenderBundleEncoder::storeVertexBufferCountsForValidation):
(WebGPU::RenderBundleEncoder::drawIndexedIndirect):
(WebGPU::RenderBundleEncoder::drawIndirect):
(WebGPU::RenderBundleEncoder::computeMininumVertexCount const): Deleted.
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::computeMininumVertexInstanceCount const):
(WebGPU::RenderPassEncoder::clampIndexBufferToValidValues):
(WebGPU::RenderPassEncoder::clampIndirectIndexBufferToValidValues):
(WebGPU::RenderPassEncoder::clampIndirectBufferToValidValues):
(WebGPU::RenderPassEncoder::drawIndexedIndirect):
(WebGPU::RenderPassEncoder::drawIndirect):
(WebGPU::RenderPassEncoder::executeBundles):
(WebGPU::RenderPassEncoder::computeMininumVertexCount const): Deleted.

Canonical link: <a href="https://commits.webkit.org/279730@main">https://commits.webkit.org/279730@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ff99d6ddc7bd4b5926646afa3f5ad18c3905af9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54335 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33739 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57615 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5067 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41264 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/5014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44001 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3378 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56429 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47055 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25136 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/28726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4377 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3210 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59205 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/29554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/5014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51426 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/30714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47148 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50787 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11835 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/31688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/30499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->