### PR TITLE
[css-anchor-position-1] Add parsing support for `anchor-name` and `position-anchor` properties

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-basics-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-basics-expected.txt
@@ -1,56 +1,56 @@
 
-FAIL e.style['anchor-name'] = "none" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['anchor-name'] = "--foo" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['anchor-name'] = "--foo, --bar" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['anchor-name'] = "none" should set the property value
+PASS e.style['anchor-name'] = "--foo" should set the property value
+PASS e.style['anchor-name'] = "--foo, --bar" should set the property value
 PASS e.style['anchor-name'] = "foo-bar" should not set the property value
 PASS e.style['anchor-name'] = "--foo --bar" should not set the property value
 PASS e.style['anchor-name'] = "100px" should not set the property value
 PASS e.style['anchor-name'] = "100%" should not set the property value
-FAIL Property anchor-name value 'none' assert_true: anchor-name doesn't seem to be supported in the computed style expected true got false
-FAIL Property anchor-name value '--foo' assert_true: anchor-name doesn't seem to be supported in the computed style expected true got false
-FAIL Property anchor-name value '--foo, --bar' assert_true: anchor-name doesn't seem to be supported in the computed style expected true got false
-FAIL Property anchor-name has initial value none assert_true: anchor-name doesn't seem to be supported in the computed style expected true got false
-FAIL Property anchor-name does not inherit assert_true: expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [none] at (-0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [none] at (0) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [none] at (0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [none] at (0.5) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [none] at (0.6) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [none] at (1) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [none] at (1.5) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [none] at (-0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [none] at (0) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [none] at (0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [none] at (0.5) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [none] at (0.6) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [none] at (1) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [none] at (1.5) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <anchor-name> from [--foo] to [none] at (-0.3) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <anchor-name> from [--foo] to [none] at (0) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <anchor-name> from [--foo] to [none] at (0.3) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <anchor-name> from [--foo] to [none] at (0.5) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <anchor-name> from [--foo] to [none] at (0.6) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <anchor-name> from [--foo] to [none] at (1) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <anchor-name> from [--foo] to [none] at (1.5) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <anchor-name> from [--foo] to [none] at (-0.3) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <anchor-name> from [--foo] to [none] at (0) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <anchor-name> from [--foo] to [none] at (0.3) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <anchor-name> from [--foo] to [none] at (0.5) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <anchor-name> from [--foo] to [none] at (0.6) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <anchor-name> from [--foo] to [none] at (1) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <anchor-name> from [--foo] to [none] at (1.5) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <anchor-name> from [--foo] to [none] at (-0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <anchor-name> from [--foo] to [none] at (0) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <anchor-name> from [--foo] to [none] at (0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <anchor-name> from [--foo] to [none] at (0.5) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <anchor-name> from [--foo] to [none] at (0.6) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <anchor-name> from [--foo] to [none] at (1) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <anchor-name> from [--foo] to [none] at (1.5) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <anchor-name> from [--foo] to [none] at (-0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <anchor-name> from [--foo] to [none] at (0) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <anchor-name> from [--foo] to [none] at (0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <anchor-name> from [--foo] to [none] at (0.5) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <anchor-name> from [--foo] to [none] at (0.6) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <anchor-name> from [--foo] to [none] at (1) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <anchor-name> from [--foo] to [none] at (1.5) should be [none] assert_true: 'from' value should be supported expected true got false
+PASS Property anchor-name value 'none'
+PASS Property anchor-name value '--foo'
+PASS Property anchor-name value '--foo, --bar'
+PASS Property anchor-name has initial value none
+PASS Property anchor-name does not inherit
+PASS CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [none] at (-0.3) should be [--foo]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [none] at (0) should be [--foo]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [none] at (0.3) should be [--foo]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [none] at (0.5) should be [none]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [none] at (0.6) should be [none]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [none] at (1) should be [none]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [none] at (1.5) should be [none]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [none] at (-0.3) should be [--foo]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [none] at (0) should be [--foo]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [none] at (0.3) should be [--foo]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [none] at (0.5) should be [none]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [none] at (0.6) should be [none]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [none] at (1) should be [none]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [none] at (1.5) should be [none]
+PASS CSS Transitions: property <anchor-name> from [--foo] to [none] at (-0.3) should be [none]
+PASS CSS Transitions: property <anchor-name> from [--foo] to [none] at (0) should be [none]
+PASS CSS Transitions: property <anchor-name> from [--foo] to [none] at (0.3) should be [none]
+PASS CSS Transitions: property <anchor-name> from [--foo] to [none] at (0.5) should be [none]
+PASS CSS Transitions: property <anchor-name> from [--foo] to [none] at (0.6) should be [none]
+PASS CSS Transitions: property <anchor-name> from [--foo] to [none] at (1) should be [none]
+PASS CSS Transitions: property <anchor-name> from [--foo] to [none] at (1.5) should be [none]
+PASS CSS Transitions with transition: all: property <anchor-name> from [--foo] to [none] at (-0.3) should be [none]
+PASS CSS Transitions with transition: all: property <anchor-name> from [--foo] to [none] at (0) should be [none]
+PASS CSS Transitions with transition: all: property <anchor-name> from [--foo] to [none] at (0.3) should be [none]
+PASS CSS Transitions with transition: all: property <anchor-name> from [--foo] to [none] at (0.5) should be [none]
+PASS CSS Transitions with transition: all: property <anchor-name> from [--foo] to [none] at (0.6) should be [none]
+PASS CSS Transitions with transition: all: property <anchor-name> from [--foo] to [none] at (1) should be [none]
+PASS CSS Transitions with transition: all: property <anchor-name> from [--foo] to [none] at (1.5) should be [none]
+PASS CSS Animations: property <anchor-name> from [--foo] to [none] at (-0.3) should be [--foo]
+PASS CSS Animations: property <anchor-name> from [--foo] to [none] at (0) should be [--foo]
+PASS CSS Animations: property <anchor-name> from [--foo] to [none] at (0.3) should be [--foo]
+PASS CSS Animations: property <anchor-name> from [--foo] to [none] at (0.5) should be [none]
+PASS CSS Animations: property <anchor-name> from [--foo] to [none] at (0.6) should be [none]
+PASS CSS Animations: property <anchor-name> from [--foo] to [none] at (1) should be [none]
+PASS CSS Animations: property <anchor-name> from [--foo] to [none] at (1.5) should be [none]
+PASS Web Animations: property <anchor-name> from [--foo] to [none] at (-0.3) should be [--foo]
+PASS Web Animations: property <anchor-name> from [--foo] to [none] at (0) should be [--foo]
+PASS Web Animations: property <anchor-name> from [--foo] to [none] at (0.3) should be [--foo]
+PASS Web Animations: property <anchor-name> from [--foo] to [none] at (0.5) should be [none]
+PASS Web Animations: property <anchor-name> from [--foo] to [none] at (0.6) should be [none]
+PASS Web Animations: property <anchor-name> from [--foo] to [none] at (1) should be [none]
+PASS Web Animations: property <anchor-name> from [--foo] to [none] at (1.5) should be [none]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-basics-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-basics-expected.txt
@@ -1,56 +1,56 @@
 
-FAIL e.style['position-anchor'] = "auto" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['position-anchor'] = "--foo" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['position-anchor'] = "auto" should set the property value
+PASS e.style['position-anchor'] = "--foo" should set the property value
 PASS e.style['position-anchor'] = "none" should not set the property value
 PASS e.style['position-anchor'] = "foo-bar" should not set the property value
 PASS e.style['position-anchor'] = "--foo --bar" should not set the property value
 PASS e.style['position-anchor'] = "--foo, --bar" should not set the property value
 PASS e.style['position-anchor'] = "100px" should not set the property value
 PASS e.style['position-anchor'] = "100%" should not set the property value
-FAIL Property position-anchor value 'auto' assert_true: position-anchor doesn't seem to be supported in the computed style expected true got false
-FAIL Property position-anchor value '--foo' assert_true: position-anchor doesn't seem to be supported in the computed style expected true got false
-FAIL Property position-anchor has initial value auto assert_true: position-anchor doesn't seem to be supported in the computed style expected true got false
-FAIL Property position-anchor does not inherit assert_true: expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [auto] at (-0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [auto] at (0) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [auto] at (0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [auto] at (0.5) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [auto] at (0.6) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [auto] at (1) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [auto] at (1.5) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [auto] at (-0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [auto] at (0) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [auto] at (0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [auto] at (0.5) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [auto] at (0.6) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [auto] at (1) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [auto] at (1.5) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <position-anchor> from [--foo] to [auto] at (-0.3) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <position-anchor> from [--foo] to [auto] at (0) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <position-anchor> from [--foo] to [auto] at (0.3) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <position-anchor> from [--foo] to [auto] at (0.5) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <position-anchor> from [--foo] to [auto] at (0.6) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <position-anchor> from [--foo] to [auto] at (1) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <position-anchor> from [--foo] to [auto] at (1.5) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <position-anchor> from [--foo] to [auto] at (-0.3) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <position-anchor> from [--foo] to [auto] at (0) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <position-anchor> from [--foo] to [auto] at (0.3) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <position-anchor> from [--foo] to [auto] at (0.5) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <position-anchor> from [--foo] to [auto] at (0.6) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <position-anchor> from [--foo] to [auto] at (1) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <position-anchor> from [--foo] to [auto] at (1.5) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <position-anchor> from [--foo] to [auto] at (-0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <position-anchor> from [--foo] to [auto] at (0) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <position-anchor> from [--foo] to [auto] at (0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <position-anchor> from [--foo] to [auto] at (0.5) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <position-anchor> from [--foo] to [auto] at (0.6) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <position-anchor> from [--foo] to [auto] at (1) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <position-anchor> from [--foo] to [auto] at (1.5) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <position-anchor> from [--foo] to [auto] at (-0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <position-anchor> from [--foo] to [auto] at (0) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <position-anchor> from [--foo] to [auto] at (0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <position-anchor> from [--foo] to [auto] at (0.5) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <position-anchor> from [--foo] to [auto] at (0.6) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <position-anchor> from [--foo] to [auto] at (1) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <position-anchor> from [--foo] to [auto] at (1.5) should be [auto] assert_true: 'from' value should be supported expected true got false
+PASS Property position-anchor value 'auto'
+PASS Property position-anchor value '--foo'
+PASS Property position-anchor has initial value auto
+PASS Property position-anchor does not inherit
+PASS CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [auto] at (-0.3) should be [--foo]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [auto] at (0) should be [--foo]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [auto] at (0.3) should be [--foo]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [auto] at (0.5) should be [auto]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [auto] at (0.6) should be [auto]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [auto] at (1) should be [auto]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [auto] at (1.5) should be [auto]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [auto] at (-0.3) should be [--foo]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [auto] at (0) should be [--foo]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [auto] at (0.3) should be [--foo]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [auto] at (0.5) should be [auto]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [auto] at (0.6) should be [auto]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [auto] at (1) should be [auto]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [auto] at (1.5) should be [auto]
+PASS CSS Transitions: property <position-anchor> from [--foo] to [auto] at (-0.3) should be [auto]
+PASS CSS Transitions: property <position-anchor> from [--foo] to [auto] at (0) should be [auto]
+PASS CSS Transitions: property <position-anchor> from [--foo] to [auto] at (0.3) should be [auto]
+PASS CSS Transitions: property <position-anchor> from [--foo] to [auto] at (0.5) should be [auto]
+PASS CSS Transitions: property <position-anchor> from [--foo] to [auto] at (0.6) should be [auto]
+PASS CSS Transitions: property <position-anchor> from [--foo] to [auto] at (1) should be [auto]
+PASS CSS Transitions: property <position-anchor> from [--foo] to [auto] at (1.5) should be [auto]
+PASS CSS Transitions with transition: all: property <position-anchor> from [--foo] to [auto] at (-0.3) should be [auto]
+PASS CSS Transitions with transition: all: property <position-anchor> from [--foo] to [auto] at (0) should be [auto]
+PASS CSS Transitions with transition: all: property <position-anchor> from [--foo] to [auto] at (0.3) should be [auto]
+PASS CSS Transitions with transition: all: property <position-anchor> from [--foo] to [auto] at (0.5) should be [auto]
+PASS CSS Transitions with transition: all: property <position-anchor> from [--foo] to [auto] at (0.6) should be [auto]
+PASS CSS Transitions with transition: all: property <position-anchor> from [--foo] to [auto] at (1) should be [auto]
+PASS CSS Transitions with transition: all: property <position-anchor> from [--foo] to [auto] at (1.5) should be [auto]
+PASS CSS Animations: property <position-anchor> from [--foo] to [auto] at (-0.3) should be [--foo]
+PASS CSS Animations: property <position-anchor> from [--foo] to [auto] at (0) should be [--foo]
+PASS CSS Animations: property <position-anchor> from [--foo] to [auto] at (0.3) should be [--foo]
+PASS CSS Animations: property <position-anchor> from [--foo] to [auto] at (0.5) should be [auto]
+PASS CSS Animations: property <position-anchor> from [--foo] to [auto] at (0.6) should be [auto]
+PASS CSS Animations: property <position-anchor> from [--foo] to [auto] at (1) should be [auto]
+PASS CSS Animations: property <position-anchor> from [--foo] to [auto] at (1.5) should be [auto]
+PASS Web Animations: property <position-anchor> from [--foo] to [auto] at (-0.3) should be [--foo]
+PASS Web Animations: property <position-anchor> from [--foo] to [auto] at (0) should be [--foo]
+PASS Web Animations: property <position-anchor> from [--foo] to [auto] at (0.3) should be [--foo]
+PASS Web Animations: property <position-anchor> from [--foo] to [auto] at (0.5) should be [auto]
+PASS Web Animations: property <position-anchor> from [--foo] to [auto] at (0.6) should be [auto]
+PASS Web Animations: property <position-anchor> from [--foo] to [auto] at (1) should be [auto]
+PASS Web Animations: property <position-anchor> from [--foo] to [auto] at (1.5) should be [auto]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/property-interpolations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/property-interpolations-expected.txt
@@ -1,172 +1,172 @@
 
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [none] to [--foo] at (-0.3) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [none] to [--foo] at (0) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [none] to [--foo] at (0.3) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [none] to [--foo] at (0.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [none] to [--foo] at (0.6) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [none] to [--foo] at (1) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [none] to [--foo] at (1.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [none] to [--foo] at (-0.3) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [none] to [--foo] at (0) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [none] to [--foo] at (0.3) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [none] to [--foo] at (0.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [none] to [--foo] at (0.6) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [none] to [--foo] at (1) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [none] to [--foo] at (1.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <anchor-name> from [none] to [--foo] at (-0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <anchor-name> from [none] to [--foo] at (0) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <anchor-name> from [none] to [--foo] at (0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <anchor-name> from [none] to [--foo] at (0.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <anchor-name> from [none] to [--foo] at (0.6) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <anchor-name> from [none] to [--foo] at (1) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <anchor-name> from [none] to [--foo] at (1.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <anchor-name> from [none] to [--foo] at (-0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <anchor-name> from [none] to [--foo] at (0) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <anchor-name> from [none] to [--foo] at (0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <anchor-name> from [none] to [--foo] at (0.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <anchor-name> from [none] to [--foo] at (0.6) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <anchor-name> from [none] to [--foo] at (1) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <anchor-name> from [none] to [--foo] at (1.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <anchor-name> from [none] to [--foo] at (-0.3) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <anchor-name> from [none] to [--foo] at (0) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <anchor-name> from [none] to [--foo] at (0.3) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <anchor-name> from [none] to [--foo] at (0.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <anchor-name> from [none] to [--foo] at (0.6) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <anchor-name> from [none] to [--foo] at (1) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <anchor-name> from [none] to [--foo] at (1.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <anchor-name> from [none] to [--foo] at (-0.3) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <anchor-name> from [none] to [--foo] at (0) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <anchor-name> from [none] to [--foo] at (0.3) should be [none] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <anchor-name> from [none] to [--foo] at (0.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <anchor-name> from [none] to [--foo] at (0.6) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <anchor-name> from [none] to [--foo] at (1) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <anchor-name> from [none] to [--foo] at (1.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (-0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (0) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (0.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (0.6) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (1) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (1.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (-0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (0) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (0.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (0.6) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (1) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (1.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <anchor-name> from [--foo] to [--bar] at (-0.3) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <anchor-name> from [--foo] to [--bar] at (0) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <anchor-name> from [--foo] to [--bar] at (0.3) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <anchor-name> from [--foo] to [--bar] at (0.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <anchor-name> from [--foo] to [--bar] at (0.6) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <anchor-name> from [--foo] to [--bar] at (1) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <anchor-name> from [--foo] to [--bar] at (1.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <anchor-name> from [--foo] to [--bar] at (-0.3) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <anchor-name> from [--foo] to [--bar] at (0) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <anchor-name> from [--foo] to [--bar] at (0.3) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <anchor-name> from [--foo] to [--bar] at (0.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <anchor-name> from [--foo] to [--bar] at (0.6) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <anchor-name> from [--foo] to [--bar] at (1) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <anchor-name> from [--foo] to [--bar] at (1.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <anchor-name> from [--foo] to [--bar] at (-0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <anchor-name> from [--foo] to [--bar] at (0) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <anchor-name> from [--foo] to [--bar] at (0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <anchor-name> from [--foo] to [--bar] at (0.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <anchor-name> from [--foo] to [--bar] at (0.6) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <anchor-name> from [--foo] to [--bar] at (1) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <anchor-name> from [--foo] to [--bar] at (1.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <anchor-name> from [--foo] to [--bar] at (-0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <anchor-name> from [--foo] to [--bar] at (0) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <anchor-name> from [--foo] to [--bar] at (0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <anchor-name> from [--foo] to [--bar] at (0.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <anchor-name> from [--foo] to [--bar] at (0.6) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <anchor-name> from [--foo] to [--bar] at (1) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <anchor-name> from [--foo] to [--bar] at (1.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [auto] to [--foo] at (-0.3) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [auto] to [--foo] at (0) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [auto] to [--foo] at (0.3) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [auto] to [--foo] at (0.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [auto] to [--foo] at (0.6) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [auto] to [--foo] at (1) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [auto] to [--foo] at (1.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [auto] to [--foo] at (-0.3) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [auto] to [--foo] at (0) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [auto] to [--foo] at (0.3) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [auto] to [--foo] at (0.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [auto] to [--foo] at (0.6) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [auto] to [--foo] at (1) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [auto] to [--foo] at (1.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <position-anchor> from [auto] to [--foo] at (-0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <position-anchor> from [auto] to [--foo] at (0) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <position-anchor> from [auto] to [--foo] at (0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <position-anchor> from [auto] to [--foo] at (0.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <position-anchor> from [auto] to [--foo] at (0.6) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <position-anchor> from [auto] to [--foo] at (1) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <position-anchor> from [auto] to [--foo] at (1.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <position-anchor> from [auto] to [--foo] at (-0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <position-anchor> from [auto] to [--foo] at (0) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <position-anchor> from [auto] to [--foo] at (0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <position-anchor> from [auto] to [--foo] at (0.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <position-anchor> from [auto] to [--foo] at (0.6) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <position-anchor> from [auto] to [--foo] at (1) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <position-anchor> from [auto] to [--foo] at (1.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <position-anchor> from [auto] to [--foo] at (-0.3) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <position-anchor> from [auto] to [--foo] at (0) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <position-anchor> from [auto] to [--foo] at (0.3) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <position-anchor> from [auto] to [--foo] at (0.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <position-anchor> from [auto] to [--foo] at (0.6) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <position-anchor> from [auto] to [--foo] at (1) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <position-anchor> from [auto] to [--foo] at (1.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <position-anchor> from [auto] to [--foo] at (-0.3) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <position-anchor> from [auto] to [--foo] at (0) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <position-anchor> from [auto] to [--foo] at (0.3) should be [auto] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <position-anchor> from [auto] to [--foo] at (0.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <position-anchor> from [auto] to [--foo] at (0.6) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <position-anchor> from [auto] to [--foo] at (1) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <position-anchor> from [auto] to [--foo] at (1.5) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (-0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (0) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (0.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (0.6) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (1) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (1.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (-0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (0) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (0.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (0.6) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (1) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (1.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <position-anchor> from [--foo] to [--bar] at (-0.3) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <position-anchor> from [--foo] to [--bar] at (0) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <position-anchor> from [--foo] to [--bar] at (0.3) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <position-anchor> from [--foo] to [--bar] at (0.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <position-anchor> from [--foo] to [--bar] at (0.6) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <position-anchor> from [--foo] to [--bar] at (1) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions: property <position-anchor> from [--foo] to [--bar] at (1.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <position-anchor> from [--foo] to [--bar] at (-0.3) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <position-anchor> from [--foo] to [--bar] at (0) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <position-anchor> from [--foo] to [--bar] at (0.3) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <position-anchor> from [--foo] to [--bar] at (0.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <position-anchor> from [--foo] to [--bar] at (0.6) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <position-anchor> from [--foo] to [--bar] at (1) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Transitions with transition: all: property <position-anchor> from [--foo] to [--bar] at (1.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <position-anchor> from [--foo] to [--bar] at (-0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <position-anchor> from [--foo] to [--bar] at (0) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <position-anchor> from [--foo] to [--bar] at (0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <position-anchor> from [--foo] to [--bar] at (0.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <position-anchor> from [--foo] to [--bar] at (0.6) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <position-anchor> from [--foo] to [--bar] at (1) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL CSS Animations: property <position-anchor> from [--foo] to [--bar] at (1.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <position-anchor> from [--foo] to [--bar] at (-0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <position-anchor> from [--foo] to [--bar] at (0) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <position-anchor> from [--foo] to [--bar] at (0.3) should be [--foo] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <position-anchor> from [--foo] to [--bar] at (0.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <position-anchor> from [--foo] to [--bar] at (0.6) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <position-anchor> from [--foo] to [--bar] at (1) should be [--bar] assert_true: 'from' value should be supported expected true got false
-FAIL Web Animations: property <position-anchor> from [--foo] to [--bar] at (1.5) should be [--bar] assert_true: 'from' value should be supported expected true got false
+PASS CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [none] to [--foo] at (-0.3) should be [none]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [none] to [--foo] at (0) should be [none]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [none] to [--foo] at (0.3) should be [none]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [none] to [--foo] at (0.5) should be [--foo]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [none] to [--foo] at (0.6) should be [--foo]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [none] to [--foo] at (1) should be [--foo]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [none] to [--foo] at (1.5) should be [--foo]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [none] to [--foo] at (-0.3) should be [none]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [none] to [--foo] at (0) should be [none]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [none] to [--foo] at (0.3) should be [none]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [none] to [--foo] at (0.5) should be [--foo]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [none] to [--foo] at (0.6) should be [--foo]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [none] to [--foo] at (1) should be [--foo]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [none] to [--foo] at (1.5) should be [--foo]
+PASS CSS Transitions: property <anchor-name> from [none] to [--foo] at (-0.3) should be [--foo]
+PASS CSS Transitions: property <anchor-name> from [none] to [--foo] at (0) should be [--foo]
+PASS CSS Transitions: property <anchor-name> from [none] to [--foo] at (0.3) should be [--foo]
+PASS CSS Transitions: property <anchor-name> from [none] to [--foo] at (0.5) should be [--foo]
+PASS CSS Transitions: property <anchor-name> from [none] to [--foo] at (0.6) should be [--foo]
+PASS CSS Transitions: property <anchor-name> from [none] to [--foo] at (1) should be [--foo]
+PASS CSS Transitions: property <anchor-name> from [none] to [--foo] at (1.5) should be [--foo]
+PASS CSS Transitions with transition: all: property <anchor-name> from [none] to [--foo] at (-0.3) should be [--foo]
+PASS CSS Transitions with transition: all: property <anchor-name> from [none] to [--foo] at (0) should be [--foo]
+PASS CSS Transitions with transition: all: property <anchor-name> from [none] to [--foo] at (0.3) should be [--foo]
+PASS CSS Transitions with transition: all: property <anchor-name> from [none] to [--foo] at (0.5) should be [--foo]
+PASS CSS Transitions with transition: all: property <anchor-name> from [none] to [--foo] at (0.6) should be [--foo]
+PASS CSS Transitions with transition: all: property <anchor-name> from [none] to [--foo] at (1) should be [--foo]
+PASS CSS Transitions with transition: all: property <anchor-name> from [none] to [--foo] at (1.5) should be [--foo]
+PASS CSS Animations: property <anchor-name> from [none] to [--foo] at (-0.3) should be [none]
+PASS CSS Animations: property <anchor-name> from [none] to [--foo] at (0) should be [none]
+PASS CSS Animations: property <anchor-name> from [none] to [--foo] at (0.3) should be [none]
+PASS CSS Animations: property <anchor-name> from [none] to [--foo] at (0.5) should be [--foo]
+PASS CSS Animations: property <anchor-name> from [none] to [--foo] at (0.6) should be [--foo]
+PASS CSS Animations: property <anchor-name> from [none] to [--foo] at (1) should be [--foo]
+PASS CSS Animations: property <anchor-name> from [none] to [--foo] at (1.5) should be [--foo]
+PASS Web Animations: property <anchor-name> from [none] to [--foo] at (-0.3) should be [none]
+PASS Web Animations: property <anchor-name> from [none] to [--foo] at (0) should be [none]
+PASS Web Animations: property <anchor-name> from [none] to [--foo] at (0.3) should be [none]
+PASS Web Animations: property <anchor-name> from [none] to [--foo] at (0.5) should be [--foo]
+PASS Web Animations: property <anchor-name> from [none] to [--foo] at (0.6) should be [--foo]
+PASS Web Animations: property <anchor-name> from [none] to [--foo] at (1) should be [--foo]
+PASS Web Animations: property <anchor-name> from [none] to [--foo] at (1.5) should be [--foo]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (-0.3) should be [--foo]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (0) should be [--foo]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (0.3) should be [--foo]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (0.5) should be [--bar]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (0.6) should be [--bar]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (1) should be [--bar]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (1.5) should be [--bar]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (-0.3) should be [--foo]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (0) should be [--foo]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (0.3) should be [--foo]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (0.5) should be [--bar]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (0.6) should be [--bar]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (1) should be [--bar]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <anchor-name> from [--foo] to [--bar] at (1.5) should be [--bar]
+PASS CSS Transitions: property <anchor-name> from [--foo] to [--bar] at (-0.3) should be [--bar]
+PASS CSS Transitions: property <anchor-name> from [--foo] to [--bar] at (0) should be [--bar]
+PASS CSS Transitions: property <anchor-name> from [--foo] to [--bar] at (0.3) should be [--bar]
+PASS CSS Transitions: property <anchor-name> from [--foo] to [--bar] at (0.5) should be [--bar]
+PASS CSS Transitions: property <anchor-name> from [--foo] to [--bar] at (0.6) should be [--bar]
+PASS CSS Transitions: property <anchor-name> from [--foo] to [--bar] at (1) should be [--bar]
+PASS CSS Transitions: property <anchor-name> from [--foo] to [--bar] at (1.5) should be [--bar]
+PASS CSS Transitions with transition: all: property <anchor-name> from [--foo] to [--bar] at (-0.3) should be [--bar]
+PASS CSS Transitions with transition: all: property <anchor-name> from [--foo] to [--bar] at (0) should be [--bar]
+PASS CSS Transitions with transition: all: property <anchor-name> from [--foo] to [--bar] at (0.3) should be [--bar]
+PASS CSS Transitions with transition: all: property <anchor-name> from [--foo] to [--bar] at (0.5) should be [--bar]
+PASS CSS Transitions with transition: all: property <anchor-name> from [--foo] to [--bar] at (0.6) should be [--bar]
+PASS CSS Transitions with transition: all: property <anchor-name> from [--foo] to [--bar] at (1) should be [--bar]
+PASS CSS Transitions with transition: all: property <anchor-name> from [--foo] to [--bar] at (1.5) should be [--bar]
+PASS CSS Animations: property <anchor-name> from [--foo] to [--bar] at (-0.3) should be [--foo]
+PASS CSS Animations: property <anchor-name> from [--foo] to [--bar] at (0) should be [--foo]
+PASS CSS Animations: property <anchor-name> from [--foo] to [--bar] at (0.3) should be [--foo]
+PASS CSS Animations: property <anchor-name> from [--foo] to [--bar] at (0.5) should be [--bar]
+PASS CSS Animations: property <anchor-name> from [--foo] to [--bar] at (0.6) should be [--bar]
+PASS CSS Animations: property <anchor-name> from [--foo] to [--bar] at (1) should be [--bar]
+PASS CSS Animations: property <anchor-name> from [--foo] to [--bar] at (1.5) should be [--bar]
+PASS Web Animations: property <anchor-name> from [--foo] to [--bar] at (-0.3) should be [--foo]
+PASS Web Animations: property <anchor-name> from [--foo] to [--bar] at (0) should be [--foo]
+PASS Web Animations: property <anchor-name> from [--foo] to [--bar] at (0.3) should be [--foo]
+PASS Web Animations: property <anchor-name> from [--foo] to [--bar] at (0.5) should be [--bar]
+PASS Web Animations: property <anchor-name> from [--foo] to [--bar] at (0.6) should be [--bar]
+PASS Web Animations: property <anchor-name> from [--foo] to [--bar] at (1) should be [--bar]
+PASS Web Animations: property <anchor-name> from [--foo] to [--bar] at (1.5) should be [--bar]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [auto] to [--foo] at (-0.3) should be [auto]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [auto] to [--foo] at (0) should be [auto]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [auto] to [--foo] at (0.3) should be [auto]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [auto] to [--foo] at (0.5) should be [--foo]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [auto] to [--foo] at (0.6) should be [--foo]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [auto] to [--foo] at (1) should be [--foo]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [auto] to [--foo] at (1.5) should be [--foo]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [auto] to [--foo] at (-0.3) should be [auto]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [auto] to [--foo] at (0) should be [auto]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [auto] to [--foo] at (0.3) should be [auto]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [auto] to [--foo] at (0.5) should be [--foo]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [auto] to [--foo] at (0.6) should be [--foo]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [auto] to [--foo] at (1) should be [--foo]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [auto] to [--foo] at (1.5) should be [--foo]
+PASS CSS Transitions: property <position-anchor> from [auto] to [--foo] at (-0.3) should be [--foo]
+PASS CSS Transitions: property <position-anchor> from [auto] to [--foo] at (0) should be [--foo]
+PASS CSS Transitions: property <position-anchor> from [auto] to [--foo] at (0.3) should be [--foo]
+PASS CSS Transitions: property <position-anchor> from [auto] to [--foo] at (0.5) should be [--foo]
+PASS CSS Transitions: property <position-anchor> from [auto] to [--foo] at (0.6) should be [--foo]
+PASS CSS Transitions: property <position-anchor> from [auto] to [--foo] at (1) should be [--foo]
+PASS CSS Transitions: property <position-anchor> from [auto] to [--foo] at (1.5) should be [--foo]
+PASS CSS Transitions with transition: all: property <position-anchor> from [auto] to [--foo] at (-0.3) should be [--foo]
+PASS CSS Transitions with transition: all: property <position-anchor> from [auto] to [--foo] at (0) should be [--foo]
+PASS CSS Transitions with transition: all: property <position-anchor> from [auto] to [--foo] at (0.3) should be [--foo]
+PASS CSS Transitions with transition: all: property <position-anchor> from [auto] to [--foo] at (0.5) should be [--foo]
+PASS CSS Transitions with transition: all: property <position-anchor> from [auto] to [--foo] at (0.6) should be [--foo]
+PASS CSS Transitions with transition: all: property <position-anchor> from [auto] to [--foo] at (1) should be [--foo]
+PASS CSS Transitions with transition: all: property <position-anchor> from [auto] to [--foo] at (1.5) should be [--foo]
+PASS CSS Animations: property <position-anchor> from [auto] to [--foo] at (-0.3) should be [auto]
+PASS CSS Animations: property <position-anchor> from [auto] to [--foo] at (0) should be [auto]
+PASS CSS Animations: property <position-anchor> from [auto] to [--foo] at (0.3) should be [auto]
+PASS CSS Animations: property <position-anchor> from [auto] to [--foo] at (0.5) should be [--foo]
+PASS CSS Animations: property <position-anchor> from [auto] to [--foo] at (0.6) should be [--foo]
+PASS CSS Animations: property <position-anchor> from [auto] to [--foo] at (1) should be [--foo]
+PASS CSS Animations: property <position-anchor> from [auto] to [--foo] at (1.5) should be [--foo]
+PASS Web Animations: property <position-anchor> from [auto] to [--foo] at (-0.3) should be [auto]
+PASS Web Animations: property <position-anchor> from [auto] to [--foo] at (0) should be [auto]
+PASS Web Animations: property <position-anchor> from [auto] to [--foo] at (0.3) should be [auto]
+PASS Web Animations: property <position-anchor> from [auto] to [--foo] at (0.5) should be [--foo]
+PASS Web Animations: property <position-anchor> from [auto] to [--foo] at (0.6) should be [--foo]
+PASS Web Animations: property <position-anchor> from [auto] to [--foo] at (1) should be [--foo]
+PASS Web Animations: property <position-anchor> from [auto] to [--foo] at (1.5) should be [--foo]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (-0.3) should be [--foo]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (0) should be [--foo]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (0.3) should be [--foo]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (0.5) should be [--bar]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (0.6) should be [--bar]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (1) should be [--bar]
+PASS CSS Transitions with transition-behavior:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (1.5) should be [--bar]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (-0.3) should be [--foo]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (0) should be [--foo]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (0.3) should be [--foo]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (0.5) should be [--bar]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (0.6) should be [--bar]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (1) should be [--bar]
+PASS CSS Transitions with transition-property:all and transition-behavor:allow-discrete: property <position-anchor> from [--foo] to [--bar] at (1.5) should be [--bar]
+PASS CSS Transitions: property <position-anchor> from [--foo] to [--bar] at (-0.3) should be [--bar]
+PASS CSS Transitions: property <position-anchor> from [--foo] to [--bar] at (0) should be [--bar]
+PASS CSS Transitions: property <position-anchor> from [--foo] to [--bar] at (0.3) should be [--bar]
+PASS CSS Transitions: property <position-anchor> from [--foo] to [--bar] at (0.5) should be [--bar]
+PASS CSS Transitions: property <position-anchor> from [--foo] to [--bar] at (0.6) should be [--bar]
+PASS CSS Transitions: property <position-anchor> from [--foo] to [--bar] at (1) should be [--bar]
+PASS CSS Transitions: property <position-anchor> from [--foo] to [--bar] at (1.5) should be [--bar]
+PASS CSS Transitions with transition: all: property <position-anchor> from [--foo] to [--bar] at (-0.3) should be [--bar]
+PASS CSS Transitions with transition: all: property <position-anchor> from [--foo] to [--bar] at (0) should be [--bar]
+PASS CSS Transitions with transition: all: property <position-anchor> from [--foo] to [--bar] at (0.3) should be [--bar]
+PASS CSS Transitions with transition: all: property <position-anchor> from [--foo] to [--bar] at (0.5) should be [--bar]
+PASS CSS Transitions with transition: all: property <position-anchor> from [--foo] to [--bar] at (0.6) should be [--bar]
+PASS CSS Transitions with transition: all: property <position-anchor> from [--foo] to [--bar] at (1) should be [--bar]
+PASS CSS Transitions with transition: all: property <position-anchor> from [--foo] to [--bar] at (1.5) should be [--bar]
+PASS CSS Animations: property <position-anchor> from [--foo] to [--bar] at (-0.3) should be [--foo]
+PASS CSS Animations: property <position-anchor> from [--foo] to [--bar] at (0) should be [--foo]
+PASS CSS Animations: property <position-anchor> from [--foo] to [--bar] at (0.3) should be [--foo]
+PASS CSS Animations: property <position-anchor> from [--foo] to [--bar] at (0.5) should be [--bar]
+PASS CSS Animations: property <position-anchor> from [--foo] to [--bar] at (0.6) should be [--bar]
+PASS CSS Animations: property <position-anchor> from [--foo] to [--bar] at (1) should be [--bar]
+PASS CSS Animations: property <position-anchor> from [--foo] to [--bar] at (1.5) should be [--bar]
+PASS Web Animations: property <position-anchor> from [--foo] to [--bar] at (-0.3) should be [--foo]
+PASS Web Animations: property <position-anchor> from [--foo] to [--bar] at (0) should be [--foo]
+PASS Web Animations: property <position-anchor> from [--foo] to [--bar] at (0.3) should be [--foo]
+PASS Web Animations: property <position-anchor> from [--foo] to [--bar] at (0.5) should be [--bar]
+PASS Web Animations: property <position-anchor> from [--foo] to [--bar] at (0.6) should be [--bar]
+PASS Web Animations: property <position-anchor> from [--foo] to [--bar] at (1) should be [--bar]
+PASS Web Animations: property <position-anchor> from [--foo] to [--bar] at (1.5) should be [--bar]
 FAIL CSS Transitions with transition-behavior:allow-discrete: property <inset-area> from [none] to [center] at (-0.3) should be [none] assert_true: 'from' value should be supported expected true got false
 FAIL CSS Transitions with transition-behavior:allow-discrete: property <inset-area> from [none] to [center] at (0) should be [none] assert_true: 'from' value should be supported expected true got false
 FAIL CSS Transitions with transition-behavior:allow-discrete: property <inset-area> from [none] to [center] at (0.3) should be [none] assert_true: 'from' value should be supported expected true got false

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -7,6 +7,7 @@ PASS align-content
 PASS align-items
 PASS align-self
 PASS alignment-baseline
+PASS anchor-name
 PASS animation-composition
 PASS animation-delay
 PASS animation-direction
@@ -260,6 +261,7 @@ PASS perspective
 PASS perspective-origin
 PASS pointer-events
 PASS position
+PASS position-anchor
 PASS print-color-adjust
 PASS quotes
 PASS r

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -7,6 +7,7 @@ PASS align-content
 PASS align-items
 PASS align-self
 PASS alignment-baseline
+PASS anchor-name
 PASS animation-composition
 PASS animation-delay
 PASS animation-direction
@@ -260,6 +261,7 @@ PASS perspective
 PASS perspective-origin
 PASS pointer-events
 PASS position
+PASS position-anchor
 PASS print-color-adjust
 PASS quotes
 PASS r

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -7,6 +7,7 @@ PASS align-content
 PASS align-items
 PASS align-self
 PASS alignment-baseline
+PASS anchor-name
 PASS animation-composition
 PASS animation-delay
 PASS animation-direction
@@ -260,6 +261,7 @@ PASS perspective
 PASS perspective-origin
 PASS pointer-events
 PASS position
+PASS position-anchor
 PASS print-color-adjust
 PASS quotes
 PASS r

--- a/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -6,6 +6,7 @@ PASS align-content
 PASS align-items
 PASS align-self
 PASS alignment-baseline
+PASS anchor-name
 PASS animation-composition
 PASS animation-delay
 PASS animation-direction
@@ -259,6 +260,7 @@ PASS perspective
 PASS perspective-origin
 PASS pointer-events
 PASS position
+PASS position-anchor
 PASS print-color-adjust
 PASS quotes
 PASS r

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -7,6 +7,7 @@ PASS align-content
 PASS align-items
 PASS align-self
 PASS alignment-baseline
+PASS anchor-name
 PASS animation-composition
 PASS animation-delay
 PASS animation-direction
@@ -259,6 +260,7 @@ PASS perspective
 PASS perspective-origin
 PASS pointer-events
 PASS position
+PASS position-anchor
 PASS print-color-adjust
 PASS quotes
 PASS r

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -875,6 +875,20 @@ CSS3DTransformBackfaceVisibilityInteroperabilityEnabled:
     WebCore:
       default: false
 
+CSSAnchorPositioningEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS Anchor Positioning"
+  humanReadableDescription: "Enable CSS Anchor Positioning"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSColorContrastEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3999,7 +3999,9 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new DiscretePropertyWrapper<const ScrollbarGutter>(CSSPropertyScrollbarGutter, &RenderStyle::scrollbarGutter, &RenderStyle::setScrollbarGutter),
         new DiscretePropertyWrapper<ScrollbarWidth>(CSSPropertyScrollbarWidth, &RenderStyle::scrollbarWidth, &RenderStyle::setScrollbarWidth),
         new DiscretePropertyWrapper<std::optional<Style::ScopedName>>(CSSPropertyViewTransitionName, &RenderStyle::viewTransitionName, &RenderStyle::setViewTransitionName),
-        new DiscretePropertyWrapper<FieldSizing>(CSSPropertyFieldSizing, &RenderStyle::fieldSizing, &RenderStyle::setFieldSizing)
+        new DiscretePropertyWrapper<FieldSizing>(CSSPropertyFieldSizing, &RenderStyle::fieldSizing, &RenderStyle::setFieldSizing),
+        new DiscretePropertyWrapper<const Vector<AtomString>&>(CSSPropertyAnchorName, &RenderStyle::anchorNames, &RenderStyle::setAnchorNames),
+        new DiscretePropertyWrapper<const AtomString&>(CSSPropertyPositionAnchor, &RenderStyle::positionAnchor, &RenderStyle::setPositionAnchor)
     };
     const unsigned animatableLonghandPropertiesCount = std::size(animatableLonghandPropertyWrappers);
 

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9278,6 +9278,29 @@
                 "url": "https://drafts.csswg.org/css-view-transitions/#view-transition-name-prop"
             }
         },
+        "anchor-name": {
+            "codegen-properties": {
+                "converter": "AnchorName",
+                "name-for-methods": "AnchorNames",
+                "parser-grammar": "none | <dashed-ident>#",
+                "settings-flag": "cssAnchorPositioningEnabled"
+            },
+            "specification": {
+                "category": "css-anchor-position",
+                "url": "https://drafts.csswg.org/css-anchor-position-1/#name"
+            }
+        },
+        "position-anchor": {
+            "codegen-properties": {
+                "converter": "StringOrAutoAtom",
+                "parser-grammar": "auto | <dashed-ident>",
+                "settings-flag": "cssAnchorPositioningEnabled"
+            },
+            "specification": {
+                "category": "css-anchor-position",
+                "url": "https://drafts.csswg.org/css-anchor-position-1/#name"
+            }
+        },
         "-webkit-tap-highlight-color": {
             "inherited": true,
             "codegen-properties": {
@@ -9915,6 +9938,11 @@
             "shortname": "CSS Box Alignment",
             "longname": "CSS Box Alignment Module",
             "url": "https://www.w3.org/TR/css-align-3/"
+        },
+        "css-anchor-position": {
+            "shortname": "CSS Anchor Positioning",
+            "longname": "CSS Anchor Positioning",
+            "url": "https://www.w3.org/TR/css-anchor-position-1/"
         },
         "css-animations": {
             "shortname": "CSS Animations",

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -3021,6 +3021,19 @@ static Ref<CSSValue> valueForScrollTimelineName(const Vector<AtomString>& names)
     return CSSValueList::createCommaSeparated(WTFMove(list));
 }
 
+static Ref<CSSValue> valueForAnchorName(const Vector<AtomString>& names)
+{
+    if (names.isEmpty())
+        return CSSPrimitiveValue::create(CSSValueNone);
+
+    CSSValueListBuilder list;
+    for (auto& name : names) {
+        ASSERT(!name.isNull());
+        list.append(CSSPrimitiveValue::createCustomIdent(name));
+    }
+    return CSSValueList::createCommaSeparated(WTFMove(list));
+}
+
 static Ref<CSSValue> scrollTimelineShorthandValue(const Vector<Ref<ScrollTimeline>>& timelines)
 {
     if (timelines.isEmpty())
@@ -4626,6 +4639,13 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
 
     case CSSPropertyQuotes:
         return valueForQuotes(style.quotes());
+
+    case CSSPropertyAnchorName:
+        return valueForAnchorName(style.anchorNames());
+    case CSSPropertyPositionAnchor:
+        if (style.positionAnchor().isNull())
+            return CSSPrimitiveValue::create(CSSValueAuto);
+        return CSSPrimitiveValue::createCustomIdent(style.positionAnchor());
 
     // Unimplemented CSS 3 properties (including CSS3 shorthand properties).
     case CSSPropertyAll:

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1912,6 +1912,10 @@ void RenderStyle::conservativelyCollectChangedAnimatableProperties(const RenderS
             changingProperties.m_properties.set(CSSPropertyViewTransitionName);
         if (first.contentVisibility != second.contentVisibility)
             changingProperties.m_properties.set(CSSPropertyContentVisibility);
+        if (first.anchorNames != second.anchorNames)
+            changingProperties.m_properties.set(CSSPropertyAnchorName);
+        if (first.positionAnchor != second.positionAnchor)
+            changingProperties.m_properties.set(CSSPropertyPositionAnchor);
 
         // Non animated styles are followings.
         // customProperties

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -2191,6 +2191,14 @@ public:
     bool scrollAnchoringSuppressionStyleDidChange(const RenderStyle*) const;
     bool outOfFlowPositionStyleDidChange(const RenderStyle*) const;
 
+    static Vector<AtomString> initialAnchorNames();
+    inline const Vector<AtomString>& anchorNames() const;
+    inline void setAnchorNames(const Vector<AtomString>&);
+
+    static inline const AtomString& initialPositionAnchor();
+    inline const AtomString& positionAnchor() const;
+    inline void setPositionAnchor(const AtomString&);
+
 private:
     struct NonInheritedFlags {
         friend bool operator==(const NonInheritedFlags&, const NonInheritedFlags&) = default;

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -71,6 +71,7 @@ inline const StyleSelfAlignmentData& RenderStyle::alignSelf() const { return m_n
 constexpr auto RenderStyle::allTransformOperations() -> OptionSet<TransformOperationOption> { return { TransformOperationOption::TransformOrigin, TransformOperationOption::Translate, TransformOperationOption::Rotate, TransformOperationOption::Scale, TransformOperationOption::Offset }; }
 inline const AnimationList* RenderStyle::animations() const { return m_nonInheritedData->miscData->animations.get(); }
 inline AnimationList* RenderStyle::animations() { return m_nonInheritedData->miscData->animations.get(); }
+inline const Vector<AtomString>& RenderStyle::anchorNames() const { return m_nonInheritedData->rareData->anchorNames; }
 inline StyleAppearance RenderStyle::appearance() const { return static_cast<StyleAppearance>(m_nonInheritedData->miscData->appearance); }
 inline const FilterOperations& RenderStyle::appleColorFilter() const { return m_rareInheritedData->appleColorFilter->operations; }
 inline double RenderStyle::aspectRatioHeight() const { return m_nonInheritedData->miscData->aspectRatioHeight; }
@@ -322,6 +323,7 @@ inline const NamedGridLinesMap& RenderStyle::implicitNamedGridColumnLines() cons
 inline const NamedGridLinesMap& RenderStyle::implicitNamedGridRowLines() const { return m_nonInheritedData->rareData->grid->implicitNamedGridRowLines; }
 constexpr auto RenderStyle::individualTransformOperations() -> OptionSet<TransformOperationOption> { return { TransformOperationOption::Translate, TransformOperationOption::Rotate, TransformOperationOption::Scale, TransformOperationOption::Offset }; }
 inline const StyleCustomPropertyData& RenderStyle::inheritedCustomProperties() const { return m_rareInheritedData->customProperties.get(); }
+inline Vector<AtomString> RenderStyle::initialAnchorNames() { return { }; }
 constexpr StyleAppearance RenderStyle::initialAppearance() { return StyleAppearance::None; }
 inline FilterOperations RenderStyle::initialAppleColorFilter() { return { }; }
 constexpr AspectRatioType RenderStyle::initialAspectRatioType() { return AspectRatioType::Auto; }
@@ -437,6 +439,7 @@ inline Length RenderStyle::initialPerspectiveOriginX() { return { 50.0f, LengthT
 inline Length RenderStyle::initialPerspectiveOriginY() { return { 50.0f, LengthType::Percent }; }
 constexpr PointerEvents RenderStyle::initialPointerEvents() { return PointerEvents::Auto; }
 constexpr PositionType RenderStyle::initialPosition() { return PositionType::Static; }
+inline const AtomString& RenderStyle::initialPositionAnchor() { return nullAtom(); }
 constexpr PrintColorAdjust RenderStyle::initialPrintColorAdjust() { return PrintColorAdjust::Economy; }
 constexpr Order RenderStyle::initialRTLOrdering() { return Order::Logical; }
 inline Length RenderStyle::initialRadius() { return LengthType::Auto; }
@@ -639,6 +642,7 @@ inline float RenderStyle::perspective() const { return m_nonInheritedData->rareD
 inline LengthPoint RenderStyle::perspectiveOrigin() const { return m_nonInheritedData->rareData->perspectiveOrigin(); }
 inline const Length& RenderStyle::perspectiveOriginX() const { return m_nonInheritedData->rareData->perspectiveOriginX; }
 inline const Length& RenderStyle::perspectiveOriginY() const { return m_nonInheritedData->rareData->perspectiveOriginY; }
+inline const AtomString& RenderStyle::positionAnchor() const { return m_nonInheritedData->rareData->positionAnchor; }
 inline bool RenderStyle::preserveNewline() const { return preserveNewline(whiteSpace()); }
 inline bool RenderStyle::preserves3D() const { return usedTransformStyle3D() == TransformStyle3D::Preserve3D; }
 inline QuotesData* RenderStyle::quotes() const { return m_rareInheritedData->quotes.get(); }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -77,6 +77,7 @@ inline void RenderStyle::setAlignItems(const StyleSelfAlignmentData& data) { SET
 inline void RenderStyle::setAlignItemsPosition(ItemPosition position) { m_nonInheritedData.access().miscData.access().alignItems.setPosition(position); }
 inline void RenderStyle::setAlignSelf(const StyleSelfAlignmentData& data) { SET_NESTED(m_nonInheritedData, miscData, alignSelf, data); }
 inline void RenderStyle::setAlignSelfPosition(ItemPosition position) { m_nonInheritedData.access().miscData.access().alignSelf.setPosition(position); }
+inline void RenderStyle::setAnchorNames(const Vector<AtomString>& names) { SET_NESTED(m_nonInheritedData, rareData, anchorNames, names); }
 inline void RenderStyle::setAppearance(StyleAppearance appearance) { SET_NESTED_PAIR(m_nonInheritedData, miscData, appearance, static_cast<unsigned>(appearance), usedAppearance, static_cast<unsigned>(appearance)); }
 inline void RenderStyle::setAppleColorFilter(FilterOperations&& ops) { SET_NESTED(m_rareInheritedData, appleColorFilter, operations, WTFMove(ops)); }
 inline void RenderStyle::setAspectRatio(double width, double height) { SET_NESTED_PAIR(m_nonInheritedData, miscData, aspectRatioWidth, width, aspectRatioHeight, height); }
@@ -265,6 +266,7 @@ inline void RenderStyle::setPaintOrder(PaintOrder order) { SET(m_rareInheritedDa
 inline void RenderStyle::setPerspective(float perspective) { SET_NESTED(m_nonInheritedData, rareData, perspective, perspective); }
 inline void RenderStyle::setPerspectiveOriginX(Length&& length) { SET_NESTED(m_nonInheritedData, rareData, perspectiveOriginX, WTFMove(length)); }
 inline void RenderStyle::setPerspectiveOriginY(Length&& length) { SET_NESTED(m_nonInheritedData, rareData, perspectiveOriginY, WTFMove(length)); }
+inline void RenderStyle::setPositionAnchor(const AtomString& anchor) { SET_NESTED(m_nonInheritedData, rareData, positionAnchor, anchor); }
 inline void RenderStyle::setResize(Resize r) { SET_NESTED(m_nonInheritedData, miscData, resize, static_cast<unsigned>(r)); }
 inline void RenderStyle::setRight(Length&& length) { SET_NESTED(m_nonInheritedData, surroundData, offset.right(), WTFMove(length)); }
 inline void RenderStyle::setRowGap(GapLength&& gapLength) { SET_NESTED(m_nonInheritedData, rareData, rowGap, WTFMove(gapLength)); }

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -92,6 +92,8 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     , scrollbarWidth(RenderStyle::initialScrollbarWidth())
     , zoom(RenderStyle::initialZoom())
     , pseudoElementNameArgument(nullAtom())
+    , anchorNames(RenderStyle::initialAnchorNames())
+    , positionAnchor(RenderStyle::initialPositionAnchor())
     , blockStepSize(RenderStyle::initialBlockStepSize())
     , blockStepInsert(static_cast<unsigned>(RenderStyle::initialBlockStepInsert()))
     , overscrollBehaviorX(static_cast<unsigned>(RenderStyle::initialOverscrollBehaviorX()))
@@ -182,6 +184,8 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , scrollbarWidth(o.scrollbarWidth)
     , zoom(o.zoom)
     , pseudoElementNameArgument(o.pseudoElementNameArgument)
+    , anchorNames(o.anchorNames)
+    , positionAnchor(o.positionAnchor)
     , blockStepSize(o.blockStepSize)
     , blockStepInsert(o.blockStepInsert)
     , overscrollBehaviorX(o.overscrollBehaviorX)
@@ -278,6 +282,8 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && scrollbarWidth == o.scrollbarWidth
         && zoom == o.zoom
         && pseudoElementNameArgument == o.pseudoElementNameArgument
+        && anchorNames == o.anchorNames
+        && positionAnchor == o.positionAnchor
         && blockStepSize == o.blockStepSize
         && blockStepInsert == o.blockStepInsert
         && overscrollBehaviorX == o.overscrollBehaviorX

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -188,6 +188,9 @@ public:
     float zoom;
     AtomString pseudoElementNameArgument;
 
+    Vector<AtomString> anchorNames;
+    AtomString positionAnchor;
+
     std::optional<Length> blockStepSize;
     unsigned blockStepInsert : 1; // BlockStepInsert
 

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -221,6 +221,8 @@ public:
     static Vector<ScrollAxis> convertScrollTimelineAxis(BuilderState&, const CSSValue&);
     static Vector<ViewTimelineInsets> convertViewTimelineInset(BuilderState&, const CSSValue&);
 
+    static Vector<AtomString> convertAnchorName(BuilderState&, const CSSValue&);
+
 private:
     friend class BuilderCustom;
 
@@ -2122,6 +2124,23 @@ inline Vector<ViewTimelineInsets> BuilderConverter::convertViewTimelineInset(Bui
         if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(item))
             return { convertLengthOrAuto(state, *primitiveValue), std::nullopt };
         return { };
+    });
+}
+
+inline Vector<AtomString> BuilderConverter::convertAnchorName(BuilderState&, const CSSValue& value)
+{
+    if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
+        if (value.valueID() == CSSValueNone)
+            return { };
+        return { AtomString { primitiveValue->stringValue() } };
+    }
+
+    auto* list = dynamicDowncast<CSSValueList>(value);
+    if (!list)
+        return { };
+
+    return WTF::map(*list, [&](auto& item) {
+        return AtomString { downcast<CSSPrimitiveValue>(item).stringValue() };
     });
 }
 


### PR DESCRIPTION
#### be62da110601f06d0ceaae86c3e8005dc22c1015
<pre>
[css-anchor-position-1] Add parsing support for `anchor-name` and `position-anchor` properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=275023">https://bugs.webkit.org/show_bug.cgi?id=275023</a>
<a href="https://rdar.apple.com/129120145">rdar://129120145</a>

Reviewed by Tim Nguyen.

Add parsing support for `anchor-name` and `position-anchor` properties as specified in:
<a href="https://drafts.csswg.org/css-anchor-position-1/#name">https://drafts.csswg.org/css-anchor-position-1/#name</a>
<a href="https://drafts.csswg.org/css-anchor-position-1/#position-anchor">https://drafts.csswg.org/css-anchor-position-1/#position-anchor</a>

Both properties are placed under a new preference named `CSSAnchorPositioningEnabled`.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-name-basics-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-anchor-basics-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/property-interpolations-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::valueForAnchorName):
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::conservativelyCollectChangedAnimatableProperties const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::anchorNames const):
(WebCore::RenderStyle::initialAnchorNames):
(WebCore::RenderStyle::initialPositionAnchor):
(WebCore::RenderStyle::positionAnchor const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setAnchorNames):
(WebCore::RenderStyle::setPositionAnchor):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
(WebCore::StyleRareNonInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertAnchorName):

Canonical link: <a href="https://commits.webkit.org/279628@main">https://commits.webkit.org/279628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18f709f740c0cd27e9e3ea3fe792e66f44fa22d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6559 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57302 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4751 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56329 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4644 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43744 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3147 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31628 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46761 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24885 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28454 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4076 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2900 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/47383 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50138 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4280 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58896 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/53535 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29211 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4369 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51162 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30396 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50513 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11770 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31351 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65836 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30177 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12533 "Passed tests") | 
<!--EWS-Status-Bubble-End-->