### PR TITLE
JSStringGetUTF8CString writes beyond the provided buffer size

### DIFF
--- a/Source/JavaScriptCore/API/tests/testapi.c
+++ b/Source/JavaScriptCore/API/tests/testapi.c
@@ -1190,6 +1190,117 @@ void JSSynchronousGarbageCollectForDebugging(JSContextRef);
 }
 #endif
 
+static void checkJSStringOOBUTF8(void)
+{
+    const size_t sourceCStringSize = 200;
+    const size_t outCStringSize = 10;
+
+    char sourceCString[sourceCStringSize];
+    memset(sourceCString, 0, sizeof(sourceCString));
+    for (size_t i = 0; i < sourceCStringSize - 1; ++i)
+        sourceCString[i] = '0' + (i%10);
+
+    char outCString[outCStringSize + sourceCStringSize];
+    memset(outCString, 0x13, sizeof(outCString));
+
+    JSStringRef str = JSStringCreateWithUTF8CString(sourceCString);
+    size_t bytesWritten = JSStringGetUTF8CString(str, outCString, outCStringSize);
+
+    assertTrue(bytesWritten == 10, "we report 10 bytes written precisely");
+
+    for (size_t i = 0; i < sizeof(outCString); ++i) {
+        if (i == outCStringSize - 1)
+            assertTrue(outCString[i] == '\0', "string terminated");
+        else if (i < outCStringSize - 1)
+            assertTrue(outCString[i] == sourceCString[i], "string copied");
+        else
+            assertTrue(outCString[i] == 0x13, "did not write past the end");
+    }
+
+    JSStringRelease(str);
+}
+
+static void checkJSStringOOBUTF16(void)
+{
+    const size_t sourceCStringSize = 22;
+    const size_t outCStringSize = 20;
+
+    char sourceCString[sourceCStringSize];
+    memset(sourceCString, 0, sizeof(sourceCString));
+    for (size_t i = 0; i < sourceCStringSize - 1; ++i)
+        sourceCString[i] = '0' + (i%10);
+
+    sourceCString[3] = '\xF0';
+    sourceCString[4] = '\x9F';
+    sourceCString[5] = '\x98';
+    sourceCString[6] = '\x81';
+
+    char outCString[outCStringSize + sourceCStringSize];
+    memset(outCString, 0x13, sizeof(outCString));
+
+    JSStringRef str = JSStringCreateWithUTF8CString(sourceCString);
+    size_t bytesWritten = JSStringGetUTF8CString(str, outCString, outCStringSize);
+
+    assertTrue(bytesWritten == 20, "we report 20 bytes written precisely");
+
+    for (size_t i = 0; i < sizeof(outCString); ++i) {
+        if (i == outCStringSize - 1)
+            assertTrue(outCString[i] == '\0', "string terminated");
+        else if (i < outCStringSize - 1)
+            assertTrue(outCString[i] == sourceCString[i], "string copied");
+        else
+            assertTrue(outCString[i] == 0x13, "did not write past the end");
+    }
+
+    JSStringRelease(str);
+}
+
+static void checkJSStringOOBUTF16AtEnd(void)
+{
+    const size_t sourceCStringSize = 22;
+    const size_t outCStringSize = 20;
+
+    char sourceCString[sourceCStringSize];
+    memset(sourceCString, 0, sizeof(sourceCString));
+    for (size_t i = 0; i < sourceCStringSize - 1; ++i)
+        sourceCString[i] = '0' + (i%10);
+
+    sourceCString[17] = '\xF0';
+    sourceCString[18] = '\x9F';
+    sourceCString[19] = '\x98';
+    sourceCString[20] = '\x81';
+
+    char outCString[outCStringSize + sourceCStringSize];
+    memset(outCString, 0x13, sizeof(outCString));
+
+    JSStringRef str = JSStringCreateWithUTF8CString(sourceCString);
+    size_t bytesWritten = JSStringGetUTF8CString(str, outCString, outCStringSize);
+
+    assertTrue(bytesWritten == 18, "we report 18 bytes written precisely");
+
+    for (size_t i = 0; i < sizeof(outCString); ++i) {
+        if (i == 17)
+            assertTrue(outCString[i] == '\0', "string terminated");
+        else if (i < 17)
+            assertTrue(outCString[i] == sourceCString[i], "string copied");
+        else
+            assertTrue(outCString[i] == 0x13, "did not write past the end");
+    }
+
+    JSStringRelease(str);
+}
+
+static void checkJSStringOOB(void)
+{
+    printf("Test: checkJSStringOOB\n");
+    checkJSStringOOBUTF8();
+    printf(".\n");
+    checkJSStringOOBUTF16();
+    printf(".\n");
+    checkJSStringOOBUTF16AtEnd();
+    printf("PASS: checkJSStringOOB\n");
+}
+
 static const unsigned numWeakRefs = 10000;
 
 static void markingConstraint(JSMarkerRef marker, void *userData)
@@ -1763,7 +1874,7 @@ int main(int argc, char* argv[])
     assertEqualsAsCharactersPtr(jsOneThird, "0.3333333333333333");
     assertEqualsAsCharactersPtr(jsEmptyString, "");
     assertEqualsAsCharactersPtr(jsOneString, "1");
-    
+
     assertEqualsAsUTF8String(jsUndefined, "undefined");
     assertEqualsAsUTF8String(jsNull, "null");
     assertEqualsAsUTF8String(jsTrue, "true");
@@ -1773,9 +1884,11 @@ int main(int argc, char* argv[])
     assertEqualsAsUTF8String(jsOneThird, "0.3333333333333333");
     assertEqualsAsUTF8String(jsEmptyString, "");
     assertEqualsAsUTF8String(jsOneString, "1");
-    
+
+    checkJSStringOOB();
+
     checkConstnessInJSObjectNames();
-    
+
     ASSERT(JSValueIsStrictEqual(context, jsTrue, jsTrue));
     ASSERT(!JSValueIsStrictEqual(context, jsOne, jsOneString));
 


### PR DESCRIPTION
#### f9a7aaf14df9fe74f266abc8fbb70cf5201e3b00
<pre>
JSStringGetUTF8CString writes beyond the provided buffer size
<a href="https://bugs.webkit.org/show_bug.cgi?id=275073">https://bugs.webkit.org/show_bug.cgi?id=275073</a>
<a href="https://rdar.apple.com/122388595">rdar://122388595</a>

Reviewed by Yusuke Suzuki.

Patch created by Justin Michaud (referring to the original commit in the last line).
ToT already fixed the issue. Only landing the test (with newer semantics adjustment) is necessary.

* Source/JavaScriptCore/API/tests/testapi.c:
(checkJSStringOOBUTF8):
(checkJSStringOOBUTF16):
(checkJSStringOOBUTF16AtEnd):
(checkJSStringOOB):
(main):

Originally-landed-as: 272448.625@safari-7618-branch (800c12a28dea). <a href="https://rdar.apple.com/128091153">rdar://128091153</a>
Canonical link: <a href="https://commits.webkit.org/279673@main">https://commits.webkit.org/279673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a10dc42f2ba7b294d9676f4985803ce1b077605

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33518 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6668 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57407 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4856 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41036 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4752 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/3235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/56228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/46864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/24982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/28574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/4182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3005 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/47491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50282 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/4388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/59001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/53640 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/29330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/4493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/59001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/30506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/46978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/59001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/31473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/65941 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8021 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/30287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/12555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->