### PR TITLE
Refactor TextIndicatorStyle to be seperate from UnifiedTextReplacementController.

### DIFF
--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -737,6 +737,7 @@ WebProcess/WebPage/WKAccessibilityWebPageObjectIOS.mm
 
 WebProcess/WebPage/Cocoa/DrawingAreaCocoa.mm
 WebProcess/WebPage/Cocoa/TextCheckingControllerProxy.mm
+WebProcess/WebPage/Cocoa/TextIndicatorStyleController.mm
 WebProcess/WebPage/Cocoa/WebCookieCacheCocoa.mm
 WebProcess/WebPage/Cocoa/WebCookieJarCocoa.mm
 WebProcess/WebPage/Cocoa/WebPageCocoa.mm

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5278,6 +5278,8 @@
 		44122266296A89820057E1A5 /* SameDocumentNavigationType.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = SameDocumentNavigationType.serialization.in; sourceTree = "<group>"; };
 		4413795F2964F0C2003C34C6 /* CacheStoragePolicy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CacheStoragePolicy.h; sourceTree = "<group>"; };
 		441379602964F0C2003C34C6 /* CacheStoragePolicy.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CacheStoragePolicy.serialization.in; sourceTree = "<group>"; };
+		442C116A2C06AC48004C67CA /* TextIndicatorStyleController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TextIndicatorStyleController.mm; sourceTree = "<group>"; };
+		442C116B2C06ACB1004C67CA /* TextIndicatorStyleController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextIndicatorStyleController.h; sourceTree = "<group>"; };
 		442E7BE827B4572B00C69AC1 /* RevealItem.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RevealItem.mm; sourceTree = "<group>"; };
 		442E7BEA27B4581300C69AC1 /* RevealItem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RevealItem.h; sourceTree = "<group>"; };
 		4447F01F2BC833F0006988E9 /* WKTextIndicatorStyleType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKTextIndicatorStyleType.h; sourceTree = "<group>"; };
@@ -10454,6 +10456,7 @@
 				2D9CD5ED21FA503F0029ACFA /* TextCheckingControllerProxy.h */,
 				2D9CD5EB21FA503F0029ACFA /* TextCheckingControllerProxy.messages.in */,
 				2D9CD5EC21FA503F0029ACFA /* TextCheckingControllerProxy.mm */,
+				442C116A2C06AC48004C67CA /* TextIndicatorStyleController.mm */,
 				074AD7202B61D58F00FFA67B /* UnifiedTextReplacementController.mm */,
 				3A8997E029B25E8E00AB88B6 /* WebCookieCacheCocoa.mm */,
 				3A36AFAF2B9667770098631A /* WebCookieJarCocoa.mm */,
@@ -13782,6 +13785,7 @@
 				2DEE709D2755A46800FBF864 /* MomentumEventDispatcher.h */,
 				7C387433172F5615001BD88A /* PageBanner.cpp */,
 				7CF47FF917275C57008ACB91 /* PageBanner.h */,
