### PR TITLE
Enable -Wvla when building WebKit

### DIFF
--- a/Configurations/CommonBase.xcconfig
+++ b/Configurations/CommonBase.xcconfig
@@ -55,7 +55,7 @@ OTHER_LDFLAGS = $(inherited) $(WK_COMMON_OTHER_LDFLAGS);
 WK_COMMON_OTHER_TAPI_FLAGS = -x objective-c++ -std=c++2a -fno-rtti $(WK_SANITIZER_OTHER_TAPI_FLAGS);
 OTHER_TAPI_FLAGS = $(inherited) $(WK_COMMON_OTHER_TAPI_FLAGS);
 
-WK_COMMON_WARNING_CFLAGS = -Wall -Wc99-designator -Wconditional-uninitialized -Wextra -Wdeprecated-enum-enum-conversion -Wdeprecated-enum-float-conversion -Wenum-float-conversion -Wfinal-dtor-non-final-class -Wformat=2 -Wmisleading-indentation -Wreorder-init-list -Wundef;
+WK_COMMON_WARNING_CFLAGS = -Wall -Wc99-designator -Wconditional-uninitialized -Wextra -Wdeprecated-enum-enum-conversion -Wdeprecated-enum-float-conversion -Wenum-float-conversion -Wfinal-dtor-non-final-class -Wformat=2 -Wmisleading-indentation -Wreorder-init-list -Wundef -Wvla;
 WARNING_CFLAGS = $(inherited) $(WK_COMMON_WARNING_CFLAGS) $(WK_SANITIZER_WARNING_CFLAGS);
 
 CLANG_CXX_STANDARD_LIBRARY_HARDENING = extensive;

--- a/Source/JavaScriptCore/API/tests/testapi.c
+++ b/Source/JavaScriptCore/API/tests/testapi.c
@@ -1195,13 +1195,13 @@ static void checkJSStringOOBUTF8(void)
     const size_t sourceCStringSize = 200;
     const size_t outCStringSize = 10;
 
-    char sourceCString[sourceCStringSize];
-    memset(sourceCString, 0, sizeof(sourceCString));
+    char* sourceCString = (char*)malloc(sourceCStringSize);
+    memset(sourceCString, 0, sourceCStringSize);
     for (size_t i = 0; i < sourceCStringSize - 1; ++i)
         sourceCString[i] = '0' + (i%10);
 
-    char outCString[outCStringSize + sourceCStringSize];
-    memset(outCString, 0x13, sizeof(outCString));
+    char* outCString = (char*)malloc(outCStringSize + sourceCStringSize);
+    memset(outCString, 0x13, outCStringSize + sourceCStringSize);
 
     JSStringRef str = JSStringCreateWithUTF8CString(sourceCString);
     size_t bytesWritten = JSStringGetUTF8CString(str, outCString, outCStringSize);
@@ -1218,6 +1218,8 @@ static void checkJSStringOOBUTF8(void)
     }
 
     JSStringRelease(str);
+    free(outCString);
+    free(sourceCString);
 }
 
 static void checkJSStringOOBUTF16(void)
@@ -1225,8 +1227,8 @@ static void checkJSStringOOBUTF16(void)
     const size_t sourceCStringSize = 22;
     const size_t outCStringSize = 20;
 
-    char sourceCString[sourceCStringSize];
-    memset(sourceCString, 0, sizeof(sourceCString));
+    char* sourceCString = (char*)malloc(sourceCStringSize);
+    memset(sourceCString, 0, sourceCStringSize);
     for (size_t i = 0; i < sourceCStringSize - 1; ++i)
         sourceCString[i] = '0' + (i%10);
 
@@ -1235,8 +1237,8 @@ static void checkJSStringOOBUTF16(void)
     sourceCString[5] = '\x98';
     sourceCString[6] = '\x81';
 
-    char outCString[outCStringSize + sourceCStringSize];
-    memset(outCString, 0x13, sizeof(outCString));
+    char* outCString = (char*)malloc(outCStringSize + sourceCStringSize);
+    memset(outCString, 0x13, outCStringSize + sourceCStringSize);
 
     JSStringRef str = JSStringCreateWithUTF8CString(sourceCString);
     size_t bytesWritten = JSStringGetUTF8CString(str, outCString, outCStringSize);
