### PR TITLE
Make sure the GraphicsContextGL is protected in WebGLBlendFuncExtended

### DIFF
--- a/Source/WebCore/html/canvas/WebGLBlendFuncExtended.cpp
+++ b/Source/WebCore/html/canvas/WebGLBlendFuncExtended.cpp
@@ -37,7 +37,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WebGLBlendFuncExtended);
 WebGLBlendFuncExtended::WebGLBlendFuncExtended(WebGLRenderingContextBase& context)
     : WebGLExtension(context, WebGLExtensionName::WebGLBlendFuncExtended)
 {
-    context.graphicsContextGL()->ensureExtensionEnabled("GL_EXT_blend_func_extended"_s);
+    context.protectedGraphicsContextGL()->ensureExtensionEnabled("GL_EXT_blend_func_extended"_s);
 }
 
 WebGLBlendFuncExtended::~WebGLBlendFuncExtended() = default;


### PR DESCRIPTION
#### c07095b5fcd9185d3c6a331c55fbbed549408d15
<pre>
Make sure the GraphicsContextGL is protected in WebGLBlendFuncExtended
<a href="https://bugs.webkit.org/show_bug.cgi?id=275049">https://bugs.webkit.org/show_bug.cgi?id=275049</a>

Reviewed by Kimmo Kinnunen.

Use protectedGraphicsContextGL there.

* Source/WebCore/html/canvas/WebGLBlendFuncExtended.cpp:
(WebCore::WebGLBlendFuncExtended::WebGLBlendFuncExtended):

Canonical link: <a href="https://commits.webkit.org/279693@main">https://commits.webkit.org/279693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8aab0230170480e098aba2213a6a1281a93a3f80

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33456 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6611 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57352 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4801 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56380 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/40974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4694 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43790 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3187 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31691 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46812 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24932 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28509 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4128 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2950 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50213 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4331 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58946 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29269 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4430 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51206 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30447 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46928 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50565 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11806 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31411 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30229 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->