### PR TITLE
Sync `SVGLength` with WebIDL specification

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL SVGLength interface assert_throws_js: function "function() { length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_PX, 'aString'); }" did not throw
+FAIL SVGLength interface The string did not match the expected pattern.
 

--- a/LayoutTests/svg/dom/SVGLength-expected.txt
+++ b/LayoutTests/svg/dom/SVGLength-expected.txt
@@ -33,22 +33,61 @@ Check invalid arguments for 'newValueSpecifiedUnits'
 PASS length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_UNKNOWN, 4) threw exception NotSupportedError: The operation is not supported..
 PASS length.newValueSpecifiedUnits(-1, 4) threw exception NotSupportedError: The operation is not supported..
 PASS length.newValueSpecifiedUnits(11, 4) threw exception NotSupportedError: The operation is not supported..
-PASS length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_PX, 'aString') is undefined.
-PASS length.value is NaN
 PASS length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_PX, 0) is undefined.
-PASS length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_PX, length) is undefined.
-PASS length.value is NaN
-PASS length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_PX, 0) is undefined.
-PASS length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_PX, svgElement) is undefined.
-PASS length.value is NaN
+PASS length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_PX, 'aString') threw exception TypeError: The provided value is non-finite.
+PASS length.value is 0
+PASS length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_PX, length) threw exception TypeError: The provided value is non-finite.
+PASS length.value is 0
+PASS length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_PX, svgElement) threw exception TypeError: The provided value is non-finite.
+PASS length.value is 0
+PASS length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_PX, NaN) threw exception TypeError: The provided value is non-finite.
+PASS length.value is 0
+PASS length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_PX, Infinity) threw exception TypeError: The provided value is non-finite.
+PASS length.value is 0
 PASS length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_PX) threw exception TypeError: Not enough arguments.
 PASS length.newValueSpecifiedUnits('aString', 4) threw exception NotSupportedError: The operation is not supported..
 PASS length.newValueSpecifiedUnits(length, 4) threw exception NotSupportedError: The operation is not supported..
 PASS length.newValueSpecifiedUnits(svgElement, 4) threw exception NotSupportedError: The operation is not supported..
-PASS length.newValueSpecifiedUnits('aString', 'aString') threw exception NotSupportedError: The operation is not supported..
-PASS length.newValueSpecifiedUnits(length, length) threw exception NotSupportedError: The operation is not supported..
-PASS length.newValueSpecifiedUnits(svgElement, svgElement) threw exception NotSupportedError: The operation is not supported..
+PASS length.newValueSpecifiedUnits('aString', 'aString') threw exception TypeError: The provided value is non-finite.
+PASS length.newValueSpecifiedUnits(length, length) threw exception TypeError: The provided value is non-finite.
+PASS length.newValueSpecifiedUnits(svgElement, svgElement) threw exception TypeError: The provided value is non-finite.
 PASS length.unitType is SVGLength.SVG_LENGTHTYPE_PX