@@ -1253,6 +1255,8 @@ static void checkJSStringOOBUTF16(void)
     }
 
     JSStringRelease(str);
+    free(outCString);
+    free(sourceCString);
 }
 
 static void checkJSStringOOBUTF16AtEnd(void)
@@ -1260,8 +1264,8 @@ static void checkJSStringOOBUTF16AtEnd(void)
     const size_t sourceCStringSize = 22;
     const size_t outCStringSize = 20;
 
-    char sourceCString[sourceCStringSize];
-    memset(sourceCString, 0, sizeof(sourceCString));
+    char* sourceCString = (char*)malloc(sourceCStringSize);
+    memset(sourceCString, 0, sourceCStringSize);
     for (size_t i = 0; i < sourceCStringSize - 1; ++i)
         sourceCString[i] = '0' + (i%10);
 
@@ -1270,8 +1274,8 @@ static void checkJSStringOOBUTF16AtEnd(void)
     sourceCString[19] = '\x98';
     sourceCString[20] = '\x81';
 
-    char outCString[outCStringSize + sourceCStringSize];
-    memset(outCString, 0x13, sizeof(outCString));
+    char* outCString = (char*)malloc(outCStringSize + sourceCStringSize);
+    memset(outCString, 0x13, outCStringSize + sourceCStringSize);
 
     JSStringRef str = JSStringCreateWithUTF8CString(sourceCString);
     size_t bytesWritten = JSStringGetUTF8CString(str, outCString, outCStringSize);
@@ -1288,6 +1292,8 @@ static void checkJSStringOOBUTF16AtEnd(void)
     }
 
     JSStringRelease(str);
+    free(outCString);
+    free(sourceCString);
 }
 
 static void checkJSStringOOB(void)

--- a/Source/ThirdParty/libwebrtc/Configurations/Base.xcconfig
+++ b/Source/ThirdParty/libwebrtc/Configurations/Base.xcconfig
@@ -77,7 +77,7 @@ WARNING_CFLAGS = $(inherited) -Wthread-safety $(WK_FIXME_WARNING_CFLAGS) -Wexit-
 
 // Remove WK_FIXME_WARNING_CFLAGS once all warnings are fixed.
 // -Wno-unknown-warning-option added for -Wno-unused-but-set-parameter.
-WK_FIXME_WARNING_CFLAGS = -Wno-conditional-uninitialized -Wno-missing-field-initializers -Wno-sign-compare -Wno-undef -Wno-unknown-warning-option -Wno-unused-but-set-parameter -Wno-unused-parameter -Wno-array-parameter -Wno-unused-but-set-variable -Wno-thread-safety-reference-return;
+WK_FIXME_WARNING_CFLAGS = -Wno-conditional-uninitialized -Wno-missing-field-initializers -Wno-sign-compare -Wno-undef -Wno-unknown-warning-option -Wno-unused-but-set-parameter -Wno-unused-parameter -Wno-array-parameter -Wno-unused-but-set-variable -Wno-thread-safety-reference-return -Wno-vla;
 
 ENTITLEMENTS_REQUIRED = $(ENTITLEMENTS_REQUIRED_USE_INTERNAL_SDK_$(USE_INTERNAL_SDK))
 ENTITLEMENTS_REQUIRED_USE_INTERNAL_SDK_ = NO;

--- a/Tools/DumpRenderTree/cg/PixelDumpSupportCG.cpp
+++ b/Tools/DumpRenderTree/cg/PixelDumpSupportCG.cpp
@@ -40,6 +40,7 @@
 #include <wtf/RefPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/SHA1.h>
+#include <wtf/Vector.h>
 
 #if PLATFORM(IOS_FAMILY)
 #include <MobileCoreServices/UTCoreTypes.h>
