### PR TITLE
AX: Import WPT accname tests.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_label-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_label-expected.txt
@@ -114,9 +114,6 @@ x	x
 x	x
 
 x
-Undefined aria-label tests
-
-
 Name computation precedence tests
 
 x   x    x  x label    label   x
@@ -245,19 +242,10 @@ PASS label valid on td element
 PASS label valid on tfoot element
 PASS label valid on textarea element
 PASS label valid on list (unordered) element
-FAIL aria-label undefined on img w/ alt assert_equals: <img alt="alt" aria-label="undefined" data-expectedlabel="alt" data-testname="aria-label undefined on img w/ alt" class="ex"> expected "alt" but got "undefined"
-FAIL aria-label undefined on img w/o alt assert_equals: <img aria-label="undefined" data-expectedlabel="" data-testname="aria-label undefined on img w/o alt" class="ex"> expected "" but got "undefined"
-FAIL aria-label undefined on img w/ empty alt assert_equals: <img alt="" aria-label="undefined" data-expectedlabel="" data-testname="aria-label undefined on img w/ empty alt" class="ex"> expected "" but got "undefined"
-FAIL aria-label undefined on img w/o alt but w/ title assert_equals: <img aria-label="undefined" data-expectedlabel="title" data-testname="aria-label undefined on img w/o alt but w/ title" class="ex"> expected "title" but got "undefined"
-FAIL aria-label undefined on img w/ empty alt but w/ title assert_equals: <img alt="" aria-label="undefined" data-expectedlabel="title" data-testname="aria-label undefined on img w/ empty alt but w/ title" class="ex"> expected "title" but got "undefined"
 PASS button's hidden referenced name (display:none) supercedes aria-label
 PASS button's hidden referenced name (visibility:hidden) supercedes aria-label
-FAIL button's hidden referenced name (visibility:hidden) with hidden aria-labelledby traversal falls back to aria-label assert_equals: <button aria-labelledby="span4" aria-label="foo" data-expectedlabel="foo" data-testname="button's hidden referenced name (visibility:hidden) with hidden aria-labelledby traversal falls back to aria-label" class="ex">
-  <span id="span4">
-    <span id="span5" style="visibility:hidden;">label</span>
-  </span>
-  x
-</button> expected "foo" but got "label"
+PASS button's hidden referenced name (visibility:hidden) with hidden aria-labelledby traversal falls back to aria-label
+PASS Hidden button's label should be the empty string
 PASS link's aria-labelledby name supercedes aria-label
 PASS img's aria-label supercedes alt attribute
 PASS svg's aria-label supercedes title tag

--- a/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_label.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_label.html
@@ -154,13 +154,6 @@
 <textarea aria-label="label" data-expectedlabel="label" data-testname="label valid on textarea element" class="ex">x</textarea>
 <ul aria-label="label" data-expectedlabel="label" data-testname="label valid on list (unordered) element" class="ex">x</ul>
 
-<h2>Undefined aria-label tests</h2>
-<img alt="alt" aria-label="undefined" data-expectedlabel="alt" data-testname="aria-label undefined on img w/ alt" class="ex" />
-<img aria-label="undefined" data-expectedlabel="" data-testname="aria-label undefined on img w/o alt" class="ex" />
-<img alt="" aria-label="undefined" data-expectedlabel="" data-testname="aria-label undefined on img w/ empty alt" class="ex" />
-<img aria-label="undefined" data-expectedlabel="title" data-testname="aria-label undefined on img w/o alt but w/ title" class="ex" />
-<img alt="" aria-label="undefined" data-expectedlabel="title" data-testname="aria-label undefined on img w/ empty alt but w/ title" class="ex" />
-
 <h2>Name computation precedence tests</h2>
 <!-- Name computation: https://w3c.github.io/accname/#computation-steps -->
 
@@ -179,16 +172,22 @@ x
   x
 </button>
 
-<button aria-labelledby="span4" aria-label="foo" data-expectedlabel="foo" data-testname="button's hidden referenced name (visibility:hidden) with hidden aria-labelledby traversal falls back to aria-label" class="ex">
-  <span id="span4">
-    <span id="span5" style="visibility:hidden;">label</span>
+<button aria-labelledby="span5" aria-label="foo" data-expectedlabel="foo" data-testname="button's hidden referenced name (visibility:hidden) with hidden aria-labelledby traversal falls back to aria-label" class="ex">
+  <span id="span5">
+    <span id="span6" style="visibility:hidden;">label</span>
   </span>
   x
 </button>
 
