### PR TITLE
[GStreamer][WebRTC] Missing a=msid in offer after setting codec preferences

### DIFF
--- a/LayoutTests/webrtc/msid-setCodecPreferences-expected.txt
+++ b/LayoutTests/webrtc/msid-setCodecPreferences-expected.txt
@@ -1,0 +1,3 @@
+
+PASS msid present in offer SDP after setting codec preferences
+

--- a/LayoutTests/webrtc/msid-setCodecPreferences.html
+++ b/LayoutTests/webrtc/msid-setCodecPreferences.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Testing basic video exchange from offerer to receiver</title>
+        <script src="../resources/testharness.js"></script>
+        <script src="../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <script src ="routines.js"></script>
+        <script>
+var track, firstConnection, secondConnection;
+promise_test(async (test) => {
+    if (window.testRunner)
+        testRunner.setUserMediaPermission(true);
+
+    let pc = new RTCPeerConnection();
+    let stream = await navigator.mediaDevices.getUserMedia({ video: true });
+	let track = stream.getVideoTracks()[0];
+    pc.addTrack(track, stream);
+    pc.getTransceivers()[0].setCodecPreferences([{mimeType: "video/VP8", clockRate: 90000}]);
+    let offer = await pc.createOffer();
+    assert_true(offer.sdp.includes(`a=msid:${stream.id} ${track.id}`), 'offer SDP includes a=msid line');
+}, "msid present in offer SDP after setting codec preferences");
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
#### 6d7fa27729b7e6308aff5b13638b0f7c514888c9
<pre>
[GStreamer][WebRTC] Missing a=msid in offer after setting codec preferences
<a href="https://bugs.webkit.org/show_bug.cgi?id=275157">https://bugs.webkit.org/show_bug.cgi?id=275157</a>

Reviewed by Philippe Normand.

When setting codec preferences on GstWebRTCRTPTransceiver, the caps object
did not contain an &quot;a-msid&quot; field, which causes the offer created by the
webrtcbin containing that transceiver to not include an `a=msid` line for it.

The issue is fixed by reusing the `a-msid` field from the pre-existent
codec preference, if one exists.

* LayoutTests/webrtc/msid-setCodecPreferences-expected.txt: Added.
* LayoutTests/webrtc/msid-setCodecPreferences.html: Added.
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp:
(WebCore::getMsidFromCurrentCodecPreferences):
(WebCore::GStreamerRtpTransceiverBackend::setCodecPreferences):

Canonical link: <a href="https://commits.webkit.org/279746@main">https://commits.webkit.org/279746@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a939165856c49beb598afabafe368d52c943f83

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6946 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57665 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5117 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56688 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5065 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44044 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3427 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56479 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47095 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25180 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/28760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4420 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3260 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59256 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/29605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/4728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/51469 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/30764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47188 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50835 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11853 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/31738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30554 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->