### PR TITLE
[GLib] Build broken with GPUProcess enabled

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1856,6 +1856,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/encryptedmedia/CDMFactory.h
     platform/encryptedmedia/CDMInstance.h
     platform/encryptedmedia/CDMInstanceSession.h
+    platform/encryptedmedia/CDMKeyGroupingStrategy.h
     platform/encryptedmedia/CDMKeyStatus.h
     platform/encryptedmedia/CDMKeySystemConfiguration.h
     platform/encryptedmedia/CDMMediaCapability.h

--- a/Source/WebCore/platform/graphics/gbm/DMABufFormat.h
+++ b/Source/WebCore/platform/graphics/gbm/DMABufFormat.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2022 Metrological Group B.V.
- * Copyright (C) 2022 Igalia S.L.
+ * Copyright (C) 2022-2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,10 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+
+namespace IPC {
+template<typename T, typename U> struct ArgumentCoder;
+}
 
 namespace WebCore {
 
@@ -129,6 +133,15 @@ struct DMABufFormat {
         FourCC fourcc { FourCC::Invalid };
         unsigned horizontalSubsampling { 0 };
         unsigned verticalSubsampling { 0 };
+
+    private:
+        Plane(const FourCC& fourcc, const unsigned& hsValue, const unsigned& vsValue)
+            : fourcc(fourcc)
+            , horizontalSubsampling(hsValue)
+            , verticalSubsampling(vsValue)
+        { }
+
+        friend struct IPC::ArgumentCoder<Plane, void>;
     };
     std::array<Plane, c_maxPlanes> planes;
 };

