### PR TITLE
Web Inspector: Create All Fonts Tab in Font Section

### DIFF
--- a/Source/JavaScriptCore/inspector/protocol/CSS.json
+++ b/Source/JavaScriptCore/inspector/protocol/CSS.json
@@ -269,6 +269,21 @@
             ]
         },
         {
+          "id": "FontFace",
+          "type": "object",
+          "description": "A FontFace",
+          "properties": [
+              { "name": "family", "type": "string", "description": "Font Family Name"},
+              { "name": "weight", "type": "string", "description": "Font Stretch"},
+              { "name": "stretch", "type": "string", "description": "Font Family Name"},
+              { "name": "unicodeRange", "type": "string", "description": "Font Unicode Range"},
+              { "name": "featureSettings", "type": "string", "description": "Font Feature Settings"},
+              { "name": "display", "type": "string", "description": "Font Display"},
+              { "name": "sizeAdjust", "type": "string", "description": "Font Size Adjust"},
+              { "name": "loaded", "type": "string", "description": "Font Loaded"}
+          ]
+        },
+        {
             "id": "FontVariationAxis",
             "type": "object",
             "description": "A single variation axis associated with a Font.",
@@ -460,6 +475,14 @@
             "targetTypes": ["page"],
             "returns": [
                 { "name": "fontFamilyNames", "type": "array", "items": { "type": "string" }, "description": "Supported system font families." }
+            ]
+        },
+        {
+            "name": "getCustomFonts",
+            "description": "Returns all loaded fonts (system and custom).",
+            "targetTypes": ["page"],
+            "returns": [
+                { "name": "fontFamilies", "type": "array", "items": { "$ref": "FontFace" }, "description": "Loaded font families." }
             ]
         },
         {

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.h
@@ -112,6 +112,7 @@ public:
     Inspector::Protocol::ErrorStringOr<Ref<Inspector::Protocol::CSS::CSSRule>> addRule(const Inspector::Protocol::CSS::StyleSheetId&, const String& selector);
     Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::CSSPropertyInfo>>> getSupportedCSSProperties();
     Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<String>>> getSupportedSystemFontFamilyNames();
+    Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::CSS::FontFace>>> getCustomFonts();
     Inspector::Protocol::ErrorStringOr<void> forcePseudoState(Inspector::Protocol::DOM::NodeId, Ref<JSON::Array>&& forcedPseudoClasses);
     Inspector::Protocol::ErrorStringOr<void> setLayoutContextTypeChangedMode(Inspector::Protocol::CSS::LayoutContextTypeChangedMode);
 

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -489,6 +489,8 @@ localizedStrings["Create audit:"] = "Create audit:";
 localizedStrings["Current"] = "Current";
 localizedStrings["Current State"] = "Current State";
 localizedStrings["Custom"] = "Custom";
+/* Section title for all custom fonts. */
+localizedStrings["Custom Fonts @ Font Details Sidebar Section"] = "Custom Fonts";
 localizedStrings["DNS"] = "DNS";
 localizedStrings["DOM"] = "DOM";
 localizedStrings["DOM Content Loaded \u2014 %s"] = "DOM Content Loaded \u2014 %s";
@@ -763,6 +765,7 @@ localizedStrings["Fade unexecuted code"] = "Fade unexecuted code";
 localizedStrings["Fail @ Audit Tab - Test Case"] = "Fail";
 localizedStrings["Failed to upgrade"] = "Failed to upgrade";
 localizedStrings["Failure status code"] = "Failure status code";
+localizedStrings["Family"] = "Family";
 /* Section title for font feature properties. */
 localizedStrings["Feature Properties @ Font Details Sidebar Section"] = "Feature Properties";
 /* Resource loaded via 'fetch' method */
@@ -1010,6 +1013,7 @@ localizedStrings["Live Activity"] = "Live Activity";
 localizedStrings["Live Size"] = "Live Size";
 localizedStrings["Load \u2014 %s"] = "Load \u2014 %s";
 localizedStrings["Load cancelled"] = "Load cancelled";
+localizedStrings["Loaded"] = "Loaded";
 localizedStrings["Loaded in %s"] = "Loaded in %s";
 localizedStrings["Loading for %s"] = "Loading for %s";
 localizedStrings["Local File"] = "Local File";
@@ -1124,6 +1128,8 @@ localizedStrings["No Canvas Selected"] = "No Canvas Selected";
 localizedStrings["No Chart Available"] = "No Chart Available";
 localizedStrings["No Child Layers"] = "No Child Layers";
 localizedStrings["No Console Snippets"] = "No Console Snippets";
+/* Message shown when there are no custom fonts. */
+localizedStrings["No Custom Fonts @ Font Details Sidebar Property"] = "No Custom Fonts";
 localizedStrings["No Data Bindings"] = "No Data Bindings";
 localizedStrings["No Enabled Audits"] = "No Enabled Audits";
 localizedStrings["No Entries"] = "No Entries";
@@ -1667,8 +1673,10 @@ localizedStrings["Stopping the \u201C%s\u201D audit"] = "Stopping the \u201C%s\u
 localizedStrings["Storage"] = "Storage";
 /* Name of Storage Tab */
 localizedStrings["Storage Tab Name"] = "Storage";
+localizedStrings["Stretch"] = "Stretch";
 /* Property title for `font-stretch`. */
 localizedStrings["Stretch @ Font Details Sidebar Property"] = "Stretch";
+localizedStrings["Style"] = "Style";
 /* Property title for `font-style`. */
 localizedStrings["Style @ Font Details Sidebar Property"] = "Style";
 /* CSS properties defined via HTML style attribute */
@@ -1977,6 +1985,7 @@ localizedStrings["WebP"] = "WebP";
 localizedStrings["WebRTC"] = "WebRTC";
 localizedStrings["WebRTC Logging:"] = "WebRTC Logging:";
 localizedStrings["WebSocket Connection Established"] = "WebSocket Connection Established";
+localizedStrings["Weight"] = "Weight";
 /* Property title for `font-weight` and `wght` variation axis. */
 localizedStrings["Weight @ Font Details Sidebar Property"] = "Weight";
 localizedStrings["Whitespace characters"] = "Whitespace characters";

--- a/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2024 Frances Cornwall.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -316,8 +317,6 @@ WI.CSSManager = class CSSManager extends WI.Object
 
     get defaultUserPreferences() { return this._defaultUserPreferences; }
 
-    get overriddenUserPreferences() { return this._overriddenUserPreferences; }
-
     get preferredColorFormat()
     {
         return this._colorFormatSetting.value;
@@ -437,20 +436,16 @@ WI.CSSManager = class CSSManager extends WI.Object
         if (!name || name.length < 4 || name.charAt(0) !== "-")
             return false;
 
-        var match = name.match(/^(?:-moz-|-ms-|-o-|-epub-)/);
+        let match = name.match(/^(?:-moz-|-ms-|-o-|-epub-)/);
         if (!match)
             return false;
-
-        return true;
     }
 
     propertyValueHasOtherVendorKeyword(value)
     {
-        var match = value.match(/(?:-moz-|-ms-|-o-|-epub-)[-\w]+/);
+        let match = value.match(/(?:-moz-|-ms-|-o-|-epub-)[-\w]+/);
         if (!match)
             return false;
-
-        return true;
     }
 
     canonicalNameForPropertyName(name)
@@ -459,7 +454,7 @@ WI.CSSManager = class CSSManager extends WI.Object
             return name;
 
         // Keep in sync with prefix list from Source/WebInspectorUI/Scripts/update-inspector-css-documentation
-        var match = name.match(/^(?:-webkit-|-khtml-|-apple-)(.+)/);
+        let match = name.match(/^(?:-webkit-|-khtml-|-apple-)(.+)/);
         if (!match)
             return name;
 
@@ -482,7 +477,7 @@ WI.CSSManager = class CSSManager extends WI.Object
         if (node.id in this._nodeStylesMap)
             return this._nodeStylesMap[node.id];
 
-        var styles = new WI.DOMNodeStyles(node);
+        let styles = new WI.DOMNodeStyles(node);
         this._nodeStylesMap[node.id] = styles;
         return styles;
     }
