### PR TITLE
Add support for easy serialization of container/ranges via StringBuilder

### DIFF
--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -734,8 +734,8 @@ public:
     {
     }
 
-    unsigned length() { return m_string.length(); }
-    bool is8Bit() { return m_string.is8Bit(); }
+    unsigned length() const { return m_string.length(); }
+    bool is8Bit() const { return m_string.is8Bit(); }
     template<typename CharacterType> void writeTo(CharacterType* destination) { m_string.getCharacters(destination); }
 
 private:

--- a/Source/WebCore/css/CSSGradientValue.cpp
+++ b/Source/WebCore/css/CSSGradientValue.cpp
@@ -298,14 +298,11 @@ String CSSLinearGradientValue::customCSSText() const
     if (appendColorInterpolationMethod(result, m_colorInterpolationMethod, wroteSomething))
         wroteSomething = true;
 
-    for (auto& stop : m_stops) {
-        if (wroteSomething)
-            result.append(", "_s);
-        wroteSomething = true;
-        writeColorStop(result, stop);
-    }
+    if (wroteSomething)
+        result.append(", "_s);
 
-    result.append(')');
+    result.append(interleave(m_stops, writeColorStop, ", "_s), ')');
+
     return result.toString();
 }
 
@@ -537,15 +534,7 @@ String CSSRadialGradientValue::customCSSText() const
     if (wroteSomething)
         result.append(", "_s);
 
-    bool wroteFirstStop = false;
-    for (auto& stop : m_stops) {
-        if (wroteFirstStop)
-            result.append(", "_s);
-        wroteFirstStop = true;
-        writeColorStop(result, stop);
-    }
-
-    result.append(')');
+    result.append(interleave(m_stops, writeColorStop, ", "_s), ')');
 
     return result.toString();
 }
@@ -729,15 +718,8 @@ String CSSConicGradientValue::customCSSText() const
     if (wroteSomething)
         result.append(", "_s);
 
-    bool wroteFirstStop = false;
-    for (auto& stop : m_stops) {
-        if (wroteFirstStop)
-            result.append(", "_s);
-        wroteFirstStop = true;
-        writeColorStop(result, stop);
-    }
+    result.append(interleave(m_stops, writeColorStop, ", "_s), ')');
 
-    result.append(')');
     return result.toString();
 }
 

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -373,16 +373,17 @@ static void appendPseudoClassFunctionTail(StringBuilder& builder, const CSSSelec
 
 }
 
+static void appendLangArgument(StringBuilder& builder, const PossiblyQuotedIdentifier& langArgument)
+{
+    if (!langArgument.wasQuoted)
+        serializeIdentifier(langArgument.identifier, builder);
+    else
+        serializeString(langArgument.identifier, builder);
+}
+
 static void appendLangArgumentList(StringBuilder& builder, const FixedVector<PossiblyQuotedIdentifier>& list)
 {
-    for (unsigned i = 0, size = list.size(); i < size; ++i) {
-        if (!list[i].wasQuoted)
-            serializeIdentifier(list[i].identifier, builder);
-        else
-            serializeString(list[i].identifier, builder);
-        if (i != size - 1)
-            builder.append(", "_s);
-    }
+    builder.append(interleave(list, appendLangArgument, ", "_s));
 }
 
 // http://dev.w3.org/csswg/css-syntax/#serializing-anb

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -115,12 +115,7 @@ String CSSSelectorList::selectorsText() const
 
 void CSSSelectorList::buildSelectorsText(StringBuilder& stringBuilder) const
 {
-    const CSSSelector* firstSubselector = first();
-    for (const CSSSelector* subSelector = firstSubselector; subSelector; subSelector = CSSSelectorList::next(subSelector)) {
-        if (subSelector != firstSubselector)
-            stringBuilder.append(", "_s);
-        stringBuilder.append(subSelector->selectorText());
-    }
+    stringBuilder.append(interleave(*this, [](auto& subSelector) { return subSelector.selectorText(); }, ", "_s));
 }
 
 template <typename Functor>

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -68,7 +68,7 @@ public:
         using iterator_category = std::forward_iterator_tag;
         reference operator*() const { return *m_ptr; }
         pointer operator->() const { return m_ptr; }
