### PR TITLE
Fix page load time regression related to Web Audio

### DIFF
--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
@@ -68,6 +68,12 @@ RemoteAudioDestinationProxy::RemoteAudioDestinationProxy(AudioIOCallback& callba
     , m_numberOfInputChannels(numberOfInputChannels)
     , m_remoteSampleRate(hardwareSampleRate())
 {
+#if PLATFORM(MAC)
+    // On macOS, we are seeing page load time improvements when eagerly creating the Audio destination in the GPU process. See rdar://124071843.
+    RunLoop::current().dispatch([protectedThis = Ref { *this }]() {
+        protectedThis->connection();
+    });
+#endif
 }
 
 uint32_t RemoteAudioDestinationProxy::totalFrameCount() const
@@ -206,20 +212,6 @@ void RemoteAudioDestinationProxy::startRendering(CompletionHandler<void(bool)>&&
 
 void RemoteAudioDestinationProxy::stopRendering(CompletionHandler<void(bool)>&& completionHandler)
 {
-#if PLATFORM(MAC)
-    // FIXME: rdar://104617724
-    // On macOS, page load testing reports a regression on a particular page if we do not
-    // start the GPU process connection and create the audio objects redundantly on a particular earlier
-    // page. This should be fixed once it is understood why.
-    auto* connection = this->connection();
-    if (!connection) {
-        RunLoop::current().dispatch([completionHandler = WTFMove(completionHandler)]() mutable {
-            // Not calling setIsPlaying(false) intentionally to match the pre-regression state.
-            completionHandler(false);
-        });
-        return;
-    }
-#else
     auto* connection = existingConnection();
     if (!connection) {
         RunLoop::current().dispatch([protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)]() mutable {
@@ -228,7 +220,6 @@ void RemoteAudioDestinationProxy::stopRendering(CompletionHandler<void(bool)>&& 
         });
         return;
     }
-#endif
 
     connection->sendWithAsyncReply(Messages::RemoteAudioDestinationManager::StopAudioDestination(m_destinationID), [protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)](bool isPlaying) mutable {
         protectedThis->setIsPlaying(isPlaying);


### PR DESCRIPTION
#### 27afdb06970183b31fd89308d60ffd92714f4202
<pre>
Fix page load time regression related to Web Audio
<a href="https://bugs.webkit.org/show_bug.cgi?id=275057">https://bugs.webkit.org/show_bug.cgi?id=275057</a>
<a href="https://rdar.apple.com/129185678">rdar://129185678</a>

Reviewed by Ben Nham.

We are observing a page load time issue, where it appears to be beneficial to eagerly create an audio
destination in the GPU process. The reason that this improves page load time is likely that creating
an audio destination in the GPU process will prewarm audio related frameworks in the GPU proceess and
benefit subsequent page loads that use audio features. We also resolved the same issue in an earlier
patch. See <a href="https://rdar.apple.com/104617724">rdar://104617724</a>.

* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp:
(WebKit::RemoteAudioDestinationProxy::RemoteAudioDestinationProxy):
(WebKit::RemoteAudioDestinationProxy::stopRendering):

Canonical link: <a href="https://commits.webkit.org/279676@main">https://commits.webkit.org/279676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76aad893cf7866df9e54dfbfdec779fd554bfdec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57412 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4861 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4757 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43843 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3242 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56233 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31763 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46871 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24988 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28573 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3010 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4395 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59006 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29336 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/4503 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/51260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30511 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46985 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31478 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8023 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30292 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->