### PR TITLE
Replace static_assert with #error in DataLog.cpp

### DIFF
--- a/Source/WTF/wtf/DataLog.cpp
+++ b/Source/WTF/wtf/DataLog.cpp
@@ -45,9 +45,12 @@
 // above to always use the fallback filename.
 #define DATA_LOG_IGNORE_ENV_VAR 0
 
-static_assert(!(DATA_LOG_TO_FILE && DATA_LOG_TO_DARWIN_TEMP_DIR), "Set at most one data-log file target");
-#if OS(WINDOWS)
-static_assert(!DATA_LOG_TO_DARWIN_TEMP_DIR, "Cannot log to Darwin temp dir on Windows");
+#if DATA_LOG_TO_FILE && DATA_LOG_TO_DARWIN_TEMP_DIR
+#error "Set at most one data-log file target"
+#endif
+
+#if OS(WINDOWS) && DATA_LOG_TO_DARWIN_TEMP_DIR
+#error "Cannot log to Darwin temp dir on Windows"
 #endif
 
 // Note that we will append ".<pid>.txt" where <pid> is the PID.


### PR DESCRIPTION
#### 00896ef855fa560af775fbbc42de4361cc571969
<pre>
Replace static_assert with #error in DataLog.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=275070">https://bugs.webkit.org/show_bug.cgi?id=275070</a>
<a href="https://rdar.apple.com/129177831">rdar://129177831</a>

Reviewed by Philippe Normand.

Using `static_assert` means that a `0 &amp;&amp; 0` survives past preprocessor
time, which causes gcc&apos;s `-Wconstant-logical-operand` to raise a
warning. Using #if + #error means that this will be cleaned out by the
preprocessor instead, avoiding that warning.

* Source/WTF/wtf/DataLog.cpp:

Canonical link: <a href="https://commits.webkit.org/279679@main">https://commits.webkit.org/279679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2901e930f60dad74c3659f9480648e3c0c126df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54123 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57398 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4847 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4743 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43833 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3228 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46856 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24975 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28561 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4173 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/2996 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/47482 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50275 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4379 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/58992 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/53631 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4484 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51248 "Found 1 new test failure: imported/w3c/web-platform-tests/pointerevents/pointerevent_pointer_boundary_events_after_reappending_last_over_target.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30497 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46970 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50613 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31460 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65932 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8025 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30277 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12553 "Passed tests") | 
<!--EWS-Status-Bubble-End-->