### PR TITLE
Address more notifyd telemetry

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -1462,6 +1462,7 @@
         ;; Keep in sync with notify_entitlements() in process-entitlements.sh.
         ;; FORWARDED_NOTIFICATIONS
         "_NS_ctasd"
+        "LetterFeedbackEnabled.notification"
         "com.apple.CFPreferences._domainsChangedExternally"
         "com.apple.WebKit.LibraryPathDiagnostics"
         "com.apple.WebKit.deleteAllCode"
@@ -1478,6 +1479,7 @@
         "com.apple.WebKit.showMemoryCache"
         "com.apple.WebKit.showPaintOrderTree"
         "com.apple.WebKit.showRenderTree"
+        "com.apple.accessibility.defaultrouteforcall"
         "com.apple.analyticsd.running"
         "com.apple.coreaudio.list_components"
         "com.apple.distnote.locale_changed"
@@ -1506,6 +1508,7 @@
 
         ;; NON_FORWARDED_NOTIFICATIONS
         "com.apple.accessibility.cache.app.ax"
+        "com.apple.accessibility.cache.ast"
         "com.apple.accessibility.cache.ax"
         "com.apple.accessibility.cache.enhance.text.legibility"
         "com.apple.accessibility.cache.enhance.text.legibilitycom.apple.WebKit.WebContent"
@@ -1514,8 +1517,10 @@
         "com.apple.accessibility.cache.hearing.aid.paired"
         "com.apple.accessibility.cache.invert.colors"
         "com.apple.accessibility.cache.invert.colorscom.apple.WebKit.WebContent"
+        "com.apple.accessibility.cache.loc.caption.mode.enabled"
         "com.apple.accessibility.cache.reduce.motion"
         "com.apple.accessibility.cache.reduce.motioncom.apple.WebKit.WebContent"
+        "com.apple.accessibility.cache.speak.this"
         "com.apple.accessibility.cache.speech.settings.disabled.by.mc"
         "com.apple.accessibility.cache.switch.control"
         "com.apple.accessibility.cache.vot"

