### PR TITLE
[Cocoa] Attributed string generation may add unexpected underlines

### DIFF
--- a/Source/WebCore/editing/cocoa/HTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/HTMLConverter.mm
@@ -2480,10 +2480,17 @@ AttributedString editingAttributedString(const SimpleRange& range, OptionSet<Inc
         if (!renderer)
             continue;
         auto& style = renderer->style();
+
         if (style.textDecorationsInEffect() & TextDecorationLine::Underline)
             [attrs setObject:[NSNumber numberWithInteger:NSUnderlineStyleSingle] forKey:NSUnderlineStyleAttributeName];
+        else
+            [attrs removeObjectForKey:NSUnderlineStyleAttributeName];
+
         if (style.textDecorationsInEffect() & TextDecorationLine::LineThrough)
             [attrs setObject:[NSNumber numberWithInteger:NSUnderlineStyleSingle] forKey:NSStrikethroughStyleAttributeName];
+        else
+            [attrs removeObjectForKey:NSStrikethroughStyleAttributeName];
+
         if (auto ctFont = style.fontCascade().primaryFont().getCTFont())
             [attrs setObject:(__bridge PlatformFont *)ctFont forKey:NSFontAttributeName];
         else {


### PR DESCRIPTION
#### 5f91eea75bc29b4f5d48f83fc4596afe5e0b149e
<pre>
[Cocoa] Attributed string generation may add unexpected underlines
<a href="https://bugs.webkit.org/show_bug.cgi?id=275041">https://bugs.webkit.org/show_bug.cgi?id=275041</a>
<a href="https://rdar.apple.com/128204838">rdar://128204838</a>

Reviewed by Richard Robinson and Wenson Hsieh.

`editingAttributedString` generates attributed strings from document ranges using
`TextIterator`. When a renderer with `TextDecorationLine::Underline` is
encountered, `NSUnderlineStyleAttributeName` is added to the attribute dictionary.
However, the attribute dictionary is created outside of the iterative loop and is
reused. Consequently, encountering a single underline currently applies an underline
style to all subsequent text.

Fix by removing `NSUnderlineStyleAttributeName` from the attribute dictionary when
it is not needed. This matches the approach used for other attributes, such as
`NSForegroundColorAttributeName`.

* Source/WebCore/editing/cocoa/HTMLConverter.mm:
(WebCore::editingAttributedString):

Canonical link: <a href="https://commits.webkit.org/279664@main">https://commits.webkit.org/279664@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/429585d90342971b569a3e504ed80ead5e79602b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6581 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57324 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4773 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56352 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4666 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43766 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3167 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56145 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46787 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24907 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28481 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4102 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2922 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50176 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4304 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58918 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29238 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4397 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51182 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30419 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50536 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31376 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8017 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30199 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->