### PR TITLE
WebGLRenderingContextBase::m_stencilEnabled and m_stencilMaskBack are unused

### DIFF
--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -528,9 +528,7 @@ void WebGLRenderingContextBase::initializeContextState()
     m_framebufferBinding = nullptr;
     m_renderbufferBinding = nullptr;
     m_depthMask = true;
-    m_stencilEnabled = false;
     m_stencilMask = 0xFFFFFFFF;
-    m_stencilMaskBack = 0xFFFFFFFF;
 
     m_rasterizerDiscardEnabled = false;
 
@@ -1526,8 +1524,6 @@ void WebGLRenderingContextBase::disable(GCGLenum cap)
 {
     if (isContextLost() || !validateCapability("disable"_s, cap))
         return;
-    if (cap == GraphicsContextGL::STENCIL_TEST)
-        m_stencilEnabled = false;
     if (cap == GraphicsContextGL::SCISSOR_TEST)
         m_scissorEnabled = false;
     if (cap == GraphicsContextGL::RASTERIZER_DISCARD)
@@ -1599,8 +1595,6 @@ void WebGLRenderingContextBase::enable(GCGLenum cap)
 {
     if (isContextLost() || !validateCapability("enable"_s, cap))
         return;
-    if (cap == GraphicsContextGL::STENCIL_TEST)
-        m_stencilEnabled = true;
     if (cap == GraphicsContextGL::SCISSOR_TEST)
         m_scissorEnabled = true;
     if (cap == GraphicsContextGL::RASTERIZER_DISCARD)
@@ -2027,7 +2021,7 @@ WebGLAny WebGLRenderingContextBase::getParameter(GCGLenum pname)
     case GraphicsContextGL::STENCIL_REF:
         return getIntParameter(pname);
     case GraphicsContextGL::STENCIL_TEST:
-        return m_stencilEnabled;
+        return getBooleanParameter(pname);
     case GraphicsContextGL::STENCIL_VALUE_MASK:
         return getUnsignedIntParameter(pname);
     case GraphicsContextGL::STENCIL_WRITEMASK:
@@ -2763,8 +2757,6 @@ GCGLboolean WebGLRenderingContextBase::isEnabled(GCGLenum cap)
 {
     if (isContextLost() || !validateCapability("isEnabled"_s, cap))
         return 0;
-    if (cap == GraphicsContextGL::STENCIL_TEST)
-        return m_stencilEnabled;
     return m_context->isEnabled(cap);
 }
 
@@ -3114,7 +3106,6 @@ void WebGLRenderingContextBase::stencilMask(GCGLuint mask)
     if (isContextLost())
         return;
     m_stencilMask = mask;
-    m_stencilMaskBack = mask;
     m_context->stencilMask(mask);
 }
 
@@ -3122,21 +3113,8 @@ void WebGLRenderingContextBase::stencilMaskSeparate(GCGLenum face, GCGLuint mask
 {
     if (isContextLost())
         return;
-    switch (face) {
-    case GraphicsContextGL::FRONT_AND_BACK:
+    if (face == GraphicsContextGL::FRONT_AND_BACK || face == GraphicsContextGL::FRONT)
         m_stencilMask = mask;
-        m_stencilMaskBack = mask;
-        break;
-    case GraphicsContextGL::FRONT:
-        m_stencilMask = mask;
-        break;
-    case GraphicsContextGL::BACK:
-        m_stencilMaskBack = mask;
-        break;
-    default:
-        synthesizeGLError(GraphicsContextGL::INVALID_ENUM, "stencilMaskSeparate"_s, "invalid face"_s);
-        return;
-    }
     m_context->stencilMaskSeparate(face, mask);
 }
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -703,10 +703,8 @@ protected:
     GCGLfloat m_clearDepth;
     GCGLint m_clearStencil;
     GCGLboolean m_colorMask[4];
+    GCGLuint m_stencilMask;
     GCGLboolean m_depthMask;
-
-    bool m_stencilEnabled;
-    GCGLuint m_stencilMask, m_stencilMaskBack;
 
     bool m_rasterizerDiscardEnabled { false };
 


### PR DESCRIPTION
#### 4d180bbfebce546963ff47b92abea749dfb19b6a
<pre>
WebGLRenderingContextBase::m_stencilEnabled and m_stencilMaskBack are unused
<a href="https://bugs.webkit.org/show_bug.cgi?id=275101">https://bugs.webkit.org/show_bug.cgi?id=275101</a>

Reviewed by Kimmo Kinnunen.

Removed unused and redundant code.

* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::initializeContextState):
(WebCore::WebGLRenderingContextBase::disable):
(WebCore::WebGLRenderingContextBase::enable):
(WebCore::WebGLRenderingContextBase::getParameter):
(WebCore::WebGLRenderingContextBase::isEnabled):
(WebCore::WebGLRenderingContextBase::stencilMask):
(WebCore::WebGLRenderingContextBase::stencilMaskSeparate):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:

Canonical link: <a href="https://commits.webkit.org/279726@main">https://commits.webkit.org/279726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6be46521e30c8d49d4996a3d142f27120139aaf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33586 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57474 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4922 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4868 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43896 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3297 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46933 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25043 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28648 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4257 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3071 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50345 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4466 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59067 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29402 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4612 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51317 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30573 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47044 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50676 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11830 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31545 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30353 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->