### PR TITLE
[UnifiedPDF] Cannot zoom out on certain large documents

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1247,7 +1247,7 @@ double UnifiedPDFPlugin::initialScale() const
 void UnifiedPDFPlugin::computeNormalizationFactor()
 {
     auto actualSizeScale = scaleForActualSize();
-    m_scaleNormalizationFactor = 1.0 / actualSizeScale;
+    m_scaleNormalizationFactor = std::max(1.0, actualSizeScale) / actualSizeScale;
 }
 
 double UnifiedPDFPlugin::fromNormalizedScaleFactor(double normalizedScale) const


### PR DESCRIPTION
#### fc175103f7d8716147c3cb41ea4066e84f51b08a
<pre>
[UnifiedPDF] Cannot zoom out on certain large documents
<a href="https://bugs.webkit.org/show_bug.cgi?id=275072">https://bugs.webkit.org/show_bug.cgi?id=275072</a>
<a href="https://rdar.apple.com/128915788">rdar://128915788</a>

Reviewed by Simon Fraser.

Some clients may have a lower and upper bounds in which they restrict
their page scales. In certain circumstances we may compute a normalized
scale factor which ends up being below the upper bound. It appears that
this can occur frequently in large documents because we compute a
&quot;large,&quot; scale for the actual size and end up computing a &quot;small,&quot;
normalization factor. This is what ends up happening if you open the PDF
in the bugzilla with Minibrowser. To limit this pathological behavior
with the increased document size let&apos;s make sure that when we compute
the normalization scale factor it is relative to the actual size scale.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::computeNormalizationFactor):

Canonical link: <a href="https://commits.webkit.org/279688@main">https://commits.webkit.org/279688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f10d08288748d0b94b4d4c2e20f153531cd96a62

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6688 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57428 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4876 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41058 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4772 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43853 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3256 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31785 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46883 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25001 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28591 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3025 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50296 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4407 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59021 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4513 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51274 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/46997 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50633 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11803 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31493 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30307 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->