+<span style="display: none">
+<button data-expectedlabel="" data-testname="Hidden button's label should be the empty string" class="ex">
+x
+</button>
+</span>
+
 <!-- Step 2B: LabelledBy supercedes 2D: AriaLabel, also see wpt/accname/name/comp_labelledby.html -->
-<a href="#" aria-labelledby="span6" aria-label="foo" data-expectedlabel="label" data-testname="link's aria-labelledby name supercedes aria-label" class="ex">x</a>
-<span id="span6">label</span>
+<a href="#" aria-labelledby="span7" aria-label="foo" data-expectedlabel="label" data-testname="link's aria-labelledby name supercedes aria-label" class="ex">x</a>
+<span id="span7">label</span>
 
 <!-- Step 2C: Embedded Control labelling supercedes 2D: AriaLabel, see wpt/accname/name/comp_embedded_control.html -->
 

--- a/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content-expected.txt
@@ -128,14 +128,6 @@ heading with two nested links referencing image using aria-labelledby
 
 link1 link2   link3
 
-heading with link referencing image using aria-labelledby, that in turn references text element via aria-labelledby
-
-link
-
-heading with link referencing image using aria-labelledby, that in turn references itself and another element via aria-labelledby
-
-link
-
 simple w/ for each child (w/o spaces and display:inline)
 
 onetwothree
@@ -225,14 +217,6 @@ FAIL heading name from content for each child including two nested links using a
   </a>
 </h3> expected "image link2 link3" but got "image link2 image link3"
 PASS link name from content for each child including nested image (referenced elsewhere via labelledby)
-PASS heading with link referencing image using aria-labelledby, that in turn references text element via aria-labelledby
-FAIL heading with link referencing image using aria-labelledby, that in turn references itself and another element via aria-labelledby assert_equals: <h3 data-expectedlabel="image link" data-testname="heading with link referencing image using aria-labelledby, that in turn references itself and another element via aria-labelledby" class="ex">
-  <a href="#" aria-labelledby="nested_image_label4">
-    <span class="note" id="crossref_link2">link</span><!-- this text is skipped the first time around because of aria-labelledby on parent element -->
-  </a>
-  <!-- but it's picked up again (after the self-referencial image alt) in inverse order b/c of cross-referencial aria-labelledby edge case -->
-  <img id="nested_image_label4" alt="image" aria-labelledby="nested_image_label4 crossref_link2" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
-</h3> expected "image link" but got "image image link"
 PASS button name from content for each child (no space, inline)
 PASS heading name from content for each child (no space, inline)
 PASS link name from content for each child (no space, inline)

--- a/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content.html
@@ -232,26 +232,6 @@
   </a>
 </h3>
 
-<!-- cross-referencial edge case-->
-<h1>heading with link referencing image using aria-labelledby, that in turn references text element via aria-labelledby</h1>
-<h3 data-expectedlabel="image link" data-testname="heading with link referencing image using aria-labelledby, that in turn references text element via aria-labelledby" class="ex">
-  <a href="#" aria-labelledby="nested_image_label3">
-    <span class="note" id="crossref_link">link</span><!-- this text is skipped the first time around because of aria-labelledby on parent element -->
-  </a>
-  <!-- but it's picked up again in inverse order b/c of cross-referencial aria-labelledby edge case -->
-  <img id="nested_image_label3" alt="image" aria-labelledby="crossref_link" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
-</h3>
-
-<!-- self-referencial edge case-->
-<h1>heading with link referencing image using aria-labelledby, that in turn references itself and another element via aria-labelledby</h1>
-<h3 data-expectedlabel="image link" data-testname="heading with link referencing image using aria-labelledby, that in turn references itself and another element via aria-labelledby" class="ex">
-  <a href="#" aria-labelledby="nested_image_label4">
-    <span class="note" id="crossref_link2">link</span><!-- this text is skipped the first time around because of aria-labelledby on parent element -->
-  </a>
-  <!-- but it's picked up again (after the self-referencial image alt) in inverse order b/c of cross-referencial aria-labelledby edge case -->
-  <img id="nested_image_label4" alt="image" aria-labelledby="nested_image_label4 crossref_link2" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
-</h3>
-
 
 <!-- Note: The following test is out of line with the spec, but matching two out of three implementations at the time of writing, and spec changes are expeected. -->
 <!-- See details in https://github.com/w3c/accname/issues/205 -->

