### PR TITLE
Incorrect Sec-Fetch-Site values on sandboxed iframes

### DIFF
--- a/LayoutTests/http/wpt/fetch/fetch-metadata-for-sandbox-iframes-expected.txt
+++ b/LayoutTests/http/wpt/fetch/fetch-metadata-for-sandbox-iframes-expected.txt
@@ -1,0 +1,8 @@
+
+PASS same-origin iframe
+PASS same-origin sandboxed iframe
+PASS same-origin redirect iframe
+PASS same-origin redirect sandboxed iframe
+PASS cross-origin redirect iframe
+PASS cross-origin redirect sandboxed iframe
+

--- a/LayoutTests/http/wpt/fetch/fetch-metadata-for-sandbox-iframes-reuse-expected.txt
+++ b/LayoutTests/http/wpt/fetch/fetch-metadata-for-sandbox-iframes-reuse-expected.txt
@@ -1,0 +1,9 @@
+
+PASS same-origin redirect iframe
+PASS same-origin redirect sandboxed iframe
+PASS cross-origin redirect iframe
+PASS cross-origin redirect sandboxed iframe
+PASS same-origin iframe
+PASS same-origin sandboxed iframe
+PASS Remove iframes
+

--- a/LayoutTests/http/wpt/fetch/fetch-metadata-for-sandbox-iframes-reuse.html
+++ b/LayoutTests/http/wpt/fetch/fetch-metadata-for-sandbox-iframes-reuse.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/fetch/metadata/resources/helper.js></script>
+<script src=/common/utils.js></script>
+<body>
+<iframe id=frameWithoutSandbox></iframe>
+<iframe id=frameWithSandbox sandbox="allow-scripts"></iframe>
+</body>
+<script>
+function load_iframe(test, url, shouldSandbox) {
+    return new Promise((resolve, reject) => {
+        setTimeout(() => reject("message frame timed out"), 5000);
+        if (shouldSandbox)
+            frameWithSandbox.src = url;
+        else
+            frameWithoutSandbox.src = url;
+        window.onmessage = e => resolve(e.data);
+    });
+}
+
+async function getFrameSecFetchSite(test, options)
+{
+    const nonce = token();
+    const path = "/WebKit/fetch/resources/sec-fetch-site.py?nonce=" + nonce;
+
+    const finalURL = options.isCrossOriginFinalURL ? "http://127.0.0.1:8800" : "http://localhost:8800" + path;
+
+    let url = finalURL
+    if (options.shouldRedirect) {
+        url = "/xhr/resources/redirect.py?location=" + encodeURIComponent(url);
+        if (options.shouldRedirectCrossOrigin)
+            url = "http://127.0.0.1:8800" + url;
+    }
+    return await load_iframe(test, url, options.shouldSandbox);
+}
+
+promise_test(async t => {
+    const result = await getFrameSecFetchSite(t, { shouldRedirect: true });
+    assert_equals(result, "same-origin");
+}, "same-origin redirect iframe");
+
+promise_test(async t => {
+    const result = await getFrameSecFetchSite(t, { shouldRedirect: true, shouldSandbox : true });
+    assert_equals(result, "same-origin");
+}, "same-origin redirect sandboxed iframe");
+
+promise_test(async t => {
+    const result = await getFrameSecFetchSite(t, { shouldRedirect: true, shouldRedirectCrossOrigin: true });
+    assert_equals(result, "cross-site");
+}, "cross-origin redirect iframe");
+
+promise_test(async t => {
+    const result = await getFrameSecFetchSite(t, { shouldRedirect: true, shouldRedirectCrossOrigin: true, shouldSandbox : true });
+    assert_equals(result, "cross-site");
+}, "cross-origin redirect sandboxed iframe");
+
+promise_test(async t => {
+    const result = await getFrameSecFetchSite(t, { });
+    assert_equals(result, "same-origin");
+}, "same-origin iframe");
+
+promise_test(async t => {
+    const result = await getFrameSecFetchSite(t, { shouldSandbox : true });
+    assert_equals(result, "same-origin");
+}, "same-origin sandboxed iframe");
+
+promise_test(async t => {
+    frameWithSandbox.remove();
+    frameWithoutSandbox.remove();
+}, "Remove iframes");
+</script>