-        bool operator!=(const const_iterator& other) const { return m_ptr != other.m_ptr; }
+        bool operator==(const const_iterator&) const = default;
         const_iterator() = default;
         const_iterator(pointer ptr) : m_ptr(ptr) { };
         const_iterator& operator++()
@@ -92,6 +92,7 @@ public:
     unsigned listSize() const;
 
     CSSSelectorList& operator=(CSSSelectorList&&) = default;
+
 private:
     // End of a multipart selector is indicated by m_isLastInTagHistory bit in the last item.
     // End of the array is indicated by m_isLastInSelectorList bit in the last item.

--- a/Source/WebCore/css/CSSValueList.cpp
+++ b/Source/WebCore/css/CSSValueList.cpp
@@ -218,10 +218,7 @@ CSSValueListBuilder CSSValueContainingVector::copyValues() const
 
 void CSSValueContainingVector::serializeItems(StringBuilder& builder) const
 {
-    auto prefix = ""_s;
-    auto separator = separatorCSSText();
-    for (auto& value : *this)
-        builder.append(std::exchange(prefix, separator), value.cssText());
+    builder.append(interleave(*this, [](auto& value) { return value.cssText(); }, separatorCSSText()));
 }
 
 String CSSValueContainingVector::serializeItems() const

--- a/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
+++ b/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
@@ -1252,21 +1252,21 @@ void CSSCalcOperationNode::buildCSSTextRecursive(const CSSCalcExpressionNode& no
             return;
         }
 
+        auto& children = operationNode->children();
+        ASSERT(children.size());
+
         // If root is anything but a Sum, Negate, Product, or Invert node, serialize a math function for the
         // function corresponding to the node type, treating the node’s children as the function’s
         // comma-separated calculation arguments, and return the result.
-        builder.append(functionPrefixForOperator(operationNode->calcOperator()));
-
-        auto& children = operationNode->children();
-        ASSERT(children.size());
-        buildCSSTextRecursive(children.first(), builder, GroupingParens::Omit);
-
-        for (unsigned i = 1; i < children.size(); ++i) {
-            builder.append(", "_s);
-            buildCSSTextRecursive(children[i], builder, GroupingParens::Omit);
-        }
-        
-        builder.append(')');
+        builder.append(
+            functionPrefixForOperator(operationNode->calcOperator()),
+            interleave(
+                children,
+                [](auto& builder, auto& child) { buildCSSTextRecursive(child, builder, GroupingParens::Omit); },
+                ", "_s
+            ),
+            ')'
+        );
         return;
     }
     

