### PR TITLE
[WebGPU] copyExternalImageToTexture incorrectly copies images from HTMLImageElement

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -222,97 +222,131 @@ static PixelFormat toPixelFormat(GPUTextureFormat textureFormat)
     return PixelFormat::RGBA8;
 }
 
-using ImageDataCallback = Function<void(std::span<const uint8_t>, size_t)>;
-static void getImageBytesFromImageBuffer(const RefPtr<ImageBuffer>& imageBuffer, const auto& destination, ImageDataCallback&& callback)
+using ImageDataCallback = Function<void(std::span<const uint8_t>, size_t, size_t)>;
+static void getImageBytesFromImageBuffer(const RefPtr<ImageBuffer>& imageBuffer, const auto& destination, bool& needsPremultipliedAlpha, ImageDataCallback&& callback)
 {
+    UNUSED_PARAM(needsPremultipliedAlpha);
     if (!imageBuffer)
-        return callback({ }, 0);
+        return callback({ }, 0, 0);
 
     auto size = imageBuffer->truncatedLogicalSize();
     if (!size.width() || !size.height())
-        return callback({ }, 0);
+        return callback({ }, 0, 0);
 
     auto pixelBuffer = imageBuffer->getPixelBuffer({ AlphaPremultiplication::Unpremultiplied, toPixelFormat(destination.texture->format()), DestinationColorSpace::SRGB() }, { { }, size });
     if (!pixelBuffer)
-        return callback({ }, 0);
+        return callback({ }, 0, 0);
 
-    callback(pixelBuffer->bytes(), size.height());
+    callback(pixelBuffer->bytes(), size.width(), size.height());
 }
 
 #if PLATFORM(COCOA) && ENABLE(VIDEO) && ENABLE(WEB_CODECS)
 static void getImageBytesFromVideoFrame(const RefPtr<VideoFrame>& videoFrame, ImageDataCallback&& callback)
 {
     if (!videoFrame.get() || !videoFrame->pixelBuffer())
-        return callback({ }, 0);
+        return callback({ }, 0, 0);
 
     auto pixelBuffer = videoFrame->pixelBuffer();
     if (!pixelBuffer)
-        return callback({ }, 0);
+        return callback({ }, 0, 0);
 
+    auto columns = CVPixelBufferGetWidth(pixelBuffer);
     auto rows = CVPixelBufferGetHeight(pixelBuffer);
     auto sizeInBytes = rows * CVPixelBufferGetBytesPerRow(pixelBuffer);
 
     CVPixelBufferLockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
-    callback({ static_cast<uint8_t*>(CVPixelBufferGetBaseAddress(pixelBuffer)), sizeInBytes }, rows);
+    callback({ reinterpret_cast<uint8_t*>(CVPixelBufferGetBaseAddress(pixelBuffer)), sizeInBytes }, columns, rows);
     CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
 }
 #endif
 
