### PR TITLE
Send all scroll events to the visualViewport

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5159,7 +5159,6 @@ void Document::runScrollSteps()
     }
     if (m_needsVisualViewportScrollEvent) {
         LOG_WITH_STREAM(Events, stream << "Document " << this << " sending scroll events to visualViewport");
-        m_needsVisualViewportScrollEvent = false;
         if (RefPtr window = domWindow())
             window->visualViewport().dispatchEvent(Event::create(eventNames().scrollEvent, Event::CanBubble::No, Event::IsCancelable::No));
     }


### PR DESCRIPTION
#### 9e6aea1af7008876605b8421b4652a66bcd1c40b
<pre>
Send all scroll events to the visualViewport
<a href="https://bugs.webkit.org/show_bug.cgi?id=218465">https://bugs.webkit.org/show_bug.cgi?id=218465</a>

Reviewed by NOBODY (OOPS!).

The previous code would send a single scroll event update to the
visual viewport interface when the visual viewport was updated, but
other browsers send all document scroll events to the visual viewport.

I opted to keep the needsVisualViewportScrollEvent boolean as a slight
optimization so that we don&apos;t send events if nothing is listening to
them.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::runScrollSteps): Do not clear the needs visual
viewport scroll event flag, so that we keep delivering scroll events to
the visualViewport.

* Source/WebCore/page/VisualViewport.cpp:
(WebCore::VisualViewport::addEventListener): Tell the document to send
scroll events to the visualViewport when a scroll listener is added.
(WebCore::VisualViewport::update): Simplify the logic now that this is
not responsible for deciding if scroll events should be sent.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/490972c6c94e147cc1d4e35b94bf8989c3da0028

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54333 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6889 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57613 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5065 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56636 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5109 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/43999 "Found 1 new test failure: fast/visual-viewport/scroll-event-fired-during-scroll-alone.html (failure)") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3376 "Found 1 new test failure: fast/visual-viewport/scroll-event-fired-during-scroll-alone.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56427 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31920 "Found 1 new test failure: fast/visual-viewport/scroll-event-fired-during-scroll-alone.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47058 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25134 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28727 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4380 "Found 1 new test failure: fast/visual-viewport/scroll-event-fired-during-scroll-alone.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3208 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50487 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4595 "Found 1 new test failure: fast/visual-viewport/scroll-event-fired-during-scroll-alone.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59203 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29552 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4766 "Found 2 new test failures: fast/visual-viewport/scroll-event-fired-during-scroll-alone.html imported/w3c/web-platform-tests/wasm/jsapi/constructor/instantiate.any.worker.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51424 "Found 1 new test failure: fast/visual-viewport/scroll-event-fired-during-scroll-alone.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30712 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47151 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50785 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31686 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30497 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->