### PR TITLE
[WebGPU] white screen on noclip.website

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_275043-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_275043-expected.txt
@@ -1,0 +1,7 @@
+CONSOLE MESSAGE: validation error
+CONSOLE MESSAGE: setPipeline: validation failed
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_275043.html
+++ b/LayoutTests/fast/webgpu/regression/repro_275043.html
@@ -1,0 +1,39 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let code = `
+@vertex
+fn v() -> @builtin(position) vec4f {
+  return vec4();
+}
+
+@fragment
+fn f() -> @location(0) vec4f {
+  return vec4();
+}
+`;
+    let module = device.createShaderModule({code});
+    let pipeline = device.createRenderPipeline({
+      layout: device.createPipelineLayout({bindGroupLayouts: []}),
+      vertex: {module, buffers: []},
+      fragment: {module, targets: [{format: 'bgra8unorm'}]},
+    });
+    let renderBundleEncoder = device.createRenderBundleEncoder({colorFormats: [undefined, undefined]});
+    renderBundleEncoder.setPipeline(pipeline);
+    renderBundleEncoder.draw(1);
+    let renderBundle = renderBundleEncoder.finish();
+    let error = await device.popErrorScope();
+    if (error) {
+      log('validation error');
+      log(error.message);
+    } else {
+      log('no validation error');
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/LayoutTests/fast/webgpu/regression/repro_275043b-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_275043b-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: no validation error
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_275043b.html
+++ b/LayoutTests/fast/webgpu/regression/repro_275043b.html
@@ -1,0 +1,39 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let code = `
+@vertex
+fn v() -> @builtin(position) vec4f {
+  return vec4();
+}
+
+@fragment
+fn f() -> @location(0) vec4f {
+  return vec4();
+}
+`;
+    let module = device.createShaderModule({code});
+    let pipeline = device.createRenderPipeline({
+      layout: device.createPipelineLayout({bindGroupLayouts: []}),
+      vertex: {module, buffers: []},
+      fragment: {module, targets: [{format: 'bgra8unorm'}]},
+    });
+    let renderBundleEncoder = device.createRenderBundleEncoder({colorFormats: ['bgra8unorm', undefined]});
+    renderBundleEncoder.setPipeline(pipeline);
+    renderBundleEncoder.draw(1);
+    let renderBundle = renderBundleEncoder.finish();
+    let error = await device.popErrorScope();
+    if (error) {
+      log('validation error');
+      log(error.message);
+    } else {
+      log('no validation error');
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/LayoutTests/fast/webgpu/regression/repro_275043c-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_275043c-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: no validation error
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_275043c.html
+++ b/LayoutTests/fast/webgpu/regression/repro_275043c.html
@@ -1,0 +1,39 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let code = `
+@vertex
+fn v() -> @builtin(position) vec4f {
+  return vec4();
+}
+
+@fragment
+fn f() -> @location(0) vec4f {
+  return vec4();
+}
+`;
+    let module = device.createShaderModule({code});
+    let pipeline = device.createRenderPipeline({
+      layout: device.createPipelineLayout({bindGroupLayouts: []}),
+      vertex: {module, buffers: []},
+      fragment: {module, targets: [{format: 'bgra8unorm'}, undefined]},
+    });
+    let renderBundleEncoder = device.createRenderBundleEncoder({colorFormats: ['bgra8unorm']});
+    renderBundleEncoder.setPipeline(pipeline);
+    renderBundleEncoder.draw(1);
+    let renderBundle = renderBundleEncoder.finish();
+    let error = await device.popErrorScope();
+    if (error) {
+      log('validation error');
+      log(error.message);
+    } else {
+      log('no validation error');
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>


### PR DESCRIPTION
#### 858f0966395a8de999845daa1e576eb4b724fce7
<pre>
[WebGPU] white screen on noclip.website
<a href="https://bugs.webkit.org/show_bug.cgi?id=275043">https://bugs.webkit.org/show_bug.cgi?id=275043</a>
&lt;radar://129051291&gt;

Reviewed by Dan Glastonbury.

colorAttachmentViews could contain nil entries, which were not accounted for.

* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::RenderPipeline::colorDepthStencilTargetsMatch const):
(WebGPU::RenderPipeline::validateRenderBundle const):

* LayoutTests/fast/webgpu/regression/repro_275043-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_275043.html: Added.
* LayoutTests/fast/webgpu/regression/repro_275043b-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_275043b.html: Added.
* LayoutTests/fast/webgpu/regression/repro_275043c-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_275043c.html: Added.
Add regression tests.

* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::RenderPipeline::colorDepthStencilTargetsMatch const):
(WebGPU::RenderPipeline::validateRenderBundle const):

Canonical link: <a href="https://commits.webkit.org/279704@main">https://commits.webkit.org/279704@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc0f2296a97a6916fcdcd388ecfc52adac7eeb5b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57429 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4877 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4773 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43854 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3257 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31811 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46891 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25007 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28600 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4211 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3026 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50299 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59022 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29354 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4515 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51276 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30527 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47005 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50653 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11813 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31494 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30308 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->