### PR TITLE
[WebGPU] Buffer binding size check does not take into account binding offset

### DIFF
--- a/LayoutTests/fast/webgpu/fuzz-126848520-explicit-layout-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-126848520-explicit-layout-expected.txt
@@ -1,5 +1,5 @@
      0                0
      8                0
-buffer length is 16 which is less than required bufferSize of 1073741820
+buffer length is 16 minus offset 0 which is less than required bufferSize of 1073741820
 done
 

--- a/LayoutTests/fast/webgpu/fuzz-128381161-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-128381161-expected.txt
@@ -4,6 +4,6 @@ TEST COMPLETE
      0                0
      8                0
 validation error:
-buffer length is 16 which is less than required bufferSize of 4294967295
+buffer length is 16 minus offset 0 which is less than required bufferSize of 4294967295
 done
 

--- a/LayoutTests/fast/webgpu/fuzz-128677742-expected.txt
+++ b/LayoutTests/fast/webgpu/fuzz-128677742-expected.txt
@@ -3,6 +3,6 @@ PASS successfullyParsed is true
 TEST COMPLETE
 0
 validation error:
-buffer length is 4 which is less than required bufferSize of 4294967295
+buffer length is 4 minus offset 0 which is less than required bufferSize of 4294967295
 done
 

--- a/LayoutTests/fast/webgpu/regression/repro_274706b-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_274706b-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: buffer length is 4 which is less than required bufferSize of 2147483648
+CONSOLE MESSAGE: buffer length is 4 minus offset 0 which is less than required bufferSize of 2147483648
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x600

--- a/LayoutTests/fast/webgpu/regression/repro_274706c-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_274706c-expected.txt
@@ -1,5 +1,5 @@
 CONSOLE MESSAGE: 0
-CONSOLE MESSAGE: buffer length is 16 which is less than required bufferSize of 2147483648
+CONSOLE MESSAGE: buffer length is 16 minus offset 0 which is less than required bufferSize of 2147483648
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x600

--- a/LayoutTests/fast/webgpu/regression/repro_275071-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_275071-expected.txt
@@ -1,4 +1,6 @@
-CONSOLE MESSAGE: buffer length is 4 minus offset 0 which is less than required bufferSize of 2147483648
+CONSOLE MESSAGE: 0
+CONSOLE MESSAGE: validation error
+CONSOLE MESSAGE: buffer length is 260 minus offset 256 which is less than required bufferSize of 260
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
 layer at (0,0) size 800x600

--- a/LayoutTests/fast/webgpu/regression/repro_275071.html
+++ b/LayoutTests/fast/webgpu/regression/repro_275071.html
@@ -1,0 +1,55 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let storageBuffer = device.createBuffer({size: 260, usage: GPUBufferUsage.STORAGE});
+    let outputBuffer = device.createBuffer({size: 4, usage: GPUBufferUsage.MAP_READ});
+    let code = `
+@group(0) @binding(0) var<storage, read_write> oob: array<u32, 65>;
+
+@compute @workgroup_size(1)
+fn c() {
+  oob[64] = 11223344;
+}
+`;
+    let bindGroupLayout = device.createBindGroupLayout({
+      entries: [
+        {binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: {type: 'storage'}},
+      ],
+    });
+    let bindGroup0 = device.createBindGroup({
+      layout: bindGroupLayout, entries: [
+        {binding: 0, resource: {buffer: storageBuffer, size: 4, offset: 256}},
+      ],
+    });
+    let module = device.createShaderModule({code});
+    let pipeline = device.createComputePipeline({
+      layout: device.createPipelineLayout({bindGroupLayouts: [bindGroupLayout]}),
+      compute: {module},
+    });
+    let commandEncoder = device.createCommandEncoder();
+    let computePassEncoder = commandEncoder.beginComputePass({});
+    computePassEncoder.setPipeline(pipeline);
+    computePassEncoder.setBindGroup(0, bindGroup0);
+    computePassEncoder.dispatchWorkgroups(1);
+    computePassEncoder.end();
+    device.queue.submit([commandEncoder.finish()]);
+    await device.queue.onSubmittedWorkDone();
+    await outputBuffer.mapAsync(GPUMapMode.READ);
+    let outputU32 = new Uint32Array(outputBuffer.getMappedRange());
+    log(outputU32);
+    outputBuffer.unmap();
+    let error = await device.popErrorScope();
+    if (error) {
+      log('validation error');
+      log(error.message);
+    } else {
+      log('no validation error');
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -880,9 +880,9 @@ static BindGroupEntryUsage usageForBuffer(WGPUBufferBindingType bufferBindingTyp
     return BindGroupEntryUsage::Undefined;
 }
 
-static BindGroupEntryUsageData makeBindGroupEntryUsageData(BindGroupEntryUsage usage, uint32_t bindingIndex, auto& resource)
+static BindGroupEntryUsageData makeBindGroupEntryUsageData(BindGroupEntryUsage usage, uint32_t bindingIndex, auto& resource, uint64_t entryOffset = 0)
 {
-    return BindGroupEntryUsageData { .usage = usage, .binding = bindingIndex, .resource = &resource };
+    return BindGroupEntryUsageData { .usage = usage, .binding = bindingIndex, .resource = &resource, .entryOffset = entryOffset };
 }
 
 Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor)
