### PR TITLE
[JSC] Implement CustomAccessor / CustomValue / Getter / Setter handlers

### DIFF
--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
@@ -197,11 +197,13 @@ public:
 
     static constexpr ptrdiff_t offsetOfUid() { return OBJECT_OFFSETOF(InlineCacheHandler, m_uid); }
     static constexpr ptrdiff_t offsetOfStructureID() { return OBJECT_OFFSETOF(InlineCacheHandler, m_structureID); }
-    static constexpr ptrdiff_t offsetOfNewStructureID() { return OBJECT_OFFSETOF(InlineCacheHandler, m_newStructureID); }
-    static constexpr ptrdiff_t offsetOfNewSize() { return OBJECT_OFFSETOF(InlineCacheHandler, m_newSize); }
-    static constexpr ptrdiff_t offsetOfOldSize() { return OBJECT_OFFSETOF(InlineCacheHandler, m_oldSize); }
     static constexpr ptrdiff_t offsetOfOffset() { return OBJECT_OFFSETOF(InlineCacheHandler, m_offset); }
-    static constexpr ptrdiff_t offsetOfHolder() { return OBJECT_OFFSETOF(InlineCacheHandler, m_holder); }
+    static constexpr ptrdiff_t offsetOfNewStructureID() { return OBJECT_OFFSETOF(InlineCacheHandler, u.s2.m_newStructureID); }
+    static constexpr ptrdiff_t offsetOfNewSize() { return OBJECT_OFFSETOF(InlineCacheHandler, u.s2.m_newSize); }
+    static constexpr ptrdiff_t offsetOfOldSize() { return OBJECT_OFFSETOF(InlineCacheHandler, u.s2.m_oldSize); }
+    static constexpr ptrdiff_t offsetOfHolder() { return OBJECT_OFFSETOF(InlineCacheHandler, u.s1.m_holder); }
+    static constexpr ptrdiff_t offsetOfGlobalObject() { return OBJECT_OFFSETOF(InlineCacheHandler, u.s1.m_globalObject); }
+    static constexpr ptrdiff_t offsetOfCustomAccessor() { return OBJECT_OFFSETOF(InlineCacheHandler, u.s1.m_customAccessor); }
     static constexpr ptrdiff_t offsetOfCallLinkInfos() { return Base::offsetOfData(); }
 
 private:
@@ -218,10 +220,18 @@ private:
     StructureID m_structureID { };
     PropertyOffset m_offset { invalidOffset };
     UniquedStringImpl* m_uid { nullptr };
-    JSCell* m_holder { nullptr };
-    StructureID m_newStructureID { };
-    unsigned m_newSize { 0 };
-    unsigned m_oldSize { 0 };
+    union {
+        struct {
+            StructureID m_newStructureID { };
+            unsigned m_newSize { };
+            unsigned m_oldSize { };
+        } s2 { };
+        struct {
+            JSCell* m_holder;
+            JSGlobalObject* m_globalObject;
+            void* m_customAccessor;
+        } s1;
+    } u;
     RefPtr<PolymorphicAccessJITStubRoutine> m_stubRoutine;
     std::unique_ptr<StructureStubInfoClearingWatchpoint> m_watchpoint;
     RefPtr<InlineCacheHandler> m_next;
