### PR TITLE
[git-webkit] Handle ambiguous GitHub PR branches

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/checkout_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/checkout_unittest.py
@@ -129,7 +129,7 @@ Reviewed by NOBODY (OOPS!).
                 reviews=[dict(user=dict(login='rreviewer'), state='CHANGES_REQUESTED')],
                 draft=False,
             )]
-            repo.commits['eng/example'] = [
+            repo.commits['remotes/tcontributor/eng/example'] = [
                 repo.commits[repo.default_branch][2],
                 Commit(
                     hash='a5fe8afe9bf7d07158fcd9e9732ff02a712db2fd',
@@ -142,6 +142,49 @@ Reviewed by NOBODY (OOPS!).
 
             self.assertEqual(0, program.main(
                 args=('checkout', 'PR-1'),
+                path=self.path,
+            ))
+
+            self.assertEqual('a5fe8afe9bf7d07158fcd9e9732ff02a712db2fd', local.Git(self.path).commit().hash)
+
+    def test_checkout_specific_remote(self):
+        with OutputCapture(), mocks.remote.GitHub() as remote, mocks.local.Git(self.path, remote='https://{}'.format(remote.remote)) as repo, mocks.local.Svn():
+            repo.edit_config('remote.webkit.url', 'https://github.com/WebKit/WebKit')
+            repo.commits['remotes/webkit/eng/example'] = [
+                repo.commits[repo.default_branch][2],
+                Commit(
+                    hash='a5fe8afe9bf7d07158fcd9e9732ff02a712db2fd',
+                    identifier='3.1@eng/example',
+                    timestamp=int(time.time()) - 60,
+                    author=Contributor('Tim Committer', ['tcommitter@webkit.org']),
+                    message='To Be Committed\n\nReviewed by NOBODY (OOPS!).\n',
+                )
+            ]
+
+            self.assertEqual(0, program.main(
+                args=('checkout', 'webkit:eng/example'),
+                path=self.path,
+            ))
+
+            self.assertEqual('a5fe8afe9bf7d07158fcd9e9732ff02a712db2fd', local.Git(self.path).commit().hash)
+
+    def test_checkout_ambiguous_remote(self):
+        with mocks.remote.GitHub() as remote, mocks.local.Git(self.path, remote='https://{}'.format(remote.remote)) as repo, mocks.local.Svn():
+            repo.edit_config('remote.webkit.url', 'https://github.com/WebKit/WebKit')
+            repo.edit_config('remote.webkit-integration.url', 'https://github.com/WebKit/WebKit')
+            repo.commits['remotes/webkit-integration/eng/example'] = [
+                repo.commits[repo.default_branch][2],
+                Commit(
+                    hash='a5fe8afe9bf7d07158fcd9e9732ff02a712db2fd',
+                    identifier='3.1@eng/example',
+                    timestamp=int(time.time()) - 60,
+                    author=Contributor('Tim Committer', ['tcommitter@webkit.org']),
+                    message='To Be Committed\n\nReviewed by NOBODY (OOPS!).\n',
+                )
+            ]
+
+            self.assertEqual(0, program.main(
+                args=('checkout', 'webkit:eng/example'),
                 path=self.path,
             ))
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/conflict_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/conflict_unittest.py
@@ -85,7 +85,8 @@ class TestConflict(testing.PathTestCase):
                 reviews=[dict(user=dict(login='rreviewer'), state='CHANGES_REQUESTED')],
                 draft=False,
             )]
-            repo.commits['integration/conflict/1234'] = [
+            repo.edit_config('remote.tcontributor.url', 'https://github.com/tcontributor/WebKit')
+            repo.commits['remotes/tcontributor/integration/conflict/1234'] = [
                 repo.commits[repo.default_branch][2],
                 Commit(
                     hash='a5fe8afe9bf7d07158fcd9e9732ff02a712db2fd',


### PR DESCRIPTION
#### 68b2c9d66ab294432d2a2e31d6297ac2bb7b821b
<pre>
[git-webkit] Handle ambiguous GitHub PR branches
<a href="https://bugs.webkit.org/show_bug.cgi?id=275006">https://bugs.webkit.org/show_bug.cgi?id=275006</a>
<a href="https://rdar.apple.com/129087899">rdar://129087899</a>

Reviewed by Dewei Zhu.

Handle case where a user has multiple types of forks for a given
repository, such as the -security forks many WebKit contributors
maintain.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.checkout): Attempt multiple variations of a given fork prefix.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
(Git.__init__): &apos;git checkout -B&apos; should fail if the source branch cannot be found.
(Git.find): Support finding remote branches.
(Git.checkout): Support checking out remote branches as a local ones.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/checkout_unittest.py:
(TestCheckout.test_checkout_specific_remote): Added.
(TestCheckout.test_checkout_ambiguous_remote): Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/conflict_unittest.py:

Canonical link: <a href="https://commits.webkit.org/279782@main">https://commits.webkit.org/279782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a433bac58bd6cf7e40d6a2aad44e67c41e6d29e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57799 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5253 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56824 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41480 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5256 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44151 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3522 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56616 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47221 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25279 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/54350 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28877 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4551 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3394 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4765 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59390 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29753 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/4923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51576 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/54516 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30901 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47308 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50947 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31883 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8069 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30691 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->