### PR TITLE
Use PromiseConverter for Media IPC promises where useful

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -1299,7 +1299,7 @@ void SourceBuffer::reportExtraMemoryAllocated(uint64_t extraMemory)
     scriptExecutionContext()->vm().heap.deprecatedReportExtraMemory(extraMemoryCostDelta);
 }
 
-Ref<SourceBuffer::SamplesPromise> SourceBuffer::bufferedSamplesForTrackId(TrackID trackID)
+Ref<SourceBufferPrivate::SamplesPromise> SourceBuffer::bufferedSamplesForTrackId(TrackID trackID)
 {
     // Internals only API
     assertIsMainThread();
@@ -1307,7 +1307,7 @@ Ref<SourceBuffer::SamplesPromise> SourceBuffer::bufferedSamplesForTrackId(TrackI
     return m_private->bufferedSamplesForTrackId(trackID);
 }
 
-Ref<SourceBuffer::SamplesPromise> SourceBuffer::enqueuedSamplesForTrackID(TrackID trackID)
+Ref<SourceBufferPrivate::SamplesPromise> SourceBuffer::enqueuedSamplesForTrackID(TrackID trackID)
 {
     // Internals only API
     assertIsMainThread();

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -213,9 +213,8 @@ private:
     void rangeRemoval(const MediaTime&, const MediaTime&);
 
     friend class Internals;
-    using SamplesPromise = NativePromise<Vector<String>, int>;
-    WEBCORE_EXPORT Ref<SamplesPromise> bufferedSamplesForTrackId(TrackID);
-    WEBCORE_EXPORT Ref<SamplesPromise> enqueuedSamplesForTrackID(TrackID);
+    WEBCORE_EXPORT Ref<SourceBufferPrivate::SamplesPromise> bufferedSamplesForTrackId(TrackID);
+    WEBCORE_EXPORT Ref<SourceBufferPrivate::SamplesPromise> enqueuedSamplesForTrackID(TrackID);
     WEBCORE_EXPORT MediaTime minimumUpcomingPresentationTimeForTrackID(TrackID);
     WEBCORE_EXPORT void setMaximumQueueDepthForTrackID(TrackID, uint64_t);
     WEBCORE_EXPORT Ref<GenericPromise> setMaximumSourceBufferSize(uint64_t);

--- a/Source/WebCore/platform/MediaPromiseTypes.h
+++ b/Source/WebCore/platform/MediaPromiseTypes.h
@@ -34,4 +34,24 @@ namespace WebCore {
 using MediaPromise = NativePromise<void, PlatformMediaError>;
 using MediaTimePromise = NativePromise<MediaTime, PlatformMediaError>;
 
+template<typename P>
+struct MediaErrorPromiseConverter {
+    using Promise = P;
+
+    template<typename T>
+    static typename Promise::Result convertResult(T&& result)
+    {
+        if constexpr (std::is_void<typename Promise::ResolveValueType>::value)
+            return { };
+        else
+            return { WTFMove(result) };
+    }
+
+    template<typename E>
+    static typename Promise::RejectValueType convertError(E) { return WebCore::PlatformMediaError::IPCError; }
+};
+
+using MediaPromiseConverter = MediaErrorPromiseConverter<MediaPromise>;
+using MediaTimePromiseConverter = MediaErrorPromiseConverter<MediaTimePromise>;
+
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -145,7 +145,7 @@ public:
     WEBCORE_EXPORT virtual void memoryPressure(const MediaTime& currentTime);
 
     // Internals Utility methods
-    using SamplesPromise = NativePromise<Vector<String>, int>;
+    using SamplesPromise = NativePromise<Vector<String>, PlatformMediaError>;
     WEBCORE_EXPORT virtual Ref<SamplesPromise> bufferedSamplesForTrackId(TrackID);
     WEBCORE_EXPORT virtual Ref<SamplesPromise> enqueuedSamplesForTrackID(TrackID);
     virtual MediaTime minimumUpcomingPresentationTimeForTrackID(TrackID) { return MediaTime::invalidTime(); }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4679,6 +4679,10 @@ void Internals::setMaximumSourceBufferSize(SourceBuffer& buffer, uint64_t maximu
 void Internals::bufferedSamplesForTrackId(SourceBuffer& buffer, const AtomString& trackId, BufferedSamplesPromise&& promise)
 {
     buffer.bufferedSamplesForTrackId(parseInteger<uint64_t>(trackId).value_or(0))->whenSettled(RunLoop::current(), [promise = WTFMove(promise)](auto&& samples) mutable {
+        if (!samples) {
+            promise.reject(Exception { ExceptionCode::OperationError, makeString("Error "_s, samples.error()) });
+            return;
+        }
         promise.resolve(WTFMove(*samples));
     });
 }
@@ -4686,6 +4690,10 @@ void Internals::bufferedSamplesForTrackId(SourceBuffer& buffer, const AtomString
 void Internals::enqueuedSamplesForTrackID(SourceBuffer& buffer, const AtomString& trackID, BufferedSamplesPromise&& promise)
 {
     buffer.enqueuedSamplesForTrackID(parseInteger<uint64_t>(trackID).value_or(0))->whenSettled(RunLoop::current(), [promise = WTFMove(promise)](auto&& samples) mutable {
+        if (!samples) {
+            promise.reject(Exception { ExceptionCode::OperationError, makeString("Error "_s, samples.error()) });
+            return;
+        }
         promise.resolve(WTFMove(*samples));
     });
 }

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -136,11 +136,7 @@ Ref<MediaPromise> RemoteMediaPlayerProxy::commitAllTransactions()
     if (!m_manager || !m_manager->gpuConnectionToWebProcess())
         return MediaPromise::createAndReject(PlatformMediaError::ClientDisconnected);
 
-    return m_webProcessConnection->sendWithPromisedReply(Messages::MediaPlayerPrivateRemote::CommitAllTransactions(), m_id)->whenSettled(RunLoop::current(), [](auto&& result) {
-        if (!result)
-            return MediaPromise::createAndReject(PlatformMediaError::IPCError);
-        return MediaPromise::createAndResolve();
-    });
+    return m_webProcessConnection->sendWithPromisedReply<Messages::MediaPlayerPrivateRemote::CommitAllTransactions, MediaPromiseConverter>({ }, m_id);
 }
 
 void RemoteMediaPlayerProxy::getConfiguration(RemoteMediaPlayerConfiguration& configuration)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp
@@ -77,9 +77,7 @@ Ref<MediaTimePromise> RemoteMediaSourceProxy::waitForTarget(const SeekTarget& ta
     if (!connection)
         return MediaTimePromise::createAndReject(PlatformMediaError::IPCError);
 
-    return connection->connection().sendWithPromisedReply(Messages::MediaSourcePrivateRemoteMessageReceiver::ProxyWaitForTarget(target), m_identifier)->whenSettled(RunLoop::current(), [](auto&& result) {
-        return result ? MediaTimePromise::createAndSettle(WTFMove(*result)) : MediaTimePromise::createAndReject(PlatformMediaError::IPCError);
-    });
+    return connection->connection().sendWithPromisedReply<Messages::MediaSourcePrivateRemoteMessageReceiver::ProxyWaitForTarget, MediaTimePromiseConverter>(target, m_identifier);
 }
 
 Ref<MediaPromise> RemoteMediaSourceProxy::seekToTime(const MediaTime& time)
@@ -88,9 +86,7 @@ Ref<MediaPromise> RemoteMediaSourceProxy::seekToTime(const MediaTime& time)
     if (!connection)
         return MediaPromise::createAndReject(PlatformMediaError::IPCError);
 
-    return connection->connection().sendWithPromisedReply(Messages::MediaSourcePrivateRemoteMessageReceiver::ProxySeekToTime(time), m_identifier)->whenSettled(RunLoop::current(), [](auto&& result) {
-        return result ? MediaPromise::createAndSettle(WTFMove(*result)) : MediaPromise::createAndReject(PlatformMediaError::IPCError);
-    });
+    return connection->connection().sendWithPromisedReply<Messages::MediaSourcePrivateRemoteMessageReceiver::ProxySeekToTime, MediaPromiseConverter>(time, m_identifier);
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
@@ -116,9 +116,7 @@ Ref<MediaPromise> RemoteSourceBufferProxy::sourceBufferPrivateDidReceiveInitiali
         if (!protectedThis  || !result || !connection)
             return MediaPromise::createAndReject(PlatformMediaError::IPCError);
 
-        return connection->connection().sendWithPromisedReply(Messages::SourceBufferPrivateRemoteMessageReceiver::SourceBufferPrivateDidReceiveInitializationSegment(WTFMove(segmentInfo)), m_identifier)->whenSettled(RunLoop::current(), [](auto&& result) {
-            return MediaPromise::createAndSettle(!result ? makeUnexpected(PlatformMediaError::IPCError) : WTFMove(*result));
-        });
+        return connection->connection().sendWithPromisedReply<Messages::SourceBufferPrivateRemoteMessageReceiver::SourceBufferPrivateDidReceiveInitializationSegment, MediaPromiseConverter>(WTFMove(segmentInfo), m_identifier);
     });
 }
 
@@ -136,9 +134,7 @@ Ref<MediaPromise> RemoteSourceBufferProxy::sourceBufferPrivateDurationChanged(co
     if (!connection)
         return MediaPromise::createAndReject(PlatformMediaError::IPCError);
 
-    return connection->connection().sendWithPromisedReply(Messages::SourceBufferPrivateRemoteMessageReceiver::SourceBufferPrivateDurationChanged(duration), m_identifier)->whenSettled(RunLoop::current(), [](auto&& result) {
-        return result ? MediaPromise::createAndResolve() : MediaPromise::createAndReject(PlatformMediaError::IPCError);
-    });
+    return connection->connection().sendWithPromisedReply<Messages::SourceBufferPrivateRemoteMessageReceiver::SourceBufferPrivateDurationChanged, MediaPromiseConverter>(duration, m_identifier);
 }
 
 Ref<MediaPromise> RemoteSourceBufferProxy::sourceBufferPrivateBufferedChanged(const Vector<WebCore::PlatformTimeRanges>& trackRanges)
@@ -147,9 +143,7 @@ Ref<MediaPromise> RemoteSourceBufferProxy::sourceBufferPrivateBufferedChanged(co
     if (!connection)
         return MediaPromise::createAndResolve();
 
-    return connection->connection().sendWithPromisedReply(Messages::SourceBufferPrivateRemoteMessageReceiver::SourceBufferPrivateBufferedChanged(trackRanges), m_identifier)->whenSettled(RunLoop::current(), [](auto&& result) {
-        return result ? MediaPromise::createAndResolve() : MediaPromise::createAndReject(PlatformMediaError::IPCError);
-    });
+    return connection->connection().sendWithPromisedReply<Messages::SourceBufferPrivateRemoteMessageReceiver::SourceBufferPrivateBufferedChanged, MediaPromiseConverter>(trackRanges, m_identifier);
 }
 
 void RemoteSourceBufferProxy::sourceBufferPrivateDidDropSample()

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -41,6 +41,7 @@ namespace IPC {
 class Connection;
 class Decoder;
 class SharedBufferReference;
+enum class Error : uint8_t;
 }
 
 namespace WebCore {

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -359,10 +359,10 @@ public:
     }
 
     // Thread-safe.
-    template<typename T, typename RawValue>
-    Ref<typename T::Promise> sendWithPromisedReply(T&& message, const ObjectIdentifierGenericBase<RawValue>& destinationID, OptionSet<SendOption> sendOptions = { })
+    template<typename T, typename PC = PromiseConverter<typename T::Promise>, typename M = T, typename RawValue>
+    Ref<typename PC::Promise> sendWithPromisedReply(M&& message, const ObjectIdentifierGenericBase<RawValue>& destinationID, OptionSet<SendOption> sendOptions = { })
     {
-        return sendWithPromisedReply<T>(WTFMove(message), destinationID.toUInt64(), sendOptions);
+        return sendWithPromisedReply<T, PC, M>(std::forward<M>(message), destinationID.toUInt64(), sendOptions);
     }
     template<typename T, typename RawValue>
     Ref<typename T::Promise> sendWithPromisedReplyOnDispatcher(T&& message, RefCountedSerialFunctionDispatcher& dispatcher, const ObjectIdentifierGenericBase<RawValue>& destinationID, OptionSet<SendOption> sendOptions = { })

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7518,7 +7518,7 @@ header: <WebCore/SourceBufferPrivateClient.h>
     size_t numMediaSamples;
 };
 
