### PR TITLE
WebGLRenderingContextBase::validateStencilFunc is redundant

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -3078,8 +3078,6 @@ void WebGLRenderingContextBase::stencilFunc(GCGLenum func, GCGLint ref, GCGLuint
 {
     if (isContextLost())
         return;
-    if (!validateStencilFunc("stencilFunc"_s, func))
-        return;
     m_context->stencilFunc(func, ref, mask);
 }
 
@@ -3087,17 +3085,6 @@ void WebGLRenderingContextBase::stencilFuncSeparate(GCGLenum face, GCGLenum func
 {
     if (isContextLost())
         return;
-    if (!validateStencilFunc("stencilFuncSeparate"_s, func))
-        return;
-    switch (face) {
-    case GraphicsContextGL::FRONT_AND_BACK:
-    case GraphicsContextGL::FRONT:
-    case GraphicsContextGL::BACK:
-        break;
-    default:
-        synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "stencilFuncSeparate"_s, "invalid face"_s);
-        return;
-    }
     m_context->stencilFuncSeparate(face, func, ref, mask);
 }
 
@@ -4914,24 +4901,6 @@ bool WebGLRenderingContextBase::validateCompressedTexFormat(ASCIILiteral functio
         return false;
     }
     return true;
-}
-
-bool WebGLRenderingContextBase::validateStencilFunc(ASCIILiteral functionName, GCGLenum func)
-{
-    switch (func) {
-    case GraphicsContextGL::NEVER:
-    case GraphicsContextGL::LESS:
-    case GraphicsContextGL::LEQUAL:
-    case GraphicsContextGL::GREATER:
-    case GraphicsContextGL::GEQUAL:
-    case GraphicsContextGL::EQUAL:
-    case GraphicsContextGL::NOTEQUAL:
-    case GraphicsContextGL::ALWAYS:
-        return true;
-    default:
-        synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid function"_s);
-        return false;
-    }
 }
 
 bool WebGLRenderingContextBase::shouldPrintToConsole() const

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -945,9 +945,6 @@ protected:
     // Helper function for validating compressed texture formats.
     bool validateCompressedTexFormat(ASCIILiteral functionName, GCGLenum format);
 
-    // Helper function to validate stencil func.
-    bool validateStencilFunc(ASCIILiteral functionName, GCGLenum);
-
     // Helper function for texParameterf and texParameteri.
     void texParameter(GCGLenum target, GCGLenum pname, GCGLfloat paramf, GCGLint parami, bool isFloat);
 


### PR DESCRIPTION
#### 9a8ab03235fde48f5c22a15449621f36d6877e87
<pre>
WebGLRenderingContextBase::validateStencilFunc is redundant
<a href="https://bugs.webkit.org/show_bug.cgi?id=275051">https://bugs.webkit.org/show_bug.cgi?id=275051</a>

Reviewed by Kimmo Kinnunen.

Removed redundant code.

* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::stencilFunc):
(WebCore::WebGLRenderingContextBase::stencilFuncSeparate):
(WebCore::WebGLRenderingContextBase::validateStencilFunc): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:

Canonical link: <a href="https://commits.webkit.org/279727@main">https://commits.webkit.org/279727@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8534ce6683b8920e7826facf24f48e570c3d6d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57467 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4915 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41101 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4874 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43886 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3288 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56287 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46923 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25033 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28634 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4243 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3064 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50335 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4449 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59060 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29395 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4620 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51310 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30566 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47034 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50668 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11829 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31534 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30346 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->