-static void imageBytesForSource(const auto& source, const auto& destination, ImageDataCallback&& callback)
+static void imageBytesForSource(const auto& sourceDescriptor, const auto& destination, bool& needsYFlip, bool& needsPremultipliedAlpha, ImageDataCallback&& callback)
 {
+    UNUSED_PARAM(needsYFlip);
+    UNUSED_PARAM(needsPremultipliedAlpha);
+
+    const auto& source = sourceDescriptor.source;
     using ResultType = void;
     return WTF::switchOn(source, [&](const RefPtr<ImageBitmap>& imageBitmap) -> ResultType {
-        return getImageBytesFromImageBuffer(imageBitmap->buffer(), destination, WTFMove(callback));
+        return getImageBytesFromImageBuffer(imageBitmap->buffer(), destination, needsPremultipliedAlpha, WTFMove(callback));
 #if ENABLE(VIDEO) && ENABLE(WEB_CODECS)
     }, [&](const RefPtr<ImageData> imageData) -> ResultType {
-        callback(imageData->pixelBuffer()->bytes(), imageData->height());
+        callback(imageData->pixelBuffer()->bytes(), imageData->width(), imageData->height());
     }, [&](const RefPtr<HTMLImageElement> imageElement) -> ResultType {
 #if PLATFORM(COCOA)
         if (!imageElement)
-            return callback({ }, 0);
+            return callback({ }, 0, 0);
         auto* cachedImage = imageElement->cachedImage();
         if (!cachedImage)
-            return callback({ }, 0);
+            return callback({ }, 0, 0);
         RefPtr image = cachedImage->image();
         if (!image || !image->isBitmapImage())
-            return callback({ }, 0);
+            return callback({ }, 0, 0);
         RefPtr nativeImage = static_cast<BitmapImage*>(image.get())->nativeImage();
         if (!nativeImage)
-            return callback({ }, 0);
+            return callback({ }, 0, 0);
         RetainPtr platformImage = nativeImage->platformImage();
         if (!platformImage)
-            return callback({ }, 0);
+            return callback({ }, 0, 0);
         RetainPtr pixelDataCfData = adoptCF(CGDataProviderCopyData(CGImageGetDataProvider(platformImage.get())));
         if (!pixelDataCfData)
-            return callback({ }, 0);
+            return callback({ }, 0, 0);
 
         auto width = CGImageGetWidth(platformImage.get());
         auto height = CGImageGetHeight(platformImage.get());
         if (!width || !height)
-            return callback({ }, 0);
+            return callback({ }, 0, 0);
 
         auto sizeInBytes = height * CGImageGetBytesPerRow(platformImage.get());
         auto bytePointer = reinterpret_cast<const uint8_t*>(CFDataGetBytePtr(pixelDataCfData.get()));
         auto requiredSize = width * height * 4;
-        if (sizeInBytes == requiredSize)
-            return callback({ bytePointer, sizeInBytes }, height);
+        auto alphaInfo = CGImageGetAlphaInfo(platformImage.get());
+        bool channelLayoutIsRGB = false;
+        bool isBGRA = toPixelFormat(destination.texture->format()) == PixelFormat::BGRA8;
+        constexpr int channelsRGBX[] = { 0, 1, 2, 3 };
+        constexpr int channelsBGRX[] = { 2, 1, 0, 3 };
+        constexpr int channelsXRGB[] = { 3, 0, 1, 2 };
+        constexpr int channelsXBGR[] = { 3, 2, 1, 0 };
+        const int* channels = channelsRGBX;
+        switch (alphaInfo) {
+        case kCGImageAlphaNone:               /* For example, RGB. */
+        case kCGImageAlphaPremultipliedLast:  /* For example, premultiplied RGBA */
+        case kCGImageAlphaLast:               /* For example, non-premultiplied RGBA */
+        case kCGImageAlphaNoneSkipLast:       /* For example, RGBX. */
+            channelLayoutIsRGB = true;
+            channels = isBGRA ? channelsBGRX : channelsRGBX;
+            break;
+        case kCGImageAlphaPremultipliedFirst: /* For example, premultiplied ARGB */
+        case kCGImageAlphaFirst:              /* For example, non-premultiplied ARGB */
+        case kCGImageAlphaNoneSkipFirst:      /* For example, XRGB. */
+        case kCGImageAlphaOnly:                /* No color data, alpha data only */
+            channels = isBGRA ? channelsXBGR : channelsXRGB;
+            break;
+        }
+        if (sizeInBytes == requiredSize && channelLayoutIsRGB)
+            return callback({ bytePointer, sizeInBytes }, width, height);
 
         auto bytesPerRow = CGImageGetBytesPerRow(platformImage.get());
         Vector<uint8_t> tempBuffer(requiredSize, 255);
         auto bytesPerPixel = sizeInBytes / (width * height);
         auto bytesToCopy = std::min<size_t>(4, bytesPerPixel);
-        for (size_t y = 0; y < height; ++y) {
+        bool flipY = sourceDescriptor.flipY;
+        needsYFlip = false;
+        int direction = flipY ? -1 : 1;
+        for (size_t y = 0, y0 = flipY ? (height - 1) : 0; y < height; ++y, y0 += direction) {
             for (size_t x = 0; x < width; ++x) {
+                // FIXME: These pixel values are probably incorrect after only copying 4 if bytesPerPixel is not 4.
                 for (size_t c = 0; c < bytesToCopy; ++c) {
                     // FIXME: These pixel values are probably incorrect after only copying 4 if bytesPerPixel is not 4.
-                    tempBuffer[y * (width * 4) + x * 4 + c] = bytePointer[y * bytesPerRow + x * bytesPerPixel + c];
+                    tempBuffer[y * (width * 4) + x * 4 + channels[c]] = bytePointer[y * bytesPerRow + x * bytesPerPixel + c];
                 }
             }
         }
-        callback(tempBuffer.span(), height);
+        callback(tempBuffer.span(), width, height);
 #else
+        UNUSED_PARAM(needsYFlip);
         UNUSED_PARAM(imageElement);
-        return callback({ }, 0);
+        return callback({ }, 0, 0);
 #endif
     }, [&](const RefPtr<HTMLVideoElement> videoElement) -> ResultType {
 #if PLATFORM(COCOA)
@@ -321,21 +355,21 @@ static void imageBytesForSource(const auto& source, const auto& destination, Ima
 #else
         UNUSED_PARAM(videoElement);
 #endif
-        return callback({ }, 0);
+        return callback({ }, 0, 0);
     }, [&](const RefPtr<WebCodecsVideoFrame> webCodecsFrame) -> ResultType {
 #if PLATFORM(COCOA)
         return getImageBytesFromVideoFrame(webCodecsFrame->internalFrame(), WTFMove(callback));
 #else
         UNUSED_PARAM(webCodecsFrame);
-        return callback({ }, 0);
+        return callback({ }, 0, 0);
 #endif
 #endif
     }, [&](const RefPtr<HTMLCanvasElement>& canvasElement) -> ResultType {
-        return getImageBytesFromImageBuffer(canvasElement->makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect::No), destination, WTFMove(callback));
+        return getImageBytesFromImageBuffer(canvasElement->makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect::No), destination, needsPremultipliedAlpha, WTFMove(callback));
     }
 #if ENABLE(OFFSCREEN_CANVAS)
     , [&](const RefPtr<OffscreenCanvas>& offscreenCanvasElement) -> ResultType {
-        return getImageBytesFromImageBuffer(offscreenCanvasElement->makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect::No), destination, WTFMove(callback));
+        return getImageBytesFromImageBuffer(offscreenCanvasElement->makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect::No), destination, needsPremultipliedAlpha, WTFMove(callback));
     }
 #endif
     );