--- a/LayoutTests/http/wpt/fetch/fetch-metadata-for-sandbox-iframes.html
+++ b/LayoutTests/http/wpt/fetch/fetch-metadata-for-sandbox-iframes.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src=/fetch/metadata/resources/helper.js></script>
+<script src=/common/utils.js></script>
+<body></body>
+<script>
+function load_iframe(test, url, shouldSandbox) {
+    return new Promise((resolve, reject) => {
+        setTimeout(() => reject("message frame timed out"), 5000);
+        const frame = document.createElement('iframe');
+        test.add_cleanup(() => frame.remove());
+        if (shouldSandbox)
+            frame.sandbox = "allow-scripts";
+        frame.src = url;
+        window.onmessage = e => resolve(e.data);
+        document.body.appendChild(frame);
+    });
+}
+
+async function getFrameSecFetchSite(test, options)
+{
+    const nonce = token();
+    const path = "/WebKit/fetch/resources/sec-fetch-site.py?nonce=" + nonce;
+
+    const finalURL = options.isCrossOriginFinalURL ? "http://127.0.0.1:8800" : "http://localhost:8800" + path;
+
+    let url = finalURL
+    if (options.shouldRedirect) {
+        url = "/xhr/resources/redirect.py?location=" + encodeURIComponent(url);
+        if (options.shouldRedirectCrossOrigin)
+            url = "http://127.0.0.1:8800" + url;
+    }
+    return await load_iframe(test, url, options.shouldSandbox);
+}
+
+promise_test(async t => {
+    const result = await getFrameSecFetchSite(t, { });
+    assert_equals(result, "same-origin");
+}, "same-origin iframe");
+
+promise_test(async t => {
+    const result = await getFrameSecFetchSite(t, { shouldSandbox : true });
+    assert_equals(result, "same-origin");
+}, "same-origin sandboxed iframe");
+
+promise_test(async t => {
+    const result = await getFrameSecFetchSite(t, { shouldRedirect: true });
+    assert_equals(result, "same-origin");
+}, "same-origin redirect iframe");
+
+promise_test(async t => {
+    const result = await getFrameSecFetchSite(t, { shouldRedirect: true, shouldSandbox : true });
+    assert_equals(result, "same-origin");
+}, "same-origin redirect sandboxed iframe");
+
+promise_test(async t => {
+    const result = await getFrameSecFetchSite(t, { shouldRedirect: true, shouldRedirectCrossOrigin: true });
+    assert_equals(result, "cross-site");
+}, "cross-origin redirect iframe");
+
+promise_test(async t => {
+    const result = await getFrameSecFetchSite(t, { shouldRedirect: true, shouldRedirectCrossOrigin: true, shouldSandbox : true });
+    assert_equals(result, "cross-site");
+}, "cross-origin redirect sandboxed iframe");
+
+</script>

--- a/LayoutTests/http/wpt/fetch/resources/sec-fetch-site.py
+++ b/LayoutTests/http/wpt/fetch/resources/sec-fetch-site.py
@@ -1,0 +1,11 @@
+import os
+import hashlib
+import json
+
+from wptserve.utils import isomorphic_decode
+
+
+def main(request, response):
+    secFetchSite = request.headers.get(b"sec-fetch-site", b"")
+    response.headers.set(b"Content-Type", b"text/html")
+    return b"<html><script>window.parent.postMessage('" + secFetchSite + b"', '*');</script></html>"

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -69,6 +69,8 @@ enum class CachePolicy : uint8_t;
 enum class ImageLoading : uint8_t { Immediate, DeferredUntilVisible };
 enum class FetchMetadataSite : uint8_t { None, SameOrigin, SameSite, CrossSite };
 
+const String& convertEnumerationToString(FetchMetadataSite);
+
 // The CachedResourceLoader provides a per-context interface to the MemoryCache
 // and enforces a bunch of security checks and rules for resource revalidation.
 // Its lifetime is roughly per-DocumentLoader, in that it is generally created
@@ -173,7 +175,8 @@ public:
 
     Vector<CachedResourceHandle<CachedResource>> visibleResourcesToPrioritize();
 
-    static FetchMetadataSite computeFetchMetadataSite(const ResourceRequest&, CachedResource::Type, FetchOptions::Mode, const SecurityOrigin& originalOrigin, FetchMetadataSite originalSite, bool isDirectlyUserInitiatedRequest);
+    static FetchMetadataSite computeFetchMetadataSite(const ResourceRequest&, CachedResource::Type, FetchOptions::Mode, const LocalFrame&, bool isDirectlyUserInitiatedRequest);
+    static FetchMetadataSite computeFetchMetadataSiteAfterRedirection(const ResourceRequest&, CachedResource::Type, FetchOptions::Mode, const SecurityOrigin& originalOrigin, FetchMetadataSite originalSite, bool isDirectlyUserInitiatedRequest);
 
 private:
     explicit CachedResourceLoader(DocumentLoader*);


### PR DESCRIPTION
#### deeefb52b7fdf76d21c9d747106deb3045e14119
<pre>
Incorrect Sec-Fetch-Site values on sandboxed iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=260284">https://bugs.webkit.org/show_bug.cgi?id=260284</a>
<a href="https://rdar.apple.com/114340186">rdar://114340186</a>

Reviewed by Brady Eidson.

For navigation loads, we were always using the frame origin to compute sec-fetch-site.
This does not work for initial iframe loads, since the load is made on behalf of the context that created the iframe.
For navigation loads, we are now reyling on the requester origin info from the document loader if available.

* LayoutTests/http/wpt/fetch/fetch-metadata-for-sandbox-iframes-expected.txt: Added.
* LayoutTests/http/wpt/fetch/fetch-metadata-for-sandbox-iframes-reuse-expected.txt: Added.
* LayoutTests/http/wpt/fetch/fetch-metadata-for-sandbox-iframes-reuse.html: Added.
* LayoutTests/http/wpt/fetch/fetch-metadata-for-sandbox-iframes.html: Added.
* LayoutTests/http/wpt/fetch/resources/sec-fetch-site.py: Added.
(main):
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::SubresourceLoader):
(WebCore::SubresourceLoader::willSendRequestInternal):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::convertEnumerationToString):
(WebCore::computeFetchMetadataSiteInternal):
(WebCore::CachedResourceLoader::computeFetchMetadataSite):
(WebCore::CachedResourceLoader::computeFetchMetadataSiteAfterRedirection):
(WebCore::CachedResourceLoader::updateHTTPRequestHeaders):
* Source/WebCore/loader/cache/CachedResourceLoader.h:

Canonical link: <a href="https://commits.webkit.org/280065@main">https://commits.webkit.org/280065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b129162285da62711fc255272961b555a9454299

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55523 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34846 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58507 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5953 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57649 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42468 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44712 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4087 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57552 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32753 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47852 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25840 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29537 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5180 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4097 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51471 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5448 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60098 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30677 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5570 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52145 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31762 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47922 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51617 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12325 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32843 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31509 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->