@@ -1023,7 +1023,7 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
                 }
                 if (buffer) {
                     stageResources[metalRenderStage(stage)][resourceUsage - 1].append(buffer);
-                    stageResourceUsages[metalRenderStage(stage)][resourceUsage - 1].append(makeBindGroupEntryUsageData(usageForBuffer(layoutBinding->type), entry.binding, apiBuffer));
+                    stageResourceUsages[metalRenderStage(stage)][resourceUsage - 1].append(makeBindGroupEntryUsageData(usageForBuffer(layoutBinding->type), entry.binding, apiBuffer, entryOffset));
                 }
             } else if (samplerIsPresent) {
                 auto* layoutBinding = hasBinding<WGPUSamplerBindingLayout>(bindGroupLayoutEntries, bindingIndex);

--- a/Source/WebGPU/WebGPU/BindableResource.h
+++ b/Source/WebGPU/WebGPU/BindableResource.h
@@ -61,6 +61,7 @@ struct BindGroupEntryUsageData {
     uint32_t binding { 0 };
     using Resource = std::variant<RefPtr<Buffer>, RefPtr<const TextureView>, RefPtr<const ExternalTexture>>;
     Resource resource;
+    uint64_t entryOffset { 0 };
     static constexpr uint32_t invalidBindingIndex = INT_MAX;
     static constexpr BindGroupEntryUsage invalidBindGroupUsage = static_cast<BindGroupEntryUsage>(std::numeric_limits<std::underlying_type<BindGroupEntryUsage>::type>::max());
 };

--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -195,8 +195,9 @@ NSString* errorValidatingBindGroup(const BindGroup& bindGroup, const BufferBindi
             }
 
             if (bufferSize && buffer->get()) {
-                if (buffer->get()->buffer().length < bufferSize)
-                    return [NSString stringWithFormat:@"buffer length is %zu which is less than required bufferSize of %llu", buffer->get()->buffer().length, bufferSize];
+                auto mtlBufferLength = buffer->get()->buffer().length;
+                if (resource.entryOffset > mtlBufferLength || (mtlBufferLength - resource.entryOffset) < bufferSize)
+                    return [NSString stringWithFormat:@"buffer length is %zu minus offset %llu which is less than required bufferSize of %llu", mtlBufferLength, resource.entryOffset, bufferSize];
             }
         }
     }


### PR DESCRIPTION
#### f0946544d1cfcb15dbf526744d0916e7d6a19e37
<pre>
[WebGPU] Buffer binding size check does not take into account binding offset
<a href="https://bugs.webkit.org/show_bug.cgi?id=275071">https://bugs.webkit.org/show_bug.cgi?id=275071</a>
&lt;radar://129160139&gt;

Reviewed by Dan Glastonbury.

Correct buffer size validation so the buffer offset is taken into account.

* LayoutTests/fast/webgpu/regression/repro_275071-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_275071.html: Added.
Add regression tests.

* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::makeBindGroupEntryUsageData):
(WebGPU::Device::createBindGroup):
* Source/WebGPU/WebGPU/BindableResource.h:
* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::errorValidatingBindGroup):

Canonical link: <a href="https://commits.webkit.org/279689@main">https://commits.webkit.org/279689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc977804dada54baf65c8fcfc92dc9bcf2140d34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54138 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57414 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4862 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4758 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43859 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3244 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46873 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24990 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28579 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4192 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3011 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50288 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4397 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59007 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29337 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4526 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51262 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30512 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46987 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50624 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11802 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31479 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30293 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->