@@ -511,65 +545,155 @@ static uint32_t convertRGBA8888ToRGB10A2(uint8_t r, uint8_t g, uint8_t b, uint8_
 }
 #endif
 
-static void* copyToDestinationFormat(const uint8_t* rgbaBytes, GPUTextureFormat format, size_t& sizeInBytes, bool& supportedFormat)
+static void populdateXYFromOrigin(const GPUOrigin2D& origin2D, uint32_t& x, uint32_t& y)
 {
+    WTF::switchOn(origin2D, [&](const Vector<GPUIntegerCoordinate>& vector) {
+        x = vector.size() ? vector[0] : 0;
+        y = vector.size() > 1 ? vector[1] : 0;
+    }, [&](const GPUOrigin2DDict& origin2D) {
+        x = origin2D.x;
+        y = origin2D.y;
+    });
+}
+
+static void* copyToDestinationFormat(const uint8_t* rgbaBytes, GPUTextureFormat format, size_t& sizeInBytes, bool& supportedFormat, size_t rows, bool flipY, bool premultiplyAlpha, const std::optional<GPUOrigin2D>& sourceOrigin)
+{
+    uint32_t sourceX = 0, sourceY = 0;
+    if (sourceOrigin)
+        populdateXYFromOrigin(*sourceOrigin, sourceX, sourceY);
+
+#if PLATFORM(COCOA)
+    auto flipAndPremultiply = [&](auto* bytes, bool flipY, bool premultiplyAlpha, auto oneValue) {
+        if (!rows || (!flipY && !premultiplyAlpha))
+            return bytes;
+
+        size_t widthInBytes = sizeInBytes / rows;
+        size_t widthInElements = widthInBytes / sizeof(decltype(*bytes));
+        auto* typedBytes = static_cast<decltype(bytes)>(bytes);
+        auto oneForAlpha = premultiplyAlpha ? 1 : 0;
+        if (premultiplyAlpha) {
+            RELEASE_ASSERT(!(widthInElements % 4));
+            for (size_t y = 0, y0 = rows - 1; y < y0 + oneForAlpha; ++y, --y0) {
+                for (size_t x = 0; x < widthInElements; x += 4) {
+                    auto alpha = typedBytes[y * widthInElements + x + 3];
+                    auto alpha0 = typedBytes[y0 * widthInElements + x + 3];
+                    typedBytes[y * widthInElements + x + 3] = oneValue;
+                    typedBytes[y0 * widthInElements + x + 3] = oneValue;
+                    for (size_t c = 0; c < 3; ++c) {
+                        float f = static_cast<float>(typedBytes[y0 * widthInElements + x + c]);
+                        f = f * alpha0 / static_cast<float>(oneValue);
+                        typedBytes[y0 * widthInElements + x + c] = static_cast<decltype(oneValue)>(f);
+                        f = static_cast<float>(typedBytes[y * widthInElements + x + c]);
+                        f = f * alpha / static_cast<float>(oneValue);
+                        typedBytes[y * widthInElements + x + c] = static_cast<decltype(oneValue)>(f);
+                        if (flipY)
+                            std::swap(typedBytes[y0 * widthInElements + x + c], typedBytes[y * widthInElements + x + c]);
+                    }
+                }
+            }
+        } else if (flipY) {
+            for (size_t y = 0, y0 = rows - 1; y < y0 + oneForAlpha; ++y, --y0) {
+                for (size_t x = 0; x < widthInElements; ++x)
+                    std::swap(typedBytes[y0 * widthInElements + x], typedBytes[y * widthInElements + x]);
+            }
+        }
+        return bytes;
+    };
+#endif
+
     supportedFormat = true;
 #if PLATFORM(COCOA)
     switch (format) {
     case GPUTextureFormat::R8unorm: {
         uint8_t* data = (uint8_t*)malloc(sizeInBytes / 4);
-        for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, ++i0)
-            data[i0] = rgbaBytes[i];
+        if (premultiplyAlpha) {
+            for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, ++i0)
+                data[i0] = static_cast<uint8_t>((rgbaBytes[i] * static_cast<uint32_t>(rgbaBytes[i + 3])) / 255);
+        } else {
+            for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, ++i0)
+                data[i0] = rgbaBytes[i];
+        }
 
         sizeInBytes = sizeInBytes / 4;
