### PR TITLE
PlaceholderRenderingContext is not consistent wrt isGPUBased() accessor

### DIFF
--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -172,11 +172,7 @@ private:
 
     void setSurfaceSize(const IntSize&);
 
-    bool paintsIntoCanvasBuffer() const;
-
-    bool isGPUBased() const;
-
-    bool shouldNotifyRendererOnDidDraw() const;
+    bool usesContentsAsLayerContents() const;
 
     void refCanvasBase() const final { HTMLElement::ref(); }
     void derefCanvasBase() const final { HTMLElement::deref(); }

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
@@ -98,6 +98,11 @@ bool CanvasRenderingContext::isSurfaceBufferTransparentBlack(SurfaceBuffer) cons
     return false;
 }
 
+bool CanvasRenderingContext::delegatesDisplay() const
+{
+    return false;
+}
+
 RefPtr<GraphicsLayerContentsDisplayDelegate> CanvasRenderingContext::layerContentsDisplayDelegate()
 {
     return nullptr;

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -72,7 +72,6 @@ public:
     bool isWebGL() const { return isWebGL1() || isWebGL2(); }
     virtual bool isWebGPU() const { return false; }
     virtual bool isGPUBased() const { return false; }
-    virtual bool isAccelerated() const { return false; }
     virtual bool isBitmapRenderer() const { return false; }
     virtual bool isPlaceholder() const { return false; }
     virtual bool isOffscreen2d() const { return false; }
@@ -93,6 +92,7 @@ public:
     // Draws the source buffer to the canvasBase().buffer().
     virtual RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer);
     virtual bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const;
+    virtual bool delegatesDisplay() const;
     virtual RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate();
     virtual void setContentsToLayer(GraphicsLayer&);
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -254,12 +254,8 @@ CanvasRenderingContext2DBase::~CanvasRenderingContext2DBase()
 
 bool CanvasRenderingContext2DBase::isAccelerated() const
 {
-#if USE(IOSURFACE_CANVAS_BACKING_STORE) || USE(SKIA)
     auto* context = existingDrawingContext();
     return context && context->renderingMode() == RenderingMode::Accelerated;
-#else
-    return false;
-#endif
 }
 
 bool CanvasRenderingContext2DBase::isSurfaceBufferTransparentBlack(SurfaceBuffer) const
@@ -269,12 +265,19 @@ bool CanvasRenderingContext2DBase::isSurfaceBufferTransparentBlack(SurfaceBuffer
     return !canvasBase().hasCreatedImageBuffer();
 }
 
+#if USE(SKIA)
+bool CanvasRenderingContext2DBase::delegatesDisplay() const
+{
+    return isAccelerated();
+}
+
 RefPtr<GraphicsLayerContentsDisplayDelegate> CanvasRenderingContext2DBase::layerContentsDisplayDelegate()
 {
     if (auto buffer = canvasBase().buffer())
         return buffer->layerContentsDisplayDelegate();
     return nullptr;
 }
+#endif
 
 bool CanvasRenderingContext2DBase::hasDeferredOperations() const
 {

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -98,6 +98,8 @@ protected:
 public:
     virtual ~CanvasRenderingContext2DBase();
 
+    bool isAccelerated() const;
+
     const CanvasRenderingContext2DSettings& getContextAttributes() const { return m_settings; }
     using RenderingMode = WebCore::RenderingMode;
     std::optional<RenderingMode> getEffectiveRenderingModeForTesting();
@@ -458,10 +460,11 @@ private:
 
     template<class T> void fullCanvasCompositedDrawImage(T&, const FloatRect&, const FloatRect&, CompositeOperator);
 
-    bool isAccelerated() const override;
     bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const override;
+#if USE(SKIA)
+    bool delegatesDisplay() const override;
     RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() override;
-
+#endif
     bool hasDeferredOperations() const final;
     void flushDeferredOperations() final;
 

--- a/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
@@ -41,7 +41,7 @@ public:
     void deref() const final { CanvasRenderingContext::deref(); }
 
     bool isGPUBased() const override { return true; }
-    bool isAccelerated() const override { return true; }
+    bool delegatesDisplay() const override { return true; }
 
     virtual void reshape(int width, int height, int oldWidth, int oldHeight) = 0;
 protected:

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
@@ -64,11 +64,6 @@ ImageBitmapCanvas ImageBitmapRenderingContext::canvas()
     return &downcast<HTMLCanvasElement>(base);
 }
 
