### PR TITLE
Reverse sendWithPromisedReply first and second template parameters

### DIFF
--- a/Source/WebKit/Platform/IPC/MessageSenderInlines.h
+++ b/Source/WebKit/Platform/IPC/MessageSenderInlines.h
@@ -172,7 +172,7 @@ template<typename MessageType> Ref<typename MessageType::Promise> inline Message
 {
     static_assert(!MessageType::isSync);
     if (RefPtr connection = messageSenderConnection())
-        return connection->sendWithPromisedReply<MessageType>(std::forward<MessageType>(message), destinationID, options);
+        return connection->sendWithPromisedReply<Connection::NoOpPromiseConverter, MessageType>(std::forward<MessageType>(message), destinationID, options);
     return MessageType::Promise::createAndReject(Error::NoMessageSenderConnection);
 }
 

--- a/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h
+++ b/Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h
@@ -52,7 +52,7 @@ public:
 private:
     explicit WebCacheStorageConnection(WebCacheStorageProvider&);
 
-    template<typename P> struct PromiseConverter;
+    struct PromiseConverter;
 
     IPC::Connection& connection();
 

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp
@@ -684,7 +684,7 @@ template<typename Frame> int32_t LibWebRTCCodecs::encodeFrameInternal(Encoder& e
         return WEBRTC_VIDEO_CODEC_ERROR;
 
     SharedVideoFrame sharedVideoFrame { mediaTime, false, rotation, WTFMove(*buffer) };
-    encoder.connection->sendWithPromisedReply<Messages::LibWebRTCCodecsProxy::EncodeFrame>({ encoder.identifier, WTFMove(sharedVideoFrame), timestamp, duration, shouldEncodeAsKeyFrame })->whenSettled(workQueue(), [callback = WTFMove(callback)] (auto&& result) mutable {
+    encoder.connection->sendWithPromisedReply(Messages::LibWebRTCCodecsProxy::EncodeFrame { encoder.identifier, WTFMove(sharedVideoFrame), timestamp, duration, shouldEncodeAsKeyFrame })->whenSettled(workQueue(), [callback = WTFMove(callback)] (auto&& result) mutable {
         callback(result ? result.value() : false);
     });
     return WEBRTC_VIDEO_CODEC_OK;
@@ -709,7 +709,7 @@ void LibWebRTCCodecs::flushEncoder(Encoder& encoder, Function<void()>&& callback
         return;
     }
 
-    connection->sendWithPromisedReply<Messages::LibWebRTCCodecsProxy::FlushEncoder>(encoder.identifier)->whenSettled(workQueue(), WTFMove(callback));
+    connection->sendWithPromisedReply(Messages::LibWebRTCCodecsProxy::FlushEncoder { encoder.identifier })->whenSettled(workQueue(), WTFMove(callback));
 }
 
 void LibWebRTCCodecs::registerEncodeFrameCallback(Encoder& encoder, void* encodedImageCallback)

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
@@ -113,29 +113,26 @@ void RemoteRealtimeMediaSourceProxy::applyConstraints(const MediaConstraints& co
     m_connection->send(Messages::UserMediaCaptureManagerProxy::ApplyConstraints { m_identifier, constraints }, 0);
 }
 
-template<typename P>
 struct RemoteRealtimeMediaSourceProxy::PromiseConverter {
-    using Promise = P;
-
-    template<typename T>
-    static typename Promise::Result convertResult(T&& result) { return { WTFMove(result) }; }
-
-    static String convertError(IPC::Error) { return "IPC Connection closed"_s; }
+    static auto convertError(IPC::Error)
+    {
+        return makeUnexpected(String { "IPC Connection closed"_s });
+    }
 };
 
 Ref<WebCore::RealtimeMediaSource::TakePhotoNativePromise> RemoteRealtimeMediaSourceProxy::takePhoto(PhotoSettings&& settings)
 {
-    return m_connection->sendWithPromisedReply<Messages::UserMediaCaptureManagerProxy::TakePhoto, PromiseConverter<WebCore::RealtimeMediaSource::TakePhotoNativePromise>>({ identifier(), WTFMove(settings) });
+    return m_connection->sendWithPromisedReply<PromiseConverter>(Messages::UserMediaCaptureManagerProxy::TakePhoto { identifier(), WTFMove(settings) });
 }
 
 Ref<WebCore::RealtimeMediaSource::PhotoCapabilitiesNativePromise> RemoteRealtimeMediaSourceProxy::getPhotoCapabilities()
 {
-    return m_connection->sendWithPromisedReply<Messages::UserMediaCaptureManagerProxy::GetPhotoCapabilities, PromiseConverter<WebCore::RealtimeMediaSource::PhotoCapabilitiesNativePromise>>(identifier());
+    return m_connection->sendWithPromisedReply<PromiseConverter>(Messages::UserMediaCaptureManagerProxy::GetPhotoCapabilities { identifier() });
 }
 
 Ref<WebCore::RealtimeMediaSource::PhotoSettingsNativePromise> RemoteRealtimeMediaSourceProxy::getPhotoSettings()
 {
-    return m_connection->sendWithPromisedReply<Messages::UserMediaCaptureManagerProxy::GetPhotoSettings, PromiseConverter<WebCore::RealtimeMediaSource::PhotoSettingsNativePromise>>(identifier());
+    return m_connection->sendWithPromisedReply<PromiseConverter>(Messages::UserMediaCaptureManagerProxy::GetPhotoSettings { identifier() });
 }
 
 void RemoteRealtimeMediaSourceProxy::applyConstraintsSucceeded()

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h
@@ -91,7 +91,7 @@ public:
     void updateConnection();
 
 private:
-    template<typename P> struct PromiseConverter;
+    struct PromiseConverter;
 
     WebCore::RealtimeMediaSourceIdentifier m_identifier;
     Ref<IPC::Connection> m_connection;

--- a/Tools/TestWebKitAPI/Tests/IPC/MessageSenderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/MessageSenderTests.cpp
@@ -99,7 +99,7 @@ TEST_P(MessageSenderTest, SendWithPromisedReplyAfterInvalidateCancelsAllAsyncRep
     // This works for IPC::Connection.
     bool done = false;
 
-    b()->sendWithPromisedReply<MockTestMessageWithAsyncReply1>({ }, 100)->whenSettled(RunLoop::current(), [&] (MockTestMessageWithAsyncReply1::Promise::Result result) {
+    b()->sendWithPromisedReply(MockTestMessageWithAsyncReply1 { }, 100)->whenSettled(RunLoop::current(), [&] (MockTestMessageWithAsyncReply1::Promise::Result result) {
         EXPECT_FALSE(result.has_value());
         EXPECT_EQ(result.error(), IPC::Error::InvalidConnection);
         done = true;
@@ -112,7 +112,7 @@ TEST_P(MessageSenderTest, SendWithPromisedReplyAfterInvalidateCancelsAllAsyncRep
     done = false;
     SimpleMessageSender sender { b() };
 
-    sender.sendWithPromisedReply<MockTestMessageWithAsyncReply1>({ }, 100)->whenSettled(RunLoop::current(), [&] (MockTestMessageWithAsyncReply1::Promise::Result result) {
+    sender.sendWithPromisedReply(MockTestMessageWithAsyncReply1 { }, 100)->whenSettled(RunLoop::current(), [&] (MockTestMessageWithAsyncReply1::Promise::Result result) {
         EXPECT_FALSE(result.has_value());
         EXPECT_EQ(result.error(), IPC::Error::InvalidConnection);
         done = true;
@@ -141,7 +141,7 @@ TEST_P(MessageSenderTest, SendAsyncWithErrorAsynchronousCallback)
         RunLoop::current().cycle();
 
     done = false;
-    b()->sendWithPromisedReply<MockTestMessageWithAsyncReply1>({ }, 100)->whenSettled(RunLoop::current(), [&] (MockTestMessageWithAsyncReply1::Promise::Result result) {
+    b()->sendWithPromisedReply(MockTestMessageWithAsyncReply1 { }, 100)->whenSettled(RunLoop::current(), [&] (MockTestMessageWithAsyncReply1::Promise::Result result) {
         EXPECT_FALSE(result.has_value());
         EXPECT_EQ(result.error(), IPC::Error::InvalidConnection);
         done = true;


### PR DESCRIPTION
#### 819dab4131c790b064fae8c1d99f5a155ce392f9
<pre>
Reverse sendWithPromisedReply first and second template parameters
<a href="https://bugs.webkit.org/show_bug.cgi?id=275119">https://bugs.webkit.org/show_bug.cgi?id=275119</a>
<a href="https://rdar.apple.com/129230812">rdar://129230812</a>

Reviewed by Jean-Yves Avenard.

To go back to previous sendWithPromisedReply style, we reverse the Message and PromiseConverter termplate parameter order.
We also further simplify the PromiseConverter by only handling error and not result types.
This removes the need for the PromiseConverter to define how to convert results (usually a no-op).
We use type deduction to compute the converted promise so that the PromiseConverter no longer has to define the converted promise type.
Covered by existing tests.

* Source/WebKit/Platform/IPC/Connection.h:
(IPC::Connection::NoOpPromiseConverter::convertError):
(IPC::Connection::sendWithPromisedReply):
(IPC::Connection::makeAsyncReplyHandlerWithDispatcher):
(IPC::Connection::PromiseConverter::convertResult): Deleted.
(IPC::Connection::PromiseConverter::convertError): Deleted.
* Source/WebKit/Platform/IPC/MessageSenderInlines.h:
(IPC::MessageSender::sendWithPromisedReply):
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.cpp:
(WebKit::WebCacheStorageConnection::PromiseConverter::convertError):
(WebKit::WebCacheStorageConnection::open):
(WebKit::WebCacheStorageConnection::remove):
(WebKit::WebCacheStorageConnection::retrieveCaches):
(WebKit::WebCacheStorageConnection::retrieveRecords):
(WebKit::WebCacheStorageConnection::batchDeleteOperation):
(WebKit::WebCacheStorageConnection::batchPutOperation):
(WebKit::WebCacheStorageConnection::clearMemoryRepresentation):
(WebKit::WebCacheStorageConnection::engineRepresentation):
(WebKit::WebCacheStorageConnection::PromiseConverter::convertResult): Deleted.
* Source/WebKit/WebProcess/Cache/WebCacheStorageConnection.h:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::encodeFrameInternal):
(WebKit::LibWebRTCCodecs::flushEncoder):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp:
(WebKit::RemoteRealtimeMediaSourceProxy::PromiseConverter::convertError):
(WebKit::RemoteRealtimeMediaSourceProxy::takePhoto):
(WebKit::RemoteRealtimeMediaSourceProxy::getPhotoCapabilities):
(WebKit::RemoteRealtimeMediaSourceProxy::getPhotoSettings):
(WebKit::RemoteRealtimeMediaSourceProxy::PromiseConverter::convertResult): Deleted.
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h:
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::TEST_P):
(TestWebKitAPI::PromiseConverter::convertError):
(TestWebKitAPI::PromiseConverter::convertResult): Deleted.
* Tools/TestWebKitAPI/Tests/IPC/MessageSenderTests.cpp:
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/279758@main">https://commits.webkit.org/279758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03c2e74aa81bdf71e5f28d0dadc4fd6d439b0fea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54385 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33791 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57664 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5116 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56687 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41323 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44042 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3426 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56478 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31952 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47093 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25178 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/28759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4418 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3259 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4626 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59255 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/29604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/4794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51471 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/30763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47186 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50837 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11876 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/31737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30553 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->