-        return data;
+        return flipAndPremultiply(data, flipY, false, 255);
     }
 
     // 16-bit formats
     case GPUTextureFormat::R16float: {
         __fp16* data = (__fp16*)malloc(sizeInBytes / 2);
-        for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, ++i0)
-            data[i0] = rgbaBytes[i] / 255.f;
+        if (premultiplyAlpha) {
+            for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, ++i0)
+                data[i0] = (rgbaBytes[i] / 255.f) * (rgbaBytes[i + 3] / 255.f);
+        } else {
+            for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, ++i0)
+                data[i0] = rgbaBytes[i] / 255.f;
+        }
 
         sizeInBytes = sizeInBytes / 2;
-        return data;
+        return flipAndPremultiply(data, flipY, false, 1.f);
     }
 
     case GPUTextureFormat::Rg8unorm: {
         uint8_t* data = (uint8_t*)malloc(sizeInBytes / 2);
-        for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, i0 += 2) {
-            data[i0] = rgbaBytes[i];
-            data[i0 + 1] = rgbaBytes[i + 1];
+        if (premultiplyAlpha) {
+            for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, i0 += 2) {
+                data[i0] = static_cast<uint8_t>((rgbaBytes[i] * static_cast<uint32_t>(rgbaBytes[i + 3])) / 255);
+                data[i0 + 1] = static_cast<uint8_t>((rgbaBytes[i + 1] * static_cast<uint32_t>(rgbaBytes[i + 3])) / 255);
+            }
+        } else {
+            for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, i0 += 2) {
+                data[i0] = rgbaBytes[i];
+                data[i0 + 1] = rgbaBytes[i + 1];
+            }
         }
 
         sizeInBytes = sizeInBytes / 2;
-        return data;
+        return flipAndPremultiply(data, flipY, false, 255);
     }
 
     // 32-bit formats
     case GPUTextureFormat::R32float: {
         float* data = (float*)malloc(sizeInBytes);
-        for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, ++i0)
-            data[i0] = rgbaBytes[i] / 255.f;
+        if (premultiplyAlpha) {
+            for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, ++i0)
+                data[i0] = (rgbaBytes[i] / 255.f) * (rgbaBytes[i + 3] / 255.f);
+        } else {
+            for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, ++i0)
+                data[i0] = rgbaBytes[i] / 255.f;
+        }
 
