### PR TITLE
Fix several warnings for the PlayStation build

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -181,6 +181,8 @@ bool IPIntPlan::ensureEntrypoint(IPIntCallee& ipintCallee, unsigned functionInde
     m_entrypoints[functionIndex] = WTFMove(callee);
     return true;
 #else
+    UNUSED_PARAM(ipintCallee);
+    UNUSED_PARAM(functionIndex);
     return false;
 #endif
 }

--- a/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
@@ -190,6 +190,8 @@ bool LLIntPlan::ensureEntrypoint(LLIntCallee& llintCallee, unsigned functionInde
     m_entrypoints[functionIndex] = WTFMove(callee);
     return true;
 #else
+    UNUSED_PARAM(llintCallee);
+    UNUSED_PARAM(functionIndex);
     return false;
 #endif
 }

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.cpp
@@ -78,8 +78,8 @@ void NicosiaImageBufferPipeSource::handle(ImageBuffer& buffer)
 #if PLATFORM(GTK) || PLATFORM(WPE)
         std::unique_ptr<GLFence> fence;
 #endif // PLATFORM(GTK) || PLATFORM(WPE)
-        unsigned textureID = 0;
 #if USE(SKIA)
+        unsigned textureID = 0;
         auto image = nativeImage->platformImage();
         if (image->isTextureBacked()) {
             auto& display = PlatformDisplay::sharedDisplayForCompositing();
@@ -106,11 +106,14 @@ void NicosiaImageBufferPipeSource::handle(ImageBuffer& buffer)
         }
 #endif
 
+        downcast<TextureMapperPlatformLayerProxyGL>(m_nicosiaLayer->proxy()).scheduleUpdateOnCompositorThread([this
+#if USE(SKIA)
+        , textureID
+#endif
 #if PLATFORM(GTK) || PLATFORM(WPE)
-        downcast<TextureMapperPlatformLayerProxyGL>(m_nicosiaLayer->proxy()).scheduleUpdateOnCompositorThread([this, textureID, fence = WTFMove(fence)] () mutable {
-#else
-        downcast<TextureMapperPlatformLayerProxyGL>(m_nicosiaLayer->proxy()).scheduleUpdateOnCompositorThread([this, textureID] () mutable {
-#endif // PLATFORM(GTK) || PLATFORM(WPE)
+        , fence = WTFMove(fence)
+#endif
+        ] () mutable {
             auto& proxy = m_nicosiaLayer->proxy();
             Locker locker { proxy.lock() };
             if (!proxy.isActive())

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.h
@@ -46,6 +46,8 @@
 #include <stdint.h>
 #include <string.h>
 
+PAS_IGNORE_CLANG_WARNINGS_BEGIN("qualifier-requires-header")
+
 #include "pas_utils_prefix.h"
 
 #define PAS_BEGIN_EXTERN_C __PAS_BEGIN_EXTERN_C
@@ -1196,5 +1198,7 @@ enum cpp_initialization_t { cpp_initialization };
 } while (0)
 
 PAS_END_EXTERN_C;
+
+PAS_IGNORE_CLANG_WARNINGS_END // "qualifier-requires-header"
 
 #endif /* PAS_UTILS_H */


### PR DESCRIPTION
#### 1d29d73814fcd3cbcb76f3635a5c673f8c540041
<pre>
Fix several warnings for the PlayStation build
<a href="https://bugs.webkit.org/show_bug.cgi?id=275142">https://bugs.webkit.org/show_bug.cgi?id=275142</a>

Reviewed by Don Olmstead.

* Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp:
(JSC::Wasm::IPIntPlan::ensureEntrypoint):
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::ensureEntrypoint):
Add UNUSED_PARAMs for !ENABLE(JIT).

* Source/WebCore/platform/graphics/nicosia/NicosiaImageBufferPipe.cpp:
(Nicosia::NicosiaImageBufferPipeSource::handle):
Properly guard variable / lambda capture with USE(SKIA).

* Source/bmalloc/libpas/src/libpas/pas_utils.h:
Silence `use of qualifier &apos;_Atomic&apos; requires inclusion of the header &lt;stdatomic.h&gt;` warning from building C as C++.

Canonical link: <a href="https://commits.webkit.org/279763@main">https://commits.webkit.org/279763@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7b3e0f830a520a1e1ef3ee430ed570e5510ed2c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33740 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57616 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5068 "Built successfully") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56639 "Build is in progress. Recent messages:OS: Unknown (10.15.7), Xcode: 11.7; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed bindings tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5116 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44004 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3379 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56430 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31921 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47059 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25139 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28731 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4381 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3211 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/47698 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59206 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/53843 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29555 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/4783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51428 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30715 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47152 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11882 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/31689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/66143 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30500 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12602 "Passed tests") | 
<!--EWS-Status-Bubble-End-->