### PR TITLE
OffscreenCanvas.transferToImageBitmap() context specific code should exist in the context

### DIFF
--- a/LayoutTests/fast/canvas/offscreen-giant-transfer-to-imagebitmap.html
+++ b/LayoutTests/fast/canvas/offscreen-giant-transfer-to-imagebitmap.html
@@ -1,11 +1,36 @@
+<body>
+<script src="../../resources/js-test.js"></script>
 <script>
-  onload = () => {
-    if (window.testRunner) {
-        testRunner.dumpAsText();
+function runTest() {
+    if (!window.OffscreenCanvas) {
+        debug("OffscreenCanvas not enabled");
+        return;
     }
-    let offscreenCanvas = new OffscreenCanvas(1, 100000000);
-    offscreenCanvas.getContext('2d');
-    offscreenCanvas.width = 100;
-    offscreenCanvas.transferToImageBitmap();
-  }
+    let types = ["none", "2d", "webgl", "webgl2", "webgpu", "bitmaprenderer"];
+    let heights = [100, 100000000];
+    for (let height of heights) {
+        for (let type of types) {
+            debug(`Testing height: ${height} type: ${type} `);
+            let canvas = new OffscreenCanvas(1, height);
+            if (type != "none") {
+                let ctx = canvas.getContext(type);
+                debug(`Got context: "${ctx}"`);
+            }
+            canvas.width = 100;
+            try {
+                let result = canvas.transferToImageBitmap();
+                if (result)
+                    debug(`Got result with size: ${result.width}x${result.height}`);
+                else
+                    debug(`Got result: "${result}"`);
+            } catch (e) {
+                debug(`Got exception: "${e}"`);
+            }
+            delete ctx;
+            delete canvas;
+        }
+    }
+}
+runTest();
 </script>
+</body>

--- a/LayoutTests/platform/ios/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
+++ b/LayoutTests/platform/ios/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
@@ -1,2 +1,43 @@
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
+Testing height: 100 type: none
+Got exception: "InvalidStateError: The object is in an invalid state."
+Testing height: 100 type: 2d
+Got context: "[object OffscreenCanvasRenderingContext2D]"
+Got result with size: 100x100
+Testing height: 100 type: webgl
+Got context: "[object WebGLRenderingContext]"
+Got result with size: 100x100
+Testing height: 100 type: webgl2
+Got context: "[object WebGL2RenderingContext]"
+Got result with size: 100x100
+Testing height: 100 type: webgpu
+Got context: "[object GPUCanvasContext]"
+Got result with size: 100x100
+Testing height: 100 type: bitmaprenderer
+Got context: "[object ImageBitmapRenderingContext]"
+Got result with size: 100x100
+Testing height: 100000000 type: none
+Got exception: "InvalidStateError: The object is in an invalid state."
+Testing height: 100000000 type: 2d
+Got context: "[object OffscreenCanvasRenderingContext2D]"
+Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
+Testing height: 100000000 type: webgl
+Got context: "[object WebGLRenderingContext]"
+Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
+Testing height: 100000000 type: webgl2
+Got context: "[object WebGL2RenderingContext]"
+Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
+Testing height: 100000000 type: webgpu
+Got context: "[object GPUCanvasContext]"
+Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
+Testing height: 100000000 type: bitmaprenderer
+Got context: "[object ImageBitmapRenderingContext]"
+Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
+PASS successfullyParsed is true
+
+TEST COMPLETE
 

--- a/LayoutTests/platform/mac-wk2/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
@@ -2,6 +2,7 @@ CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 2684354
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
+CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
 Testing height: 100 type: none
 Got exception: "InvalidStateError: The object is in an invalid state."
 Testing height: 100 type: 2d
@@ -14,8 +15,8 @@ Testing height: 100 type: webgl2
 Got context: "[object WebGL2RenderingContext]"
 Got result with size: 100x100
 Testing height: 100 type: webgpu
-Got context: "null"
-Got exception: "InvalidStateError: The object is in an invalid state."
+Got context: "[object GPUCanvasContext]"
+Got result with size: 100x100
 Testing height: 100 type: bitmaprenderer
 Got context: "[object ImageBitmapRenderingContext]"
 Got result with size: 100x100
@@ -31,8 +32,8 @@ Testing height: 100000000 type: webgl2
 Got context: "[object WebGL2RenderingContext]"
 Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
 Testing height: 100000000 type: webgpu
-Got context: "null"
-Got exception: "InvalidStateError: The object is in an invalid state."
+Got context: "[object GPUCanvasContext]"
+Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."
 Testing height: 100000000 type: bitmaprenderer
 Got context: "[object ImageBitmapRenderingContext]"
 Got exception: "UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)."

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -153,7 +153,9 @@ public:
     void setNoiseInjectionSalt(NoiseInjectionHashSalt salt) { m_canvasNoiseHashSalt = salt; }
     bool havePendingCanvasNoiseInjection() const { return m_canvasNoiseInjection.haveDirtyRects(); }
 
+    // FIXME(https://bugs.webkit.org/show_bug.cgi?id=275100): The image buffer from CanvasBase should be moved to CanvasRenderingContext2DBase.
     virtual bool hasCreatedImageBuffer() const { return false; }
+    RefPtr<ImageBuffer> allocateImageBuffer() const;
 
 protected:
     explicit CanvasBase(IntSize, const std::optional<NoiseInjectionHashSalt>&);
@@ -163,7 +165,6 @@ protected:
     virtual void setSize(const IntSize&);
 
     RefPtr<ImageBuffer> setImageBuffer(RefPtr<ImageBuffer>&&) const;
-    RefPtr<ImageBuffer> allocateImageBuffer() const;
     String lastFillText() const { return m_lastFillText; }
     void addCanvasNeedingPreparationForDisplayOrFlush();
     void removeCanvasNeedingPreparationForDisplayOrFlush();

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -304,68 +304,13 @@ ExceptionOr<RefPtr<ImageBitmap>> OffscreenCanvas::transferToImageBitmap()
 {
     if (m_detached || !m_context)
         return Exception { ExceptionCode::InvalidStateError };
-
-    if (is<OffscreenCanvasRenderingContext2D>(*m_context) || is<ImageBitmapRenderingContext>(*m_context)) {
-        if (!width() || !height())
-            return { RefPtr<ImageBitmap> { nullptr } };
-
-        if (!m_hasCreatedImageBuffer) {
-            auto buffer = allocateImageBuffer();
-            if (!buffer)
-                return { RefPtr<ImageBitmap> { nullptr } };
-            return { ImageBitmap::create(buffer.releaseNonNull(), originClean()) };
-        }
-
-        if (!buffer())
-            return { RefPtr<ImageBitmap> { nullptr } };
-
-        RefPtr<ImageBuffer> bitmap;
-        if (RefPtr context = dynamicDowncast<OffscreenCanvasRenderingContext2D>(*m_context)) {
-            // As the canvas context state is stored in GraphicsContext, which is owned
-            // by buffer(), to avoid resetting the context state, we have to make a copy and
-            // clear the original buffer rather than returning the original buffer.
-            bitmap = buffer()->clone();
-            context->clearCanvas();
-        } else {
-            // ImageBitmapRenderingContext doesn't use the context state, so we can just take its
-            // buffer, and then call transferFromImageBitmap(nullptr) which will trigger it to allocate
-            // a new blank bitmap.
-            bitmap = buffer();
-            downcast<ImageBitmapRenderingContext>(*m_context).transferFromImageBitmap(nullptr);
-        }
-        clearCopiedImage();
-        if (!bitmap)
-            return { RefPtr<ImageBitmap> { nullptr } };
-        return { ImageBitmap::create(bitmap.releaseNonNull(), originClean(), false, false) };
-    }
-
-#if ENABLE(WEBGL)
-    if (auto* webGLContext = dynamicDowncast<WebGLRenderingContextBase>(*m_context)) {
-        // FIXME: We're supposed to create an ImageBitmap using the backing
-        // store from this canvas (or its context), but for now we'll just
-        // create a new bitmap and paint into it.
-        auto buffer = allocateImageBuffer();
-        if (!buffer)
-            return { RefPtr<ImageBitmap> { nullptr } };
-        if (webGLContext->compositingResultsNeedUpdating())
-            webGLContext->prepareForDisplay();
-        RefPtr gc3d = webGLContext->graphicsContextGL();
-        gc3d->drawSurfaceBufferToImageBuffer(GraphicsContextGL::SurfaceBuffer::DisplayBuffer, *buffer);
-        webGLContext->markDrawingBuffersDirtyAfterTransfer();
-        return { ImageBitmap::create(buffer.releaseNonNull(), originClean()) };
-    }
-#endif
-
-    if (auto* context = dynamicDowncast<GPUCanvasContext>(*m_context)) {
-        auto buffer = allocateImageBuffer();
-        if (!buffer)
-            return Exception { ExceptionCode::OutOfMemoryError };
-
-        Ref<ImageBuffer> bufferRef = buffer.releaseNonNull();
-        return context->getCurrentTextureAsImageBitmap(bufferRef, originClean());
-    }
-
-    return Exception { ExceptionCode::NotSupportedError };
+    if (size().isEmpty())
+        return { RefPtr<ImageBitmap> { nullptr } };
+    clearCopiedImage();
+    RefPtr buffer = m_context->transferToImageBuffer();
+    if (!buffer)
+        return Exception { ExceptionCode::UnknownError }; // UnknownError is used for DOM out-of-memory.
+    return { ImageBitmap::create(buffer.releaseNonNull(), originClean()) };
 }
 
 static String toEncodingMimeType(const String& mimeType)

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "config.h"
@@ -106,6 +106,12 @@ RefPtr<GraphicsLayerContentsDisplayDelegate> CanvasRenderingContext::layerConten
 void CanvasRenderingContext::setContentsToLayer(GraphicsLayer& layer)
 {
     layer.setContentsDisplayDelegate(layerContentsDisplayDelegate(), GraphicsLayer::ContentsLayerPurpose::Canvas);
+}
+
+RefPtr<ImageBuffer> CanvasRenderingContext::transferToImageBuffer()
+{
+    ASSERT_NOT_REACHED(); // Implemented and called only for offscreen capable contexts.
+    return nullptr;
 }
 
 PixelFormat CanvasRenderingContext::pixelFormat() const

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -96,6 +96,9 @@ public:
     virtual RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate();
     virtual void setContentsToLayer(GraphicsLayer&);
 
+    // Returns the drawing buffer and runs the compositing steps of transferToImageBitmap.
+    virtual RefPtr<ImageBuffer> transferToImageBuffer();
+
     bool hasActiveInspectorCanvasCallTracer() const { return m_hasActiveInspectorCanvasCallTracer; }
     void setHasActiveInspectorCanvasCallTracer(bool hasActiveInspectorCanvasCallTracer) { m_hasActiveInspectorCanvasCallTracer = hasActiveInspectorCanvasCallTracer; }
 

--- a/Source/WebCore/html/canvas/GPUCanvasContext.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.h
@@ -60,7 +60,6 @@ public:
     virtual ExceptionOr<void> configure(GPUCanvasConfiguration&&) = 0;
     virtual void unconfigure() = 0;
     virtual ExceptionOr<RefPtr<GPUTexture>> getCurrentTexture() = 0;
-    virtual ExceptionOr<RefPtr<ImageBitmap>> getCurrentTextureAsImageBitmap(ImageBuffer&, bool originClean) = 0;
 
     bool isWebGPU() const override { return true; }
 

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -72,7 +72,7 @@ public:
     ExceptionOr<void> configure(GPUCanvasConfiguration&&) override;
     void unconfigure() override;
     ExceptionOr<RefPtr<GPUTexture>> getCurrentTexture() override;
-    ExceptionOr<RefPtr<ImageBitmap>> getCurrentTextureAsImageBitmap(ImageBuffer&, bool originClean) override;
+    RefPtr<ImageBuffer> transferToImageBuffer() override;
 
     bool isWebGPU() const override { return true; }
 

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -199,20 +199,20 @@ RefPtr<ImageBuffer> GPUCanvasContextCocoa::surfaceBufferToImageBuffer(SurfaceBuf
     return canvasBase().buffer();
 }
 
-ExceptionOr<RefPtr<ImageBitmap>> GPUCanvasContextCocoa::getCurrentTextureAsImageBitmap(ImageBuffer& buffer, bool originClean)
+RefPtr<ImageBuffer> GPUCanvasContextCocoa::transferToImageBuffer()
 {
+    auto buffer = canvasBase().allocateImageBuffer();
+    if (!buffer)
+        return nullptr;
+    Ref<ImageBuffer> bufferRef = buffer.releaseNonNull();
     if (m_configuration) {
-        buffer.flushDrawingContext();
         if (m_compositorIntegration)
-            m_compositorIntegration->paintCompositedResultsToCanvas(buffer, m_configuration->frameCount);
+            m_compositorIntegration->paintCompositedResultsToCanvas(bufferRef, m_configuration->frameCount);
         m_currentTexture = nullptr;
         if (m_presentationContext)
             m_presentationContext->present(true);
-
-        return { ImageBitmap::create(buffer, originClean) };
     }
-
-    return { ImageBitmap::create(buffer, originClean) };
+    return bufferRef;
 }
 
 GPUCanvasContext::CanvasType GPUCanvasContextCocoa::canvas()

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp
@@ -74,28 +74,14 @@ void ImageBitmapRenderingContext::setOutputBitmap(RefPtr<ImageBitmap> imageBitma
     // 1. If a bitmap argument was not provided, then:
 
     if (!imageBitmap) {
-
         // 1.1. Set context's bitmap mode to blank.
-
-        m_bitmapMode = BitmapMode::Blank;
-
         // 1.2. Let canvas be the canvas element to which context is bound.
-
         // 1.3. Set context's output bitmap to be transparent black with an
         //      intrinsic width equal to the numeric value of canvas's width attribute
         //      and an intrinsic height equal to the numeric value of canvas's height
         //      attribute, those values being interpreted in CSS pixels.
-
-        // FIXME: What is the point of creating a full size transparent buffer that
-        // can never be changed? Wouldn't a 1x1 buffer give the same rendering? The
-        // only reason I can think of is toDataURL(), but that doesn't seem like
-        // a good enough argument to waste memory.
-
-        auto buffer = ImageBuffer::create(FloatSize(canvasBase().width(), canvasBase().height()), RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8, bufferOptionsForRendingMode(RenderingMode::Unaccelerated));
-        canvasBase().setImageBufferAndMarkDirty(WTFMove(buffer));
-
+        setBlank();
         // 1.4. Set the output bitmap's origin-clean flag to true.
-
         canvasBase().setOriginClean();
         return;
     }
@@ -155,6 +141,28 @@ ExceptionOr<void> ImageBitmapRenderingContext::transferFromImageBitmap(RefPtr<Im
     imageBitmap->close();
 
     return { };
+}
+
+void ImageBitmapRenderingContext::setBlank()
+{
+    m_bitmapMode = BitmapMode::Blank;
+    // FIXME: What is the point of creating a full size transparent buffer that
+    // can never be changed? Wouldn't a 1x1 buffer give the same rendering? The
+    // only reason I can think of is toDataURL(), but that doesn't seem like
+    // a good enough argument to waste memory.
+    auto buffer = ImageBuffer::create(FloatSize(canvasBase().width(), canvasBase().height()), RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8, bufferOptionsForRendingMode(RenderingMode::Unaccelerated));
+    canvasBase().setImageBufferAndMarkDirty(WTFMove(buffer));
+}
+
+RefPtr<ImageBuffer> ImageBitmapRenderingContext::transferToImageBuffer()
+{
+    if (!canvasBase().hasCreatedImageBuffer())
+        return canvasBase().allocateImageBuffer();
+    RefPtr result = canvasBase().buffer();
+    if (!result)
+        return nullptr;
+    setBlank();
+    return result;
 }
 
 }

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
@@ -68,8 +68,10 @@ private:
 
     bool isBitmapRenderer() const final { return true; }
     bool isAccelerated() const override;
+    RefPtr<ImageBuffer> transferToImageBuffer() final;
 
     void setOutputBitmap(RefPtr<ImageBitmap>);
+    void setBlank();
 
     BitmapMode m_bitmapMode { BitmapMode::Blank };
     ImageBitmapRenderingContextSettings m_settings;

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
@@ -117,6 +117,21 @@ void OffscreenCanvasRenderingContext2D::setFont(const String& newFont)
     }
 }
 