-using WebCore::SourceBufferPrivate::SamplesPromise::Result = Expected<Vector<String>, int>
+using WebCore::SourceBufferPrivate::SamplesPromise::Result = Expected<Vector<String>, WebCore::PlatformMediaError>
 
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp
@@ -111,7 +111,7 @@ Ref<MediaPromise> SourceBufferPrivateRemote::append(Ref<SharedBuffer>&& data)
         if (!gpuProcessConnection || !isGPURunning())
             return MediaPromise::createAndReject(PlatformMediaError::IPCError);
 
-        return sendWithPromisedReply(Messages::RemoteSourceBufferProxy::Append(IPC::SharedBufferReference { WTFMove(data) }))->whenSettled(m_dispatcher, [weakThis = ThreadSafeWeakPtr { *this }](auto&& result) {
+        return sendWithPromisedReply<Messages::RemoteSourceBufferProxy::Append>(IPC::SharedBufferReference { WTFMove(data) })->whenSettled(m_dispatcher, [weakThis = ThreadSafeWeakPtr { *this }](auto&& result) {
             if (!result)
                 return MediaPromise::createAndReject(PlatformMediaError::IPCError);
             if (RefPtr protectedThis = weakThis.get()) {
@@ -214,11 +214,7 @@ Ref<MediaPromise> SourceBufferPrivateRemote::removeCodedFrames(const MediaTime& 
         if (!gpuProcessConnection || !isGPURunning())
             return MediaPromise::createAndReject(PlatformMediaError::IPCError);
 
-        return sendWithPromisedReply(Messages::RemoteSourceBufferProxy::RemoveCodedFrames(start, end, currentMediaTime))->whenSettled(m_dispatcher, [] (auto&& result) mutable {
-                if (!result)
-                    return MediaPromise::createAndReject(PlatformMediaError::IPCError);
-                return MediaPromise::createAndResolve();
-            });
+        return sendWithPromisedReply<Messages::RemoteSourceBufferProxy::RemoveCodedFrames, MediaPromiseConverter>({ start, end, currentMediaTime });
     });
 }
 
@@ -370,7 +366,7 @@ Ref<GenericPromise> SourceBufferPrivateRemote::setMaximumBufferSize(size_t size)
     GenericPromise::AutoRejectProducer producer;
     Ref promise = producer.promise();
     ensureWeakOnDispatcher([this, size, producer = WTFMove(producer)]() mutable {
-        m_gpuProcessConnection.get()->connection().sendWithPromisedReply(Messages::RemoteSourceBufferProxy::SetMaximumBufferSize(size), m_remoteSourceBufferIdentifier)->chainTo(WTFMove(producer));
+        sendWithPromisedReply<Messages::RemoteSourceBufferProxy::SetMaximumBufferSize>(size)->chainTo(WTFMove(producer));
     });
     return promise;
 }
@@ -382,9 +378,7 @@ Ref<SourceBufferPrivate::ComputeSeekPromise> SourceBufferPrivateRemote::computeS
         if (!gpuProcessConnection || !isGPURunning())
             return ComputeSeekPromise::createAndReject(PlatformMediaError::IPCError);
 
-        return sendWithPromisedReply(Messages::RemoteSourceBufferProxy::ComputeSeekTime(target))->whenSettled(m_dispatcher, [](auto&& result) {
-            return result ? ComputeSeekPromise::createAndSettle(*result) : ComputeSeekPromise::createAndReject(PlatformMediaError::IPCError);
-        });
+        return sendWithPromisedReply<Messages::RemoteSourceBufferProxy::ComputeSeekTime, MediaErrorPromiseConverter<ComputeSeekPromise>>(target);
     });
 }
 
