### PR TITLE
[JSC] Fix behavior of `Intl.DurationFormat` for negative values

### DIFF
--- a/JSTests/stress/intl-duration-format-negative-values.js
+++ b/JSTests/stress/intl-duration-format-negative-values.js
@@ -1,0 +1,18 @@
+function sameValue(a, b) {
+  if (a !== b)
+      throw new Error(`Expected ${b} but got ${a}`);
+}
+
+{
+  const duration = { hours: 0, seconds: -1 };
+  const df = new Intl.DurationFormat("en", { hoursDisplay: "always" });
+  const formatted = df.format(duration);
+  sameValue(formatted, "-0 hr, 1 sec");
+}
+
+{
+  const duration = { years: -1, months: -2 };
+  const df = new Intl.DurationFormat("en");
+  const formatted = df.format(duration);
+  sameValue(formatted, "-1 yr, 2 mths");
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1026,36 +1026,6 @@ test/intl402/DateTimeFormat/timezone-legacy-non-iana.js:
 test/intl402/DateTimeFormat/timezone-not-canonicalized.js:
   default: 'Test262Error: Expected SameValue(«Asia/Calcutta», «Asia/Kolkata») to be true'
   strict mode: 'Test262Error: Expected SameValue(«Asia/Calcutta», «Asia/Kolkata») to be true'
-test/intl402/DurationFormat/prototype/format/negative-duration-style-default-en.js:
-  default: 'Test262Error: DurationFormat format output using default style option Expected SameValue(«-1 yr, -2 mths, -3 wks, -3 days, -4 hr, -5 min, -6 sec, -7 ms, -8 μs, -9 ns», «-1 yr, 2 mths, 3 wks, 3 days, 4 hr, 5 min, 6 sec, 7 ms, 8 μs, 9 ns») to be true'
-  strict mode: 'Test262Error: DurationFormat format output using default style option Expected SameValue(«-1 yr, -2 mths, -3 wks, -3 days, -4 hr, -5 min, -6 sec, -7 ms, -8 μs, -9 ns», «-1 yr, 2 mths, 3 wks, 3 days, 4 hr, 5 min, 6 sec, 7 ms, 8 μs, 9 ns») to be true'
-test/intl402/DurationFormat/prototype/format/negative-duration-style-short-en.js:
-  default: 'Test262Error: DurationFormat format output using short style option Expected SameValue(«-1 yr, -2 mths, -3 wks, -3 days, -4 hr, -5 min, -6 sec, -7 ms, -8 μs, -9 ns», «-1 yr, 2 mths, 3 wks, 3 days, 4 hr, 5 min, 6 sec, 7 ms, 8 μs, 9 ns») to be true'
-  strict mode: 'Test262Error: DurationFormat format output using short style option Expected SameValue(«-1 yr, -2 mths, -3 wks, -3 days, -4 hr, -5 min, -6 sec, -7 ms, -8 μs, -9 ns», «-1 yr, 2 mths, 3 wks, 3 days, 4 hr, 5 min, 6 sec, 7 ms, 8 μs, 9 ns») to be true'
-test/intl402/DurationFormat/prototype/format/negative-duration-with-leading-zero-style-default-en.js:
-  default: 'Test262Error: DurationFormat format output using default style option Expected SameValue(«0 hr, -1 sec», «-0 hr, 1 sec») to be true'
-  strict mode: 'Test262Error: DurationFormat format output using default style option Expected SameValue(«0 hr, -1 sec», «-0 hr, 1 sec») to be true'
-test/intl402/DurationFormat/prototype/format/negative-duration-with-leading-zero-style-digital-en.js:
-  default: 'Test262Error: DurationFormat format output using digital style option Expected SameValue(«0:00:-01», «-0:00:01») to be true'
-  strict mode: 'Test262Error: DurationFormat format output using digital style option Expected SameValue(«0:00:-01», «-0:00:01») to be true'
-test/intl402/DurationFormat/prototype/format/negative-duration-with-leading-zero-style-long-en.js:
-  default: 'Test262Error: DurationFormat format output using long style option Expected SameValue(«0 hours, -1 second», «-0 hours, 1 second») to be true'
-  strict mode: 'Test262Error: DurationFormat format output using long style option Expected SameValue(«0 hours, -1 second», «-0 hours, 1 second») to be true'
-test/intl402/DurationFormat/prototype/format/negative-duration-with-leading-zero-style-narrow-en.js:
-  default: 'Test262Error: DurationFormat format output using narrow style option Expected SameValue(«0h -1s», «-0h 1s») to be true'
-  strict mode: 'Test262Error: DurationFormat format output using narrow style option Expected SameValue(«0h -1s», «-0h 1s») to be true'
-test/intl402/DurationFormat/prototype/format/negative-duration-with-leading-zero-style-short-en.js:
-  default: 'Test262Error: DurationFormat format output using short style option Expected SameValue(«0 hr, -1 sec», «-0 hr, 1 sec») to be true'
-  strict mode: 'Test262Error: DurationFormat format output using short style option Expected SameValue(«0 hr, -1 sec», «-0 hr, 1 sec») to be true'
-test/intl402/DurationFormat/prototype/format/negative-durationstyle-digital-en.js:
-  default: 'Test262Error: DurationFormat format output using digital style option Expected SameValue(«-1 yr, -2 mths, -3 wks, -3 days, -4:-05:-06.007008009», «-1 yr, 2 mths, 3 wks, 3 days, 4:05:06.007008009») to be true'
-  strict mode: 'Test262Error: DurationFormat format output using digital style option Expected SameValue(«-1 yr, -2 mths, -3 wks, -3 days, -4:-05:-06.007008009», «-1 yr, 2 mths, 3 wks, 3 days, 4:05:06.007008009») to be true'
-test/intl402/DurationFormat/prototype/format/negative-durationstyle-long-en.js:
-  default: 'Test262Error: DurationFormat format output using long style option Expected SameValue(«-1 year, -2 months, -3 weeks, -3 days, -4 hours, -5 minutes, -6 seconds, -7 milliseconds, -8 microseconds, -9 nanoseconds», «-1 year, 2 months, 3 weeks, 3 days, 4 hours, 5 minutes, 6 seconds, 7 milliseconds, 8 microseconds, 9 nanoseconds») to be true'
-  strict mode: 'Test262Error: DurationFormat format output using long style option Expected SameValue(«-1 year, -2 months, -3 weeks, -3 days, -4 hours, -5 minutes, -6 seconds, -7 milliseconds, -8 microseconds, -9 nanoseconds», «-1 year, 2 months, 3 weeks, 3 days, 4 hours, 5 minutes, 6 seconds, 7 milliseconds, 8 microseconds, 9 nanoseconds») to be true'
-test/intl402/DurationFormat/prototype/format/negative-durationstyle-narrow-en.js:
-  default: 'Test262Error: DurationFormat format output using narrow style option Expected SameValue(«-1y -2mo -3w -3d -4h -5m -6s -7ms -8μs -9ns», «-1y 2mo 3w 3d 4h 5m 6s 7ms 8μs 9ns») to be true'
-  strict mode: 'Test262Error: DurationFormat format output using narrow style option Expected SameValue(«-1y -2mo -3w -3d -4h -5m -6s -7ms -8μs -9ns», «-1y 2mo 3w 3d 4h 5m 6s 7ms 8μs 9ns») to be true'
 test/intl402/DurationFormat/prototype/format/numeric-hour-with-zero-minutes-and-non-zero-seconds-with-auto-display-and-zero-fractional.js:
   default: 'Test262Error: Duration is {"hours":0,"minutes":0,"seconds":1} Expected SameValue(«0, 01», «0:00:01») to be true'
   strict mode: 'Test262Error: Duration is {"hours":0,"minutes":0,"seconds":1} Expected SameValue(«0, 01», «0:00:01») to be true'
@@ -1068,36 +1038,6 @@ test/intl402/DurationFormat/prototype/format/numeric-hour-with-zero-minutes-and-
 test/intl402/DurationFormat/prototype/format/precision-exact-mathematical-values.js:
   default: 'Test262Error: Duration is {"seconds":10000000,"nanoseconds":1} Expected SameValue(«0:00:10,000,000.000000002», «0:00:10,000,000.000000001») to be true'
   strict mode: 'Test262Error: Duration is {"seconds":10000000,"nanoseconds":1} Expected SameValue(«0:00:10,000,000.000000002», «0:00:10,000,000.000000001») to be true'
-test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-default-en.js:
-  default: 'Test262Error: Using style : default: length Expected SameValue(«49», «40») to be true'
-  strict mode: 'Test262Error: Using style : default: length Expected SameValue(«49», «40») to be true'
-test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-digital-en.js:
-  default: 'Test262Error: Using style : digital: length Expected SameValue(«30», «24») to be true'
-  strict mode: 'Test262Error: Using style : digital: length Expected SameValue(«30», «24») to be true'
-test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-long-en.js:
-  default: 'Test262Error: Using style : long: length Expected SameValue(«49», «40») to be true'
-  strict mode: 'Test262Error: Using style : long: length Expected SameValue(«49», «40») to be true'
-test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-narrow-en.js:
-  default: 'Test262Error: Using style : narrow: length Expected SameValue(«39», «30») to be true'
-  strict mode: 'Test262Error: Using style : narrow: length Expected SameValue(«39», «30») to be true'
-test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-short-en.js:
-  default: 'Test262Error: Using style : short: length Expected SameValue(«49», «40») to be true'
-  strict mode: 'Test262Error: Using style : short: length Expected SameValue(«49», «40») to be true'
-test/intl402/DurationFormat/prototype/formatToParts/negative-duration-with-leading-zero-style-default-en.js:
-  default: 'Test262Error: type for entry 0 Expected SameValue(«integer», «minusSign») to be true'
-  strict mode: 'Test262Error: type for entry 0 Expected SameValue(«integer», «minusSign») to be true'
-test/intl402/DurationFormat/prototype/formatToParts/negative-duration-with-leading-zero-style-digital-en.js:
-  default: 'Test262Error: type for entry 0 Expected SameValue(«integer», «minusSign») to be true'
-  strict mode: 'Test262Error: type for entry 0 Expected SameValue(«integer», «minusSign») to be true'
-test/intl402/DurationFormat/prototype/formatToParts/negative-duration-with-leading-zero-style-long-en.js:
-  default: 'Test262Error: type for entry 0 Expected SameValue(«integer», «minusSign») to be true'
-  strict mode: 'Test262Error: type for entry 0 Expected SameValue(«integer», «minusSign») to be true'
-test/intl402/DurationFormat/prototype/formatToParts/negative-duration-with-leading-zero-style-narrow-en.js:
-  default: 'Test262Error: type for entry 0 Expected SameValue(«integer», «minusSign») to be true'
-  strict mode: 'Test262Error: type for entry 0 Expected SameValue(«integer», «minusSign») to be true'
-test/intl402/DurationFormat/prototype/formatToParts/negative-duration-with-leading-zero-style-short-en.js:
-  default: 'Test262Error: type for entry 0 Expected SameValue(«integer», «minusSign») to be true'
-  strict mode: 'Test262Error: type for entry 0 Expected SameValue(«integer», «minusSign») to be true'
 test/intl402/Intl/getCanonicalLocales/non-iana-canon.js:
   default: 'Test262Error: The value of Intl.getCanonicalLocales(tag)[0] equals the value of `canonical` Expected SameValue(«en-US-u-va-posix», «posix») to be true'
   strict mode: 'Test262Error: The value of Intl.getCanonicalLocales(tag)[0] equals the value of `canonical` Expected SameValue(«en-US-u-va-posix», «posix») to be true'


### PR DESCRIPTION
#### 3f74bba5c41c78732611942b04ba1d43a5fa030c
<pre>
[JSC] Fix behavior of `Intl.DurationFormat` for negative values
<a href="https://bugs.webkit.org/show_bug.cgi?id=275095">https://bugs.webkit.org/show_bug.cgi?id=275095</a>

Reviewed by Ross Kirsling.

This patch includes the following two related fixes:

1. When the values of multiple units are negative, display `-` only for the largest unit.
For example, the duration `{ years: -1, months: -2 }` should be formatted as `&quot;-1 years, 2 months&quot;`.
According to the spec[1], this behavior is controlled by the `signDisplayed` variable (initially
set to true). This variable is set to false once any unit is formatted.

2. Implement the DurationSign abstract operation [2] to display negative zero.
For example, the duration `{ hours: 0, seconds: -1 }` should be formatted as `&quot;-0 hours, 1 second&quot;`.
This is described in section 4.f.iii.3.b of the spec [1] as follows:

    &gt; b. If value is 0 and DurationSign(duration.[[Years]], duration.[[Months]], duration.[[Weeks]], duration.[[Days]], duration.[[Hours]], duration.[[Minutes]], duration.[[Seconds]], duration.[[Milliseconds]], duration.[[Microseconds]], duration.[[Nanoseconds]]) is -1, then
    &gt;     i. Set value to negative-zero.

The `partitionDurationFormatPattern` function [3] in the `harness/testintl.js` of test262 describes
a similar process to the changes in this patch.

[1]: <a href="https://tc39.es/proposal-intl-duration-format/#sec-partitiondurationformatpattern">https://tc39.es/proposal-intl-duration-format/#sec-partitiondurationformatpattern</a>
[2]: <a href="https://tc39.es/proposal-intl-duration-format/#sec-durationsign">https://tc39.es/proposal-intl-duration-format/#sec-durationsign</a>
[3]: <a href="https://github.com/tc39/test262/blob/249657722525cc8e43b1ddb91f8df0b4b011fcf6/harness/testIntl.js#L2649-L2662">https://github.com/tc39/test262/blob/249657722525cc8e43b1ddb91f8df0b4b011fcf6/harness/testIntl.js#L2649-L2662</a>

* JSTests/stress/intl-duration-format-negative-values.js: Added.
(sameValue):
(throw.new.Error):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/IntlDurationFormat.cpp:
(JSC::getDurationSign):
(JSC::collectElements):

Canonical link: <a href="https://commits.webkit.org/279902@main">https://commits.webkit.org/279902@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9bb2a6a1587cb16c68ab88bac9568978a316940

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54894 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58172 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5625 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5649 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44458 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3812 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56989 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/32443 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47559 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25585 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/29233 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4900 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3766 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/48261 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5120 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59762 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/54399 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30151 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/5269 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/51880 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31288 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47637 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51299 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12057 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32303 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/66695 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31076 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12719 "Passed tests") | 
<!--EWS-Status-Bubble-End-->