+				442C116B2C06ACB1004C67CA /* TextIndicatorStyleController.h */,
 				074AD71E2B61D51E00FFA67B /* UnifiedTextReplacementController.h */,
 				2D819B99186275B3001F03D1 /* ViewGestureGeometryCollector.cpp */,
 				2D819B9A186275B3001F03D1 /* ViewGestureGeometryCollector.h */,

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextIndicatorStyleController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextIndicatorStyleController.mm
@@ -1,0 +1,325 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+
+#include "config.h"
+#include "TextIndicatorStyleController.h"
+
+#include "TextIndicatorStyle.h"
+#include "UnifiedTextReplacementController.h"
+#include "WebPage.h"
+#include <WebCore/DocumentMarkerController.h>
+#include <WebCore/FocusController.h>
+#include <WebCore/RenderedDocumentMarker.h>
+#include <WebCore/SimpleRange.h>
+#include <WebCore/TextIndicator.h>
+#include <WebCore/TextIterator.h>
+
+namespace WebKit {
+
+// This should mirror what is in UnifiedTextIndicatorController, and eventually not be copied.
+static constexpr auto defaultTextIndicatorStyleControllerTextIteratorBehaviors = WebCore::TextIteratorBehaviors {
+    WebCore::TextIteratorBehavior::EmitsObjectReplacementCharactersForImages,
+#if ENABLE(ATTACHMENT_ELEMENT)
+    WebCore::TextIteratorBehavior::EmitsObjectReplacementCharactersForAttachments
+#endif
+};
+
+TextIndicatorStyleController::TextIndicatorStyleController(WebPage& webPage)
+    : m_webPage(webPage)
+{
+}
+
+RefPtr<WebCore::Document> TextIndicatorStyleController::document() const
+{
+    if (!m_webPage) {
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+
+    RefPtr corePage = m_webPage->corePage();
+    if (!corePage) {
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+
+    RefPtr frame = corePage->checkedFocusController()->focusedOrMainFrame();
+    if (!frame) {
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+
+    return frame->document();
+}
+
+std::optional<WebCore::SimpleRange> TextIndicatorStyleController::contextRangeForTextIndicatorStyle(const WTF::UUID& uuid) const
+{
+    if (auto sessionRange = m_webPage->unifiedTextReplacementController().contextRangeForSessionWithUUID(uuid))
+        return sessionRange;
+
+    if (m_textIndicatorStyleEnablementRanges.contains(uuid))
+        return makeSimpleRange(m_textIndicatorStyleEnablementRanges.find(uuid)->value.get());
+
+    for (auto sessionUUID : m_activeTextIndicatorStyles.keys()) {
+        for (auto styleState : m_activeTextIndicatorStyles.get(sessionUUID)) {
+            if (styleState.styleID == uuid) {
+                if (auto fullSessionRange = m_webPage->unifiedTextReplacementController().contextRangeForSessionWithUUID(sessionUUID))
+                    return WebCore::resolveCharacterRange(*fullSessionRange, styleState.range, defaultTextIndicatorStyleControllerTextIteratorBehaviors);
+            }
+        }
+    }
+    return std::nullopt;
+}
+
+void TextIndicatorStyleController::cleanUpTextStylesForSessionID(const WTF::UUID& sessionUUID)
+{
+    auto styleStates = m_activeTextIndicatorStyles.take(sessionUUID);
+    if (styleStates.isEmpty())
+        return;
+    for (auto styleState : styleStates)
+        removeTransparentMarkersForUUID(styleState.styleID);
+
+    auto unstyledRange = m_unstyledRanges.find(sessionUUID);
+    if (unstyledRange->value)
+        removeTransparentMarkersForUUID(unstyledRange->value->styleID);
+}
+
+void TextIndicatorStyleController::removeTransparentMarkersForUUID(const WTF::UUID& uuid)
+{
+    RefPtr document = this->document();
+    if (!document) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    document->markers().removeMarkers({ WebCore::DocumentMarker::Type::TransparentContent }, [&](const WebCore::DocumentMarker& marker) {
+        return std::get<WebCore::DocumentMarker::TransparentContentData>(marker.data()).uuid == uuid ? WebCore::FilterMarkerResult::Remove : WebCore::FilterMarkerResult::Keep;
+    });
+}
+
+#if PLATFORM(MAC)
+static WebCore::CharacterRange newlyReplacedCharacterRange(WebCore::CharacterRange superRange, WebCore::CharacterRange previousRange)
+{
+    auto location = previousRange.location + previousRange.length;
+    auto length = superRange.length - previousRange.length;
+    if (superRange.length < previousRange.length) {
+        ASSERT_NOT_REACHED();
+        return WebCore::CharacterRange { 0, 0 };
+    }
+    return WebCore::CharacterRange { location, length };
+};
+#endif
+
+void TextIndicatorStyleController::addSourceTextIndicatorStyle(const WTF::UUID& sessionUUID, const WebCore::CharacterRange& currentReplacedRange, const WebCore::SimpleRange& resolvedRange)
+{
+    auto replacedRange = resolvedRange;
+    auto currentlyStyledRange = m_currentlyStyledRange.getOptional(sessionUUID);
+    if (!currentlyStyledRange)
+        return;
+#if PLATFORM(MAC)
+    auto replaceCharacterRange = newlyReplacedCharacterRange(currentReplacedRange, *currentlyStyledRange);
+    auto sessionRange = m_webPage->unifiedTextReplacementController().contextRangeForSessionWithUUID(sessionUUID);
+    replacedRange = WebCore::resolveCharacterRange(*sessionRange, *currentlyStyledRange, defaultTextIndicatorStyleControllerTextIteratorBehaviors);
+
+    auto sourceTextIndicatorUUID = WTF::UUID::createVersion4();
+    createTextIndicatorForRange(replacedRange, [sourceTextIndicatorUUID, weakWebPage = WeakPtr { m_webPage }](std::optional<WebCore::TextIndicatorData>&& textIndicatorData) {
+        if (!weakWebPage)
+            return;
+        RefPtr protectedWebPage = weakWebPage.get();
+        if (textIndicatorData)
+            protectedWebPage->addTextIndicatorStyleForID(sourceTextIndicatorUUID, { WebKit::TextIndicatorStyle::Source, WTF::UUID(WTF::UUID::emptyValue)  }, *textIndicatorData);
+    });
+    TextIndicatorStyleState styleState = { sourceTextIndicatorUUID, replaceCharacterRange };
+    auto& styleStates = m_activeTextIndicatorStyles.ensure(sessionUUID, [&] {
+        return Vector<TextIndicatorStyleState> { };
+    }).iterator->value;
+
+    styleStates.append(styleState);
+
+    m_currentlyStyledRange.set(sessionUUID, currentReplacedRange);
+#endif
+}
+void TextIndicatorStyleController::addDestinationTextIndicatorStyle(const WTF::UUID& sessionUUID, const WebCore::CharacterRange& characterRangeAfterReplace, const WebCore::SimpleRange& resolvedRange)
+{
+    auto finalTextIndicatorUUID = WTF::UUID::createVersion4();
+    auto sessionRange = m_webPage->unifiedTextReplacementController().contextRangeForSessionWithUUID(sessionUUID);
+    if (!sessionRange) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    RefPtr document = this->document();
+    if (!document) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    auto replacedRangeAfterReplace = WebCore::resolveCharacterRange(*sessionRange, characterRangeAfterReplace, defaultTextIndicatorStyleControllerTextIteratorBehaviors);
+
+    auto unstyledRange = WebCore::makeRangeSelectingNodeContents(*document);
+    unstyledRange.start.container = replacedRangeAfterReplace.endContainer();
+    unstyledRange.start.offset = replacedRangeAfterReplace.endOffset();
+
+    auto unstyledRangeUUID = WTF::UUID::createVersion4();
+    TextIndicatorStyleUnstyledRangeData unstyledRangeData = { unstyledRangeUUID, unstyledRange };
+    m_unstyledRanges.add(sessionUUID, unstyledRangeData);
+
+    createTextIndicatorForRange(replacedRangeAfterReplace, [finalTextIndicatorUUID, unstyledRangeUUID, weakWebPage = WeakPtr { m_webPage }](std::optional<WebCore::TextIndicatorData>&& textIndicatorData) {
+        if (!weakWebPage)
+            return;
+        RefPtr protectedWebPage = weakWebPage.get();
+        if (textIndicatorData)
+            protectedWebPage->addTextIndicatorStyleForID(finalTextIndicatorUUID, { TextIndicatorStyle::Final, unstyledRangeUUID }, *textIndicatorData);
+    });
+    TextIndicatorStyleState styleState = { finalTextIndicatorUUID, characterRangeAfterReplace };
+    auto& styleStates = m_activeTextIndicatorStyles.ensure(sessionUUID, [&] {
+        return Vector<TextIndicatorStyleState> { };
+    }).iterator->value;
+
+    styleStates.append(styleState);
+}
+
+void TextIndicatorStyleController::updateTextIndicatorStyleVisibilityForID(const WTF::UUID& uuid, bool visible, CompletionHandler<void()>&& completionHandler)
+{
+    RefPtr document = this->document();
+    if (!document) {
+        ASSERT_NOT_REACHED();
+        completionHandler();
+        return;
+    }
+
+    if (visible)
+        removeTransparentMarkersForUUID(uuid);
+    else {
+        auto sessionRange = contextRangeForTextIndicatorStyle(uuid);
+
+        if (!sessionRange) {
+            completionHandler();
+            return;
+        }
+        document->markers().addTransparentContentMarker(*sessionRange, uuid);
+    }
+    completionHandler();
+}
+
+
+void TextIndicatorStyleController::createTextIndicatorForRange(const WebCore::SimpleRange& range, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&& completionHandler)
+{
+    if (!m_webPage) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    RefPtr corePage = m_webPage->corePage();
+    if (!corePage) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    if (RefPtr localMainFrame = dynamicDowncast<WebCore::LocalFrame>(corePage->mainFrame())) {
+        std::optional<WebCore::TextIndicatorData> textIndicatorData;
+        constexpr OptionSet textIndicatorOptions {
+            WebCore::TextIndicatorOption::IncludeSnapshotOfAllVisibleContentWithoutSelection,
+            WebCore::TextIndicatorOption::ExpandClipBeyondVisibleRect,
+            WebCore::TextIndicatorOption::UseSelectionRectForSizing,
+            WebCore::TextIndicatorOption::SkipReplacedContent,
+            WebCore::TextIndicatorOption::RespectTextColor
+        };
+        if (auto textIndicator = WebCore::TextIndicator::createWithRange(range, textIndicatorOptions, WebCore::TextIndicatorPresentationTransition::None, { }))
+            textIndicatorData = textIndicator->data();
+        completionHandler(WTFMove(textIndicatorData));
+        return;
+    }
+    completionHandler(std::nullopt);
+}
+
+void TextIndicatorStyleController::createTextIndicatorForID(const WTF::UUID& uuid, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&& completionHandler)
+{
+    auto sessionRange = contextRangeForTextIndicatorStyle(uuid);
+
+    if (!sessionRange) {
+        completionHandler(std::nullopt);
+        return;
+    }
+    createTextIndicatorForRange(*sessionRange, WTFMove(completionHandler));
+}
+
+void TextIndicatorStyleController::enableTextIndicatorStyleAfterElementWithID(const String& elementID, const WTF::UUID& uuid)
+{
+    RefPtr document = this->document();
+    if (!document) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    RefPtr root = document->documentElement();
+    if (!root) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    WebCore::VisibleSelection fullDocumentSelection(WebCore::VisibleSelection::selectionFromContentsOfNode(root.get()));
+    auto simpleRange = fullDocumentSelection.range();
+    if (!simpleRange) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    if (RefPtr element = document->getElementById(elementID)) {
+        auto elementRange = WebCore::makeRangeSelectingNodeContents(*element);
+        if (!elementRange.collapsed())
+            simpleRange->start = elementRange.end;
+    }
+
+    m_textIndicatorStyleEnablementRanges.add(uuid, createLiveRange(*simpleRange));
+}
+
+void TextIndicatorStyleController::enableTextIndicatorStyleForElementWithID(const String& elementID, const WTF::UUID& uuid)
+{
+    RefPtr document = this->document();
+    if (!document) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    RefPtr element = document->getElementById(elementID);
+    if (!element) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    auto elementRange = WebCore::makeRangeSelectingNodeContents(*element);
+    if (elementRange.collapsed()) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    m_textIndicatorStyleEnablementRanges.add(uuid, createLiveRange(elementRange));
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(UNIFIED_TEXT_REPLACEMENT)

--- a/Source/WebKit/WebProcess/WebPage/TextIndicatorStyleController.h
+++ b/Source/WebKit/WebProcess/WebPage/TextIndicatorStyleController.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+
+#include <WebCore/CharacterRange.h>
+#include <WebCore/SimpleRange.h>
+#include <wtf/FastMalloc.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/UUID.h>
+#include <wtf/WeakPtr.h>
+
+namespace WebCore {
+
+class Range;
+
+struct TextIndicatorData;
+
+enum class TextIndicatorOption : uint16_t;
+
+}
+
+namespace WebKit {
+
+class WebPage;
+
+struct TextIndicatorStyleState {
+    WTF::UUID styleID;
+    WebCore::CharacterRange range;
+};
+
+struct TextIndicatorStyleUnstyledRangeData {
+    WTF::UUID styleID;
+    WebCore::SimpleRange range;
+};
+
+class TextIndicatorStyleController final {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(TextIndicatorStyleController);
+
+public:
+    explicit TextIndicatorStyleController(WebPage&);
+
+    std::optional<WebCore::SimpleRange> contextRangeForRangeWithIdentifier(const WTF::UUID&) const;
+    std::optional<WebCore::SimpleRange> contextRangeForTextIndicatorStyle(const WTF::UUID&) const;
+    void cleanUpTextStylesForSessionID(const WTF::UUID& sessionUUID);
+    void removeTransparentMarkersForUUID(const WTF::UUID&);
+    void addSourceTextIndicatorStyle(const WTF::UUID& sessionUUID, const WebCore::CharacterRange& currentReplacedRange, const WebCore::SimpleRange& resolvedRange);
+    void addDestinationTextIndicatorStyle(const WTF::UUID& sessionUUID, const WebCore::CharacterRange& characterRangeAfterReplace, const WebCore::SimpleRange& resolvedRange);
+    void updateTextIndicatorStyleVisibilityForID(const WTF::UUID&, bool visible, CompletionHandler<void()>&&);
+    void createTextIndicatorForRange(const WebCore::SimpleRange&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
+    void createTextIndicatorForID(const WTF::UUID&, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&&);
+    void enableTextIndicatorStyleAfterElementWithID(const String& elementID, const WTF::UUID&);
+    void enableTextIndicatorStyleForElementWithID(const String& elementID, const WTF::UUID&);
+
+private:
+    RefPtr<WebCore::Document> document() const;
+    WeakPtr<WebPage> m_webPage;
+
+    HashMap<WTF::UUID, Vector<TextIndicatorStyleState>> m_activeTextIndicatorStyles;
+    HashMap<WTF::UUID, WebCore::CharacterRange> m_currentlyStyledRange;
+    HashMap<WTF::UUID, std::optional<TextIndicatorStyleUnstyledRangeData>> m_unstyledRanges;
+    HashMap<WTF::UUID, Ref<WebCore::Range>> m_textIndicatorStyleEnablementRanges;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(UNIFIED_TEXT_REPLACEMENT)

--- a/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
+++ b/Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h
@@ -49,8 +49,6 @@ namespace WebKit {
 
 enum class WebUnifiedTextReplacementSessionDataReplacementType : uint8_t;
 
-enum class RemoveAllMarkersForSession : uint8_t { No, Yes };
-
 class WebPage;
 
 struct WebUnifiedTextReplacementContextData;
@@ -79,10 +77,6 @@ public:
     void updateStateForSelectedReplacementIfNeeded();
 
     std::optional<WebCore::SimpleRange> contextRangeForSessionWithUUID(const WTF::UUID&) const;
-    std::optional<WebCore::SimpleRange> contextRangeForSessionOrRangeWithUUID(const WTF::UUID&) const;
-
-    void removeTransparentMarkersForUUID(const WTF::UUID&);
-    void removeTransparentMarkersForSession(const WTF::UUID&, RemoveAllMarkersForSession);
 
 private:
     struct State {
@@ -112,10 +106,6 @@ private:
     RefPtr<WebCore::Document> document() const;
 
     WeakPtr<WebPage> m_webPage;
-
-    using TextIndicatorCharacterRange = std::pair<WTF::UUID, WebCore::CharacterRange>;
-    Vector<std::pair<WTF::UUID, Vector<TextIndicatorCharacterRange>>> m_textIndicatorCharacterRangesForSessions;
-    Vector<std::pair<WTF::UUID, std::pair<WTF::UUID, WebCore::SimpleRange>>> m_remainingRangesForSessions;
 
     // FIXME: Unify these states into a single `State` struct.
     HashMap<WTF::UUID, Ref<WebCore::Range>> m_contextRanges;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -336,6 +336,7 @@
 #include "RemoteLayerTreeTransaction.h"
 #include "RemoteObjectRegistryMessages.h"
 #include "TextCheckingControllerProxy.h"
+#include "TextIndicatorStyleController.h"
 #include "VideoPresentationManager.h"
 #include "WKStringCF.h"
 #include "WebRemoteObjectRegistry.h"
@@ -632,6 +633,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     , m_historyItemClient(WebHistoryItemClient::create())
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
     , m_unifiedTextReplacementController(makeUniqueRef<UnifiedTextReplacementController>(*this))
+    , m_textIndicatorStyleController(makeUniqueRef<TextIndicatorStyleController>(*this))
 #endif
 {
     ASSERT(m_identifier);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -339,6 +339,7 @@ class RemoteRenderingBackendProxy;
 class RemoteWebInspectorUI;
 class SharedMemoryHandle;
 class TextCheckingControllerProxy;
+class TextIndicatorStyleController;
 class UserMediaPermissionRequestManager;
 class ViewGestureGeometryCollector;
 class WebColorChooser;
@@ -860,6 +861,12 @@ public:
 #if PLATFORM(COCOA)
     void insertTextPlaceholder(const WebCore::IntSize&, CompletionHandler<void(const std::optional<WebCore::ElementContext>&)>&&);
     void removeTextPlaceholder(const WebCore::ElementContext&, CompletionHandler<void()>&&);
+#endif
+
+#if ENABLE(UNIFIED_TEXT_REPLACEMENT)
+    TextIndicatorStyleController& textIndicatorStyleController() { return m_textIndicatorStyleController.get(); };
+
+    UnifiedTextReplacementController& unifiedTextReplacementController() { return m_unifiedTextReplacementController.get(); };
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -2257,8 +2264,6 @@ private:
 
     void textReplacementSessionDidReceiveEditAction(const WebUnifiedTextReplacementSessionData&, WebKit::WebTextReplacementDataEditAction);
 
-    std::optional<WebCore::SimpleRange> getRangeForUUID(const WTF::UUID&);
-
     void updateTextIndicatorStyleVisibilityForID(const WTF::UUID&, bool, CompletionHandler<void()>&&);
 #endif
 
@@ -2811,7 +2816,7 @@ private:
 
 #if ENABLE(UNIFIED_TEXT_REPLACEMENT)
     UniqueRef<UnifiedTextReplacementController> m_unifiedTextReplacementController;
-    HashMap<WTF::UUID, Ref<WebCore::Range>> m_textIndicatorStyleEnablementRanges;
+    UniqueRef<TextIndicatorStyleController> m_textIndicatorStyleController;
 #endif
 
     std::unique_ptr<WebCore::NowPlayingMetadataObserver> m_nowPlayingMetadataObserver;


### PR DESCRIPTION
#### 6b87830de4887034635dd02fdba85bdf0ebc18a6
<pre>
Refactor TextIndicatorStyle to be seperate from UnifiedTextReplacementController.
<a href="https://bugs.webkit.org/show_bug.cgi?id=275169">https://bugs.webkit.org/show_bug.cgi?id=275169</a>
<a href="https://rdar.apple.com/129292403">rdar://129292403</a>

Reviewed by Aditya Keerthi.

TextIndicatorStyle is not always tied to what is happening in UnifiedTextReplacementController,
so it should be it&apos;s own separate system that interacts with UnifiedTextReplacementController
and WebPage to handle the current styling for all text indicators.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextIndicatorStyleController.mm: Added.
(WebKit::TextIndicatorStyleController::TextIndicatorStyleController):
(WebKit::TextIndicatorStyleController::document const):
(WebKit::TextIndicatorStyleController::contextRangeForTextIndicatorStyle const):
(WebKit::TextIndicatorStyleController::cleanUpTextStylesForSessionID):
(WebKit::TextIndicatorStyleController::removeTransparentMarkersForUUID):
(WebKit::newlyReplacedCharacterRange):
(WebKit::TextIndicatorStyleController::addSourceTextIndicatorStyle):
(WebKit::TextIndicatorStyleController::addDestinationTextIndicatorStyle):
(WebKit::TextIndicatorStyleController::updateTextIndicatorStyleVisibilityForID):
(WebKit::TextIndicatorStyleController::createTextIndicatorForRange):
(WebKit::TextIndicatorStyleController::createTextIndicatorForID):
(WebKit::TextIndicatorStyleController::enableTextIndicatorStyleAfterElementWithID):
(WebKit::TextIndicatorStyleController::enableTextIndicatorStyleForElementWithID):
* Source/WebKit/WebProcess/WebPage/Cocoa/UnifiedTextReplacementController.mm:
(WebKit::UnifiedTextReplacementController::didEndTextReplacementSession):
(WebKit::UnifiedTextReplacementController::textReplacementSessionDidReceiveTextWithReplacementRange):
(WebKit::UnifiedTextReplacementController::removeTransparentMarkersForUUID): Deleted.
(WebKit::UnifiedTextReplacementController::removeTransparentMarkersForSession): Deleted.
(WebKit::UnifiedTextReplacementController::contextRangeForSessionOrRangeWithUUID const): Deleted.
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::createTextIndicatorForID):
(WebKit::WebPage::updateTextIndicatorStyleVisibilityForID):
(WebKit::WebPage::enableTextIndicatorStyleAfterElementWithID):
(WebKit::WebPage::enableTextIndicatorStyleForElementWithID):
(WebKit::WebPage::getRangeForUUID): Deleted.
(WebKit::WebPage::createTextIndicatorForRange): Deleted.
* Source/WebKit/WebProcess/WebPage/TextIndicatorStyleController.h: Added.
* Source/WebKit/WebProcess/WebPage/UnifiedTextReplacementController.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_textIndicatorStyleController):
(WebKit::m_unifiedTextReplacementController): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
(WebKit::WebPage::textIndicatorStyleController):
(WebKit::WebPage::unifiedTextReplacementController):

Canonical link: <a href="https://commits.webkit.org/279792@main">https://commits.webkit.org/279792@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32bc45135c39b074a31a9d44bb8891c1407a50c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57845 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5298 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41522 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5300 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3568 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56659 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25317 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28930 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3438 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4805 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59435 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29797 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4951 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51618 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30947 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50995 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11926 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31925 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30735 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->