--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -67,6 +67,7 @@ list(APPEND WebKit_MESSAGES_IN_FILES
 )
 
 list(APPEND WebKit_SERIALIZATION_IN_FILES
+    Shared/glib/DMABufObject.serialization.in
     Shared/glib/DMABufRendererBufferFormat.serialization.in
     Shared/glib/DMABufRendererBufferMode.serialization.in
     Shared/glib/InputMethodState.serialization.in

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -105,6 +105,7 @@ list(APPEND WebKit_UNIFIED_SOURCE_LIST_FILES
 list(APPEND WebKit_SERIALIZATION_IN_FILES Shared/glib/DMABufRendererBufferFormat.serialization.in)
 
 list(APPEND WebKit_SERIALIZATION_IN_FILES
+    Shared/glib/DMABufObject.serialization.in
     Shared/glib/DMABufRendererBufferMode.serialization.in
     Shared/glib/InputMethodState.serialization.in
     Shared/glib/UserMessage.serialization.in

--- a/Source/WebKit/Shared/glib/DMABufObject.serialization.in
+++ b/Source/WebKit/Shared/glib/DMABufObject.serialization.in
@@ -1,0 +1,103 @@
+# Copyright (C) 2024 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+header: <WebCore/DMABufColorSpace.h>
+enum class WebCore::DMABufColorSpace : uint32_t {
+    Invalid,
+    SRGB,
+    BT601,
+    BT709,
+    BT2020,
+    SMPTE240M,
+};
+
+header: <WebCore/DMABufFormat.h>
+struct WebCore::DMABufFormat {
+    WebCore::DMABufFormat::FourCC fourcc;
+    unsigned numPlanes;
+
+    std::array<WebCore::DMABufFormat::Plane, 4> planes;
+};
+
+[Nested] enum class WebCore::DMABufFormat::FourCC : uint32_t {
+    Invalid,
+    R8,
+    GR88,
+    R16,
+    GR32,
+    XRGB8888,
+    XBGR8888,
+    RGBX8888,
+    BGRX8888,
+    ARGB8888,
+    ABGR8888,
+    RGBA8888,
+    BGRA8888,
+    RGB888,
+    BGR888,
+    I420,
+    YV12,
+    A420,
+    NV12,
+    NV21,
+    YUY2,
+    YVYU,
+    UYVY,
+    VYUY,
+    VUYA,
+    AYUV,
+    Y444,
+    Y41B,
+    Y42B,
+    P010,
+    P016,
+};
+
+[Nested] struct WebCore::DMABufFormat::Plane {
+    WebCore::DMABufFormat::FourCC fourcc;
+    unsigned horizontalSubsampling;
+    unsigned verticalSubsampling;
+};
+
+[Nested] enum class WebCore::DMABufFormat::Modifier : uint64_t {
+    Invalid,
+};
+
+header: <WebCore/DMABufReleaseFlag.h>
+struct WebCore::DMABufReleaseFlag {
+    UnixFileDescriptor fd;
+};
+
+header: <WebCore/DMABufObject.h>
+[CustomHeader] class WebCore::DMABufObject {
+    uintptr_t handle;
+    WebCore::DMABufFormat format;
+    WebCore::DMABufColorSpace colorSpace;
+    uint32_t width;
+    uint32_t height;
+    WebCore::DMABufReleaseFlag releaseFlag;
+    std::array<UnixFileDescriptor, WebCore::DMABufFormat::c_maxPlanes> fd;
+    std::array<size_t, WebCore::DMABufFormat::c_maxPlanes> offset;
+    std::array<uint32_t, WebCore::DMABufFormat::c_maxPlanes> stride;
+    std::array<bool, WebCore::DMABufFormat::c_maxPlanes> modifierPresent;
+    std::array<uint64_t, WebCore::DMABufFormat::c_maxPlanes> modifierValue;
+}


### PR DESCRIPTION
#### 70b15c333938fb66571b288480c05bab42435914
<pre>
[GLib] Build broken with GPUProcess enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=274965">https://bugs.webkit.org/show_bug.cgi?id=274965</a>

Reviewed by Carlos Garcia Campos.

Use the new ArgumentCoder infrastructure for DMABufObject and its
related types, adding the needed descriptions in new .serialization.in
file, and removing the encode/decode methods used by the old coding
mechanism. While at it, apply cleanups and update the CMake build
system accordingly.

Most of the adaptation to the new ArgumentCoder infrastructure is based
on a patch initially written by Pablo Saavedra.

* Source/WebCore/Headers.cmake: List missing CDMKeyGroupingStrategy.h
header as a WebCore private header.
* Source/WebCore/platform/graphics/gbm/DMABufFormat.h:
(WebCore::DMABufFormat::Plane::Plane): Add a private constructor to be
used by IPC::ArgumentCoder.
* Source/WebCore/platform/graphics/gbm/DMABufObject.h:
(WebCore::DMABufObject::DMABufObject): Define the DMABufObject type as
&quot;class&quot; instead of &quot;struct&quot;, to match forward declarations used by the
code written by IPC message generators.
(WebCore::DMABufObject::DMABufObject): Add a private constructor to be
used by IPC::ArgumentCoder.
(WebCore::DMABufObject::encode): Deleted.
(WebCore::DMABufObject::decode): Deleted.
* Source/WebCore/platform/graphics/gbm/DMABufReleaseFlag.h:
(WebCore::DMABufReleaseFlag::DMABufReleaseFlag): Use initializer syntax
to set the value of the &quot;fd&quot; member, add a private constructor to be
used by IPC::ArgumentCoder.
(WebCore::DMABufReleaseFlag::encode): Deleted.
(WebCore::DMABufReleaseFlag::decode): Deleted.
* Source/WebKit/PlatformGTK.cmake: List DMABufObject.serialization.in
for the ArgumentCoder code generator.
* Source/WebKit/PlatformWPE.cmake: Ditto.
* Source/WebKit/Shared/glib/DMABufObject.serialization.in: Added.

Canonical link: <a href="https://commits.webkit.org/279732@main">https://commits.webkit.org/279732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab5d423af3472b55c38ae49abd2efbf04175560d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57479 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4927 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56506 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4876 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43907 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3307 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56299 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31856 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46943 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25048 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28666 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4269 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3076 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50366 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59072 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29407 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4621 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51330 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30580 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47048 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50683 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31550 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8048 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30360 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->