### PR TITLE
dataLogIf should check the condition is a bool or enum

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
@@ -99,9 +99,9 @@ StreamingParser::StreamingParser(ModuleInformation& info, StreamingParserClient&
     dataLogLnIf(WasmStreamingParserInternal::verbose, "starting validation");
 
 #if ASSERT_ENABLED
-    dataLogLnIf(Options::dumpWasmSourceFileName(), "Wasm streaming parser created, capturing source.");
+    dataLogLnIf(!!Options::dumpWasmSourceFileName(), "Wasm streaming parser created, capturing source.");
 #else
-    dataLogLnIf(Options::dumpWasmSourceFileName(), "Wasm streaming parser created, but we can only dump source in debug builds.");
+    dataLogLnIf(!!Options::dumpWasmSourceFileName(), "Wasm streaming parser created, but we can only dump source in debug builds.");
 #endif
 }
 

--- a/Source/WTF/wtf/DataLog.h
+++ b/Source/WTF/wtf/DataLog.h
@@ -53,11 +53,15 @@ void dataLogLn(const Types&... values)
 }
 
 #define dataLogIf(shouldLog, ...) do { \
+        using ShouldLogType = std::decay_t<decltype(shouldLog)>; \
+        static_assert(std::is_same_v<ShouldLogType, bool> || std::is_enum_v<ShouldLogType>, "You probably meant to pass a bool or enum as dataLogIf's first parameter"); \
         if (UNLIKELY(shouldLog)) \
             dataLog(__VA_ARGS__); \
     } while (0)
 
 #define dataLogLnIf(shouldLog, ...) do { \
+        using ShouldLogType = std::decay_t<decltype(shouldLog)>; \
+        static_assert(std::is_same_v<ShouldLogType, bool> || std::is_enum_v<ShouldLogType>, "You probably meant to pass a bool or enum as dataLogLnIf's first parameter"); \
         if (UNLIKELY(shouldLog)) \
             dataLogLn(__VA_ARGS__); \
     } while (0)


### PR DESCRIPTION
#### ccb2f0d494326452b30f8f40174d5195e60e5e49
<pre>
dataLogIf should check the condition is a bool or enum
<a href="https://bugs.webkit.org/show_bug.cgi?id=275155">https://bugs.webkit.org/show_bug.cgi?id=275155</a>
<a href="https://rdar.apple.com/problem/129280739">rdar://problem/129280739</a>

Reviewed by Justin Michaud.

I often make the mistake of accidentally writing `dataLogIf(&quot;thing I want to log&quot;);`
Which is probably not what people intended. This patch adds some simple validation
to make that harder.

* Source/JavaScriptCore/wasm/WasmStreamingParser.cpp:
(JSC::Wasm::StreamingParser::StreamingParser):
* Source/WTF/wtf/DataLog.h:

Canonical link: <a href="https://commits.webkit.org/279753@main">https://commits.webkit.org/279753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/687cfd83902315919c82b84197b78a51fd924797

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54379 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33784 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6938 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57658 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5110 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41317 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/5129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44039 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3424 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56472 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47089 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25175 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/28755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4414 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3253 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/47740 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59249 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/53886 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/29598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4725 "Exiting early after 60 failures. 60 tests run. 1 flakes 60 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51464 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/30757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47182 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50828 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11866 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/31731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/66185 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30547 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12610 "Passed tests") | 
<!--EWS-Status-Bubble-End-->