### PR TITLE
Add libwebrtc specific WebCore RTCStat object constructors

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCStatsReport.h
+++ b/Source/WebCore/Modules/mediastream/RTCStatsReport.h
@@ -33,6 +33,32 @@
 #include "RTCIceTransportState.h"
 #include <wtf/KeyValuePair.h>
 
+#if USE(LIBWEBRTC)
+namespace webrtc {
+class RTCAudioPlayoutStats;
+class RTCAudioSourceStats;
+class RTCCertificateStats;
+class RTCCodecStats;
+class RTCDataChannelStats;
+class RTCIceCandidatePairStats;
+class RTCIceCandidateStats;
+class RTCInboundRtpStreamStats;
+class RTCInboundRtpStreamStats;
+class RTCMediaSourceStats;
+class RTCOutboundRtpStreamStats;
+class RTCPeerConnectionStats;
+class RTCReceivedRtpStreamStats;
+class RTCRemoteIceCandidateStats;
+class RTCRemoteInboundRtpStreamStats;
+class RTCRemoteOutboundRtpStreamStats;
+class RTCRtpStreamStats;
+class RTCSentRtpStreamStats;
+class RTCStats;
+class RTCTransportStats;
+class RTCVideoSourceStats;
+}
+#endif
+
 namespace WebCore {
 
 class DOMMapAdapter;
@@ -61,12 +87,22 @@ public:
         Certificate,
     };
     struct Stats {
+        Stats() = default;
+#if USE(LIBWEBRTC)
+        Stats(Type, const webrtc::RTCStats&);
+#endif
+
         double timestamp { 0 };
         Type type;
         String id;
     };
 
     struct RtpStreamStats : Stats {
+        RtpStreamStats() = default;
+#if USE(LIBWEBRTC)
+        RtpStreamStats(Type, const webrtc::RTCRtpStreamStats&);
+#endif
+
         uint32_t ssrc { 0 };
         String kind;
         String transportId;
@@ -74,13 +110,21 @@ public:
     };
 
     struct ReceivedRtpStreamStats : RtpStreamStats {
+        ReceivedRtpStreamStats() = default;
+#if USE(LIBWEBRTC)
+        ReceivedRtpStreamStats(Type, const webrtc::RTCReceivedRtpStreamStats&);
+#endif
+
         std::optional<uint64_t> packetsReceived;
         std::optional<int64_t> packetsLost;
         std::optional<double> jitter;
     };
 
     struct InboundRtpStreamStats : ReceivedRtpStreamStats {
-        InboundRtpStreamStats() { type = RTCStatsReport::Type::InboundRtp; }
+        InboundRtpStreamStats() = default;
+#if USE(LIBWEBRTC)
+        InboundRtpStreamStats(const webrtc::RTCInboundRtpStreamStats&);
+#endif
 
         String trackIdentifier;
         String mid;
@@ -142,7 +186,10 @@ public:
     };
 
     struct RemoteInboundRtpStreamStats : ReceivedRtpStreamStats {
-        RemoteInboundRtpStreamStats() { type = RTCStatsReport::Type::RemoteInboundRtp; }
+        RemoteInboundRtpStreamStats() = default;
+#if USE(LIBWEBRTC)
+        RemoteInboundRtpStreamStats(const webrtc::RTCRemoteInboundRtpStreamStats&);
+#endif
 
         String localId;
         std::optional<double> roundTripTime;
@@ -152,6 +199,11 @@ public:
     };
 
     struct SentRtpStreamStats : RtpStreamStats {
+        SentRtpStreamStats() = default;
+#if USE(LIBWEBRTC)
+        SentRtpStreamStats(Type, const webrtc::RTCSentRtpStreamStats&);
+#endif
+
         std::optional<uint32_t> packetsSent;
         std::optional<uint64_t> bytesSent;
     };
@@ -164,7 +216,10 @@ public:
     };
 
     struct OutboundRtpStreamStats : SentRtpStreamStats {
-        OutboundRtpStreamStats() { type = RTCStatsReport::Type::OutboundRtp; }
+        OutboundRtpStreamStats() = default;
+#if USE(LIBWEBRTC)
+        OutboundRtpStreamStats(const webrtc::RTCOutboundRtpStreamStats&);
+#endif
 
         String mid;
         String mediaSourceId;
@@ -197,7 +252,10 @@ public:
     };
 
     struct RemoteOutboundRtpStreamStats : SentRtpStreamStats {
-        RemoteOutboundRtpStreamStats() { type = RTCStatsReport::Type::RemoteOutboundRtp; }
+        RemoteOutboundRtpStreamStats() = default;
+#if USE(LIBWEBRTC)
+        RemoteOutboundRtpStreamStats(const webrtc::RTCRemoteOutboundRtpStreamStats&);
+#endif
 
         String localId;
         std::optional<double> remoteTimestamp;
@@ -208,7 +266,10 @@ public:
     };
 
     struct DataChannelStats : Stats {
-        DataChannelStats() { type = RTCStatsReport::Type::DataChannel; }
+        DataChannelStats() = default;
+#if USE(LIBWEBRTC)
+        DataChannelStats(const webrtc::RTCDataChannelStats&);
+#endif
 
         String label;
         String protocol;
@@ -229,7 +290,10 @@ public:
     };
 
     struct IceCandidatePairStats : Stats {
-        IceCandidatePairStats() { type = RTCStatsReport::Type::CandidatePair; }
+        IceCandidatePairStats() = default;
+#if USE(LIBWEBRTC)
+        IceCandidatePairStats(const webrtc::RTCIceCandidatePairStats&);
+#endif
 
         String transportId;
         String localCandidateId;
@@ -256,6 +320,11 @@ public:
     };
 
     struct IceCandidateStats : Stats {
+        IceCandidateStats() = default;
+#if USE(LIBWEBRTC)
+        IceCandidateStats(const webrtc::RTCIceCandidateStats&);
+#endif
+
         String transportId;
         String address;
         std::optional<int32_t> port;
@@ -272,7 +341,10 @@ public:
     };
 
     struct CertificateStats : Stats {
-        CertificateStats() { type = RTCStatsReport::Type::Certificate; }
+        CertificateStats() = default;
+#if USE(LIBWEBRTC)
+        CertificateStats(const webrtc::RTCCertificateStats&);
+#endif
 
         String fingerprint;
         String fingerprintAlgorithm;
@@ -286,7 +358,11 @@ public:
     };
 
     struct CodecStats : Stats {
-        CodecStats() { type = RTCStatsReport::Type::Codec; }
+        CodecStats() = default;
+
+#if USE(LIBWEBRTC)
+        CodecStats(const webrtc::RTCCodecStats&);
+#endif
 
         std::optional<uint32_t> payloadType;
         String transportId;
@@ -304,7 +380,10 @@ public:
     };
 
     struct TransportStats : Stats {
-        TransportStats() { type = RTCStatsReport::Type::Transport; }
+        TransportStats() = default;
+#if USE(LIBWEBRTC)
+        TransportStats(const webrtc::RTCTransportStats&);
+#endif
 
         std::optional<uint64_t> packetsSent;
         std::optional<uint64_t> packetsReceived;
@@ -325,7 +404,10 @@ public:
     };
 
     struct AudioPlayoutStats : Stats {
-        AudioPlayoutStats() { type = RTCStatsReport::Type::MediaPlayout; }
+        AudioPlayoutStats() = default;
+#if USE(LIBWEBRTC)
+        AudioPlayoutStats(const webrtc::RTCAudioPlayoutStats&);
+#endif
 
         String kind;
         std::optional<double> synthesizedSamplesDuration;
@@ -336,20 +418,31 @@ public:
     };
 
     struct PeerConnectionStats : Stats {
-        PeerConnectionStats() { type = RTCStatsReport::Type::PeerConnection; }
+        PeerConnectionStats() = default;
+#if USE(LIBWEBRTC)
+        PeerConnectionStats(const webrtc::RTCPeerConnectionStats&);
+#endif
 
         std::optional<uint32_t> dataChannelsOpened;
         std::optional<uint32_t> dataChannelsClosed;
     };
 
     struct MediaSourceStats : Stats {
+        MediaSourceStats() = default;
+#if USE(LIBWEBRTC)
+        MediaSourceStats(Type, const webrtc::RTCMediaSourceStats&);
+#endif
+
         String trackIdentifier;
         String kind;
         std::optional<bool> relayedSource;
     };
 
     struct AudioSourceStats : MediaSourceStats {
-        AudioSourceStats() { type = RTCStatsReport::Type::MediaSource; }
+        AudioSourceStats() = default;
+#if USE(LIBWEBRTC)
+        AudioSourceStats(const webrtc::RTCAudioSourceStats&);
+#endif
 
         std::optional<double> audioLevel;
         std::optional<double> totalAudioEnergy;
@@ -363,7 +456,10 @@ public:
     };
 
     struct VideoSourceStats : MediaSourceStats {
-        VideoSourceStats() { type = RTCStatsReport::Type::MediaSource; }
+        VideoSourceStats() = default;
+#if USE(LIBWEBRTC)
+        VideoSourceStats(const webrtc::RTCVideoSourceStats&);
+#endif
 
         std::optional<unsigned long> width;
         std::optional<unsigned long> height;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp
@@ -52,187 +52,183 @@ LibWebRTCStatsCollector::~LibWebRTCStatsCollector()
     });
 }
 