+RefPtr<ImageBuffer> OffscreenCanvasRenderingContext2D::transferToImageBuffer()
+{
+    if (!canvasBase().hasCreatedImageBuffer())
+        return canvasBase().allocateImageBuffer();
+    auto* buffer = canvasBase().buffer();
+    if (!buffer)
+        return nullptr;
+    // As the canvas context state is stored in GraphicsContext, which is owned
+    // by buffer(), to avoid resetting the context state, we have to make a copy and
+    // clear the original buffer rather than returning the original buffer.
+    RefPtr result = buffer->clone();
+    clearCanvas();
+    return result;
+}
+
 CanvasDirection OffscreenCanvasRenderingContext2D::direction() const
 {
     // FIXME: What should we do about inherit here?

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.h
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.h
@@ -54,6 +54,7 @@ public:
 private:
     OffscreenCanvasRenderingContext2D(CanvasBase&, CanvasRenderingContext2DSettings&&);
     bool isOffscreen2d() const final { return true; }
+    RefPtr<ImageBuffer> transferToImageBuffer() final;
     const FontProxy* fontProxy() final;
 };
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -826,12 +826,19 @@ RefPtr<VideoFrame> WebGLRenderingContextBase::surfaceBufferToVideoFrame(SurfaceB
 }
 #endif
 