@@ -407,13 +401,9 @@ Ref<SourceBufferPrivate::SamplesPromise> SourceBufferPrivateRemote::bufferedSamp
     return invokeAsync(m_dispatcher, [protectedThis = Ref { *this }, this, trackID]() -> Ref<SamplesPromise> {
         auto gpuProcessConnection = m_gpuProcessConnection.get();
         if (!gpuProcessConnection || !isGPURunning())
-            return SamplesPromise::createAndResolve(Vector<String> { });
+            return SamplesPromise::createAndReject(PlatformMediaError::IPCError);
 
-        return sendWithPromisedReply(Messages::RemoteSourceBufferProxy::BufferedSamplesForTrackId(trackID))->whenSettled(m_dispatcher, [](auto&& result) {
-            if (!result)
-                return SamplesPromise::createAndResolve(Vector<String> { });
-            return SamplesPromise::createAndSettle(WTFMove(*result));
-        });
+        return sendWithPromisedReply<Messages::RemoteSourceBufferProxy::BufferedSamplesForTrackId, MediaErrorPromiseConverter<SamplesPromise>>(trackID);
     });
 }
 
@@ -424,11 +414,7 @@ Ref<SourceBufferPrivate::SamplesPromise> SourceBufferPrivateRemote::enqueuedSamp
         if (!gpuProcessConnection || !isGPURunning())
             return SamplesPromise::createAndResolve(Vector<String> { });
 
