### PR TITLE
[tvOS] Start button incorrectly shown when entering fullscreen

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -7616,9 +7616,6 @@ void HTMLMediaElement::privateBrowsingStateDidChange(PAL::SessionID sessionID)
 
 bool HTMLMediaElement::shouldForceControlsDisplay() const
 {
-    if (isFullscreen() && videoUsesElementFullscreen())
-        return true;
-
     // Always create controls for autoplay video that requires user gesture due to being in low power mode.
     return isVideo() && autoplay() && mediaSession().hasBehaviorRestriction(MediaElementSession::RequireUserGestureForVideoDueToLowPowerMode);
 }


### PR DESCRIPTION
#### 4eb5890b06fef636c92e25930b303010b12184f6
<pre>
[tvOS] Start button incorrectly shown when entering fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=275021">https://bugs.webkit.org/show_bug.cgi?id=275021</a>
<a href="https://rdar.apple.com/129115814">rdar://129115814</a>

Reviewed by Eric Carlson.

When in video fullscreen via element fullscreen, HTMLMediaElement::shouldForceControlsDisplay()
would return true. This causes media controls to show a start button even though the media is
already playing. Resolved this by modifying HTMLMediaElement::shouldForceControlsDisplay() to return
false when in video fullscreen via element fullscreen. Note that
HTMLMediaElement::configureMediaControls() will already enable media controls when in video
fullscreen via element fullscreen; we just don&apos;t want to *force* controls, which is akin to showing
the start button on iOS-family platforms.

No new tests; covered by an existing test (media/modern-media-controls/start-support/start-support-fullscreen.html).

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::shouldForceControlsDisplay const):

Canonical link: <a href="https://commits.webkit.org/279622@main">https://commits.webkit.org/279622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d69738da0ae1484a9e2d77cb8debc13b25c70f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54005 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57281 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4730 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56307 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40891 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43726 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3127 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56102 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31597 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46734 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24867 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28424 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4053 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2879 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50089 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4254 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58875 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29187 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4339 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51142 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30371 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46861 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50485 "2 api tests failed or timed out") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11767 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31326 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30152 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->