### PR TITLE
[MultiRep HEIC] Add support for matching style via drag and drop

### DIFF
--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -645,7 +645,7 @@ bool DragController::concludeEditDrag(const DragData& dragData)
                 OptionSet<ReplaceSelectionCommand::CommandOption> options { ReplaceSelectionCommand::SelectReplacement, ReplaceSelectionCommand::PreventNesting };
                 if (dragData.canSmartReplace())
                     options.add(ReplaceSelectionCommand::SmartReplace);
-                if (chosePlainText)
+                if (chosePlainText || dragData.shouldMatchStyleOnDrop())
                     options.add(ReplaceSelectionCommand::MatchStyle);
                 ReplaceSelectionCommand::create(protectedDocumentUnderMouse().releaseNonNull(), fragment.releaseNonNull(), options, EditAction::InsertFromDrop)->apply();
             }

--- a/Source/WebCore/platform/DragData.h
+++ b/Source/WebCore/platform/DragData.h
@@ -124,6 +124,8 @@ public:
     bool containsPromise() const;
 #endif
 
+    bool shouldMatchStyleOnDrop() const;
+
     std::optional<PageIdentifier> pageID() const { return m_pageID; }
 
     std::unique_ptr<PasteboardContext> createPasteboardContext() const;

--- a/Source/WebCore/platform/cocoa/DragDataCocoa.mm
+++ b/Source/WebCore/platform/cocoa/DragDataCocoa.mm
@@ -43,6 +43,10 @@
 #import <MobileCoreServices/MobileCoreServices.h>
 #endif
 
+#if USE(APPLE_INTERNAL_SDK)
+#include <WebKitAdditions/MultiRepresentationHEICAdditions.h>
+#endif
+
 namespace WebCore {
 
 static inline String rtfPasteboardType()
@@ -182,6 +186,18 @@ bool DragData::containsURLTypeIdentifier() const
 bool DragData::canSmartReplace() const
 {
     return Pasteboard(createPasteboardContext(), m_pasteboardName).canSmartReplace();
+}
+
+bool DragData::shouldMatchStyleOnDrop() const
+{
+#if ENABLE(MULTI_REPRESENTATION_HEIC)
+    Vector<String> types;
+    auto context = createPasteboardContext();
+    platformStrategies()->pasteboardStrategy()->getTypes(types, m_pasteboardName, context.get());
+    return types.contains(MULTI_REPRESENTATION_HEIC_PASTEBOARD_TYPE_STRING);
+#else
+    return false;
+#endif
 }
 
 bool DragData::containsColor() const

--- a/Source/WebCore/platform/gtk/DragDataGtk.cpp
+++ b/Source/WebCore/platform/gtk/DragDataGtk.cpp
@@ -89,4 +89,9 @@ String DragData::asURL(FilenameConversionPolicy filenamePolicy, String* title) c
     return m_platformDragData->url().string();
 }
 
+bool DragData::shouldMatchStyleOnDrop() const
+{
+    return false;
+}
+
 }

--- a/Source/WebCore/platform/win/DragDataWin.cpp
+++ b/Source/WebCore/platform/win/DragDataWin.cpp
@@ -200,4 +200,9 @@ Color DragData::asColor() const
     return Color();
 }
 
+bool DragData::shouldMatchStyleOnDrop() const
+{
+    return false;
+}
+
 }


### PR DESCRIPTION
#### dc64ddecd5016f366828681647a09813f67c2f51
<pre>
[MultiRep HEIC] Add support for matching style via drag and drop
<a href="https://bugs.webkit.org/show_bug.cgi?id=275042">https://bugs.webkit.org/show_bug.cgi?id=275042</a>
<a href="https://rdar.apple.com/128092529">rdar://128092529</a>

Reviewed by Richard Robinson, Abrar Rahman Protyasha and Wenson Hsieh.

* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::concludeEditDrag):
* Source/WebCore/platform/DragData.h:
* Source/WebCore/platform/cocoa/DragDataCocoa.mm:
(WebCore::DragData::shouldMatchStyleOnDrop const):

Consult declared pasteboard types to decide whether to match style when dropping
a multi-representation HEIC into web content.

* Source/WebCore/platform/gtk/DragDataGtk.cpp:
(WebCore::DragData::shouldMatchStyleOnDrop const):
* Source/WebCore/platform/win/DragDataWin.cpp:
(WebCore::DragData::shouldMatchStyleOnDrop const):

Canonical link: <a href="https://commits.webkit.org/279666@main">https://commits.webkit.org/279666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d55fc40ad3d6c669c88778611bd1f7d8f5f9bba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33433 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57330 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4779 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56358 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40950 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4672 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43771 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3169 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46791 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24912 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28486 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4104 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2928 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50185 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58924 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29244 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4403 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51187 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30425 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50542 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31383 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8019 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30205 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->