### PR TITLE
[WTF] allow `Base64EncodeMode::URL` to include padding

### DIFF
--- a/Source/WTF/wtf/text/Base64.cpp
+++ b/Source/WTF/wtf/text/Base64.cpp
@@ -95,12 +95,12 @@ static const char base64URLDecMap[decodeMapSize] = {
     0x31, 0x32, 0x33, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet
 };
 
-template<typename CharacterType> static void base64EncodeInternal(std::span<const uint8_t> inputDataBuffer, std::span<CharacterType> destinationDataBuffer, Base64EncodeMode mode)
+template<typename CharacterType> static void base64EncodeInternal(std::span<const uint8_t> inputDataBuffer, std::span<CharacterType> destinationDataBuffer, OptionSet<Base64EncodeOption> options)
 {
     ASSERT(destinationDataBuffer.size() > 0);
-    ASSERT(calculateBase64EncodedSize(inputDataBuffer.size(), mode) == destinationDataBuffer.size());
+    ASSERT(calculateBase64EncodedSize(inputDataBuffer.size(), options) == destinationDataBuffer.size());
 
-    auto encodeMap = (mode == Base64EncodeMode::URL) ? base64URLEncMap : base64EncMap;
+    auto encodeMap = options.contains(Base64EncodeOption::URL) ? base64URLEncMap : base64EncMap;
 
     unsigned sidx = 0;
     unsigned didx = 0;
@@ -124,55 +124,57 @@ template<typename CharacterType> static void base64EncodeInternal(std::span<cons
             destinationDataBuffer[didx++] = encodeMap[ (inputDataBuffer[sidx    ] << 4) & 077];
     }
 
-    ASSERT(mode != Base64EncodeMode::URL || didx == destinationDataBuffer.size());
+    if (!options.contains(Base64EncodeOption::OmitPadding)) {
+        while (didx < destinationDataBuffer.size())
+            destinationDataBuffer[didx++] = '=';
+    }
 
-    while (didx < destinationDataBuffer.size())
-        destinationDataBuffer[didx++] = '=';
+    ASSERT(didx == destinationDataBuffer.size());
 }
 
-template<typename CharacterType> static void base64EncodeInternal(std::span<const std::byte> input, std::span<CharacterType> destinationDataBuffer, Base64EncodeMode mode)
+template<typename CharacterType> static void base64EncodeInternal(std::span<const std::byte> input, std::span<CharacterType> destinationDataBuffer, OptionSet<Base64EncodeOption> options)
 {
-    base64EncodeInternal(asBytes(input), destinationDataBuffer, mode);
+    base64EncodeInternal(asBytes(input), destinationDataBuffer, options);
 }
 
-static Vector<uint8_t> base64EncodeInternal(std::span<const std::byte> input, Base64EncodeMode mode)
+static Vector<uint8_t> base64EncodeInternal(std::span<const std::byte> input, OptionSet<Base64EncodeOption> options)
 {
-    auto destinationLength = calculateBase64EncodedSize(input.size(), mode);
+    auto destinationLength = calculateBase64EncodedSize(input.size(), options);
     if (!destinationLength)
         return { };
 
     Vector<uint8_t> destinationVector(destinationLength);
-    base64EncodeInternal(input, std::span(destinationVector), mode);
+    base64EncodeInternal(input, std::span(destinationVector), options);
     return destinationVector;
 }
 
-void base64Encode(std::span<const std::byte> input, std::span<UChar> destination, Base64EncodeMode mode)
+void base64Encode(std::span<const std::byte> input, std::span<UChar> destination, OptionSet<Base64EncodeOption> options)
 {
     if (!destination.size())
         return;
-    base64EncodeInternal(input, destination, mode);
+    base64EncodeInternal(input, destination, options);
 }
 
-void base64Encode(std::span<const std::byte> input, std::span<LChar> destination, Base64EncodeMode mode)
+void base64Encode(std::span<const std::byte> input, std::span<LChar> destination, OptionSet<Base64EncodeOption> options)
 {
     if (!destination.size())
         return;
-    base64EncodeInternal(input, destination, mode);
+    base64EncodeInternal(input, destination, options);
 }
 
-Vector<uint8_t> base64EncodeToVector(std::span<const std::byte> input, Base64EncodeMode mode)
+Vector<uint8_t> base64EncodeToVector(std::span<const std::byte> input, OptionSet<Base64EncodeOption> options)
 {
-    return base64EncodeInternal(input, mode);
+    return base64EncodeInternal(input, options);
 }
 
