### PR TITLE
Detached OffscreenCanvas should not transfer ImageBuffer

### DIFF
--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -5873,12 +5873,6 @@ size_t SerializedScriptValue::computeMemoryCost() const
             cost += detachedImageBitmap->memoryCost();
     }
 
-#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
-    for (auto& canvas : m_internals.detachedOffscreenCanvases) {
-        if (canvas)
-            cost += canvas->memoryCost();
-    }
-#endif
 #if ENABLE(WEB_RTC)
     for (auto& channel : m_internals.detachedRTCDataChannels) {
         if (channel)

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -82,23 +82,13 @@ class DetachedOffscreenCanvas {
     friend class OffscreenCanvas;
 
 public:
-    DetachedOffscreenCanvas(std::unique_ptr<SerializedImageBuffer>, const IntSize&, bool originClean, RefPtr<OffscreenCanvasPlaceholderData>);
+    DetachedOffscreenCanvas(const IntSize&, bool originClean, RefPtr<OffscreenCanvasPlaceholderData>);
     WEBCORE_EXPORT ~DetachedOffscreenCanvas();
-
-    RefPtr<ImageBuffer> takeImageBuffer(ScriptExecutionContext&);
     const IntSize& size() const { return m_size; }
     bool originClean() const { return m_originClean; }
-    size_t memoryCost() const
-    {
-        auto* buffer = m_buffer.get();
-        if (buffer)
-            return buffer->memoryCost();
-        return 0;
-    }
     RefPtr<OffscreenCanvasPlaceholderData> takePlaceholderData();
 
 private:
-    std::unique_ptr<SerializedImageBuffer> m_buffer;
     RefPtr<OffscreenCanvasPlaceholderData> m_placeholderData;
     IntSize m_size;
     bool m_originClean;
@@ -181,7 +171,6 @@ private:
     void setSize(const IntSize&) final;
 
     void createImageBuffer() const final;
-    std::unique_ptr<SerializedImageBuffer> takeImageBuffer() const;
 
     void reset();
     void scheduleCommitToPlaceholderCanvas();


### PR DESCRIPTION
#### fa20ed6ab7ad3700d16e07ed7f2df1f3554b7063
<pre>
Detached OffscreenCanvas should not transfer ImageBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=275144">https://bugs.webkit.org/show_bug.cgi?id=275144</a>
<a href="https://rdar.apple.com/129270155">rdar://129270155</a>

Reviewed by Simon Fraser.

The buffer cannot contain anything, as only the context-less
OffscreenCanvases can be detached.

* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::SerializedScriptValue::computeMemoryCost const):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::DetachedOffscreenCanvas::DetachedOffscreenCanvas):
(WebCore::OffscreenCanvas::create):
(WebCore::OffscreenCanvas::detach):
(WebCore::DetachedOffscreenCanvas::takeImageBuffer): Deleted.
(WebCore::OffscreenCanvas::takeImageBuffer const): Deleted.
* Source/WebCore/html/OffscreenCanvas.h:
(WebCore::DetachedOffscreenCanvas::originClean const):
(WebCore::DetachedOffscreenCanvas::memoryCost const): Deleted.

Canonical link: <a href="https://commits.webkit.org/279775@main">https://commits.webkit.org/279775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/108581d66e979a4537ee802edfb3805c2ce5f6e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54352 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57632 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5084 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56655 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5113 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44013 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3392 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47069 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25149 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28736 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4391 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3227 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50494 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4601 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59222 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29572 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4779 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/jsapi/constructor/instantiate.any.worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51438 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30731 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47162 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50799 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11910 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31705 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30517 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->