### PR TITLE
[Navigation] NavigateEvent hashChange should be false in certain cases

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-pushState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-pushState-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL history.pushState() fires the navigate event assert_false: expected false got true
+PASS history.pushState() fires the navigate event
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-replaceState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-replaceState-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL history.replaceState() fires the navigate event assert_false: expected false got true
+PASS history.replaceState() fires the navigate event
 

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -275,7 +275,7 @@ ExceptionOr<void> History::stateObjectAdded(RefPtr<SerializedScriptValue>&& data
 
     if (RefPtr document = frame->document(); document && document->settings().navigationAPIEnabled()) {
         auto& navigation = document->domWindow()->navigation();
-        if (!navigation.dispatchPushReplaceReloadNavigateEvent(fullURL, stateObjectType == StateObjectType::Push ? NavigationNavigationType::Push : NavigationNavigationType::Replace, true))
+        if (!navigation.dispatchPushReplaceReloadNavigateEvent(fullURL, stateObjectType == StateObjectType::Push ? NavigationNavigationType::Push : NavigationNavigationType::Replace, true, data.get()))
             return { };
     }
 

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -136,7 +136,7 @@ public:
     ExceptionOr<void> updateCurrentEntry(UpdateCurrentEntryOptions&&);
 
     bool dispatchTraversalNavigateEvent(HistoryItem&);
-    bool dispatchPushReplaceReloadNavigateEvent(const URL&, NavigationNavigationType, bool isSameDocument);
+    bool dispatchPushReplaceReloadNavigateEvent(const URL&, NavigationNavigationType, bool isSameDocument, SerializedScriptValue* classicHistoryAPIState = nullptr);
     bool dispatchDownloadNavigateEvent(const URL&, const String& downloadFilename);
 
     void updateForNavigation(Ref<HistoryItem>&&, NavigationNavigationType);
@@ -155,7 +155,7 @@ private:
     Result performTraversal(const String& key, Navigation::Options, FrameLoadType, Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished);
     std::optional<Ref<NavigationHistoryEntry>> findEntryByKey(const String& key);
     ExceptionOr<RefPtr<SerializedScriptValue>> serializeState(JSC::JSValue state);
-    bool innerDispatchNavigateEvent(NavigationNavigationType, Ref<NavigationDestination>&&, const String& downloadRequestFilename);
+    bool innerDispatchNavigateEvent(NavigationNavigationType, Ref<NavigationDestination>&&, const String& downloadRequestFilename, SerializedScriptValue* classicHistoryAPIState = nullptr);
 
     RefPtr<NavigationAPIMethodTracker> maybeSetUpcomingNonTraversalTracker(Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, JSC::JSValue info, RefPtr<SerializedScriptValue>&&);
     RefPtr<NavigationAPIMethodTracker> addUpcomingTrarveseAPIMethodTracker(Ref<DeferredPromise>&& committed, Ref<DeferredPromise>&& finished, const String& key, JSC::JSValue info);


### PR DESCRIPTION
#### 1a99ded3fddd6d32ff97a3c2bd0cb3d332a77e5b
<pre>
[Navigation] NavigateEvent hashChange should be false in certain cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=275054">https://bugs.webkit.org/show_bug.cgi?id=275054</a>

Reviewed by Alex Christensen and Darin Adler.

When determining hashChange now we have one extra requirement [1]:

- event&apos;s classic history API state is null.

[1] <a href="https://github.com/whatwg/html/pull/10393">https://github.com/whatwg/html/pull/10393</a>

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-pushState-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-replaceState-expected.txt:
* Source/WebCore/page/History.cpp:
(WebCore::History::stateObjectAdded):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::innerDispatchNavigateEvent):
(WebCore::Navigation::dispatchPushReplaceReloadNavigateEvent):
* Source/WebCore/page/Navigation.h:

Canonical link: <a href="https://commits.webkit.org/279770@main">https://commits.webkit.org/279770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2114e2a56020055fa249e264643b82d28829957

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57747 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5199 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56771 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5189 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44104 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3483 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56563 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32018 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47168 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25240 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28816 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4497 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3342 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4711 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59338 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29694 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/4868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51529 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/30847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47257 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50899 "Found 1 new API test failure: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/select-all/non-editable (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11894 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/31826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30639 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->