### PR TITLE
Fix miscellaneous complaints of the clang static analyzer.

### DIFF
--- a/Source/JavaScriptCore/API/tests/TypedArrayCTest.cpp
+++ b/Source/JavaScriptCore/API/tests/TypedArrayCTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -199,11 +199,11 @@ static int testConstructors(JSGlobalContextRef context, JSTypedArrayType type, u
 
     if (byteSizes[type] > 1) {
         exception = nullptr;
-        typedArray = JSObjectMakeTypedArrayWithArrayBufferAndOffset(context, type, data, 1, length-1, &exception);
+        JSObjectMakeTypedArrayWithArrayBufferAndOffset(context, type, data, 1, length-1, &exception);
         failed = failed || !exception;
     }
 
-    typedArray = JSObjectMakeTypedArrayWithArrayBufferAndOffset(context, type, data, byteSizes[type], length, &exception);
+    JSObjectMakeTypedArrayWithArrayBufferAndOffset(context, type, data, byteSizes[type], length, &exception);
     failed = failed || !exception;
 
     exception = nullptr;

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -2580,7 +2580,6 @@ private:
         bool isBranch = m_value->opcode() == Branch;
         bool isStrong = atomic->opcode() == AtomicStrongCAS;
         bool returnsOldValue = m_value->opcode() == AtomicStrongCAS;
-        bool hasFence = atomic->hasFence();
         
         Width width = atomic->accessWidth();
         Arg address = addr(atomic);
@@ -2699,6 +2698,7 @@ private:
             failure = failBlock;
         }
         Air::BasicBlock* strongFailBlock = nullptr;
+        bool hasFence = atomic->hasFence();
         if (isStrong && hasFence)
             strongFailBlock = newBlock();
         Air::FrequentedBlock comparisonFail = failure;

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -2181,6 +2181,7 @@ private:
                     m_changed = true;
                 }
             }
+            UNUSED_PARAM(address); // placate clang static analyzer.
 
             if (m_value->opcode() == Store) {
                 // Turn this: Store(float-constant, address)

--- a/Source/JavaScriptCore/bytecode/ArithProfile.cpp
+++ b/Source/JavaScriptCore/bytecode/ArithProfile.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -241,6 +241,7 @@ void printInternal(PrintStream& out, const JSC::ObservedType& observedType)
         out.print(separator, "NonNumber");
         separator = "|";
     }