-static inline void fillRTCStats(RTCStatsReport::Stats& stats, const webrtc::RTCStats& rtcStats)
+RTCStatsReport::Stats::Stats(Type type, const webrtc::RTCStats& rtcStats)
+    : timestamp(Performance::reduceTimeResolution(Seconds::fromMicroseconds(rtcStats.timestamp().us_or(0))).milliseconds())
+    , type(type)
+    , id(fromStdString(rtcStats.id()))
 {
-    stats.timestamp = Performance::reduceTimeResolution(Seconds::fromMicroseconds(rtcStats.timestamp().us_or(0))).milliseconds();
-    stats.id = fromStdString(rtcStats.id());
 }
 
-static inline void fillRtpStreamStats(RTCStatsReport::RtpStreamStats& stats, const webrtc::RTCRtpStreamStats& rtcStats)
+RTCStatsReport::RtpStreamStats::RtpStreamStats(Type type, const webrtc::RTCRtpStreamStats& rtcStats)
+    : Stats(type, rtcStats)
 {
-    fillRTCStats(stats, rtcStats);
-
     if (rtcStats.ssrc.is_defined())
-        stats.ssrc = *rtcStats.ssrc;
+        ssrc = *rtcStats.ssrc;
     if (rtcStats.kind.is_defined())
-        stats.kind = fromStdString(*rtcStats.kind);
+        kind = fromStdString(*rtcStats.kind);
     if (rtcStats.transport_id.is_defined())
-        stats.transportId = fromStdString(*rtcStats.transport_id);
+        transportId = fromStdString(*rtcStats.transport_id);
     if (rtcStats.codec_id.is_defined())
-        stats.codecId = fromStdString(*rtcStats.codec_id);
+        codecId = fromStdString(*rtcStats.codec_id);
 }
 
-static inline void fillReceivedRtpStreamStats(RTCStatsReport::ReceivedRtpStreamStats& stats, const webrtc::RTCReceivedRtpStreamStats& rtcStats)
+RTCStatsReport::ReceivedRtpStreamStats::ReceivedRtpStreamStats(Type type, const webrtc::RTCReceivedRtpStreamStats& rtcStats)
+    : RtpStreamStats(type, rtcStats)
 {
-    fillRtpStreamStats(stats, rtcStats);
-
     // packetsReceived should be in the base class, but somehow isn't, it's only define for RTCInboundRtpStreamStats
     // if (rtcStats.packets_received.is_defined())
     //     stats.packetsReceived = *rtcStats.packets_received;
     if (rtcStats.packets_lost.is_defined())
-        stats.packetsLost = *rtcStats.packets_lost;
+        packetsLost = *rtcStats.packets_lost;
     if (rtcStats.jitter.is_defined())
-        stats.jitter = *rtcStats.jitter;
+        jitter = *rtcStats.jitter;
 }
 
-static inline void fillInboundRtpStreamStats(RTCStatsReport::InboundRtpStreamStats& stats, const webrtc::RTCInboundRtpStreamStats& rtcStats)
+RTCStatsReport::InboundRtpStreamStats::InboundRtpStreamStats(const webrtc::RTCInboundRtpStreamStats& rtcStats)
+    : ReceivedRtpStreamStats(RTCStatsReport::Type::InboundRtp, rtcStats)
 {
-    fillReceivedRtpStreamStats(stats, rtcStats);
-
     // should be in the base class.
     if (rtcStats.packets_received.is_defined())
-        stats.packetsReceived = *rtcStats.packets_received;
+        packetsReceived = *rtcStats.packets_received;
 
     if (rtcStats.track_identifier.is_defined())
-        stats.trackIdentifier = fromStdString(*rtcStats.track_identifier);
+        trackIdentifier = fromStdString(*rtcStats.track_identifier);
     if (rtcStats.mid.is_defined())
-        stats.mid = fromStdString(*rtcStats.mid);
+        mid = fromStdString(*rtcStats.mid);
     if (rtcStats.remote_id.is_defined())
-        stats.remoteId = fromStdString(*rtcStats.remote_id);
+        remoteId = fromStdString(*rtcStats.remote_id);
     if (rtcStats.frames_decoded.is_defined())
-        stats.framesDecoded = *rtcStats.frames_decoded;
+        framesDecoded = *rtcStats.frames_decoded;
     if (rtcStats.key_frames_decoded.is_defined())
-        stats.keyFramesDecoded = *rtcStats.key_frames_decoded;
+        keyFramesDecoded = *rtcStats.key_frames_decoded;
     if (rtcStats.frames_dropped.is_defined())
-        stats.framesDropped = *rtcStats.frames_dropped;
+        framesDropped = *rtcStats.frames_dropped;
     if (rtcStats.frame_width.is_defined())
-        stats.frameWidth = *rtcStats.frame_width;
+        frameWidth = *rtcStats.frame_width;
     if (rtcStats.frame_height.is_defined())
-        stats.frameHeight = *rtcStats.frame_height;
+        frameHeight = *rtcStats.frame_height;
     if (rtcStats.frames_per_second.is_defined())
-        stats.framesPerSecond = *rtcStats.frames_per_second;
+        framesPerSecond = *rtcStats.frames_per_second;
     if (rtcStats.qp_sum.is_defined())
-        stats.qpSum = *rtcStats.qp_sum;
+        qpSum = *rtcStats.qp_sum;
     if (rtcStats.total_decode_time.is_defined())
-        stats.totalDecodeTime = *rtcStats.total_decode_time;
+        totalDecodeTime = *rtcStats.total_decode_time;
     if (rtcStats.total_inter_frame_delay.is_defined())
-        stats.totalInterFrameDelay = *rtcStats.total_inter_frame_delay;
+        totalInterFrameDelay = *rtcStats.total_inter_frame_delay;
     if (rtcStats.total_squared_inter_frame_delay.is_defined())
-        stats.totalSquaredInterFrameDelay = *rtcStats.total_squared_inter_frame_delay;
+        totalSquaredInterFrameDelay = *rtcStats.total_squared_inter_frame_delay;
     if (rtcStats.pause_count.is_defined())
-        stats.pauseCount = *rtcStats.pause_count;
+        pauseCount = *rtcStats.pause_count;
     if (rtcStats.total_pauses_duration.is_defined())
-        stats.totalPausesDuration = *rtcStats.total_pauses_duration;
+        totalPausesDuration = *rtcStats.total_pauses_duration;
     if (rtcStats.freeze_count.is_defined())
-        stats.freezeCount = *rtcStats.freeze_count;
+        freezeCount = *rtcStats.freeze_count;
     if (rtcStats.total_freezes_duration.is_defined())
-        stats.totalFreezesDuration = *rtcStats.total_freezes_duration;
+        totalFreezesDuration = *rtcStats.total_freezes_duration;
     if (rtcStats.last_packet_received_timestamp.is_defined())
-        stats.lastPacketReceivedTimestamp = *rtcStats.last_packet_received_timestamp;
+        lastPacketReceivedTimestamp = *rtcStats.last_packet_received_timestamp;
 
     if (rtcStats.fec_packets_received.is_defined())
-        stats.fecPacketsReceived = *rtcStats.fec_packets_received;
+        fecPacketsReceived = *rtcStats.fec_packets_received;
     if (rtcStats.fec_bytes_received.is_defined())
-        stats.fecBytesReceived = *rtcStats.fec_bytes_received;
+        fecBytesReceived = *rtcStats.fec_bytes_received;
     if (rtcStats.fec_packets_discarded.is_defined())
-        stats.fecPacketsDiscarded = *rtcStats.fec_packets_discarded;
+        fecPacketsDiscarded = *rtcStats.fec_packets_discarded;
     if (rtcStats.fec_ssrc.is_defined())
-        stats.fecSsrc = *rtcStats.fec_ssrc;
+        fecSsrc = *rtcStats.fec_ssrc;
     if (rtcStats.header_bytes_received.is_defined())
-        stats.headerBytesReceived = *rtcStats.header_bytes_received;
+        headerBytesReceived = *rtcStats.header_bytes_received;
     if (rtcStats.rtx_ssrc.is_defined())
-        stats.rtxSsrc = *rtcStats.rtx_ssrc;
+        rtxSsrc = *rtcStats.rtx_ssrc;
     if (rtcStats.packets_discarded.is_defined())
-        stats.packetsDiscarded = *rtcStats.packets_discarded;
+        packetsDiscarded = *rtcStats.packets_discarded;
     if (rtcStats.fec_packets_received.is_defined())
-        stats.fecPacketsReceived = *rtcStats.fec_packets_received;
+        fecPacketsReceived = *rtcStats.fec_packets_received;
     if (rtcStats.fec_packets_discarded.is_defined())
-        stats.fecPacketsDiscarded = *rtcStats.fec_packets_discarded;
+        fecPacketsDiscarded = *rtcStats.fec_packets_discarded;
     if (rtcStats.bytes_received.is_defined())
-        stats.bytesReceived = *rtcStats.bytes_received;
+        bytesReceived = *rtcStats.bytes_received;
     if (rtcStats.fir_count.is_defined())
-        stats.firCount = *rtcStats.fir_count;
+        firCount = *rtcStats.fir_count;
     if (rtcStats.pli_count.is_defined())
-        stats.pliCount = *rtcStats.pli_count;
+        pliCount = *rtcStats.pli_count;
     if (rtcStats.nack_count.is_defined())
-        stats.nackCount = *rtcStats.nack_count;
+        nackCount = *rtcStats.nack_count;
     if (rtcStats.total_processing_delay.is_defined())
-        stats.totalProcessingDelay = *rtcStats.total_processing_delay;
+        totalProcessingDelay = *rtcStats.total_processing_delay;
     if (rtcStats.estimated_playout_timestamp.is_defined())
-        stats.estimatedPlayoutTimestamp = *rtcStats.estimated_playout_timestamp;
+        estimatedPlayoutTimestamp = *rtcStats.estimated_playout_timestamp;
     if (rtcStats.jitter_buffer_delay.is_defined())
-        stats.jitterBufferDelay = *rtcStats.jitter_buffer_delay;
+        jitterBufferDelay = *rtcStats.jitter_buffer_delay;
     if (rtcStats.jitter_buffer_target_delay.is_defined())
-        stats.jitterBufferTargetDelay = *rtcStats.jitter_buffer_target_delay;
+        jitterBufferTargetDelay = *rtcStats.jitter_buffer_target_delay;
     if (rtcStats.jitter_buffer_emitted_count.is_defined())
-        stats.jitterBufferEmittedCount = *rtcStats.jitter_buffer_emitted_count;
+        jitterBufferEmittedCount = *rtcStats.jitter_buffer_emitted_count;
     if (rtcStats.jitter_buffer_minimum_delay.is_defined())
-        stats.jitterBufferMinimumDelay = *rtcStats.jitter_buffer_minimum_delay;
+        jitterBufferMinimumDelay = *rtcStats.jitter_buffer_minimum_delay;
     if (rtcStats.total_samples_received.is_defined())
-        stats.totalSamplesReceived = *rtcStats.total_samples_received;
+        totalSamplesReceived = *rtcStats.total_samples_received;
     if (rtcStats.concealed_samples.is_defined())
-        stats.concealedSamples = *rtcStats.concealed_samples;
+        concealedSamples = *rtcStats.concealed_samples;
     if (rtcStats.silent_concealed_samples.is_defined())
-        stats.silentConcealedSamples = *rtcStats.silent_concealed_samples;
+        silentConcealedSamples = *rtcStats.silent_concealed_samples;
     if (rtcStats.concealment_events.is_defined())
-        stats.concealmentEvents = *rtcStats.concealment_events;
+        concealmentEvents = *rtcStats.concealment_events;
     if (rtcStats.inserted_samples_for_deceleration.is_defined())
-        stats.insertedSamplesForDeceleration = *rtcStats.inserted_samples_for_deceleration;
+        insertedSamplesForDeceleration = *rtcStats.inserted_samples_for_deceleration;
     if (rtcStats.removed_samples_for_acceleration.is_defined())
-        stats.removedSamplesForAcceleration = *rtcStats.removed_samples_for_acceleration;
+        removedSamplesForAcceleration = *rtcStats.removed_samples_for_acceleration;
     if (rtcStats.audio_level.is_defined())
-        stats.audioLevel = *rtcStats.audio_level;
+        audioLevel = *rtcStats.audio_level;
     if (rtcStats.total_audio_energy.is_defined())
-        stats.totalAudioEnergy = *rtcStats.total_audio_energy;
+        totalAudioEnergy = *rtcStats.total_audio_energy;
     if (rtcStats.total_samples_duration.is_defined())
-        stats.totalSamplesDuration = *rtcStats.total_samples_duration;
+        totalSamplesDuration = *rtcStats.total_samples_duration;
     if (rtcStats.frames_received.is_defined())
-        stats.framesReceived = *rtcStats.frames_received;
+        framesReceived = *rtcStats.frames_received;
     // TODO: Restrict Access
     // if (rtcStats.decoder_implementation.is_defined())
     //     stats.decoderImplementation = fromStdString(*rtcStats.decoder_implementation);
     if (rtcStats.playout_id.is_defined())
-        stats.playoutId = fromStdString(*rtcStats.playout_id);
+        playoutId = fromStdString(*rtcStats.playout_id);
     // TODO: Restrict Access
     // if (rtcStats.power_efficient_decoder.is_defined())
     //     stats.powerEfficientDecoder = *rtcStats.power_efficient_decoder;
     if (rtcStats.frames_assembled_from_multiple_packets.is_defined())
-        stats.framesAssembledFromMultiplePackets = *rtcStats.frames_assembled_from_multiple_packets;
+        framesAssembledFromMultiplePackets = *rtcStats.frames_assembled_from_multiple_packets;
     if (rtcStats.total_assembly_time.is_defined())
-        stats.totalAssemblyTime = *rtcStats.total_assembly_time;
+        totalAssemblyTime = *rtcStats.total_assembly_time;
     if (rtcStats.retransmitted_packets_received.is_defined())
-        stats.retransmittedPacketsReceived = *rtcStats.retransmitted_packets_received;
+        retransmittedPacketsReceived = *rtcStats.retransmitted_packets_received;
     if (rtcStats.retransmitted_bytes_received.is_defined())
-        stats.retransmittedBytesReceived = *rtcStats.retransmitted_bytes_received;
+        retransmittedBytesReceived = *rtcStats.retransmitted_bytes_received;
 }
 
