### PR TITLE
Allow speculative parser to see inside Declarative Shadow DOM (DSD) templates

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-img-src.tentative.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-img-src.tentative.sub-expected.txt
@@ -1,8 +1,8 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_not_equals: speculative case did not fetch got disallowed value ""
 
     <!-- speculative case in document.write -->
     <div><template shadowrootmode="closed"><img src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=d8ca7a97-e8c3-4d61-8912-aff8350abd50&amp;encodingcheck=&Gbreve;"></template></div>
 
 
-FAIL Speculative parsing, document.write(): template-shadowrootmode-img-src Unhandled rejection: assert_not_equals: speculative case did not fetch got disallowed value ""
+
+PASS Speculative parsing, document.write(): template-shadowrootmode-img-src
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-link-stylesheet.tentative.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-link-stylesheet.tentative.sub-expected.txt
@@ -1,8 +1,8 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_not_equals: speculative case did not fetch got disallowed value ""
 
     <!-- speculative case in document.write -->
     <div><template shadowrootmode="closed"><link rel=stylesheet href="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=4bdd6438-73b9-4b3d-a8c7-58b5e5aace62&amp;encodingcheck=&Gbreve;"></template></div>
 
 
-FAIL Speculative parsing, document.write(): template-shadowrootmode-link-stylesheet Unhandled rejection: assert_not_equals: speculative case did not fetch got disallowed value ""
+
+PASS Speculative parsing, document.write(): template-shadowrootmode-link-stylesheet
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-script-src.tentative.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-script-src.tentative.sub-expected.txt
@@ -1,8 +1,8 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_not_equals: speculative case did not fetch got disallowed value ""
 
     <!-- speculative case in document.write -->
     <div><template shadowrootmode="closed"><script src="/html/syntax/speculative-parsing/resources/stash.py?action=put&amp;uuid=6f013501-95b1-4d24-abac-9e33c7c8ee6b&amp;encodingcheck=&Gbreve;"></script></template></div>
 
 
-FAIL Speculative parsing, document.write(): template-shadowrootmode-script-src Unhandled rejection: assert_not_equals: speculative case did not fetch got disallowed value ""
+
+PASS Speculative parsing, document.write(): template-shadowrootmode-script-src
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-img-src.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-img-src.tentative-expected.txt
@@ -1,5 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_not_equals: speculative case did not fetch got disallowed value ""
 
 
-FAIL Speculative parsing, page load: template-shadowrootmode-img-src Unhandled rejection: assert_not_equals: speculative case did not fetch got disallowed value ""
+PASS Speculative parsing, page load: template-shadowrootmode-img-src
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-link-stylesheet.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-link-stylesheet.tentative-expected.txt
@@ -1,5 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_not_equals: speculative case did not fetch got disallowed value ""
 
 
-FAIL Speculative parsing, page load: template-shadowrootmode-link-stylesheet Unhandled rejection: assert_not_equals: speculative case did not fetch got disallowed value ""
+PASS Speculative parsing, page load: template-shadowrootmode-link-stylesheet
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-script-src.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-script-src.tentative-expected.txt
@@ -1,5 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_not_equals: speculative case did not fetch got disallowed value ""
 
 
-FAIL Speculative parsing, page load: template-shadowrootmode-script-src Unhandled rejection: assert_not_equals: speculative case did not fetch got disallowed value ""
+PASS Speculative parsing, page load: template-shadowrootmode-script-src
 


### PR DESCRIPTION
#### 83e87b6e6a3beda3ed62ced43e7dc01aaf44d327
<pre>
Allow speculative parser to see inside Declarative Shadow DOM (DSD) templates

<a href="https://bugs.webkit.org/show_bug.cgi?id=269697">https://bugs.webkit.org/show_bug.cgi?id=269697</a>
<a href="https://rdar.apple.com/problem/123623233">rdar://problem/123623233</a>

Reviewed by Antti Koivisto.

Merge: <a href="https://chromium-review.googlesource.com/c/chromium/src/+/4200836">https://chromium-review.googlesource.com/c/chromium/src/+/4200836</a>

Prior to this patch, the speculative parser would bail out at the sight
of any `template` element. However, if that template was a
Declarative Shadow DOM shadow root, like `template shadowrootmode=open`,
it should be scanned.

Note that DSD shadow roots inside &quot;normal&quot; template elements
should still be skipped, since everything in the `template`
is inert.

* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::scan):
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-img-src.tentative.sub-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-link-stylesheet.tentative.sub-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/document-write/template-shadowrootmode-script-src.tentative.sub-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-img-src.tentative-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-link-stylesheet.tentative-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/template-shadowrootmode-script-src.tentative-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/279668@main">https://commits.webkit.org/279668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/535de1d30538fcc541d44e48d76d7ff074af7b28

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54112 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57387 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4836 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4730 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43823 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3220 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56208 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31735 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46847 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/24965 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28549 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4163 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2985 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58981 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29307 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4471 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/51238 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30486 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46961 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50601 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11792 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31449 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30266 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->