### PR TITLE
Web Inspector: remove duplicate for (let j = 0; j < properties.length; ++j) in _associateRelatedProperties(styles, propertyNameToEffectiveProperty)

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
@@ -946,41 +946,31 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
         }
     }
 
-    _associateRelatedProperties(styles, propertyNameToEffectiveProperty)
-    {
-        for (var i = 0; i < styles.length; ++i) {
-            var properties = styles[i].enabledProperties;
+    _associateRelatedProperties(styles, propertyNameToEffectiveProperty) {
+        for (let i = 0; i < styles.length; ++i) {
+            const properties = styles[i].enabledProperties;
+            const knownShorthands = {};
 
-            var knownShorthands = {};
-
-            for (var j = 0; j < properties.length; ++j) {
-                var property = properties[j];
+            for (let j = 0; j < properties.length; ++j) {
+                const property = properties[j];
 
                 if (!property.valid)
                     continue;
 
-                if (!WI.CSSKeywordCompletions.LonghandNamesForShorthandProperty.has(property.name))
-                    continue;
-
-                if (knownShorthands[property.canonicalName] && !knownShorthands[property.canonicalName].overridden) {
-                    console.assert(property.overridden);
-                    continue;
-                }
+                if (WI.CSSKeywordCompletions.LonghandNamesForShorthandProperty.has(property.name)) {
+                    if (knownShorthands[property.canonicalName] && !knownShorthands[property.canonicalName].overridden) {
+                        console.assert(property.overridden);
+                        continue;
+                    }
 
                 knownShorthands[property.canonicalName] = property;
             }
 
-            for (var j = 0; j < properties.length; ++j) {
-                var property = properties[j];
-
-                if (!property.valid)
-                    continue;
-
-                var shorthandProperty = null;
+                let shorthandProperty = null;
 
                 if (!isEmptyObject(knownShorthands)) {
-                    var possibleShorthands = WI.CSSKeywordCompletions.ShorthandNamesForLongHandProperty.get(property.canonicalName) || [];
-                    for (var k = 0; k < possibleShorthands.length; ++k) {
+                    const possibleShorthands = WI.CSSKeywordCompletions.ShorthandNamesForLongHandProperty.get(property.canonicalName) || [];
+                    for (let k = 0; k < possibleShorthands.length; ++k) {
                         if (possibleShorthands[k] in knownShorthands) {
                             shorthandProperty = knownShorthands[possibleShorthands[k]];
                             break;

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
@@ -964,7 +964,7 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
                     }
 
                 knownShorthands[property.canonicalName] = property;
-            }
+                }
 
                 let shorthandProperty = null;
 


### PR DESCRIPTION
#### 6f54ed8d325b30d16afefb730617245c5ed27dbe
<pre>
Web Inspector: remove duplicate for (let j = 0; j &lt; properties.length; ++j) in _associateRelatedProperties(styles, propertyNameToEffectiveProperty)
<a href="https://bugs.webkit.org/show_bug.cgi?id=275132">https://bugs.webkit.org/show_bug.cgi?id=275132</a>

Reviewed by NOBODY (OOPS!).

I am nesting everything following the first for (var j = 0; j &lt; properties.length; ++j) into it and removing the second (var j = 0; j &lt; properties.length; ++j).

* Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js:
(WI.DOMNodeStyles.prototype._associateRelatedProperties):
</pre>
----------------------------------------------------------------------
#### 741503dd078540a29409230832d8641f6ded1d3f
<pre>
Web Inspector: remove duplicate for (let j = 0; j &lt; properties.length; ++j) in _associateRelatedProperties(styles, propertyNameToEffectiveProperty)
<a href="https://bugs.webkit.org/show_bug.cgi?id=275132">https://bugs.webkit.org/show_bug.cgi?id=275132</a>

Reviewed by NOBODY (OOPS!).

I am nesting everything following the first (let j = 0; j &lt; properties.length; ++j) inside the first (let j = 0; j &lt; properties.length; ++j) and removing the second (let j = 0; j &lt; properties.length; ++j).

* Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js:
(WI.DOMNodeStyles.prototype._associateRelatedProperties):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f54ed8d325b30d16afefb730617245c5ed27dbe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54314 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/33717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57594 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/5045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/41240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/4992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/43982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/5045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56408 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/41240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/47036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25117 "Found 1 new API test failure: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/41240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4358 "Found 1 new test failure: inspector/css/overridden-property.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3189 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/41240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4568 "Found 1 new test failure: inspector/css/overridden-property.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59184 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/29531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/4992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/51407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/30693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47129 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/31666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/30477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->