--- a/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content.tentative-expected.txt
@@ -1,0 +1,18 @@
+heading with link referencing image using aria-labelledby, that in turn references text element via aria-labelledby
+
+link
+
+heading with link referencing image using aria-labelledby, that in turn references itself and another element via aria-labelledby
+
+link
+
+
+PASS heading with link referencing image using aria-labelledby, that in turn references text element via aria-labelledby
+FAIL heading with link referencing image using aria-labelledby, that in turn references itself and another element via aria-labelledby assert_equals: <h3 data-expectedlabel="image link" data-testname="heading with link referencing image using aria-labelledby, that in turn references itself and another element via aria-labelledby" class="ex">
+  <a href="#" aria-labelledby="nested_image_label4">
+    <span class="note" id="crossref_link2">link</span><!-- this text is skipped the first time around because of aria-labelledby on parent element -->
+  </a>
+  <!-- but it's picked up again (after the self-referencial image alt) in inverse order b/c of cross-referencial aria-labelledby edge case -->
+  <img id="nested_image_label4" alt="image" aria-labelledby="nested_image_label4 crossref_link2" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
+</h3> expected "image link" but got "image image link"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content.tentative.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+<head>
+  <title>Name Comp: Name From Content (Tentative)</title>
+  <meta charset="utf-8">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/resources/testdriver.js"></script>
+  <script src="/resources/testdriver-vendor.js"></script>
+  <script src="/resources/testdriver-actions.js"></script>
+  <script src="/wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<!--
+  These aria-labelledby tests may not be valid, pending spec discussion.
+  See https://github.com/w3c/accname/issues/209
+-->
+
+<!-- cross-referencial edge case-->
+<h1>heading with link referencing image using aria-labelledby, that in turn references text element via aria-labelledby</h1>
+<h3 data-expectedlabel="image link" data-testname="heading with link referencing image using aria-labelledby, that in turn references text element via aria-labelledby" class="ex">
+  <a href="#" aria-labelledby="nested_image_label3">
+    <span class="note" id="crossref_link">link</span><!-- this text is skipped the first time around because of aria-labelledby on parent element -->
+  </a>
+  <!-- but it's picked up again in inverse order b/c of cross-referencial aria-labelledby edge case -->
+  <img id="nested_image_label3" alt="image" aria-labelledby="crossref_link" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
+</h3>
+
+<!-- self-referencial edge case-->
+<h1>heading with link referencing image using aria-labelledby, that in turn references itself and another element via aria-labelledby</h1>
+<h3 data-expectedlabel="image link" data-testname="heading with link referencing image using aria-labelledby, that in turn references itself and another element via aria-labelledby" class="ex">
+  <a href="#" aria-labelledby="nested_image_label4">
+    <span class="note" id="crossref_link2">link</span><!-- this text is skipped the first time around because of aria-labelledby on parent element -->
+  </a>
+  <!-- but it's picked up again (after the self-referencial image alt) in inverse order b/c of cross-referencial aria-labelledby edge case -->
+  <img id="nested_image_label4" alt="image" aria-labelledby="nested_image_label4 crossref_link2" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
+</h3>
+
+<script>
+AriaUtils.verifyLabelsBySelector(".ex");
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/accname/name/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/accname/name/w3c-import.log
@@ -22,5 +22,6 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_labelledby.html
 /LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_labelledby_hidden_nodes.html
 /LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content.html
+/LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_text_node.html
 /LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_tooltip.html

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/accname/name/comp_label-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/accname/name/comp_label-expected.txt
@@ -114,9 +114,6 @@ x	x
 x	x
 
 x
-Undefined aria-label tests
-
-
 Name computation precedence tests
 
 x   x    x  x label    label  x
@@ -245,19 +242,10 @@ PASS label valid on td element
 PASS label valid on tfoot element
 PASS label valid on textarea element
 PASS label valid on list (unordered) element