-static inline void fillRemoteInboundRtpStreamStats(RTCStatsReport::RemoteInboundRtpStreamStats& stats, const webrtc::RTCRemoteInboundRtpStreamStats& rtcStats)
+RTCStatsReport::RemoteInboundRtpStreamStats::RemoteInboundRtpStreamStats(const webrtc::RTCRemoteInboundRtpStreamStats& rtcStats)
+    : ReceivedRtpStreamStats(RTCStatsReport::Type::RemoteInboundRtp, rtcStats)
 {
-    fillReceivedRtpStreamStats(stats, rtcStats);
-
     if (rtcStats.local_id.is_defined())
-        stats.localId = fromStdString(*rtcStats.local_id);
+        localId = fromStdString(*rtcStats.local_id);
     if (rtcStats.round_trip_time.is_defined())
-        stats.roundTripTime = *rtcStats.round_trip_time;
+        roundTripTime = *rtcStats.round_trip_time;
     if (rtcStats.total_round_trip_time.is_defined())
-        stats.totalRoundTripTime = *rtcStats.total_round_trip_time;
+        totalRoundTripTime = *rtcStats.total_round_trip_time;
     if (rtcStats.fraction_lost.is_defined())
-        stats.fractionLost = *rtcStats.fraction_lost;
+        fractionLost = *rtcStats.fraction_lost;
     if (rtcStats.round_trip_time_measurements.is_defined())
-        stats.roundTripTimeMeasurements = *rtcStats.round_trip_time_measurements;
+        roundTripTimeMeasurements = *rtcStats.round_trip_time_measurements;
 }
 
-static inline void fillSentRtpStreamStats(RTCStatsReport::SentRtpStreamStats& stats, const webrtc::RTCSentRtpStreamStats& rtcStats)
+RTCStatsReport::SentRtpStreamStats::SentRtpStreamStats(Type type, const webrtc::RTCSentRtpStreamStats& rtcStats)
+    : RtpStreamStats(type, rtcStats)
 {
-    fillRtpStreamStats(stats, rtcStats);
-
     if (rtcStats.packets_sent.is_defined())
-        stats.packetsSent = *rtcStats.packets_sent;
+        packetsSent = *rtcStats.packets_sent;
     if (rtcStats.bytes_sent.is_defined())
-        stats.bytesSent = *rtcStats.bytes_sent;
+        bytesSent = *rtcStats.bytes_sent;
 }
 
-static inline std::optional<RTCStatsReport::QualityLimitationReason> qualityLimitationReason(const std::string& reason)
+static inline std::optional<RTCStatsReport::QualityLimitationReason> convertQualityLimitationReason(const std::string& reason)
 {
     if (reason == "none")
         return RTCStatsReport::QualityLimitationReason::None;
@@ -243,54 +239,53 @@ static inline std::optional<RTCStatsReport::QualityLimitationReason> qualityLimi
     return RTCStatsReport::QualityLimitationReason::Other;
 }
 