--- a/Source/WebCore/css/query/MediaQueryParser.cpp
+++ b/Source/WebCore/css/query/MediaQueryParser.cpp
@@ -189,11 +189,7 @@ const FeatureSchema* MediaQueryParser::schemaForFeatureName(const AtomString& na
 
 void serialize(StringBuilder& builder, const MediaQueryList& list)
 {
-    for (auto& query : list) {
-        if (&query != &list.first())
-            builder.append(", "_s);
-        serialize(builder, query);
-    }
+    builder.append(interleave(list, serialize, ", "_s));
 }
 
 void serialize(StringBuilder& builder, const MediaQuery& query)

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.cpp
@@ -170,11 +170,7 @@ CSSTransformValue::CSSTransformValue(Vector<Ref<CSSTransformComponent>>&& transf
 void CSSTransformValue::serialize(StringBuilder& builder, OptionSet<SerializationArguments>) const
 {
     // https://drafts.css-houdini.org/css-typed-om/#serialize-a-csstransformvalue
-    for (size_t i = 0; i < m_components.size(); ++i) {
-        if (i)
-            builder.append(' ');
-        m_components[i]->serialize(builder);
-    }
+    builder.append(interleave(m_components, [](auto& builder, auto& transform) { transform->serialize(builder); }, ' '));
 }
 
 RefPtr<CSSValue> CSSTransformValue::toCSSValue() const

--- a/Source/WebCore/platform/text/TextFlags.cpp
+++ b/Source/WebCore/platform/text/TextFlags.cpp
@@ -81,7 +81,7 @@ WTF::TextStream& operator<<(TextStream& ts, const FontVariantAlternates& alterna
     else {
         auto values = alternates.values();
         StringBuilder builder;
-        auto append = [&builder] <typename ...Ts> (Ts&& ...args) {
+        auto append = [&builder]<typename ...Ts>(Ts&& ...args) {
             // Separate elements with a space.
             builder.append(builder.isEmpty() ? ""_s: " "_s, std::forward<Ts>(args)...);
         };
@@ -91,9 +91,9 @@ WTF::TextStream& operator<<(TextStream& ts, const FontVariantAlternates& alterna
         if (values.historicalForms)
             append("historical-forms"_s);
         if (!values.styleset.isEmpty())
-            append("styleset("_s, makeStringByJoining(values.styleset, ", "_s), ')');
+            append("styleset("_s, interleave(values.styleset, ", "_s), ')');
         if (!values.characterVariant.isEmpty())
-            append("character-variant("_s, makeStringByJoining(values.characterVariant, ", "_s), ')');
+            append("character-variant("_s, interleave(values.characterVariant, ", "_s), ')');
         if (!values.swash.isNull())
             append("swash("_s, values.swash, ')');
         if (!values.ornaments.isNull())

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5389,22 +5389,16 @@ MockContentFilterSettings& Internals::mockContentFilterSettings()
 
 #endif
 
-static void appendOffsets(StringBuilder& builder, const Vector<SnapOffset<LayoutUnit>>& snapOffsets)
+static void serializeOffset(StringBuilder& builder, const SnapOffset<LayoutUnit>& snapOffset)
 {
-    bool justStarting = true;
+    builder.append(snapOffset.offset.toUnsigned());
+    if (snapOffset.stop == ScrollSnapStop::Always)
+        builder.append(" (always)"_s);
+}
 
-    builder.append("{ "_s);
-    for (auto& coordinate : snapOffsets) {
-        if (!justStarting)
-            builder.append(", "_s);
-        else
-            justStarting = false;
-        builder.append(coordinate.offset.toUnsigned());
-        if (coordinate.stop == ScrollSnapStop::Always)
-            builder.append(" (always)"_s);
-
-    }
-    builder.append(" }"_s);
+static void serializeOffsets(StringBuilder& builder, const Vector<SnapOffset<LayoutUnit>>& snapOffsets)
+{
+    builder.append("{ "_s, interleave(snapOffsets, serializeOffset, ", "_s), " }"_s);
 }
 
 void Internals::setPlatformMomentumScrollingPredictionEnabled(bool enabled)
@@ -5426,14 +5420,14 @@ ExceptionOr<String> Internals::scrollSnapOffsets(Element& element)
     StringBuilder result;
     if (offsetInfo && !offsetInfo->horizontalSnapOffsets.isEmpty()) {
         result.append("horizontal = "_s);
-        appendOffsets(result, offsetInfo->horizontalSnapOffsets);
+        serializeOffsets(result, offsetInfo->horizontalSnapOffsets);
     }
 
     if (offsetInfo && !offsetInfo->verticalSnapOffsets.isEmpty()) {
         if (result.length())
             result.append(", "_s);
         result.append("vertical = "_s);
-        appendOffsets(result, offsetInfo->verticalSnapOffsets);
+        serializeOffsets(result, offsetInfo->verticalSnapOffsets);
     }
 
     return result.toString();


### PR DESCRIPTION
#### 7fd3deadf8b1a134082e4420ac140a3227d68d34
<pre>
Add support for easy serialization of container/ranges via StringBuilder
<a href="https://bugs.webkit.org/show_bug.cgi?id=275062">https://bugs.webkit.org/show_bug.cgi?id=275062</a>

Reviewed by Darin Adler.

Introduced a new `StringTypeAdapter`, `Interleave`, which takes
a container/range, a joining string, and an optional mapping function.
`Interleaves` can currently only be used with StringBuilder, but can
be extended to makeString() as well with a bit of header factoring.

`Interleave` replaces common hand written loops when trying to
serialize container/ranges. For example, the following code:

    StringBuilder builder;

    ...

    builder.append(&apos;(&apos;);
    bool wroteFirstItem = false;
    for (auto&amp; item : container) {
        if (wroteFirstItem)
            builder.append(&quot;, &quot;_s);
        wroteFirstItem = true;
        builder.append(item-&gt;value);
    }
    builder.append(&apos;)&apos;);

can be replaced with:

    StringBuilder builder;

    ...

    builder.append(&apos;(&apos;, interleave(container, [](auto&amp; item) { return item-&gt;value; }, &quot;, &quot;_s), &apos;)&apos;);

`Interleave` works via a new kind of `StringTypeAdapter` that doesn&apos;t
know the length/8-bit-ness of its value before hand, causing the
builder to go down a new &quot;slow&quot; path. This &quot;slow&quot; path is just as
efficient as the old hand written loop, but a bit more ergonomic.

In addition to introducing `Interleave`, it has been adopted in places
in WebCore where it can be deployed (that I found), but has not been
adopted in places where adopting it would have turned the builder usage
into a one-liner. Those will be become makeString() calls when added.

* Source/WTF/wtf/text/StringBuilder.h:
(WTF::StringBuilder::appendFromAdapters):
(WTF::StringBuilder::appendFromAdapterSlow):
(WTF::StringBuilder::appendFromAdaptersSlow):
    - Detect use of a &quot;slow&quot; `StringTypeAdapter` and use the
      alternative path, iteratively appending each adapter.

      The current strategy checks if any of the remaining
      `StringTypeAdapters` are &quot;slow&quot; and goes down the
      alternative path, peeling off the first adapter and
      appending it, and then recursing back to the beginning
      with the remainder of the adapters. This means that
      if an append() contains:

          append(&apos;(&apos;, 10, interleave(range, &apos; &apos;), hex(10), &apos;)&apos;); [ aka &quot;fast&quot;, &quot;fast&quot;, &quot;slow&quot;, &quot;fast&quot;, &quot;fast&quot;]

      We will do the equivalent of:

          append(&apos;(&apos;);
          append(10);
          append(interleave(range, &apos; &apos;));
          append(10, &apos;)&apos;);

      This can be improved to find fast prefixes as well in
      the future.

* Tools/TestWebKitAPI/Tests/WTF/StringBuilder.cpp:
(TestWebKitAPI::TEST(StringBuilderTest, Interleave)):
    - Add tests for the three forms of interleave.

* Source/WTF/wtf/text/StringConcatenate.h:
(WTF::Interleave::writeUsing const):
(WTF::interleave):
    - Adds Interleave struct and introducing function.

(WTF::are8Bit):
    - Simplify to a single function using a fold.

(WTF::hasKnownLength):
(WTF::haveKnownLength):
    - Add helper to determine if the StringTypeAdapter has a known
      length to determine fast vs slow cases.

* Source/WebCore/css/CSSGradientValue.cpp:
(WebCore::CSSLinearGradientValue::customCSSText const):
(WebCore::CSSRadialGradientValue::customCSSText const):
(WebCore::CSSConicGradientValue::customCSSText const):
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::appendLangArgument):
(WebCore::appendLangArgumentList):
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::buildSelectorsText const):
* Source/WebCore/css/CSSSelectorList.h:
(WebCore::CSSSelectorList::const_iterator::operator!= const): Deleted.
* Source/WebCore/css/CSSValueList.cpp:
(WebCore::CSSValueContainingVector::serializeItems const):
* Source/WebCore/css/calc/CSSCalcOperationNode.cpp:
(WebCore::CSSCalcOperationNode::buildCSSTextRecursive):
* Source/WebCore/css/query/MediaQueryParser.cpp:
(WebCore::MQ::serialize):
* Source/WebCore/css/typedom/transform/CSSTransformValue.cpp:
(WebCore::CSSTransformValue::serialize const):
* Source/WebCore/platform/text/TextFlags.cpp:
* Source/WebCore/testing/Internals.cpp:
(WebCore::serializeOffset):
(WebCore::serializeOffsets):
(WebCore::Internals::scrollSnapOffsets):
(WebCore::appendOffsets): Deleted.
    - Adopt interleave() for container serialization.

Canonical link: <a href="https://commits.webkit.org/279755@main">https://commits.webkit.org/279755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4d5217368b18be1156afbb5f652f16648f0f8f4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54410 "Failed to checkout and rebase branch from PR 29463") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33820 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6973 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57689 "Hash e4d52173 for PR 29463 does not build (failure)") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5141 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56712 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41355 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5104 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/57689 "Hash e4d52173 for PR 29463 does not build (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3449 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56504 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47118 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/57689 "Hash e4d52173 for PR 29463 does not build (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/28777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4444 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3284 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/47771 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59280 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/53917 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/29630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/4765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51489 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/30788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47212 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50858 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11871 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/31765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/66216 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30580 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12617 "Passed tests") | 
<!--EWS-Status-Bubble-End-->