+    UNUSED_PARAM(separator); // placate clang static analyzer.
 }
 
 } // namespace WTF

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -3607,7 +3607,6 @@ void InlineCacheCompiler::emitDOMJITGetter(GetterSetterAccessCase& accessCase, c
 {
     CCallHelpers& jit = *m_jit;
     JSValueRegs valueRegs = m_stubInfo->valueRegs();
-    GPRReg baseGPR = m_stubInfo->m_baseGPR;
     GPRReg scratchGPR = m_scratchGPR;
 
     if (jit.codeBlock()->useDataIC()) {
@@ -3674,7 +3673,7 @@ void InlineCacheCompiler::emitDOMJITGetter(GetterSetterAccessCase& accessCase, c
         allocator.preserveReusedRegistersByPushing(jit, ScratchRegisterAllocator::ExtraStackSpace::SpaceForCCall);
 
     if (InlineCacheCompilerInternal::verbose) {
-        dataLog("baseGPR = ", baseGPR, "\n");
+        dataLog("baseGPR = ", m_stubInfo->m_baseGPR, "\n");
         dataLog("valueRegs = ", valueRegs, "\n");
         dataLog("scratchGPR = ", scratchGPR, "\n");
         dataLog("paramBaseGPR = ", paramBaseGPR, "\n");

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -1,7 +1,7 @@
 /*
 *  Copyright (C) 1999-2002 Harri Porten (porten@kde.org)
 *  Copyright (C) 2001 Peter Kelly (pmk@post.com)
-*  Copyright (C) 2003-2022 Apple Inc. All rights reserved.
+*  Copyright (C) 2003-2024 Apple Inc. All rights reserved.
 *  Copyright (C) 2007 Cameron Zwarich (cwzwarich@uwaterloo.ca)
 *  Copyright (C) 2007 Maks Orlovich
 *  Copyright (C) 2007 Eric Seidel <eric@webkit.org>
@@ -3283,7 +3283,7 @@ RegisterID* BinaryOpNode::emitBytecode(BytecodeGenerator& generator, RegisterID*
 
             // Since the both sides only accept Int32, replacing operands is not observable to users.
             bool replaceOperands = false;
-            OpcodeID resultOp = opcodeID;
+            OpcodeID resultOp;
             switch (opcodeID) {
             case op_less:
                 resultOp = op_below;

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1168,10 +1168,9 @@ bool Graph::isLiveInBytecode(Operand operand, CodeOrigin codeOrigin)
     bool isCallerOrigin = false;
 
     CodeOrigin* codeOriginPtr = &codeOrigin;
-    auto* inlineCallFrame = codeOriginPtr->inlineCallFrame();
     // We need to handle tail callers because we may decide to exit to the
     // the return bytecode following the tail call.
-    for (; codeOriginPtr; codeOriginPtr = inlineCallFrame ? &inlineCallFrame->directCaller : nullptr) {
+    for (InlineCallFrame* inlineCallFrame; codeOriginPtr; codeOriginPtr = inlineCallFrame ? &inlineCallFrame->directCaller : nullptr) {
         inlineCallFrame = codeOriginPtr->inlineCallFrame();
         if (operand.isTmp()) {
             unsigned tmpOffset = inlineCallFrame ? inlineCallFrame->tmpOffset : 0;

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -3089,19 +3089,19 @@ private:
                     unsure(continuation), unsure(notLessThan));
 
                 // The spec for Math.min and Math.max states that +0 is considered to be larger than -0.
-                LBasicBlock lastNext = m_out.appendTo(notLessThan, isEqual);
+                m_out.appendTo(notLessThan, isEqual);
                 m_out.branch(
                     m_out.doubleEqual(left, right),
                         rarely(isEqual), usually(notEqual));
 
-                lastNext = m_out.appendTo(isEqual, notEqual);
+                m_out.appendTo(isEqual, notEqual);
                 results.append(m_out.anchor(
                     m_node->op() == ArithMin
                         ? m_out.bitOr(left, right)
                         : m_out.bitAnd(left, right)));
                 m_out.jump(continuation);
 
-                lastNext = m_out.appendTo(notEqual, continuation);
+                LBasicBlock lastNext = m_out.appendTo(notEqual, continuation);
                 results.append(
                     m_out.anchor(
                         m_out.select(

--- a/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2011 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -401,7 +401,9 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::Runtime::TypeDescription>>> 
 
     auto types = JSON::ArrayOf<Protocol::Runtime::TypeDescription>::create();
 
-    MonotonicTime start = MonotonicTime::now();
+    MonotonicTime start;
+    if (verbose)
+        start = MonotonicTime::now();
     m_vm.typeProfilerLog()->processLogEntries(m_vm, "User Query"_s);
 
     for (size_t i = 0; i < locations->length(); i++) {
@@ -438,9 +440,10 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::Runtime::TypeDescription>>> 
         types->addItem(WTFMove(description));
     }
 
-    MonotonicTime end = MonotonicTime::now();
-    if (verbose)
+    if (verbose) {
+        MonotonicTime end = MonotonicTime::now();
         dataLogF("Inspector::getRuntimeTypesForVariablesAtOffsets took %lfms\n", (end - start).milliseconds());
+    }
 
     return types;
 }

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2008 Cameron Zwarich <cwzwarich@uwaterloo.ca>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -893,7 +893,7 @@ NEVER_INLINE CatchInfo Interpreter::unwind(VM& vm, CallFrame*& callFrame, Except
     if (seenRemoteFunction) {
         ASSERT(!vm.isTerminationException(exception));
         sanitizeRemoteFunctionException(vm, seenRemoteFunction, exception);
-        exception = scope.exception(); // clear m_needExceptionCheck
+        scope.exception(); // clear m_needExceptionCheck
     }
 
     if (vm.hasCheckpointOSRSideState())

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2015 Andy VanWagoner (andy@vanwagoner.family)
  * Copyright (C) 2016 Sukolsak Sakshuwong (sukolsak@gmail.com)
- * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2020 Sony Interactive Entertainment Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -1041,7 +1041,7 @@ void IntlNumberFormat::formatRangeToPartsInternal(JSGlobalObject* globalObject, 
 
     for (auto& field : flatten) {
         bool sign = false;
-        IntlMathematicalValue::NumberType numberType = start.numberType();
+        IntlMathematicalValue::NumberType numberType;
         if (startRange.contains(field.m_range.begin())) {
             numberType = start.numberType();
             sign = start.sign();

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -4120,11 +4120,10 @@ void JSObject::putOwnDataPropertyBatching(VM& vm, const RefPtr<UniquedStringImpl
 
         // Flush batching here. Note that it is possible that offsets.size() is not equal to size, if we stop batching due to transition-watchpoint-firing.
 
-        Butterfly* newButterfly = butterfly();
         auto* oldStructure = this->structure();
         if (oldStructure->outOfLineCapacity() != structure->outOfLineCapacity()) {
             ASSERT(structure != oldStructure);
-            newButterfly = allocateMoreOutOfLineStorage(vm, oldStructure->outOfLineCapacity(), structure->outOfLineCapacity());
+            Butterfly* newButterfly = allocateMoreOutOfLineStorage(vm, oldStructure->outOfLineCapacity(), structure->outOfLineCapacity());
             nukeStructureAndSetButterfly(vm, StructureID::encode(oldStructure), newButterfly);
         }
 

--- a/Source/JavaScriptCore/runtime/Options.h
+++ b/Source/JavaScriptCore/runtime/Options.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -96,7 +96,7 @@ public:
         }
 
     private:
-        bool m_savedAllowUnfinalizedUse;
+        bool m_savedAllowUnfinalizedUse { false };
 #else
         ALWAYS_INLINE AllowUnfinalizedAccessScope() = default;
         ALWAYS_INLINE ~AllowUnfinalizedAccessScope() { }

--- a/Source/JavaScriptCore/runtime/TypeSet.cpp
+++ b/Source/JavaScriptCore/runtime/TypeSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2019 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2014-2024 Apple Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -299,6 +299,7 @@ String TypeSet::toJSONString() const
         json.append("\"Symbol\""_s);
     }
     json.append(']');
+    UNUSED_PARAM(hasAnItem); // placate clang static analyzer.
 
     json.append(',');
 

--- a/Source/JavaScriptCore/tools/VMInspector.cpp
+++ b/Source/JavaScriptCore/tools/VMInspector.cpp
@@ -688,6 +688,7 @@ void VMInspector::dumpCellMemoryToStream(JSCell* cell, PrintStream& out)
 
                 index = dumpSection(index, endOfIndexedPropertiesIndex, "indexedProperties");
                 index = dumpSection(index, endOfButterflyIndex, "unallocated capacity");
+                UNUSED_PARAM(index); // placate clang static analyzer.
             }
         }
     }

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -760,7 +760,8 @@ void BBQJIT::emitAtomicStoreOp(ExtAtomicOpType storeOp, Type, Location pointer, 
             m_jit.move(valueLocation.asGPR(), newGPR);
         });
         return;
-    }
+    } else
+        UNUSED_PARAM(scratch2GPR); // placate clang static analyzer.
 
     switch (storeOp) {
     case ExtAtomicOpType::I32AtomicStore: {

--- a/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -239,8 +239,6 @@ RefPtr<JSEntrypointCallee> LLIntPlan::tryCreateInterpretedJSToWasmCallee(unsigne
         if (wasmFrameConvention.params[i].location.isStackArgument()) {
             auto wasmParam = static_cast<JSEntrypointInterpreterCalleeMetadata>(safeCast<int8_t>(
                 (wasmFrameConvention.params[i].location.offsetFromSP() + static_cast<int>(PayloadOffset)) / 8));
-            auto wasmParamTag = static_cast<JSEntrypointInterpreterCalleeMetadata>(safeCast<int8_t>(
-                (wasmFrameConvention.params[i].location.offsetFromSP() + static_cast<int>(TagOffset)) / 8));
             auto loadType = (type.width() == Width32) ? JSEntrypointInterpreterCalleeMetadata::LoadI32 : JSEntrypointInterpreterCalleeMetadata::LoadI64;
             auto storeType = (type.width() == Width32) ? JSEntrypointInterpreterCalleeMetadata::StoreI32 : JSEntrypointInterpreterCalleeMetadata::StoreI64;
             metadata.append(loadType);
@@ -249,6 +247,9 @@ RefPtr<JSEntrypointCallee> LLIntPlan::tryCreateInterpretedJSToWasmCallee(unsigne
             metadata.append(wasmParam);
 
             if (!is64Bit() && loadType == JSEntrypointInterpreterCalleeMetadata::LoadI32) {
+                auto wasmParamTag = static_cast<JSEntrypointInterpreterCalleeMetadata>(safeCast<int8_t>(
+                    (wasmFrameConvention.params[i].location.offsetFromSP() + static_cast<int>(TagOffset)) / 8));
+
                 metadata.append(JSEntrypointInterpreterCalleeMetadata::Zero);
                 metadata.append(JSEntrypointInterpreterCalleeMetadata::StoreI32);
                 metadata.append(wasmParamTag);

--- a/Source/ThirdParty/ANGLE/src/compiler/translator/Symbol.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/Symbol.cpp
@@ -77,7 +77,7 @@ ImmutableString TSymbol::name() const
     int uniqueId = mUniqueId.get();
     ImmutableStringBuilder symbolNameOut(sizeof(uniqueId) * 2u + 1u);
     symbolNameOut << 's';
-    symbolNameOut.appendHex(mUniqueId.get());
+    symbolNameOut.appendHex(uniqueId); // Use the already read value to placate clang static analyzer.
     return symbolNameOut;
 }
 

--- a/Source/ThirdParty/ANGLE/src/compiler/translator/glsl/OutputGLSLBase.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/glsl/OutputGLSLBase.cpp
@@ -776,7 +776,7 @@ bool TOutputGLSLBase::visitBinary(Visit visit, TIntermBinary *node)
 
 bool TOutputGLSLBase::visitUnary(Visit visit, TIntermUnary *node)
 {
-    const char *preString  = "";
+    const char *preString; // Removed unneeded initializer to placate clang static analyzer.
     const char *postString = ")";
 
     switch (node->getOp())

--- a/Source/ThirdParty/ANGLE/src/compiler/translator/tree_util/IntermTraverse.cpp
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/tree_util/IntermTraverse.cpp
@@ -372,6 +372,7 @@ void TLValueTrackingTraverser::traverseBinary(TIntermBinary *node)
             // hasn't been cancelled yet.
             if (postVisit)
                 visit = node->visit(PostVisit, this);
+            (void)visit; // placate clang static analyzer.
         }
     }
 }
@@ -413,6 +414,7 @@ void TLValueTrackingTraverser::traverseUnary(TIntermUnary *node)
 
         if (postVisit)
             visit = node->visit(PostVisit, this);
+        (void)visit; // placate clang static analyzer.
     }
 }
 
@@ -445,6 +447,7 @@ void TIntermTraverser::traverseFunctionDefinition(TIntermFunctionDefinition *nod
             mInGlobalScope     = true;
             if (postVisit)
                 visit = node->visit(PostVisit, this);
+            (void)visit; // placate clang static analyzer.
         }
     }
 }
@@ -489,6 +492,7 @@ void TIntermTraverser::traverseBlock(TIntermBlock *node)
 
         if (visit && postVisit)
             visit = node->visit(PostVisit, this);
+        (void)visit; // placate clang static analyzer.
     }
 
     popParentBlock();
@@ -698,6 +702,7 @@ void TLValueTrackingTraverser::traverseAggregate(TIntermAggregate *node)
 
         if (visit && postVisit)
             visit = node->visit(PostVisit, this);
+        (void)visit; // placate clang static analyzer.
     }
 }
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/FramebufferGL.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/FramebufferGL.cpp
@@ -960,8 +960,8 @@ angle::Result FramebufferGL::adjustSrcDstRegion(const gl::Context *context,
 
         GLuint destXHalvings = 0;
         GLuint destYHalvings = 0;
-        GLint destOriginX    = bounds.destRegion.x;
-        GLint destOriginY    = bounds.destRegion.y;
+        GLint destOriginX; // Removed unneeded initializer to placate clang static analyzer.
+        GLint destOriginY; // Removed unneeded initializer to placate clang static analyzer.
 
         GLint destClippedWidth = bounds.destRegion.width;
         while (destClippedWidth > 2 * bounds.destBounds.width)
@@ -1084,8 +1084,8 @@ angle::Result FramebufferGL::adjustSrcDstRegion(const gl::Context *context,
 
         GLuint sourceXHalvings = 0;
         GLuint sourceYHalvings = 0;
-        GLint sourceOriginX    = bounds.sourceRegion.x;
-        GLint sourceOriginY    = bounds.sourceRegion.y;
+        GLint sourceOriginX; // Removed unneeded initializer to placate clang static analyzer.
+        GLint sourceOriginY; // Removed unneeded initializer to placate clang static analyzer.
 
         GLint sourceClippedWidth = bounds.sourceRegion.width;
         while (sourceClippedWidth > 2 * bounds.sourceBounds.width)

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/renderergl_utils.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/renderergl_utils.cpp
@@ -2266,6 +2266,8 @@ void InitializeFeatures(const FunctionsGL *functions, angle::FeaturesGL *feature
         qualcommVersion = GetQualcommVersion(functions);
     }
 
+    (void)isVMWare; // placate clang static analyzer.
+
     // Don't use 1-bit alpha formats on desktop GL with AMD drivers.
     ANGLE_FEATURE_CONDITION(features, avoid1BitAlphaTextureFormats,
                             functions->standard == STANDARD_GL_DESKTOP && isAMD);

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/TextureMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/TextureMtl.mm
@@ -1442,7 +1442,7 @@ angle::Result TextureMtl::generateMipmapCPU(const gl::Context *context)
 
             prevLevelWidth      = dstWidth;
             prevLevelHeight     = dstHeight;
-            prevLevelDepth      = dstDepth;
+            // prevLevelDepth      = dstDepth; // Unneeded: removed to placate clang static analyzer.
             prevLevelRowPitch   = dstRowPitch;
             prevLevelDepthPitch = dstDepthPitch;
             std::swap(prevLevelData, dstLevelData);

--- a/Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/pem/pem_lib.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/pem/pem_lib.c
@@ -296,6 +296,7 @@ int PEM_ASN1_write_bio(i2d_of_void *i2d, const char *name, BIO *bp, void *x,
   if ((dsize = i2d(x, NULL)) < 0) {
     OPENSSL_PUT_ERROR(PEM, ERR_R_ASN1_LIB);
     dsize = 0;
+    (void)dsize; // placate clang static analyzer.
     goto err;
   }
   // dzise + 8 bytes are needed
@@ -311,7 +312,7 @@ int PEM_ASN1_write_bio(i2d_of_void *i2d, const char *name, BIO *bp, void *x,
     const unsigned iv_len = EVP_CIPHER_iv_length(enc);
 
     if (kstr == NULL) {
-      klen = 0;
+      // klen = 0; // Unneeded: removed to placate clang static analyzer.
       if (!callback) {
         callback = PEM_def_callback;
       }
@@ -387,7 +388,7 @@ int PEM_do_header(EVP_CIPHER_INFO *cipher, unsigned char *data, long *plen,
     return 1;
   }
 
-  klen = 0;
+  // klen = 0; // Unneeded: removed to placate clang static analyzer.
   if (!callback) {
     callback = PEM_def_callback;
   }

--- a/Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/pem/pem_pk8.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/pem/pem_pk8.c
@@ -112,7 +112,7 @@ static int do_pk8pkey(BIO *bp, const EVP_PKEY *x, int isder, int nid,
   }
   if (enc || (nid != -1)) {
     if (!kstr) {
-      klen = 0;
+      // klen = 0; // Unneeded: removed to placate clang static analyzer.
       if (!cb) {
         cb = PEM_def_callback;
       }
@@ -160,7 +160,7 @@ EVP_PKEY *d2i_PKCS8PrivateKey_bio(BIO *bp, EVP_PKEY **x, pem_password_cb *cb,
     return NULL;
   }
 
-  klen = 0;
+  // klen = 0; // Unneeded: removed to placate clang static analyzer.
   if (!cb) {
     cb = PEM_def_callback;
   }

--- a/Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/pem/pem_pkey.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/pem/pem_pkey.c
@@ -105,7 +105,7 @@ EVP_PKEY *PEM_read_bio_PrivateKey(BIO *bp, EVP_PKEY **x, pem_password_cb *cb,
       goto p8err;
     }
 
-    klen = 0;
+    // klen = 0; // Unneeded: removed to placate clang static analyzer.
     if (!cb) {
       cb = PEM_def_callback;
     }

--- a/Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/x509/by_dir.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/x509/by_dir.c
@@ -261,6 +261,7 @@ static int get_cert_by_subject(X509_LOOKUP *xl, int type, X509_NAME *name,
   BUF_MEM *b = NULL;
   X509_OBJECT stmp, *tmp;
   const char *postfix = "";
+  (void)postfix; // placate clang static analyzer.
 
   if (name == NULL) {
     return 0;

--- a/Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/ssl/ssl_cipher.cc
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/ssl/ssl_cipher.cc
@@ -973,6 +973,7 @@ static bool ssl_cipher_process_rulestr(const char *rule_str,
 
       if (ch == '|') {
         rule = CIPHER_ADD;
+        (void)rule; // placate clang static analyzer.
         l++;
         continue;
       } else if (!OPENSSL_isalnum(ch)) {

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/aom_dsp/arm/mem_neon.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/aom_dsp/arm/mem_neon.h
@@ -83,7 +83,7 @@ static INLINE void store_u8_8x2(uint8_t *s, ptrdiff_t p, const uint8x8_t s0,
   vst1_u8(s, s0);
   s += p;
   vst1_u8(s, s1);
-  s += p;
+  // s += p; // Unneeded: removed to placate clang static analyzer.
 }
 
 static INLINE uint8x16_t load_u8_8x2(const uint8_t *s, ptrdiff_t p) {
@@ -174,7 +174,7 @@ static INLINE void load_u16_4x4(const uint16_t *s, const ptrdiff_t p,
   *s2 = vld1_u16(s);
   s += p;
   *s3 = vld1_u16(s);
-  s += p;
+  // s += p; // Unneeded: removed to placate clang static analyzer.
 }
 
 static INLINE void load_u16_4x7(const uint16_t *s, ptrdiff_t p,
@@ -221,7 +221,7 @@ static INLINE void load_u16_8x4(const uint16_t *s, const ptrdiff_t p,
   *s2 = vld1q_u16(s);
   s += p;
   *s3 = vld1q_u16(s);
-  s += p;
+  // s += p; // Unneeded: removed to placate clang static analyzer.
 }
 
 static INLINE void load_s16_4x12(const int16_t *s, ptrdiff_t p,
@@ -403,7 +403,7 @@ static INLINE void load_u16_4x5(const uint16_t *s, const ptrdiff_t p,
   *s3 = vld1_u16(s);
   s += p;
   *s4 = vld1_u16(s);
-  s += p;
+  // s += p; // Unneeded: removed to placate clang static analyzer.
 }
 
 static INLINE void load_u8_8x5(const uint8_t *s, ptrdiff_t p,
@@ -434,7 +434,7 @@ static INLINE void load_u16_8x5(const uint16_t *s, const ptrdiff_t p,
   *s3 = vld1q_u16(s);
   s += p;
   *s4 = vld1q_u16(s);
-  s += p;
+  // s += p; // Unneeded: removed to placate clang static analyzer.
 }
 
 static INLINE void load_s16_4x4(const int16_t *s, ptrdiff_t p,
@@ -1115,7 +1115,7 @@ static INLINE uint16x8_t load_unaligned_u16_4x2(const uint16_t *buf,
   a_u64 = vdupq_n_u64(0);
   a_u64 = vsetq_lane_u64(a, a_u64, 0);
   memcpy(&a, buf, 8);
-  buf += stride;
+  // buf += stride; // Unneeded: removed to placate clang static analyzer.
   a_u64 = vsetq_lane_u64(a, a_u64, 1);
   return vreinterpretq_u16_u64(a_u64);
 }

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/common/arm/selfguided_neon.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/common/arm/selfguided_neon.c
@@ -306,9 +306,9 @@ static INLINE void boxsum2(int16_t *src, const int src_stride, int16_t *dst16,
   const int dst_stride_2 = (dst_stride << 1);
   const int dst_stride_8 = (dst_stride << 3);
 
-  dst1_16_ptr = dst16;
-  dst2_ptr = dst2;
-  src_ptr = src;
+  // dst1_16_ptr = dst16; // Unneeded: removed to placate clang static analyzer.
+  // dst2_ptr = dst2; // Unneeded: removed to placate clang static analyzer.
+  // src_ptr = src; // Unneeded: removed to placate clang static analyzer.
   w = width;
   {
     int16x8_t t1, t2, t3, t4, t5, t6, t7;
@@ -835,7 +835,7 @@ static INLINE void boxsum1(int16_t *src, const int src_stride, uint16_t *dst1,
     uint16_t *src1_ptr;
     count = 0;
     h = height;
-    w = width;
+    // w = width; // Unneeded: removed to placate clang static analyzer.
     do {
       dst1_ptr = dst1 + (count << 2) * dst_stride;
       dst2_ptr = dst2 + (count << 2) * dst_stride;
@@ -1055,10 +1055,10 @@ static void final_filter_fast_internal(uint16_t *A, int32_t *B,
   assert(SGRPROJ_SGR_BITS == 8);
   assert(SGRPROJ_RST_BITS == 4);
 
-  A_tmp = A;
-  B_tmp = B;
-  src_ptr = src;
-  dst_ptr = dst;
+  // A_tmp = A; // Unneeded: removed to placate clang static analyzer.
+  // B_tmp = B; // Unneeded: removed to placate clang static analyzer.
+  // src_ptr = src; // Unneeded: removed to placate clang static analyzer.
+  // dst_ptr = dst; // Unneeded: removed to placate clang static analyzer.
   h = height;
   do {
     A_tmp = (A + count * buf_stride);

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/common/arm/wiener_convolve_neon.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/common/arm/wiener_convolve_neon.c
@@ -172,6 +172,7 @@ static INLINE void process_row_for_horz_filtering(
       uint8x8_t tt5 = vext_u8(ttemp_0, tt7, 5);  // a5 a6 a7 a8 a9 a10 a11 a12
       uint8x8_t tt6 = vext_u8(ttemp_0, tt7, 6);  // a6 a7 a8 a9 a10 a11 a12 a13
       tt7 = vext_u8(ttemp_0, tt7, 7);            // a7 a8 a9 a10 a11 a12 a13 a14
+      (void)tt7; // placate clang static analyzer.
 
       int16x8_t ttt0 = vreinterpretq_s16_u16(vaddl_u8(ttemp_0, tt6));
       int16x8_t ttt1 = vreinterpretq_s16_u16(vaddl_u8(tt1, tt5));
@@ -332,8 +333,8 @@ void av1_wiener_convolve_add_src_neon(const uint8_t *src, ptrdiff_t src_stride,
   {
     int16_t *src_tmp_ptr, *s;
     uint8_t *dst_tmp_ptr;
-    height = h;
-    width = w;
+    // height = h; // Unneeded: removed to placate clang static analyzer.
+    // width = w; // Unneeded: removed to placate clang static analyzer.
     src_tmp_ptr = (int16_t *)temp;
     dst_tmp_ptr = dst;
     src_stride = MAX_SB_SIZE;

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/encoder/arm/neon/pickrst_neon.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/encoder/arm/neon/pickrst_neon.c
@@ -178,6 +178,7 @@ static INLINE uint8_t find_average_neon(const uint8_t *src, int src_stride,
           avg_u16 = vaddw_u8(avg_u16, s);
           j -= 8;
           src_ptr += 8;
+          (void)src_ptr; // placate clang static analyzer.
         }
         // Scalar tail case.
         while (j > 0) {
@@ -188,7 +189,7 @@ static INLINE uint8_t find_average_neon(const uint8_t *src, int src_stride,
       } while (++h < h_limit);
       avg_u32 = vpadalq_u16(avg_u32, avg_u16);
 
-      h_limit += h_overflow;
+      // h_limit += h_overflow; // Unneeded: removed to placate clang static analyzer.
       h_limit = height > h_overflow ? h_overflow : height;
     } while (h < height);
     return (uint8_t)((horizontal_long_add_u32x4(avg_u32) + sum) /
@@ -212,6 +213,7 @@ static INLINE uint8_t find_average_neon(const uint8_t *src, int src_stride,
         avg_u16 = vpadal_u8(avg_u16, s);
         j -= 8;
         src_ptr += 8;
+        (void)src_ptr; // placate clang static analyzer.
         // Scalar tail case.
         while (j > 0) {
           sum += src[width - j];
@@ -221,7 +223,7 @@ static INLINE uint8_t find_average_neon(const uint8_t *src, int src_stride,
       } while (++h < h_limit);
       avg_u32 = vpadal_u16(avg_u32, avg_u16);
 
-      h_limit += h_overflow;
+      // h_limit += h_overflow; // Unneeded: removed to placate clang static analyzer.
       h_limit = height > h_overflow ? h_overflow : height;
     } while (h < height);
     return (uint8_t)((horizontal_long_add_u32x2(avg_u32) + sum) /

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libsrtp/srtp/srtp.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libsrtp/srtp/srtp.c
@@ -1050,6 +1050,7 @@ srtp_err_status_t srtp_stream_init_keys(srtp_stream_ctx_t *srtp,
         } else {
             /* Reuse main KDF. */
             rtp_xtn_hdr_keylen = rtp_keylen;
+            (void)rtp_xtn_hdr_keylen; /* placate clang static analyzer. */
             rtp_xtn_hdr_base_key_len = rtp_base_key_len;
             rtp_xtn_hdr_salt_len = rtp_salt_len;
             xtn_hdr_kdf = &kdf;

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp8/common/arm/neon/bilinearpredict_neon.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp8/common/arm/neon/bilinearpredict_neon.c
@@ -632,6 +632,7 @@ void vp8_bilinear_predict16x16_neon(unsigned char *src_ptr,
   d15u8 = vld1_u8(src_ptr + 8);
   d16u8 = vld1_u8(src_ptr + 16);
   src_ptr += src_pixels_per_line;
+  (void)src_ptr; // placate clang static analyzer.
 
   q9u16 = vmull_u8(d2u8, d0u8);
   q10u16 = vmull_u8(d3u8, d0u8);

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp8/common/arm/neon/iwalsh_neon.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp8/common/arm/neon/iwalsh_neon.c
@@ -97,6 +97,6 @@ void vp8_short_inv_walsh4x4_neon(int16_t *input, int16_t *mb_dqcoeff) {
   vst1_lane_s16(mb_dqcoeff, vget_low_s16(q1s16), 3);
   mb_dqcoeff += 16;
   vst1_lane_s16(mb_dqcoeff, vget_high_s16(q1s16), 3);
-  mb_dqcoeff += 16;
+  // mb_dqcoeff += 16; // Unneeded: removed to placate clang static analyzer.
   return;
 }

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_pickmode.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_pickmode.c
@@ -1412,6 +1412,7 @@ static void recheck_zeromv_after_denoising(
     // is higher than best_ref mode (on original source).
     if (this_rdc.rdcost > best_rdc->rdcost) {
       this_rdc = *best_rdc;
+      (void)this_rdc; // placate clang static analyzer.
       mi->mode = ctx_den->best_mode;
       mi->ref_frame[0] = ctx_den->best_ref_frame;
       set_ref_ptrs(cm, xd, mi->ref_frame[0], NO_REF_FRAME);

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx_dsp/arm/mem_neon.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx_dsp/arm/mem_neon.h
@@ -216,7 +216,7 @@ static INLINE uint8x16_t load_unaligned_u8q(const uint8_t *buf,
   buf += stride;
   a_u32 = vsetq_lane_u32(a, a_u32, 2);
   memcpy(&a, buf, 4);
-  buf += stride;
+  // buf += stride; // Unneeded: removed to placate clang static analyzer.
   a_u32 = vsetq_lane_u32(a, a_u32, 3);
   return vreinterpretq_u8_u32(a_u32);
 }

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libyuv/source/cpu_id.cc
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libyuv/source/cpu_id.cc
@@ -337,6 +337,7 @@ static SAFEBUFFERS int GetCpuFlags(void) {
 // For Linux, /proc/cpuinfo can be tested but without that assume Neon.
 #if defined(__ARM_NEON__) || defined(__native_client__) || !defined(__linux__)
   cpu_info = kCpuHasNEON;
+  (void)cpu_info; // placate clang static analyzer.
 // For aarch64(arm64), /proc/cpuinfo's feature is not complete, e.g. no neon
 // flag in it.
 // So for aarch64, neon enabling is hard coded here.

--- a/Source/ThirdParty/libwebrtc/Source/third_party/yasm/libyasm/errwarn.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/yasm/libyasm/errwarn.c
@@ -498,6 +498,7 @@ yasm_errwarns_output_all(yasm_errwarns *errwarns, yasm_linemap *lm,
                     yasm_gettext_hook(N_("warnings being treated as errors")),
                     NULL, 0, NULL);
         warning_as_error = 2;
+        (void)warning_as_error; /* placate clang static analyzer. */
     }
 
     /* Output error/warnings. */

--- a/Source/ThirdParty/libwebrtc/Source/third_party/yasm/libyasm/section.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/yasm/libyasm/section.c
@@ -1557,6 +1557,7 @@ yasm_object_optimize(yasm_object *object, yasm_errwarns *errwarns)
             retval = yasm_bc_expand(os->bc, 1, (long)os->cur_val,
                                     (long)os->new_val, &neg_thres_temp,
                                     (long *)&os->thres);
+            (void)retval; // placate clang static analyzer.
             yasm_errwarn_propagate(errwarns, os->bc->line);
 
             offset_diff = os->new_val + os->bc->len - old_next_offset;

--- a/Source/ThirdParty/libwebrtc/Source/third_party/yasm/modules/arch/x86/x86expr.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/yasm/modules/arch/x86/x86expr.c
@@ -239,7 +239,7 @@ x86_expr_checkea_distcheck_reg(yasm_expr **ep, unsigned int bits)
         ne = e->terms[havereg_expr].data.expn;
         e->terms[havereg_expr].type = YASM_EXPR_NONE;   /* don't delete it! */
         yasm_expr_destroy(e);                       /* but everything else */
-        e = ne;
+        /* e = ne; // Unneeded: removed to placate clang static analyzer. */
         /*@-onlytrans@*/
         *ep = ne;
         /*@=onlytrans@*/
@@ -401,6 +401,8 @@ x86_expr_checkea_getregusage(yasm_expr **ep, /*@null@*/ int *indexreg,
                         *indexreg = -1;
                         indexval = 0;
                         indexmult = 0;
+                        (void)indexval; /* placate clang static analyzer. */
+                        (void)indexmult; /* placate clang static analyzer. */
                     }
                     else
                         *indexreg = regnum;

--- a/Source/ThirdParty/libwebrtc/Source/third_party/yasm/modules/objfmts/macho/macho-objfmt.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/yasm/modules/objfmts/macho/macho-objfmt.c
@@ -949,6 +949,7 @@ macho_objfmt_output_symtable(yasm_symrec *sym, /*@null@*/ void *d)
         YASM_WRITE_16_L(localbuf, n_desc);      /* extra description */
         yasm_intnum_get_sized(val, localbuf, long_int_bytes, ((long_int_bytes) << 3), 0, 0, 0); /* value/argument */
         localbuf += long_int_bytes;
+        (void)localbuf; /* placate clang static analyzer. */
         if (symd)
             symd->value = val;
         else
@@ -1426,6 +1427,7 @@ macho_objfmt_section_switch(yasm_object *object, yasm_valparamhead *valparams,
             align = 0;
 
             sectname = s;
+            (void)sectname; /* placate clang static analyzer. */
             vp = yasm_vps_next(vp);
         } else {
             data.f_segname = NULL;

--- a/Source/ThirdParty/libwebrtc/Source/third_party/yasm/modules/parsers/nasm/nasm-parse.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/yasm/modules/parsers/nasm/nasm-parse.c
@@ -416,6 +416,7 @@ parse_line(yasm_parser_nasm *parser_nasm)
 
                 if (parser_nasm->tasm && curtok == SIZE_OVERRIDE) {
                     size = SIZE_OVERRIDE_val;
+                    (void)size; /* placate clang static analyzer. */
                     get_next_token();
                 }
 

--- a/Source/ThirdParty/libwebrtc/Source/third_party/yasm/modules/preprocs/gas/gas-eval.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/yasm/modules/preprocs/gas/gas-eval.c
@@ -423,7 +423,7 @@ yasm_expr *evaluate (scanner sc, void *scprivate, struct tokenval *tv,
                      yasm_symtab *st)
 {
     if (critical & CRITICAL) {
-        critical &= ~CRITICAL;
+        /* critical &= ~CRITICAL; // Unneeded: removed to placate clang static analyzer. */
         bexpr = rexp0;
     } else
         bexpr = expr0;

--- a/Source/ThirdParty/libwebrtc/Source/third_party/yasm/modules/preprocs/nasm/nasm-eval.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/yasm/modules/preprocs/nasm/nasm-eval.c
@@ -422,7 +422,7 @@ yasm_expr *nasm_evaluate (scanner sc, void *scprivate, struct tokenval *tv,
                           int critical, efunc report_error)
 {
     if (critical & CRITICAL) {
-        critical &= ~CRITICAL;
+        /* critical &= ~CRITICAL; // Unneeded: removed to placate clang static analyzer. */
         bexpr = rexp0;
     } else
         bexpr = expr0;

--- a/Source/ThirdParty/libwebrtc/Source/third_party/yasm/modules/preprocs/nasm/nasm-pp.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/yasm/modules/preprocs/nasm/nasm-pp.c
@@ -2217,6 +2217,7 @@ if_condition(Token * tline, int i)
             if (tline && tok_is_(tline->next, "+"))
             {
                 tline = tline->next;
+                (void)tline; /* placate clang static analyzer. */
                 searching.plus = TRUE;
             }
             mmac = mmacros[hash(searching.name)];
@@ -2518,6 +2519,7 @@ do_directive(Token * tline)
             {
                 char *arg, directive[256];
                 int size = StackSize;
+                (void)size; /* placate clang static analyzer. */
 
                 /* Find the argument name */
                 tline = tline->next;
@@ -2614,6 +2616,7 @@ do_directive(Token * tline)
             {
                 char *local, directive[256];
                 int size = StackSize;
+                (void)size; /* placate clang static analyzer. */
 
                 /* Find the argument name */
                 tline = tline->next;
@@ -3264,6 +3267,7 @@ do_directive(Token * tline)
 
             list->uplevel(defining->nolist ? LIST_MACRO_NOLIST : LIST_MACRO);
             tmp_defining = defining;
+            (void)tmp_defining; /* placate clang static analyzer. */
             defining = defining->rep_nest;
             free_tlist(origline);
             return DIRECTIVE_FOUND;

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/modules/third_party/g711/g711.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/modules/third_party/g711/g711.h
@@ -127,7 +127,7 @@ static __inline int top_bit(unsigned int bits) {
     i += 2;
   }
   if (bits & 0xAAAAAAAA) {
-    bits &= 0xAAAAAAAA;
+    /* bits &= 0xAAAAAAAA; // Unneeded: removed to placate clang static analyzer. */
     i += 1;
   }
   return i;
@@ -157,7 +157,7 @@ static __inline int bottom_bit(unsigned int bits) {
     i -= 2;
   }
   if (bits & 0x55555555) {
-    bits &= 0x55555555;
+    /* bits &= 0x55555555; // Unneeded: removed to placate clang static analyzer. */
     i -= 1;
   }
   return i;

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/video/receive_statistics_proxy.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/video/receive_statistics_proxy.cc
@@ -239,7 +239,7 @@ void ReceiveStatisticsProxy::UpdateHistograms(
   std::map<VideoContentType, ContentSpecificStats> aggregated_stats;
   for (const auto& it : content_specific_stats_) {
     // Calculate simulcast specific metrics (".S0" ... ".S2" suffixes).
-    VideoContentType content_type = it.first;
+    VideoContentType content_type; // Removed unneeded initialization to placate clang static analyzer.
     // Calculate aggregated metrics (no suffixes. Aggregated on everything).
     content_type = it.first;
     aggregated_stats[content_type].Add(it.second);

--- a/Source/WTF/wtf/SegmentedVector.h
+++ b/Source/WTF/wtf/SegmentedVector.h
@@ -262,7 +262,7 @@ namespace WTF {
 
         void allocateSegment()
         {
-            m_segments.append(static_cast<Segment*>(SegmentedVectorMalloc::malloc(sizeof(T) * SegmentSize)));
+            m_segments.append(bitwise_cast<Segment*>(SegmentedVectorMalloc::malloc(sizeof(T) * SegmentSize)));
         }
 
         size_t m_size { 0 };

--- a/Source/WTF/wtf/fast_float/float_common.h
+++ b/Source/WTF/wtf/fast_float/float_common.h
@@ -227,7 +227,7 @@ int leading_zeroes_generic(uint64_t input_num, int last_bit = 0) {
   if(input_num & uint64_t(            0xff00)) { input_num >>=  8; last_bit |=  8; }
   if(input_num & uint64_t(              0xf0)) { input_num >>=  4; last_bit |=  4; }
   if(input_num & uint64_t(               0xc)) { input_num >>=  2; last_bit |=  2; }
-  if(input_num & uint64_t(               0x2)) { input_num >>=  1; last_bit |=  1; }
+  if(input_num & uint64_t(               0x2)) { last_bit |=  1; }
   return 63 - last_bit;
 }
 

--- a/Source/WebCore/PAL/ThirdParty/libavif/ThirdParty/dav1d/src/thread_task.c
+++ b/Source/WebCore/PAL/ThirdParty/libavif/ThirdParty/dav1d/src/thread_task.c
@@ -453,6 +453,7 @@ static inline void delayed_fg_task(const Dav1dContext *const c,
         }
         row = atomic_fetch_add(&ttd->delayed_fg.progress[0], 1);
         int done = atomic_fetch_add(&ttd->delayed_fg.progress[1], 1) + 1;
+        (void)done; // placate clang static analyzer.
         if (row < progmax) goto fg_apply_loop;
         pthread_mutex_lock(&ttd->lock);
         ttd->delayed_fg.exec = 0;

--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h
@@ -430,7 +430,9 @@ static PAS_ALWAYS_INLINE pas_bitfit_allocation_result pas_bitfit_page_allocate(
                             break;
                         }
                     } else {
+#if PAS_ENABLE_TESTING
                         num_available_leading_bits = PAS_BITVECTOR_BITS_PER_WORD64;
+#endif
                         if (num_remaining_needed_bits > PAS_BITVECTOR_BITS_PER_WORD64) {
                             num_remaining_needed_bits -= PAS_BITVECTOR_BITS_PER_WORD64;
                             continue;

--- a/Source/bmalloc/libpas/src/libpas/pas_expendable_memory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_expendable_memory.c
@@ -174,7 +174,9 @@ bool pas_expendable_memory_commit_if_necessary(pas_expendable_memory* header,
 
     header_version = ((pas_expendable_memory_state_version*)object)[-1];
     first_state = header->states[first];
+#if PAS_ENABLE_TESTING
     first_kind = pas_expendable_memory_state_get_kind(first_state);
+#endif
     first_version = pas_expendable_memory_state_get_version(first_state);
 
     PAS_TESTING_ASSERT(first_kind != PAS_EXPENDABLE_MEMORY_STATE_KIND_INTERIOR);

--- a/Source/bmalloc/libpas/src/libpas/pas_generic_large_free_heap.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_generic_large_free_heap.h
@@ -194,7 +194,6 @@ pas_generic_large_free_heap_try_allocate(
     
     pas_alignment_validate(alignment);
     pas_heap_lock_assert_held();
-    result = pas_allocation_result_create_failure();
     
     test_allocation_candidate_data.heap = heap;
     test_allocation_candidate_data.size = size;

--- a/Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.c
@@ -110,25 +110,20 @@ static void validate_min_heap(void)
 {
     size_t index;
     
-    if (verbose)
+    if (verbose) {
         pas_log("min_heap:");
-    
-    for (index = 1; index <= pas_large_sharing_min_heap_instance.size; ++index) {
-        pas_large_sharing_node* node;
+        for (index = 1; index <= pas_large_sharing_min_heap_instance.size; ++index) {
+            pas_large_sharing_node* node;
+            node = *pas_large_sharing_min_heap_get_ptr_by_index(
+                &pas_large_sharing_min_heap_instance, index);
 
-        node = *pas_large_sharing_min_heap_get_ptr_by_index(
-            &pas_large_sharing_min_heap_instance, index);
-        
-        if (verbose) {
             pas_log(" %d:%p:%lu-%lu:%llu",
                     node->index_in_min_heap,
                     node, node->range.begin, node->range.end,
                     (unsigned long long)node->use_epoch);
         }
-    }
-    
-    if (verbose)
         pas_log("\n");
+    }
 
     for (index = 1; index <= pas_large_sharing_min_heap_instance.size; ++index) {
         pas_large_sharing_node* node;

--- a/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h
@@ -918,7 +918,6 @@ pas_local_allocator_refill_with_known_config(
     pas_segregated_page* old_page;
     pas_segregated_page* new_page;
     pas_segregated_size_directory* size_directory;
-    pas_segregated_directory* directory;
     pas_thread_local_cache_node* cache_node;
     pas_segregated_exclusive_view* exclusive;
     pas_segregated_partial_view* partial;
@@ -932,10 +931,9 @@ pas_local_allocator_refill_with_known_config(
     size_directory = pas_segregated_view_get_size_directory(allocator->view);
 
     pas_segregated_heap_touch_lookup_tables(size_directory->heap, pas_expendable_memory_touch_to_note_use);
-    
-    directory = &size_directory->base;
 
     if (verbose) {
+        pas_segregated_directory* directory = &size_directory->base;
         pas_log("Refilling allocator = %p with size = %u and mode = %s\n",
                 allocator,
                 allocator->object_size,
@@ -1043,7 +1041,6 @@ pas_local_allocator_refill_with_known_config(
             PAS_ASSERT(!pas_segregated_page_config_is_utility(page_config));
             partial = (pas_segregated_partial_view*)pas_segregated_view_get_ptr(old_view);
             if (partial->eligibility_has_been_noted) {
-                new_view = old_view;
                 new_page = old_page;
                 pas_segregated_page_switch_lock(new_page, &held_lock, page_config);
                 partial->eligibility_has_been_noted = false;

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_directory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_directory.c
@@ -172,9 +172,6 @@ pas_segregated_directory_get_sharing_payload(pas_segregated_directory* directory
             payload = (pas_page_sharing_participant_payload*)(
                 encoded_payload & ~PAS_SEGREGATED_DIRECTORY_SHARING_PAYLOAD_IS_INITIALIZED_BIT);
         } else {
-            payload = (pas_page_sharing_participant_payload*)(
-                encoded_payload & ~PAS_SEGREGATED_DIRECTORY_SHARING_PAYLOAD_IS_INITIALIZED_BIT);
-            
             payload = pas_immortal_heap_allocate(
                 sizeof(pas_page_sharing_participant_payload),
                 "pas_segregated_directory_data/sharing_payload",

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_partial_view.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_partial_view.c
@@ -110,16 +110,9 @@ void pas_segregated_partial_view_set_is_in_use_for_allocation(
     pas_segregated_shared_handle* shared_handle)
 {
     static const bool verbose = false;
-    
-    pas_segregated_shared_page_directory* shared_page_directory;
-    size_t index;
-
-    shared_page_directory = shared_handle->directory;
-    index = shared_view->index;
-
-    PAS_UNUSED_PARAM(shared_page_directory);
-
+    PAS_UNUSED_PARAM(shared_handle);
     if (verbose) {
+        size_t index = shared_view->index;
         pas_log("Setting partial %p, shared %p (index %zu) as in use for allocation.\n",
                 view, shared_view, index);
     }
@@ -175,7 +168,6 @@ static pas_heap_summary compute_summary(pas_segregated_partial_view* view)
     pas_segregated_page* page;
     unsigned* full_alloc_bits;
     unsigned* alloc_bits;
-    uintptr_t page_boundary;
     size_t object_size;
     size_t index;
     size_t begin_index;
@@ -193,7 +185,7 @@ static pas_heap_summary compute_summary(pas_segregated_partial_view* view)
     full_alloc_bits = pas_lenient_compact_unsigned_ptr_load(&view->alloc_bits);
 
     if (shared_view->is_owned) {
-        page_boundary = (uintptr_t)pas_shared_handle_or_page_boundary_get_page_boundary(
+        uintptr_t page_boundary = (uintptr_t)pas_shared_handle_or_page_boundary_get_page_boundary(
             shared_view->shared_handle_or_page_boundary, page_config);
         page = pas_segregated_page_for_boundary((void*)page_boundary, page_config);
         alloc_bits = page->alloc_bits;
@@ -205,7 +197,6 @@ static pas_heap_summary compute_summary(pas_segregated_partial_view* view)
     } else {
         page = NULL;
         alloc_bits = NULL;
-        page_boundary = 0;
     }
 
     /* This doesn't have to be optimized since this is just for internal introspection.

--- a/Source/bmalloc/libpas/src/libpas/pas_segregated_view_allocator_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_segregated_view_allocator_inlines.h
@@ -57,7 +57,6 @@ pas_segregated_view_will_start_allocating(pas_segregated_view view,
     pas_segregated_partial_view* partial;
     pas_segregated_view ineligible_owning_view;
     pas_segregated_size_directory* size_directory;
-    pas_segregated_directory* size_directory_base;
     pas_lock_hold_mode heap_lock_hold_mode;
     pas_segregated_shared_page_directory* shared_page_directory;
     pas_segregated_heap* heap;
@@ -67,6 +66,8 @@ pas_segregated_view_will_start_allocating(pas_segregated_view view,
     switch (pas_segregated_view_get_kind(view)) {
     case pas_segregated_exclusive_view_kind:
     case pas_segregated_ineligible_exclusive_view_kind: {
+        pas_segregated_directory* size_directory_base;
+
         exclusive = (pas_segregated_exclusive_view*)pas_segregated_view_get_ptr(view);
         ineligible_owning_view = pas_segregated_exclusive_view_as_ineligible_view_non_null(exclusive);
 
@@ -231,7 +232,6 @@ pas_segregated_view_will_start_allocating(pas_segregated_view view,
         partial = pas_segregated_view_get_partial(view);
     
         size_directory = pas_compact_segregated_size_directory_ptr_load_non_null(&partial->directory);
-        size_directory_base = &size_directory->base;
         heap = size_directory->heap;
         shared_page_directory = page_config.shared_page_directory_selector(heap, size_directory);
         heap_lock_hold_mode = pas_segregated_page_config_heap_lock_hold_mode(page_config);

--- a/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c
@@ -679,7 +679,8 @@ process_deallocation_log_with_config(pas_thread_local_cache* cache,
             break;
 
         default:
-            last_held_lock = *held_lock;
+            if (verbose)
+                last_held_lock = *held_lock;
             pas_segregated_page_deallocate(begin, held_lock, deallocation_mode, cache, page_config, role);
             if (verbose && *held_lock != last_held_lock && last_held_lock)
                 pas_log("Switched lock from %p to %p.\n", last_held_lock, *held_lock);

--- a/Tools/lldb/lldbWebKitTester/main.cpp
+++ b/Tools/lldb/lldbWebKitTester/main.cpp
@@ -59,15 +59,19 @@ static void testSummaryProviders()
 {
     String aNullString { ""_s };
     StringImpl* aNullStringImpl = aNullString.impl();
+    (void)aNullStringImpl; // placate clang static analyzer.
 
     String anEmptyString { ""_s };
     StringImpl* anEmptyStringImpl = anEmptyString.impl();
+    (void)anEmptyStringImpl; // placate clang static analyzer.
 
     auto an8BitString = String::fromLatin1("résumé");
     StringImpl* an8BitStringImpl = an8BitString.impl();
+    (void)an8BitStringImpl; // placate clang static analyzer.
 
     String a16BitString = utf16String(u"\u1680Cappuccino\u1680");
     StringImpl* a16BitStringImpl = a16BitString.impl();
+    (void)a16BitStringImpl; // placate clang static analyzer.
 
     Vector<int> anEmptyVector;
     Vector<int> aVectorWithOneItem;


### PR DESCRIPTION
#### 3c662d3260630699a57d988c2b7768b2e306b76e
<pre>
Fix miscellaneous complaints of the clang static analyzer.
<a href="https://bugs.webkit.org/show_bug.cgi?id=275038">https://bugs.webkit.org/show_bug.cgi?id=275038</a>
<a href="https://rdar.apple.com/129144030">rdar://129144030</a>

Reviewed by NOBODY (OOPS!).

1. Address unneeded variable initializations in a few ways:
   a. Where the variable is clearly unused or overridden after initialization, remove the variable.

      In 3rd party code, just comment out the initialization with an added comment that this is to placate the static analyzer.
      This makes it easier for folks doing an update of the 3rd party code later to understand why this change was made, and
      decide how to handle merge conflicts.

   b. Where the variable initialization is part of a repeated idiom.

      For example, a parser may parse for a sequence of words. The parser is therefore made up of blobs of code to parse
      for each word in the sequence.  Each code blob is expected to follow an idiom of advancing the cursor when it&apos;s done.
      This enables the next code blob to parse for the next word.

      When we get to the last word, technically we can elide the cursor advance in the last code blob because no one is
      currently dependent on the cursor beyond this point.  However, this opens up an opportunity for a bug to be introduced
      later.  In the future, if someone adds more code blobs to parse additional words downstream, the new code blobs will
      expect the previous last code blob to follow the idiom and advance the cursor.  Our elision broke the idiom, thereby
      introducing a bug in the new code, unless we remember to go back an un-elide the cursor advance.

      For cases like this, it&apos;s better to just keep the unneeded initialization.  Instead, we&apos;ll add a `(void)var` (which is
      what the UNUSED_PARAM macro does) to placate the static analyzer.

   c. Where the variable initialization is in a body of code deemed to be somewhat complex.

      Similar to (2), while it is possible to determine that the variable will be unused thereafter, it is difficult for
      future code that gets added to realize that the variable wasn&apos;t updated.  As a result, this is an opportunity for
      introducing bugs.  So, instead of eliding the initialization, we apply the solution in (2) to placate the static
      analyzer.

2. In 1st party code where possible and appropriate, we&apos;ll reshape the code to move variable initializations to where they
   are needed e.g. inside a `if (verbose)` code block.  This avoids initializing the variable when unneeded.

3. For cases of uninitialized variables in non-performance sensitive code (e.g. AllowUnfinalizedAccessScope), we&apos;ll just
   initialize the variables (though unneeded) to placate the static analyzer.

These changes resolves about 300 clang static analyzer warnings from building all of WebKit.

* Source/JavaScriptCore/API/tests/TypedArrayCTest.cpp:
(testConstructors):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/bytecode/ArithProfile.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::emitDOMJITGetter):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::BinaryOpNode::emitBytecode):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::isLiveInBytecode):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileArithMinOrMax):
* Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp:
(Inspector::InspectorRuntimeAgent::getRuntimeTypesForVariablesAtOffsets):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::unwind):
* Source/JavaScriptCore/runtime/IntlNumberFormat.cpp:
(JSC::IntlNumberFormat::formatRangeToPartsInternal):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::putOwnDataPropertyBatching):
* Source/JavaScriptCore/runtime/Options.h:
* Source/JavaScriptCore/runtime/TypeSet.cpp:
(JSC::TypeSet::toJSONString const):
* Source/JavaScriptCore/tools/VMInspector.cpp:
(JSC::VMInspector::dumpCellMemoryToStream):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitAtomicStoreOp):
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::tryCreateInterpretedJSToWasmCallee):
* Source/ThirdParty/ANGLE/src/compiler/translator/Symbol.cpp:
(sh::TSymbol::name const):
* Source/ThirdParty/ANGLE/src/compiler/translator/glsl/OutputGLSLBase.cpp:
(sh::TOutputGLSLBase::visitUnary):
* Source/ThirdParty/ANGLE/src/compiler/translator/tree_util/IntermTraverse.cpp:
(sh::TLValueTrackingTraverser::traverseBinary):
(sh::TLValueTrackingTraverser::traverseUnary):
(sh::TIntermTraverser::traverseFunctionDefinition):
(sh::TIntermTraverser::traverseBlock):
(sh::TLValueTrackingTraverser::traverseAggregate):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/FramebufferGL.cpp:
(rx::FramebufferGL::adjustSrcDstRegion):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/renderergl_utils.cpp:
(rx::nativegl_gl::InitializeFeatures):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/TextureMtl.mm:
(rx::TextureMtl::generateMipmapCPU):
* Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/pem/pem_lib.c:
(PEM_ASN1_write_bio):
(PEM_do_header):
* Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/pem/pem_pk8.c:
(do_pk8pkey):
(d2i_PKCS8PrivateKey_bio):
* Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/pem/pem_pkey.c:
(PEM_read_bio_PrivateKey):
* Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/crypto/x509/by_dir.c:
(get_cert_by_subject):
* Source/ThirdParty/libwebrtc/Source/third_party/boringssl/src/ssl/ssl_cipher.cc:
* Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/aom_dsp/arm/mem_neon.h:
(store_u8_8x2):
(load_u16_4x4):
(load_u16_8x4):
(load_u16_4x5):
(load_u16_8x5):
(load_unaligned_u16_4x2):
* Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/common/arm/selfguided_neon.c:
(boxsum2):
(boxsum1):
(final_filter_fast_internal):
* Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/common/arm/wiener_convolve_neon.c:
(process_row_for_horz_filtering):
(av1_wiener_convolve_add_src_neon):
* Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/encoder/arm/neon/pickrst_neon.c:
(find_average_neon):
* Source/ThirdParty/libwebrtc/Source/third_party/libsrtp/srtp/srtp.c:
(srtp_stream_init_keys):
* Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp8/common/arm/neon/bilinearpredict_neon.c:
(vp8_bilinear_predict16x16_neon):
* Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp8/common/arm/neon/iwalsh_neon.c:
(vp8_short_inv_walsh4x4_neon):
* Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_pickmode.c:
(recheck_zeromv_after_denoising):
* Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vpx_dsp/arm/mem_neon.h:
(load_unaligned_u8q):
* Source/ThirdParty/libwebrtc/Source/third_party/libyuv/source/cpu_id.cc:
* Source/ThirdParty/libwebrtc/Source/third_party/yasm/libyasm/errwarn.c:
(yasm_errwarns_output_all):
* Source/ThirdParty/libwebrtc/Source/third_party/yasm/libyasm/section.c:
(yasm_object_optimize):
* Source/ThirdParty/libwebrtc/Source/third_party/yasm/modules/arch/x86/x86expr.c:
(x86_expr_checkea_distcheck_reg):
(x86_expr_checkea_getregusage):
* Source/ThirdParty/libwebrtc/Source/third_party/yasm/modules/objfmts/macho/macho-objfmt.c:
(macho_objfmt_output_symtable):
(macho_objfmt_section_switch):
* Source/ThirdParty/libwebrtc/Source/third_party/yasm/modules/parsers/nasm/nasm-parse.c:
(parse_line):
* Source/ThirdParty/libwebrtc/Source/third_party/yasm/modules/preprocs/gas/gas-eval.c:
(evaluate):
* Source/ThirdParty/libwebrtc/Source/third_party/yasm/modules/preprocs/nasm/nasm-eval.c:
(nasm_evaluate):
* Source/ThirdParty/libwebrtc/Source/third_party/yasm/modules/preprocs/nasm/nasm-pp.c:
(if_condition):
(do_directive):
* Source/ThirdParty/libwebrtc/Source/webrtc/modules/third_party/g711/g711.h:
* Source/ThirdParty/libwebrtc/Source/webrtc/video/receive_statistics_proxy.cc:
* Source/WTF/wtf/SegmentedVector.h:
* Source/WTF/wtf/fast_float/float_common.h:
(fast_float::leading_zeroes_generic):
* Source/WebCore/PAL/ThirdParty/libavif/ThirdParty/dav1d/src/thread_task.c:
(delayed_fg_task):
* Source/bmalloc/libpas/src/libpas/pas_bitfit_page_inlines.h:
(pas_bitfit_page_allocate):
* Source/bmalloc/libpas/src/libpas/pas_expendable_memory.c:
(pas_expendable_memory_commit_if_necessary):
* Source/bmalloc/libpas/src/libpas/pas_generic_large_free_heap.h:
(pas_generic_large_free_heap_try_allocate):
* Source/bmalloc/libpas/src/libpas/pas_large_sharing_pool.c:
(validate_min_heap):
* Source/bmalloc/libpas/src/libpas/pas_local_allocator_inlines.h:
(pas_local_allocator_refill_with_known_config):
* Source/bmalloc/libpas/src/libpas/pas_segregated_directory.c:
(pas_segregated_directory_get_sharing_payload):
* Source/bmalloc/libpas/src/libpas/pas_segregated_partial_view.c:
(pas_segregated_partial_view_set_is_in_use_for_allocation):
(compute_summary):
* Source/bmalloc/libpas/src/libpas/pas_segregated_view_allocator_inlines.h:
(pas_segregated_view_will_start_allocating):
* Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c:
(process_deallocation_log_with_config):
* Tools/lldb/lldbWebKitTester/main.cpp:
(testSummaryProviders):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c662d3260630699a57d988c2b7768b2e306b76e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54046 "11 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6578 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57321 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4770 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56349 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4663 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43763 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3164 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56142 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31651 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24904 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28475 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4096 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2919 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/47403 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50172 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58915 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/53554 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29234 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4394 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51181 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30415 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46900 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50535 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31374 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65855 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30196 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12542 "Passed tests") | 
<!--EWS-Status-Bubble-End-->