### PR TITLE
document.execCommand('insertOrderedList'); can hang browser on removing list

### DIFF
--- a/LayoutTests/editing/selection/insert-list-over-uneditable-in-contenteditable-expected.txt
+++ b/LayoutTests/editing/selection/insert-list-over-uneditable-in-contenteditable-expected.txt
@@ -1,0 +1,3 @@
+
+PASS No time out when inserting a list over selected paragraphs that has a non-editable child element
+

--- a/LayoutTests/editing/selection/insert-list-over-uneditable-in-contenteditable.html
+++ b/LayoutTests/editing/selection/insert-list-over-uneditable-in-contenteditable.html
@@ -1,0 +1,10 @@
+<!doctype HTML>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../resources/assert-selection.js"></script>
+<script>
+test(() => assert_selection('<div contenteditable><p>^line1<button contenteditable="false">hello</button></p><p>line2|</p></div>',
+  'insertUnorderedList',
+  '<div contenteditable><p><ul><li>^line1</li></ul><button contenteditable="false">hello</button></p><p><ul><li>line2|</li></ul></p></div>'),
+  'No time out when inserting a list over selected paragraphs that has a non-editable child element');
+</script>

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
- * Copyright (C) 2015 Google Inc. All rights reserved.
+ * Copyright (C) 2004-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2016 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -275,12 +275,19 @@ Position firstEditablePositionAfterPositionInRoot(const Position& position, Cont
         candidate = positionAfterNode(shadowAncestor.get());
     }
 
-    while (candidate.deprecatedNode() && !isEditablePosition(candidate) && candidate.protectedDeprecatedNode()->isDescendantOf(*highestRoot))
+    Node* nonEditableNode = nullptr;
+    while (candidate.deprecatedNode() && !isEditablePosition(candidate) && candidate.protectedDeprecatedNode()->isDescendantOf(*highestRoot)) {
+        nonEditableNode = candidate.deprecatedNode();
         candidate = isAtomicNode(candidate.deprecatedNode()) ? positionInParentAfterNode(candidate.protectedDeprecatedNode().get()) : nextVisuallyDistinctCandidate(candidate);
+    }
 
     if (candidate.deprecatedNode() && candidate.deprecatedNode() != highestRoot && !candidate.protectedDeprecatedNode()->isDescendantOf(*highestRoot))
         return { };
 
+    // If 'editablePosition' has the non-editable child skipped, get the next sibling position.
+    // If not, we can't get the next paragraph in InsertListCommand::doApply's while loop.
+    if (nonEditableNode && nonEditableNode->isDescendantOf(candidate.deprecatedNode()))
+        candidate = nextVisuallyDistinctCandidate(candidate);
     return candidate;
 }
 


### PR DESCRIPTION
<pre>
document.execCommand('insertOrderedList'); can hang browser on removing list
<a href="https://bugs.webkit.org/show_bug.cgi?id=258254">https://bugs.webkit.org/show_bug.cgi?id=258254</a>
rdar://problem/111272008

Reviewed by NOBODY (OOPS!).

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/f15d4cc339737df653274e39726ae0d14d409b18">https://chromium.googlesource.com/chromium/src.git/+/f15d4cc339737df653274e39726ae0d14d409b18</a>

While firstEditablePositionAfterPositionInRoot() is running,
we can get the next editable paragraph under the highest editable
node by skipping non-editable paragraph.

However, if an editable paragraph has a non-editable child, the next
paragraph can be the same editable paragraph that is the parent of the
non-editable child. In this case, we can't get the next editable
paragraph in InsertListCommand::doApply's while loop. As a result,
the while loop can't break, which makes the tab hang.

This patch allows to get the next editable paragraph by considering the
non-editable child element.

* Source/WebCore/editing/Editing.cpp:
(WebCore::firstEditablePositionAfterPositionInRoot):
* LayoutTests/editing/selection/insert-list-over-uneditable-in-contenteditable.html: Add Test Case
* LayoutTests/editing/selection/insert-list-over-uneditable-in-contenteditable-expected.txt: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ebb97decaa7afc69c850ae5056bb9aa6642855f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56214 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59820 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6650 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58340 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6844 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45487 "Found 1 new test failure: imported/w3c/web-platform-tests/editing/run/forwarddelete.html?6001-7000 (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4622 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48497 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26387 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30207 "Found 2 new test failures: imported/w3c/web-platform-tests/editing/run/forwarddelete.html?6001-7000 imported/w3c/web-platform-tests/mathml/presentation-markup/mrow/inferred-mrow-stretchy.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5827 "Found 2 new test failures: editing/selection/5825350-2.html imported/w3c/web-platform-tests/editing/run/forwarddelete.html?6001-7000 (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5654 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52220 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6099 "Found 1 new test failure: imported/w3c/web-platform-tests/editing/run/forwarddelete.html?6001-7000 (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61503 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/122 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6223 "Found 1 new test failure: imported/w3c/web-platform-tests/editing/run/forwarddelete.html?6001-7000 (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52786 "Found 1 new test failure: imported/w3c/web-platform-tests/editing/run/forwarddelete.html?6001-7000 (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/122 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48564 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52652 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/108 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31367 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32453 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33536 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32200 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->