### PR TITLE
[UnifiedPDF] Migrate from "scroll to" to "reveal" terminology in preparation for discrete mode

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -472,12 +472,14 @@ private:
     WebCore::ScrollingCoordinator* scrollingCoordinator();
     void createScrollingNodeIfNecessary();
 
-    void revealRectInContentsSpace(WebCore::FloatRect);
+    void revealPDFDestination(PDFDestination *);
+    void revealPointInPage(WebCore::FloatPoint pointInPDFPageSpace, PDFDocumentLayout::PageIndex);
+    void revealRectInPage(const WebCore::FloatRect& rectInPDFPageSpace, PDFDocumentLayout::PageIndex);
+    void revealPage(PDFDocumentLayout::PageIndex);
+    void revealFragmentIfNeeded();
+
+    // Only use this if some other functio has ensured that the correct page is visible.
     void scrollToPointInContentsSpace(WebCore::FloatPoint);
-    void scrollToPDFDestination(PDFDestination *);
-    void scrollToPointInPage(WebCore::FloatPoint pointInPDFPageSpace, PDFDocumentLayout::PageIndex);
-    void scrollToPage(PDFDocumentLayout::PageIndex);
-    void scrollToFragmentIfNeeded();
 
     // ScrollableArea
     bool requestScrollToPosition(const WebCore::ScrollPosition&, const WebCore::ScrollPositionChangeOptions& = WebCore::ScrollPositionChangeOptions::createProgrammatic()) override;


### PR DESCRIPTION
#### 685f1d6a32833c4313e0cf537addf5451f7372e0
<pre>
[UnifiedPDF] Migrate from &quot;scroll to&quot; to &quot;reveal&quot; terminology in preparation for discrete mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=275011">https://bugs.webkit.org/show_bug.cgi?id=275011</a>
<a href="https://rdar.apple.com/129095225">rdar://129095225</a>

Reviewed by Abrar Rahman Protyasha.

In discrete (non-scrolling) mode, making some part of the PDF visible is a &quot;reveal&quot;, not
a &quot;scroll&quot;, so rename functions accordingly.

It&apos;s best to keep things in page-relative coordinates with a PageIndex as long as possible,
so the most common &quot;reveal&quot; functions are `revealPointInPage()` and `revealRectInPage()`.
Ultimately these call `scrollToPointInContentsSpace()`.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::installPDFDocument):
(WebKit::UnifiedPDFPlugin::attemptToUnlockPDF):
(WebKit::UnifiedPDFPlugin::didAttachScrollingNode):
(WebKit::UnifiedPDFPlugin::didSameDocumentNavigationForFrame):
(WebKit::UnifiedPDFPlugin::restoreScrollPositionWithInfo):
(WebKit::UnifiedPDFPlugin::followLinkAnnotation):
(WebKit::UnifiedPDFPlugin::revealRectInPage):
(WebKit::UnifiedPDFPlugin::revealPDFDestination):
(WebKit::UnifiedPDFPlugin::revealPointInPage):
(WebKit::UnifiedPDFPlugin::revealPage):
(WebKit::UnifiedPDFPlugin::revealFragmentIfNeeded):
(WebKit::UnifiedPDFPlugin::performContextMenuAction):
(WebKit::UnifiedPDFPlugin::findString):
(WebKit::UnifiedPDFPlugin::accessibilityScrollToPage):
(WebKit::UnifiedPDFPlugin::revealAnnotation):
(WebKit::UnifiedPDFPlugin::handlePDFActionForAnnotation):
(WebKit::UnifiedPDFPlugin::revealRectInContentsSpace): Deleted.
(WebKit::UnifiedPDFPlugin::scrollToPDFDestination): Deleted.
(WebKit::UnifiedPDFPlugin::scrollToPointInPage): Deleted.
(WebKit::UnifiedPDFPlugin::scrollToPage): Deleted.
(WebKit::UnifiedPDFPlugin::scrollToFragmentIfNeeded): Deleted.

Canonical link: <a href="https://commits.webkit.org/279623@main">https://commits.webkit.org/279623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29d34f27338e9c380b97d2adb0ed773ec1f3681c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33349 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57254 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4703 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4591 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43700 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3102 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31553 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46700 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24841 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28393 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2852 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50047 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58848 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29156 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4305 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51117 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30344 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46835 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50454 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11768 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31295 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30121 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->