-        return data;
+        return flipAndPremultiply(data, flipY, false, 1.f);
     }
 
     case GPUTextureFormat::Rg16float: {
         __fp16* data = (__fp16*)malloc(sizeInBytes);
-        for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, i0 += 2) {
-            data[i0] = rgbaBytes[i] / 255.f;
-            data[i0 + 1] = rgbaBytes[i + 1] / 255.f;
+        if (premultiplyAlpha) {
+            for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, i0 += 2) {
+                data[i0] = (rgbaBytes[i] / 255.f) * (rgbaBytes[i + 3] / 255.f);
+                data[i0 + 1] = (rgbaBytes[i + 1] / 255.f) * (rgbaBytes[i + 3] / 255.f);
+            }
+        } else {
+            for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, i0 += 2) {
+                data[i0] = rgbaBytes[i] / 255.f;
+                data[i0 + 1] = rgbaBytes[i + 1] / 255.f;
+            }
         }
 
-        return data;
+        return flipAndPremultiply(data, flipY, false, 1.f);
     }
 
     case GPUTextureFormat::Rgba8unorm:
     case GPUTextureFormat::Rgba8unormSRGB:
     case GPUTextureFormat::Bgra8unorm:
-    case GPUTextureFormat::Bgra8unormSRGB:
+    case GPUTextureFormat::Bgra8unormSRGB: {
+        if (flipY || premultiplyAlpha || sourceX || sourceY) {
+            uint8_t* data = (uint8_t*)malloc(sizeInBytes);
+            memcpy(data, rgbaBytes, sizeInBytes);
+            flipAndPremultiply(data, flipY, premultiplyAlpha, 255);
+            return data;
+        }
         return nullptr;
+    }
     case GPUTextureFormat::Rgb10a2unorm: {
         uint32_t* data = (uint32_t*)malloc(sizeInBytes);
         for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, ++i0)