-void WebGLRenderingContextBase::markDrawingBuffersDirtyAfterTransfer()
+RefPtr<ImageBuffer> WebGLRenderingContextBase::transferToImageBuffer()
 {
+    auto buffer = canvasBase().allocateImageBuffer();
+    if (!buffer)
+        return nullptr;
+    if (compositingResultsNeedUpdating())
+        prepareForDisplay();
+    m_context->drawSurfaceBufferToImageBuffer(GraphicsContextGL::SurfaceBuffer::DisplayBuffer, *buffer);
     // Any draw or read sees cleared drawing buffer.
     m_defaultFramebuffer->markAllBuffersDirty();
     // Next transfer uses the cleared drawing buffer.
     m_compositingResultsNeedUpdating = true;
+    return buffer;
 }
 
 void WebGLRenderingContextBase::reshape(int width, int height, int oldWidth, int oldHeight)

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -445,7 +445,7 @@ public:
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
     RefPtr<VideoFrame> surfaceBufferToVideoFrame(SurfaceBuffer);
 #endif
-    void markDrawingBuffersDirtyAfterTransfer();
+    RefPtr<ImageBuffer> transferToImageBuffer() final;
 
     void removeSharedObject(WebGLObject&);
     void removeContextObject(WebGLObject&);


### PR DESCRIPTION
#### 4720cc2edd86517a19354cf49515fb03bf1d3e85
<pre>
OffscreenCanvas.transferToImageBitmap() context specific code should exist in the context
<a href="https://bugs.webkit.org/show_bug.cgi?id=275105">https://bugs.webkit.org/show_bug.cgi?id=275105</a>
<a href="https://rdar.apple.com/129217576">rdar://129217576</a>

