### PR TITLE
Change some THROW_UNLESS calls into RELEASE_LOG_ERROR instead.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h
@@ -111,15 +111,6 @@ WK_API_AVAILABLE(macos(13.3), ios(16.4))
 - (nullable WKWebView *)mainWebViewForWebExtensionContext:(_WKWebExtensionContext *)context;
 
 /*!
- @abstract Called when the web views for the tab are needed.
- @param context The context in which the web extension is running.
- @return An array of web views for the tab.
- @discussion Defaults to an array containing the main web view if not implemented.
- @seealso mainWebViewForWebExtensionContext:
- */
-- (NSArray<WKWebView *> *)webViewsForWebExtensionContext:(_WKWebExtensionContext *)context;
-
-/*!
  @abstract Called when the title of the tab is needed.
  @param context The context in which the web extension is running.
  @return The title of the tab.

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm
@@ -226,7 +226,7 @@ void WebExtensionContext::cookiesGetAllCookieStores(CompletionHandler<void(Expec
     stores.set(defaultSessionID, Vector<WebExtensionTabIdentifier> { });
 
     for (Ref tab : openTabs()) {
-        for (WKWebView *webView in tab->webViews()) {
+        if (WKWebView *webView = tab->mainWebView()) {
             auto sessionID = webView.configuration.websiteDataStore->_websiteDataStore.get()->sessionID();
 
             auto& tabsVector = stores.ensure(sessionID, [] {

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -98,7 +98,7 @@ public:
     using ImageFormat = WebExtensionTabImageFormat;
 
     enum class AssumeWindowMatches : bool { No, Yes };
-    enum class MainWebViewOnly : bool { No, Yes };
+    enum class SkipValidation : bool { No, Yes };
 
     using WebProcessProxySet = HashSet<Ref<WebProcessProxy>>;
 
@@ -125,14 +125,13 @@ public:
     void addChangedProperties(OptionSet<ChangedProperties> properties) { m_changedProperties.add(properties); }
     void clearChangedProperties() { m_changedProperties = { }; }
 
-    RefPtr<WebExtensionWindow> window() const;
+    RefPtr<WebExtensionWindow> window(SkipValidation = SkipValidation::No) const;
     size_t index() const;
 
     RefPtr<WebExtensionTab> parentTab() const;
     void setParentTab(RefPtr<WebExtensionTab>, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&&);
 
     WKWebView *mainWebView() const;
-    NSArray *webViews() const;
 
     String title() const;
 
@@ -191,7 +190,7 @@ public:
 
     bool shouldGrantTabPermissionsOnUserGesture() const;
 
-    WebProcessProxySet processes(WebExtensionEventListenerType, WebExtensionContentWorldType, MainWebViewOnly = MainWebViewOnly::Yes) const;
+    WebProcessProxySet processes(WebExtensionEventListenerType, WebExtensionContentWorldType) const;
 
 #ifdef __OBJC__
     _WKWebExtensionTab *delegate() const { return m_delegate.getAutoreleased(); }
@@ -212,7 +211,6 @@ private:
     bool m_respondsToParentTab : 1 { false };
     bool m_respondsToSetParentTab : 1 { false };
     bool m_respondsToMainWebView : 1 { false };
-    bool m_respondsToWebViews : 1 { false };
     bool m_respondsToTabTitle : 1 { false };
     bool m_respondsToIsSelected : 1 { false };
     bool m_respondsToIsPinned : 1 { false };

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
@@ -88,6 +88,7 @@ public:
     };
 
     enum class PopulateTabs : bool { No, Yes };
+    enum class SkipValidation : bool { No, Yes };
 
     using TabVector = Vector<Ref<WebExtensionTab>>;
 
@@ -103,8 +104,8 @@ public:
 
     bool extensionHasAccess() const;
 
-    TabVector tabs() const;
-    RefPtr<WebExtensionTab> activeTab() const;
+    TabVector tabs(SkipValidation = SkipValidation::No) const;
+    RefPtr<WebExtensionTab> activeTab(SkipValidation = SkipValidation::No) const;
 
     Type type() const;
 

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -639,6 +639,8 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
         tab.mainWebView = nil;
 
         [_extensionController didCloseTab:tab windowIsClosing:NO];
+
+        [tab assignWindow:nil];
     }
 
     _tabs = [tabs mutableCopy];
@@ -699,6 +701,9 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
         completionHandler(duplicatedTab, nil);
     };
 
+    if (!_activeTab)
+        _activeTab = newTab;
+
     [_tabs insertObject:newTab atIndex:index];
     [_extensionController didOpenTab:newTab];
 
@@ -725,6 +730,8 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
     }
 
     [_extensionController didCloseTab:tab windowIsClosing:windowIsClosing];
+
+    [tab assignWindow:nil];
 }
 
 - (void)replaceTab:(TestWebExtensionTab *)oldTab withTab:(TestWebExtensionTab *)newTab
@@ -740,6 +747,8 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
     [_tabs replaceObjectAtIndex:[_tabs indexOfObject:oldTab] withObject:newTab];
     [_extensionController didReplaceTab:oldTab withTab:newTab];
+
+    [oldTab assignWindow:nil];
 }
 
 - (void)moveTab:(TestWebExtensionTab *)tab toIndex:(NSUInteger)newIndex


### PR DESCRIPTION
#### e1a34394bf941789aafa0a92a13a8c605b6a4f1e
<pre>
Change some THROW_UNLESS calls into RELEASE_LOG_ERROR instead.
<a href="https://webkit.org/b/275035">https://webkit.org/b/275035</a>
<a href="https://rdar.apple.com/problem/129138876">rdar://problem/129138876</a>

Reviewed by Brady Eidson.

Change the tabs / activeTab and mainWebView exceptions into error logs.
This also removes webViewsForWebExtensionContext: which is no longer used.
Fixed some test harness code for tabs, so they are in the correct state
and not hitting these ASSERTs in debug runs of the tests.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionTab.h:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPICookiesCocoa.mm:
(WebKit::WebExtensionContext::cookiesGetAllCookieStores):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::getOrCreateTab const): Fix issue with private tabs.
(WebKit::WebExtensionContext::getCurrentTab const):
(WebKit::WebExtensionContext::didCloseTab):
(WebKit::WebExtensionContext::reportWebViewConfigurationErrorIfNeeded const): Simplify
by letting the logging in the webView() method do the work.
(WebKit::WebExtensionContext::openInspectors const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::WebExtensionTab):
(WebKit::WebExtensionTab::window const):
(WebKit::WebExtensionTab::mainWebView const):
(WebKit::WebExtensionTab::isActive const):
(WebKit::WebExtensionTab::isPrivate const):
(WebKit::WebExtensionTab::processes const):
(WebKit::WebExtensionTab::webViews const): Deleted.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionWindowCocoa.mm:
(WebKit::WebExtensionWindow::tabs const):
(WebKit::WebExtensionWindow::activeTab const):
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionWindow setTabs:]):
(-[TestWebExtensionWindow openNewTabAtIndex:]):
(-[TestWebExtensionWindow closeTab:windowIsClosing:]):
(-[TestWebExtensionWindow replaceTab:withTab:]):

Canonical link: <a href="https://commits.webkit.org/279630@main">https://commits.webkit.org/279630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fb4745904577b2f08e50b4dd4d17bba86dc1a04

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57315 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4764 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56343 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4657 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43758 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3158 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31646 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46779 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24899 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28471 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4090 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2913 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50163 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/4295 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58909 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4386 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/51173 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30409 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50526 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31366 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8001 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30190 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->