### PR TITLE
Replace ShareableResource::data() with span()

### DIFF
--- a/Source/WebCore/platform/ShareableResource.cpp
+++ b/Source/WebCore/platform/ShareableResource.cpp
@@ -43,7 +43,7 @@ ShareableResourceHandle::ShareableResourceHandle(SharedMemory::Handle&& handle, 
 RefPtr<SharedBuffer> ShareableResource::wrapInSharedBuffer()
 {
     return SharedBuffer::create(DataSegment::Provider {
-        [self = Ref { *this }]() { return self->data(); },
+        [self = Ref { *this }]() { return self->span().data(); },
         [self = Ref { *this }]() { return self->size(); }
     });
 }
@@ -100,9 +100,9 @@ auto ShareableResource::createHandle() -> std::optional<Handle>
     return { Handle { WTFMove(*memoryHandle), m_offset, m_size } };
 }
 
-const uint8_t* ShareableResource::data() const
+std::span<const uint8_t> ShareableResource::span() const
 {
-    return m_sharedMemory->span().subspan(m_offset).data();
+    return m_sharedMemory->span().subspan(m_offset);
 }
 
 unsigned ShareableResource::size() const

--- a/Source/WebCore/platform/ShareableResource.h
+++ b/Source/WebCore/platform/ShareableResource.h
@@ -71,8 +71,8 @@ public:
 
     WEBCORE_EXPORT ~ShareableResource();
 
-    const uint8_t* data() const;
     unsigned size() const;
+    std::span<const uint8_t> span() const;
 
 private:
     friend class ShareableResourceHandle;


### PR DESCRIPTION
#### 8878ce39d1e3aa3f0959f5eb18ee5b5d5efb1a78
<pre>
Replace ShareableResource::data() with span()
<a href="https://bugs.webkit.org/show_bug.cgi?id=275005">https://bugs.webkit.org/show_bug.cgi?id=275005</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/ShareableResource.cpp:
(WebCore::ShareableResource::wrapInSharedBuffer):
(WebCore::ShareableResource::span const):
(WebCore::ShareableResource::data const): Deleted.
* Source/WebCore/platform/ShareableResource.h:

Canonical link: <a href="https://commits.webkit.org/279611@main">https://commits.webkit.org/279611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a27e84905057c54c52498f59fe93d37ed3c79c4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53952 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57230 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4676 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56256 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4562 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43688 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3086 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56049 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31536 "Found 1 new test failure: compositing/rtl/rtl-relative.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46682 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24829 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28374 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4012 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2828 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50019 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4206 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58823 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4280 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51107 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30319 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46819 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50442 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31270 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7990 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30094 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->