### PR TITLE
[WPE][WebDriver] Avoid leaking WPEKeymapEntry array

### DIFF
--- a/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp
+++ b/Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp
@@ -230,16 +230,16 @@ static void doKeyStrokeEvent(WebPageProxy &page, bool pressed, uint32_t keyVal, 
         return;
     }
 
-    WPEKeymapEntry* entries;
+    GUniqueOutPtr<WPEKeymapEntry> entries;
     guint entriesCount;
-    if (!wpe_keymap_get_entries_for_keyval(keymap, keyVal, &entries, &entriesCount)) {
+    if (!wpe_keymap_get_entries_for_keyval(keymap, keyVal, &entries.outPtr(), &entriesCount)) {
         LOG(Automation, "WebAutomationSession::doKeyStrokeEvent: Failed to get keymap entries for keyval %u. Ignoring event.", keyVal);
         return;
     }
-    unsigned keyCode = entries[0].keycode;
+    unsigned keyCode = entries.get()[0].keycode;
 
     WPEModifiers consumedModifiers;
-    if (!wpe_keymap_translate_keyboard_state(keymap, keyCode, static_cast<WPEModifiers>(modifiers), entries[0].group, &keyVal, nullptr, nullptr, &consumedModifiers)) {
+    if (!wpe_keymap_translate_keyboard_state(keymap, keyCode, static_cast<WPEModifiers>(modifiers), entries.get()[0].group, &keyVal, nullptr, nullptr, &consumedModifiers)) {
         LOG(Automation, "WebAutomationSession::doKeyStrokeEvent: Failed to translate keyboard state for keycode %u. Ignoring event.", keyCode);
         return;
     }


### PR DESCRIPTION
#### 1082d80b7bbf16e6bd7cd4ca28f2a400db6500e1
<pre>
[WPE][WebDriver] Avoid leaking WPEKeymapEntry array
<a href="https://bugs.webkit.org/show_bug.cgi?id=275026">https://bugs.webkit.org/show_bug.cgi?id=275026</a>

Reviewed by Michael Catanzaro.

Wrap the leaked entries with GUniqueOutPtr.

* Source/WebKit/UIProcess/Automation/libwpe/WebAutomationSessionWPE.cpp:
(WebKit::doKeyStrokeEvent):

Canonical link: <a href="https://commits.webkit.org/279661@main">https://commits.webkit.org/279661@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/360a892b71905b041ea68caaec01c1b24f597c5f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33398 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6555 "Failed to checkout and rebase branch from PR 29425") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57298 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4747 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40913 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4639 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43740 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3143 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56119 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31622 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/6555 "Failed to checkout and rebase branch from PR 29425") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24881 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28450 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/6555 "Failed to checkout and rebase branch from PR 29425") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2896 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50127 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/6555 "Failed to checkout and rebase branch from PR 29425") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58892 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29207 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4364 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51157 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30392 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/6555 "Failed to checkout and rebase branch from PR 29425") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50505 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11788 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31347 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30173 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->