### PR TITLE
Makes interaction region visible on a HTMLTextFormControlElement when focused.

### DIFF
--- a/LayoutTests/interaction-region/text-input-focused-edited-empty-expected.txt
+++ b/LayoutTests/interaction-region/text-input-focused-edited-empty-expected.txt
@@ -1,15 +1,15 @@
 
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 800.00 600.00)
+  (bounds 768.00 1004.00)
   (children 1
     (GraphicsLayer
-      (bounds 800.00 600.00)
+      (bounds 768.00 1004.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=800 height=600)
+        (rect (0,0) width=768 height=1004)
 
       (interaction regions [
         (interaction (8,8) width=332 height=57)

--- a/LayoutTests/interaction-region/text-input-focused-edited-empty.html
+++ b/LayoutTests/interaction-region/text-input-focused-edited-empty.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../resources/ui-helper.js"></script>
+<style>
+    input {
+        width: 300px;
+        font-size: 30px;
+        line-height: 40px;
+        background: blue;
+    }
+</style>
+</head>
+<body>
+
+<input type="text"/>
+<pre id="results"></pre>
+
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+}
+
+(async () => {
+    element = document.querySelector("input");
+
+    await UIHelper.activateElementAndWaitForInputSession(element);
+    await UIHelper.typeCharacter("a");
+    await UIHelper.typeCharacter("delete");
+
+    await UIHelper.animationFrame();
+    await UIHelper.ensureStablePresentationUpdate();
+
+    results.textContent = element.value;
+
+    if (window.internals)
+       results.textContent += internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    await UIHelper.waitForInputSessionToDismiss();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+})();
+</script>
+</body>
+</html>

--- a/LayoutTests/interaction-region/text-input-focused-edited-expected.txt
+++ b/LayoutTests/interaction-region/text-input-focused-edited-expected.txt
@@ -1,0 +1,18 @@
+
+A
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 768.00 1004.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 768.00 1004.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=768 height=1004)
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/text-input-focused-edited.html
+++ b/LayoutTests/interaction-region/text-input-focused-edited.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../resources/ui-helper.js"></script>
+<style>
+    input {
+        width: 300px;
+        font-size: 30px;
+        line-height: 40px;
+        background: blue;
+    }
+</style>
+</head>
+<body>
+
+<input type="text"/>
+<pre id="results"></pre>
+
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+}
+
+(async () => {
+    element = document.querySelector("input");
+
+    await UIHelper.activateElementAndWaitForInputSession(element);
+    await UIHelper.typeCharacter("a");
+
+    await UIHelper.animationFrame();
+    await UIHelper.ensureStablePresentationUpdate();
+
+    results.textContent = element.value + "\n";
+
+    if (window.internals)
+       results.textContent += internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    await UIHelper.waitForInputSessionToDismiss();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+})();
+</script>
+</body>
+</html>

--- a/LayoutTests/interaction-region/text-input-focused-expected.txt
+++ b/LayoutTests/interaction-region/text-input-focused-expected.txt
@@ -10,6 +10,10 @@
       (backgroundColor #FFFFFF)
       (event region
         (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (interaction (9,9) width=211 height=204)
+        (cornerRadius 5.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/textarea-focused-edited-empty-expected.txt
+++ b/LayoutTests/interaction-region/textarea-focused-edited-empty-expected.txt
@@ -1,18 +1,18 @@
 
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 800.00 600.00)
+  (bounds 768.00 1004.00)
   (children 1
     (GraphicsLayer
-      (bounds 800.00 600.00)
+      (bounds 768.00 1004.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=800 height=600)
+        (rect (0,0) width=768 height=1004)
 
       (interaction regions [
-        (interaction (8,8) width=332 height=57)
+        (interaction (9,9) width=211 height=204)
         (cornerRadius 5.00)])
       )
     )

--- a/LayoutTests/interaction-region/textarea-focused-edited-empty.html
+++ b/LayoutTests/interaction-region/textarea-focused-edited-empty.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../resources/ui-helper.js"></script>
+<style>
+    textarea {
+        width: 200px;
+        height: 200px;
+        background: green;
+    }
+</style>
+</head>
+<body>
+
+<textarea></textarea>
+<pre id="results"></pre>
+
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+}
+
+(async () => {
+    element = document.querySelector("textarea");
+
+    await UIHelper.activateElementAndWaitForInputSession(element);
+    await UIHelper.typeCharacter("a");
+    await UIHelper.typeCharacter("delete");
+
+    await UIHelper.animationFrame();
+    await UIHelper.ensureStablePresentationUpdate();
+
+    results.textContent = element.value;
+
+    if (window.internals)
+       results.textContent += internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    await UIHelper.waitForInputSessionToDismiss();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+})();
+</script>
+</body>
+</html>

--- a/LayoutTests/interaction-region/textarea-focused-edited-expected.txt
+++ b/LayoutTests/interaction-region/textarea-focused-edited-expected.txt
@@ -1,0 +1,18 @@
+
+A
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 768.00 1004.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 768.00 1004.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=768 height=1004)
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/textarea-focused-edited.html
+++ b/LayoutTests/interaction-region/textarea-focused-edited.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<script src="../resources/ui-helper.js"></script>
+<style>
+    textarea {
+        width: 200px;
+        height: 200px;
+        background: green;
+    }
+</style>
+</head>
+<body>
+
+<textarea></textarea>
+<pre id="results"></pre>
+
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+}
+
+(async () => {
+    element = document.querySelector("textarea");
+
+    await UIHelper.activateElementAndWaitForInputSession(element);
+    await UIHelper.typeCharacter("a");
+
+    await UIHelper.animationFrame();
+    await UIHelper.ensureStablePresentationUpdate();
+
+    results.textContent = element.value + "\n";
+
+    if (window.internals)
+       results.textContent += internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    await UIHelper.waitForInputSessionToDismiss();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+})();
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -162,8 +162,8 @@ static bool shouldAllowNonInteractiveCursorForElement(const Element& element)
         return true;
 #endif
 
-    if (is<HTMLTextFormControlElement>(element))
-        return !element.focused();
+    if (RefPtr textElement = dynamicDowncast<HTMLTextFormControlElement>(element))
+        return !textElement->focused() || !textElement->lastChangeWasUserEdit() || textElement->value().isEmpty();
 
     if (is<HTMLFormControlElement>(element))
         return true;


### PR DESCRIPTION
#### c31a3bd6fa34624051e51534ba90c847f98b6488
<pre>
Makes interaction region visible on a HTMLTextFormControlElement when focused.
<a href="https://bugs.webkit.org/show_bug.cgi?id=275064">https://bugs.webkit.org/show_bug.cgi?id=275064</a>
<a href="https://rdar.apple.com/120749461">rdar://120749461</a>

Reviewed by Aditya Keerthi.

Interaction region is visible in almost all states of a HTMLTextFormControlElement
except when editing the text and when focused + edited + has-value.

* LayoutTests/interaction-region/text-input-focused-edited-empty-expected.txt: Added.
* LayoutTests/interaction-region/text-input-focused-edited-empty.html: Added.
* LayoutTests/interaction-region/text-input-focused-edited-expected.txt: Copied from LayoutTests/interaction-region/text-input-focused-expected.txt.
* LayoutTests/interaction-region/text-input-focused-edited.html: Added.
* LayoutTests/interaction-region/text-input-focused-expected.txt:
* LayoutTests/interaction-region/textarea-focused-edited-empty-expected.txt: Added.
* LayoutTests/interaction-region/textarea-focused-edited-empty.html: Added.
* LayoutTests/interaction-region/textarea-focused-edited-expected.txt: Copied from LayoutTests/interaction-region/text-input-focused-expected.txt.
* LayoutTests/interaction-region/textarea-focused-edited.html: Added.
* LayoutTests/interaction-region/textarea-focused-expected.txt:
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::shouldAllowNonInteractiveCursorForElement):

Canonical link: <a href="https://commits.webkit.org/279828@main">https://commits.webkit.org/279828@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2459068e8a9aae8d58a9e4f7e95a2b53bb95ddd2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57922 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5375 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5383 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44263 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3627 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56737 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32205 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47329 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25388 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29002 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4663 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3515 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59512 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29880 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5023 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51687 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31025 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47415 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51071 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11984 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32012 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30812 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->