-static inline void fillOutboundRtpStreamStats(RTCStatsReport::OutboundRtpStreamStats& stats, const webrtc::RTCOutboundRtpStreamStats& rtcStats)
+RTCStatsReport::OutboundRtpStreamStats::OutboundRtpStreamStats(const webrtc::RTCOutboundRtpStreamStats& rtcStats)
+    : SentRtpStreamStats(RTCStatsReport::Type::OutboundRtp, rtcStats)
 {
-    fillSentRtpStreamStats(stats, rtcStats);
-
     if (rtcStats.mid.is_defined())
-        stats.mid = fromStdString(*rtcStats.mid);
+        mid = fromStdString(*rtcStats.mid);
     if (rtcStats.media_source_id.is_defined())
-        stats.mediaSourceId = fromStdString(*rtcStats.media_source_id);
+        mediaSourceId = fromStdString(*rtcStats.media_source_id);
     if (rtcStats.remote_id.is_defined())
-        stats.remoteId = fromStdString(*rtcStats.remote_id);
+        remoteId = fromStdString(*rtcStats.remote_id);
     if (rtcStats.rid.is_defined())
-        stats.rid = fromStdString(*rtcStats.rid);
+        rid = fromStdString(*rtcStats.rid);
     if (rtcStats.header_bytes_sent.is_defined())
-        stats.headerBytesSent = *rtcStats.header_bytes_sent;
+        headerBytesSent = *rtcStats.header_bytes_sent;
     if (rtcStats.retransmitted_packets_sent.is_defined())
-        stats.retransmittedPacketsSent = *rtcStats.retransmitted_packets_sent;
+        retransmittedPacketsSent = *rtcStats.retransmitted_packets_sent;
     if (rtcStats.retransmitted_bytes_sent.is_defined())
-        stats.retransmittedBytesSent = *rtcStats.retransmitted_bytes_sent;
+        retransmittedBytesSent = *rtcStats.retransmitted_bytes_sent;
     if (rtcStats.target_bitrate.is_defined())
-        stats.targetBitrate = *rtcStats.target_bitrate;
+        targetBitrate = *rtcStats.target_bitrate;
     if (rtcStats.total_encoded_bytes_target.is_defined())
-        stats.totalEncodedBytesTarget = *rtcStats.total_encoded_bytes_target;
+        totalEncodedBytesTarget = *rtcStats.total_encoded_bytes_target;
     if (rtcStats.frame_width.is_defined())
-        stats.frameWidth = *rtcStats.frame_width;
+        frameWidth = *rtcStats.frame_width;
     if (rtcStats.frame_height.is_defined())
-        stats.frameHeight = *rtcStats.frame_height;
+        frameHeight = *rtcStats.frame_height;
     if (rtcStats.frames_per_second.is_defined())
-        stats.framesPerSecond = *rtcStats.frames_per_second;
+        framesPerSecond = *rtcStats.frames_per_second;
     if (rtcStats.frames_sent.is_defined())
-        stats.framesSent = *rtcStats.frames_sent;
+        framesSent = *rtcStats.frames_sent;
     if (rtcStats.huge_frames_sent.is_defined())
-        stats.hugeFramesSent = *rtcStats.huge_frames_sent;
+        hugeFramesSent = *rtcStats.huge_frames_sent;
     if (rtcStats.frames_encoded.is_defined())
-        stats.framesEncoded = *rtcStats.frames_encoded;
+        framesEncoded = *rtcStats.frames_encoded;
     if (rtcStats.key_frames_encoded.is_defined())
-        stats.keyFramesEncoded = *rtcStats.key_frames_encoded;
+        keyFramesEncoded = *rtcStats.key_frames_encoded;
     if (rtcStats.qp_sum.is_defined())
-        stats.qpSum = *rtcStats.qp_sum;
+        qpSum = *rtcStats.qp_sum;
     if (rtcStats.total_encode_time.is_defined())
-        stats.totalEncodeTime = *rtcStats.total_encode_time;
+        totalEncodeTime = *rtcStats.total_encode_time;
     if (rtcStats.total_packet_send_delay.is_defined())
-        stats.totalPacketSendDelay = *rtcStats.total_packet_send_delay;
+        totalPacketSendDelay = *rtcStats.total_packet_send_delay;
     if (rtcStats.quality_limitation_reason.is_defined())
-        stats.qualityLimitationReason = qualityLimitationReason(*rtcStats.quality_limitation_reason);
+        qualityLimitationReason = convertQualityLimitationReason(*rtcStats.quality_limitation_reason);
     if (rtcStats.quality_limitation_durations.is_defined()) {
         auto& durations = *rtcStats.quality_limitation_durations;
         auto it = durations.begin();
-        stats.qualityLimitationDurations = Vector<KeyValuePair<String, double>>(durations.size(), [&] (size_t) {
+        qualityLimitationDurations = Vector<KeyValuePair<String, double>>(durations.size(), [&] (size_t) {
             ASSERT(it != durations.end());
             KeyValuePair<String, double> element = { fromStdString(it->first), it->second };
             ++it;
@@ -298,61 +293,58 @@ static inline void fillOutboundRtpStreamStats(RTCStatsReport::OutboundRtpStreamS
         });
     }
     if (rtcStats.quality_limitation_resolution_changes.is_defined())
-        stats.qualityLimitationResolutionChanges = *rtcStats.quality_limitation_resolution_changes;
+        qualityLimitationResolutionChanges = *rtcStats.quality_limitation_resolution_changes;
     if (rtcStats.nack_count.is_defined())
-        stats.nackCount = *rtcStats.nack_count;
+        nackCount = *rtcStats.nack_count;
     if (rtcStats.fir_count.is_defined())
-        stats.firCount = *rtcStats.fir_count;
+        firCount = *rtcStats.fir_count;
     if (rtcStats.pli_count.is_defined())
-        stats.pliCount = *rtcStats.pli_count;
+        pliCount = *rtcStats.pli_count;
 
     if (rtcStats.active.is_defined())
-        stats.active = *rtcStats.active;
+        active = *rtcStats.active;
     if (rtcStats.scalability_mode.is_defined())
-        stats.scalabilityMode = fromStdString(*rtcStats.scalability_mode);
+        scalabilityMode = fromStdString(*rtcStats.scalability_mode);
     if (rtcStats.rtx_ssrc.is_defined())
-        stats.rtxSsrc = *rtcStats.rtx_ssrc;
+        rtxSsrc = *rtcStats.rtx_ssrc;
 }
 
-
-static inline void fillRemoteOutboundRtpStreamStats(RTCStatsReport::RemoteOutboundRtpStreamStats& stats, const webrtc::RTCRemoteOutboundRtpStreamStats& rtcStats)
+RTCStatsReport::RemoteOutboundRtpStreamStats::RemoteOutboundRtpStreamStats(const webrtc::RTCRemoteOutboundRtpStreamStats& rtcStats)
+    : SentRtpStreamStats(RTCStatsReport::Type::RemoteOutboundRtp, rtcStats)
 {
-    fillSentRtpStreamStats(stats, rtcStats);
-
     if (rtcStats.local_id.is_defined())
-        stats.localId = fromStdString(*rtcStats.local_id);
+        localId = fromStdString(*rtcStats.local_id);
     if (rtcStats.remote_timestamp.is_defined())
-        stats.remoteTimestamp = *rtcStats.remote_timestamp;
+        remoteTimestamp = *rtcStats.remote_timestamp;
     if (rtcStats.reports_sent.is_defined())
-        stats.reportsSent = *rtcStats.reports_sent;
+        reportsSent = *rtcStats.reports_sent;
     if (rtcStats.round_trip_time.is_defined())
-        stats.roundTripTime = *rtcStats.round_trip_time;
+        roundTripTime = *rtcStats.round_trip_time;
     if (rtcStats.total_round_trip_time.is_defined())
-        stats.totalRoundTripTime = *rtcStats.total_round_trip_time;
+        totalRoundTripTime = *rtcStats.total_round_trip_time;
     if (rtcStats.round_trip_time_measurements.is_defined())
-        stats.roundTripTimeMeasurements = *rtcStats.round_trip_time_measurements;
+        roundTripTimeMeasurements = *rtcStats.round_trip_time_measurements;
 }
 
-static inline void fillRTCDataChannelStats(RTCStatsReport::DataChannelStats& stats, const webrtc::RTCDataChannelStats& rtcStats)
+RTCStatsReport::DataChannelStats::DataChannelStats(const webrtc::RTCDataChannelStats& rtcStats)
+    : Stats(RTCStatsReport::Type::DataChannel, rtcStats)
 {
-    fillRTCStats(stats, rtcStats);
-
     if (rtcStats.label.is_defined())
-        stats.label = fromStdString(*rtcStats.label);
+        label = fromStdString(*rtcStats.label);
     if (rtcStats.protocol.is_defined())
-        stats.protocol = fromStdString(*rtcStats.protocol);
+        protocol = fromStdString(*rtcStats.protocol);
     if (rtcStats.data_channel_identifier.is_defined())
-        stats.dataChannelIdentifier = *rtcStats.data_channel_identifier;
+        dataChannelIdentifier = *rtcStats.data_channel_identifier;
     if (rtcStats.state.is_defined())
-        stats.state = fromStdString(*rtcStats.state);
+        state = fromStdString(*rtcStats.state);
     if (rtcStats.messages_sent.is_defined())
-        stats.messagesSent = *rtcStats.messages_sent;
+        messagesSent = *rtcStats.messages_sent;
     if (rtcStats.bytes_sent.is_defined())
-        stats.bytesSent = *rtcStats.bytes_sent;
+        bytesSent = *rtcStats.bytes_sent;
     if (rtcStats.messages_received.is_defined())
-        stats.messagesReceived = *rtcStats.messages_received;
+        messagesReceived = *rtcStats.messages_received;
     if (rtcStats.bytes_received.is_defined())
-        stats.bytesReceived = *rtcStats.bytes_received;
+        bytesReceived = *rtcStats.bytes_received;
 }
 
 static inline RTCStatsReport::IceCandidatePairState iceCandidatePairState(const std::string& state)
@@ -371,55 +363,54 @@ static inline RTCStatsReport::IceCandidatePairState iceCandidatePairState(const 
     return RTCStatsReport::IceCandidatePairState::Frozen;
 }
 
-static inline void fillRTCIceCandidatePairStats(RTCStatsReport::IceCandidatePairStats& stats, const webrtc::RTCIceCandidatePairStats& rtcStats)
+RTCStatsReport::IceCandidatePairStats::IceCandidatePairStats(const webrtc::RTCIceCandidatePairStats& rtcStats)
+    : Stats(RTCStatsReport::Type::CandidatePair, rtcStats)
 {
-    fillRTCStats(stats, rtcStats);
-
     if (rtcStats.transport_id.is_defined())
-        stats.transportId = fromStdString(*rtcStats.transport_id);
+        transportId = fromStdString(*rtcStats.transport_id);
     if (rtcStats.local_candidate_id.is_defined())
-        stats.localCandidateId = fromStdString(*rtcStats.local_candidate_id);
+        localCandidateId = fromStdString(*rtcStats.local_candidate_id);
     if (rtcStats.remote_candidate_id.is_defined())
-        stats.remoteCandidateId = fromStdString(*rtcStats.remote_candidate_id);
+        remoteCandidateId = fromStdString(*rtcStats.remote_candidate_id);
     if (rtcStats.state.is_defined())
-        stats.state = iceCandidatePairState(*rtcStats.state);
+        state = iceCandidatePairState(*rtcStats.state);
     if (rtcStats.nominated.is_defined())
-        stats.nominated = *rtcStats.nominated;
+        nominated = *rtcStats.nominated;
     if (rtcStats.packets_sent.is_defined())
-        stats.packetsSent = *rtcStats.packets_sent;
+        packetsSent = *rtcStats.packets_sent;
     if (rtcStats.packets_received.is_defined())
-        stats.packetsReceived = *rtcStats.packets_received;
+        packetsReceived = *rtcStats.packets_received;
     if (rtcStats.bytes_sent.is_defined())
-        stats.bytesSent = *rtcStats.bytes_sent;
+        bytesSent = *rtcStats.bytes_sent;
     if (rtcStats.bytes_received.is_defined())
-        stats.bytesReceived = *rtcStats.bytes_received;
+        bytesReceived = *rtcStats.bytes_received;
     if (rtcStats.last_packet_sent_timestamp.is_defined())
-        stats.lastPacketSentTimestamp = *rtcStats.last_packet_sent_timestamp;
+        lastPacketSentTimestamp = *rtcStats.last_packet_sent_timestamp;
     if (rtcStats.last_packet_received_timestamp.is_defined())
-        stats.lastPacketReceivedTimestamp = *rtcStats.last_packet_received_timestamp;
+        lastPacketReceivedTimestamp = *rtcStats.last_packet_received_timestamp;
     if (rtcStats.total_round_trip_time.is_defined())
-        stats.totalRoundTripTime = *rtcStats.total_round_trip_time;
+        totalRoundTripTime = *rtcStats.total_round_trip_time;
     if (rtcStats.current_round_trip_time.is_defined())
-        stats.currentRoundTripTime = *rtcStats.current_round_trip_time;
+        currentRoundTripTime = *rtcStats.current_round_trip_time;
     if (rtcStats.available_outgoing_bitrate.is_defined())
-        stats.availableOutgoingBitrate = *rtcStats.available_outgoing_bitrate;
+        availableOutgoingBitrate = *rtcStats.available_outgoing_bitrate;
     if (rtcStats.available_incoming_bitrate.is_defined())
-        stats.availableIncomingBitrate = *rtcStats.available_incoming_bitrate;
+        availableIncomingBitrate = *rtcStats.available_incoming_bitrate;
     if (rtcStats.requests_received.is_defined())
-        stats.requestsReceived = *rtcStats.requests_received;
+        requestsReceived = *rtcStats.requests_received;
     if (rtcStats.requests_sent.is_defined())
-        stats.requestsSent = *rtcStats.requests_sent;
+        requestsSent = *rtcStats.requests_sent;
     if (rtcStats.responses_received.is_defined())
-        stats.responsesReceived = *rtcStats.responses_received;
+        responsesReceived = *rtcStats.responses_received;
     if (rtcStats.responses_sent.is_defined())
-        stats.responsesSent = *rtcStats.responses_sent;
+        responsesSent = *rtcStats.responses_sent;
 
     if (rtcStats.consent_requests_sent.is_defined())
-        stats.consentRequestsSent = *rtcStats.consent_requests_sent;
+        consentRequestsSent = *rtcStats.consent_requests_sent;
     if (rtcStats.packets_discarded_on_send.is_defined())
-        stats.packetsDiscardedOnSend = *rtcStats.packets_discarded_on_send;
+        packetsDiscardedOnSend = *rtcStats.packets_discarded_on_send;
     if (rtcStats.bytes_discarded_on_send.is_defined())
-        stats.bytesDiscardedOnSend = *rtcStats.bytes_discarded_on_send;
+        bytesDiscardedOnSend = *rtcStats.bytes_discarded_on_send;
 }
 
 static inline RTCIceCandidateType iceCandidateState(const std::string& state)
@@ -437,73 +428,68 @@ static inline RTCIceCandidateType iceCandidateState(const std::string& state)
     return RTCIceCandidateType::Host;
 }
 
-static inline void fillRTCIceCandidateStats(RTCStatsReport::IceCandidateStats& stats, const webrtc::RTCIceCandidateStats& rtcStats)
+RTCStatsReport::IceCandidateStats::IceCandidateStats(const webrtc::RTCIceCandidateStats& rtcStats)
+    : Stats(rtcStats.type() == webrtc::RTCRemoteIceCandidateStats::kType ? RTCStatsReport::Type::RemoteCandidate : RTCStatsReport::Type::LocalCandidate, rtcStats)
 {
-    stats.type = rtcStats.type() == webrtc::RTCRemoteIceCandidateStats::kType ? RTCStatsReport::Type::RemoteCandidate : RTCStatsReport::Type::LocalCandidate;
-
-    fillRTCStats(stats, rtcStats);
-
     if (rtcStats.transport_id.is_defined())
-        stats.transportId = fromStdString(*rtcStats.transport_id);
+        transportId = fromStdString(*rtcStats.transport_id);
     if (rtcStats.ip.is_defined())
-        stats.address = fromStdString(*rtcStats.ip);
+        address = fromStdString(*rtcStats.ip);
     if (rtcStats.port.is_defined())
-        stats.port = *rtcStats.port;
+        port = *rtcStats.port;
     if (rtcStats.protocol.is_defined())
-        stats.protocol = fromStdString(*rtcStats.protocol);
+        protocol = fromStdString(*rtcStats.protocol);
     ASSERT(rtcStats.candidate_type.is_defined());
     if (rtcStats.candidate_type.is_defined())
-        stats.candidateType = iceCandidateState(*rtcStats.candidate_type);
-    if (stats.candidateType == RTCIceCandidateType::Prflx || stats.candidateType == RTCIceCandidateType::Host)
-        stats.address = { };
+        candidateType = iceCandidateState(*rtcStats.candidate_type);
+    if (candidateType == RTCIceCandidateType::Prflx || candidateType == RTCIceCandidateType::Host)
+        address = { };
 
     if (rtcStats.priority.is_defined())
-        stats.priority = *rtcStats.priority;
+        priority = *rtcStats.priority;
     if (rtcStats.url.is_defined())
-        stats.url = fromStdString(*rtcStats.url);
+        url = fromStdString(*rtcStats.url);
     if (rtcStats.foundation.is_defined())
-        stats.foundation = fromStdString(*rtcStats.foundation);
+        foundation = fromStdString(*rtcStats.foundation);
     if (rtcStats.username_fragment.is_defined())
-        stats.usernameFragment = fromStdString(*rtcStats.username_fragment);
+        usernameFragment = fromStdString(*rtcStats.username_fragment);
     if (rtcStats.tcp_type.is_defined()) {
         if (auto tcpType = parseEnumerationFromString<RTCIceTcpCandidateType>(fromStdString(*rtcStats.tcp_type)))
-            stats.tcpType = *tcpType;
+            tcpType = *tcpType;
     }
 }
 
-static inline void fillRTCCertificateStats(RTCStatsReport::CertificateStats& stats, const webrtc::RTCCertificateStats& rtcStats)
+RTCStatsReport::CertificateStats::CertificateStats(const webrtc::RTCCertificateStats& rtcStats)
+    : Stats(RTCStatsReport::Type::Certificate, rtcStats)
 {
-    fillRTCStats(stats, rtcStats);
-
     if (rtcStats.fingerprint.is_defined())
-        stats.fingerprint = fromStdString(*rtcStats.fingerprint);
+        fingerprint = fromStdString(*rtcStats.fingerprint);
     if (rtcStats.fingerprint_algorithm.is_defined())
-        stats.fingerprintAlgorithm = fromStdString(*rtcStats.fingerprint_algorithm);
+        fingerprintAlgorithm = fromStdString(*rtcStats.fingerprint_algorithm);
     if (rtcStats.base64_certificate.is_defined())
-        stats.base64Certificate = fromStdString(*rtcStats.base64_certificate);
+        base64Certificate = fromStdString(*rtcStats.base64_certificate);
     if (rtcStats.issuer_certificate_id.is_defined())
-        stats.issuerCertificateId = fromStdString(*rtcStats.issuer_certificate_id);
+        issuerCertificateId = fromStdString(*rtcStats.issuer_certificate_id);
 }
 
-static inline void fillRTCCodecStats(RTCStatsReport::CodecStats& stats, const webrtc::RTCCodecStats& rtcStats)
+RTCStatsReport::CodecStats::CodecStats(const webrtc::RTCCodecStats& rtcStats)
+    : Stats(RTCStatsReport::Type::Codec, rtcStats)
 {
-    fillRTCStats(stats, rtcStats);
-
     if (rtcStats.payload_type.is_defined())
-        stats.payloadType = *rtcStats.payload_type;
+        payloadType = *rtcStats.payload_type;
     if (rtcStats.transport_id.is_defined())
-        stats.transportId = fromStdString(*rtcStats.transport_id);
+        transportId = fromStdString(*rtcStats.transport_id);
     if (rtcStats.mime_type.is_defined())
-        stats.mimeType = fromStdString(*rtcStats.mime_type);
+        mimeType = fromStdString(*rtcStats.mime_type);
     if (rtcStats.clock_rate.is_defined())
-        stats.clockRate = *rtcStats.clock_rate;
+        clockRate = *rtcStats.clock_rate;
     if (rtcStats.channels.is_defined())
-        stats.channels = *rtcStats.channels;
+        channels = *rtcStats.channels;
     if (rtcStats.sdp_fmtp_line.is_defined())
-        stats.sdpFmtpLine = fromStdString(*rtcStats.sdp_fmtp_line);
+        sdpFmtpLine = fromStdString(*rtcStats.sdp_fmtp_line);
 }
 
-static inline std::optional<RTCIceRole> iceRole(const std::string& state)
+static inline std::optional<RTCIceRole> convertIceRole(const std::string& state)
 {
     if (state == "unkown")
         return RTCIceRole::Unknown;
@@ -552,7 +538,7 @@ static inline std::optional<RTCIceTransportState> iceTransportState(const std::s
     return { };
 }
 
-static inline std::optional<RTCStatsReport::DtlsRole> dtlsRole(const std::string& state)
+static inline std::optional<RTCStatsReport::DtlsRole> convertDtlsRole(const std::string& state)
 {
     if (state == "client")
         return RTCStatsReport::DtlsRole::Client;
@@ -564,76 +550,74 @@ static inline std::optional<RTCStatsReport::DtlsRole> dtlsRole(const std::string
     return { };
 }
 
-static inline void fillRTCTransportStats(RTCStatsReport::TransportStats& stats, const webrtc::RTCTransportStats& rtcStats)
+RTCStatsReport::TransportStats::TransportStats(const webrtc::RTCTransportStats& rtcStats)
+    : Stats(RTCStatsReport::Type::Transport, rtcStats)
 {
-    fillRTCStats(stats, rtcStats);
-
     if (rtcStats.packets_sent.is_defined())
-        stats.packetsSent = *rtcStats.packets_sent;
+        packetsSent = *rtcStats.packets_sent;
     if (rtcStats.packets_received.is_defined())
-        stats.packetsReceived = *rtcStats.packets_received;
+        packetsReceived = *rtcStats.packets_received;
     if (rtcStats.bytes_sent.is_defined())
-        stats.bytesSent = *rtcStats.bytes_sent;
+        bytesSent = *rtcStats.bytes_sent;
     if (rtcStats.bytes_received.is_defined())
-        stats.bytesReceived = *rtcStats.bytes_received;
+        bytesReceived = *rtcStats.bytes_received;
     if (rtcStats.ice_role.is_defined())
-        stats.iceRole = iceRole(*rtcStats.ice_role);
+        iceRole = convertIceRole(*rtcStats.ice_role);
     if (rtcStats.ice_local_username_fragment.is_defined())
-        stats.iceLocalUsernameFragment = fromStdString(*rtcStats.ice_local_username_fragment);
+        iceLocalUsernameFragment = fromStdString(*rtcStats.ice_local_username_fragment);
     if (rtcStats.dtls_state.is_defined())
-        stats.dtlsState = *dtlsTransportState(*rtcStats.dtls_state);
+        dtlsState = *dtlsTransportState(*rtcStats.dtls_state);
     if (rtcStats.ice_state.is_defined())
-        stats.iceState = iceTransportState(*rtcStats.ice_state);
+        iceState = iceTransportState(*rtcStats.ice_state);
     if (rtcStats.selected_candidate_pair_id.is_defined())
-        stats.selectedCandidatePairId = fromStdString(*rtcStats.selected_candidate_pair_id);
+        selectedCandidatePairId = fromStdString(*rtcStats.selected_candidate_pair_id);
     if (rtcStats.local_certificate_id.is_defined())
-        stats.localCertificateId = fromStdString(*rtcStats.local_certificate_id);
+        localCertificateId = fromStdString(*rtcStats.local_certificate_id);
     if (rtcStats.remote_certificate_id.is_defined())
-        stats.remoteCertificateId = fromStdString(*rtcStats.remote_certificate_id);
+        remoteCertificateId = fromStdString(*rtcStats.remote_certificate_id);
     if (rtcStats.tls_version.is_defined())
-        stats.tlsVersion = fromStdString(*rtcStats.tls_version);
+        tlsVersion = fromStdString(*rtcStats.tls_version);
     if (rtcStats.dtls_cipher.is_defined())
-        stats.dtlsCipher = fromStdString(*rtcStats.dtls_cipher);
+        dtlsCipher = fromStdString(*rtcStats.dtls_cipher);
     if (rtcStats.dtls_role.is_defined())
-        stats.dtlsRole = dtlsRole(*rtcStats.dtls_role);
+        dtlsRole = convertDtlsRole(*rtcStats.dtls_role);
     if (rtcStats.srtp_cipher.is_defined())
-        stats.srtpCipher = fromStdString(*rtcStats.srtp_cipher);
+        srtpCipher = fromStdString(*rtcStats.srtp_cipher);
     if (rtcStats.selected_candidate_pair_changes.is_defined())
-        stats.selectedCandidatePairChanges = *rtcStats.selected_candidate_pair_changes;
+        selectedCandidatePairChanges = *rtcStats.selected_candidate_pair_changes;
 }
 
-static inline void fillRTCPeerConnectionStats(RTCStatsReport::PeerConnectionStats& stats, const webrtc::RTCPeerConnectionStats& rtcStats)
+RTCStatsReport::PeerConnectionStats::PeerConnectionStats(const webrtc::RTCPeerConnectionStats& rtcStats)
+    : Stats(RTCStatsReport::Type::PeerConnection, rtcStats)
 {
-    fillRTCStats(stats, rtcStats);
-
     if (rtcStats.data_channels_opened.is_defined())
-        stats.dataChannelsOpened = *rtcStats.data_channels_opened;
+        dataChannelsOpened = *rtcStats.data_channels_opened;
     if (rtcStats.data_channels_closed.is_defined())
-        stats.dataChannelsClosed = *rtcStats.data_channels_closed;
+        dataChannelsClosed = *rtcStats.data_channels_closed;
 }
 
-static inline void fillRTCMediaSourceStats(RTCStatsReport::MediaSourceStats& stats, const webrtc::RTCMediaSourceStats& rtcStats)
+RTCStatsReport::MediaSourceStats::MediaSourceStats(Type type, const webrtc::RTCMediaSourceStats& rtcStats)
+    : Stats(type, rtcStats)
 {
-    fillRTCStats(stats, rtcStats);
     if (rtcStats.track_identifier.is_defined())
-        stats.trackIdentifier = fromStdString(*rtcStats.track_identifier);
+        trackIdentifier = fromStdString(*rtcStats.track_identifier);
     if (rtcStats.kind.is_defined())
-        stats.kind = fromStdString(*rtcStats.kind);
+        kind = fromStdString(*rtcStats.kind);
 }
 
-static inline void fillRTCAudioSourceStats(RTCStatsReport::AudioSourceStats& stats, const webrtc::RTCAudioSourceStats& rtcStats)
+RTCStatsReport::AudioSourceStats::AudioSourceStats(const webrtc::RTCAudioSourceStats& rtcStats)
+    : MediaSourceStats(RTCStatsReport::Type::MediaSource, rtcStats)
 {
-    fillRTCMediaSourceStats(stats, rtcStats);
     if (rtcStats.audio_level.is_defined())
-        stats.audioLevel = *rtcStats.audio_level;
+        audioLevel = *rtcStats.audio_level;
     if (rtcStats.total_audio_energy.is_defined())
-        stats.totalAudioEnergy = *rtcStats.total_audio_energy;
+        totalAudioEnergy = *rtcStats.total_audio_energy;
     if (rtcStats.total_samples_duration.is_defined())
-        stats.totalSamplesDuration = *rtcStats.total_samples_duration;
+        totalSamplesDuration = *rtcStats.total_samples_duration;
     if (rtcStats.echo_return_loss.is_defined())
-        stats.echoReturnLoss = *rtcStats.echo_return_loss;
+        echoReturnLoss = *rtcStats.echo_return_loss;
     if (rtcStats.echo_return_loss_enhancement.is_defined())
-        stats.echoReturnLossEnhancement = *rtcStats.echo_return_loss_enhancement;
+        echoReturnLossEnhancement = *rtcStats.echo_return_loss_enhancement;
     // Not Implemented
     // if (rtcStats.dropped_samples_duration.is_defined())
     //     stats.droppedSamplesDuration = *rtcStats.dropped_samples_duration;
@@ -648,98 +632,75 @@ static inline void fillRTCAudioSourceStats(RTCStatsReport::AudioSourceStats& sta
     //     stats.totalSamplesCaptured = *rtcStats.total_samples_captured;
 }
 
-static inline void fillRTCAudioPlayoutStats(RTCStatsReport::AudioPlayoutStats& stats, const webrtc::RTCAudioPlayoutStats& rtcStats)
+RTCStatsReport::AudioPlayoutStats::AudioPlayoutStats(const webrtc::RTCAudioPlayoutStats& rtcStats)
+    : Stats(RTCStatsReport::Type::MediaPlayout, rtcStats)
 {
-    fillRTCStats(stats, rtcStats);
-
     if (rtcStats.kind.is_defined())
-        stats.kind = fromStdString(*rtcStats.kind);
+        kind = fromStdString(*rtcStats.kind);
     if (rtcStats.synthesized_samples_duration.is_defined())
-        stats.synthesizedSamplesDuration = *rtcStats.synthesized_samples_duration;
+        synthesizedSamplesDuration = *rtcStats.synthesized_samples_duration;
     if (rtcStats.synthesized_samples_events.is_defined())
-        stats.synthesizedSamplesEvents = *rtcStats.synthesized_samples_events;
+        synthesizedSamplesEvents = *rtcStats.synthesized_samples_events;
     if (rtcStats.total_samples_duration.is_defined())
-        stats.totalSamplesDuration = *rtcStats.total_samples_duration;
+        totalSamplesDuration = *rtcStats.total_samples_duration;
     if (rtcStats.total_playout_delay.is_defined())
-        stats.totalPlayoutDelay = *rtcStats.total_playout_delay;
+        totalPlayoutDelay = *rtcStats.total_playout_delay;
     if (rtcStats.total_samples_count.is_defined())
-        stats.totalSamplesCount = *rtcStats.total_samples_count;
+        totalSamplesCount = *rtcStats.total_samples_count;
 }
 
-static inline void fillRTCVideoSourceStats(RTCStatsReport::VideoSourceStats& stats, const webrtc::RTCVideoSourceStats& rtcStats)
+RTCStatsReport::VideoSourceStats::VideoSourceStats(const webrtc::RTCVideoSourceStats& rtcStats)
+    : MediaSourceStats(RTCStatsReport::Type::MediaSource, rtcStats)
 {
-    fillRTCMediaSourceStats(stats, rtcStats);
-
     if (rtcStats.width.is_defined())
-        stats.width = *rtcStats.width;
+        width = *rtcStats.width;
     if (rtcStats.height.is_defined())
-        stats.height = *rtcStats.height;
+        height = *rtcStats.height;
     if (rtcStats.frames.is_defined())
-        stats.frames = *rtcStats.frames;
+        frames = *rtcStats.frames;
     if (rtcStats.frames_per_second.is_defined())
-        stats.framesPerSecond = *rtcStats.frames_per_second;
+        framesPerSecond = *rtcStats.frames_per_second;
+}
+
+template <typename T, typename PreciseType>
+void addToStatsMap(DOMMapAdapter& report, const webrtc::RTCStats& rtcStats)
+{
+    T stats { static_cast<const PreciseType&>(rtcStats) };
+    String statsId = stats.id;
+    report.set<IDLDOMString, IDLDictionary<T>>(WTFMove(statsId), WTFMove(stats));
 }
 
 static inline void initializeRTCStatsReportBackingMap(DOMMapAdapter& report, const webrtc::RTCStatsReport& rtcReport)
 {
     for (const auto& rtcStats : rtcReport) {
-        if (rtcStats.type() == webrtc::RTCInboundRtpStreamStats::kType) {
-            RTCStatsReport::InboundRtpStreamStats stats;
-            fillInboundRtpStreamStats(stats, static_cast<const webrtc::RTCInboundRtpStreamStats&>(rtcStats));
-            report.set<IDLDOMString, IDLDictionary<RTCStatsReport::InboundRtpStreamStats>>(stats.id, WTFMove(stats));
-        } else if (rtcStats.type() == webrtc::RTCOutboundRtpStreamStats::kType) {
-            RTCStatsReport::OutboundRtpStreamStats stats;
-            fillOutboundRtpStreamStats(stats, static_cast<const webrtc::RTCOutboundRtpStreamStats&>(rtcStats));
-            report.set<IDLDOMString, IDLDictionary<RTCStatsReport::OutboundRtpStreamStats>>(stats.id, WTFMove(stats));
-        } else if (rtcStats.type() == webrtc::RTCDataChannelStats::kType) {
-            RTCStatsReport::DataChannelStats stats;
-            fillRTCDataChannelStats(stats, static_cast<const webrtc::RTCDataChannelStats&>(rtcStats));
-            report.set<IDLDOMString, IDLDictionary<RTCStatsReport::DataChannelStats>>(stats.id, WTFMove(stats));
-        } else if (rtcStats.type() == webrtc::RTCIceCandidatePairStats::kType) {
-            RTCStatsReport::IceCandidatePairStats stats;
-            fillRTCIceCandidatePairStats(stats, static_cast<const webrtc::RTCIceCandidatePairStats&>(rtcStats));
-            report.set<IDLDOMString, IDLDictionary<RTCStatsReport::IceCandidatePairStats>>(stats.id, WTFMove(stats));
-        } else if (rtcStats.type() == webrtc::RTCRemoteIceCandidateStats::kType || rtcStats.type() == webrtc::RTCLocalIceCandidateStats::kType) {
-            RTCStatsReport::IceCandidateStats stats;
-            fillRTCIceCandidateStats(stats, static_cast<const webrtc::RTCIceCandidateStats&>(rtcStats));
-            report.set<IDLDOMString, IDLDictionary<RTCStatsReport::IceCandidateStats>>(stats.id, WTFMove(stats));
-        } else if (rtcStats.type() == webrtc::RTCCertificateStats::kType) {
-            RTCStatsReport::CertificateStats stats;
-            fillRTCCertificateStats(stats, static_cast<const webrtc::RTCCertificateStats&>(rtcStats));
-            report.set<IDLDOMString, IDLDictionary<RTCStatsReport::CertificateStats>>(stats.id, WTFMove(stats));
-        } else if (rtcStats.type() == webrtc::RTCCodecStats::kType) {
-            RTCStatsReport::CodecStats stats;
-            fillRTCCodecStats(stats, static_cast<const webrtc::RTCCodecStats&>(rtcStats));
-            report.set<IDLDOMString, IDLDictionary<RTCStatsReport::CodecStats>>(stats.id, WTFMove(stats));
-        } else if (rtcStats.type() == webrtc::RTCTransportStats::kType) {
-            RTCStatsReport::TransportStats stats;
-            fillRTCTransportStats(stats, static_cast<const webrtc::RTCTransportStats&>(rtcStats));
-            report.set<IDLDOMString, IDLDictionary<RTCStatsReport::TransportStats>>(stats.id, WTFMove(stats));
-        } else if (rtcStats.type() == webrtc::RTCPeerConnectionStats::kType) {
-            RTCStatsReport::PeerConnectionStats stats;
-            fillRTCPeerConnectionStats(stats, static_cast<const webrtc::RTCPeerConnectionStats&>(rtcStats));
-            report.set<IDLDOMString, IDLDictionary<RTCStatsReport::PeerConnectionStats>>(stats.id, WTFMove(stats));
-        } else if (rtcStats.type() == webrtc::RTCAudioSourceStats::kType) {
-            RTCStatsReport::AudioSourceStats stats;
-            fillRTCAudioSourceStats(stats, static_cast<const webrtc::RTCAudioSourceStats&>(rtcStats));
-            report.set<IDLDOMString, IDLDictionary<RTCStatsReport::AudioSourceStats>>(stats.id, WTFMove(stats));
-        } else if (rtcStats.type() == webrtc::RTCVideoSourceStats::kType) {
-            RTCStatsReport::VideoSourceStats stats;
-            fillRTCVideoSourceStats(stats, static_cast<const webrtc::RTCVideoSourceStats&>(rtcStats));
-            report.set<IDLDOMString, IDLDictionary<RTCStatsReport::VideoSourceStats>>(stats.id, WTFMove(stats));
-        } else if (rtcStats.type() == webrtc::RTCRemoteInboundRtpStreamStats::kType) {
-            RTCStatsReport::RemoteInboundRtpStreamStats stats;
-            fillRemoteInboundRtpStreamStats(stats, static_cast<const webrtc::RTCRemoteInboundRtpStreamStats&>(rtcStats));
-            report.set<IDLDOMString, IDLDictionary<RTCStatsReport::RemoteInboundRtpStreamStats>>(stats.id, WTFMove(stats));
-        } else if (rtcStats.type() == webrtc::RTCRemoteOutboundRtpStreamStats::kType) {
-            RTCStatsReport::RemoteOutboundRtpStreamStats stats;
-            fillRemoteOutboundRtpStreamStats(stats, static_cast<const webrtc::RTCRemoteOutboundRtpStreamStats&>(rtcStats));
-            report.set<IDLDOMString, IDLDictionary<RTCStatsReport::RemoteOutboundRtpStreamStats>>(stats.id, WTFMove(stats));
-        } else if (rtcStats.type() == webrtc::RTCAudioPlayoutStats::kType) {
-            RTCStatsReport::AudioPlayoutStats stats;
-            fillRTCAudioPlayoutStats(stats, static_cast<const webrtc::RTCAudioPlayoutStats&>(rtcStats));
-            report.set<IDLDOMString, IDLDictionary<RTCStatsReport::AudioPlayoutStats>>(stats.id, WTFMove(stats));
-        }
+        if (rtcStats.type() == webrtc::RTCInboundRtpStreamStats::kType)
+            addToStatsMap<RTCStatsReport::InboundRtpStreamStats, webrtc::RTCInboundRtpStreamStats>(report, rtcStats);
+        else if (rtcStats.type() == webrtc::RTCOutboundRtpStreamStats::kType)
+            addToStatsMap<RTCStatsReport::OutboundRtpStreamStats, webrtc::RTCOutboundRtpStreamStats>(report, rtcStats);
+        else if (rtcStats.type() == webrtc::RTCDataChannelStats::kType)
+            addToStatsMap<RTCStatsReport::DataChannelStats, webrtc::RTCDataChannelStats>(report, rtcStats);
+        else if (rtcStats.type() == webrtc::RTCIceCandidatePairStats::kType)
+            addToStatsMap<RTCStatsReport::IceCandidatePairStats, webrtc::RTCIceCandidatePairStats>(report, rtcStats);
+        else if (rtcStats.type() == webrtc::RTCRemoteIceCandidateStats::kType || rtcStats.type() == webrtc::RTCLocalIceCandidateStats::kType)
+            addToStatsMap<RTCStatsReport::IceCandidateStats, webrtc::RTCIceCandidateStats>(report, rtcStats);
+        else if (rtcStats.type() == webrtc::RTCCertificateStats::kType)
+            addToStatsMap<RTCStatsReport::CertificateStats, webrtc::RTCCertificateStats>(report, rtcStats);
+        else if (rtcStats.type() == webrtc::RTCCodecStats::kType)
+            addToStatsMap<RTCStatsReport::CodecStats, webrtc::RTCCodecStats>(report, rtcStats);
+        else if (rtcStats.type() == webrtc::RTCTransportStats::kType)
+            addToStatsMap<RTCStatsReport::TransportStats, webrtc::RTCTransportStats>(report, rtcStats);
+        else if (rtcStats.type() == webrtc::RTCPeerConnectionStats::kType)
+            addToStatsMap<RTCStatsReport::PeerConnectionStats, webrtc::RTCPeerConnectionStats>(report, rtcStats);
+        else if (rtcStats.type() == webrtc::RTCAudioSourceStats::kType)
+            addToStatsMap<RTCStatsReport::AudioSourceStats, webrtc::RTCAudioSourceStats>(report, rtcStats);
+        else if (rtcStats.type() == webrtc::RTCVideoSourceStats::kType)
+            addToStatsMap<RTCStatsReport::VideoSourceStats, webrtc::RTCVideoSourceStats>(report, rtcStats);
+        else if (rtcStats.type() == webrtc::RTCRemoteInboundRtpStreamStats::kType)
+            addToStatsMap<RTCStatsReport::RemoteInboundRtpStreamStats, webrtc::RTCRemoteInboundRtpStreamStats>(report, rtcStats);
+        else if (rtcStats.type() == webrtc::RTCRemoteOutboundRtpStreamStats::kType)
+            addToStatsMap<RTCStatsReport::RemoteOutboundRtpStreamStats, webrtc::RTCRemoteOutboundRtpStreamStats>(report, rtcStats);
+        else if (rtcStats.type() == webrtc::RTCAudioPlayoutStats::kType)
+            addToStatsMap<RTCStatsReport::AudioPlayoutStats, webrtc::RTCAudioPlayoutStats>(report, rtcStats);
     }
 }
 


### PR DESCRIPTION
#### d7759dc9cbb90b3fda92a54521c132c18cc5a0df
<pre>
Add libwebrtc specific WebCore RTCStat object constructors
<a href="https://rdar.apple.com/129205417">rdar://129205417</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=275096">https://bugs.webkit.org/show_bug.cgi?id=275096</a>

Reviewed by Jean-Yves Avenard.

Refactoring to do more initialization in constructors.
This makes it easier to initialize all values and will help code analysis.

* Source/WebCore/Modules/mediastream/RTCStatsReport.h:
(WebCore::RTCStatsReport::InboundRtpStreamStats::InboundRtpStreamStats): Deleted.
(WebCore::RTCStatsReport::RemoteInboundRtpStreamStats::RemoteInboundRtpStreamStats): Deleted.
(WebCore::RTCStatsReport::OutboundRtpStreamStats::OutboundRtpStreamStats): Deleted.
(WebCore::RTCStatsReport::RemoteOutboundRtpStreamStats::RemoteOutboundRtpStreamStats): Deleted.
(WebCore::RTCStatsReport::DataChannelStats::DataChannelStats): Deleted.
(WebCore::RTCStatsReport::IceCandidatePairStats::IceCandidatePairStats): Deleted.
(WebCore::RTCStatsReport::CertificateStats::CertificateStats): Deleted.
(WebCore::RTCStatsReport::CodecStats::CodecStats): Deleted.
(WebCore::RTCStatsReport::TransportStats::TransportStats): Deleted.
(WebCore::RTCStatsReport::AudioPlayoutStats::AudioPlayoutStats): Deleted.
(WebCore::RTCStatsReport::PeerConnectionStats::PeerConnectionStats): Deleted.
(WebCore::RTCStatsReport::AudioSourceStats::AudioSourceStats): Deleted.
(WebCore::RTCStatsReport::VideoSourceStats::VideoSourceStats): Deleted.
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp:
(WebCore::RTCStatsReport::Stats::Stats):
(WebCore::RTCStatsReport::RtpStreamStats::RtpStreamStats):
(WebCore::RTCStatsReport::ReceivedRtpStreamStats::ReceivedRtpStreamStats):
(WebCore::RTCStatsReport::InboundRtpStreamStats::InboundRtpStreamStats):
(WebCore::RTCStatsReport::RemoteInboundRtpStreamStats::RemoteInboundRtpStreamStats):
(WebCore::RTCStatsReport::SentRtpStreamStats::SentRtpStreamStats):
(WebCore::convertQualityLimitationReason):
(WebCore::RTCStatsReport::OutboundRtpStreamStats::OutboundRtpStreamStats):
(WebCore::RTCStatsReport::RemoteOutboundRtpStreamStats::RemoteOutboundRtpStreamStats):
(WebCore::RTCStatsReport::DataChannelStats::DataChannelStats):
(WebCore::RTCStatsReport::IceCandidatePairStats::IceCandidatePairStats):
(WebCore::RTCStatsReport::IceCandidateStats::IceCandidateStats):
(WebCore::RTCStatsReport::CertificateStats::CertificateStats):
(WebCore::RTCStatsReport::CodecStats::CodecStats):
(WebCore::convertIceRole):
(WebCore::convertDtlsRole):
(WebCore::RTCStatsReport::TransportStats::TransportStats):
(WebCore::RTCStatsReport::PeerConnectionStats::PeerConnectionStats):
(WebCore::RTCStatsReport::MediaSourceStats::MediaSourceStats):
(WebCore::RTCStatsReport::AudioSourceStats::AudioSourceStats):
(WebCore::RTCStatsReport::AudioPlayoutStats::AudioPlayoutStats):
(WebCore::RTCStatsReport::VideoSourceStats::VideoSourceStats):
(WebCore::addToStatsMap):
(WebCore::initializeRTCStatsReportBackingMap):
(WebCore::fillRTCStats): Deleted.
(WebCore::fillRtpStreamStats): Deleted.
(WebCore::fillReceivedRtpStreamStats): Deleted.
(WebCore::fillInboundRtpStreamStats): Deleted.
(WebCore::fillRemoteInboundRtpStreamStats): Deleted.
(WebCore::fillSentRtpStreamStats): Deleted.
(WebCore::qualityLimitationReason): Deleted.
(WebCore::fillOutboundRtpStreamStats): Deleted.
(WebCore::fillRemoteOutboundRtpStreamStats): Deleted.
(WebCore::fillRTCDataChannelStats): Deleted.
(WebCore::fillRTCIceCandidatePairStats): Deleted.
(WebCore::fillRTCIceCandidateStats): Deleted.
(WebCore::fillRTCCertificateStats): Deleted.
(WebCore::fillRTCCodecStats): Deleted.
(WebCore::iceRole): Deleted.
(WebCore::dtlsRole): Deleted.
(WebCore::fillRTCTransportStats): Deleted.
(WebCore::fillRTCPeerConnectionStats): Deleted.
(WebCore::fillRTCMediaSourceStats): Deleted.
(WebCore::fillRTCAudioSourceStats): Deleted.
(WebCore::fillRTCAudioPlayoutStats): Deleted.
(WebCore::fillRTCVideoSourceStats): Deleted.

Canonical link: <a href="https://commits.webkit.org/279731@main">https://commits.webkit.org/279731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03250f464d8c3dbba4c29f77f290d082f32c8101

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6905 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57629 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5081 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56652 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41279 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/5029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44010 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3391 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56443 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47064 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25146 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/28735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4386 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3224 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4596 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59219 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/29568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/5029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/51437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/30728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47157 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11836 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/31702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/30514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->