### PR TITLE
Get Upstream Commit reference for people using a local source

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_importer.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer.py
@@ -79,6 +79,7 @@ except ImportError:
 
 from webkitpy.common.host import Host
 from webkitpy.common.system.filesystem import FileSystem
+from webkitpy.common.system.executive import ScriptError
 from webkitpy.common.webkit_finder import WebKitFinder
 from webkitpy.port.factory import PortFactory
 from webkitpy.layout_tests.controllers.layout_test_finder_legacy import LayoutTestFinder
@@ -209,7 +210,14 @@ class TestImporter(object):
         }
 
     def do_import(self):
-        if not self.source_directory:
+        if self.source_directory:
+            source_path = str(Path(self.source_directory) / 'web-platform-tests')
+            try:
+                git = self.test_downloader().git(source_path)
+                self.upstream_revision = git.rev_parse('HEAD')
+            except (OSError, ScriptError):
+                pass
+        else:
             _log.info('Downloading W3C test repositories')
             self.filesystem.maybe_make_directory(self.tests_download_path)
             self.test_downloader().download_tests(self.options.use_tip_of_tree)


### PR DESCRIPTION
#### 83de710ceb2c01600466ced314d13874b4aa6d1b
<pre>
Get Upstream Commit reference for people using a local source
<a href="https://bugs.webkit.org/show_bug.cgi?id=272142">https://bugs.webkit.org/show_bug.cgi?id=272142</a>
<a href="https://rdar.apple.com/125894887">rdar://125894887</a>

Reviewed by Jonathan Bedard.

This provides the hash of the HEAD for people using a local checkout
of WPT tests. This is a followup on webkit.org/b/248445 which gave
this information for people using the remote checkout. We wrapped in
a try/except to make sure the directory was really a checkout of a repo.

It makes it possible for people to directly copy paste in the commit
message the hash of the WPT checkout when they import
or re-import WPT tests.

Example:
--------- Please include the following in your commit message: ---------
Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/3324586879a38951098d072bf5ae8f56408a9afa">https://github.com/web-platform-tests/wpt/commit/3324586879a38951098d072bf5ae8f56408a9afa</a>
------------------------------------------------------------------------

* Tools/Scripts/webkitpy/w3c/test_downloader.py:
(TestDownloader.checkout_test_repository):
(TestDownloader):
(TestDownloader.get_rev_parse_head):
* Tools/Scripts/webkitpy/w3c/test_importer.py:
(TestImporter.do_import):

Canonical link: <a href="https://commits.webkit.org/279698@main">https://commits.webkit.org/279698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a58ce5c68db42793a965f28038f4457bf418926c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54173 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57449 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4897 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56476 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4877 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43871 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3274 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56269 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31806 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46908 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25018 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/54005 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4228 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3046 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50320 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4433 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59042 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29376 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/4622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51291 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30548 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47020 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50647 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11810 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31518 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30328 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->