Reviewed by Antti Koivisto.

OffscreenCanvas::transferToImageBitmap() has code conditionalized to
different canvas rendering contexts. Move this code to
the contexts, into overrides of new virtual function
CanvasRenderingContext::transferToImageBuffer().

This way the contexts are able to manage the buffers themselves in
future commits.

Fix the error-case where the out-of-memory causes an exception instead
of null ImageBitmap for all backends. The exception should be
DOM UnknownError, that is used to signify out-of-memory.

* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::transferToImageBitmap):
* Source/WebCore/html/canvas/CanvasRenderingContext.cpp:
(WebCore::CanvasRenderingContext::transferToImageBuffer):
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
* Source/WebCore/html/canvas/GPUCanvasContext.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::transferToImageBuffer):
(WebCore::GPUCanvasContextCocoa::getCurrentTextureAsImageBitmap): Deleted.
* Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp:
(WebCore::ImageBitmapRenderingContext::setOutputBitmap):
(WebCore::ImageBitmapRenderingContext::setBlank):
(WebCore::ImageBitmapRenderingContext::transferToImageBuffer):
* Source/WebCore/html/canvas/ImageBitmapRenderingContext.h:
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp:
(WebCore::OffscreenCanvasRenderingContext2D::transferToImageBuffer):
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::transferToImageBuffer):
(WebCore::WebGLRenderingContextBase::markDrawingBuffersDirtyAfterTransfer): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:

Canonical link: <a href="https://commits.webkit.org/279872@main">https://commits.webkit.org/279872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2f56d3212b3f2ef8bfb31449b65a04d38b021db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54785 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7363 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58063 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5516 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57085 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5530 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44374 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3730 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56880 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47463 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25498 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29138 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4800 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3657 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50956 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5017 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59653 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30032 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5165 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51797 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31173 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47545 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51205 "Found 3 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12037 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32182 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30961 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->