@@ -581,13 +705,20 @@ static void* copyToDestinationFormat(const uint8_t* rgbaBytes, GPUTextureFormat 
     // 64-bit formats
     case GPUTextureFormat::Rg32float: {
         float* data = (float*)malloc((sizeInBytes / 2) * sizeof(float));
-        for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, i0 += 2) {
-            data[i0] = rgbaBytes[i];
-            data[i0 + 1] = rgbaBytes[i + 1];
+        if (premultiplyAlpha) {
+            for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, i0 += 2) {
+                data[i0] = (rgbaBytes[i] / 255.f) * (rgbaBytes[i + 3] / 255.f);
+                data[i0 + 1] = (rgbaBytes[i + 1] / 255.f) * (rgbaBytes[i + 3] / 255.f);
+            }
+        } else {
+            for (size_t i = 0, i0 = 0; i < sizeInBytes; i += 4, i0 += 2) {
+                data[i0] = (rgbaBytes[i] / 255.f);
+                data[i0 + 1] = (rgbaBytes[i + 1] / 255.f);
+            }
         }
 
         sizeInBytes = (sizeInBytes / 2) * sizeof(float);
-        return data;
+        return flipAndPremultiply(data, flipY, false, 1.f);
     }
 
     case GPUTextureFormat::Rgba16float: {
@@ -596,7 +727,7 @@ static void* copyToDestinationFormat(const uint8_t* rgbaBytes, GPUTextureFormat 
             data[i] = rgbaBytes[i] / 255.f;
 
         sizeInBytes = sizeInBytes * sizeof(__fp16);
-        return data;
+        return flipAndPremultiply(data, flipY, premultiplyAlpha, 1.f);
     }
 
     // 128-bit formats
@@ -606,7 +737,7 @@ static void* copyToDestinationFormat(const uint8_t* rgbaBytes, GPUTextureFormat 
             data[i] = rgbaBytes[i] / 255.f;
 
         sizeInBytes = sizeInBytes * sizeof(float);
-        return data;
+        return flipAndPremultiply(data, flipY, premultiplyAlpha, 1.f);
     }
 
     // Formats which are not allowed
@@ -701,6 +832,9 @@ static void* copyToDestinationFormat(const uint8_t* rgbaBytes, GPUTextureFormat 
     UNUSED_PARAM(format);
     UNUSED_PARAM(sizeInBytes);
     UNUSED_PARAM(rgbaBytes);
+    UNUSED_PARAM(rows);
+    UNUSED_PARAM(flipY);
+    UNUSED_PARAM(premultiplyAlpha);
 
     return nullptr;
 #endif
@@ -716,7 +850,9 @@ ExceptionOr<void> GPUQueue::copyExternalImageToTexture(ScriptExecutionContext& c
         return Exception { ExceptionCode::SecurityError, "GPUQueue.copyExternalImageToTexture: Cross origin external images are not allowed in WebGPU"_s };
 
     bool callbackScopeIsSafe { true };
-    imageBytesForSource(source.source, destination, [&](std::span<const uint8_t> imageBytes, size_t rows) {
+    bool needsYFlip = source.flipY;
+    bool needsPremultipliedAlpha = destination.premultipliedAlpha;
+    imageBytesForSource(source, destination, needsYFlip, needsPremultipliedAlpha, [&](std::span<const uint8_t> imageBytes, size_t columns, size_t rows) {
         RELEASE_ASSERT(callbackScopeIsSafe);
         auto destinationTexture = destination.texture;
         auto sizeInBytes = imageBytes.size();
@@ -724,8 +860,25 @@ ExceptionOr<void> GPUQueue::copyExternalImageToTexture(ScriptExecutionContext& c
             return;
 
         bool supportedFormat;
-        uint8_t* newImageBytes = static_cast<uint8_t*>(copyToDestinationFormat(imageBytes.data(), destination.texture->format(), sizeInBytes, supportedFormat));
-        GPUImageDataLayout dataLayout { 0, sizeInBytes / rows, rows };
+        uint8_t* newImageBytes = static_cast<uint8_t*>(copyToDestinationFormat(imageBytes.data(), destination.texture->format(), sizeInBytes, supportedFormat, rows, needsYFlip, needsPremultipliedAlpha, source.origin));
+        uint32_t sourceX = 0, sourceY = 0;
+        auto widthInBytes = sizeInBytes / rows;
+        auto channels = widthInBytes / columns;
+        GPUImageDataLayout dataLayout { 0, widthInBytes, rows };
+
+        if (source.origin) {
+            populdateXYFromOrigin(*source.origin, sourceX, sourceY);
+            if (sourceX || sourceY) {
+                RELEASE_ASSERT(newImageBytes);
+                for (size_t y = sourceY, y0 = 0; y < rows; ++y, ++y0) {
+                    for (size_t x = sourceX, x0 = 0; x < columns; ++x, ++x0) {
+                        for (size_t c = 0; c < channels; ++c)
+                            newImageBytes[y0 * widthInBytes + x0 * channels + c] = newImageBytes[y * widthInBytes + x * channels + c];
+                    }
+                }
+            }
+        }
+
         auto copyDestination = destination.convertToBacking();
 
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=263692 - this code should be removed once copyExternalImageToTexture


### PR DESCRIPTION
#### ba118a8e2812438fef7ee0535f3e70d9dea5047a
<pre>
[WebGPU] copyExternalImageToTexture incorrectly copies images from HTMLImageElement
<a href="https://bugs.webkit.org/show_bug.cgi?id=274789">https://bugs.webkit.org/show_bug.cgi?id=274789</a>
&lt;radar://128380266&gt;

Reviewed by Dan Glastonbury.

We were assuming the byte order was always RGBA and not handling
ARGB or ABGR, where A can be X or A.

Correct this by manually swapping.

<a href="https://bugs.webkit.org/show_bug.cgi?id=263692">https://bugs.webkit.org/show_bug.cgi?id=263692</a> tracks moving this to the GPU
process and we could perform the swaps in a fragment shader as the goal is to
populate a MTLTexture.

Re-land with release assert in correct location.

* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::getImageBytesFromImageBuffer):
(WebCore::getImageBytesFromVideoFrame):
(WebCore::imageBytesForSource):
(WebCore::populdateXYFromOrigin):
(WebCore::copyToDestinationFormat):
(WebCore::GPUQueue::copyExternalImageToTexture):

Canonical link: <a href="https://commits.webkit.org/279714@main">https://commits.webkit.org/279714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf7ced67b8da4492adbfd66357163667259d4731

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54245 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57522 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/4971 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56548 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/41165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/4918 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43938 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3329 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56341 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/41165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/46975 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25080 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/41165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4302 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3118 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/41165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4510 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59114 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/29456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/4661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51358 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30623 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50721 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11814 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/31599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30406 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->