-FAIL aria-label undefined on img w/ alt assert_equals: <img alt="alt" aria-label="undefined" data-expectedlabel="alt" data-testname="aria-label undefined on img w/ alt" class="ex"> expected "alt" but got "undefined"
-FAIL aria-label undefined on img w/o alt assert_equals: <img aria-label="undefined" data-expectedlabel="" data-testname="aria-label undefined on img w/o alt" class="ex"> expected "" but got "undefined"
-FAIL aria-label undefined on img w/ empty alt assert_equals: <img alt="" aria-label="undefined" data-expectedlabel="" data-testname="aria-label undefined on img w/ empty alt" class="ex"> expected "" but got "undefined"
-FAIL aria-label undefined on img w/o alt but w/ title assert_equals: <img aria-label="undefined" data-expectedlabel="title" data-testname="aria-label undefined on img w/o alt but w/ title" class="ex"> expected "title" but got "undefined"
-FAIL aria-label undefined on img w/ empty alt but w/ title assert_equals: <img alt="" aria-label="undefined" data-expectedlabel="title" data-testname="aria-label undefined on img w/ empty alt but w/ title" class="ex"> expected "title" but got "undefined"
 PASS button's hidden referenced name (display:none) supercedes aria-label
 PASS button's hidden referenced name (visibility:hidden) supercedes aria-label
-FAIL button's hidden referenced name (visibility:hidden) with hidden aria-labelledby traversal falls back to aria-label assert_equals: <button aria-labelledby="span4" aria-label="foo" data-expectedlabel="foo" data-testname="button's hidden referenced name (visibility:hidden) with hidden aria-labelledby traversal falls back to aria-label" class="ex">
-  <span id="span4">
-    <span id="span5" style="visibility:hidden;">label</span>
-  </span>
-  x
-</button> expected "foo" but got "label"
+PASS button's hidden referenced name (visibility:hidden) with hidden aria-labelledby traversal falls back to aria-label
+PASS Hidden button's label should be the empty string
 PASS link's aria-labelledby name supercedes aria-label
 PASS img's aria-label supercedes alt attribute
 PASS svg's aria-label supercedes title tag

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7424,13 +7424,9 @@ bool Internals::readyToRetrieveComputedRoleOrLabel(Element& element) const
     if (element.renderer())
         return true;
 
-    auto* computedStyle = element.computedStyle();
-    // If we can't get computed style for some reason, assume we can query for computed role or label.
-    if (!computedStyle)
-        return true;
-
-    // If the element needs a renderer but doesn't have one yet, we aren't ready to query the computed accessibility role or label. Doing so before the renderer has been attached will yield incorrect results.
-    return !element.rendererIsNeeded(*computedStyle);
+    // If the RenderTree is not laid out, we aren't ready to query the computed accessibility role or label. Doing so will yield incorrect results.
+    auto& document = element.document();
+    return !document.inRenderTreeUpdate() && !(document.view() && document.view()->layoutContext().isInRenderTreeLayout());
 }
 
 bool Internals::hasScopeBreakingHasSelectors() const


### PR DESCRIPTION
#### 001bd0d42e302190f5936b03957b21f3e427fc82
<pre>
AX: Import WPT accname tests.
<a href="https://bugs.webkit.org/show_bug.cgi?id=275059">https://bugs.webkit.org/show_bug.cgi?id=275059</a>
&lt;<a href="https://rdar.apple.com/problem/129164464">rdar://problem/129164464</a>&gt;

Reviewed by Tyler Wilcock.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/a975c0fc84f2a43f7a9bccc3d8f1d68f3d348828">https://github.com/web-platform-tests/wpt/commit/a975c0fc84f2a43f7a9bccc3d8f1d68f3d348828</a>

In addition to importing the WPT tests as of today, this patch includes a fix for the method to determine whether we can determine the accessibility role and label of a given element based on the status of the RenderTree layout. The previous method caused the comp_label.html new test case to timeout because the button inside a span with display:none never has a RenderObject.

* LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_label-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_label.html:
* LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content.html:
* LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/accname/name/comp_name_from_content.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/accname/name/w3c-import.log:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/accname/name/comp_label-expected.txt:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::readyToRetrieveComputedRoleOrLabel const):

Canonical link: <a href="https://commits.webkit.org/279779@main">https://commits.webkit.org/279779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be094a8848fe9eac28208fa0c0bf0599c006b83f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33858 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57725 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5177 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56749 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44086 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3467 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25222 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28801 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4553 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3320 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59316 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29669 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4888 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51511 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30824 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47310 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50881 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11914 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31802 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30617 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->