-String base64EncodeToString(std::span<const std::byte> input, Base64EncodeMode mode)
+String base64EncodeToString(std::span<const std::byte> input, OptionSet<Base64EncodeOption> options)
 {
-    return makeString(base64Encoded(input, mode));
+    return makeString(base64Encoded(input, options));
 }
 
-String base64EncodeToStringReturnNullIfOverflow(std::span<const std::byte> input, Base64EncodeMode mode)
+String base64EncodeToStringReturnNullIfOverflow(std::span<const std::byte> input, OptionSet<Base64EncodeOption> options)
 {
-    return tryMakeString(base64Encoded(input, mode));
+    return tryMakeString(base64Encoded(input, options));
 }
 
 template<typename T, typename Malloc = VectorBufferMalloc>

--- a/Source/WTF/wtf/text/Base64.h
+++ b/Source/WTF/wtf/text/Base64.h
@@ -33,7 +33,10 @@
 
 namespace WTF {
 
-enum class Base64EncodeMode : bool { Default, URL };
+enum class Base64EncodeOption {
+    URL = 1 << 0,
+    OmitPadding = 1 << 1,
+};
 
 enum class Base64DecodeOption {
     URL = 1 << 0,
@@ -43,28 +46,28 @@ enum class Base64DecodeOption {
 
 struct Base64Specification {
     std::span<const std::byte> input;
-    Base64EncodeMode mode;
+    OptionSet<Base64EncodeOption> options;
 };
 
 // If the input string is pathologically large, just return nothing.
 // Rather than being perfectly precise, this is a bit conservative.
 static constexpr unsigned maximumBase64EncoderInputBufferSize = std::numeric_limits<unsigned>::max() / 77 * 76 / 4 * 3 - 2;
 
-unsigned calculateBase64EncodedSize(unsigned inputLength, Base64EncodeMode);
+unsigned calculateBase64EncodedSize(unsigned inputLength, OptionSet<Base64EncodeOption> options);
 
 template<typename CharacterType> bool isBase64OrBase64URLCharacter(CharacterType);
 
-WTF_EXPORT_PRIVATE void base64Encode(std::span<const std::byte>, std::span<UChar>, Base64EncodeMode = Base64EncodeMode::Default);
-WTF_EXPORT_PRIVATE void base64Encode(std::span<const std::byte>, std::span<LChar>, Base64EncodeMode = Base64EncodeMode::Default);
+WTF_EXPORT_PRIVATE void base64Encode(std::span<const std::byte>, std::span<UChar>, OptionSet<Base64EncodeOption> = { });
+WTF_EXPORT_PRIVATE void base64Encode(std::span<const std::byte>, std::span<LChar>, OptionSet<Base64EncodeOption> = { });
 
-WTF_EXPORT_PRIVATE Vector<uint8_t> base64EncodeToVector(std::span<const std::byte>, Base64EncodeMode = Base64EncodeMode::Default);
-Vector<uint8_t> base64EncodeToVector(std::span<const uint8_t>, Base64EncodeMode = Base64EncodeMode::Default);
+WTF_EXPORT_PRIVATE Vector<uint8_t> base64EncodeToVector(std::span<const std::byte>, OptionSet<Base64EncodeOption> = { });
+Vector<uint8_t> base64EncodeToVector(std::span<const uint8_t>, OptionSet<Base64EncodeOption> = { });
 
-WTF_EXPORT_PRIVATE String base64EncodeToString(std::span<const std::byte>, Base64EncodeMode = Base64EncodeMode::Default);
-String base64EncodeToString(std::span<const uint8_t>, Base64EncodeMode = Base64EncodeMode::Default);
+WTF_EXPORT_PRIVATE String base64EncodeToString(std::span<const std::byte>, OptionSet<Base64EncodeOption> = { });
+String base64EncodeToString(std::span<const uint8_t>, OptionSet<Base64EncodeOption> = { });
 
-WTF_EXPORT_PRIVATE String base64EncodeToStringReturnNullIfOverflow(std::span<const std::byte>, Base64EncodeMode = Base64EncodeMode::Default);
-String base64EncodeToStringReturnNullIfOverflow(const CString&, Base64EncodeMode = Base64EncodeMode::Default);
+WTF_EXPORT_PRIVATE String base64EncodeToStringReturnNullIfOverflow(std::span<const std::byte>, OptionSet<Base64EncodeOption> = { });
+String base64EncodeToStringReturnNullIfOverflow(const CString&, OptionSet<Base64EncodeOption> = { });
 
 WTF_EXPORT_PRIVATE std::optional<Vector<uint8_t>> base64Decode(std::span<const std::byte>, OptionSet<Base64DecodeOption> = { });
 WTF_EXPORT_PRIVATE std::optional<Vector<uint8_t>> base64Decode(StringView, OptionSet<Base64DecodeOption> = { });
@@ -88,31 +91,30 @@ std::optional<Vector<uint8_t>> base64URLDecode(std::span<const uint8_t>);
 
 // Versions for use with StringBuilder / makeString.
 
-Base64Specification base64Encoded(std::span<const std::byte>, Base64EncodeMode = Base64EncodeMode::Default);
-Base64Specification base64Encoded(std::span<const uint8_t>, Base64EncodeMode = Base64EncodeMode::Default);
+Base64Specification base64Encoded(std::span<const std::byte>, OptionSet<Base64EncodeOption> = { });
+Base64Specification base64Encoded(std::span<const uint8_t>, OptionSet<Base64EncodeOption> = { });
 
 Base64Specification base64URLEncoded(std::span<const std::byte>);
 Base64Specification base64URLEncoded(std::span<const uint8_t>);
 
-
-inline Vector<uint8_t> base64EncodeToVector(std::span<const uint8_t> input, Base64EncodeMode mode)
+inline Vector<uint8_t> base64EncodeToVector(std::span<const uint8_t> input, OptionSet<Base64EncodeOption> options)
 {
-    return base64EncodeToVector(std::as_bytes(input), mode);
+    return base64EncodeToVector(std::as_bytes(input), options);
 }
 
-inline String base64EncodeToString(std::span<const uint8_t> input, Base64EncodeMode mode)
+inline String base64EncodeToString(std::span<const uint8_t> input, OptionSet<Base64EncodeOption> options)
 {
-    return base64EncodeToString(std::as_bytes(input), mode);
+    return base64EncodeToString(std::as_bytes(input), options);
 }
 
-inline String base64EncodeToStringReturnNullIfOverflow(std::span<const uint8_t> input, Base64EncodeMode mode)
+inline String base64EncodeToStringReturnNullIfOverflow(std::span<const uint8_t> input, OptionSet<Base64EncodeOption> options)
 {
-    return base64EncodeToStringReturnNullIfOverflow(std::as_bytes(input), mode);
+    return base64EncodeToStringReturnNullIfOverflow(std::as_bytes(input), options);
 }
 
-inline String base64EncodeToStringReturnNullIfOverflow(const CString& input, Base64EncodeMode mode)
+inline String base64EncodeToStringReturnNullIfOverflow(const CString& input, OptionSet<Base64EncodeOption> options)
 {
-    return base64EncodeToStringReturnNullIfOverflow(input.span(), mode);
+    return base64EncodeToStringReturnNullIfOverflow(input.span(), options);
 }
 
 inline std::optional<Vector<uint8_t>> base64Decode(std::span<const uint8_t> input, OptionSet<Base64DecodeOption> options)
@@ -122,22 +124,22 @@ inline std::optional<Vector<uint8_t>> base64Decode(std::span<const uint8_t> inpu
 
 inline Vector<uint8_t> base64URLEncodeToVector(std::span<const std::byte> input)
 {
-    return base64EncodeToVector(input, Base64EncodeMode::URL);
+    return base64EncodeToVector(input, { Base64EncodeOption::URL, Base64EncodeOption::OmitPadding });
 }
 
 inline Vector<uint8_t> base64URLEncodeToVector(std::span<const uint8_t> input)
 {
-    return base64EncodeToVector(input, Base64EncodeMode::URL);
+    return base64EncodeToVector(input, { Base64EncodeOption::URL, Base64EncodeOption::OmitPadding });
 }
 
 inline String base64URLEncodeToString(std::span<const std::byte> input)
 {
-    return base64EncodeToString(input, Base64EncodeMode::URL);
+    return base64EncodeToString(input, { Base64EncodeOption::URL, Base64EncodeOption::OmitPadding });
 }
 
 inline String base64URLEncodeToString(std::span<const uint8_t> input)
 {
-    return base64EncodeToString(input, Base64EncodeMode::URL);
+    return base64EncodeToString(input, { Base64EncodeOption::URL, Base64EncodeOption::OmitPadding });
 }
 
 inline std::optional<Vector<uint8_t>> base64URLDecode(StringView input)
@@ -160,7 +162,7 @@ template<typename CharacterType> bool isBase64OrBase64URLCharacter(CharacterType
     return isASCIIAlphanumeric(c) || c == '+' || c == '/' || c == '-' || c == '_';
 }
 
-inline unsigned calculateBase64EncodedSize(unsigned inputLength, Base64EncodeMode mode)
+inline unsigned calculateBase64EncodedSize(unsigned inputLength, OptionSet<Base64EncodeOption> options)
 {
     if (!inputLength)
         return 0;
@@ -168,51 +170,37 @@ inline unsigned calculateBase64EncodedSize(unsigned inputLength, Base64EncodeMod
     if (inputLength > maximumBase64EncoderInputBufferSize)
         return 0;
 
-    auto basePaddedEncodedSize = [&] {
-        return ((inputLength + 2) / 3) * 4;
-    };
-
-    auto baseUnpaddedEncodedSize = [&] {
+    if (options.contains(Base64EncodeOption::OmitPadding))
         return ((inputLength * 4) + 2) / 3;
-    };
 
-    switch (mode) {
-    case Base64EncodeMode::Default:
-        return basePaddedEncodedSize();
-
-    case Base64EncodeMode::URL:
-        return baseUnpaddedEncodedSize();
-    }
-
-    ASSERT_NOT_REACHED();
-    return 0;
+    return ((inputLength + 2) / 3) * 4;
 }
 
-inline Base64Specification base64Encoded(std::span<const std::byte> input, Base64EncodeMode mode)
+inline Base64Specification base64Encoded(std::span<const std::byte> input, OptionSet<Base64EncodeOption> options)
 {
-    return { input, mode };
+    return { input, options };
 }
 
-inline Base64Specification base64Encoded(std::span<const uint8_t> input, Base64EncodeMode mode)
+inline Base64Specification base64Encoded(std::span<const uint8_t> input, OptionSet<Base64EncodeOption> options)
 {
-    return base64Encoded(std::as_bytes(input), mode);
+    return base64Encoded(std::as_bytes(input), options);
 }
 
 inline Base64Specification base64URLEncoded(std::span<const std::byte> input)
 {
-    return base64Encoded(input, Base64EncodeMode::URL);
+    return base64Encoded(input, { Base64EncodeOption::URL, Base64EncodeOption::OmitPadding });
 }
 
 inline Base64Specification base64URLEncoded(std::span<const uint8_t> input)
 {
-    return base64Encoded(input, Base64EncodeMode::URL);
+    return base64Encoded(input, { Base64EncodeOption::URL, Base64EncodeOption::OmitPadding });
 }
 
 template<> class StringTypeAdapter<Base64Specification> {
 public:
     StringTypeAdapter(const Base64Specification& base64)
         : m_base64 { base64 }
-        , m_encodedLength { calculateBase64EncodedSize(base64.input.size(), base64.mode) }
+        , m_encodedLength { calculateBase64EncodedSize(base64.input.size(), base64.options) }
     {
     }
 
@@ -221,7 +209,7 @@ public:
 
     template<typename CharacterType> void writeTo(CharacterType* destination) const
     {
-        base64Encode(m_base64.input, std::span(destination, m_encodedLength), m_base64.mode);
+        base64Encode(m_base64.input, std::span(destination, m_encodedLength), m_base64.options);
     }
 
 private:
@@ -231,6 +219,7 @@ private:
 
 } // namespace WTF
 
+using WTF::Base64EncodeOption;
 using WTF::Base64DecodeOption;
 using WTF::base64Decode;
 using WTF::base64EncodeToString;

--- a/Tools/TestWebKitAPI/Tests/WTF/Base64.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Base64.cpp
@@ -29,7 +29,96 @@
 
 namespace TestWebKitAPI {
 
+#define EXPECT_ENCODE(expected, input) EXPECT_STREQ(expected, base64EncodeToString(input, options).utf8().data())
 #define EXPECT_DECODE(expected, input) EXPECT_STREQ(expected, base64DecodeToString(input, options).utf8().data())
+
+TEST(Base64, Encode)
+{
+    static constexpr OptionSet<Base64EncodeOption> options;
+
+    EXPECT_ENCODE("", ""_s.span8());
+    EXPECT_ENCODE("Zg==", "f"_s.span8());
+    EXPECT_ENCODE("Zm8=", "fo"_s.span8());
+    EXPECT_ENCODE("Zm9v", "foo"_s.span8());
+    EXPECT_ENCODE("Zm9vYg==", "foob"_s.span8());
+    EXPECT_ENCODE("Zm9vYmE=", "fooba"_s.span8());
+    EXPECT_ENCODE("Zm9vYmFy", "foobar"_s.span8());
+
+    EXPECT_ENCODE("AA==", Vector<uint8_t>({ 0 }));
+    EXPECT_ENCODE("AQ==", Vector<uint8_t>({ 1 }));
+    EXPECT_ENCODE("gA==", Vector<uint8_t>({ 128 }));
+    EXPECT_ENCODE("/g==", Vector<uint8_t>({ 254 }));
+    EXPECT_ENCODE("/w==", Vector<uint8_t>({ 255 }));
+    EXPECT_ENCODE("AAE=", Vector<uint8_t>({ 0, 1 }));
+    EXPECT_ENCODE("/v8=", Vector<uint8_t>({ 254, 255 }));
+    EXPECT_ENCODE("AAGA/v8=", Vector<uint8_t>({ 0, 1, 128, 254, 255 }));
+}
+
+TEST(Base64, EncodeOmitPadding)
+{
+    static constexpr OptionSet<Base64EncodeOption> options = { Base64EncodeOption::OmitPadding };
+
+    EXPECT_ENCODE("", ""_s.span8());
+    EXPECT_ENCODE("Zg", "f"_s.span8());
+    EXPECT_ENCODE("Zm8", "fo"_s.span8());
+    EXPECT_ENCODE("Zm9v", "foo"_s.span8());
+    EXPECT_ENCODE("Zm9vYg", "foob"_s.span8());
+    EXPECT_ENCODE("Zm9vYmE", "fooba"_s.span8());
+    EXPECT_ENCODE("Zm9vYmFy", "foobar"_s.span8());
+
+    EXPECT_ENCODE("AA", Vector<uint8_t>({ 0 }));
+    EXPECT_ENCODE("AQ", Vector<uint8_t>({ 1 }));
+    EXPECT_ENCODE("gA", Vector<uint8_t>({ 128 }));
+    EXPECT_ENCODE("/g", Vector<uint8_t>({ 254 }));
+    EXPECT_ENCODE("/w", Vector<uint8_t>({ 255 }));
+    EXPECT_ENCODE("AAE", Vector<uint8_t>({ 0, 1 }));
+    EXPECT_ENCODE("/v8", Vector<uint8_t>({ 254, 255 }));
+    EXPECT_ENCODE("AAGA/v8", Vector<uint8_t>({ 0, 1, 128, 254, 255 }));
+}
+
+TEST(Base64, EncodeURL)
+{
+    static constexpr OptionSet<Base64EncodeOption> options = { Base64EncodeOption::URL };
+
+    EXPECT_ENCODE("", ""_s.span8());
+    EXPECT_ENCODE("Zg==", "f"_s.span8());
+    EXPECT_ENCODE("Zm8=", "fo"_s.span8());
+    EXPECT_ENCODE("Zm9v", "foo"_s.span8());
+    EXPECT_ENCODE("Zm9vYg==", "foob"_s.span8());
+    EXPECT_ENCODE("Zm9vYmE=", "fooba"_s.span8());
+    EXPECT_ENCODE("Zm9vYmFy", "foobar"_s.span8());
+
+    EXPECT_ENCODE("AA==", Vector<uint8_t>({ 0 }));
+    EXPECT_ENCODE("AQ==", Vector<uint8_t>({ 1 }));
+    EXPECT_ENCODE("gA==", Vector<uint8_t>({ 128 }));
+    EXPECT_ENCODE("_g==", Vector<uint8_t>({ 254 }));
+    EXPECT_ENCODE("_w==", Vector<uint8_t>({ 255 }));
+    EXPECT_ENCODE("AAE=", Vector<uint8_t>({ 0, 1 }));
+    EXPECT_ENCODE("_v8=", Vector<uint8_t>({ 254, 255 }));
+    EXPECT_ENCODE("AAGA_v8=", Vector<uint8_t>({ 0, 1, 128, 254, 255 }));
+}
+
+TEST(Base64, EncodeURLOmitPadding)
+{
+    static constexpr OptionSet<Base64EncodeOption> options = { Base64EncodeOption::URL, Base64EncodeOption::OmitPadding };
+
+    EXPECT_ENCODE("", ""_s.span8());
+    EXPECT_ENCODE("Zg", "f"_s.span8());
+    EXPECT_ENCODE("Zm8", "fo"_s.span8());
+    EXPECT_ENCODE("Zm9v", "foo"_s.span8());
+    EXPECT_ENCODE("Zm9vYg", "foob"_s.span8());
+    EXPECT_ENCODE("Zm9vYmE", "fooba"_s.span8());
+    EXPECT_ENCODE("Zm9vYmFy", "foobar"_s.span8());
+
+    EXPECT_ENCODE("AA", Vector<uint8_t>({ 0 }));
+    EXPECT_ENCODE("AQ", Vector<uint8_t>({ 1 }));
+    EXPECT_ENCODE("gA", Vector<uint8_t>({ 128 }));
+    EXPECT_ENCODE("_g", Vector<uint8_t>({ 254 }));
+    EXPECT_ENCODE("_w", Vector<uint8_t>({ 255 }));
+    EXPECT_ENCODE("AAE", Vector<uint8_t>({ 0, 1 }));
+    EXPECT_ENCODE("_v8", Vector<uint8_t>({ 254, 255 }));
+    EXPECT_ENCODE("AAGA_v8", Vector<uint8_t>({ 0, 1, 128, 254, 255 }));
+}
 
 TEST(Base64, Decode)
 {


### PR DESCRIPTION
#### 1d7c9c3993271d02efb514b5f3099ce60e6b85f9
<pre>
[WTF] allow `Base64EncodeMode::URL` to include padding
<a href="https://bugs.webkit.org/show_bug.cgi?id=275141">https://bugs.webkit.org/show_bug.cgi?id=275141</a>

Reviewed by Yusuke Suzuki.

Technically &quot;base64url&quot; is the exact same as &quot;base64&quot; but the alphabet slightly adjusted (e.g. `_` instead of `/`), and &quot;base64&quot; by default includes padding, so &quot;base64url&quot; should too.

This will assist with implementing `Uint8Array.prototype.toBase64` since that expects padding to be included regardless of the alphabet &lt;<a href="https://webkit.org/b/274635">https://webkit.org/b/274635</a>&gt;.

* Source/WTF/wtf/text/Base64.h:
(WTF::base64Encode):
(WTF::base64EncodeToVector):
(WTF::base64EncodeToString):
(WTF::base64EncodeToStringReturnNullIfOverflow):
(WTF::base64URLEncodeToVector):
(WTF::base64URLEncodeToString):
(WTF::base64Encoded):
(WTF::calculateBase64EncodedSize):
(WTF::base64URLEncoded):
(WTF::StringTypeAdapter&lt;Base64Specification&gt;::writeTo const):
* Source/WTF/wtf/text/Base64.cpp:
(WTF::base64EncodeInternal):
(WTF::base64Encode):
(WTF::base64EncodeToVector):
(WTF::base64EncodeToString):
(WTF::base64EncodeToStringReturnNullIfOverflow):
Introduce a `Base64EncodeOption` that&apos;s wrapped in an `OptionSet` (for future extensibility) as a parameter for adjusting base64 encoding.
Convert `Base64EncodeMode::URL` into `Base64EncodeOption::URL`.
Add a new `Base64EncodeOption::OmitPadding` that controls whether padding is included instead of assuming it should be omitted if `Base64EncodeOption::URL`.

* Tools/TestWebKitAPI/Tests/WTF/Base64.cpp: Added.
(TestWebKitAPI::TEST(Base64, Encode)):
(TestWebKitAPI::TEST(Base64, EncodeOmitPadding)):
(TestWebKitAPI::TEST(Base64, EncodeURL)):
(TestWebKitAPI::TEST(Base64, EncodeURLOmitPadding)):

* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/280647@main">https://commits.webkit.org/280647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f082f21298f25cb9f3b87b39c96bf5c1ece67097

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55781 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8248 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58765 "") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6212 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57907 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6410 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/58765 "") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4282 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33002 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48084 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/58765 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29788 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5413 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4355 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/48858 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51759 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5682 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60356 "") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/55018 "Found 1 new JSC stress test failure: stress/scoped-arguments-table-should-be-tolerant-for-oom.js.bytecode-cache (failure)") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5811 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/60356 "") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48155 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/60356 "") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12644 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/76780 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30935 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12774 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32020 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33101 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31767 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->