+PASS length.value is 2
+PASS length.valueInSpecifiedUnits is 2
+PASS length.unitType is SVGLength.SVG_LENGTHTYPE_PX
+
+Check setting invalid 'valueAsString' arguments
+PASS length.valueAsString = '10deg' threw exception SyntaxError: The string did not match the expected pattern..
+PASS length.valueAsString is "2px"
+PASS length.value is 2
+PASS length.valueInSpecifiedUnits is 2
+PASS length.unitType is SVGLength.SVG_LENGTHTYPE_PX
+PASS length.valueAsString is "2px"
+PASS length.valueAsString is "2px"
+PASS length.value is 2
+PASS length.valueInSpecifiedUnits is 2
+PASS length.unitType is SVGLength.SVG_LENGTHTYPE_PX
+PASS length.valueAsString = ',5 em' threw exception SyntaxError: The string did not match the expected pattern..
+PASS length.valueAsString is "2px"
+PASS length.value is 2
+PASS length.valueInSpecifiedUnits is 2
+PASS length.unitType is SVGLength.SVG_LENGTHTYPE_PX
+PASS length.valueAsString = null threw exception SyntaxError: The string did not match the expected pattern..
+PASS length.valueAsString is "2px"
+PASS length.value is 2
+PASS length.valueInSpecifiedUnits is 2
+PASS length.unitType is SVGLength.SVG_LENGTHTYPE_PX
+
+Check setting invalid 'value' arguments
+PASS length.value = NaN threw exception TypeError: The provided value is non-finite.
+PASS length.value = Infinity threw exception TypeError: The provided value is non-finite.
+PASS length.value is 2
+PASS length.valueInSpecifiedUnits is 2
+PASS length.unitType is SVGLength.SVG_LENGTHTYPE_PX
+
+Check setting invalid 'valueInSpecifiedUnits' arguments
+PASS length.valueInSpecifiedUnits = NaN threw exception TypeError: The provided value is non-finite.
+PASS length.valueInSpecifiedUnits = Infinity threw exception TypeError: The provided value is non-finite.
 PASS length.value is 2
 PASS length.valueInSpecifiedUnits is 2
 PASS length.unitType is SVGLength.SVG_LENGTHTYPE_PX

--- a/LayoutTests/svg/dom/SVGLength.html
+++ b/LayoutTests/svg/dom/SVGLength.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <p id="description"></p>
@@ -47,14 +47,17 @@ shouldThrow("length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_UNKNOWN, 4)"
 shouldThrow("length.newValueSpecifiedUnits(-1, 4)");
 shouldThrow("length.newValueSpecifiedUnits(11, 4)");
 // ECMA-262, 9.3, "ToNumber"
-shouldBeUndefined("length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_PX, 'aString')");
-shouldBe("length.value", "NaN");
 shouldBeUndefined("length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_PX, 0)");
-shouldBeUndefined("length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_PX, length)");
-shouldBe("length.value", "NaN");
-shouldBeUndefined("length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_PX, 0)");
-shouldBeUndefined("length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_PX, svgElement)");
-shouldBe("length.value", "NaN");
+shouldThrow("length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_PX, 'aString')");
+shouldBe("length.value", "0");
+shouldThrow("length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_PX, length)");
+shouldBe("length.value", "0");
+shouldThrow("length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_PX, svgElement)");
+shouldBe("length.value", "0");
+shouldThrow("length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_PX, NaN)");
+shouldBe("length.value", "0");
+shouldThrow("length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_PX, Infinity)");
+shouldBe("length.value", "0");
 shouldThrow("length.newValueSpecifiedUnits(SVGLength.SVG_LENGTHTYPE_PX)");
 // Reset to original value above.
 length.valueAsString = "2px";
@@ -69,8 +72,47 @@ shouldBe("length.value", "2");
 shouldBe("length.valueInSpecifiedUnits", "2");
 shouldBe("length.unitType", "SVGLength.SVG_LENGTHTYPE_PX");
 
+debug("");
+debug("Check setting invalid 'valueAsString' arguments");
+shouldThrow("length.valueAsString = '10deg'");
+shouldBeEqualToString("length.valueAsString", "2px");
+shouldBe("length.value", "2");
+shouldBe("length.valueInSpecifiedUnits", "2");
+shouldBe("length.unitType", "SVGLength.SVG_LENGTHTYPE_PX");
+shouldBeEqualToString("length.valueAsString", "2px");
+shouldBeEqualToString("length.valueAsString", "2px");
+shouldBe("length.value", "2");
+shouldBe("length.valueInSpecifiedUnits", "2");
+shouldBe("length.unitType", "SVGLength.SVG_LENGTHTYPE_PX");
+
+shouldThrow("length.valueAsString = ',5 em'");
+shouldBeEqualToString("length.valueAsString", "2px");
+shouldBe("length.value", "2");
+shouldBe("length.valueInSpecifiedUnits", "2");
+shouldBe("length.unitType", "SVGLength.SVG_LENGTHTYPE_PX");
+shouldThrow("length.valueAsString = null");
+shouldBeEqualToString("length.valueAsString", "2px");
+shouldBe("length.value", "2");
+shouldBe("length.valueInSpecifiedUnits", "2");
+shouldBe("length.unitType", "SVGLength.SVG_LENGTHTYPE_PX");
+
+debug("");
+debug("Check setting invalid 'value' arguments");
+shouldThrow("length.value = NaN");
+shouldThrow("length.value = Infinity");
+shouldBe("length.value", "2");
+shouldBe("length.valueInSpecifiedUnits", "2");
+shouldBe("length.unitType", "SVGLength.SVG_LENGTHTYPE_PX");
+
+debug("");
+debug("Check setting invalid 'valueInSpecifiedUnits' arguments");
+shouldThrow("length.valueInSpecifiedUnits = NaN");
+shouldThrow("length.valueInSpecifiedUnits = Infinity");
+shouldBe("length.value", "2");
+shouldBe("length.valueInSpecifiedUnits", "2");
+shouldBe("length.unitType", "SVGLength.SVG_LENGTHTYPE_PX");
+
 successfullyParsed = true;
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/svg/SVGLength.idl
+++ b/Source/WebCore/svg/SVGLength.idl
@@ -2,7 +2,7 @@
  * Copyright (C) 2004, 2005, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005 Rob Buis <buis@kde.org>
  * Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
- * Copyright (C) 2006 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -37,11 +37,11 @@
     const unsigned short SVG_LENGTHTYPE_PC = 10;
 
     readonly attribute unsigned short unitType;
-    [ImplementedAs=valueForBindings] attribute unrestricted float value;
+    [ImplementedAs=valueForBindings] attribute float value;
 
-    attribute unrestricted float valueInSpecifiedUnits;
+    attribute float valueInSpecifiedUnits;
     attribute DOMString valueAsString;
 
-    undefined newValueSpecifiedUnits(unsigned short unitType, unrestricted float valueInSpecifiedUnits);
+    undefined newValueSpecifiedUnits(unsigned short unitType, float valueInSpecifiedUnits);
     undefined convertToSpecifiedUnits(unsigned short unitType);
 };


