### PR TITLE
[WebGPU] shader accesses null texture when video frame is not available

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2091,6 +2091,7 @@ webkit.org/b/139639 [ Debug ] cssom/non-subpixel-scroll-top-left-values.html [ S
 [ Debug ] fast/webgpu/multidimensional-texture-bounds.html [ Slow ]
 
 fast/webgpu/regression [ Pass ]
+fast/webgpu/regression/repro_275108.html [ Pass Failure Timeout ]
 
 [ Debug ] fast/webgpu/fuzz-272863.html [ Skip ]
 [ Release ] fast/webgpu/fuzz-272863.html [ Pass Failure Timeout ]

--- a/LayoutTests/fast/webgpu/regression/repro_275108-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_275108-expected.txt
@@ -1,0 +1,8 @@
+CONSOLE MESSAGE: no validation error
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584
+layer at (8,8) size 300x150
+  RenderHTMLCanvas {CANVAS} at (0,0) size 300x150

--- a/LayoutTests/fast/webgpu/regression/repro_275108.html
+++ b/LayoutTests/fast/webgpu/regression/repro_275108.html
@@ -1,0 +1,97 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  const format = 'bgra8unorm';
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+
+  function videoWithData() {
+    let video = document.createElement('video');
+    video.src = veryBrightVideo;
+    video.muted = true;
+    return new Promise(resolve => {
+      video.onloadeddata = () => {
+        resolve(video);
+      };
+    });
+  }
+
+  function createCanvasAndContext(device) {
+    let canvas = document.createElement('canvas');
+    document.body.append(canvas);
+    let context = canvas.getContext('webgpu');
+    context.configure({device, format, usage: GPUTextureUsage.RENDER_ATTACHMENT});
+    return context;
+  }
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    let context = createCanvasAndContext(device);
+    let vertexesF32 = new Float32Array([1, -1, -1, 1, -1, -1]);
+    let vertexBuffer = device.createBuffer({size: vertexesF32.byteLength, usage: GPUBufferUsage.VERTEX, mappedAtCreation: true});
+    new Float32Array(vertexBuffer.getMappedRange()).set(vertexesF32);
+    vertexBuffer.unmap();
+    let v = await videoWithData();
+    let code = `
+@vertex
+fn v(@location(0) position : vec4f) -> @builtin(position) vec4f {
+  return position;
+}
+
+@group(0) @binding(0) var et: texture_external;
+
+@fragment
+fn f() -> @location(0) vec4f {
+  return textureLoad(et, vec2());
+}
+`;
+    let bindGroupLayout = device.createBindGroupLayout({
+      entries: [{binding: 0, externalTexture: {}, visibility: GPUShaderStage.FRAGMENT}],
+    });
+    let module = device.createShaderModule({code});
+    let pipeline = device.createRenderPipeline({
+      layout: device.createPipelineLayout({bindGroupLayouts: [bindGroupLayout]}),
+      vertex: {
+        module,
+        buffers: [{arrayStride: 8, attributes: [{shaderLocation: 0, offset: 0, format: 'float32x2'}]}],
+      },
+      fragment: {module, targets: [{format}]},
+    });
+
+    let oneFrame = async _ => {
+      device.pushErrorScope('validation');
+      let commandEncoder = device.createCommandEncoder();
+      let renderPassEncoder = commandEncoder.beginRenderPass({
+        colorAttachments: [
+          {
+            view: context.getCurrentTexture().createView(),
+            clearValue: [0.5, 0.5, 0.5, 0.5],
+            loadOp: 'clear', storeOp: 'store',
+          },
+        ],
+      });
+      let externalTexture0 = device.importExternalTexture({source: v});
+      let textureBindGroup = device.createBindGroup({
+        layout: bindGroupLayout,
+        entries: [{binding: 0, resource: externalTexture0}],
+      });
+      renderPassEncoder.setPipeline(pipeline);
+      renderPassEncoder.setVertexBuffer(0, vertexBuffer);
+      renderPassEncoder.setBindGroup(0, textureBindGroup);
+      renderPassEncoder.draw(3);
+      renderPassEncoder.end();
+      device.queue.submit([commandEncoder.finish()]);
+      await device.queue.onSubmittedWorkDone();
+      let error = await device.popErrorScope();
+      if (error) {
+        log(error.message);
+      } else {
+        log('no validation error');
+      }
+      globalThis.testRunner?.notifyDone();
+    };
+    v.src = 'data:';
+    requestAnimationFrame(oneFrame);
+  };
+</script>

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -1115,18 +1115,20 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
                 }
                 auto& externalTexture = WebGPU::fromAPI(wgpuExternalTexture);
                 auto textureData = createExternalTextureFromPixelBuffer(externalTexture.pixelBuffer(), externalTexture.colorSpace());
