### PR TITLE
Gardening: temporarily disabling --useJITCage on some wasm tests.

### DIFF
--- a/JSTests/wasm/stress/cc-i32-kitchen-sink.js
+++ b/JSTests/wasm/stress/cc-i32-kitchen-sink.js
@@ -1,3 +1,4 @@
+//@ requireOptions("--useJITCage=0") # temporary workaround for rdar://127308350
 //@ requireOptions("--useInterpretedJSEntryWrappers=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/cc-int-to-int-cross-module-with-exception.js
+++ b/JSTests/wasm/stress/cc-int-to-int-cross-module-with-exception.js
@@ -1,4 +1,5 @@
 //@ skip if $architecture != "arm64" and $architecture != "x86_64" or $memoryLimited
+//@ requireOptions("--useJITCage=0") # temporary workaround for rdar://127308350
 //@ runDefault("-m", "--wasmFunctionIndexRangeToCompile=0:5", "--useOMGJIT=0", "--useInterpretedJSEntryWrappers=1")
 
 // This tests will use more than the 600M that $memoryLimited devices are capped

--- a/JSTests/wasm/stress/cc-int-to-int-cross-module.js
+++ b/JSTests/wasm/stress/cc-int-to-int-cross-module.js
@@ -1,4 +1,5 @@
 //@ skip if $architecture != "arm64" and $architecture != "x86_64"
+//@ requireOptions("--useJITCage=0") # temporary workaround for rdar://127308350
 //@ requireOptions("--useInterpretedJSEntryWrappers=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/cc-int-to-int-memory.js
+++ b/JSTests/wasm/stress/cc-int-to-int-memory.js
@@ -1,4 +1,5 @@
 //  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useInterpretedJSEntryWrappers=1 --dumpDisassembly=0
+//@ requireOptions("--useJITCage=0") # temporary workaround for rdar://127308350
 //@ requireOptions("--useInterpretedJSEntryWrappers=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/cc-int-to-int.js
+++ b/JSTests/wasm/stress/cc-int-to-int.js
@@ -1,4 +1,5 @@
 //  Debugging: jsc -m cc-int-to-int.js --useConcurrentJIT=0 --useBBQJIT=0 --useOMGJIT=0 --jitAllowList=nothing --useDFGJIT=0 --dumpDisassembly=0 --forceICFailure=1 --useInterpretedJSEntryWrappers=1 --dumpDisassembly=0
+//@ requireOptions("--useJITCage=0") # temporary workaround for rdar://127308350
 //@ requireOptions("--useInterpretedJSEntryWrappers=1")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"


### PR DESCRIPTION
#### 5714d726d6743fa621760cc389c11f381c96b02f
<pre>
Gardening: temporarily disabling --useJITCage on some wasm tests.
<a href="https://bugs.webkit.org/show_bug.cgi?id=275003">https://bugs.webkit.org/show_bug.cgi?id=275003</a>
<a href="https://rdar.apple.com/129086234">rdar://129086234</a>

Reviewed by Yijia Huang.

The following tests were found to be crash on internal bots when --useJITCage is set to true.
wasm/stress/cc-i32-kitchen-sink.js
wasm/stress/cc-int-to-int-cross-module-with-exception.js
wasm/stress/cc-int-to-int-cross-module.js
wasm/stress/cc-int-to-int-memory.js
wasm/stress/cc-int-to-int.js

Temporarily disable --useJITCage on these tests to green the bots until we can fix the underlying issue.

* JSTests/wasm/stress/cc-i32-kitchen-sink.js:
* JSTests/wasm/stress/cc-int-to-int-cross-module-with-exception.js:
* JSTests/wasm/stress/cc-int-to-int-cross-module.js:
* JSTests/wasm/stress/cc-int-to-int-memory.js:
* JSTests/wasm/stress/cc-int-to-int.js:

Canonical link: <a href="https://commits.webkit.org/279599@main">https://commits.webkit.org/279599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d0f425fbb4f7a2533f3b2aee2ff3388c4d5a8e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57229 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/4675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/40829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4561 "Failed to checkout and rebase branch from PR 29405") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/4675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56048 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/40829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/46670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/24823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/40829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2827 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/47309 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/40829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/4193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/58822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/53461 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/29126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/4561 "Failed to checkout and rebase branch from PR 29405") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/58822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/30318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46808 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/58822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/31269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65763 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7984 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/30093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/12514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->