-        return sendWithPromisedReply(Messages::RemoteSourceBufferProxy::EnqueuedSamplesForTrackID(trackID))->whenSettled(m_dispatcher, [](auto&& result) {
-            if (!result)
-                return SamplesPromise::createAndResolve(Vector<String> { });
-            return SamplesPromise::createAndSettle(WTFMove(*result));
-        });
+        return sendWithPromisedReply<Messages::RemoteSourceBufferProxy::EnqueuedSamplesForTrackID, MediaErrorPromiseConverter<SamplesPromise>>(trackID);
     });
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -143,9 +143,10 @@ private:
 
     void ensureOnDispatcherSync(Function<void()>&&);
     void ensureWeakOnDispatcher(Function<void()>&&);
-    template<typename T> Ref<typename T::Promise> sendWithPromisedReply(T&& message)
+
+    template<typename T, typename PC = IPC::Connection::PromiseConverter<typename T::Promise>, typename M = T> Ref<typename PC::Promise> sendWithPromisedReply(M&& message)
     {
-        return m_gpuProcessConnection.get()->connection().sendWithPromisedReply(std::forward<T>(message), m_remoteSourceBufferIdentifier);
+        return m_gpuProcessConnection.get()->connection().sendWithPromisedReply<T, PC, M>(std::forward<M>(message), m_remoteSourceBufferIdentifier);
     }
 
     friend class MessageReceiver;


