### PR TITLE
Change call sites of `narrowPrecisionToFloat` to `clampTo<float>` in SVG directory

### DIFF
--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -31,7 +31,6 @@
 #include "CSSPropertyNames.h"
 #include "CSSPropertyParser.h"
 #include "Document.h"
-#include "FloatConversion.h"
 #include "NodeName.h"
 #include "RenderObject.h"
 #include "SVGAnimateElement.h"
@@ -232,12 +231,12 @@ ExceptionOr<float> SVGAnimationElement::getStartTime() const
     auto intervalBegin = this->intervalBegin();
     if (!intervalBegin.isFinite())
         return Exception { ExceptionCode::InvalidStateError, "The animation element does not have a current interval."_s };
-    return narrowPrecisionToFloat(intervalBegin.value());
+    return clampTo<float>(intervalBegin.value());
 }
 
 float SVGAnimationElement::getCurrentTime() const
 {
-    return narrowPrecisionToFloat(elapsed().value());
+    return clampTo<float>(elapsed().value());
 }
 
 ExceptionOr<float> SVGAnimationElement::getSimpleDuration() const
@@ -245,7 +244,7 @@ ExceptionOr<float> SVGAnimationElement::getSimpleDuration() const
     auto simpleDuration = this->simpleDuration();
     if (!simpleDuration.isFinite())
         return Exception { ExceptionCode::NotSupportedError, "The simple duration is not determined on the given element."_s };
-    return narrowPrecisionToFloat(simpleDuration.value());
+    return clampTo<float>(simpleDuration.value());
 }    
     
 void SVGAnimationElement::beginElement()
@@ -421,7 +420,7 @@ float SVGAnimationElement::calculatePercentForSpline(float percent, unsigned spl
     SMILTime duration = simpleDuration();
     if (!duration.isFinite())
         duration = 100.0;
-    return narrowPrecisionToFloat(bezier.solve(percent, solveEpsilon(duration.value())));
+    return clampTo<float>(bezier.solve(percent, solveEpsilon(duration.value())));
 }
 
 float SVGAnimationElement::calculatePercentFromKeyPoints(float percent) const

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -544,7 +544,7 @@ bool SVGSVGElement::hasActiveAnimation() const
 
 float SVGSVGElement::getCurrentTime() const
 {
-    return narrowPrecisionToFloat(protectedTimeContainer()->elapsed().value());
+    return clampTo<float>(protectedTimeContainer()->elapsed().value());
 }
 
 void SVGSVGElement::setCurrentTime(float seconds)

--- a/Source/WebCore/svg/SVGTransformValue.h
+++ b/Source/WebCore/svg/SVGTransformValue.h
@@ -275,8 +275,8 @@ private:
         double cosAngle = std::cos(angleInRad);
         double sinAngle = std::sin(angleInRad);
 
-        float cx = narrowPrecisionToFloat(cosAngle != 1 ? (m_matrix->e() * (1 - cosAngle) - m_matrix->f() * sinAngle) / (1 - cosAngle) / 2 : 0);
-        float cy = narrowPrecisionToFloat(cosAngle != 1 ? (m_matrix->e() * sinAngle / (1 - cosAngle) + m_matrix->f()) / 2 : 0);
+        float cx = clampTo<float>(cosAngle != 1 ? (m_matrix->e() * (1 - cosAngle) - m_matrix->f() * sinAngle) / (1 - cosAngle) / 2 : 0);
+        float cy = clampTo<float>(cosAngle != 1 ? (m_matrix->e() * sinAngle / (1 - cosAngle) + m_matrix->f()) / 2 : 0);
 
         if (cx || cy)
             appendFixedPrecisionNumbers(builder, m_angle, cx, cy);

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -34,7 +34,6 @@
 #include "EventListener.h"
 #include "EventNames.h"
 #include "EventSender.h"
-#include "FloatConversion.h"
 #include "LocalFrameView.h"
 #include "NodeName.h"
 #include "Page.h"
@@ -1063,11 +1062,11 @@ float SVGSMILElement::calculateAnimationPercentAndRepeat(SMILTime elapsed, unsig
         percent = percent - floor(percent);
         if (percent < std::numeric_limits<float>::epsilon() || 1 - percent < std::numeric_limits<float>::epsilon())
             return 1.0f;
-        return narrowPrecisionToFloat(percent);
+        return clampTo<float>(percent);
     }
     repeat = static_cast<unsigned>(activeTime.value() / simpleDuration.value());
     SMILTime simpleTime = fmod(activeTime.value(), simpleDuration.value());
-    return narrowPrecisionToFloat(simpleTime.value() / simpleDuration.value());
+    return clampTo<float>(simpleTime.value() / simpleDuration.value());
 }
     
 SMILTime SVGSMILElement::calculateNextProgressTime(SMILTime elapsed) const


### PR DESCRIPTION
<pre>
Change call sites of `narrowPrecisionToFloat` to `clampTo<float>` in SVG directory
<a href="https://bugs.webkit.org/show_bug.cgi?id=275163">https://bugs.webkit.org/show_bug.cgi?id=275163</a>

Reviewed by NOBODY (OOPS!).

This patch updates `narrowPrecisionToFloat` on call sites to
clampTo<float> through SVG directory.

* Source/WebCore/svg/SVGAnimationElement.cpp:
(WebCore::SVGAnimationElement::getStartTime const):
(WebCore::SVGAnimationElement::getCurrentTime const):
(WebCore::SVGAnimationElement::getSimpleDuration const):
(WebCore::SVGAnimationElement::calculatePercentForSpline const):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::getCurrentTime const):
* Source/WebCore/svg/SVGTransformValue.h:
(WebCore::SVGTransformValue::appendRotate const):
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::calculateAnimationPercentAndRepeat const):
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02af0a941f1157f615560acbc254dd9954bf9c0e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57669 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5121 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56692 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5133 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44049 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3429 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31958 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47097 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25185 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28766 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4422 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3264 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50564 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4631 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59260 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29610 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4925 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51473 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30768 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47190 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50839 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31742 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30558 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->