### PR TITLE
[Site Isolation] Begin to fix back forward navigations going to cross-origin iframes

### DIFF
--- a/Source/WebKit/Shared/SessionState.cpp
+++ b/Source/WebKit/Shared/SessionState.cpp
@@ -54,4 +54,15 @@ void FrameState::setDocumentState(const Vector<AtomString>& documentState, Shoul
         validateDocumentState(m_documentState);
 }
 
+const FrameState* FrameState::stateForFrameID(WebCore::FrameIdentifier frameID) const
+{
+    if (this->frameID == frameID)
+        return this;
+    for (auto& child : children) {
+        if (auto* state = child.stateForFrameID(frameID))
+            return state;
+    }
+    return nullptr;
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/SessionState.h
+++ b/Source/WebKit/Shared/SessionState.h
@@ -77,6 +77,8 @@ public:
     void setDocumentState(const Vector<AtomString>&, ShouldValidate = ShouldValidate::No);
     static bool validateDocumentState(const Vector<AtomString>&);
 
+    const FrameState* stateForFrameID(WebCore::FrameIdentifier) const;
+
     String urlString;
     String originalURLString;
     String referrer;

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -92,6 +92,9 @@ public:
     void setIsRootChildFrameItem(bool rootChildFrameItem) { m_isRootChildFrameItem = rootChildFrameItem; }
     bool isRootChildFrameItem() const { return m_isRootChildFrameItem; }
 
+    void setFrameID(WebCore::FrameIdentifier frameID) { m_frameID = frameID; }
+    WebCore::FrameIdentifier frameID() const { return m_frameID; }
+
 #if !LOG_DISABLED
     String loggingString();
 #endif
@@ -111,6 +114,7 @@ private:
     URL m_resourceDirectoryURL;
     WebPageProxyIdentifier m_pageID;
     WebCore::ProcessIdentifier m_lastProcessIdentifier;
+    WebCore::FrameIdentifier m_frameID;
     std::unique_ptr<WebBackForwardCacheEntry> m_backForwardCacheEntry;
     bool m_isRootChildFrameItem { false };
 };


### PR DESCRIPTION
#### c5709a29db791789619cafaf51afa16e59175735
<pre>
[Site Isolation] Begin to fix back forward navigations going to cross-origin iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=275083">https://bugs.webkit.org/show_bug.cgi?id=275083</a>
<a href="https://rdar.apple.com/129192542">rdar://129192542</a>

Reviewed by Alex Christensen.

If we are navigating to a back forward item that corresponds to an out-of-process iframe, and the process
that was hosting the frame no longer exists, we should navigate the process that is now hosting the frame.

* Source/WebKit/Shared/SessionState.cpp:
(WebKit::FrameState::stateForFrameID const):
* Source/WebKit/Shared/SessionState.h:
Add `stateForFrameID` that is used to get the URL for the frame that navigated.

* Source/WebKit/Shared/WebBackForwardListItem.h:
(WebKit::WebBackForwardListItem::setFrameID):
(WebKit::WebBackForwardListItem::frameID const):
Add a `m_frameID` member variable that indicates the frame that was navigated.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::goToBackForwardItem):
(WebKit::WebPageProxy::continueNavigationInNewProcess):
If a frame has a pending back forward item here, we are moving in the back forward list, so the list
should not be updated.

(WebKit::WebPageProxy::backForwardAddItemShared):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, NavigateIframeCrossOriginBackForward)):

Canonical link: <a href="https://commits.webkit.org/279690@main">https://commits.webkit.org/279690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7340e4f3dbfc2e843beae1e307ca1d736e646e19

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57427 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4875 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56454 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4771 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43855 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3255 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56247 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31786 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46886 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25004 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28593 "Found 1 new test failure: imported/w3c/web-platform-tests/content-security-policy/connect-src/connect-src-beacon-blocked.sub.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4205 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3024 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50300 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4410 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59020 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29352 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4519 "Found 1 new test failure: swipe/navigate-event-back-swipe-verify-ua-transition.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51275 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30525 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50631 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31492 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8030 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30306 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->