@@ -494,7 +489,7 @@ WI.CSSManager = class CSSManager extends WI.Object
 
     preferredInspectorStyleSheetForFrame(frame, callback)
     {
-        var inspectorStyleSheets = this.inspectorStyleSheetsForFrame(frame);
+        let inspectorStyleSheets = this.inspectorStyleSheetsForFrame(frame);
         for (let styleSheet of inspectorStyleSheets) {
             if (styleSheet[WI.CSSManager.PreferredInspectorStyleSheetSymbol]) {
                 callback(styleSheet);
@@ -589,13 +584,13 @@ WI.CSSManager = class CSSManager extends WI.Object
 
     mediaQueryResultChanged()
     {
-        for (var key in this._nodeStylesMap)
+        for (let key in this._nodeStylesMap)
             this._nodeStylesMap[key].mediaQueryResultDidChange();
     }
 
     styleSheetChanged(styleSheetIdentifier)
     {
-        var styleSheet = this.styleSheetForIdentifier(styleSheetIdentifier);
+        let styleSheet = this.styleSheetForIdentifier(styleSheetIdentifier);
         console.assert(styleSheet);
 
         // Do not observe inline styles
@@ -635,10 +630,10 @@ WI.CSSManager = class CSSManager extends WI.Object
 
     _nodePseudoClassesDidChange(event)
     {
-        var node = event.target;
+        let node = event.target;
 
-        for (var key in this._nodeStylesMap) {
-            var nodeStyles = this._nodeStylesMap[key];
+        for (let key in this._nodeStylesMap) {
+            let nodeStyles = this._nodeStylesMap[key];
             if (nodeStyles.node !== node && !nodeStyles.node.isDescendant(node))
                 continue;
             nodeStyles.pseudoClassesDidChange(node);
@@ -647,10 +642,10 @@ WI.CSSManager = class CSSManager extends WI.Object
 
     _nodeAttributesDidChange(event)
     {
-        var node = event.target;
+        let node = event.target;
 
-        for (var key in this._nodeStylesMap) {
-            var nodeStyles = this._nodeStylesMap[key];
+        for (let key in this._nodeStylesMap) {
+            let nodeStyles = this._nodeStylesMap[key];
             if (nodeStyles.node !== node && !nodeStyles.node.isDescendant(node))
                 continue;
             nodeStyles.attributeDidChange(node, event.data.name);
@@ -685,7 +680,7 @@ WI.CSSManager = class CSSManager extends WI.Object
     {
         console.assert(event.target instanceof WI.Frame);
 
-        var resource = event.data.resource;
+        let resource = event.data.resource;
         console.assert(resource);
 
         if (resource.type !== WI.Resource.Type.StyleSheet)
@@ -698,7 +693,7 @@ WI.CSSManager = class CSSManager extends WI.Object
     {
         console.assert(event.target instanceof WI.Resource);
 
-        var resource = event.target;
+        let resource = event.target;
         if (resource.type !== WI.Resource.Type.StyleSheet)
             return;
 
@@ -773,7 +768,7 @@ WI.CSSManager = class CSSManager extends WI.Object
 
     _resourceContentDidChange(event)
     {
-        var resource = event.target;
+        let resource = event.target;
         if (resource === this._ignoreResourceContentDidChangeEventForResource)
             return;
 

--- a/Source/WebInspectorUI/UserInterface/Views/DataGrid.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DataGrid.js
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2008, 2013-2016 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2024 Frances Cornwall.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -44,7 +45,6 @@ WI.DataGrid = class DataGrid extends WI.View
         this._rows = [];
 
         this.children = [];
-        this.expandNodesWhenArrowing = false;
         this.root = true;
         this.hasChildren = false;
         this.expanded = true;
@@ -134,10 +134,10 @@ WI.DataGrid = class DataGrid extends WI.View
         this.element.appendChild(this._scrollContainerElement);
 
         if (preferredColumnOrder) {
-            for (var columnIdentifier of preferredColumnOrder)
+            for (let columnIdentifier of preferredColumnOrder)
                 this.insertColumn(columnIdentifier, columnsData[columnIdentifier]);
         } else {
-            for (var columnIdentifier in columnsData)
+            for (let columnIdentifier in columnsData)
                 this.insertColumn(columnIdentifier, columnsData[columnIdentifier]);
         }
 
@@ -165,12 +165,12 @@ WI.DataGrid = class DataGrid extends WI.View
 
     static createSortableDataGrid(columnNames, values)
     {
-        var numColumns = columnNames.length;
+        let numColumns = columnNames.length;
         if (!numColumns)
             return null;
 
-        var columnsData = {};
-        for (var columnName of columnNames) {
+        let columnsData = {};
+        for (let columnName of columnNames) {
             columnsData[columnName] = {
                 width: columnName.length,
                 title: columnName,
@@ -179,35 +179,35 @@ WI.DataGrid = class DataGrid extends WI.View
         }
 
         let dataGrid = new WI.DataGrid(columnsData, {preferredColumnOrder: columnNames});
-        for (var i = 0; i < values.length / numColumns; ++i) {
-            var data = {};
-            for (var j = 0; j < columnNames.length; ++j)
+        for (let i = 0; i < values.length / numColumns; ++i) {
+            let data = {};
+            for (let j = 0; j < columnNames.length; ++j)
                 data[columnNames[j]] = values[numColumns * i + j];
 
-            var node = new WI.DataGridNode(data);
+            let node = new WI.DataGridNode(data);
             dataGrid.appendChild(node);
         }
 
         function sortDataGrid()
         {
-            var sortColumnIdentifier = dataGrid.sortColumnIdentifier;
+            let sortColumnIdentifier = dataGrid.sortColumnIdentifier;
 
-            var columnIsNumeric = true;
-            for (var node of dataGrid.children) {
-                var value = dataGrid.textForDataGridNodeColumn(node, sortColumnIdentifier);
+            let columnIsNumeric = true;
+            for (let node of dataGrid.children) {
+                let value = dataGrid.textForDataGridNodeColumn(node, sortColumnIdentifier);
                 if (isNaN(Number(value)))
                     columnIsNumeric = false;
             }
 
             function comparator(dataGridNode1, dataGridNode2)
             {
-                var item1 = dataGrid.textForDataGridNodeColumn(dataGridNode1, sortColumnIdentifier);
-                var item2 = dataGrid.textForDataGridNodeColumn(dataGridNode2, sortColumnIdentifier);
+                let item1 = dataGrid.textForDataGridNodeColumn(dataGridNode1, sortColumnIdentifier);
+                let item2 = dataGrid.textForDataGridNodeColumn(dataGridNode2, sortColumnIdentifier);
 
-                var comparison;
+                let comparison;
                 if (columnIsNumeric) {
-                    var number1 = parseFloat(item1);
-                    var number2 = parseFloat(item2);
+                    let number1 = parseFloat(item1);
+                    let number2 = parseFloat(item2);
                     comparison = number1 < number2 ? -1 : (number1 > number2 ? 1 : 0);
                 } else
                     comparison = item1 < item2 ? -1 : (item1 > item2 ? 1 : 0);
@@ -271,7 +271,7 @@ WI.DataGrid = class DataGrid extends WI.View
         if (!this._sortColumnIdentifier)
             return;
 
-        var sortHeaderCellElement = this._headerTableCellElements.get(this._sortColumnIdentifier);
+        let sortHeaderCellElement = this._headerTableCellElements.get(this._sortColumnIdentifier);
 
         sortHeaderCellElement.classList.toggle(WI.DataGrid.SortColumnAscendingStyleClassName, this._sortOrder === WI.DataGrid.SortOrder.Ascending);
         sortHeaderCellElement.classList.toggle(WI.DataGrid.SortColumnDescendingStyleClassName, this._sortOrder === WI.DataGrid.SortOrder.Descending);
@@ -579,7 +579,7 @@ WI.DataGrid = class DataGrid extends WI.View
 
         this._beforeEditCallback?.(node, this.orderedColumns[columnIndex]);
 
-        var element = this._editingNode.element.children[columnIndex];
+        let element = this._editingNode.element.children[columnIndex];
         WI.startEditing(element, this._startEditingConfig(element));
 
         window.getSelection().setBaseAndExtent(element, 0, element, 1);
@@ -625,12 +625,12 @@ WI.DataGrid = class DataGrid extends WI.View
 
     _editingCommitted(element, newText, oldText, context, moveDirection)
     {
-        var columnIdentifier = element.__columnIdentifier;
-        var columnIndex = this.orderedColumns.indexOf(columnIdentifier);
+        let columnIdentifier = element.__columnIdentifier;
+        let columnIndex = this.orderedColumns.indexOf(columnIdentifier);
 
-        var textBeforeEditing = this._editingNode.data[columnIdentifier] || "";
+        let textBeforeEditing = this._editingNode.data[columnIdentifier] || "";
 
-        var currentEditingNode = this._editingNode;
+        let currentEditingNode = this._editingNode;
         currentEditingNode.data[columnIdentifier] = newText.trim();
 
         // Returns an object with the next node and column index to edit, and whether it
@@ -642,7 +642,7 @@ WI.DataGrid = class DataGrid extends WI.View
                     return {shouldSort: false, editingNode: currentEditingNode, columnIndex: columnIndex + 1};
 
                 // Continue by editing the first column of the next row if it exists.
-                var nextDataGridNode = currentEditingNode.traverseNextNode(true, null, true);
+                let nextDataGridNode = currentEditingNode.traverseNextNode(true, null, true);
                 return {shouldSort: true, editingNode: nextDataGridNode || currentEditingNode, columnIndex: 0};
             }
 
@@ -650,7 +650,7 @@ WI.DataGrid = class DataGrid extends WI.View
                 if (columnIndex > 0)
                     return {shouldSort: false, editingNode: currentEditingNode, columnIndex: columnIndex - 1};
 
-                var previousDataGridNode = currentEditingNode.traversePreviousNode(true, null, true);
+                let previousDataGridNode = currentEditingNode.traversePreviousNode(true, null, true);
                 return {shouldSort: true, editingNode: previousDataGridNode || currentEditingNode, columnIndex: this.orderedColumns.length - 1};
             }
 
@@ -659,7 +659,7 @@ WI.DataGrid = class DataGrid extends WI.View
         }
 
         function moveToNextCell(valueDidChange) {
-            var moveCommand = determineNextCell.call(this, valueDidChange);
+            let moveCommand = determineNextCell.call(this, valueDidChange);
             if (moveCommand.shouldSort && this._sortAfterEditingCallback) {
                 this._sortAfterEditingCallback();
                 this._sortAfterEditingCallback = null;
@@ -672,7 +672,7 @@ WI.DataGrid = class DataGrid extends WI.View
 
         this._afterEditCallback(currentEditingNode, columnIdentifier, textBeforeEditing, newText, moveDirection);
 
-        var textDidChange = textBeforeEditing.trim() !== newText.trim();
+        let textDidChange = textBeforeEditing.trim() !== newText.trim();
         moveToNextCell.call(this, textDidChange);
     }
 
@@ -690,29 +690,29 @@ WI.DataGrid = class DataGrid extends WI.View
     {
         if (minPercent)
             minPercent = Math.min(minPercent, Math.floor(100 / this.orderedColumns.length));
-        var widths = {};
+        let widths = {};
         // For the first width approximation, use the character length of column titles.
-        for (var [identifier, column] of this.columns)
+        for (let [identifier, column] of this.columns)
             widths[identifier] = (column["title"] || "").length;
 
         // Now approximate the width of each column as max(title, cells).
-        var children = maxDescentLevel ? this._enumerateChildren(this, [], maxDescentLevel + 1) : this.children;
-        for (var node of children) {
-            for (var identifier of this.columns.keys()) {
-                var text = this.textForDataGridNodeColumn(node, identifier);
+        let children = maxDescentLevel ? this._enumerateChildren(this, [], maxDescentLevel + 1) : this.children;
+        for (let node of children) {
+            for (let identifier of this.columns.keys()) {
+                let text = this.textForDataGridNodeColumn(node, identifier);
                 if (text.length > widths[identifier])
                     widths[identifier] = text.length;
             }
         }
 
-        var totalColumnWidths = 0;
-        for (var identifier of this.columns.keys())
+        let totalColumnWidths = 0;
+        for (let identifier of this.columns.keys())
             totalColumnWidths += widths[identifier];
 
         // Compute percentages and clamp desired widths to min and max widths.
-        var recoupPercent = 0;
-        for (var identifier of this.columns.keys()) {
-            var width = Math.round(100 * widths[identifier] / totalColumnWidths);
+        let recoupPercent = 0;
+        for (let identifier of this.columns.keys()) {
+            let width = Math.round(100 * widths[identifier] / totalColumnWidths);
             if (minPercent && width < minPercent) {
                 recoupPercent += minPercent - width;
                 width = minPercent;
@@ -725,7 +725,7 @@ WI.DataGrid = class DataGrid extends WI.View
 
         // If we assigned too much width due to the above, reduce column widths.
         while (minPercent && recoupPercent > 0) {
-            for (var identifier of this.columns.keys()) {
+            for (let identifier of this.columns.keys()) {
                 if (widths[identifier] > minPercent) {
                     --widths[identifier];
                     --recoupPercent;
@@ -737,7 +737,7 @@ WI.DataGrid = class DataGrid extends WI.View
 
         // If extra width remains after clamping widths, expand column widths.
         while (maxPercent && recoupPercent < 0) {
-            for (var identifier of this.columns.keys()) {
+            for (let identifier of this.columns.keys()) {
                 if (widths[identifier] < maxPercent) {
                     ++widths[identifier];
                     ++recoupPercent;
@@ -747,7 +747,7 @@ WI.DataGrid = class DataGrid extends WI.View
             }
         }
 
-        for (var [identifier, column] of this.columns) {
+        for (let [identifier, column] of this.columns) {
             column["element"].style.width = widths[identifier] + "%";
             column["bodyElement"].style.width = widths[identifier] + "%";
         }
@@ -763,14 +763,14 @@ WI.DataGrid = class DataGrid extends WI.View
         insertionIndex = Number.constrain(insertionIndex, 0, this.orderedColumns.length);
 
         // Copy configuration properties instead of keeping a reference to the passed-in object.
-        var column = Object.shallowCopy(columnData);
+        let column = Object.shallowCopy(columnData);
         column["ordinal"] = insertionIndex;
         column["columnIdentifier"] = columnIdentifier;
 
         this.orderedColumns.splice(insertionIndex, 0, columnIdentifier);
 
-        for (var [identifier, existingColumn] of this.columns) {
-            var ordinal = existingColumn["ordinal"];
+        for (let [existingColumn] of this.columns) {
+            let ordinal = existingColumn["ordinal"];
             if (ordinal >= insertionIndex) // Also adjust the "old" column at insertion index.
                 existingColumn["ordinal"] = ordinal + 1;
         }
@@ -779,21 +779,20 @@ WI.DataGrid = class DataGrid extends WI.View
         if (column["disclosure"])
             this.disclosureColumnIdentifier = columnIdentifier;
 
-        var headerColumnElement = document.createElement("col");
+        let headerColumnElement = document.createElement("col");
         if (column["width"])
             headerColumnElement.style.width = column["width"];
         column["element"] = headerColumnElement;
-        var referenceElement = this._headerTableColumnGroupElement.children[insertionIndex];
-        this._headerTableColumnGroupElement.insertBefore(headerColumnElement, referenceElement);
+        let headerReferenceElement = this._headerTableColumnGroupElement.children[insertionIndex];
+        this._headerTableColumnGroupElement.insertBefore(headerColumnElement, headerReferenceElement);
 
-        var headerCellElement = document.createElement("th");
+        let headerCellElement = document.createElement("th");
         headerCellElement.className = columnIdentifier + "-column";
         headerCellElement.columnIdentifier = columnIdentifier;
         if (column["aligned"])
             headerCellElement.classList.add(column["aligned"]);
         this._headerTableCellElements.set(columnIdentifier, headerCellElement);
-        var referenceElement = this._headerTableRowElement.children[insertionIndex];
-        this._headerTableRowElement.insertBefore(headerCellElement, referenceElement);
+        this._headerTableRowElement.insertBefore(headerCellElement, headerReferenceElement);
 
         if (column["headerView"]) {
             let headerView = column["headerView"];
@@ -826,7 +825,7 @@ WI.DataGrid = class DataGrid extends WI.View
 
             headerCellElement.createChild("div", "divider");
 
-            var collapseDiv = headerCellElement.createChild("div", "collapser-button");
+            let collapseDiv = headerCellElement.createChild("div", "collapser-button");
             collapseDiv.title = this._collapserButtonCollapseColumnsToolTip();
             collapseDiv.addEventListener("mouseover", this._mouseoverColumnCollapser.bind(this));
             collapseDiv.addEventListener("mouseout", this._mouseoutColumnCollapser.bind(this));
@@ -838,18 +837,18 @@ WI.DataGrid = class DataGrid extends WI.View
 
         this._headerTableColumnGroupElement.span = this.orderedColumns.length;
 
-        var dataColumnElement = headerColumnElement.cloneNode();
-        var referenceElement = this._dataTableColumnGroupElement.children[insertionIndex];
-        this._dataTableColumnGroupElement.insertBefore(dataColumnElement, referenceElement);
+        let dataColumnElement = headerColumnElement.cloneNode();
+        let dataReferenceElement = this._dataTableColumnGroupElement.children[insertionIndex];
+        this._dataTableColumnGroupElement.insertBefore(dataColumnElement, dataReferenceElement);
         column["bodyElement"] = dataColumnElement;
 
-        var fillerCellElement = document.createElement("td");
+        let fillerCellElement = document.createElement("td");
         fillerCellElement.className = columnIdentifier + "-column";
         fillerCellElement.__columnIdentifier = columnIdentifier;
         if (column["group"])
             fillerCellElement.classList.add("column-group-" + column["group"]);
-        var referenceElement = this._fillerRowElement.children[insertionIndex];
-        this._fillerRowElement.insertBefore(fillerCellElement, referenceElement);
+        let fillerReferenceElement = this._fillerRowElement.children[insertionIndex];
+        this._fillerRowElement.insertBefore(fillerCellElement, fillerReferenceElement);
 
         this.setColumnVisible(columnIdentifier, !column.hidden);
     }
@@ -857,13 +856,13 @@ WI.DataGrid = class DataGrid extends WI.View
     removeColumn(columnIdentifier)
     {
         console.assert(this.columns.has(columnIdentifier));
-        var removedColumn = this.columns.get(columnIdentifier);
+        let removedColumn = this.columns.get(columnIdentifier);
         this.columns.delete(columnIdentifier);
         this.orderedColumns.splice(this.orderedColumns.indexOf(columnIdentifier), 1);
 
-        var removedOrdinal = removedColumn["ordinal"];
-        for (var [identifier, column] of this.columns) {
-            var ordinal = column["ordinal"];
+        let removedOrdinal = removedColumn["ordinal"];
+        for (let [column] of this.columns) {
+            let ordinal = column["ordinal"];
             if (ordinal > removedOrdinal)
                 column["ordinal"] = ordinal - 1;
         }
@@ -882,7 +881,7 @@ WI.DataGrid = class DataGrid extends WI.View
 
         this._headerTableColumnGroupElement.span = this.orderedColumns.length;
 
-        for (var child of this.children)
+        for (let child of this.children)
             child.refresh();
     }
 
@@ -892,7 +891,7 @@ WI.DataGrid = class DataGrid extends WI.View
             result.push(rootNode);
         if (!maxLevel)
             return;
-        for (var i = 0; i < rootNode.children.length; ++i)
+        for (let i = 0; i < rootNode.children.length; ++i)
             this._enumerateChildren(rootNode.children[i], result, maxLevel - 1);
         return result;
     }
@@ -1008,27 +1007,27 @@ WI.DataGrid = class DataGrid extends WI.View
     _positionResizerElements()
     {
         let leadingOffset = 0;
-        var previousResizer = null;
+        let previousResizer = null;
 
         // Make n - 1 resizers for n columns.
-        var numResizers = this.orderedColumns.length - 1;
+        let numResizers = this.orderedColumns.length - 1;
 
         // Calculate leading offsets.
         // Get the width of the cell in the first (and only) row of the
         // header table in order to determine the width of the column, since
         // it is not possible to query a column for its width.
-        var cells = this._headerTableBodyElement.rows[0].cells;
-        var columnWidths = [];
-        for (var i = 0; i < numResizers; ++i) {
+        let cells = this._headerTableBodyElement.rows[0].cells;
+        let columnWidths = [];
+        for (let i = 0; i < numResizers; ++i) {
             leadingOffset += cells[i].getBoundingClientRect().width;
             columnWidths.push(leadingOffset);
         }
 
         // Apply leading offsets.
-        for (var i = 0; i < numResizers; ++i) {
+        for (let i = 0; i < numResizers; ++i) {
             // Create a new resizer if one does not exist for this column.
             // This resizer is associated with the column to its right.
-            var resizer = this.resizers[i];
+            let resizer = this.resizers[i];
             if (!resizer) {
                 resizer = this.resizers[i] = new WI.Resizer(WI.Resizer.RuleOrientation.Vertical, this);
                 this.element.appendChild(resizer.element);
@@ -1210,8 +1209,8 @@ WI.DataGrid = class DataGrid extends WI.View
         if (this.placeholderNode)
             this.placeholderNode.makeNormal();
 
-        var emptyData = {};
-        for (var identifier of this.columns.keys())
+        let emptyData = {};
+        for (let identifier of this.columns.keys())
             emptyData[identifier] = "";
         this.placeholderNode = new WI.PlaceholderDataGridNode(emptyData);
         this.appendChild(this.placeholderNode);
@@ -1248,7 +1247,7 @@ WI.DataGrid = class DataGrid extends WI.View
         delete child._leftPadding;
         child._shouldRefreshChildren = true;
 
-        var current = child.children[0];
+        let current = child.children[0];
         while (current) {
             current.dataGrid = this.dataGrid;
             delete current._depth;
@@ -1307,8 +1306,8 @@ WI.DataGrid = class DataGrid extends WI.View
 
     removeChildren()
     {
-        for (var i = 0; i < this.children.length; ++i) {
-            var child = this.children[i];
+        for (let i = 0; i < this.children.length; ++i) {
+            let child = this.children[i];
             child.deselect();
             child._detach();
 
@@ -1370,7 +1369,7 @@ WI.DataGrid = class DataGrid extends WI.View
             if (bNode.isPlaceholderNode)
                 return -1;
 
-            var reverseFactor = this.sortOrder !== WI.DataGrid.SortOrder.Ascending ? -1 : 1;
+            let reverseFactor = this.sortOrder !== WI.DataGrid.SortOrder.Ascending ? -1 : 1;
             return reverseFactor * comparator(aNode, bNode);
         }
 
@@ -1421,8 +1420,8 @@ WI.DataGrid = class DataGrid extends WI.View
         let expandKeyIdentifier = isRTL ? "Left" : "Right";
         let collapseKeyIdentifier = isRTL ? "Right" : "Left";
 
-        var handled = false;
-        var nextSelectedNode;
+        let handled = false;
+        let nextSelectedNode;
 
         if (this.selectedNode) {
             if (event.keyIdentifier === collapseKeyIdentifier) {
@@ -1536,14 +1535,14 @@ WI.DataGrid = class DataGrid extends WI.View
 
     dataGridNodeFromNode(target)
     {
-        var rowElement = target.closest("tr");
+        let rowElement = target.closest("tr");
         return rowElement && rowElement._dataGridNode;
     }
 
     dataGridNodeFromPoint(x, y)
     {
-        var node = this._dataTableElement.ownerDocument.elementFromPoint(x, y);
-        var rowElement = node.closest("tr");
+        let node = this._dataTableElement.ownerDocument.elementFromPoint(x, y);
+        let rowElement = node.closest("tr");
         return rowElement && rowElement._dataGridNode;
     }
 
@@ -1559,7 +1558,7 @@ WI.DataGrid = class DataGrid extends WI.View
 
     _mouseoverColumnCollapser(event)
     {
-        var cell = event.target.closest("th");
+        let cell = event.target.closest("th");
         if (!cell || !cell.collapsesGroup)
             return;
 
@@ -1568,7 +1567,7 @@ WI.DataGrid = class DataGrid extends WI.View
 
     _mouseoutColumnCollapser(event)
     {
-        var cell = event.target.closest("th");
+        let cell = event.target.closest("th");
         if (!cell || !cell.collapsesGroup)
             return;
 
@@ -1577,7 +1576,7 @@ WI.DataGrid = class DataGrid extends WI.View
 
     _clickInColumnCollapser(event)
     {
-        var cell = event.target.closest("th");
+        let cell = event.target.closest("th");
         if (!cell || !cell.collapsesGroup)
             return;
 
@@ -1589,8 +1588,8 @@ WI.DataGrid = class DataGrid extends WI.View
 
     collapseColumnGroup(columnGroup)
     {
-        var collapserColumnIdentifier = null;
-        for (var [identifier, column] of this.columns) {
+        let collapserColumnIdentifier = null;
+        for (let [identifier, column] of this.columns) {
             if (column["collapsesGroup"] === columnGroup) {
                 collapserColumnIdentifier = identifier;
                 break;
@@ -1601,22 +1600,22 @@ WI.DataGrid = class DataGrid extends WI.View
         if (!collapserColumnIdentifier)
             return;
 
-        var cell = this._headerTableCellElements.get(collapserColumnIdentifier);
+        let cell = this._headerTableCellElements.get(collapserColumnIdentifier);
         this._collapseColumnGroupWithCell(cell);
     }
 
     _collapseColumnGroupWithCell(cell)
     {
-        var columnsWillCollapse = cell.classList.toggle("collapsed");
+        let columnsWillCollapse = cell.classList.toggle("collapsed");
 
         this.willToggleColumnGroup(cell.collapsesGroup, columnsWillCollapse);
 
-        for (var [identifier, column] of this.columns) {
+        for (let [identifier, column] of this.columns) {
             if (column["group"] === cell.collapsesGroup)
                 this.setColumnVisible(identifier, !columnsWillCollapse);
         }
 
-        var collapserButton = cell.querySelector(".collapser-button");
+        let collapserButton = cell.querySelector(".collapser-button");
         if (collapserButton)
             collapserButton.title = columnsWillCollapse ? this._collapserButtonExpandColumnsToolTip() : this._collapserButtonCollapseColumnsToolTip();
 
@@ -1760,7 +1759,7 @@ WI.DataGrid = class DataGrid extends WI.View
 
     _clickInDataTable(event)
     {
-        var gridNode = this.dataGridNodeFromNode(event.target);
+        let gridNode = this.dataGridNodeFromNode(event.target);
         if (!gridNode || !gridNode.hasChildren)
             return;
 
@@ -1782,7 +1781,7 @@ WI.DataGrid = class DataGrid extends WI.View
 
     textForDataGridNodeColumn(node, columnIdentifier)
     {
-        var data = node.data[columnIdentifier];
+        let data = node.data[columnIdentifier];
         return (data instanceof Node ? data.textContent : data) || "";
     }
 
@@ -1893,9 +1892,9 @@ WI.DataGrid = class DataGrid extends WI.View
 
         // Constrain the dragpoint to be within the space made up by the
         // column directly to the left and the column directly to the right.
-        var leftColumnIndex = resizer[WI.DataGrid.PreviousColumnOrdinalSymbol];
-        var rightColumnIndex = resizer[WI.DataGrid.NextColumnOrdinalSymbol];
-        var firstRowCells = this._headerTableBodyElement.rows[0].cells;
+        let leftColumnIndex = resizer[WI.DataGrid.PreviousColumnOrdinalSymbol];
+        let rightColumnIndex = resizer[WI.DataGrid.NextColumnOrdinalSymbol];
+        let firstRowCells = this._headerTableBodyElement.rows[0].cells;
         let leadingEdgeOfPreviousColumn = 0;
         for (let i = 0; i < leftColumnIndex; ++i)
             leadingEdgeOfPreviousColumn += firstRowCells[i].offsetWidth;


### PR DESCRIPTION
#### b6f332bf9b5fc5c853b02114cc98cdf1bd489272
<pre>
Web Inspector: Create All Fonts Tab in Font Section
<a href="https://bugs.webkit.org/show_bug.cgi?id=260127">https://bugs.webkit.org/show_bug.cgi?id=260127</a>

Reviewed by NOBODY (OOPS!).

Co-authored by Brandon Stewart.

We created a Custom Fonts tab to display all of the Custom Fonts in the DOM, and to auto refresh to account for adjusting webpages such as slideshows.
There are parameters font-family name, stretch, style, and loaded, and can sort by each parameter as well.
If there are no custom fonts in the DOM, &quot;No Custom Fonts&quot; will be displayed.

* Source/JavaScriptCore/inspector/protocol/CSS.json:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::getCustomFonts):
* Source/WebCore/inspector/agents/InspectorCSSAgent.h:
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js:
(WI.DOMNodeStyles):
(WI.DOMNodeStyles.prototype.get customFonts):
(WI.DOMNodeStyles.prototype.refresh):
* Source/WebInspectorUI/UserInterface/Views/FontDetailsPanel.js:
(WI.FontDetailsPanel.prototype.update):
(WI.FontDetailsPanel.prototype.initialLayout):
(WI.FontDetailsPanel.prototype._sortDataGrid.comparator):
(WI.FontDetailsPanel.prototype._sortDataGrid):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6f332bf9b5fc5c853b02114cc98cdf1bd489272

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54582 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34001 "Hash b6f332bf for PR 29525 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7154 "Hash b6f332bf for PR 29525 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57863 "Hash b6f332bf for PR 29525 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5316 "Hash b6f332bf for PR 29525 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56884 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41540 "Hash b6f332bf for PR 29525 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5318 "Hash b6f332bf for PR 29525 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/57863 "Hash b6f332bf for PR 29525 does not build (failure)") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/59/builds/5316 "Hash b6f332bf for PR 29525 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56677 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/41540 "Hash b6f332bf for PR 29525 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/7154 "Hash b6f332bf for PR 29525 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/57863 "Hash b6f332bf for PR 29525 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/41540 "Hash b6f332bf for PR 29525 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/7154 "Hash b6f332bf for PR 29525 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3456 "Hash b6f332bf for PR 29525 does not build (failure)") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/47947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/41540 "Hash b6f332bf for PR 29525 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/7154 "Hash b6f332bf for PR 29525 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59453 "Hash b6f332bf for PR 29525 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/54088 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/29815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/5318 "Hash b6f332bf for PR 29525 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/59453 "Hash b6f332bf for PR 29525 does not build (failure)") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30965 "Hash b6f332bf for PR 29525 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/7154 "Hash b6f332bf for PR 29525 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/59453 "Hash b6f332bf for PR 29525 does not build (failure)") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/31943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/66386 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/30753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12656 "Passed tests") | 
<!--EWS-Status-Bubble-End-->