-                if (textureData.texture0) {
-                    stageResources[metalRenderStage(stage)][resourceUsage - 1].append(textureData.texture0);
+                id<MTLTexture> texture0 = textureData.texture0 ?: placeholderTexture(WGPUTextureFormat_BGRA8Unorm);
+                if (texture0) {
+                    stageResources[metalRenderStage(stage)][resourceUsage - 1].append(texture0);
                     stageResourceUsages[metalRenderStage(stage)][resourceUsage - 1].append(makeBindGroupEntryUsageData(BindGroupEntryUsage::ConstantTexture, entry.binding, externalTexture));
                 }
-                if (textureData.texture1) {
-                    stageResources[metalRenderStage(stage)][resourceUsage - 1].append(textureData.texture1);
+                id<MTLTexture> texture1 = textureData.texture1 ?: placeholderTexture(WGPUTextureFormat_BGRA8Unorm);
+                if (texture1) {
+                    stageResources[metalRenderStage(stage)][resourceUsage - 1].append(texture1);
                     stageResourceUsages[metalRenderStage(stage)][resourceUsage - 1].append(makeBindGroupEntryUsageData(BindGroupEntryUsage::ConstantTexture, entry.binding, externalTexture));
                 }
 
                 if (stage != ShaderStage::Undefined) {
-                    [argumentEncoder[stage] setTexture:textureData.texture0 atIndex:index++];
-                    [argumentEncoder[stage] setTexture:textureData.texture1 atIndex:index++];
+                    [argumentEncoder[stage] setTexture:texture0 atIndex:index++];
+                    [argumentEncoder[stage] setTexture:texture1 atIndex:index++];
 
                     auto* uvRemapAddress = static_cast<simd::float3x2*>([argumentEncoder[stage] constantDataAtIndex:index++]);
                     *uvRemapAddress = textureData.uvRemappingMatrix;


### PR DESCRIPTION
#### 8f98c5f845ce898a54ff140ae4ed7a3d05bd680a
<pre>
[WebGPU] shader accesses null texture when video frame is not available
<a href="https://bugs.webkit.org/show_bug.cgi?id=275108">https://bugs.webkit.org/show_bug.cgi?id=275108</a>
&lt;radar://129218790&gt;

Reviewed by Dan Glastonbury.

Fallback to placeholder when video texture is not available.

* LayoutTests/fast/webgpu/regression/repro_275108-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_275108.html: Added.
* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createBindGroup):

Canonical link: <a href="https://commits.webkit.org/279773@main">https://commits.webkit.org/279773@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91782f560ae9345089eb317a5709bc19759acca7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57710 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5162 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5148 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44085 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3461 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31987 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47135 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25212 "Found 1 new API test failure: /WPE/TestMultiprocess:/webkit/WebKitWebView/multiprocess-create-ready-close (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28789 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4462 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3305 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4677 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59301 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29652 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/4857 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51503 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30809 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47228 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50888 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11908 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/31787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30602 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->