### PR TITLE
Textarea incorrectly reserves space for overlay scrollbar

### DIFF
--- a/LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-textarea-cols-size-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-textarea-cols-size-expected.txt
@@ -1,0 +1,12 @@
+Test textarea cols size
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Initial state
+PASS textareaA.width is textareaB.width
+PASS textareaA.height is textareaB.height
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-textarea-cols-size.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-textarea-cols-size.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ MockScrollbarsEnabled=false AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <script src="../../../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<textarea cols="3" id="textareaA" style="overflow-x: scroll"></textarea>
+<textarea cols="3" style="overflow: hidden" id="textareaB"></textarea>
+
+    <script>
+        jsTestIsAsync = true;
+        
+        if (window.internals)
+            internals.setUsesOverlayScrollbars(true);
+
+        async function doTest()
+        {
+            description('Test textarea cols size');
+            if (!window.internals) {
+                finishJSTest();
+                return;
+            }
+            
+            debug('Initial state');
+
+            shouldBe("textareaA.width", "textareaB.width");
+            shouldBe("textareaA.height", "textareaB.height");
+
+            finishJSTest();
+        }
+
+        window.addEventListener('load', () => {
+            doTest();
+        }, false);
+    </script>
+    <script src="../../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-textarea-rows-size-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-textarea-rows-size-expected.txt
@@ -1,0 +1,12 @@
+Test textarea rows size
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Initial state
+PASS textareaA.width is textareaB.width
+PASS textareaA.height is textareaB.height
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-textarea-rows-size.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-textarea-rows-size.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ MockScrollbarsEnabled=false AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <script src="../../../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<textarea rows="3" id="textareaA"></textarea>
+<textarea rows="3" style="overflow: hidden" id="textareaB"></textarea>
+
+    <script>
+        jsTestIsAsync = true;
+        
+        if (window.internals)
+            internals.setUsesOverlayScrollbars(true);
+
+        async function doTest()
+        {
+            description('Test textarea rows size');
+            if (!window.internals) {
+                finishJSTest();
+                return;
+            }
+            
+            debug('Initial state');
+
+            shouldBe("textareaA.width", "textareaB.width");
+            shouldBe("textareaA.height", "textareaB.height");
+
+            finishJSTest();
+        }
+
+        window.addEventListener('load', () => {
+            doTest();
+        }, false);
+    </script>
+    <script src="../../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/platform/ScrollTypes.h
+++ b/Source/WebCore/platform/ScrollTypes.h
@@ -260,6 +260,11 @@ inline BoxSide boxSideForDirection(ScrollDirection direction)
     return BoxSide::Top;
 }
 
+enum class OverlayScrollbarSizeRelevancy : bool {
+    IgnoreOverlayScrollbarSize,
+    IncludeOverlayScrollbarSize
+};
+
 enum ScrollbarControlStateMask {
     ActiveScrollbarState = 1,
     EnabledScrollbarState = 1 << 1,

--- a/Source/WebCore/platform/ScrollbarTheme.h
+++ b/Source/WebCore/platform/ScrollbarTheme.h
@@ -53,7 +53,7 @@ public:
     virtual bool paint(Scrollbar&, GraphicsContext&, const IntRect& /*damageRect*/) { return false; }
     virtual ScrollbarPart hitTest(Scrollbar&, const IntPoint&) { return NoPart; }
     
-    virtual int scrollbarThickness(ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) { return 0; }
+    virtual int scrollbarThickness(ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded, OverlayScrollbarSizeRelevancy = OverlayScrollbarSizeRelevancy::IncludeOverlayScrollbarSize) { return 0; }
 
     virtual ScrollbarButtonsPlacement buttonsPlacement() const { return ScrollbarButtonsSingle; }
 

--- a/Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.cpp
+++ b/Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.cpp
@@ -89,9 +89,9 @@ bool ScrollbarThemeAdwaita::usesOverlayScrollbars() const
 #endif
 }
 
-int ScrollbarThemeAdwaita::scrollbarThickness(ScrollbarWidth scrollbarWidth, ScrollbarExpansionState)
+int ScrollbarThemeAdwaita::scrollbarThickness(ScrollbarWidth scrollbarWidth, ScrollbarExpansionState, OverlayScrollbarSizeRelevancy overlayRelevancy)
 {
-    if (scrollbarWidth == ScrollbarWidth::None)
+    if (scrollbarWidth == ScrollbarWidth::None || (usesOverlayScrollbars() && overlayRelevancy == OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize))
         return 0;
     return scrollbarSize;
 }

--- a/Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.h
+++ b/Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.h
@@ -46,7 +46,7 @@ protected:
     void paintScrollCorner(ScrollableArea&, GraphicsContext&, const IntRect&) override;
     ScrollbarButtonPressAction handleMousePressEvent(Scrollbar&, const PlatformMouseEvent&, ScrollbarPart) override;
 
