### PR TITLE
Add occasional logging of all existing PlatformMediaSessions.

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioContext.h
+++ b/Source/WebCore/Modules/webaudio/AudioContext.h
@@ -104,6 +104,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final;
+    const void* logIdentifier() const final { return BaseAudioContext::logIdentifier(); }
 #endif
 
     void constructCommon();

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -215,7 +215,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const override { return m_logger.get(); }
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    const void* logIdentifier() const override { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
     const void* nextAudioNodeLogIdentifier() { return childLogIdentifier(m_logIdentifier, ++m_nextAudioNodeIdentifier); }
     const void* nextAudioParameterLogIdentifier() { return childLogIdentifier(m_logIdentifier, ++m_nextAudioParameterIdentifier); }

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -5991,7 +5991,7 @@ void HTMLMediaElement::mediaPlayerDidInitializeMediaEngine() WTF_IGNORES_THREAD_
 
 void HTMLMediaElement::mediaPlayerCharacteristicChanged()
 {
-    ALWAYS_LOG(LOGIDENTIFIER);
+    ALWAYS_LOG(LOGIDENTIFIER, m_mediaSession ? m_mediaSession->description() : emptyString());
 
     beginProcessingMediaPlayerCallback();
 

--- a/Source/WebCore/html/MediaElementSession.h
+++ b/Source/WebCore/html/MediaElementSession.h
@@ -175,7 +175,7 @@ public:
     std::optional<MediaUsageInfo> mediaUsageInfo() const { return m_mediaUsageInfo; }
 
 #if !RELEASE_LOG_DISABLED
-    const void* logIdentifier() const final { return m_logIdentifier; }
+    String description() const final;
     ASCIILiteral logClassName() const final { return "MediaElementSession"_s; }
 #endif
 

--- a/Source/WebCore/platform/audio/PlatformMediaSession.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.h
@@ -232,8 +232,8 @@ public:
     bool preparingToPlay() const { return m_preparingToPlay; }
 
 #if !RELEASE_LOG_DISABLED
-    const Logger& logger() const final { return m_logger.get(); }
-    const void* logIdentifier() const override { return m_logIdentifier; }
+    const Logger& logger() const final;
+    const void* logIdentifier() const final;
     ASCIILiteral logClassName() const override { return "PlatformMediaSession"_s; }
     WTFLogChannel& logChannel() const final;
 #endif
@@ -250,6 +250,10 @@ public:
     virtual bool isLongEnoughForMainContent() const { return false; }
 
     MediaSessionIdentifier mediaSessionIdentifier() const { return m_mediaSessionIdentifier; }
+
+#if !RELEASE_LOG_DISABLED
+    virtual String description() const;
+#endif
 
 protected:
     PlatformMediaSession(PlatformMediaSessionManager&, PlatformMediaSessionClient&);
@@ -270,11 +274,6 @@ private:
     bool m_isPlayingToWirelessPlaybackTarget { false };
     bool m_hasPlayedAudiblySinceLastInterruption { false };
     bool m_preparingToPlay { false };
-
-#if !RELEASE_LOG_DISABLED
-    Ref<const Logger> m_logger;
-    const void* m_logIdentifier;
-#endif
 
     friend class PlatformMediaSessionManager;
 };
@@ -328,6 +327,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     virtual const Logger& logger() const = 0;
+    virtual const void* logIdentifier() const = 0;
 #endif
 
 protected:
@@ -336,6 +336,7 @@ protected:
 
 String convertEnumerationToString(PlatformMediaSession::State);
 String convertEnumerationToString(PlatformMediaSession::InterruptionType);
+String convertEnumerationToString(PlatformMediaSession::MediaType);
 WEBCORE_EXPORT String convertEnumerationToString(PlatformMediaSession::RemoteControlCommandType);
 
 } // namespace WebCore
@@ -366,6 +367,14 @@ struct LogArgument<WebCore::PlatformMediaSession::RemoteControlCommandType> {
     static String toString(const WebCore::PlatformMediaSession::RemoteControlCommandType command)
     {
         return convertEnumerationToString(command);
+    }
+};
+
+template <>
+struct LogArgument<WebCore::PlatformMediaSession::MediaType> {
+    static String toString(const WebCore::PlatformMediaSession::MediaType mediaType)
+    {
+        return convertEnumerationToString(mediaType);
     }
 };
 

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
@@ -234,6 +234,11 @@ private:
 
     Vector<WeakPtr<PlatformMediaSession>> sessionsMatching(const Function<bool(const PlatformMediaSession&)>&) const;
 
+#if !RELEASE_LOG_DISABLED
+    void scheduleStateLog();
+    void dumpSessionStates();
+#endif
+
     SessionRestrictions m_restrictions[static_cast<unsigned>(PlatformMediaSession::MediaType::WebAudio) + 1];
     mutable Vector<WeakPtr<PlatformMediaSession>> m_sessions;
 
@@ -281,6 +286,7 @@ private:
 #endif
 
 #if !RELEASE_LOG_DISABLED
+    UniqueRef<Timer> m_stateLogTimer;
     Ref<AggregateLogger> m_logger;
 #endif
 };


### PR DESCRIPTION
#### 269b48ddc5e00155f754dec9d082c16687efc3e8
<pre>
Add occasional logging of all existing PlatformMediaSessions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=275077">https://bugs.webkit.org/show_bug.cgi?id=275077</a>
<a href="https://rdar.apple.com/129185327">rdar://129185327</a>

Reviewed by Andy Estes.

Add a logging entry that is triggered whenever a PlatformMediaSession changes state().

In order to not overload the logging when many sessions change all at once, only do the
logging after a short timeout.

* Source/WebCore/Modules/webaudio/AudioContext.h:
* Source/WebCore/Modules/webaudio/BaseAudioContext.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaPlayerCharacteristicChanged):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::MediaElementSession):
(WebCore::MediaElementSession::description const):
* Source/WebCore/html/MediaElementSession.h:
* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::convertEnumerationToString):
(WebCore::PlatformMediaSession::PlatformMediaSession):
(WebCore::PlatformMediaSession::processClientWillPausePlayback):
(WebCore::PlatformMediaSession::logger const):
(WebCore::PlatformMediaSession::logIdentifier const):
(WebCore::PlatformMediaSession::description const):
* Source/WebCore/platform/audio/PlatformMediaSession.h:
(WTF::LogArgument&lt;WebCore::PlatformMediaSession::MediaType&gt;::toString):
* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::PlatformMediaSessionManager):
(WebCore::PlatformMediaSessionManager::sessionStateChanged):
(WebCore::PlatformMediaSessionManager::scheduleStateLog):
(WebCore::PlatformMediaSessionManager::dumpSessionStates):
* Source/WebCore/platform/audio/PlatformMediaSessionManager.h:

Canonical link: <a href="https://commits.webkit.org/279700@main">https://commits.webkit.org/279700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1d1b41cb6473b594df5bc8702c4425fb718875f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54136 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57411 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4860 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56439 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4756 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43846 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3241 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56232 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31770 "Found 4 new test failures: animations/3d/change-transform-in-end-event.html, fast/forms/ios/focus-input-via-button.html, fast/forms/ios/zoom-after-input-tap-wide-input.html, fast/forms/ios/zoom-after-input-tap.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46870 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/24991 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28577 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4188 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3009 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50287 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4394 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59005 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29334 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4500 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51261 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30510 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46984 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50623 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11811 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31477 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30291 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->