-bool ImageBitmapRenderingContext::isAccelerated() const
-{
-    return false;
-}
-
 void ImageBitmapRenderingContext::setOutputBitmap(RefPtr<ImageBitmap> imageBitmap)
 {
     // 1. If a bitmap argument was not provided, then:

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
@@ -67,7 +67,6 @@ private:
     ImageBitmapRenderingContext(CanvasBase&, ImageBitmapRenderingContextSettings&&);
 
     bool isBitmapRenderer() const final { return true; }
-    bool isAccelerated() const override;
     RefPtr<ImageBuffer> transferToImageBuffer() final;
 
     void setOutputBitmap(RefPtr<ImageBitmap>);

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
@@ -45,9 +45,7 @@ public:
 
 private:
     bool isPlaceholder() const final { return true; }
-
-    bool isAccelerated() const final { return !!m_imageBufferPipe; }
-    bool isGPUBased() const final { return !!m_imageBufferPipe; }
+    bool delegatesDisplay() const final { return true; }
     void setContentsToLayer(GraphicsLayer&);
 
     RefPtr<ImageBufferPipe> m_imageBufferPipe;

--- a/Source/WebCore/rendering/RenderHTMLCanvas.cpp
+++ b/Source/WebCore/rendering/RenderHTMLCanvas.cpp
@@ -39,6 +39,7 @@
 #include "RenderBoxInlines.h"
 #include "RenderBoxModelObjectInlines.h"
 #include "RenderLayer.h"
+#include "RenderLayerBacking.h"
 #include "RenderStyleInlines.h"
 #include "RenderView.h"
 #include <wtf/IsoMallocInlines.h>
@@ -67,10 +68,7 @@ bool RenderHTMLCanvas::requiresLayer() const
     if (RenderReplaced::requiresLayer())
         return true;
 
-    if (CanvasRenderingContext* context = canvasElement().renderingContext())
-        return context->isAccelerated();
-
-    return false;
+    return canvasCompositingStrategy(*this) != CanvasPaintedToEnclosingLayer;
 }
 
 void RenderHTMLCanvas::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOffset)

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -461,7 +461,7 @@ private:
 };
 
 enum CanvasCompositingStrategy {
-    UnacceleratedCanvas,
+    CanvasPaintedToEnclosingLayer,
     CanvasPaintedToLayer,
     CanvasAsLayerContents
 };


### PR DESCRIPTION
#### bd385cf6b6e514e2458d87d0a0705da7814835e0
<pre>
PlaceholderRenderingContext is not consistent wrt isGPUBased() accessor
<a href="https://bugs.webkit.org/show_bug.cgi?id=275053">https://bugs.webkit.org/show_bug.cgi?id=275053</a>
<a href="https://rdar.apple.com/129160039">rdar://129160039</a>

Reviewed by Antti Koivisto.

CanvasRenderingContext::isGPUBased() was used for two
conflicting purposes:
 1. Downcasting to GPUBasedCanvasRenderingContext
 2. Forcing RenderLayerBacking creation for canvas RenderLayers.

1. is a bit dangerous, as PlaceholderRenderingContext is-not-a
GPUBasedCanvasRenderingContext.

Forcing RenderLayerBacking / RenderLayer creation also used
CanvasRenderingContext::isAccelerated().

Rename CanvasRenderingContext::isAccelerated() to
CanvasRenderingContext::delegatesDisplay(). The property means
that the context is able to directly replace the GraphicsLayer contents.

* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::didDraw):
(WebCore::HTMLCanvasElement::contentsUsedAsLayerContents const):
(WebCore::HTMLCanvasElement::paint):
(WebCore::HTMLCanvasElement::transferControlToOffscreen):
(WebCore::HTMLCanvasElement::shouldNotifyRendererOnDidDraw const): Deleted.
(WebCore::HTMLCanvasElement::paintsIntoCanvasBuffer const): Deleted.
(WebCore::HTMLCanvasElement::isGPUBased const): Deleted.
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/canvas/CanvasRenderingContext.cpp:
(WebCore::CanvasRenderingContext::delegatesDisplay const):
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
(WebCore::CanvasRenderingContext::isGPUBased const):
(WebCore::CanvasRenderingContext::isAccelerated const): Deleted.
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::isAccelerated const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h:
* Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp:
(WebCore::ImageBitmapRenderingContext::isAccelerated const): Deleted.
* Source/WebCore/html/canvas/ImageBitmapRenderingContext.h:
* Source/WebCore/html/canvas/PlaceholderRenderingContext.h:
* Source/WebCore/rendering/RenderHTMLCanvas.cpp:
(WebCore::RenderHTMLCanvas::requiresLayer const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::canvasCompositingStrategy):
(WebCore::RenderLayerBacking::shouldSetContentsDisplayDelegate const):
* Source/WebCore/rendering/RenderLayerBacking.h:

Canonical link: <a href="https://commits.webkit.org/280006@main">https://commits.webkit.org/280006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4da023bb66f04f67189e56f275c463d809a9ed0e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55494 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58479 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5925 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57620 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6121 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44686 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4061 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32724 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47822 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25814 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29508 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5150 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4069 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51440 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60070 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30647 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5542 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52120 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31732 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47892 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51592 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12289 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32814 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31480 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->