### PR TITLE
Enable GraphicsContext filters for Canvas filter

### DIFF
--- a/Source/WebCore/html/canvas/CanvasLayerContextSwitcher.cpp
+++ b/Source/WebCore/html/canvas/CanvasLayerContextSwitcher.cpp
@@ -39,10 +39,6 @@ RefPtr<CanvasLayerContextSwitcher> CanvasLayerContextSwitcher::create(CanvasRend
     if (!effectiveDrawingContext)
         return nullptr;
 
-    // FIXME: Disable GraphicsContext filters for now. The CG coordinates need to be flipped before applying the style.
-    if (filter)
-        filter->setFilterRenderingModes(filter->filterRenderingModes() - FilterRenderingMode::GraphicsContext);
-
     auto targetSwitcher = GraphicsContextSwitcher::create(*effectiveDrawingContext, bounds, context.colorSpace(), WTFMove(filter));
     if (!targetSwitcher)
         return nullptr;

--- a/Source/WebCore/platform/graphics/GraphicsContextSwitcher.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextSwitcher.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 std::unique_ptr<GraphicsContextSwitcher> GraphicsContextSwitcher::create(GraphicsContext& destinationContext, const FloatRect &sourceImageRect, const DestinationColorSpace& colorSpace, RefPtr<Filter>&& filter, FilterResults* results)
 {
     if (filter && filter->filterRenderingModes().contains(FilterRenderingMode::GraphicsContext))
-        return makeUnique<TransparencyLayerContextSwitcher>(sourceImageRect, WTFMove(filter));
+        return makeUnique<TransparencyLayerContextSwitcher>(destinationContext, sourceImageRect, WTFMove(filter));
     return makeUnique<ImageBufferContextSwitcher>(destinationContext, sourceImageRect, colorSpace, WTFMove(filter), results);
 }
 

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -351,7 +351,7 @@ RefPtr<NativeImage> ImageBuffer::filteredNativeImage(Filter& filter, Function<vo
     std::unique_ptr<GraphicsContextSwitcher> targetSwitcher;
 
     if (filter.filterRenderingModes().contains(FilterRenderingMode::GraphicsContext)) {
-        targetSwitcher = makeUnique<TransparencyLayerContextSwitcher>(FloatRect { { }, logicalSize() }, &filter);
+        targetSwitcher = makeUnique<TransparencyLayerContextSwitcher>(context(), FloatRect { { }, logicalSize() }, &filter);
         if (!targetSwitcher)
             return nullptr;
         targetSwitcher->beginDrawSourceImage(context());

--- a/Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.cpp
+++ b/Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.cpp
@@ -31,11 +31,11 @@
 
 namespace WebCore {
 
-TransparencyLayerContextSwitcher::TransparencyLayerContextSwitcher(const FloatRect& sourceImageRect, RefPtr<Filter>&& filter)
+TransparencyLayerContextSwitcher::TransparencyLayerContextSwitcher(GraphicsContext& destinationContext, const FloatRect& sourceImageRect, RefPtr<Filter>&& filter)
     : GraphicsContextSwitcher(WTFMove(filter))
 {
     if (m_filter)
-        m_filterStyles = m_filter->createFilterStyles(sourceImageRect);
+        m_filterStyles = m_filter->createFilterStyles(destinationContext, sourceImageRect);
 }
 
 void TransparencyLayerContextSwitcher::beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect&, const FloatRect& clipRect)

--- a/Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.h
+++ b/Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.h
@@ -33,7 +33,7 @@ namespace WebCore {
 class TransparencyLayerContextSwitcher : public GraphicsContextSwitcher {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    TransparencyLayerContextSwitcher(const FloatRect &sourceImageRect, RefPtr<Filter>&&);
+    TransparencyLayerContextSwitcher(GraphicsContext& destinationContext, const FloatRect &sourceImageRect, RefPtr<Filter>&&);
 
 private:
     void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect& clipRect) override;

--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
@@ -158,7 +158,7 @@ std::unique_ptr<FilterEffectApplier> FEColorMatrix::createSoftwareApplier() cons
 #endif
 }
 
-std::optional<GraphicsStyle> FEColorMatrix::createGraphicsStyle(const Filter&) const
+std::optional<GraphicsStyle> FEColorMatrix::createGraphicsStyle(GraphicsContext&, const Filter&) const
 {
     std::array<float, 20> values;
     std::copy_n(m_values.begin(), std::min<size_t>(m_values.size(), 20), values.begin());

--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
@@ -62,7 +62,7 @@ private:
 
     std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const override;
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
-    std::optional<GraphicsStyle> createGraphicsStyle(const Filter&) const override;
+    std::optional<GraphicsStyle> createGraphicsStyle(GraphicsContext&, const Filter&) const override;
 
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const override;
 

--- a/Source/WebCore/platform/graphics/filters/FEDropShadow.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEDropShadow.cpp
@@ -25,6 +25,7 @@
 #include "FEDropShadowSoftwareApplier.h"
 #include "FEGaussianBlur.h"
 #include "Filter.h"
+#include "GraphicsContext.h"
 #include <wtf/text/TextStream.h>
 
 #if USE(SKIA)
@@ -149,11 +150,11 @@ OptionSet<FilterRenderingMode> FEDropShadow::supportedFilterRenderingModes() con
     return modes;
 }
 
-std::optional<GraphicsStyle> FEDropShadow::createGraphicsStyle(const Filter& filter) const
+std::optional<GraphicsStyle> FEDropShadow::createGraphicsStyle(GraphicsContext& context, const Filter& filter) const
 {
     ASSERT(m_stdX == m_stdY);
 
-    auto offset = filter.resolvedSize({ m_dx, m_dy });
+    auto offset = filter.resolvedSize(context.platformShadowOffset({ m_dx, m_dy }));
     auto radius = FEGaussianBlur::calculateUnscaledKernelSize(filter.resolvedSize({ m_stdX, m_stdY }));
 
     return GraphicsDropShadow { offset, static_cast<float>(radius.width()), m_shadowColor, ShadowRadiusMode::Default, m_shadowOpacity };

--- a/Source/WebCore/platform/graphics/filters/FEDropShadow.h
+++ b/Source/WebCore/platform/graphics/filters/FEDropShadow.h
@@ -66,7 +66,7 @@ private:
 
     std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const override;
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
-    std::optional<GraphicsStyle> createGraphicsStyle(const Filter&) const override;
+    std::optional<GraphicsStyle> createGraphicsStyle(GraphicsContext&, const Filter&) const override;
 
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const override;
 

--- a/Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp
@@ -185,7 +185,7 @@ std::unique_ptr<FilterEffectApplier> FEGaussianBlur::createSoftwareApplier() con
     return FilterEffectApplier::create<FEGaussianBlurSoftwareApplier>(*this);
 }
 
-std::optional<GraphicsStyle> FEGaussianBlur::createGraphicsStyle(const Filter& filter) const
+std::optional<GraphicsStyle> FEGaussianBlur::createGraphicsStyle(GraphicsContext&, const Filter& filter) const
 {
     auto radius = calculateUnscaledKernelSize(filter.resolvedSize({ m_stdX, m_stdY }));
     return GraphicsGaussianBlur { radius };

--- a/Source/WebCore/platform/graphics/filters/FEGaussianBlur.h
+++ b/Source/WebCore/platform/graphics/filters/FEGaussianBlur.h
@@ -61,7 +61,7 @@ private:
 
     std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const override;
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
-    std::optional<GraphicsStyle> createGraphicsStyle(const Filter&) const override;
+    std::optional<GraphicsStyle> createGraphicsStyle(GraphicsContext&, const Filter&) const override;
 
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const override;
 

--- a/Source/WebCore/platform/graphics/filters/Filter.cpp
+++ b/Source/WebCore/platform/graphics/filters/Filter.cpp
@@ -121,10 +121,10 @@ RefPtr<FilterImage> Filter::apply(ImageBuffer* sourceImage, const FloatRect& sou
     return result;
 }
 
-FilterStyleVector Filter::createFilterStyles(const FloatRect& sourceImageRect) const
+FilterStyleVector Filter::createFilterStyles(GraphicsContext& context, const FloatRect& sourceImageRect) const
 {
     auto input = FilterStyle { std::nullopt, m_filterRegion, sourceImageRect };
-    auto result = createFilterStyles(input);
+    auto result = createFilterStyles(context, input);
     if (result.isEmpty())
         return { };
 

--- a/Source/WebCore/platform/graphics/filters/Filter.h
+++ b/Source/WebCore/platform/graphics/filters/Filter.h
@@ -66,14 +66,14 @@ public:
     bool clampFilterRegionIfNeeded();
 
     WEBCORE_EXPORT RefPtr<FilterImage> apply(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, FilterResults&);
-    WEBCORE_EXPORT FilterStyleVector createFilterStyles(const FloatRect& sourceImageRect) const;
+    WEBCORE_EXPORT FilterStyleVector createFilterStyles(GraphicsContext&, const FloatRect& sourceImageRect) const;
 
 protected:
     Filter(Filter::Type, std::optional<RenderingResourceIdentifier> = std::nullopt);
     Filter(Filter::Type, const FloatSize& filterScale, const FloatRect& filterRegion = { }, std::optional<RenderingResourceIdentifier> = std::nullopt);
 
     virtual RefPtr<FilterImage> apply(FilterImage* sourceImage, FilterResults&) = 0;
-    virtual FilterStyleVector createFilterStyles(const FilterStyle& sourceStyle) const = 0;
+    virtual FilterStyleVector createFilterStyles(GraphicsContext&, const FilterStyle& sourceStyle) const = 0;
 
 private:
     OptionSet<FilterRenderingMode> m_filterRenderingModes { FilterRenderingMode::Software };

--- a/Source/WebCore/platform/graphics/filters/FilterEffect.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterEffect.cpp
@@ -191,19 +191,19 @@ RefPtr<FilterImage> FilterEffect::apply(const Filter& filter, const FilterImageV
     return result;
 }
 
-FilterStyleVector FilterEffect::createFilterStyles(const Filter& filter, const FilterStyle& input) const
+FilterStyleVector FilterEffect::createFilterStyles(GraphicsContext& context, const Filter& filter, const FilterStyle& input) const
 {
-    return { createFilterStyle(filter, input) };
+    return { createFilterStyle(context, filter, input) };
 }
 
-FilterStyle FilterEffect::createFilterStyle(const Filter& filter, const FilterStyle& input, const std::optional<FilterEffectGeometry>& geometry) const
+FilterStyle FilterEffect::createFilterStyle(GraphicsContext& context, const Filter& filter, const FilterStyle& input, const std::optional<FilterEffectGeometry>& geometry) const
 {
     ASSERT(supportedFilterRenderingModes().contains(FilterRenderingMode::GraphicsContext));
 
     auto primitiveSubregion = calculatePrimitiveSubregion(filter, { &input.primitiveSubregion, 1 }, geometry);
     auto imageRect = calculateImageRect(filter, { &input.imageRect, 1 }, primitiveSubregion);
 
-    auto style = createGraphicsStyle(filter);
+    auto style = createGraphicsStyle(context, filter);
     return FilterStyle { style, primitiveSubregion, imageRect };
 }
 

--- a/Source/WebCore/platform/graphics/filters/FilterEffect.h
+++ b/Source/WebCore/platform/graphics/filters/FilterEffect.h
@@ -50,7 +50,7 @@ public:
     FilterImageVector takeImageInputs(FilterImageVector& stack) const;
 
     RefPtr<FilterImage> apply(const Filter&, const FilterImageVector& inputs, FilterResults&, const std::optional<FilterEffectGeometry>& = std::nullopt);
-    FilterStyle createFilterStyle(const Filter&, const FilterStyle& input, const std::optional<FilterEffectGeometry>& = std::nullopt) const;
+    FilterStyle createFilterStyle(GraphicsContext&, const Filter&, const FilterStyle& input, const std::optional<FilterEffectGeometry>& = std::nullopt) const;
 
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const override;
 
@@ -85,10 +85,10 @@ protected:
 
     virtual std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const { return nullptr; }
     virtual std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const = 0;
-    virtual std::optional<GraphicsStyle> createGraphicsStyle(const Filter&) const { return std::nullopt; }
+    virtual std::optional<GraphicsStyle> createGraphicsStyle(GraphicsContext&, const Filter&) const { return std::nullopt; }
 
     RefPtr<FilterImage> apply(const Filter&, FilterImage& input, FilterResults&) override;
-    FilterStyleVector createFilterStyles(const Filter&, const FilterStyle& input) const override;
+    FilterStyleVector createFilterStyles(GraphicsContext&, const Filter&, const FilterStyle& input) const override;
 
     DestinationColorSpace m_operatingColorSpace { DestinationColorSpace::SRGB() };
 };

--- a/Source/WebCore/platform/graphics/filters/FilterFunction.h
+++ b/Source/WebCore/platform/graphics/filters/FilterFunction.h
@@ -43,6 +43,7 @@ namespace WebCore {
 
 class Filter;
 class FilterResults;
+class GraphicsContext;
 
 enum class FilterRepresentation : uint8_t {
     TestOutput,
@@ -94,7 +95,7 @@ public:
 
     virtual OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const { return FilterRenderingMode::Software; }
     virtual RefPtr<FilterImage> apply(const Filter&, FilterImage&, FilterResults&) { return nullptr; }
-    virtual FilterStyleVector createFilterStyles(const Filter&, const FilterStyle&) const { return { }; }
+    virtual FilterStyleVector createFilterStyles(GraphicsContext&, const Filter&, const FilterStyle&) const { return { }; }
 
     virtual WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation = FilterRepresentation::TestOutput) const = 0;
 

--- a/Source/WebCore/rendering/CSSFilter.cpp
+++ b/Source/WebCore/rendering/CSSFilter.cpp
@@ -354,7 +354,7 @@ RefPtr<FilterImage> CSSFilter::apply(FilterImage* sourceImage, FilterResults& re
     return result;
 }
 
-FilterStyleVector CSSFilter::createFilterStyles(const FilterStyle& sourceStyle) const
+FilterStyleVector CSSFilter::createFilterStyles(GraphicsContext& context, const FilterStyle& sourceStyle) const
 {
     ASSERT(supportedFilterRenderingModes().contains(FilterRenderingMode::GraphicsContext));
 
@@ -365,7 +365,7 @@ FilterStyleVector CSSFilter::createFilterStyles(const FilterStyle& sourceStyle) 
         if (function->filterType() == FilterEffect::Type::SourceGraphic)
             continue;
 
-        auto result = function->createFilterStyles(*this, lastStyle);
+        auto result = function->createFilterStyles(context, *this, lastStyle);
         if (result.isEmpty())
             return { };
 

--- a/Source/WebCore/rendering/CSSFilter.h
+++ b/Source/WebCore/rendering/CSSFilter.h
@@ -51,7 +51,7 @@ public:
     FilterEffectVector effectsOfType(FilterFunction::Type) const final;
 
     RefPtr<FilterImage> apply(FilterImage* sourceImage, FilterResults&) final;
-    FilterStyleVector createFilterStyles(const FilterStyle& sourceStyle) const final;
+    FilterStyleVector createFilterStyles(GraphicsContext&, const FilterStyle& sourceStyle) const final;
 
     static bool isIdentity(RenderElement&, const FilterOperations&);
     static IntOutsets calculateOutsets(RenderElement&, const FilterOperations&, const FloatRect& targetBoundingBox);

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
@@ -326,12 +326,12 @@ RefPtr<FilterImage> SVGFilter::apply(FilterImage* sourceImage, FilterResults& re
     return stack.takeLast();
 }
 
-FilterStyleVector SVGFilter::createFilterStyles(const Filter&, const FilterStyle& sourceStyle) const
+FilterStyleVector SVGFilter::createFilterStyles(GraphicsContext& context, const Filter&, const FilterStyle& sourceStyle) const
 {
-    return createFilterStyles(sourceStyle);
+    return createFilterStyles(context, sourceStyle);
 }
 
-FilterStyleVector SVGFilter::createFilterStyles(const FilterStyle& sourceStyle) const
+FilterStyleVector SVGFilter::createFilterStyles(GraphicsContext& context, const FilterStyle& sourceStyle) const
 {
     ASSERT(!m_expression.isEmpty());
     ASSERT(supportedFilterRenderingModes().contains(FilterRenderingMode::GraphicsContext));
@@ -347,7 +347,7 @@ FilterStyleVector SVGFilter::createFilterStyles(const FilterStyle& sourceStyle) 
             continue;
         
         ASSERT(effect->numberOfImageInputs() == 1);
-        auto style = effect->createFilterStyle(*this, lastStyle, geometry);
+        auto style = effect->createFilterStyle(context, *this, lastStyle, geometry);
 
         lastStyle = style;
         styles.append(style);

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.h
@@ -57,7 +57,7 @@ public:
     WEBCORE_EXPORT void mergeEffects(const FilterEffectVector&);
 
     RefPtr<FilterImage> apply(FilterImage* sourceImage, FilterResults&) final;
-    FilterStyleVector createFilterStyles(const FilterStyle& sourceStyle) const final;
+    FilterStyleVector createFilterStyles(GraphicsContext&, const FilterStyle& sourceStyle) const final;
 
     static FloatSize calculateResolvedSize(const FloatSize&, const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits);
 
@@ -78,7 +78,7 @@ private:
     OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const final;
 
     RefPtr<FilterImage> apply(const Filter&, FilterImage& sourceImage, FilterResults&) final;
-    FilterStyleVector createFilterStyles(const Filter&, const FilterStyle& sourceStyle) const final;
+    FilterStyleVector createFilterStyles(GraphicsContext&, const Filter&, const FilterStyle& sourceStyle) const final;
 
     FloatRect m_targetBoundingBox;
     SVGUnitTypes::SVGUnitType m_primitiveUnits;


### PR DESCRIPTION
#### 8e66e149a07d0c405a6ab569513ca1e4692bbb6e
<pre>
Enable GraphicsContext filters for Canvas filter
<a href="https://bugs.webkit.org/show_bug.cgi?id=275134">https://bugs.webkit.org/show_bug.cgi?id=275134</a>
<a href="https://rdar.apple.com/129249264">rdar://129249264</a>

Reviewed by Dan Glastonbury.

If the destination context has shadowsIgnoreTransforms() true, the sign of drop-
shadow vertical offset has to be flipped when creating GraphicsDropShadow style.

The destination GraphicsContext has to be passed all the way from
TransparencyLayerContextSwitcher till FEDropShadow::createGraphicsStyle().

* Source/WebCore/html/canvas/CanvasLayerContextSwitcher.cpp:
(WebCore::CanvasLayerContextSwitcher::create):
* Source/WebCore/platform/graphics/GraphicsContextSwitcher.cpp:
(WebCore::GraphicsContextSwitcher::create):
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::ImageBuffer::filteredNativeImage):
* Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.cpp:
(WebCore::TransparencyLayerContextSwitcher::TransparencyLayerContextSwitcher):
* Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.h:
* Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp:
(WebCore::FEColorMatrix::createGraphicsStyle const):
* Source/WebCore/platform/graphics/filters/FEColorMatrix.h:
* Source/WebCore/platform/graphics/filters/FEDropShadow.cpp:
(WebCore::FEDropShadow::createGraphicsStyle const):
(WebCore::FEDropShadow::createAcceleratedApplier const): Deleted.
(WebCore::FEDropShadow::createSoftwareApplier const): Deleted.
(WebCore::FEDropShadow::externalRepresentation const): Deleted.
* Source/WebCore/platform/graphics/filters/FEDropShadow.h:
* Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp:
(WebCore::FEGaussianBlur::createGraphicsStyle const):
* Source/WebCore/platform/graphics/filters/FEGaussianBlur.h:
* Source/WebCore/platform/graphics/filters/Filter.cpp:
(WebCore::Filter::createFilterStyles const):
* Source/WebCore/platform/graphics/filters/Filter.h:
* Source/WebCore/platform/graphics/filters/FilterEffect.cpp:
(WebCore::FilterEffect::createFilterStyles const):
(WebCore::FilterEffect::createFilterStyle const):
* Source/WebCore/platform/graphics/filters/FilterEffect.h:
(WebCore::FilterEffect::createGraphicsStyle const):
* Source/WebCore/platform/graphics/filters/FilterFunction.h:
(WebCore::FilterFunction::createFilterStyles const):
* Source/WebCore/rendering/CSSFilter.cpp:
(WebCore::CSSFilter::createFilterStyles const):
* Source/WebCore/rendering/CSSFilter.h:
* Source/WebCore/svg/graphics/filters/SVGFilter.cpp:
(WebCore::SVGFilter::createFilterStyles const):
* Source/WebCore/svg/graphics/filters/SVGFilter.h:

Canonical link: <a href="https://commits.webkit.org/280195@main">https://commits.webkit.org/280195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfe866e14400df80e53b32ddf2603f470bf90efc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58934 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6367 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58061 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6563 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45043 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4400 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57964 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48229 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26181 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29935 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5557 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4510 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51903 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5828 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60521 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5948 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52471 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48298 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51994 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12404 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31088 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32172 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33254 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31920 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->