@@ -385,10 +395,17 @@ private:
 MacroAssemblerCodeRef<JITThunkPtrTag> getByIdLoadOwnPropertyHandlerCodeGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> getByIdLoadPrototypePropertyHandlerCodeGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> getByIdMissHandlerCodeGenerator(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> getByIdCustomAccessorHandler(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> getByIdCustomValueHandler(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> getByIdGetterHandler(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> putByIdReplaceHandlerCodeGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> putByIdTransitionNonAllocatingHandlerCodeGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> putByIdTransitionNewlyAllocatingHandlerCodeGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> putByIdTransitionReallocatingHandlerCodeGenerator(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> putByIdCustomAccessorHandler(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> putByIdCustomValueHandler(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> putByIdStrictSetterHandler(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> putByIdSloppySetterHandler(VM&);
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/jit/JITThunks.h
+++ b/Source/JavaScriptCore/jit/JITThunks.h
@@ -74,10 +74,17 @@ class NativeExecutable;
     macro(GetByIdLoadOwnPropertyHandler, getByIdLoadOwnPropertyHandlerCodeGenerator) \
     macro(GetByIdLoadPrototypePropertyHandler, getByIdLoadPrototypePropertyHandlerCodeGenerator) \
     macro(GetByIdMissHandler, getByIdMissHandlerCodeGenerator) \
+    macro(GetByIdCustomAccessorHandler, getByIdCustomAccessorHandler) \
+    macro(GetByIdCustomValueHandler, getByIdCustomValueHandler) \
+    macro(GetByIdGetterHandler, getByIdGetterHandler) \
     macro(PutByIdReplaceHandler, putByIdReplaceHandlerCodeGenerator) \
     macro(PutByIdTransitionNonAllocatingHandler, putByIdTransitionNonAllocatingHandlerCodeGenerator) \
     macro(PutByIdTransitionNewlyAllocatingHandler, putByIdTransitionNewlyAllocatingHandlerCodeGenerator) \
     macro(PutByIdTransitionReallocatingHandler, putByIdTransitionReallocatingHandlerCodeGenerator) \
+    macro(PutByIdCustomAccessorHandler, putByIdCustomAccessorHandler) \
+    macro(PutByIdCustomValueHandler, putByIdCustomValueHandler) \
+    macro(PutByIdStrictSetterHandler, putByIdStrictSetterHandler) \
+    macro(PutByIdSloppySetterHandler, putByIdSloppySetterHandler) \
 
 #if ENABLE(YARR_JIT_BACKREFERENCES_FOR_16BIT_EXPRS)
 #define JSC_FOR_EACH_YARR_JIT_BACKREFERENCES_THUNK(macro) \

--- a/Source/JavaScriptCore/runtime/StackAlignment.h
+++ b/Source/JavaScriptCore/runtime/StackAlignment.h
@@ -51,19 +51,19 @@ constexpr unsigned stackAdjustmentForAlignment()
 
 // Align argument count taking into account the CallFrameHeaderSize may be
 // an "unaligned" count of registers.
-inline unsigned roundArgumentCountToAlignFrame(unsigned argumentCount)
+constexpr unsigned roundArgumentCountToAlignFrame(unsigned argumentCount)
 {
     return WTF::roundUpToMultipleOf(stackAlignmentRegisters(), argumentCount + CallFrame::headerSizeInRegisters) - CallFrame::headerSizeInRegisters;
 }
 
 // Align local register count to make the last local end on a stack aligned address given the
 // CallFrame is at an address that is stack aligned minus CallerFrameAndPC::sizeInRegisters
-inline unsigned roundLocalRegisterCountForFramePointerOffset(unsigned localRegisterCount)
+constexpr unsigned roundLocalRegisterCountForFramePointerOffset(unsigned localRegisterCount)
 {
     return WTF::roundUpToMultipleOf(stackAlignmentRegisters(), localRegisterCount + CallerFrameAndPC::sizeInRegisters) - CallerFrameAndPC::sizeInRegisters;
 }
 
-inline unsigned argumentCountForStackSize(unsigned sizeInBytes)
+constexpr unsigned argumentCountForStackSize(unsigned sizeInBytes)
 {
     unsigned sizeInRegisters = sizeInBytes / sizeof(void*);
 

--- a/Source/JavaScriptCore/runtime/StructureID.h
+++ b/Source/JavaScriptCore/runtime/StructureID.h
@@ -73,9 +73,9 @@ public:
     static constexpr CPURegister structureIDMask = structureHeapAddressSize - 1;
 #endif
 
-    StructureID() = default;
-    StructureID(StructureID const&) = default;
-    StructureID& operator=(StructureID const&) = default;
+    constexpr StructureID() = default;
+    constexpr StructureID(StructureID const&) = default;
+    constexpr StructureID& operator=(StructureID const&) = default;
 
     StructureID nuke() const { return StructureID(m_bits | nukedStructureIDBit); }
     bool isNuked() const { return m_bits & nukedStructureIDBit; }
@@ -89,11 +89,11 @@ public:
     friend auto operator<=>(const StructureID&, const StructureID&) = default;
     constexpr uint32_t bits() const { return m_bits; }
 
-    StructureID(WTF::HashTableDeletedValueType) : m_bits(nukedStructureIDBit) { }
+    constexpr StructureID(WTF::HashTableDeletedValueType) : m_bits(nukedStructureIDBit) { }
     bool isHashTableDeletedValue() const { return *this == StructureID(WTF::HashTableDeletedValue); }
 
 private:
-    explicit StructureID(uint32_t bits) : m_bits(bits) { }
+    explicit constexpr StructureID(uint32_t bits) : m_bits(bits) { }
 
     uint32_t m_bits { 0 };
 };


### PR DESCRIPTION
#### 42753c19054a45320d8d7039591808d569106b2e
<pre>
[JSC] Implement CustomAccessor / CustomValue / Getter / Setter handlers
<a href="https://bugs.webkit.org/show_bug.cgi?id=275008">https://bugs.webkit.org/show_bug.cgi?id=275008</a>
<a href="https://rdar.apple.com/129088798">rdar://129088798</a>

Reviewed by Justin Michaud.

This patch extends Handler IC to support CustomAccessor / CustomValue / Getter / Setter.
We simply add handler implementations for them. To clean up our implementations,
we introduce StaticScratchRegisterAllocator, which assigns scratch registers
at compile time. And we use it to define BaselineJITRegisters.

* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheHandler::createPreCompiled):
(JSC::getByIdCustomHandlerImpl):
(JSC::getByIdCustomAccessorHandler):
(JSC::getByIdCustomValueHandler):
(JSC::getByIdGetterHandler):
(JSC::putByIdCustomHandlerImpl):
(JSC::putByIdCustomAccessorHandler):
(JSC::putByIdCustomValueHandler):
(JSC::putByIdSetterHandlerImpl):
(JSC::putByIdStrictSetterHandler):
(JSC::putByIdSloppySetterHandler):
(JSC::InlineCacheCompiler::compileOneAccessCaseHandler):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.h:
* Source/JavaScriptCore/jit/BaselineJITRegisters.h:
* Source/JavaScriptCore/jit/GPRInfo.h:
(JSC::StaticScratchRegisterAllocator::countRegisters):
(JSC::StaticScratchRegisterAllocator::constructScratchRegisters):
* Source/JavaScriptCore/jit/JITThunks.h:
* Source/JavaScriptCore/runtime/StackAlignment.h:
(JSC::roundArgumentCountToAlignFrame):
(JSC::roundLocalRegisterCountForFramePointerOffset):
(JSC::argumentCountForStackSize):
* Source/JavaScriptCore/runtime/StructureID.h:
(JSC::StructureID::StructureID):

Canonical link: <a href="https://commits.webkit.org/279657@main">https://commits.webkit.org/279657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1255d231c861aff9f6d0e011e15fbf2b11dd8b46

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54020 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33396 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57296 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4745 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43738 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3141 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31620 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46753 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24879 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4069 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2894 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/47377 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50128 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4274 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58890 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/53529 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29205 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4362 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51155 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30389 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46876 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50503 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31344 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65830 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8012 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30171 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12531 "Passed tests") | 
<!--EWS-Status-Bubble-End-->