### PR DESCRIPTION
#### 57c43e3f0aeb00f783372730d703ce8b3aa10c99
<pre>
Sync `SVGLength` with WebIDL specification

<a href="https://bugs.webkit.org/show_bug.cgi?id=275028">https://bugs.webkit.org/show_bug.cgi?id=275028</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with web-specification [1]:

[1] <a href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGLength">https://svgwg.org/svg2-draft/types.html#InterfaceSVGLength</a>

From above, `value` and `valueInSpecifiedUnits` should not be
&apos;unrestricted&apos;, so this patch remove it from both.

Unfortunately, we do still have few issues in &apos;valueAsString&apos; to
fix and enable us to progress further in sub-tests but this patch
do reduce our failures further.

I synced additional tests for local copy from below Blink commit (minus
some changes).

Commit: <a href="https://chromium.googlesource.com/chromium/src/+/7d9f4bebeb65115c81918032278174ad01858d33">https://chromium.googlesource.com/chromium/src/+/7d9f4bebeb65115c81918032278174ad01858d33</a>

In future, we should delete local copy and just use WPT as reference.

* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-expected.txt:
* LayoutTests/svg/dom/SVGLength-expected.txt:
* LayoutTests/svg/dom/SVGLength.html:
* Source/WebCore/svg/SVGLength.idl:

Canonical link: <a href="https://commits.webkit.org/279659@main">https://commits.webkit.org/279659@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/243b90007f6351f84ed416664557f35ae5f99b27

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33399 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57299 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4748 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56326 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40914 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4641 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43741 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3144 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31623 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46757 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24882 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28451 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4071 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2897 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50131 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58893 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4365 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51158 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30393 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46878 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50507 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11790 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31348 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30174 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->