@@ -89,10 +90,10 @@ void computeSHA1HashStringForBitmapContext(BitmapContext* context, char hashStri
     unsigned char* bitmapData = static_cast<unsigned char*>(CGBitmapContextGetData(bitmapContext));
     if ((CGBitmapContextGetBitmapInfo(bitmapContext) & kCGBitmapByteOrderMask) == kCGBitmapByteOrder32Big) {
         for (unsigned row = 0; row < pixelsHigh; row++) {
-            uint32_t buffer[pixelsWide];
+            Vector<uint32_t> buffer(pixelsWide);
             for (unsigned column = 0; column < pixelsWide; column++)
                 buffer[column] = OSReadLittleInt32(bitmapData, 4 * column);
-            sha1.addBytes(std::span { reinterpret_cast<const uint8_t*>(buffer), 4 * pixelsWide });
+            sha1.addBytes(asBytes(buffer.span()));
             bitmapData += bytesPerRow;
         }
     } else {

--- a/Tools/DumpRenderTree/mac/AccessibilityNotificationHandler.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityNotificationHandler.mm
@@ -122,7 +122,9 @@ static JSValueRef makeValueRefForValue(JSContextRef context, id value)
 static JSObjectRef makeArrayRefForArray(JSContextRef context, NSArray *array)
 {
     NSUInteger count = array.count;
+IGNORE_WARNINGS_BEGIN("vla")
     JSValueRef arguments[count];
+IGNORE_WARNINGS_END
     for (NSUInteger i = 0; i < count; i++)
         arguments[i] = makeValueRefForValue(context, [array objectAtIndex:i]);
     return JSObjectMakeArray(context, count, arguments, nullptr);

--- a/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
@@ -66,7 +66,9 @@ Class webAccessibilityObjectWrapperClass()
 JSObjectRef makeJSArray(JSContextRef context, NSArray *array)
 {
     NSUInteger count = array.count;
+IGNORE_WARNINGS_BEGIN("vla")
     JSValueRef arguments[count];
+IGNORE_WARNINGS_END
     for (NSUInteger i = 0; i < count; i++)
         arguments[i] = makeValueRefForValue(context, [array objectAtIndex:i]);
     return JSObjectMakeArray(context, count, arguments, nullptr);


### PR DESCRIPTION
#### b39622eb0b6b8c1d0b248d189986100521b139e7
<pre>
Enable -Wvla when building WebKit
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=275081">https://bugs.webkit.org/show_bug.cgi?id=275081</a>&gt;
&lt;<a href="https://rdar.apple.com/129190911">rdar://129190911</a>&gt;

Reviewed by Yusuke Suzuki.

* Configurations/CommonBase.xcconfig:
(WK_COMMON_WARNING_CFLAGS): Add -Wvla.
* Source/JavaScriptCore/API/tests/testapi.c:
(checkJSStringOOBUTF8):
(checkJSStringOOBUTF16):
(checkJSStringOOBUTF16AtEnd):
- Stop using VLAs.  Since this is C, we use malloc()/free() instead.
  Regressed recently in 279673@main.
* Source/ThirdParty/libwebrtc/Configurations/Base.xcconfig:
(WK_FIXME_WARNING_CFLAGS): Add -Wno-vla.
- The opus project and one pffft source file use VLAs.
* Tools/DumpRenderTree/cg/PixelDumpSupportCG.cpp:
(computeSHA1HashStringForBitmapContext):
- Use a Vector&lt;uint32_t&gt; instead of a VLA.
* Tools/DumpRenderTree/mac/AccessibilityNotificationHandler.mm:
(makeArrayRefForArray):
- Ignore -Wvla warnings for JSValueRef objects that must be allocated on
  the stack.
* Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm:
(WTR::makeJSArray): Ditto.
* Tools/WebKitTestRunner/ios/HIDEventGenerator.mm:
(-[HIDEventGenerator touchDown:touchCount:]):
(-[HIDEventGenerator liftUp:touchCount:]):
(-[HIDEventGenerator moveToPoints:touchCount:duration:]):
- Use a Vector&lt;CGPoint&gt; instead of a VLA.

Canonical link: <a href="https://commits.webkit.org/279702@main">https://commits.webkit.org/279702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c56ff493f1bda3848b85005f24283429bdc8793

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54210 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6752 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57487 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4936 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56513 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41125 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4883 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43912 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3308 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56306 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31860 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25054 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28670 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4275 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3083 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/47570 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50370 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59079 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/53718 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29416 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/4640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51336 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30588 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47057 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50696 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31562 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/66019 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8033 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30371 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12572 "Passed tests") | 
<!--EWS-Status-Bubble-End-->