### PR DESCRIPTION
#### a43c20c52551a34aeb7c957da79952e8c07e95a3
<pre>
Use PromiseConverter for Media IPC promises where useful
<a href="https://rdar.apple.com/129161680">rdar://129161680</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=275056">https://bugs.webkit.org/show_bug.cgi?id=275056</a>

Reviewed by NOBODY (OOPS!).

We use PromiseConverter in Media code so as to translate MediaPromise and MediaTimePromise from IPC NativePromises.
We introduce a MediaErrorPromiseConverter for that purpose.

We use it in Remote objects.
We update SourceBuffer::SamplesPromise to take a PlatformMediaError instead of an int.
This allows to reuse MediaErrorPromiseConverter a bit more.
We update Internals::bufferedSamplesForTrackId and Internals::enqueuedSamplesForTrackID to test for potential errors and reject the JS promise accordingly.

We also update SourceBufferPrivateRemote::bufferedSamplesForTrackId and SourceBufferPrivateRemote::enqueuedSamplesForTrackID to reject in case of IPC error.
This is ok as this is a testing API only.

* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::bufferedSamplesForTrackId):
(WebCore::SourceBuffer::enqueuedSamplesForTrackID):
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/MediaPromiseTypes.h:
(WebCore::MediaErrorPromiseConverter::convertResult):
(WebCore::MediaErrorPromiseConverter::convertError):
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::bufferedSamplesForTrackId):
(WebCore::Internals::enqueuedSamplesForTrackID):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::commitAllTransactions):
* Source/WebKit/GPUProcess/media/RemoteMediaSourceProxy.cpp:
(WebKit::RemoteMediaSourceProxy::waitForTarget):
(WebKit::RemoteMediaSourceProxy::seekToTime):
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::sourceBufferPrivateDidReceiveInitializationSegment):
(WebKit::RemoteSourceBufferProxy::sourceBufferPrivateDurationChanged):
(WebKit::RemoteSourceBufferProxy::sourceBufferPrivateBufferedChanged):
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h:
* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::sendWithPromisedReply):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::append):
(WebKit::SourceBufferPrivateRemote::removeCodedFrames):
(WebKit::SourceBufferPrivateRemote::setMaximumBufferSize):
(WebKit::SourceBufferPrivateRemote::computeSeekTime):
(WebKit::SourceBufferPrivateRemote::bufferedSamplesForTrackId):
(WebKit::SourceBufferPrivateRemote::enqueuedSamplesForTrackID):
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a43c20c52551a34aeb7c957da79952e8c07e95a3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57372 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4821 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56400 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4714 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43808 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3208 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56193 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31738 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46841 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24950 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28551 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4150 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2970 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50276 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4353 "Found 4 new test failures: media/media-source/media-source-multiple-initialization-segments.html, media/media-source/media-source-seek-detach-crash.html, media/media-source/media-source-stpp-crash.html, media/video-webkit-playsinline.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58966 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29291 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4456 "Found 3 new test failures: media/media-source/media-source-multiple-initialization-segments.html, media/media-source/media-source-seek-detach-crash.html, media/media-source/media-source-stpp-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51227 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30470 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46948 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50590 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31435 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30249 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->