-    int scrollbarThickness(ScrollbarWidth, ScrollbarExpansionState) override;
+    int scrollbarThickness(ScrollbarWidth, ScrollbarExpansionState, OverlayScrollbarSizeRelevancy = OverlayScrollbarSizeRelevancy::IncludeOverlayScrollbarSize) override;
     int minimumThumbLength(Scrollbar&) override;
 
     bool hasButtons(Scrollbar&) override;

--- a/Source/WebCore/platform/gtk/ScrollbarThemeGtk.cpp
+++ b/Source/WebCore/platform/gtk/ScrollbarThemeGtk.cpp
@@ -509,12 +509,12 @@ ScrollbarButtonPressAction ScrollbarThemeGtk::handleMousePressEvent(Scrollbar&, 
     return ScrollbarButtonPressAction::None;
 }
 
-int ScrollbarThemeGtk::scrollbarThickness(ScrollbarWidth scrollbarWidth, ScrollbarExpansionState expansionState)
+int ScrollbarThemeGtk::scrollbarThickness(ScrollbarWidth scrollbarWidth, ScrollbarExpansionState expansionState, OverlayScrollbarSizeRelevancy overlayRelevancy)
 {
     if (!m_useSystemAppearance)
-        return ScrollbarThemeAdwaita::scrollbarThickness(scrollbarWidth, expansionState);
+        return ScrollbarThemeAdwaita::scrollbarThickness(scrollbarWidth, expansionState, overlayRelevancy);
 
-    if (scrollbarWidth == ScrollbarWidth::None)
+    if (scrollbarWidth == ScrollbarWidth::None || (usesOverlayScrollbars() && overlayRelevancy == OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize))
         return 0;
 
     auto& scrollbarWidget = static_cast<RenderThemeScrollbar&>(RenderThemeScrollbar::getOrCreate(RenderThemeScrollbar::Type::VerticalScrollbarRight));

--- a/Source/WebCore/platform/gtk/ScrollbarThemeGtk.h
+++ b/Source/WebCore/platform/gtk/ScrollbarThemeGtk.h
@@ -45,7 +45,7 @@ private:
 
     bool paint(Scrollbar&, GraphicsContext&, const IntRect& damageRect) override;
     ScrollbarButtonPressAction handleMousePressEvent(Scrollbar&, const PlatformMouseEvent&, ScrollbarPart) override;
-    int scrollbarThickness(ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
+    int scrollbarThickness(ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded, OverlayScrollbarSizeRelevancy = OverlayScrollbarSizeRelevancy::IncludeOverlayScrollbarSize) override;
     int minimumThumbLength(Scrollbar&) override;
 
     void themeChanged() override;

--- a/Source/WebCore/platform/ios/ScrollbarThemeIOS.h
+++ b/Source/WebCore/platform/ios/ScrollbarThemeIOS.h
@@ -38,7 +38,7 @@ public:
 
     bool paint(Scrollbar&, GraphicsContext&, const IntRect& damageRect) override;
 
-    int scrollbarThickness(ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
+    int scrollbarThickness(ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded, OverlayScrollbarSizeRelevancy = OverlayScrollbarSizeRelevancy::IncludeOverlayScrollbarSize) override;
     
     bool supportsControlTints() const override { return true; }
 

--- a/Source/WebCore/platform/ios/ScrollbarThemeIOS.mm
+++ b/Source/WebCore/platform/ios/ScrollbarThemeIOS.mm
@@ -63,7 +63,7 @@ void ScrollbarThemeIOS::preferencesChanged()
 {
 }
 
-int ScrollbarThemeIOS::scrollbarThickness(ScrollbarWidth, ScrollbarExpansionState)
+int ScrollbarThemeIOS::scrollbarThickness(ScrollbarWidth, ScrollbarExpansionState, OverlayScrollbarSizeRelevancy)
 {
     return 0;
 }

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.h
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.h
@@ -45,7 +45,7 @@ public:
     bool paint(Scrollbar&, GraphicsContext&, const IntRect& damageRect) override;
     void paintScrollCorner(ScrollableArea&, GraphicsContext&, const IntRect& cornerRect) override;
 
-    int scrollbarThickness(ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
+    int scrollbarThickness(ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded, OverlayScrollbarSizeRelevancy = OverlayScrollbarSizeRelevancy::IncludeOverlayScrollbarSize) override;
     
     bool supportsControlTints() const override { return true; }
     bool usesOverlayScrollbars() const  override;

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
@@ -223,10 +223,10 @@ void ScrollbarThemeMac::preferencesChanged()
     usesOverlayScrollbarsChanged();
 }
 
-int ScrollbarThemeMac::scrollbarThickness(ScrollbarWidth scrollbarWidth, ScrollbarExpansionState expansionState)
+int ScrollbarThemeMac::scrollbarThickness(ScrollbarWidth scrollbarWidth, ScrollbarExpansionState expansionState, OverlayScrollbarSizeRelevancy overlayRelevancy)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    if (scrollbarWidth == ScrollbarWidth::None)
+    if (scrollbarWidth == ScrollbarWidth::None || (usesOverlayScrollbars() && overlayRelevancy == OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize))
         return 0;
     NSScrollerImp *scrollerImp = [NSScrollerImp scrollerImpWithStyle:ScrollerStyle::recommendedScrollerStyle() controlSize:nsControlSizeFromScrollbarWidth(scrollbarWidth) horizontal:NO replacingScrollerImp:nil];
     [scrollerImp setExpanded:(expansionState == ScrollbarExpansionState::Expanded)];

--- a/Source/WebCore/platform/mock/ScrollbarThemeMock.cpp
+++ b/Source/WebCore/platform/mock/ScrollbarThemeMock.cpp
@@ -37,8 +37,11 @@ IntRect ScrollbarThemeMock::trackRect(Scrollbar& scrollbar, bool)
     return scrollbar.frameRect();
 }
 
-int ScrollbarThemeMock::scrollbarThickness(ScrollbarWidth scrollbarWidth, ScrollbarExpansionState)
+int ScrollbarThemeMock::scrollbarThickness(ScrollbarWidth scrollbarWidth, ScrollbarExpansionState, OverlayScrollbarSizeRelevancy overlayRelavancy)
 {
+    if (usesOverlayScrollbars() && overlayRelavancy == OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize)
+        return 0;
+
     switch (scrollbarWidth) {
     case ScrollbarWidth::Auto:
         return 15;

--- a/Source/WebCore/platform/mock/ScrollbarThemeMock.h
+++ b/Source/WebCore/platform/mock/ScrollbarThemeMock.h
@@ -33,7 +33,7 @@ namespace WebCore {
 // Scrollbar theme used in image snapshots, to eliminate appearance differences between platforms.
 class ScrollbarThemeMock : public ScrollbarThemeComposite {
 public:
-    int scrollbarThickness(ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
+    int scrollbarThickness(ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded, OverlayScrollbarSizeRelevancy = OverlayScrollbarSizeRelevancy::IncludeOverlayScrollbarSize) override;
 
 protected:
     bool hasButtons(Scrollbar&) override { return false; }

--- a/Source/WebCore/platform/playstation/ScrollbarThemePlayStation.cpp
+++ b/Source/WebCore/platform/playstation/ScrollbarThemePlayStation.cpp
@@ -39,7 +39,7 @@ ScrollbarTheme& ScrollbarTheme::nativeTheme()
     return theme;
 }
 
-int ScrollbarThemePlayStation::scrollbarThickness(ScrollbarWidth scrollbarWidth, ScrollbarExpansionState)
+int ScrollbarThemePlayStation::scrollbarThickness(ScrollbarWidth scrollbarWidth, ScrollbarExpansionState, OverlayScrollbarSizeRelevancy)
 {
     if (scrollbarWidth == ScrollbarWidth::None)
         return 0;

--- a/Source/WebCore/platform/playstation/ScrollbarThemePlayStation.h
+++ b/Source/WebCore/platform/playstation/ScrollbarThemePlayStation.h
@@ -34,7 +34,7 @@ public:
     ScrollbarThemePlayStation() = default;
     virtual ~ScrollbarThemePlayStation() = default;
 
-    int scrollbarThickness(ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
+    int scrollbarThickness(ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded, OverlayScrollbarSizeRelevancy = OverlayScrollbarSizeRelevancy::IncludeOverlayScrollbarSize) override;
 
     bool hasButtons(Scrollbar&) override;
     bool hasThumb(Scrollbar&) override;

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -40,7 +40,6 @@ class RoundedRectRadii;
 struct PaintInfo;
 
 enum class AvailableLogicalHeightType : bool { ExcludeMarginBorderPadding, IncludeMarginBorderPadding };
-enum class OverlayScrollbarSizeRelevancy : bool { IgnoreOverlayScrollbarSize, IncludeOverlayScrollbarSize };
 
 enum class ShouldComputePreferred : bool { ComputeActual, ComputePreferred };
 

--- a/Source/WebCore/rendering/RenderScrollbarTheme.h
+++ b/Source/WebCore/rendering/RenderScrollbarTheme.h
@@ -37,7 +37,7 @@ class RenderScrollbarTheme final : public ScrollbarThemeComposite {
 public:
     virtual ~RenderScrollbarTheme() = default;
     
-    int scrollbarThickness(ScrollbarWidth scrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState expansionState = ScrollbarExpansionState::Expanded) override { return ScrollbarTheme::theme().scrollbarThickness(scrollbarWidth, expansionState); }
+    int scrollbarThickness(ScrollbarWidth scrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState expansionState = ScrollbarExpansionState::Expanded, OverlayScrollbarSizeRelevancy overlayRelevancy = OverlayScrollbarSizeRelevancy::IncludeOverlayScrollbarSize) override { return ScrollbarTheme::theme().scrollbarThickness(scrollbarWidth, expansionState, overlayRelevancy); }
 
     ScrollbarButtonsPlacement buttonsPlacement() const override { return ScrollbarTheme::theme().buttonsPlacement(); }
 

--- a/Source/WebCore/rendering/RenderTextControl.cpp
+++ b/Source/WebCore/rendering/RenderTextControl.cpp
@@ -87,7 +87,7 @@ void RenderTextControl::styleDidChange(StyleDifference diff, const RenderStyle* 
 int RenderTextControl::scrollbarThickness() const
 {
     // FIXME: We should get the size of the scrollbar from the RenderTheme instead.
-    return ScrollbarTheme::theme().scrollbarThickness(this->style().scrollbarWidth());
+    return ScrollbarTheme::theme().scrollbarThickness(this->style().scrollbarWidth(), ScrollbarExpansionState::Expanded, OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize);
 }
 
 RenderBox::LogicalExtentComputedValues RenderTextControl::computeLogicalHeight(LayoutUnit logicalHeight, LayoutUnit logicalTop) const


### PR DESCRIPTION
#### cda20f66eecb111c71be0960b981e596473e889f
<pre>
Textarea incorrectly reserves space for overlay scrollbar
<a href="https://bugs.webkit.org/show_bug.cgi?id=275114">https://bugs.webkit.org/show_bug.cgi?id=275114</a>

Reviewed by Simon Fraser.

Check the ScrollbarTheme::usesOverlayScrollbar in the various ScrollbarTheme&apos;s scrollbarThickness method.
Update RenderTextControl to tell scrollbarThickness to ignore overlay scrollbar sizing.

This aligns WebKit with Firefox.

* LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-textarea-cols-size-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-textarea-cols-size.html: Added.
* LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-textarea-rows-size-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/scrollbars/overlay-scrollbar-textarea-rows-size.html: Added.
* Source/WebCore/platform/ScrollTypes.h:
* Source/WebCore/platform/ScrollbarTheme.h:
(WebCore::ScrollbarTheme::scrollbarThickness):
* Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.cpp:
(WebCore::ScrollbarThemeAdwaita::scrollbarThickness):
* Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.h:
* Source/WebCore/platform/gtk/ScrollbarThemeGtk.cpp:
(WebCore::ScrollbarThemeGtk::scrollbarThickness):
* Source/WebCore/platform/gtk/ScrollbarThemeGtk.h:
* Source/WebCore/platform/ios/ScrollbarThemeIOS.h:
* Source/WebCore/platform/ios/ScrollbarThemeIOS.mm:
(WebCore::ScrollbarThemeIOS::scrollbarThickness):
* Source/WebCore/platform/mac/ScrollbarThemeMac.h:
* Source/WebCore/platform/mac/ScrollbarThemeMac.mm:
(WebCore::ScrollbarThemeMac::scrollbarThickness):
* Source/WebCore/platform/mock/ScrollbarThemeMock.cpp:
(WebCore::ScrollbarThemeMock::scrollbarThickness):
* Source/WebCore/platform/mock/ScrollbarThemeMock.h:
* Source/WebCore/platform/playstation/ScrollbarThemePlayStation.cpp:
(WebCore::ScrollbarThemePlayStation::scrollbarThickness):
* Source/WebCore/platform/playstation/ScrollbarThemePlayStation.h:
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderScrollbarTheme.h:
* Source/WebCore/rendering/RenderTextControl.cpp:
(WebCore::RenderTextControl::scrollbarThickness const):

Canonical link: <a href="https://commits.webkit.org/287837@main">https://commits.webkit.org/287837@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1893e453da77f5a0b319c3feed558fbf52513f73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/80706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/34642 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/85233 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/31690 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/82817 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/8025 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/63037 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/20827 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/83775 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/91 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/73463 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/43339 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/255 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/27623 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/30147 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/71589 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/28148 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/86665 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/7933 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/5608 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/71331 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/8110 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/69299 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/70572 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17625 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/14589 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/13535 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/7895 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/13416 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/7734 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/11253 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/9540 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->