### PR TITLE
[view-transitions] Prevent async scrolling while a view-transition is active.

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1680,7 +1680,7 @@ public:
     void resetObservationSizeForContainIntrinsicSize(Element&);
 
     RefPtr<ViewTransition> startViewTransition(RefPtr<ViewTransitionUpdateCallback>&& = nullptr);
-    ViewTransition* activeViewTransition() const;
+    WEBCORE_EXPORT ViewTransition* activeViewTransition() const;
     bool activeViewTransitionCapturedDocumentElement() const;
     void setActiveViewTransition(RefPtr<ViewTransition>&&);
 

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -162,6 +162,8 @@ public:
     bool updateCompositingLayersAfterStyleChange();
     void updateCompositingLayersAfterLayout();
 
+    void setNeedsUpdateCompositingLayers() { m_updateCompositingLayersIsPending = true; }
+
     // Returns true if a pending compositing layer update was done.
     bool updateCompositingLayersAfterLayoutIfNeeded();
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1889,6 +1889,26 @@ void Page::updateRendering()
         scrollingCoordinator->willStartRenderingUpdate();
 #endif
 
+    bool hasActiveViewTransition = false;
+    forEachDocument([&](auto& document) {
+        hasActiveViewTransition |= !!document.activeViewTransition();
+    });
+    if (hasActiveViewTransition != m_hasActiveViewTransition) {
+        m_hasActiveViewTransition = hasActiveViewTransition;
+
+        forEachDocument([&](auto& document) {
+            if (CheckedPtr renderView = document.renderView()) {
+                RenderBoxModelObject::forRendererAndContinuations(*renderView, [](RenderBoxModelObject& renderer) {
+                    if (renderer.hasLayer()) {
+                        renderer.layer()->setNeedsScrollingTreeUpdate();
+                        renderer.layer()->setNeedsCompositingConfigurationUpdate();
+                    }
+                });
+                renderView->frameView().setNeedsUpdateCompositingLayers();
+            }
+        });
+    }
+
     // Timestamps should not change while serving the rendering update steps.
     Vector<WeakPtr<Document, WeakPtrImplWithEventTargetData>> initialDocuments;
     forEachDocument([&initialDocuments] (Document& document) {

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1167,6 +1167,7 @@ public:
     WEBCORE_EXPORT std::optional<SimpleRange> contextRangeForSessionWithID(const UnifiedTextReplacement::SessionID&) const;
 #endif
 
+    bool hasActiveViewTransition() const { return m_hasActiveViewTransition; }
 private:
     explicit Page(PageConfiguration&&);
 
@@ -1433,6 +1434,7 @@ private:
     bool m_mediaBufferingIsSuspended { false };
     bool m_hasResourceLoadClient { false };
     bool m_delegatesScaling { false };
+    bool m_hasActiveViewTransition;
 
     bool m_hasEverSetVisibilityAdjustment { false };
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -5187,6 +5187,11 @@ void RenderLayerCompositor::detachScrollCoordinatedLayer(RenderLayer& layer, Opt
 OptionSet<ScrollCoordinationRole> RenderLayerCompositor::coordinatedScrollingRolesForLayer(const RenderLayer& layer, const RenderLayer* compositingAncestor) const
 {
     OptionSet<ScrollCoordinationRole> coordinationRoles;
+    if (!hasCoordinatedScrolling()) {
+        // If this frame isn't coordinated, it cannot contain any scrolling tree nodes.
+        return coordinationRoles;
+    }
+
     if (isViewportConstrainedFixedOrStickyLayer(layer))
         coordinationRoles.add(ScrollCoordinationRole::ViewportConstrained);
 
@@ -5226,11 +5231,6 @@ ScrollingNodeID RenderLayerCompositor::updateScrollCoordinationForLayer(RenderLa
             m_legacyScrollingLayerCoordinator->removeViewportConstrainedLayer(layer);
     }
 #endif
-
-    if (!hasCoordinatedScrolling()) {
-        // If this frame isn't coordinated, it cannot contain any scrolling tree nodes.
-        return { };
-    }
 
     auto newNodeID = treeState.parentNodeID.value_or(ScrollingNodeID { });
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -154,6 +154,7 @@ header: "RemoteLayerBackingStore.h"
     bool m_viewportMetaTagWidthWasExplicit;
     bool m_viewportMetaTagCameFromImageDocument;
     bool m_isInStableState;
+    bool m_hasActiveViewTransition;
 
     std::optional<WebKit::EditorState> m_editorState;
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -205,6 +205,9 @@ public:
     bool viewportMetaTagWidthWasExplicit() const { return m_viewportMetaTagWidthWasExplicit; }
     void setViewportMetaTagWidthWasExplicit(bool widthWasExplicit) { m_viewportMetaTagWidthWasExplicit = widthWasExplicit; }
 
+    bool hasActiveViewTransition() const { return m_hasActiveViewTransition; }
+    void setHasActiveViewTransition(bool activeViewTransition) { m_hasActiveViewTransition = activeViewTransition; }
+
     bool viewportMetaTagCameFromImageDocument() const { return m_viewportMetaTagCameFromImageDocument; }
     void setViewportMetaTagCameFromImageDocument(bool cameFromImageDocument) { m_viewportMetaTagCameFromImageDocument = cameFromImageDocument; }
 
@@ -289,6 +292,7 @@ private:
     bool m_viewportMetaTagWidthWasExplicit { false };
     bool m_viewportMetaTagCameFromImageDocument { false };
     bool m_isInStableState { false };
+    bool m_hasActiveViewTransition { false };
 
     std::optional<EditorState> m_editorState;
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm
@@ -281,6 +281,7 @@ String RemoteLayerTreeTransaction::description() const
     ts.dumpProperty("allowsUserScaling", m_allowsUserScaling);
     ts.dumpProperty("avoidsUnsafeArea", m_avoidsUnsafeArea);
     ts.dumpProperty("isInStableState", m_isInStableState);
+    ts.dumpProperty("hasActiveViewTransition", m_hasActiveViewTransition);
     ts.dumpProperty("renderTreeSize", m_renderTreeSize);
     ts.dumpProperty("root-layer", m_rootLayerID);
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -160,6 +160,8 @@ void WebPageProxy::didCommitLayerTree(const WebKit::RemoteLayerTreeTransaction& 
         m_hitRenderTreeSizeThreshold = true;
         didReachLayoutMilestone(WebCore::LayoutMilestone::ReachedSessionRestorationRenderTreeSizeThreshold);
     }
+
+    m_hasActiveViewTransition = layerTreeTransaction.hasActiveViewTransition();
 }
 
 void WebPageProxy::layerTreeCommitComplete()

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3664,7 +3664,7 @@ void WebPageProxy::handleWheelEvent(const WebWheelEvent& wheelEvent)
     if (!hasRunningProcess())
         return;
 
-    if (drawingArea()->shouldSendWheelEventsToEventDispatcher()) {
+    if (drawingArea()->shouldSendWheelEventsToEventDispatcher() || m_hasActiveViewTransition) {
         continueWheelEventHandling(wheelEvent, { WheelEventProcessingSteps::SynchronousScrolling, false }, { });
         return;
     }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3544,7 +3544,8 @@ private:
     bool m_sessionStateWasRestoredByAPIRequest { false };
     bool m_isQuotaIncreaseDenied { false };
     bool m_isLayerTreeFrozenDueToSwipeAnimation { false };
-    
+    bool m_hasActiveViewTransition { false };
+
     String m_overriddenMediaType;
 
     Vector<String> m_corsDisablingPatterns;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
@@ -73,6 +73,7 @@ private:
     // ScrollingCoordinator
     bool coordinatesScrollingForFrameView(const WebCore::LocalFrameView&) const override;
     void scheduleTreeStateCommit() override;
+    void willStartRenderingUpdate() final;
 
     bool isRubberBandInProgress(WebCore::ScrollingNodeID) const final;
     bool isUserScrollInProgress(WebCore::ScrollingNodeID) const final;
@@ -107,7 +108,8 @@ private:
     NodeAndGestureState m_currentWheelGestureInfo;
 
     bool m_clearScrollLatchingInNextTransaction { false };
-    
+    bool m_hasActiveViewTransition { false };
+
     std::optional<bool> m_currentWheelEventWillStartSwipe;
 };
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
@@ -71,8 +71,15 @@ void RemoteScrollingCoordinator::scheduleTreeStateCommit()
     m_webPage->drawingArea()->triggerRenderingUpdate();
 }
 
+void RemoteScrollingCoordinator::willStartRenderingUpdate()
+{
+    m_hasActiveViewTransition = page()->hasActiveViewTransition();
+}
+
 bool RemoteScrollingCoordinator::coordinatesScrollingForFrameView(const LocalFrameView& frameView) const
 {
+    if (m_hasActiveViewTransition)
+        return false;
     RenderView* renderView = frameView.renderView();
     return renderView && renderView->usesCompositing();
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4931,6 +4931,11 @@ void WebPage::willCommitLayerTree(RemoteLayerTreeTransaction& layerTransaction, 
     }
 #endif
 
+    if (RefPtr page = corePage())
+        layerTransaction.setHasActiveViewTransition(page->hasActiveViewTransition());
+    else
+        layerTransaction.setHasActiveViewTransition(false);
+
     layerTransaction.setContentsSize(frameView->contentsSize());
     layerTransaction.setScrollOrigin(frameView->scrollOrigin());
     layerTransaction.setPageScaleFactor(corePage()->pageScaleFactor());


### PR DESCRIPTION
#### 090f0fa067e5ecc8254389d02c019381b352a811
<pre>
[view-transitions] Prevent async scrolling while a view-transition is active.
<a href="https://bugs.webkit.org/show_bug.cgi?id=273612">https://bugs.webkit.org/show_bug.cgi?id=273612</a>
&lt;<a href="https://rdar.apple.com/127797661">rdar://127797661</a>&gt;

Reviewed by NOBODY (OOPS!).

During rendering suppression, we don&apos;t want any rendering updates, so prevent
async scrolling from causing any and send the mouse events to the WebProcess.

During the animation phase, the &apos;real&apos; layers for captured elements are parented
under their pseudo element as if they were a captured snapshot. This confuses
the async scrolling tree. Skip async scrolling for this too, and let the
RenderLayer tree (which doesn&apos;t have the reparenting) handle the events
correctly.

We can&apos;t use the existing methods of forcing synchronous scrolling, since
these still update the UI-side layers and just block for a limited time
waiting for a WebContent process response. This instead adds a view transition
specific (to prevent other consumers) way of skipping the scroll thread handling
entirely.

It also disables RemoteScrollingCoordinator::willStartRenderingUpdate to prevent
any scrolling trees from being created, and invalidates all layers at the start/end
to ensure these get rebuilt afterwards.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateRendering):
* Source/WebCore/page/Page.h:
(WebCore::Page::hasActiveViewTransition const):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::coordinatedScrollingRolesForLayer const):
(WebCore::RenderLayerCompositor::updateScrollCoordinationForLayer):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
(WebKit::RemoteLayerTreeTransaction::hasActiveViewTransition const):
(WebKit::RemoteLayerTreeTransaction::setHasActiveViewTransition):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.mm:
(WebKit::RemoteLayerTreeTransaction::description const):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::didCommitLayerTree):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::handleWheelEvent):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm:
(WebKit::RemoteScrollingCoordinator::coordinatesScrollingForFrameView const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::willCommitLayerTree):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/090f0fa067e5ecc8254389d02c019381b352a811

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56526 "Failed to checkout and rebase branch from PR 29520") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35852 "Failed to checkout and rebase branch from PR 29520") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8998 "Failed to checkout and rebase branch from PR 29520") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60137 "Failed to checkout and rebase branch from PR 29520") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6966 "Failed to checkout and rebase branch from PR 29520") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58653 "Failed to checkout and rebase branch from PR 29520") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43474 "Failed to checkout and rebase branch from PR 29520") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7158 "Failed to checkout and rebase branch from PR 29520") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/60137 "Failed to checkout and rebase branch from PR 29520") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/59/builds/6966 "Failed to checkout and rebase branch from PR 29520") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58556 "Failed to checkout and rebase branch from PR 29520") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/43474 "Failed to checkout and rebase branch from PR 29520") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/8998 "Failed to checkout and rebase branch from PR 29520") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/60137 "Failed to checkout and rebase branch from PR 29520") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/43474 "Failed to checkout and rebase branch from PR 29520") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/8998 "Failed to checkout and rebase branch from PR 29520") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5970 "Failed to checkout and rebase branch from PR 29520") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/43474 "Failed to checkout and rebase branch from PR 29520") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/8998 "Failed to checkout and rebase branch from PR 29520") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61820 "Failed to checkout and rebase branch from PR 29520") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/434 "Failed to checkout and rebase branch from PR 29520") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/7158 "Failed to checkout and rebase branch from PR 29520") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/61820 "Failed to checkout and rebase branch from PR 29520") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/435 "Failed to checkout and rebase branch from PR 29520") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/8998 "Failed to checkout and rebase branch from PR 29520") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/61820 "Failed to checkout and rebase branch from PR 29520") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31680 "Failed to checkout and rebase branch from PR 29520") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32767 "Failed to checkout and rebase branch from PR 29520") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33851 "Failed to checkout and rebase branch from PR 29520") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32513 "Failed to checkout and rebase branch from PR 29520") | | | 
<!--EWS-Status-Bubble-End-->