### PR TITLE
Compute and pass $platform to run-jsc-stress-tests to make it easier to skip tests for specific platforms.

### DIFF
--- a/Tools/Scripts/run-javascriptcore-tests
+++ b/Tools/Scripts/run-javascriptcore-tests
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2005-2023 Apple Inc.  All rights reserved.
+# Copyright (C) 2005-2024 Apple Inc.  All rights reserved.
 # Copyright (C) 2007 Eric Seidel <eric@webkit.org>
 #
 # Redistribution and use in source and binary forms, with or without
@@ -68,6 +68,7 @@ my $rubyRunner;
 my $gnuParallelRunner;
 my $gnuParallelChunkSize;
 my $testWriter;
+my $fullConfiguration;
 my $memoryLimited;
 my $reportExecutionTime;
 my $treatFailingAsFlaky;
@@ -411,7 +412,7 @@ sub enableTestOrNot {
     return $state;
 }
 
-sub configurationForUpload()
+sub computeFullConfiguration()
 {
     my $platform;
     my $sdk;
@@ -577,7 +578,7 @@ if ($archs ne nativeArchitecture($remotes) && (nativeArchitecture($remotes) ne "
     die "Cannot run tests with $archs on this machine";
 }
 
-configurationForUpload() if (defined($report));
+$fullConfiguration = computeFullConfiguration();
 
 if (defined($jsonFileName)) {
     $jsonFileName = File::Spec->rel2abs($jsonFileName);
@@ -931,6 +932,9 @@ sub runJSCStressTests
         push(@jscStressDriverCmd, $testWriter);
     }
 
+    push(@jscStressDriverCmd, "--platform");
+    push(@jscStressDriverCmd, $fullConfiguration->{"platform"});
+
     if ($memoryLimited) {
         push(@jscStressDriverCmd, "--memory-limited");
     }
@@ -1107,7 +1111,7 @@ sub uploadResults
         version => 0,
         suite => 'javascriptcore-tests',
         commits => @commits,
-        configuration => configurationForUpload(),
+        configuration => $fullConfiguration,
         test_results => {
             run_stats => {
                 start_time => $startTime,

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -186,6 +186,7 @@ def usage
     puts "--jsc                (-j)   Path to JavaScriptCore build product. This option is required."
     puts "--no-copy                   Do not copy the JavaScriptCore build product before testing."
     puts "                            --jsc specifies an already present JavaScriptCore to test."
+    puts "--platform                  Indicate the target platform we are running on."
     puts "--memory-limited            Indicate that we are targeting the test for a memory limited device."
     puts "                            Skip tests tagged with //@skip if $memoryLimited"
     puts "--no-jit                    Do not run JIT specific tests."
@@ -235,6 +236,7 @@ GetoptLong.new(['--help', '-h', GetoptLong::NO_ARGUMENT],
                ['--jsc', '-j', GetoptLong::REQUIRED_ARGUMENT],
                ['--no-copy', GetoptLong::NO_ARGUMENT],
                ['--cloop', GetoptLong::NO_ARGUMENT],
+               ['--platform', GetoptLong::REQUIRED_ARGUMENT],
                ['--memory-limited', GetoptLong::NO_ARGUMENT],
                ['--no-jit', GetoptLong::NO_ARGUMENT],
                ['--force-collectContinuously', GetoptLong::NO_ARGUMENT],
@@ -281,6 +283,8 @@ GetoptLong.new(['--help', '-h', GetoptLong::NO_ARGUMENT],
     when '--cloop'
         $cloop = true
         $jitTests = false
+    when '--platform'
+        $platform = arg
     when '--memory-limited'
         $memoryLimited = true
     when '--no-jit'


### PR DESCRIPTION
#### e038053db43ba33ab0a4bc59a2d7fdeb1ce1690b
<pre>
Compute and pass $platform to run-jsc-stress-tests to make it easier to skip tests for specific platforms.
<a href="https://bugs.webkit.org/show_bug.cgi?id=275018">https://bugs.webkit.org/show_bug.cgi?id=275018</a>
<a href="https://rdar.apple.com/129111944">rdar://129111944</a>

Reviewed by Yijia Huang.

run-javascriptcore-tests already has a sub-routine to compute $platform and other configuration details.
Re-purpose this sub-routine and always run it.  Then, pass the $platform value to run-jsc-stress-tests.

* Tools/Scripts/run-javascriptcore-tests:
(runJSCStressTests):
(uploadResults):
(configurationForUpload): Deleted.
* Tools/Scripts/run-jsc-stress-tests:

Canonical link: <a href="https://commits.webkit.org/279616@main">https://commits.webkit.org/279616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9437de94b4b9e2441f23d41465bf29365dfef60e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/53993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33366 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57270 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4719 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56295 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4610 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43716 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3117 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56090 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31583 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46720 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24857 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28412 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4043 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2868 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/47350 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50074 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4243 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58864 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/53503 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29172 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4327 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51132 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30360 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50478 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31316 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65804 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7992 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30137 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12518 "Passed tests") | 
<!--EWS-Status-Bubble-End-->