--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -205,6 +205,7 @@ function notify_entitlements()
         # Keep in sync with the list in WebProcessPool::registerNotificationObservers.
         FORWARDED_NOTIFICATIONS=(
             "_NS_ctasd"
+            "LetterFeedbackEnabled.notification"
             "com.apple.CFPreferences._domainsChangedExternally"
             "com.apple.WebKit.LibraryPathDiagnostics"
             "com.apple.WebKit.deleteAllCode"
@@ -221,6 +222,7 @@ function notify_entitlements()
             "com.apple.WebKit.showMemoryCache"
             "com.apple.WebKit.showPaintOrderTree"
             "com.apple.WebKit.showRenderTree"
+            "com.apple.accessibility.defaultrouteforcall"
             "com.apple.analyticsd.running"
             "com.apple.coreaudio.list_components"
             "com.apple.distnote.locale_changed"
@@ -268,6 +270,7 @@ function notify_entitlements()
         # WebContent registers for these notifications but they are only posted in-process.
         NON_FORWARDED_NOTIFICATIONS=(
             "com.apple.accessibility.cache.app.ax"
+            "com.apple.accessibility.cache.ast"
             "com.apple.accessibility.cache.ax"
             "com.apple.accessibility.cache.enhance.text.legibility"
             "com.apple.accessibility.cache.enhance.text.legibilitycom.apple.WebKit.WebContent"
@@ -276,6 +279,7 @@ function notify_entitlements()
             "com.apple.accessibility.cache.hearing.aid.paired"
             "com.apple.accessibility.cache.invert.colors"
             "com.apple.accessibility.cache.invert.colorscom.apple.WebKit.WebContent"
+            "com.apple.accessibility.cache.loc.caption.mode.enabled"
             "com.apple.accessibility.cache.reduce.motion"
             "com.apple.accessibility.cache.reduce.motioncom.apple.WebKit.WebContent"
             "com.apple.accessibility.cache.speech.settings.disabled.by.mc"

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -704,6 +704,7 @@ void WebProcessPool::registerNotificationObservers()
         // Keep in sync with notify_entitlements() in process-entitlements.sh.
         // FORWARDED_NOTIFICATIONS
         "_NS_ctasd"_s,
+        "LetterFeedbackEnabled.notification"_s,
         "com.apple.CFPreferences._domainsChangedExternally"_s,
         "com.apple.WebKit.LibraryPathDiagnostics"_s,
         "com.apple.WebKit.deleteAllCode"_s,
@@ -720,6 +721,7 @@ void WebProcessPool::registerNotificationObservers()
         "com.apple.WebKit.showMemoryCache"_s,
         "com.apple.WebKit.showPaintOrderTree"_s,
         "com.apple.WebKit.showRenderTree"_s,
+        "com.apple.accessibility.defaultrouteforcall"_s,
         "com.apple.analyticsd.running"_s,
         "com.apple.coreaudio.list_components"_s,
         "com.apple.distnote.locale_changed"_s,

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -2034,6 +2034,7 @@
         ;; Keep in sync with notify_entitlements() in process-entitlements.sh.
         ;; FORWARDED_NOTIFICATIONS
         "_NS_ctasd"
+        "LetterFeedbackEnabled.notification"
         "com.apple.CFPreferences._domainsChangedExternally"
         "com.apple.WebKit.LibraryPathDiagnostics"
         "com.apple.WebKit.deleteAllCode"
@@ -2050,6 +2051,7 @@
         "com.apple.WebKit.showMemoryCache"
         "com.apple.WebKit.showPaintOrderTree"
         "com.apple.WebKit.showRenderTree"
+        "com.apple.accessibility.defaultrouteforcall"
         "com.apple.analyticsd.running"
         "com.apple.coreaudio.list_components"
         "com.apple.distnote.locale_changed"
@@ -2086,6 +2088,7 @@
 
         ;; NON_FORWARDED_NOTIFICATIONS
         "com.apple.accessibility.cache.app.ax"
+        "com.apple.accessibility.cache.ast"
         "com.apple.accessibility.cache.ax"
         "com.apple.accessibility.cache.enhance.text.legibility"
         "com.apple.accessibility.cache.enhance.text.legibilitycom.apple.WebKit.WebContent"
@@ -2094,8 +2097,10 @@
         "com.apple.accessibility.cache.hearing.aid.paired"
         "com.apple.accessibility.cache.invert.colors"
         "com.apple.accessibility.cache.invert.colorscom.apple.WebKit.WebContent"
+        "com.apple.accessibility.cache.loc.caption.mode.enabled"
         "com.apple.accessibility.cache.reduce.motion"
         "com.apple.accessibility.cache.reduce.motioncom.apple.WebKit.WebContent"
+        "com.apple.accessibility.cache.speak.this"
         "com.apple.accessibility.cache.speech.settings.disabled.by.mc"
         "com.apple.accessibility.cache.switch.control"
         "com.apple.accessibility.cache.vot"


### PR DESCRIPTION
#### b88e00d67608d5087314f9ff357d6aafb4873e81
<pre>
Address more notifyd telemetry
<a href="https://bugs.webkit.org/show_bug.cgi?id=275139">https://bugs.webkit.org/show_bug.cgi?id=275139</a>
<a href="https://rdar.apple.com/128576428">rdar://128576428</a>

Reviewed by Ben Nham.

Address more notifyd telemetry by adding notifications to forwarding list
and adding them to the entitlement allow list and sandbox.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/Scripts/process-entitlements.sh:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::registerNotificationObservers):
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/279752@main">https://commits.webkit.org/279752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/389dde91ad7d9b91db179dea5fa7d4ef5f96d1ad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33727 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6880 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57604 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5056 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5090 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43993 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3371 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56418 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31915 "Found 60 new test failures: accessibility/accessibility-node-reparent.html accessibility/ancestor-computation.html accessibility/announcement-notification.html accessibility/aria-braillelabel.html accessibility/aria-brailleroledescription.html accessibility/aria-checked-mixed-value.html accessibility/aria-current-state-changed-notification.html accessibility/aria-current.html accessibility/aria-describedby-on-input.html accessibility/aria-description.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47047 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25128 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/54154 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/28722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3199 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4578 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59194 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29541 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/4749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51418 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/30703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47140 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50779 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/31676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8056 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30488 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->