### PR TITLE
Revert "Fire open and closed events when a tab is replaced."

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIRuntimeCocoa.mm
@@ -132,11 +132,6 @@ void WebExtensionContext::runtimeSendMessage(const String& extensionID, const St
     WebExtensionMessageSenderParameters completeSenderParameters = senderParameters;
     if (RefPtr tab = getTab(senderParameters.pageProxyIdentifier))
         completeSenderParameters.tabParameters = tab->parameters();
-    else if (senderParameters.contentWorldType == WebExtensionContentWorldType::ContentScript) {
-        RELEASE_LOG_ERROR(Extensions, "Tab not found for message for content script message");
-        completionHandler(toWebExtensionError(apiName, nil, @"tab not found"));
-        return;
-    }
 
     constexpr auto targetContentWorldType = WebExtensionContentWorldType::Main;
     constexpr auto eventType = WebExtensionEventListenerType::RuntimeOnMessage;
@@ -182,11 +177,6 @@ void WebExtensionContext::runtimeConnect(const String& extensionID, WebExtension
     WebExtensionMessageSenderParameters completeSenderParameters = senderParameters;
     if (RefPtr tab = getTab(senderParameters.pageProxyIdentifier))
         completeSenderParameters.tabParameters = tab->parameters();
-    else if (senderParameters.contentWorldType == WebExtensionContentWorldType::ContentScript) {
-        RELEASE_LOG_ERROR(Extensions, "Tab not found for message for content script port");
-        completionHandler(toWebExtensionError(apiName, nil, @"tab not found"));
-        return;
-    }
 
     constexpr auto eventType = WebExtensionEventListenerType::RuntimeOnConnect;
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -2138,10 +2138,8 @@ void WebExtensionContext::didCloseTab(WebExtensionTab& tab, WindowIsClosing wind
     ASSERT(isValidTab(tab));
 
     // The tab might already be closed, don't log an error.
-    if (!tab.isOpen()) {
-        forgetTab(tab.identifier());
+    if (!tab.isOpen())
         return;
-    }
 
     RELEASE_LOG_DEBUG(Extensions, "Closed tab %{public}llu %{public}s", tab.identifier().toUInt64(), windowIsClosing == WindowIsClosing::Yes ? "(window closing)" : "");
 
@@ -2271,32 +2269,25 @@ void WebExtensionContext::didMoveTab(WebExtensionTab& tab, size_t oldIndex, cons
     }
 }
 
-void WebExtensionContext::didReplaceTab(WebExtensionTab& oldTab, WebExtensionTab& newTab, SuppressEvents suppressEvents)
+void WebExtensionContext::didReplaceTab(WebExtensionTab& oldTab, WebExtensionTab& newTab)
 {
     ASSERT(isValidTab(oldTab));
     ASSERT(isValidTab(newTab));
 
-    if (oldTab == newTab) {
-        RELEASE_LOG_ERROR(Extensions, "Replaced tab %{public}llu with the same tab", newTab.identifier().toUInt64());
-        return;
-    }
-
-    Ref protectedOldTab { oldTab };
-
-    didOpenTab(newTab, suppressEvents);
-
     if (!oldTab.isOpen()) {
         RELEASE_LOG_ERROR(Extensions, "Replaced tab %{public}llu with tab %{public}llu, but old tab is not open", oldTab.identifier().toUInt64(), newTab.identifier().toUInt64());
-        forgetTab(oldTab.identifier());
         return;
     }
+
+    didCloseTab(oldTab, WindowIsClosing::No, SuppressEvents::Yes);
+    didOpenTab(newTab, SuppressEvents::Yes);
 
     RELEASE_LOG_DEBUG(Extensions, "Replaced tab %{public}llu with tab %{public}llu", oldTab.identifier().toUInt64(), newTab.identifier().toUInt64());
 
-    if (isLoaded() && newTab.extensionHasAccess() && suppressEvents == SuppressEvents::No)
-        fireTabsReplacedEventIfNeeded(oldTab.identifier(), newTab.identifier());
+    if (!isLoaded() || !newTab.extensionHasAccess())
+        return;
 
-    didCloseTab(oldTab, WindowIsClosing::No, suppressEvents);
+    fireTabsReplacedEventIfNeeded(oldTab.identifier(), newTab.identifier());
 }
 
 void WebExtensionContext::didChangeTabProperties(WebExtensionTab& tab, OptionSet<WebExtensionTab::ChangedProperties> properties)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -120,9 +120,9 @@ WebExtensionTabParameters WebExtensionTab::parameters() const
         hasPermission ? url() : URL { },
         hasPermission ? title() : nullString(),
 
-        window ? window->identifier() : WebExtensionWindowConstants::NoneIdentifier,
-        index,
+        window ? std::optional(window->identifier()) : std::nullopt,
 
+        index != notFound ? std::optional(index) : std::nullopt,
         size(),
 
         parentTab ? std::optional(parentTab->identifier()) : std::nullopt,

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -400,7 +400,7 @@ public:
     void didSelectOrDeselectTabs(const TabSet&);
 
     void didMoveTab(WebExtensionTab&, size_t oldIndex, const WebExtensionWindow* oldWindow = nullptr);
-    void didReplaceTab(WebExtensionTab& oldTab, WebExtensionTab& newTab, SuppressEvents = SuppressEvents::No);
+    void didReplaceTab(WebExtensionTab& oldTab, WebExtensionTab& newTab);
     void didChangeTabProperties(WebExtensionTab&, OptionSet<WebExtensionTab::ChangedProperties> = { });
 
     void didStartProvisionalLoadForFrame(WebPageProxyIdentifier, WebExtensionFrameIdentifier, WebExtensionFrameIdentifier parentFrameID, const URL&, WallTime);

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -146,7 +146,7 @@ NSDictionary *toWebAPI(const WebExtensionTabParameters& parameters)
         result[windowIdKey] = @(toWebAPI(parameters.windowIdentifier.value()));
 
     if (parameters.index)
-        result[indexKey] = toWebAPI(parameters.index.value());
+        result[indexKey] = @(parameters.index.value());
 
     if (parameters.size) {
         auto size = parameters.size.value();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITabs.mm
@@ -1171,23 +1171,9 @@ TEST(WKWebExtensionAPITabs, RemovedEvent)
 TEST(WKWebExtensionAPITabs, ReplacedEvent)
 {
     auto backgroundScript = Util::constructScript(@[
-        @"let createdTabId = null",
-        @"let removedTabId = null",
-
-        @"browser.tabs.onCreated.addListener((tab) => {",
-        @"  browser.test.assertEq(createdTabId, null, 'No tab should be created yet')",
-        @"  createdTabId = tab.id",
-        @"})",
-
-        @"browser.tabs.onRemoved.addListener((tabId) => {",
-        @"  browser.test.assertEq(removedTabId, null, 'No tab should be removed yet')",
-        @"  removedTabId = tabId",
-        @"})",
-
         @"browser.tabs.onReplaced.addListener((addedTabId, removedTabId) => {",
-        @"  browser.test.assertTrue(addedTabId !== removedTabId, 'The added tab should not match the removed tab')",
-        @"  browser.test.assertEq(addedTabId, createdTabId, 'The added tab should match the created tab')",
-        @"  browser.test.assertEq(removedTabId, initialTabId, 'The removed tab should match the initial tab')",
+        @"  browser.test.assertTrue(addedTabId !== removedTabId, 'The addedTabId should not match the removedTabId')",
+        @"  browser.test.assertEq(removedTabId, initialTabId, 'The initial tab id should match the removedTabId')",
 
         @"  browser.test.notifyPass()",
         @"})",

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -735,9 +735,6 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
     [oldTab.mainWebView _close];
     oldTab.mainWebView = nil;
 
-    if (_activeTab == oldTab)
-        _activeTab = newTab;
-
     [_tabs replaceObjectAtIndex:[_tabs indexOfObject:oldTab] withObject:newTab];
     [_extensionController didReplaceTab:oldTab withTab:newTab];
 }


### PR DESCRIPTION
#### 512675d23eab6aed5cdf0fd3f75ebdbd472f28b0
<pre>
Revert &quot;Fire open and closed events when a tab is replaced.&quot;
<a href="https://rdar.apple.com/129111074">rdar://129111074</a>

Reviewed by Brian Weinstein and Timothy Hatcher.

This reverts commit d0a6863b9a013dedac63c644883b0736f5d5dd63.

Canonical link: <a href="https://commits.webkit.org/279626@main">https://commits.webkit.org/279626@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2017c8890ec34d56484e7126dd27867f58cb3c5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6560 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57303 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4752 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56331 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40918 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4645 "Failed to checkout and rebase branch from PR 29429") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/3149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56124 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/46765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/24887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/28456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/4078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2901 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/4283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58897 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29212 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/4645 "Failed to checkout and rebase branch from PR 29429") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/51163 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30397 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/46883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50514 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31352 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/7997 "") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30178 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->