### PR TITLE
[WebGPU] RenderBundleEncoder::drawIndexed does not check for the buffer being destroyed

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-275167-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-275167-expected.txt
@@ -1,0 +1,57 @@
+CONSOLE MESSAGE: device0.uncapturederror
+CONSOLE MESSAGE: [object GPUUncapturedErrorEvent]
+CONSOLE MESSAGE: device0.uncapturederror
+CONSOLE MESSAGE: [object GPUUncapturedErrorEvent]
+CONSOLE MESSAGE: device0.uncapturederror
+CONSOLE MESSAGE: [object GPUUncapturedErrorEvent]
+CONSOLE MESSAGE: device1.uncapturederror
+CONSOLE MESSAGE: [object GPUUncapturedErrorEvent]
+CONSOLE MESSAGE: device2.uncapturederror
+CONSOLE MESSAGE: [object GPUUncapturedErrorEvent]
+CONSOLE MESSAGE: Unhandled Promise Rejection: OperationError: map async was not successful
+CONSOLE MESSAGE: error
+CONSOLE MESSAGE: OperationError: not mapped or destroyed
+CONSOLE MESSAGE: DOMException
+CONSOLE MESSAGE: getMappedRange@[native code]
+@fuzz-275167.html:9065:43
+CONSOLE MESSAGE: not mapped or destroyed
+layer at (0,0) size 2383x959
+  RenderView at (0,0) size 785x585
+layer at (0,0) size 785x959
+  RenderBlock {HTML} at (0,0) size 785x959 [color=#99DDBBCC] [bgcolor=#102030E0]
+    RenderBody {BODY} at (8,8) size 769x943
+      RenderImage {IMG} at (32,170) size 249x114
+      RenderImage {IMG} at (281,163) size 3x121
+      RenderHTMLCanvas {CANVAS} at (0,284) size 74x150
+      RenderHTMLCanvas {CANVAS} at (0,434) size 2375x150
+      RenderImage {IMG} at (0,786) size 281x21
+      RenderImage {IMG} at (497,667) size 138x140
+      RenderImage {IMG} at (635,797) size 126x10
+layer at (8,276) size 16x16
+  RenderVideo {VIDEO} at (0,268) size 16x16
+layer at (24,276) size 16x16
+  RenderVideo {VIDEO} at (16,268) size 16x16
+layer at (292,228) size 64x64
+  RenderVideo {VIDEO} at (284,220) size 64x64
+layer at (356,8) size 284x284
+  RenderVideo {VIDEO} at (348,0) size 284x284
+layer at (640,276) size 16x16
+  RenderVideo {VIDEO} at (632,268) size 16x16
+layer at (656,244) size 48x48
+  RenderVideo {VIDEO} at (648,236) size 48x48
+layer at (82,426) size 16x16
+  RenderVideo {VIDEO} at (74,418) size 16x16
+layer at (98,292) size 300x150
+  RenderHTMLCanvas {CANVAS} at (90,284) size 300x150
+layer at (398,426) size 16x16
+  RenderVideo {VIDEO} at (390,418) size 16x16
+layer at (289,592) size 216x223
+  RenderVideo {VIDEO} at (281,584) size 216x223
+layer at (8,845) size 16x16
+  RenderVideo {VIDEO} at (0,837) size 16x16
+layer at (24,815) size 753x46
+  RenderHTMLCanvas {CANVAS} at (16,807) size 753x46
+layer at (8,861) size 90x90
+  RenderVideo {VIDEO} at (0,853) size 90x90
+layer at (98,935) size 16x16
+  RenderVideo {VIDEO} at (90,927) size 16x16

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-275167.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-275167.html
@@ -1,0 +1,9291 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = console.debug;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ */
+function pseudoSubmit(device) {
+  for (let i = 0; i < 63; i++) {
+    device.createCommandEncoder();
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter({powerPreference: 'high-performance'});
+let device0 = await adapter0.requestDevice({
+  label: '\u53f4\u7613\u0b94\u0b51',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 10,
+    maxColorAttachmentBytesPerSample: 59,
+    maxVertexAttributes: 21,
+    maxVertexBufferArrayStride: 46908,
+    maxStorageTexturesPerShaderStage: 19,
+    maxStorageBuffersPerShaderStage: 34,
+    maxDynamicStorageBuffersPerPipelineLayout: 62655,
+    maxDynamicUniformBuffersPerPipelineLayout: 30351,
+    maxBindingsPerBindGroup: 4740,
+    maxTextureArrayLayers: 620,
+    maxTextureDimension1D: 8268,
+    maxTextureDimension2D: 14057,
+    maxVertexBuffers: 9,
+    maxBindGroupsPlusVertexBuffers: 30,
+    minStorageBufferOffsetAlignment: 128,
+    minUniformBufferOffsetAlignment: 64,
+    maxUniformBufferBindingSize: 25953004,
+    maxStorageBufferBindingSize: 155194963,
+    maxUniformBuffersPerShaderStage: 40,
+    maxSampledTexturesPerShaderStage: 44,
+    maxInterStageShaderVariables: 48,
+    maxInterStageShaderComponents: 67,
+    maxSamplersPerShaderStage: 21,
+  },
+});
+let querySet0 = device0.createQuerySet({label: '\u0a6c\u{1fc92}\u085c\u{1fcb5}\u{1fe6b}', type: 'occlusion', count: 1352});
+let bindGroupLayout0 = device0.createBindGroupLayout({entries: [{binding: 4222, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }}]});
+let pipelineLayout0 = device0.createPipelineLayout({
+  label: '\u08b5\uf43a',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0],
+});
+let commandEncoder0 = device0.createCommandEncoder({label: '\u0a95\u4180\ue02b\u05d8\u0fac\u0d47\u8615'});
+let texture0 = device0.createTexture({
+  size: {width: 2000, height: 8, depthOrArrayLayers: 302},
+  mipLevelCount: 5,
+  dimension: '2d',
+  format: 'astc-8x8-unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['astc-8x8-unorm', 'astc-8x8-unorm'],
+});
+let textureView0 = texture0.createView({
+  label: '\u8429\u7ee4\u059a\uf3e7\u0029\u944c\u3ade\u01f8\u0612\ue592',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 38,
+  arrayLayerCount: 71,
+});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({colorFormats: ['rg8uint', 'r8sint', 'rg8sint', 'rg16float', 'rgba32sint'], stencilReadOnly: false});
+let renderBundle0 = renderBundleEncoder0.finish({label: '\u423f\u{1fc84}\uf7d9\u0718\uf648\uf6e0\u2f28\u0fd4\u5a5a'});
+let shaderModule0 = device0.createShaderModule({
+  code: `@group(3) @binding(4222)
+var<storage, read_write> parameter0: array<u32>;
+@group(1) @binding(4222)
+var<storage, read_write> function0: array<u32>;
+@group(0) @binding(4222)
+var<storage, read_write> n0: array<u32>;
+@group(4) @binding(4222)
+var<storage, read_write> function1: array<u32>;
+@group(2) @binding(4222)
+var<storage, read_write> parameter1: array<u32>;
+
+@compute @workgroup_size(4, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec2<u32>,
+  @location(3) f2: vec3<f32>,
+  @location(1) f3: i32,
+  @location(4) f4: vec4<i32>,
+  @location(7) f5: vec4<u32>,
+  @location(2) f6: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(front_facing) a2: bool, @builtin(sample_mask) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S0 {
+  @location(5) f0: vec3<i32>,
+  @location(4) f1: vec3<u32>,
+  @location(13) f2: vec2<i32>,
+  @location(9) f3: vec3<i32>,
+  @location(19) f4: vec3<f16>,
+  @location(14) f5: vec2<i32>,
+  @builtin(vertex_index) f6: u32,
+  @location(15) f7: vec3<i32>,
+  @location(10) f8: vec4<u32>,
+  @location(11) f9: vec4<f16>,
+  @location(20) f10: vec3<u32>,
+  @location(3) f11: vec3<f16>,
+  @location(2) f12: vec3<f32>,
+  @location(6) f13: vec3<f32>,
+  @location(17) f14: i32,
+  @location(18) f15: i32,
+  @location(12) f16: i32,
+  @location(8) f17: vec3<f32>,
+  @location(7) f18: vec4<u32>,
+  @location(0) f19: i32,
+  @builtin(instance_index) f20: u32
+}
+
+@vertex
+fn vertex0(@location(16) a0: f16, @location(1) a1: vec2<f32>, a2: S0) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder1 = device0.createCommandEncoder({label: '\u{1f818}\u{1f60d}\u{1fd84}\u{1ff04}'});
+let sampler0 = device0.createSampler({
+  label: '\u0b72\ufd20\u0308\u3514\u9e66\u{1fe9d}\u78ba\ueb4c',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 89.25,
+  lodMaxClamp: 96.27,
+  compare: 'less-equal',
+});
+let promise0 = device0.createRenderPipelineAsync({
+  label: '\u3b46\ua40f\u0746\u0809\u1459\u6c9b\u0356\ubcbe',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'r8sint', writeMask: 0}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rg16float', writeMask: GPUColorWrite.ALPHA}, {format: 'rgba32sint', writeMask: GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'less-equal', failOp: 'keep', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilBack: {compare: 'equal', failOp: 'replace', depthFailOp: 'decrement-wrap', passOp: 'increment-wrap'},
+    stencilWriteMask: 2764692900,
+    depthBiasSlopeScale: 33.049187917012404,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 16096,
+        attributes: [
+          {format: 'sint16x2', offset: 300, shaderLocation: 13},
+          {format: 'sint8x2', offset: 2186, shaderLocation: 14},
+          {format: 'unorm16x4', offset: 1984, shaderLocation: 11},
+          {format: 'sint16x2', offset: 3464, shaderLocation: 15},
+          {format: 'snorm16x4', offset: 1208, shaderLocation: 2},
+          {format: 'float32', offset: 1024, shaderLocation: 16},
+          {format: 'uint16x2', offset: 1400, shaderLocation: 7},
+          {format: 'sint16x2', offset: 1028, shaderLocation: 9},
+          {format: 'unorm16x2', offset: 2836, shaderLocation: 8},
+          {format: 'sint32x4', offset: 2464, shaderLocation: 0},
+          {format: 'sint32', offset: 3172, shaderLocation: 5},
+          {format: 'unorm16x4', offset: 4524, shaderLocation: 3},
+          {format: 'snorm8x2', offset: 846, shaderLocation: 1},
+          {format: 'sint8x4', offset: 628, shaderLocation: 18},
+          {format: 'sint8x2', offset: 1232, shaderLocation: 12},
+          {format: 'uint32x2', offset: 3140, shaderLocation: 20},
+          {format: 'float32x3', offset: 204, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 5640,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 196, shaderLocation: 17},
+          {format: 'uint8x2', offset: 402, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 2228,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 1140, shaderLocation: 19},
+          {format: 'uint32x3', offset: 44, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  label: '\u5813\u0ce2\u{1f9e0}\uc5a3\u04f3\u0545\u682b',
+  entries: [
+    {binding: 3048, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 1928,
+      visibility: 0,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+  ],
+});
+let querySet1 = device0.createQuerySet({label: '\uff6a\u0df0\uddb8\u08eb', type: 'occlusion', count: 592});
+let texture1 = device0.createTexture({
+  label: '\u0874\u0dcb\u{1fdc4}',
+  size: {width: 900, height: 120, depthOrArrayLayers: 19},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle1 = renderBundleEncoder0.finish({label: '\u{1f94f}\u{1fd40}\u0fe6\u0e55\ud49f'});
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let buffer0 = device0.createBuffer({
+  label: '\u{1ff03}\uaabc\u1fc7\u06cc\u0228\ude5f',
+  size: 148365,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let querySet2 = device0.createQuerySet({label: '\u04cb\u{1fbf3}\u96df\u03c8', type: 'occlusion', count: 639});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  colorFormats: ['rg8uint', 'r8sint', 'rg8sint', 'rg16float', 'rgba32sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle2 = renderBundleEncoder0.finish();
+try {
+renderBundleEncoder1.setVertexBuffer(5528, undefined, 4057185867, 3353112);
+} catch {}
+try {
+  await buffer0.mapAsync(GPUMapMode.READ, 0, 101244);
+} catch {}
+try {
+commandEncoder0.clearBuffer(buffer0, 14160, 13416);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandBuffer0 = commandEncoder1.finish();
+let texture2 = device0.createTexture({
+  size: [20, 6, 1],
+  mipLevelCount: 4,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg8sint', 'rg8sint'],
+});
+let computePassEncoder0 = commandEncoder0.beginComputePass({label: '\udaaf\ucf52\u08fe'});
+let sampler1 = device0.createSampler({
+  label: '\ub4c6\u{1fb93}\u{1fa88}\u202a\uefec\uadad',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 92.37,
+  lodMaxClamp: 98.71,
+  compare: 'equal',
+  maxAnisotropy: 13,
+});
+let commandEncoder2 = device0.createCommandEncoder();
+let textureView1 = texture0.createView({
+  label: '\u8910\u09f0',
+  format: 'astc-8x8-unorm',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 145,
+  arrayLayerCount: 90,
+});
+let renderBundle3 = renderBundleEncoder1.finish({label: '\u7ff5\u0563\u0c91\u{1fc7b}\u02fa\u920c\ud598'});
+let sampler2 = device0.createSampler({
+  label: '\u3427\u{1fb73}\u{1fa97}\ud046\u{1f67f}\u{1fe96}\u05d6\uf7c4\u0719',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 93.65,
+  lodMaxClamp: 99.97,
+});
+let promise1 = device0.createComputePipelineAsync({layout: pipelineLayout0, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+let canvas0 = document.createElement('canvas');
+let shaderModule1 = device0.createShaderModule({
+  label: '\u{1ffd1}\u{1f77b}',
+  code: `@group(0) @binding(4222)
+var<storage, read_write> type0: array<u32>;
+@group(4) @binding(4222)
+var<storage, read_write> global0: array<u32>;
+@group(2) @binding(4222)
+var<storage, read_write> parameter2: array<u32>;
+@group(3) @binding(4222)
+var<storage, read_write> type1: array<u32>;
+
+@compute @workgroup_size(8, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(3) f1: vec3<f32>,
+  @location(4) f2: vec4<i32>,
+  @location(2) f3: vec2<i32>,
+  @builtin(sample_mask) f4: u32,
+  @location(1) f5: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool, @builtin(position) a2: vec4<f32>, @builtin(sample_mask) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(9) a0: vec3<f32>, @location(16) a1: vec4<f32>, @location(7) a2: vec3<f16>, @location(20) a3: u32, @location(15) a4: vec3<f16>, @location(8) a5: vec4<f16>, @location(6) a6: vec4<f32>, @location(17) a7: vec2<f32>, @builtin(vertex_index) a8: u32, @builtin(instance_index) a9: u32, @location(2) a10: i32, @location(11) a11: vec2<f32>, @location(1) a12: vec2<u32>, @location(12) a13: vec2<u32>, @location(5) a14: i32, @location(10) a15: f16, @location(4) a16: f16, @location(13) a17: vec2<u32>, @location(0) a18: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let commandEncoder3 = device0.createCommandEncoder();
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  label: '\u6054\u{1fe4e}\ua6f6\u0e44\uf635\u{1f610}\u819d\uae0b\ua0b2\u2bd7\udfe9',
+  colorFormats: ['rg8uint', 'r8sint', 'rg8sint', 'rg16float', 'rgba32sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle4 = renderBundleEncoder0.finish({label: '\ucdfe\u0881\uc2e1\u1a32\u38c1'});
+try {
+renderBundleEncoder2.setVertexBuffer(779, undefined, 2625504507);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  label: '\u{1fa17}\u{1fd6a}\u658d\ue1ed\uf9e4\u0a2e\u{1fe85}',
+  code: `@group(1) @binding(4222)
+var<storage, read_write> local0: array<u32>;
+@group(4) @binding(4222)
+var<storage, read_write> field0: array<u32>;
+@group(0) @binding(4222)
+var<storage, read_write> field1: array<u32>;
+@group(3) @binding(4222)
+var<storage, read_write> local1: array<u32>;
+
+@compute @workgroup_size(5, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<f32>,
+  @location(1) f1: vec2<i32>,
+  @location(2) f2: vec3<i32>,
+  @location(0) f3: vec2<u32>,
+  @location(4) f4: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S1 {
+  @location(9) f0: vec4<f16>,
+  @location(16) f1: f16
+}
+
+@vertex
+fn vertex0(a0: S1, @location(4) a1: vec2<u32>, @builtin(instance_index) a2: u32, @location(20) a3: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+});
+let bindGroup0 = device0.createBindGroup({
+  label: '\ue453\u035f\u0de4\u8c24\u6c48\u648f',
+  layout: bindGroupLayout0,
+  entries: [{binding: 4222, resource: sampler1}],
+});
+let commandEncoder4 = device0.createCommandEncoder();
+let texture3 = device0.createTexture({
+  size: [112],
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8uint', 'rg8uint', 'rg8uint'],
+});
+let textureView2 = texture0.createView({
+  label: '\u6a4f\u{1fe1c}\u0fc6\u{1f8a3}\u07f2',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 256,
+  arrayLayerCount: 44,
+});
+let sampler3 = device0.createSampler({
+  label: '\ud104\u5223\u{1fa7e}\u{1fb45}\u4092\u08b6\u0943\u217d\uaa8a',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 89.38,
+  lodMaxClamp: 96.82,
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder2.setBindGroup(1, bindGroup0, []);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(new ArrayBuffer(32)), /* required buffer size: 536 */
+{offset: 344, bytesPerRow: 94}, {width: 2, height: 3, depthOrArrayLayers: 1});
+} catch {}
+canvas0.width = 200;
+gc();
+let pipelineLayout1 = device0.createPipelineLayout({
+  label: '\u9048\u028c\u8504\u{1f9a7}\uaa03\u{1fa40}\u8f7c\u05ce\u99ed',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout1, bindGroupLayout0, bindGroupLayout1, bindGroupLayout1],
+});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  label: '\u{1f6a0}\u3aaa\u861c',
+  colorFormats: ['rg8uint', 'r8sint', 'rg8sint', 'rg16float', 'rgba32sint'],
+  stencilReadOnly: true,
+});
+let renderBundle5 = renderBundleEncoder3.finish({label: '\u3386\u{1fe87}\u{1f9b2}\u{1fa41}'});
+let sampler4 = device0.createSampler({
+  label: '\u9214\ufa13\u{1fa41}\udab7\ucc91\ub39a',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 66.23,
+  lodMaxClamp: 99.17,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+let commandEncoder5 = device0.createCommandEncoder();
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 2812});
+let textureView3 = texture1.createView({aspect: 'all', baseArrayLayer: 7, arrayLayerCount: 5});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\u029a\u{1ff76}\u{1f7aa}\uf77f\u438a\u{1fefe}',
+  colorFormats: ['rg8uint', 'r8sint', 'rg8sint', 'rg16float', 'rgba32sint'],
+  depthReadOnly: true,
+});
+try {
+commandEncoder5.clearBuffer(buffer0, 89296, 37572);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+adapter0.label = '\u067a\u{1f789}\u{1f973}\u790f\u3689\u0d14\u61ac';
+} catch {}
+let pipelineLayout2 = device0.createPipelineLayout({
+  label: '\u8efb\u0468\ub68c\u0591',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout0, bindGroupLayout1, bindGroupLayout1, bindGroupLayout0, bindGroupLayout0, bindGroupLayout1, bindGroupLayout1, bindGroupLayout1, bindGroupLayout1],
+});
+let textureView4 = texture3.createView({label: '\u86bc\u0586\u0065\u01fe\ub813\u{1f63c}\u75e6\u0cbb\ube6a'});
+let computePassEncoder1 = commandEncoder2.beginComputePass({label: '\u6731\u61ca'});
+try {
+buffer0.destroy();
+} catch {}
+try {
+commandEncoder0.clearBuffer(buffer0, 99088, 6996);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let commandEncoder6 = device0.createCommandEncoder();
+let textureView5 = texture1.createView({label: '\ud9b1\ubf14\u6cbd\u0ca6\u{1f7c3}', mipLevelCount: 1, baseArrayLayer: 10, arrayLayerCount: 6});
+try {
+commandEncoder3.clearBuffer(buffer0, 70680, 59744);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise2 = device0.createRenderPipelineAsync({
+  label: '\u9596\u11fe\ubcd6\u0b03\u{1fe01}\u{1f88d}\u6270\ua611',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL}, {format: 'r8sint', writeMask: 0}, {format: 'rg8sint'}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'dst'},
+    alpha: {operation: 'add', srcFactor: 'src', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'greater-equal', failOp: 'replace', depthFailOp: 'zero', passOp: 'zero'},
+    stencilBack: {compare: 'greater-equal', failOp: 'replace', depthFailOp: 'invert', passOp: 'increment-wrap'},
+    stencilWriteMask: 2882939831,
+    depthBiasSlopeScale: 332.4302213387692,
+    depthBiasClamp: 581.4066805532325,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 17384,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 852, shaderLocation: 20},
+          {format: 'uint32x4', offset: 1556, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 5492,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x4', offset: 2884, shaderLocation: 9}],
+      },
+      {arrayStride: 0, attributes: [{format: 'float32x2', offset: 26748, shaderLocation: 16}]},
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let commandEncoder7 = device0.createCommandEncoder({});
+let querySet4 = device0.createQuerySet({
+  label: '\u4f5a\u03d5\u{1f805}\u1dc3\u3496\ub545\uc69e\udc7a\u06bf\u1339\u03da',
+  type: 'occlusion',
+  count: 2816,
+});
+try {
+buffer0.destroy();
+} catch {}
+let textureView6 = texture3.createView({label: '\u04e4\ufa08\u7303\u009a'});
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+commandEncoder3.clearBuffer(buffer0, 110516, 30252);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({label: '\u45d2\u911d\u{1f85f}\u0bba\u8b02\u{1f838}\u06c3\u054e\u0a99'});
+let textureView7 = texture3.createView({label: '\u{1f896}\u90d3\u4d97\u{1fa57}\u4015\u0fed', aspect: 'all'});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  label: '\u4ac4\u052d\u4037\u0584\u82fa\u4eb9\u97ac\ua982',
+  colorFormats: ['rg8uint', 'r8sint', 'rg8sint', 'rg16float', 'rgba32sint'],
+  stencilReadOnly: false,
+});
+let pipeline0 = device0.createRenderPipeline({
+  label: '\u1882\u{1f6aa}\u5ea6\u66a7\u023e\u7225\u0e48\u{1f7df}\u{1f87c}',
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8sint', writeMask: 0}, {format: 'rg8sint', writeMask: GPUColorWrite.GREEN}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'one-minus-src'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}, {format: 'rgba32sint'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'not-equal', failOp: 'increment-clamp', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilReadMask: 3088431816,
+    depthBias: -1590381287,
+    depthBiasSlopeScale: 496.21068622953203,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 15048,
+        attributes: [
+          {format: 'uint32x4', offset: 356, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 2184, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 21240,
+        stepMode: 'vertex',
+        attributes: [{format: 'float32x4', offset: 3392, shaderLocation: 9}],
+      },
+      {arrayStride: 3820, attributes: [{format: 'unorm8x4', offset: 96, shaderLocation: 20}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'front', unclippedDepth: true},
+});
+let shaderModule3 = device0.createShaderModule({
+  label: '\u{1f9bc}\u3f9c\ube27\u235f\u6493\u0388\u005b',
+  code: `@group(2) @binding(4222)
+var<storage, read_write> function2: array<u32>;
+@group(0) @binding(4222)
+var<storage, read_write> field2: array<u32>;
+@group(3) @binding(4222)
+var<storage, read_write> type2: array<u32>;
+@group(4) @binding(4222)
+var<storage, read_write> global1: array<u32>;
+@group(1) @binding(4222)
+var<storage, read_write> parameter3: array<u32>;
+
+@compute @workgroup_size(2, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S2 {
+  @location(8) f0: vec3<f32>,
+  @location(44) f1: vec3<f16>
+}
+struct FragmentOutput0 {
+  @location(3) f0: vec4<f32>,
+  @location(0) f1: vec3<u32>,
+  @location(1) f2: vec2<i32>,
+  @location(4) f3: vec4<i32>,
+  @location(2) f4: vec2<i32>
+}
+
+@fragment
+fn fragment0(@location(41) a0: vec4<i32>, @location(32) a1: vec2<f32>, a2: S2, @location(9) a3: vec3<f16>, @location(0) a4: f16) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(19) f0: vec3<i32>,
+  @location(10) f1: vec4<u32>,
+  @location(42) f2: vec3<f16>,
+  @location(3) f3: vec3<i32>,
+  @location(0) f4: f16,
+  @location(8) f5: vec3<f32>,
+  @location(4) f6: f16,
+  @location(43) f7: i32,
+  @location(45) f8: vec2<f16>,
+  @location(28) f9: u32,
+  @location(24) f10: vec4<u32>,
+  @location(32) f11: vec2<f32>,
+  @location(37) f12: f32,
+  @location(21) f13: u32,
+  @builtin(position) f14: vec4<f32>,
+  @location(47) f15: f32,
+  @location(7) f16: vec4<f32>,
+  @location(35) f17: vec4<f32>,
+  @location(22) f18: f16,
+  @location(16) f19: vec2<i32>,
+  @location(39) f20: f32,
+  @location(20) f21: vec3<f32>,
+  @location(11) f22: i32,
+  @location(9) f23: vec3<f16>,
+  @location(12) f24: vec3<f16>,
+  @location(15) f25: vec3<f16>,
+  @location(44) f26: vec3<f16>,
+  @location(18) f27: vec2<u32>,
+  @location(41) f28: vec4<i32>,
+  @location(23) f29: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec2<i32>, @location(13) a1: vec4<u32>, @location(0) a2: vec3<f32>, @location(5) a3: f16, @location(7) a4: vec3<i32>, @location(3) a5: i32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder9 = device0.createCommandEncoder({label: '\u{1f655}\u5f06\uf0f4\u270b\u{1f6d1}\u0d48'});
+let textureView8 = texture2.createView({label: '\u8755\u066e\u014e\u{1fcb8}\uaa79', dimension: '2d-array', baseMipLevel: 2});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({
+  label: '\u39c3\udaf7\u3b75\u0191\u{1f6c2}\u9e8d\ue80e\u{1f607}\ud0e5\u1f46\u0330',
+  colorFormats: ['rg8uint', 'r8sint', 'rg8sint', 'rg16float', 'rgba32sint'],
+  depthReadOnly: true,
+});
+let sampler5 = device0.createSampler({
+  label: '\u02c5\udb49\u0251',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 5.572,
+  compare: 'never',
+  maxAnisotropy: 17,
+});
+try {
+renderBundleEncoder6.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(8, bindGroup0, new Uint32Array(3925), 3605, 0);
+} catch {}
+let pipelineLayout3 = device0.createPipelineLayout({
+  label: '\u{1f9ac}\u5547\u755b\u0e48\uaabf\u0c91\u0000\u03cb\u0a95\u88d0\u{1f702}',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout1, bindGroupLayout1, bindGroupLayout1, bindGroupLayout0, bindGroupLayout1, bindGroupLayout0],
+});
+let commandEncoder10 = device0.createCommandEncoder({label: '\u0dcb\u{1ff9f}\u4ccd\u15c8\u084d\u{1f8bb}\u1f5c'});
+let commandBuffer1 = commandEncoder9.finish({label: '\u574b\u{1fb29}'});
+let renderBundle6 = renderBundleEncoder4.finish({label: '\u038e\udd5e\u6f18\u540e\u5001\u{1f81c}\u0d16\ub88f\u0502\u{1f8b4}\u{1ff4c}'});
+try {
+commandEncoder6.clearBuffer(buffer0, 87420, 45168);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let commandEncoder11 = device0.createCommandEncoder({});
+let querySet5 = device0.createQuerySet({label: '\u0e4f\ub0cd\u{1fbb1}\ue882\u052f\ufb37\uf66b\u0f6f', type: 'occlusion', count: 2953});
+try {
+commandEncoder10.clearBuffer(buffer0, 3940, 86548);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+let pipeline1 = await device0.createComputePipelineAsync({
+  label: '\uc1e7\u0c4b\u{1fa97}\u{1fa7f}\u0fa7\u3dd0\u00fa\u209a\u07a1',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder12 = device0.createCommandEncoder();
+let textureView9 = texture3.createView({label: '\ue95d\u10ed\u{1fef6}\u3471\ue4b1\u23ae\u23a6\u0fe1\u4a5d\u0245', mipLevelCount: 1});
+let renderBundle7 = renderBundleEncoder5.finish({label: '\u0f00\u9163\u051e\u71c9\u{1ff6f}\u934d\u05ac\u50fd'});
+let video0 = await videoWithData();
+let commandEncoder13 = device0.createCommandEncoder({label: '\u{1fbbf}\u047f\u0158\u08f9\u18ef\u134c\ud1f2'});
+let querySet6 = device0.createQuerySet({label: '\u970d\u{1f614}\u{1fcbe}\ub486\u0413\u0928\u0be7\u{1f639}', type: 'occlusion', count: 261});
+let renderBundle8 = renderBundleEncoder0.finish({label: '\uf494\u{1fdc4}\u3bee\u{1f937}\u1791\u{1fd3b}'});
+let sampler6 = device0.createSampler({
+  label: '\uaf00\uf119\ub8fb\u53b2\u0221\ub2b1\u4a45',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 81.25,
+  maxAnisotropy: 3,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 23, y: 1, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 3_784_163 */
+{offset: 126, bytesPerRow: 4069, rowsPerImage: 279}, {width: 246, height: 93, depthOrArrayLayers: 4});
+} catch {}
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+let renderBundle9 = renderBundleEncoder3.finish({label: '\u9e19\u047e\u0265\u{1fe60}\u{1f856}\u3ec1\uad3d'});
+try {
+querySet2.destroy();
+} catch {}
+let pipeline2 = await device0.createComputePipelineAsync({
+  label: '\ub566\u{1f6ce}\u7ef7',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipeline3 = device0.createRenderPipeline({
+  label: '\u0fda\u022d\uf602\u304d\u074b\uec00\u5bca\u{1fc13}\uc9f6\u7bfa\u3fe7',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0xf3ce07d5},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8uint', writeMask: 0}, {format: 'r8sint', writeMask: 0}, {format: 'rg8sint', writeMask: 0}, {format: 'rg16float', writeMask: GPUColorWrite.ALPHA}, {format: 'rgba32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {
+      compare: 'greater-equal',
+      failOp: 'decrement-clamp',
+      depthFailOp: 'increment-clamp',
+      passOp: 'decrement-clamp',
+    },
+    stencilBack: {failOp: 'increment-clamp', depthFailOp: 'replace'},
+    stencilReadMask: 1836193706,
+    stencilWriteMask: 3451320584,
+    depthBias: -1335016703,
+    depthBiasSlopeScale: 531.726218528964,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4932,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 330, shaderLocation: 5},
+          {format: 'sint32x3', offset: 1140, shaderLocation: 3},
+          {format: 'sint16x4', offset: 1176, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 28,
+        attributes: [
+          {format: 'snorm16x2', offset: 0, shaderLocation: 0},
+          {format: 'sint16x4', offset: 0, shaderLocation: 14},
+        ],
+      },
+      {arrayStride: 11024, stepMode: 'vertex', attributes: []},
+      {arrayStride: 7136, attributes: [{format: 'uint32x2', offset: 616, shaderLocation: 13}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+try {
+  await promise3;
+} catch {}
+let bindGroup1 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 4222, resource: sampler1}]});
+let pipelineLayout4 = device0.createPipelineLayout({
+  label: '\u0b9a\u719f\uf690\u{1f62d}\u058d\uf24d\u6205\ued0f',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout1, bindGroupLayout0, bindGroupLayout1, bindGroupLayout0, bindGroupLayout1, bindGroupLayout1, bindGroupLayout1, bindGroupLayout0, bindGroupLayout1],
+});
+let buffer1 = device0.createBuffer({
+  label: '\u{1fa51}\u{1fbcd}\u4857\u72b8\u{1f6e1}\u0289\u0d55\u9aac\u0f5f\u{1f71d}\u079b',
+  size: 16024,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder14 = device0.createCommandEncoder({});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\u324f\u{1feed}\u0ed2\u0198',
+  colorFormats: ['rg8uint', 'r8sint', 'rg8sint', 'rg16float', 'rgba32sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder8.clearBuffer(buffer0, 66828, 70824);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let imageBitmap0 = await createImageBitmap(video0);
+let commandEncoder15 = device0.createCommandEncoder({label: '\u0120\u{1fe41}\u1c72\u02fb\u{1faad}\u771f\u0d7e\u0889\ud5d5'});
+let texture4 = device0.createTexture({
+  label: '\u0918\u{1f673}\u087e',
+  size: {width: 225, height: 30, depthOrArrayLayers: 76},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8uint', 'rg8uint'],
+});
+let textureView10 = texture4.createView({label: '\u5873\ub886\ud035', baseMipLevel: 2, baseArrayLayer: 0});
+let computePassEncoder2 = commandEncoder6.beginComputePass({label: '\u2ca6\u{1fb2a}\u0e33\u483b\u0bca\u7169\u{1f744}\ue913\u0a71\u2850\u8363'});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  label: '\u5d94\u0fab\u07a7\u23e4\u2b40\u3226\u56b9\u2aaf',
+  colorFormats: ['rg8uint', 'r8sint', 'rg8sint', 'rg16float', 'rgba32sint'],
+});
+let renderBundle10 = renderBundleEncoder8.finish({label: '\u455c\u8656\u037d'});
+try {
+computePassEncoder2.setBindGroup(5, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(8601, undefined);
+} catch {}
+try {
+commandEncoder10.pushDebugGroup('\u12cb');
+} catch {}
+let img0 = await imageWithData(174, 161, '#b718e408', '#7b81e762');
+let bindGroup2 = device0.createBindGroup({
+  label: '\u{1f657}\u{1f7f7}\u2694\u05c1\u{1fb4f}\u{1f628}\u0502\u4012\u0aaf',
+  layout: bindGroupLayout0,
+  entries: [{binding: 4222, resource: sampler0}],
+});
+let buffer2 = device0.createBuffer({size: 713633, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let texture5 = device0.createTexture({
+  label: '\u02da\uba88\u3cee\u664c\u{1f6b7}\u{1fed8}\ufb74\u0fbd\u1dfd',
+  size: [80, 24, 1],
+  mipLevelCount: 3,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg8uint', 'rg8uint', 'rg8uint'],
+});
+let textureView11 = texture0.createView({
+  label: '\u50ef\uc9e2\uc704\uf00e\u{1fe66}\uacf6\u{1f76c}\u040c',
+  mipLevelCount: 3,
+  baseArrayLayer: 218,
+  arrayLayerCount: 39,
+});
+let externalTexture0 = device0.importExternalTexture({label: '\u0b15\u{1fc46}', source: video0, colorSpace: 'display-p3'});
+try {
+commandEncoder7.copyBufferToTexture({
+  /* bytesInLastRow: 98 widthInBlocks: 49 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 8554 */
+  offset: 264,
+  bytesPerRow: 256,
+  rowsPerImage: 4,
+  buffer: buffer1,
+}, {
+  texture: texture4,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 49, height: 1, depthOrArrayLayers: 9});
+dissociateBuffer(device0, buffer1);
+} catch {}
+let adapter1 = await navigator.gpu.requestAdapter({});
+let commandBuffer2 = commandEncoder2.finish({label: '\u7398\u5f58'});
+let texture6 = device0.createTexture({
+  label: '\u{1fd51}\u2845\u7cf8\u51a9\u{1fde3}\u08d8\u4813',
+  size: [4000],
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView12 = texture4.createView({label: '\u0a0a\u7196\u2b8e\u0754', baseMipLevel: 2, mipLevelCount: 1});
+try {
+renderBundleEncoder2.setVertexBuffer(8611, undefined, 1807406210, 1466770531);
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer0, 5992, 133516);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder11.pushDebugGroup('\u{1fc13}');
+} catch {}
+try {
+renderBundleEncoder2.insertDebugMarker('\u{1f9d4}');
+} catch {}
+let pipeline4 = await promise1;
+canvas0.height = 281;
+let imageData0 = new ImageData(176, 100);
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 102});
+let commandBuffer3 = commandEncoder7.finish({label: '\u3846\u{1fd27}\uf414'});
+let textureView13 = texture2.createView({dimension: '2d-array', format: 'rg8sint', baseMipLevel: 3});
+try {
+renderBundleEncoder7.setVertexBuffer(3430, undefined);
+} catch {}
+try {
+commandEncoder4.copyBufferToBuffer(buffer2, 638780, buffer0, 133984, 6216);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder3.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 78 widthInBlocks: 39 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 128198 */
+  offset: 5240,
+  bytesPerRow: 256,
+  rowsPerImage: 240,
+  buffer: buffer0,
+}, {width: 39, height: 1, depthOrArrayLayers: 3});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 544 */
+{offset: 544, rowsPerImage: 13}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline5 = device0.createRenderPipeline({
+  label: '\u4710\ua685\u0ee4\ua99e\u3e7d\uca61\ue594\u{1f75a}',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0x1c9ea981},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r8sint', writeMask: 0}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg16float', writeMask: 0}, {format: 'rgba32sint', writeMask: GPUColorWrite.ALL}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 7228,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 100, shaderLocation: 2},
+          {format: 'sint16x4', offset: 6956, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 2062, shaderLocation: 11},
+          {format: 'unorm10-10-10-2', offset: 3264, shaderLocation: 3},
+          {format: 'sint32', offset: 2972, shaderLocation: 0},
+          {format: 'unorm8x4', offset: 624, shaderLocation: 1},
+          {format: 'sint32x2', offset: 644, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 46908,
+        attributes: [
+          {format: 'uint32x4', offset: 11168, shaderLocation: 7},
+          {format: 'uint8x2', offset: 294, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 5764,
+        attributes: [
+          {format: 'uint8x4', offset: 1848, shaderLocation: 20},
+          {format: 'sint32x3', offset: 2596, shaderLocation: 9},
+          {format: 'sint32', offset: 332, shaderLocation: 5},
+          {format: 'snorm16x4', offset: 404, shaderLocation: 19},
+        ],
+      },
+      {
+        arrayStride: 1668,
+        attributes: [
+          {format: 'sint32x4', offset: 600, shaderLocation: 17},
+          {format: 'sint8x2', offset: 420, shaderLocation: 18},
+          {format: 'sint16x2', offset: 444, shaderLocation: 13},
+          {format: 'snorm8x4', offset: 216, shaderLocation: 8},
+          {format: 'float16x4', offset: 28, shaderLocation: 16},
+        ],
+      },
+      {arrayStride: 29772, attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 9896, shaderLocation: 6},
+          {format: 'sint32x3', offset: 2760, shaderLocation: 12},
+          {format: 'uint32x4', offset: 2720, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'back', unclippedDepth: true},
+});
+let textureView14 = texture6.createView({mipLevelCount: 1});
+let renderBundle11 = renderBundleEncoder5.finish({label: '\uca5b\u{1f69d}\uab57\u{1f937}\u1032\u{1f72d}'});
+let externalTexture1 = device0.importExternalTexture({
+  label: '\u{1f795}\u055a\u83cb\ub28c\uf7ae\u{1ff96}\u19aa\u{1fec4}\u{1f747}',
+  source: video0,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder2.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(3, bindGroup1);
+} catch {}
+let pipeline6 = await promise2;
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let querySet8 = device0.createQuerySet({
+  label: '\u5ca0\u{1fea6}\u0f6b\uf578\u022b\ud836\u0549\ue92d\u0845\ub5d5',
+  type: 'occlusion',
+  count: 2831,
+});
+try {
+commandEncoder4.clearBuffer(buffer0, 31668, 104524);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let imageData1 = new ImageData(148, 28);
+let commandEncoder16 = device0.createCommandEncoder({label: '\uc1ca\u060a\ucaec'});
+let textureView15 = texture2.createView({label: '\u22ca\uc427\u02eb\u0ac9\ud4bd\u1cbd\u0c8b\u{1fb0b}\u23e0', baseMipLevel: 1});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\u12d6\u05d1\u0675\u{1f765}\u{1f928}\ue814',
+  colorFormats: ['rg8uint', 'r8sint', 'rg8sint', 'rg16float', 'rgba32sint'],
+  stencilReadOnly: false,
+});
+let externalTexture2 = device0.importExternalTexture({label: '\u9fca\u6461\u{1f725}\u{1fd5e}\u3111', source: video0, colorSpace: 'display-p3'});
+canvas0.height = 1010;
+let buffer3 = device0.createBuffer({
+  label: '\u0d4f\u0b05\uef88\u081c\u0ef6',
+  size: 26987,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder17 = device0.createCommandEncoder({label: '\u1147\u4c32'});
+let querySet9 = device0.createQuerySet({label: '\u0cd3\u9f48', type: 'occlusion', count: 3295});
+let textureView16 = texture2.createView({label: '\u1a74\u8983\u48c1\u202d\u{1f679}', dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 2});
+let computePassEncoder3 = commandEncoder5.beginComputePass({label: '\u{1f9c3}\u3162\u{1fb1c}\u02d6\u7025\u0720\u4d8e\u0d04\u05ce\u01ab'});
+let pipeline7 = device0.createComputePipeline({
+  label: '\ub3aa\u0bc2\u5c05\u{1fa41}\u{1f947}\u0cf5\u0843\u0aa3\u020b',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let bindGroup3 = device0.createBindGroup({
+  label: '\ufff7\uae62\ueccc\u{1ff2c}\u0b40\u9059\u{1fac7}\u0644\ud0ca',
+  layout: bindGroupLayout0,
+  entries: [{binding: 4222, resource: sampler0}],
+});
+try {
+commandEncoder3.copyBufferToTexture({
+  /* bytesInLastRow: 76 widthInBlocks: 38 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 568624 */
+  offset: 7984,
+  bytesPerRow: 256,
+  rowsPerImage: 146,
+  buffer: buffer2,
+}, {
+  texture: texture4,
+  mipLevel: 2,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 38, height: 0, depthOrArrayLayers: 16});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder15.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 11, y: 5, z: 4},
+  aspect: 'all',
+},
+{width: 9, height: 9, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer3, commandBuffer2]);
+} catch {}
+let pipeline8 = device0.createComputePipeline({
+  label: '\ubd42\u34d2\u4ae1\uc50f\u{1fdbe}\u0bae\u{1fd1f}',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+gc();
+let videoFrame0 = new VideoFrame(video0, {timestamp: 0});
+let commandEncoder18 = device0.createCommandEncoder({label: '\ufab6\u0fc0\u02a0\u59c8\ufcf7\u3a4f\ufb3b\u0f4f\ud32d\u0bd8\u070a'});
+let sampler7 = device0.createSampler({
+  label: '\ubd8a\ud0c2\ua91a\u3cd9\u0b12\u388c\uac21\u2653',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 93.32,
+});
+try {
+computePassEncoder2.setBindGroup(5, bindGroup2, new Uint32Array(1993), 1230, 0);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(6, bindGroup2);
+} catch {}
+try {
+commandEncoder10.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 117, y: 7, z: 2},
+  aspect: 'all',
+}, new Int8Array(new ArrayBuffer(40)), /* required buffer size: 249 */
+{offset: 249, bytesPerRow: 7843}, {width: 479, height: 63, depthOrArrayLayers: 0});
+} catch {}
+let pipeline9 = device0.createRenderPipeline({
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'r8sint', writeMask: 0}, {format: 'rg8sint'}, {
+  format: 'rg16float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgba32sint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'less', failOp: 'increment-clamp', depthFailOp: 'replace', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'equal', failOp: 'invert', depthFailOp: 'increment-clamp'},
+    stencilReadMask: 3851460740,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4228,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 1208, shaderLocation: 6},
+          {format: 'sint32x3', offset: 1564, shaderLocation: 9},
+          {format: 'sint8x2', offset: 1136, shaderLocation: 12},
+          {format: 'uint16x2', offset: 416, shaderLocation: 4},
+          {format: 'uint8x4', offset: 1556, shaderLocation: 7},
+          {format: 'uint8x4', offset: 708, shaderLocation: 10},
+          {format: 'sint32x3', offset: 260, shaderLocation: 14},
+          {format: 'float16x4', offset: 832, shaderLocation: 8},
+          {format: 'sint8x4', offset: 412, shaderLocation: 17},
+          {format: 'sint32x2', offset: 544, shaderLocation: 18},
+          {format: 'snorm16x2', offset: 840, shaderLocation: 11},
+          {format: 'sint16x2', offset: 476, shaderLocation: 5},
+          {format: 'sint8x2', offset: 126, shaderLocation: 0},
+          {format: 'uint8x2', offset: 528, shaderLocation: 20},
+          {format: 'unorm10-10-10-2', offset: 2428, shaderLocation: 2},
+          {format: 'snorm8x4', offset: 152, shaderLocation: 19},
+          {format: 'sint32x2', offset: 2044, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 5016,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 336, shaderLocation: 1},
+          {format: 'sint8x2', offset: 1260, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 15632,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 1628, shaderLocation: 3},
+          {format: 'snorm16x2', offset: 1396, shaderLocation: 16},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'ccw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+let textureView17 = texture6.createView({label: '\u8939\u415e\u6936\uaec5'});
+try {
+commandEncoder17.copyBufferToTexture({
+  /* bytesInLastRow: 12512 widthInBlocks: 782 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1296 */
+  offset: 1296,
+  bytesPerRow: 12800,
+  buffer: buffer3,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 782, height: 71, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout({
+  label: '\u0542\uf378\uf0f7\u0e9a\uff63\u06d5\uc396',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout1, bindGroupLayout0, bindGroupLayout0],
+});
+let texture7 = device0.createTexture({
+  label: '\u{1fedb}\u3dcb\u18cd\ue406\u0725\ue7ed',
+  size: {width: 4000},
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16float', 'rg16float', 'rg16float'],
+});
+let textureView18 = texture2.createView({label: '\u89c9\u{1f796}\u2534', dimension: '2d-array', mipLevelCount: 3});
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  label: '\u66e0\u83e4\udcb6',
+  entries: [
+    {
+      binding: 1900,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder19 = device0.createCommandEncoder({label: '\u{1f614}\u{1f77f}'});
+let renderBundle12 = renderBundleEncoder5.finish({label: '\u03bf\u0764\u021e\u{1fcb2}\u91c8\u6ae2\u{1f732}\ubd8c\u7d60\u42ae\u1d25'});
+try {
+computePassEncoder2.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder10.copyBufferToTexture({
+  /* bytesInLastRow: 4640 widthInBlocks: 1160 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 19196 */
+  offset: 19196,
+  buffer: buffer2,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1160, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder14.clearBuffer(buffer0, 52676, 8820);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+computePassEncoder2.insertDebugMarker('\uecb5');
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(447, 853);
+let texture8 = device0.createTexture({
+  label: '\u02dd\u22f5\u00f9\u01b3\u{1ffb6}',
+  size: [160, 48, 1],
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16float', 'rg16float'],
+});
+let textureView19 = texture1.createView({label: '\u0566\u{1fb94}\u0b7a', aspect: 'all', baseArrayLayer: 1, arrayLayerCount: 1});
+let computePassEncoder4 = commandEncoder4.beginComputePass({label: '\u7ef3\u0333\uc151\u34a7\u{1f6f9}\u{1f788}\u431e\u042e\ub049\u094f\ue4f8'});
+let sampler8 = device0.createSampler({
+  label: '\udab1\u08af\u4581\u0ec7\ub49b\u0843\u0dd9\u3990\u{1f6d2}\u02e0',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 14.24,
+  lodMaxClamp: 66.69,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder2.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(0, bindGroup3, []);
+} catch {}
+try {
+commandEncoder0.clearBuffer(buffer0, 50136, 4088);
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline10 = device0.createComputePipeline({
+  label: '\u1cd0\u{1f6ac}\u09f1\u096b\u0a1c\u{1f99e}',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let offscreenCanvas1 = new OffscreenCanvas(527, 158);
+let shaderModule4 = device0.createShaderModule({
+  label: '\u{1f6dc}\u{1fc60}\u094d',
+  code: `@group(0) @binding(4222)
+var<storage, read_write> function3: array<u32>;
+@group(3) @binding(4222)
+var<storage, read_write> global2: array<u32>;
+@group(4) @binding(4222)
+var<storage, read_write> field3: array<u32>;
+@group(1) @binding(4222)
+var<storage, read_write> field4: array<u32>;
+@group(2) @binding(4222)
+var<storage, read_write> type3: array<u32>;
+
+@compute @workgroup_size(2, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S3 {
+  @location(25) f0: f16,
+  @location(0) f1: vec3<f16>,
+  @location(31) f2: f32,
+  @location(27) f3: f32,
+  @location(34) f4: f32,
+  @builtin(front_facing) f5: bool,
+  @location(2) f6: vec4<u32>,
+  @location(9) f7: f32,
+  @location(44) f8: vec4<u32>,
+  @location(45) f9: vec4<f32>,
+  @location(39) f10: vec3<i32>,
+  @location(19) f11: vec4<u32>,
+  @location(35) f12: vec3<f32>,
+  @location(40) f13: vec4<i32>,
+  @location(29) f14: vec3<f16>
+}
+struct FragmentOutput0 {
+  @location(5) f0: vec2<u32>,
+  @location(0) f1: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(1) a0: vec3<i32>, @location(22) a1: vec4<u32>, a2: S3, @location(8) a3: u32, @builtin(sample_index) a4: u32, @location(12) a5: f16, @location(5) a6: vec2<u32>, @location(20) a7: vec4<f32>, @location(7) a8: vec4<f32>, @location(10) a9: vec3<f16>, @builtin(sample_mask) a10: u32, @builtin(position) a11: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(35) f30: vec3<f32>,
+  @location(9) f31: f32,
+  @location(2) f32: vec4<u32>,
+  @location(19) f33: vec4<u32>,
+  @location(39) f34: vec3<i32>,
+  @location(5) f35: vec2<u32>,
+  @builtin(position) f36: vec4<f32>,
+  @location(45) f37: vec4<f32>,
+  @location(1) f38: vec3<i32>,
+  @location(7) f39: vec4<f32>,
+  @location(12) f40: f16,
+  @location(34) f41: f32,
+  @location(44) f42: vec4<u32>,
+  @location(20) f43: vec4<f32>,
+  @location(27) f44: f32,
+  @location(8) f45: u32,
+  @location(31) f46: f32,
+  @location(25) f47: f16,
+  @location(22) f48: vec4<u32>,
+  @location(29) f49: vec3<f16>,
+  @location(40) f50: vec4<i32>,
+  @location(10) f51: vec3<f16>,
+  @location(0) f52: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(0) a0: vec2<f16>, @location(18) a1: vec4<f32>, @location(6) a2: vec4<f32>, @location(20) a3: vec4<u32>, @location(19) a4: vec4<f32>, @location(15) a5: vec3<i32>, @location(10) a6: i32, @location(12) a7: vec2<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+commandEncoder15.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 1, y: 5, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 428 widthInBlocks: 107 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 20708 */
+  offset: 20708,
+  bytesPerRow: 512,
+  buffer: buffer0,
+}, {width: 107, height: 26, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+let pipeline11 = await device0.createRenderPipelineAsync({
+  label: '\u0cf9\u0934\ub682\u8ffe\u9c9d\u{1fa1c}\u01e7\ude7b\u0297',
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: GPUColorWrite.RED}, {format: 'r8sint', writeMask: 0}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'dst'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rgba32sint'}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 2236, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 1692,
+        attributes: [
+          {format: 'sint32x2', offset: 36, shaderLocation: 14},
+          {format: 'unorm8x4', offset: 60, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 46908,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x4', offset: 380, shaderLocation: 0}],
+      },
+      {
+        arrayStride: 12404,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 1772, shaderLocation: 13},
+          {format: 'sint32x2', offset: 432, shaderLocation: 3},
+          {format: 'sint32', offset: 1036, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+});
+try {
+device0.queue.label = '\u4278\u2a89\u79e3\u{1fbdc}\u034a';
+} catch {}
+let textureView20 = texture7.createView({});
+try {
+renderBundleEncoder7.setPipeline(pipeline11);
+} catch {}
+let gpuCanvasContext1 = offscreenCanvas0.getContext('webgpu');
+let video1 = await videoWithData();
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  label: '\u{1fa74}\u8391\u72aa\ue222\uecff\u{1fe94}\ud5e7\u{1f6ee}\u1d2e\u7587',
+  entries: [
+    {
+      binding: 4613,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {binding: 96, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }},
+  ],
+});
+let bindGroupLayout4 = pipeline8.getBindGroupLayout(6);
+let pipelineLayout6 = device0.createPipelineLayout({label: '\u0cc4\u541a\u08e9\u8b82\u015e', bindGroupLayouts: []});
+let commandEncoder20 = device0.createCommandEncoder({label: '\u{1f66f}\u{1fb82}'});
+let texture9 = device0.createTexture({
+  label: '\u5af3\u1f33\u5959\u{1fb60}\u0d50\uae1e\u777e\u{1fb4d}\u0380\ud89d\u049f',
+  size: [225, 30, 179],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8uint'],
+});
+let computePassEncoder5 = commandEncoder13.beginComputePass({label: '\u{1f98b}\u85fe\u01eb\u9f88\uc5bb'});
+try {
+renderBundleEncoder6.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+commandEncoder3.clearBuffer(buffer0, 56932, 35712);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline12 = await device0.createComputePipelineAsync({
+  label: '\u3739\u04ca',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let pipeline13 = await promise0;
+document.body.prepend(video0);
+let bindGroupLayout5 = pipeline11.getBindGroupLayout(6);
+let commandEncoder21 = device0.createCommandEncoder({label: '\ub1c4\u4a94\u0621'});
+let textureView21 = texture3.createView({label: '\u05c7\u6e3a\ud66b\uefb4\u0442', arrayLayerCount: 1});
+let renderBundle13 = renderBundleEncoder4.finish({label: '\u8ea2\u0e23\u{1fac4}\u05df\ucf40'});
+try {
+renderBundleEncoder9.setBindGroup(9, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline11);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(103, 240);
+try {
+offscreenCanvas2.getContext('bitmaprenderer');
+} catch {}
+let querySet10 = device0.createQuerySet({
+  label: '\u0f37\u37ba\u0b13\u{1fce5}\ue135\u0ba8\u3686\u04ec\u0eb0\u8c30\u4d3c',
+  type: 'occlusion',
+  count: 248,
+});
+let commandBuffer4 = commandEncoder18.finish({label: '\u60d2\u{1f882}\u0ab1\u{1f7c5}\ub034'});
+let texture10 = device0.createTexture({
+  label: '\u59b7\u491d\u5e96\u0827\u00de\u071a\u05cc\u{1fb91}\u57f2',
+  size: [225],
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8sint'],
+});
+try {
+commandEncoder12.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 6, y: 12, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 138 widthInBlocks: 69 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 9388 */
+  offset: 8226,
+  bytesPerRow: 256,
+  buffer: buffer0,
+}, {width: 69, height: 5, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder22 = device0.createCommandEncoder({label: '\u8d9e\u{1f69e}\u{1fedc}\u00f8'});
+let texture11 = device0.createTexture({
+  label: '\u8bf9\u{1fb98}\ua4d5\u0deb\u035e\u053b\u{1f940}\u9897\u{1f96b}',
+  size: {width: 1000, height: 4, depthOrArrayLayers: 247},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView22 = texture0.createView({baseMipLevel: 3, mipLevelCount: 1, baseArrayLayer: 80, arrayLayerCount: 210});
+let renderBundle14 = renderBundleEncoder3.finish({label: '\u{1fc18}\u0b53\u2b01\ub9fa\ufa77\u9a47\u5fe5\uf855\u1a25\u{1f8c1}'});
+let sampler9 = device0.createSampler({
+  label: '\u64df\uba3b\u5bc8\ue1aa\ua209',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 15.41,
+  lodMaxClamp: 31.37,
+});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup0);
+} catch {}
+let pipeline14 = device0.createComputePipeline({
+  label: '\u005d\u183f\u0e7f\u{1fe45}\u{1fce3}\ufa7c\u06f3\ud876\u0a78',
+  layout: 'auto',
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let commandBuffer5 = commandEncoder12.finish({label: '\u6c6d\u0004'});
+let textureView23 = texture10.createView({label: '\u0342\u8add\ue352\u02a9\u2014\u03d1\u149b\u0252\u9cb4\u0c4e\u031d'});
+let renderBundle15 = renderBundleEncoder2.finish({label: '\u086d\uaf7c'});
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+commandEncoder17.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 10},
+  aspect: 'all',
+},
+{width: 11, height: 7, depthOrArrayLayers: 3});
+} catch {}
+let pipeline15 = device0.createComputePipeline({
+  label: '\u{1f750}\u0d26\u{1f6ec}',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule3, entryPoint: 'compute0'},
+});
+let imageBitmap1 = await createImageBitmap(offscreenCanvas1);
+let buffer4 = device0.createBuffer({label: '\u915f\u09fc', size: 43790, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: ['rg8uint', 'r8sint', 'rg8sint', 'rg16float', 'rgba32sint']});
+try {
+renderBundleEncoder9.setPipeline(pipeline11);
+} catch {}
+try {
+commandEncoder3.copyBufferToTexture({
+  /* bytesInLastRow: 10480 widthInBlocks: 655 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 17856 */
+  offset: 17856,
+  bytesPerRow: 10496,
+  rowsPerImage: 95,
+  buffer: buffer3,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 14, y: 8, z: 3},
+  aspect: 'all',
+}, {width: 655, height: 45, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder19.copyBufferToBuffer(buffer1, 2328, buffer4, 40948, 948);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let imageData2 = new ImageData(16, 236);
+let shaderModule5 = device0.createShaderModule({
+  label: '\u6c9e\u{1f72e}',
+  code: `@group(3) @binding(3048)
+var<storage, read_write> local2: array<u32>;
+@group(1) @binding(3048)
+var<storage, read_write> field5: array<u32>;
+@group(3) @binding(1928)
+var<storage, read_write> field6: array<u32>;
+@group(0) @binding(1928)
+var<storage, read_write> global3: array<u32>;
+@group(4) @binding(3048)
+var<storage, read_write> parameter4: array<u32>;
+@group(1) @binding(1928)
+var<storage, read_write> global4: array<u32>;
+
+@compute @workgroup_size(8, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @builtin(sample_mask) f1: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(19) a0: f16, @builtin(instance_index) a1: u32, @location(17) a2: vec4<f16>, @location(18) a3: vec2<u32>, @location(20) a4: vec4<i32>, @location(11) a5: vec4<i32>, @location(16) a6: vec4<u32>, @location(10) a7: u32, @location(0) a8: vec2<f16>, @location(7) a9: vec2<f32>, @location(15) a10: vec4<f32>, @location(6) a11: vec2<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder23 = device0.createCommandEncoder();
+let textureView24 = texture6.createView({label: '\u06d7\u02b1\u2533\u{1f94e}\u{1f96b}\u{1fa07}', format: 'rg8uint'});
+let computePassEncoder6 = commandEncoder20.beginComputePass({});
+try {
+renderBundleEncoder9.setPipeline(pipeline11);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder3.clearBuffer(buffer4, 28220, 5272);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder11.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 10388, new DataView(new ArrayBuffer(50086)), 47531, 1136);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageBitmap2 = await createImageBitmap(canvas0);
+let commandEncoder24 = device0.createCommandEncoder({label: '\u25a6\u3978\u2c65\u4531\u4a8f\u4254'});
+let texture12 = device0.createTexture({
+  label: '\u{1fed3}\u{1fb5b}\u00ae\u05f3\ub929',
+  size: [900, 120, 27],
+  dimension: '3d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8uint'],
+});
+let textureView25 = texture9.createView({
+  label: '\u{1fc1d}\ue9eb\u{1fa92}\u03da\u3fc4\u39a0\u{1f9a9}\uf479\u0a79',
+  aspect: 'all',
+  mipLevelCount: 2,
+});
+let computePassEncoder7 = commandEncoder15.beginComputePass({label: '\u12ad\ued20'});
+try {
+renderBundleEncoder7.setBindGroup(6, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline11);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(2, buffer4, 0, 43391);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline16 = await device0.createComputePipelineAsync({layout: pipelineLayout4, compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}}});
+let querySet11 = device0.createQuerySet({label: '\u038c\u273f\u0ec6', type: 'occlusion', count: 1896});
+try {
+commandEncoder21.clearBuffer(buffer4, 14916, 18596);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(91), /* required buffer size: 91 */
+{offset: 91}, {width: 53, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext2 = offscreenCanvas1.getContext('webgpu');
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+let shaderModule6 = device0.createShaderModule({
+  code: `@group(6) @binding(3048)
+var<storage, read_write> type4: array<u32>;
+@group(3) @binding(3048)
+var<storage, read_write> local3: array<u32>;
+@group(4) @binding(4222)
+var<storage, read_write> global5: array<u32>;
+@group(6) @binding(1928)
+var<storage, read_write> type5: array<u32>;
+@group(2) @binding(4222)
+var<storage, read_write> n1: array<u32>;
+@group(0) @binding(1928)
+var<storage, read_write> global6: array<u32>;
+@group(5) @binding(1928)
+var<storage, read_write> global7: array<u32>;
+@group(7) @binding(1928)
+var<storage, read_write> field7: array<u32>;
+@group(0) @binding(3048)
+var<storage, read_write> n2: array<u32>;
+@group(7) @binding(3048)
+var<storage, read_write> field8: array<u32>;
+@group(5) @binding(3048)
+var<storage, read_write> function4: array<u32>;
+@group(1) @binding(1928)
+var<storage, read_write> field9: array<u32>;
+@group(3) @binding(1928)
+var<storage, read_write> function5: array<u32>;
+@group(9) @binding(3048)
+var<storage, read_write> type6: array<u32>;
+@group(9) @binding(1928)
+var<storage, read_write> function6: array<u32>;
+
+@compute @workgroup_size(3, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S5 {
+  @location(13) f0: i32,
+  @location(42) f1: f32,
+  @builtin(sample_index) f2: u32,
+  @builtin(front_facing) f3: bool,
+  @location(26) f4: vec3<f32>,
+  @location(23) f5: vec2<i32>,
+  @location(20) f6: vec3<i32>,
+  @location(18) f7: vec3<f32>,
+  @location(25) f8: vec4<i32>,
+  @location(37) f9: vec3<u32>,
+  @location(33) f10: vec4<f16>,
+  @location(34) f11: vec2<f32>,
+  @location(0) f12: f16,
+  @location(3) f13: vec2<f16>,
+  @builtin(sample_mask) f14: u32,
+  @location(43) f15: vec4<f16>,
+  @location(7) f16: vec3<u32>,
+  @location(5) f17: vec3<i32>,
+  @location(12) f18: vec3<f16>,
+  @location(29) f19: vec4<u32>,
+  @location(45) f20: vec2<f16>,
+  @location(6) f21: vec3<u32>,
+  @location(1) f22: u32,
+  @location(30) f23: vec3<i32>,
+  @location(47) f24: u32,
+  @location(39) f25: vec2<f32>,
+  @location(31) f26: vec4<u32>
+}
+struct FragmentOutput0 {
+  @location(6) f0: vec2<f32>,
+  @location(0) f1: vec4<u32>,
+  @location(4) f2: vec4<i32>,
+  @location(2) f3: vec4<i32>,
+  @location(3) f4: vec3<f32>,
+  @location(1) f5: vec2<i32>
+}
+
+@fragment
+fn fragment0(@location(9) a0: f32, a1: S5, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S4 {
+  @location(3) f0: vec2<f32>,
+  @location(17) f1: vec3<i32>,
+  @builtin(vertex_index) f2: u32,
+  @location(15) f3: vec4<f16>,
+  @location(4) f4: vec2<f16>,
+  @location(11) f5: vec2<f16>
+}
+struct VertexOutput0 {
+  @location(29) f53: vec4<u32>,
+  @location(42) f54: f32,
+  @location(1) f55: u32,
+  @location(3) f56: vec2<f16>,
+  @location(12) f57: vec3<f16>,
+  @location(20) f58: vec3<i32>,
+  @location(31) f59: vec4<u32>,
+  @location(25) f60: vec4<i32>,
+  @location(13) f61: i32,
+  @location(24) f62: vec4<i32>,
+  @location(30) f63: vec3<i32>,
+  @location(18) f64: vec3<f32>,
+  @location(43) f65: vec4<f16>,
+  @location(39) f66: vec2<f32>,
+  @location(6) f67: vec3<u32>,
+  @location(45) f68: vec2<f16>,
+  @location(26) f69: vec3<f32>,
+  @builtin(position) f70: vec4<f32>,
+  @location(7) f71: vec3<u32>,
+  @location(37) f72: vec3<u32>,
+  @location(34) f73: vec2<f32>,
+  @location(5) f74: vec3<i32>,
+  @location(47) f75: u32,
+  @location(9) f76: f32,
+  @location(23) f77: vec2<i32>,
+  @location(33) f78: vec4<f16>,
+  @location(0) f79: f16
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec4<f32>, @location(1) a1: vec2<f32>, @location(8) a2: vec4<i32>, a3: S4, @location(5) a4: vec4<f32>, @location(13) a5: vec2<f16>, @builtin(instance_index) a6: u32, @location(19) a7: f32, @location(12) a8: i32, @location(20) a9: i32, @location(14) a10: f32, @location(6) a11: vec3<u32>, @location(0) a12: vec4<i32>, @location(7) a13: vec3<f32>, @location(18) a14: vec3<i32>, @location(9) a15: vec3<u32>, @location(10) a16: vec2<u32>, @location(16) a17: vec2<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet12 = device0.createQuerySet({label: '\u06e9\u{1f681}\u01e8\ud796\u0fdd\u04d2\uaa2b\u{1fc6a}', type: 'occlusion', count: 2200});
+let textureView26 = texture0.createView({
+  label: '\ud796\u8cb9\u04cb\u{1fd4e}\u{1fad3}\u{1fedb}\u1486\u{1fb94}\u066a\u01eb\u0e8b',
+  format: 'astc-8x8-unorm',
+  baseMipLevel: 2,
+  mipLevelCount: 2,
+  baseArrayLayer: 77,
+  arrayLayerCount: 18,
+});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({
+  label: '\u080f\u{1ff40}\u8af9\u6abe\u3cf8\uc15b\u{1fd9a}\u0bdf',
+  colorFormats: ['rg8uint', 'r8sint', 'rg8sint', 'rg16float', 'rgba32sint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder6.setBindGroup(8, bindGroup1);
+} catch {}
+try {
+commandEncoder22.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 38, y: 1, z: 29},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 26, height: 3, depthOrArrayLayers: 8});
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer4, 31860, 224);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let pipeline17 = device0.createRenderPipeline({
+  label: '\ua73c\u0ed5\u{1fa82}\ue7c0\u0ae8\u0b5d\u0a85\ube59',
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8uint'}, {format: 'r8sint', writeMask: 0}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: GPUColorWrite.GREEN,
+}, {format: 'rgba32sint', writeMask: GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 8868, attributes: [{format: 'float32x4', offset: 804, shaderLocation: 0}]},
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint16x4', offset: 3144, shaderLocation: 7},
+          {format: 'sint16x4', offset: 5840, shaderLocation: 14},
+          {format: 'uint8x2', offset: 28440, shaderLocation: 13},
+          {format: 'sint16x4', offset: 156, shaderLocation: 3},
+          {format: 'float32x2', offset: 1876, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'ccw', cullMode: 'front'},
+});
+let commandEncoder25 = device0.createCommandEncoder({label: '\u0cc9\u{1f79e}\uea9a\u0d47\u00e9\u{1fc54}\ua030\u{1fe10}\u1054\u8fb9\u657f'});
+try {
+computePassEncoder6.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(4, buffer4);
+} catch {}
+try {
+commandEncoder11.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 6124 widthInBlocks: 3062 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 31728 */
+  offset: 31728,
+  buffer: buffer4,
+}, {width: 3062, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 1672, new Int16Array(10183), 8027, 176);
+} catch {}
+let imageBitmap3 = await createImageBitmap(offscreenCanvas1);
+let textureView27 = texture5.createView({baseMipLevel: 1, mipLevelCount: 1});
+try {
+device0.queue.writeBuffer(buffer4, 5180, new DataView(new ArrayBuffer(46597)), 15942, 5380);
+} catch {}
+let pipeline18 = await device0.createRenderPipelineAsync({
+  label: '\u076b\u{1ffc6}\u567f\ub789\u4b8a\u086c\u115b\u2769\ud825',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'less-equal', failOp: 'increment-clamp', depthFailOp: 'replace', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'never', passOp: 'replace'},
+    stencilWriteMask: 3930355498,
+    depthBias: 1445373055,
+    depthBiasSlopeScale: 135.15020715425723,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4152,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 1600, shaderLocation: 10},
+          {format: 'uint32x2', offset: 276, shaderLocation: 20},
+          {format: 'float32x3', offset: 528, shaderLocation: 6},
+          {format: 'snorm16x2', offset: 588, shaderLocation: 18},
+          {format: 'uint8x2', offset: 264, shaderLocation: 12},
+          {format: 'float32x4', offset: 708, shaderLocation: 0},
+          {format: 'float32x2', offset: 1288, shaderLocation: 19},
+        ],
+      },
+      {arrayStride: 3712, stepMode: 'instance', attributes: []},
+      {arrayStride: 512, attributes: []},
+      {arrayStride: 7476, stepMode: 'instance', attributes: []},
+      {arrayStride: 11656, stepMode: 'instance', attributes: []},
+      {arrayStride: 4880, attributes: [{format: 'sint16x2', offset: 1916, shaderLocation: 15}]},
+    ],
+  },
+});
+let videoFrame1 = new VideoFrame(imageBitmap0, {timestamp: 0});
+let buffer5 = device0.createBuffer({size: 119392, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder26 = device0.createCommandEncoder({label: '\u1d8a\u7522\u72ce\u5b02\u07de\u009a\u0323\u6289\u0ec6'});
+let querySet13 = device0.createQuerySet({label: '\u2a00\u0398\u9aec\u338c\u0056\ua3b1\ud6e6', type: 'occlusion', count: 1460});
+let textureView28 = texture6.createView({label: '\u{1fdd3}\ued90\u04a3\u00fa\u{1f940}\u0d7d\u0f75', dimension: '1d', mipLevelCount: 1});
+let sampler10 = device0.createSampler({
+  label: '\u9bff\ufced\uff72\u0561\u{1fa53}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 70.10,
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup1, new Uint32Array(1144), 143, 0);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(6, bindGroup1, new Uint32Array(8445), 2180, 0);
+} catch {}
+try {
+commandEncoder3.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 22, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder4.insertDebugMarker('\u038e');
+} catch {}
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 14768, new Int16Array(14838), 8026, 1140);
+} catch {}
+let pipeline19 = device0.createComputePipeline({
+  label: '\u8f81\u6f6b\u{1f7ad}\ue434\u0c4b\u99c2',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+let pipeline20 = device0.createRenderPipeline({
+  label: '\u4bb8\uaf40',
+  layout: pipelineLayout2,
+  multisample: {count: 4, mask: 0x7596a767},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2200,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 284, shaderLocation: 19},
+          {format: 'float16x2', offset: 204, shaderLocation: 15},
+          {format: 'sint32x2', offset: 100, shaderLocation: 20},
+          {format: 'snorm8x4', offset: 612, shaderLocation: 0},
+          {format: 'uint16x2', offset: 388, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 10440, stepMode: 'instance', attributes: []},
+      {arrayStride: 4664, attributes: []},
+      {
+        arrayStride: 8340,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x3', offset: 1884, shaderLocation: 7}],
+      },
+      {
+        arrayStride: 9740,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 392, shaderLocation: 11},
+          {format: 'uint16x2', offset: 0, shaderLocation: 10},
+          {format: 'uint32x3', offset: 2204, shaderLocation: 16},
+          {format: 'uint8x4', offset: 756, shaderLocation: 18},
+          {format: 'float16x4', offset: 3564, shaderLocation: 17},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'none', unclippedDepth: true},
+});
+let externalTexture3 = device0.importExternalTexture({label: '\u8750\u{1f884}\u804c\u{1f7a2}\uf4d9\u994d', source: videoFrame1, colorSpace: 'srgb'});
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline17);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 14788, new BigUint64Array(5545), 3307, 132);
+} catch {}
+let bindGroup4 = device0.createBindGroup({layout: bindGroupLayout0, entries: [{binding: 4222, resource: sampler1}]});
+let querySet14 = device0.createQuerySet({label: '\u27bf\uc5d9\u297f\u0d6e\u03d6\u9619\u0e32\u{1fb4d}', type: 'occlusion', count: 1834});
+try {
+computePassEncoder7.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(2, buffer4, 0);
+} catch {}
+try {
+commandEncoder11.copyBufferToBuffer(buffer1, 10776, buffer4, 27612, 2588);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder0.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 816, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer5);
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder16.pushDebugGroup('\u2c08');
+} catch {}
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipelineLayout7 = device0.createPipelineLayout({
+  label: '\u{1ff08}\u5df0\u8023\u464e\ueb36\u0098\u04b1\uc9c6\u{1fea7}',
+  bindGroupLayouts: [bindGroupLayout5, bindGroupLayout5, bindGroupLayout1, bindGroupLayout0, bindGroupLayout5, bindGroupLayout1],
+});
+let buffer6 = device0.createBuffer({
+  label: '\u0d0a\u{1f830}\u5a31\u0e00\u{1f841}\u268f\u4ead\u{1f9b8}\ua872\u072b',
+  size: 151052,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let texture13 = device0.createTexture({
+  label: '\u534f\u18ce\u00ca\ued1b\u0406\u975c\u{1fb9e}\ueca0\ua3d2',
+  size: [40, 12, 141],
+  mipLevelCount: 1,
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['depth32float-stencil8', 'depth32float-stencil8', 'depth32float-stencil8'],
+});
+let textureView29 = texture8.createView({dimension: '2d-array'});
+let computePassEncoder8 = commandEncoder3.beginComputePass({label: '\u631f\u{1ff1c}\u5cc4\ucb48\u09e7\u011b\uf9c8\uf619\u0bc4'});
+try {
+renderBundleEncoder9.setVertexBuffer(8, buffer4, 7556, 3798);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline21 = device0.createRenderPipeline({
+  label: '\u3de4\u015b',
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8uint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8sint', writeMask: 0}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg16float'}, {format: 'rgba32sint'}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {failOp: 'keep', depthFailOp: 'increment-wrap', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'less', failOp: 'increment-wrap', depthFailOp: 'decrement-clamp', passOp: 'invert'},
+    stencilReadMask: 4294967295,
+    stencilWriteMask: 1570027903,
+    depthBias: 203412497,
+    depthBiasSlopeScale: 150.3955879081176,
+    depthBiasClamp: 320.2122041504995,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2924,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 208, shaderLocation: 6},
+          {format: 'unorm8x2', offset: 520, shaderLocation: 3},
+          {format: 'sint32x3', offset: 836, shaderLocation: 9},
+          {format: 'sint8x2', offset: 354, shaderLocation: 15},
+          {format: 'snorm16x4', offset: 144, shaderLocation: 2},
+          {format: 'uint32x4', offset: 928, shaderLocation: 7},
+          {format: 'float32x2', offset: 704, shaderLocation: 1},
+          {format: 'float32', offset: 128, shaderLocation: 19},
+          {format: 'sint8x2', offset: 962, shaderLocation: 13},
+          {format: 'sint32x2', offset: 44, shaderLocation: 14},
+          {format: 'unorm8x4', offset: 160, shaderLocation: 11},
+          {format: 'sint8x4', offset: 232, shaderLocation: 17},
+          {format: 'sint32x2', offset: 2056, shaderLocation: 12},
+          {format: 'uint32', offset: 308, shaderLocation: 4},
+          {format: 'float32x4', offset: 1632, shaderLocation: 16},
+        ],
+      },
+      {arrayStride: 4092, attributes: [{format: 'uint32x3', offset: 124, shaderLocation: 10}]},
+      {
+        arrayStride: 6604,
+        attributes: [
+          {format: 'sint32x3', offset: 2840, shaderLocation: 0},
+          {format: 'uint32x4', offset: 388, shaderLocation: 20},
+          {format: 'unorm8x4', offset: 444, shaderLocation: 8},
+          {format: 'sint32', offset: 1824, shaderLocation: 18},
+          {format: 'sint32x2', offset: 76, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', unclippedDepth: true},
+});
+let imageBitmap4 = await createImageBitmap(offscreenCanvas1);
+let shaderModule7 = device0.createShaderModule({
+  code: `@group(2) @binding(1928)
+var<storage, read_write> global8: array<u32>;
+@group(4) @binding(1928)
+var<storage, read_write> type7: array<u32>;
+@group(1) @binding(4222)
+var<storage, read_write> parameter5: array<u32>;
+@group(5) @binding(4222)
+var<storage, read_write> n3: array<u32>;
+@group(4) @binding(3048)
+var<storage, read_write> function7: array<u32>;
+@group(3) @binding(3048)
+var<storage, read_write> n4: array<u32>;
+@group(6) @binding(3048)
+var<storage, read_write> local4: array<u32>;
+@group(6) @binding(1928)
+var<storage, read_write> function8: array<u32>;
+@group(2) @binding(3048)
+var<storage, read_write> n5: array<u32>;
+@group(7) @binding(4222)
+var<storage, read_write> n6: array<u32>;
+
+@compute @workgroup_size(5, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<u32>,
+  @location(0) f1: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(front_facing) a1: bool, @builtin(sample_index) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S6 {
+  @location(17) f0: vec2<i32>,
+  @location(13) f1: vec4<u32>,
+  @builtin(vertex_index) f2: u32,
+  @builtin(instance_index) f3: u32,
+  @location(2) f4: vec4<f32>,
+  @location(10) f5: i32,
+  @location(19) f6: i32,
+  @location(3) f7: f16,
+  @location(4) f8: f16,
+  @location(6) f9: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec4<f32>, a1: S6, @location(9) a2: vec3<f32>, @location(20) a3: vec3<i32>, @location(0) a4: vec3<i32>, @location(16) a5: vec4<u32>, @location(15) a6: f16, @location(12) a7: vec2<f32>, @location(11) a8: u32, @location(14) a9: vec3<f16>, @location(1) a10: u32, @location(18) a11: vec2<i32>, @location(5) a12: vec4<f32>, @location(8) a13: i32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let renderBundle16 = renderBundleEncoder4.finish();
+try {
+renderBundleEncoder11.setPipeline(pipeline11);
+} catch {}
+try {
+texture4.destroy();
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture({
+  /* bytesInLastRow: 2924 widthInBlocks: 731 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 17700 */
+  offset: 14776,
+  buffer: buffer2,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 172, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 731, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder5.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 852, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 9, y: 3, z: 0},
+  aspect: 'all',
+},
+{width: 204, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 11, y: 16, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 6_560_425 */
+{offset: 273, bytesPerRow: 3047, rowsPerImage: 211}, {width: 188, height: 43, depthOrArrayLayers: 11});
+} catch {}
+let pipeline22 = device0.createRenderPipeline({
+  label: '\u26f8\u030b\u0bce\u2259\u8961\u0225\u5253\u0ec2\uf13a',
+  layout: pipelineLayout3,
+  multisample: {count: 1},
+  fragment: {module: shaderModule7, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rgba8sint'}]},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {failOp: 'replace', depthFailOp: 'keep', passOp: 'invert'},
+    stencilBack: {failOp: 'invert', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilReadMask: 3750125539,
+    stencilWriteMask: 1695336307,
+    depthBiasClamp: 921.7468368459007,
+  },
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 8492,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x2', offset: 90, shaderLocation: 19}],
+      },
+      {
+        arrayStride: 5396,
+        attributes: [
+          {format: 'unorm16x4', offset: 1804, shaderLocation: 15},
+          {format: 'sint32x3', offset: 236, shaderLocation: 0},
+          {format: 'unorm16x4', offset: 5388, shaderLocation: 12},
+          {format: 'float16x2', offset: 1156, shaderLocation: 5},
+          {format: 'uint16x2', offset: 1300, shaderLocation: 16},
+          {format: 'sint16x2', offset: 556, shaderLocation: 20},
+          {format: 'uint32x3', offset: 1500, shaderLocation: 13},
+          {format: 'unorm16x2', offset: 948, shaderLocation: 6},
+          {format: 'sint16x2', offset: 868, shaderLocation: 17},
+          {format: 'sint8x4', offset: 600, shaderLocation: 10},
+          {format: 'uint16x4', offset: 20, shaderLocation: 1},
+          {format: 'snorm8x4', offset: 480, shaderLocation: 14},
+          {format: 'sint8x4', offset: 456, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 584, shaderLocation: 7},
+          {format: 'float16x4', offset: 648, shaderLocation: 2},
+          {format: 'sint32x4', offset: 1468, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 6680,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 268, shaderLocation: 4},
+          {format: 'snorm8x2', offset: 974, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 13048,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint8x2', offset: 718, shaderLocation: 11},
+          {format: 'float32', offset: 1800, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', cullMode: 'front', unclippedDepth: true},
+});
+let adapter2 = await navigator.gpu.requestAdapter({});
+let pipelineLayout8 = device0.createPipelineLayout({
+  label: '\u6bac\uc4e3\u19c3\u62bc\ue4bb',
+  bindGroupLayouts: [bindGroupLayout3, bindGroupLayout4, bindGroupLayout0, bindGroupLayout3, bindGroupLayout2, bindGroupLayout2],
+});
+let computePassEncoder9 = commandEncoder14.beginComputePass({label: '\u0675\u0b5c\u6f6f\u0807\ucecd\u{1fd5e}'});
+let renderBundle17 = renderBundleEncoder2.finish({label: '\u022e\u{1fb63}\u0ad7\u1e97\u5f4c\u0fe8\u95e5\u36b2\u{1f896}'});
+try {
+computePassEncoder4.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(5, buffer4, 0, 15076);
+} catch {}
+try {
+commandEncoder24.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 1695, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 11, y: 0, z: 6},
+  aspect: 'all',
+},
+{width: 48, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder16.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let pipeline23 = await device0.createComputePipelineAsync({
+  label: '\u087e\u{1f999}\u0c1b\u24d0\u7fd0\u2b67\u3819\u0eb7',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+let imageData3 = new ImageData(108, 108);
+let commandEncoder27 = device0.createCommandEncoder({label: '\u057e\u{1f96c}'});
+let textureView30 = texture13.createView({
+  label: '\u0e6b\u{1fda4}\u3584\u132f\u72f3\u0e14\u{1fffb}\u09f5\u4c35',
+  dimension: '2d',
+  aspect: 'stencil-only',
+  baseArrayLayer: 43,
+});
+try {
+renderBundleEncoder7.setPipeline(pipeline17);
+} catch {}
+try {
+commandEncoder26.copyTextureToBuffer({
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 26 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 18888 */
+  offset: 16558,
+  bytesPerRow: 256,
+  buffer: buffer5,
+}, {width: 13, height: 10, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+commandEncoder17.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 5, y: 10, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 443, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 122, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let commandEncoder28 = device0.createCommandEncoder({label: '\u{1fcf3}\u578c\u{1fa50}\u0db2\u0444\u8eb4\ube57\u0cfa\u0613'});
+let textureView31 = texture9.createView({
+  label: '\u007f\ue663\u038e\u1341\u0ad4\u{1fbb4}\u782b\ua62a\u7a94',
+  format: 'rg8uint',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+});
+let renderBundle18 = renderBundleEncoder1.finish();
+let sampler11 = device0.createSampler({
+  label: '\u0d85\ub16e',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 44.88,
+  lodMaxClamp: 90.61,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder5.setBindGroup(7, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(7, buffer4, 276, 39976);
+} catch {}
+try {
+commandEncoder11.copyBufferToTexture({
+  /* bytesInLastRow: 6 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 8286 */
+  offset: 8286,
+  bytesPerRow: 256,
+  buffer: buffer1,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder6.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 556 widthInBlocks: 139 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 48112 */
+  offset: 12996,
+  bytesPerRow: 768,
+  buffer: buffer5,
+}, {width: 139, height: 46, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+let pipeline24 = device0.createRenderPipeline({
+  label: '\u0435\u53e7\u9a23\u{1fab1}\u0156\u0db6\u4f36\u{1ff2c}',
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint'}, {format: 'r8sint', writeMask: 0}, {format: 'rg8sint'}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.GREEN,
+}, {format: 'rgba32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 13760,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 1764, shaderLocation: 19},
+          {format: 'unorm16x4', offset: 396, shaderLocation: 15},
+          {format: 'float16x2', offset: 724, shaderLocation: 5},
+          {format: 'sint32', offset: 1896, shaderLocation: 17},
+          {format: 'uint32', offset: 744, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 8172,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 456, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 580, shaderLocation: 1},
+          {format: 'snorm8x4', offset: 840, shaderLocation: 3},
+          {format: 'unorm16x4', offset: 2816, shaderLocation: 13},
+          {format: 'snorm16x2', offset: 496, shaderLocation: 7},
+          {format: 'sint32x3', offset: 244, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 3360, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 2768,
+        attributes: [
+          {format: 'uint32', offset: 36, shaderLocation: 16},
+          {format: 'unorm8x2', offset: 78, shaderLocation: 4},
+          {format: 'unorm16x2', offset: 176, shaderLocation: 2},
+          {format: 'sint32', offset: 36, shaderLocation: 0},
+          {format: 'uint16x2', offset: 788, shaderLocation: 6},
+          {format: 'float32x3', offset: 124, shaderLocation: 14},
+          {format: 'sint32x2', offset: 244, shaderLocation: 20},
+        ],
+      },
+      {
+        arrayStride: 704,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x2', offset: 192, shaderLocation: 18}],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x2', offset: 5978, shaderLocation: 9}],
+      },
+      {arrayStride: 6228, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 5128, attributes: [{format: 'sint32x4', offset: 1096, shaderLocation: 8}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', unclippedDepth: true},
+});
+let pipelineLayout9 = device0.createPipelineLayout({
+  label: '\uddb8\u62f1\u3fd1\u1a2f\u0e73\u{1f8ee}\u{1ff9e}\u67cd\u48a8\u{1fa7b}',
+  bindGroupLayouts: [bindGroupLayout5, bindGroupLayout2, bindGroupLayout1, bindGroupLayout0, bindGroupLayout3, bindGroupLayout2, bindGroupLayout1, bindGroupLayout4, bindGroupLayout4, bindGroupLayout2],
+});
+let commandEncoder29 = device0.createCommandEncoder({label: '\ue51f\u635d\u0a9c'});
+let textureView32 = texture5.createView({label: '\u5560\u32e9\u23bb\u7df2', format: 'rg8uint', baseMipLevel: 1, arrayLayerCount: 1});
+try {
+renderBundleEncoder10.setVertexBuffer(6, buffer4, 0, 27136);
+} catch {}
+try {
+commandEncoder6.copyBufferToBuffer(buffer1, 15716, buffer4, 21016, 276);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let commandEncoder30 = device0.createCommandEncoder({label: '\u933d\u{1ffd4}\u{1f678}'});
+let querySet15 = device0.createQuerySet({
+  label: '\ucf54\u{1f642}\u6ff9\u0cbb\u{1fd8c}\u{1fbda}\u{1fa88}\ucf52\ub66b\ucaac\u{1faea}',
+  type: 'occlusion',
+  count: 1133,
+});
+let texture14 = device0.createTexture({
+  label: '\u3e64\u{1ffcf}\u9e41\u9858\u0703\u6223\uc9b5\u{1f605}\u0da7\u0fa5',
+  size: [20, 6, 1],
+  mipLevelCount: 3,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView33 = texture12.createView({label: '\u{1fe0c}\u{1f69a}\u049d\u6b12', mipLevelCount: 1});
+try {
+commandEncoder29.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 469, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1930 widthInBlocks: 965 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3796 */
+  offset: 1866,
+  bytesPerRow: 2048,
+  buffer: buffer5,
+}, {width: 965, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+let computePassEncoder10 = commandEncoder19.beginComputePass({label: '\u4662\u0446\ufccf\u{1f74d}\u{1f930}\u{1ffe3}\u183e\u86de\u843e'});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  label: '\u5077\u6f6f\u{1fec0}\ua204\ud3d9\u0b4d\u7178\u09e6\uf5b0',
+  colorFormats: ['rg8uint', 'r8sint', 'rg8sint', 'rg16float', 'rgba32sint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder5.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+  await buffer1.mapAsync(GPUMapMode.WRITE);
+} catch {}
+try {
+device0.destroy();
+} catch {}
+let video2 = await videoWithData();
+let commandBuffer6 = commandEncoder5.finish({label: '\u2c70\u526f'});
+let texture15 = device0.createTexture({
+  label: '\u0097\u7c9b\u{1f845}\u01e6\u0428\u0644',
+  size: {width: 450, height: 60, depthOrArrayLayers: 19},
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder11 = commandEncoder25.beginComputePass({});
+try {
+renderBundleEncoder11.setPipeline(pipeline11);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+  await buffer3.mapAsync(GPUMapMode.WRITE, 23776, 2652);
+} catch {}
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 7},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer4, 27556, 2588);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 72, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 632 */
+{offset: 432}, {width: 50, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let imageData4 = new ImageData(228, 200);
+let offscreenCanvas3 = new OffscreenCanvas(814, 666);
+let imageBitmap5 = await createImageBitmap(offscreenCanvas0);
+let offscreenCanvas4 = new OffscreenCanvas(456, 126);
+let videoFrame2 = new VideoFrame(imageBitmap0, {timestamp: 0});
+let gpuCanvasContext3 = offscreenCanvas4.getContext('webgpu');
+let img1 = await imageWithData(11, 50, '#6456c47b', '#aaf16d32');
+try {
+externalTexture1.label = '\u0505\ub60d\u{1f827}\ubdd2\u5384\u0f02\uea26\u0424\u1c96\u{1f707}\u0b49';
+} catch {}
+let gpuCanvasContext4 = offscreenCanvas3.getContext('webgpu');
+let img2 = await imageWithData(26, 122, '#c736feba', '#78d8c005');
+let img3 = await imageWithData(157, 216, '#c93df576', '#1797804c');
+let img4 = await imageWithData(217, 133, '#059e7589', '#e33dd779');
+let offscreenCanvas5 = new OffscreenCanvas(784, 210);
+let gpuCanvasContext5 = offscreenCanvas5.getContext('webgpu');
+let imageBitmap6 = await createImageBitmap(offscreenCanvas5);
+let img5 = await imageWithData(281, 21, '#f345a440', '#bf74cd01');
+let videoFrame3 = new VideoFrame(video2, {timestamp: 0});
+let buffer7 = device0.createBuffer({label: '\u4090\u9524\ue7ba\ufca0\u6632', size: 48575, usage: GPUBufferUsage.UNIFORM});
+let commandEncoder31 = device0.createCommandEncoder();
+let textureView34 = texture5.createView({label: '\u95b8\u9e85\u62b7', dimension: '2d-array', baseMipLevel: 0, mipLevelCount: 2});
+try {
+renderBundleEncoder10.setPipeline(pipeline24);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(0, buffer4);
+} catch {}
+try {
+commandEncoder29.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 8780 */
+  offset: 8780,
+  buffer: buffer2,
+}, {
+  texture: texture2,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder24.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 5, y: 38, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 1494, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer7 = commandEncoder16.finish();
+let texture16 = device0.createTexture({
+  label: '\u{1f85a}\ue965\u{1ff58}\u05a0\u95d5\uf066\u{1fa87}\u7033\u{1fb17}',
+  size: {width: 450},
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg8sint'],
+});
+let textureView35 = texture11.createView({dimension: '3d', baseMipLevel: 1, arrayLayerCount: 1});
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder31.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 816 */
+  offset: 816,
+  rowsPerImage: 82,
+  buffer: buffer2,
+}, {
+  texture: texture14,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+let img6 = await imageWithData(107, 291, '#f900be84', '#7c518653');
+gc();
+let img7 = await imageWithData(141, 193, '#7aa9e4eb', '#273875e8');
+let imageData5 = new ImageData(4, 96);
+try {
+externalTexture1.label = '\u2381\u2eaf\u0aa2\u5903\u0d2d\u{1f732}\uc3c1';
+} catch {}
+let img8 = await imageWithData(138, 140, '#e3371686', '#a989e2bb');
+let imageBitmap7 = await createImageBitmap(offscreenCanvas1);
+let imageBitmap8 = await createImageBitmap(offscreenCanvas5);
+let imageData6 = new ImageData(128, 232);
+try {
+adapter2.label = '\u073c\u58b4';
+} catch {}
+document.body.prepend(video2);
+video1.width = 26;
+gc();
+let video3 = await videoWithData();
+let videoFrame4 = new VideoFrame(video2, {timestamp: 0});
+let video4 = await videoWithData();
+let canvas1 = document.createElement('canvas');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+canvas1.getContext('2d');
+} catch {}
+try {
+externalTexture2.label = '\u{1fa3d}\u{1fb80}\u41ad\u02ed\u{1f67e}\u0fc7\u5eca\u6e4d\u3b35';
+} catch {}
+let device1 = await adapter2.requestDevice({
+  label: '\u443d\u1a5a\u0004\u302d\u{1ff8e}\u1dc7\ue6e6\u5beb\uc70d\u3a59\uff9a',
+  defaultQueue: {label: '\u1586\u0bb0\u{1f7ee}\u{1f656}\u{1f6e0}\uab66\u018b\u6ace\u36dd\ucbee\u81b5'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+  ],
+});
+let imageBitmap9 = await createImageBitmap(imageData5);
+let commandEncoder32 = device1.createCommandEncoder({label: '\u4c33\u3a72\ub79b\uffd2\u{1f8b9}'});
+let querySet16 = device1.createQuerySet({label: '\u{1f670}\u8c91\u3967\u0081', type: 'occlusion', count: 1099});
+let texture17 = device1.createTexture({
+  label: '\u088e\u{1f831}\u4271\ubab3\u5fee',
+  size: {width: 3340, height: 5, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'astc-10x5-unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView36 = texture17.createView({label: '\u3c5d\u1de3\u5300\u0536\u2664\u4be6', dimension: '2d-array', mipLevelCount: 3});
+let sampler12 = device1.createSampler({
+  label: '\u4d26\u52c0\u588f\u1e96\u00c7\uffc8\u0d2e\u{1fea0}\u{1f736}\uda99',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 49.24,
+  lodMaxClamp: 94.00,
+});
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+let textureView37 = texture17.createView({
+  label: '\u{1fb04}\u43d4\u{1f874}\u4028\u{1fcb7}',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+let computePassEncoder12 = commandEncoder32.beginComputePass({label: '\uabe0\ucade\ucad1'});
+try {
+window.someLabel = device0.label;
+} catch {}
+let videoFrame5 = new VideoFrame(imageBitmap7, {timestamp: 0});
+let textureView38 = texture17.createView({baseMipLevel: 3});
+document.body.prepend(canvas1);
+let imageBitmap10 = await createImageBitmap(img1);
+canvas0.height = 1331;
+let bindGroupLayout6 = device1.createBindGroupLayout({
+  label: '\u64b9\u0729\uec8b\u{1fa71}\u94ba\u005d',
+  entries: [
+    {
+      binding: 635,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 190, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let commandEncoder33 = device1.createCommandEncoder({label: '\ubc3a\uc159\ua411\u317a\ue795\u4287\ub4b2\ua959'});
+let texture18 = device1.createTexture({
+  size: [160],
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView39 = texture18.createView({label: '\uad03\u0400\ud6a5\u83b4\u0709\ud4e7'});
+let renderBundleEncoder13 = device1.createRenderBundleEncoder({
+  label: '\u0f2f\u0d0c',
+  colorFormats: ['bgra8unorm-srgb', 'rg16uint', 'rgb10a2unorm', 'r32sint', 'r32uint'],
+  sampleCount: 1,
+});
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageData7 = new ImageData(136, 124);
+let video5 = await videoWithData();
+let buffer8 = device1.createBuffer({size: 73494, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let commandBuffer8 = commandEncoder32.finish({label: '\u8d87\u{1f602}\u391d\u7860\u6f64\u0a6e\u3393\u5117\u01cc'});
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(video1);
+offscreenCanvas0.height = 3855;
+let img9 = await imageWithData(117, 178, '#9e5044a7', '#869659a6');
+let pipelineLayout10 = device1.createPipelineLayout({
+  label: '\ucedf\u{1fcfd}\u424b\ud65f\u{1fbd3}\u5aae\u02fa\u2003\u6946\u7bb6\u0913',
+  bindGroupLayouts: [],
+});
+let commandBuffer9 = commandEncoder33.finish({label: '\u00ff\u20b1'});
+let sampler13 = device1.createSampler({
+  label: '\u2d74\u04c4\uc1ef\u486f\u7d07\u9884\u0ce7\uf5bd',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 88.96,
+  lodMaxClamp: 95.03,
+  maxAnisotropy: 5,
+});
+let texture19 = device1.createTexture({
+  size: {width: 105, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['r32uint', 'r32uint', 'r32uint'],
+});
+let renderBundle19 = renderBundleEncoder13.finish({});
+try {
+adapter2.label = '\u05ed\ucaad\u04a3\u{1f789}\u3a6a\u066f\u080c';
+} catch {}
+let texture20 = device1.createTexture({
+  label: '\u0767\u{1f7c8}\u0589\u5cee\u4314\u{1fa12}\u{1fcd5}\u93fa\u{1fb19}\udf8e\u8f28',
+  size: [420],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32sint', 'r32sint'],
+});
+let canvas2 = document.createElement('canvas');
+let commandEncoder34 = device1.createCommandEncoder({label: '\u09cf\u{1fb82}\u{1fbfc}\u0ff1\u8ff1\u0e73\u041c\ud4e3\ua5de\ub3b0'});
+let textureView40 = texture17.createView({
+  label: '\u0ddf\u026e\u0bd6\u067c\u0402\u4e2a\u0bff\u03f5\u6036\u0e08\uf514',
+  baseMipLevel: 1,
+  mipLevelCount: 3,
+});
+let renderBundle20 = renderBundleEncoder13.finish({label: '\u0cb2\u5206\u8f48\u{1fbd7}\u0768\uce98\u44fc'});
+let promise4 = device1.queue.onSubmittedWorkDone();
+let textureView41 = texture19.createView({
+  label: '\u3a80\u32bc\u{1fbaa}\u202d\u0704\u{1ff72}\ub129\u8243',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+let gpuCanvasContext6 = canvas2.getContext('webgpu');
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let renderBundleEncoder14 = device1.createRenderBundleEncoder({
+  label: '\u49fe\u6c5d\ue2c1\u7901',
+  colorFormats: ['bgra8unorm-srgb', 'rg16uint', 'rgb10a2unorm', 'r32sint', 'r32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+buffer8.destroy();
+} catch {}
+try {
+device1.queue.submit([commandBuffer8]);
+} catch {}
+let commandEncoder35 = device1.createCommandEncoder({label: '\ua789\u38f5\u3aee\uc916\ue89e\uc386\ueff1\uc100\u7492\ufbf7\u{1fc1d}'});
+let querySet17 = device1.createQuerySet({label: '\uf32a\u051c\u44a1\u{1f923}', type: 'occlusion', count: 2156});
+let texture21 = device1.createTexture({
+  label: '\u0dee\u8413\u17f6\u357e\u15a0\u{1f7ed}\u{1facc}',
+  size: {width: 160, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgb10a2unorm'],
+});
+let bindGroupLayout7 = device1.createBindGroupLayout({
+  label: '\u0df2\ucac8\u{1fad9}\u{1f928}',
+  entries: [
+    {binding: 945, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 791,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder36 = device1.createCommandEncoder();
+let querySet18 = device1.createQuerySet({
+  label: '\ub4fe\u0e4b\u0823\u{1fbc4}\udbfb\u415b\u7174\u{1ffe5}\u4c5c\uda5b',
+  type: 'occlusion',
+  count: 969,
+});
+try {
+  await promise4;
+} catch {}
+let commandEncoder37 = device1.createCommandEncoder();
+let renderBundle21 = renderBundleEncoder14.finish({label: '\u{1fbfe}\u076a\u{1fb25}\ufa7f\u27ad\uefd6\u84d9\u{1fee7}'});
+let sampler14 = device1.createSampler({
+  label: '\u0040\u96ed\u0c03\u{1f651}',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 54.87,
+  lodMaxClamp: 63.04,
+  compare: 'never',
+  maxAnisotropy: 5,
+});
+let textureView42 = texture18.createView({label: '\u033c\udf68\uf00b\u250f\u{1ff92}\u030b\ueb5b', aspect: 'all'});
+try {
+window.someLabel = commandEncoder34.label;
+} catch {}
+let bindGroupLayout8 = device1.createBindGroupLayout({
+  label: '\ubd59\u601a\ued40\ub4fa\u80f3\u64c8\u{1fef3}',
+  entries: [
+    {
+      binding: 384,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 537,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 352,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 58882, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder38 = device1.createCommandEncoder({label: '\ua43e\u005c\uf11f\u{1fb3e}\u{1fa61}\u08b2\u8fae'});
+let texture22 = device1.createTexture({
+  label: '\u29d3\u0c35\u117a\uc57b\ud3c2\u68e6\u004c\u0b48',
+  size: [840, 8, 418],
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint'],
+});
+let renderBundle22 = renderBundleEncoder13.finish({label: '\u073d\u1b07\u{1ff2f}'});
+try {
+commandEncoder38.copyTextureToTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 160, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(323), /* required buffer size: 323 */
+{offset: 323}, {width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas3.height = 187;
+let commandEncoder39 = device1.createCommandEncoder({});
+let promise5 = device1.queue.onSubmittedWorkDone();
+document.body.prepend(canvas1);
+let video6 = await videoWithData();
+let renderBundle23 = renderBundleEncoder13.finish();
+let sampler15 = device1.createSampler({
+  label: '\u89cc\u2424\u2dfc\ue70b\ueb37',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 91.01,
+  lodMaxClamp: 92.98,
+  compare: 'less-equal',
+});
+let externalTexture4 = device1.importExternalTexture({label: '\u{1f64a}\u04db\u0ec7\u9a0f\u3233', source: videoFrame3, colorSpace: 'display-p3'});
+try {
+buffer8.unmap();
+} catch {}
+let promise6 = adapter1.requestAdapterInfo();
+let commandBuffer10 = commandEncoder36.finish();
+try {
+texture18.destroy();
+} catch {}
+let querySet19 = device1.createQuerySet({type: 'occlusion', count: 3386});
+let texture23 = device1.createTexture({
+  label: '\u092c\u4076\ue27a\u4c12\ud8d1',
+  size: [80, 1, 9],
+  mipLevelCount: 7,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+device1.queue.submit([commandBuffer9]);
+} catch {}
+let img10 = await imageWithData(126, 10, '#9f5d0786', '#b48ba3ed');
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+offscreenCanvas4.height = 269;
+let video7 = await videoWithData();
+video1.width = 90;
+let imageData8 = new ImageData(232, 52);
+document.body.prepend(canvas2);
+let video8 = await videoWithData();
+let pipelineLayout11 = device1.createPipelineLayout({
+  label: '\ucf8d\u5654\u0115\u7ecc\u0148\u0381\u{1f84c}\u{1fee5}\u0b75',
+  bindGroupLayouts: [bindGroupLayout8, bindGroupLayout7],
+});
+let textureView43 = texture18.createView({label: '\u9f74\u8160', dimension: '1d', baseMipLevel: 0});
+let querySet20 = device1.createQuerySet({label: '\ue4b5\ufbd8', type: 'occlusion', count: 594});
+let texture24 = device1.createTexture({
+  label: '\u01f9\u3145\u0f29\u7d63\u7cb7\u{1f91d}\u0db5\u0110\u{1fa23}\u910f',
+  size: {width: 105},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+gpuCanvasContext3.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let videoFrame6 = new VideoFrame(video1, {timestamp: 0});
+let shaderModule8 = device1.createShaderModule({
+  label: '\u1f20\u7cfa\u333e\u6179\u0fe2\u95aa\u057f\u{1ff14}',
+  code: `@group(0) @binding(537)
+var<storage, read_write> n7: array<u32>;
+@group(0) @binding(384)
+var<storage, read_write> local5: array<u32>;
+@group(0) @binding(352)
+var<storage, read_write> field10: array<u32>;
+@group(1) @binding(791)
+var<storage, read_write> field11: array<u32>;
+@group(1) @binding(945)
+var<storage, read_write> n8: array<u32>;
+
+@compute @workgroup_size(7, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S7 {
+  @location(9) f0: vec4<i32>
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(4) f1: vec2<u32>,
+  @location(1) f2: vec4<u32>,
+  @location(3) f3: vec4<i32>,
+  @location(0) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(0) a0: vec2<f32>, a1: S7, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(0) f80: vec2<f32>,
+  @location(12) f81: vec4<i32>,
+  @location(3) f82: vec3<f32>,
+  @location(1) f83: vec4<f32>,
+  @location(15) f84: vec3<i32>,
+  @location(9) f85: vec4<i32>,
+  @builtin(position) f86: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(7) a0: f16) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let renderBundle24 = renderBundleEncoder13.finish({label: '\u6f93\u{1fd5d}\u8442\uc032\u{1fef5}\u{1ff5f}'});
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline25 = await device1.createComputePipelineAsync({
+  label: '\uefba\u060f\ucf79\ue4c4\ufb29\u{1f76a}\udf61\ueae4\u{1f84d}\uf67e\ua42e',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+let bindGroup5 = device1.createBindGroup({
+  label: '\u{1f816}\uccec\ue3c7\uc60d\u0424\ub592\u026b\ueb31',
+  layout: bindGroupLayout6,
+  entries: [{binding: 635, resource: sampler12}, {binding: 190, resource: externalTexture4}],
+});
+let texture25 = device1.createTexture({
+  label: '\u{1f9ec}\u001d\ueb89\u5392\ua2b0\uc03c\ub5e6\u0cb2\u3f94',
+  size: {width: 840, height: 8, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg16uint', 'rg16uint'],
+});
+let computePassEncoder13 = commandEncoder35.beginComputePass({label: '\u485a\u296e\u0003'});
+let renderBundle25 = renderBundleEncoder14.finish({label: '\u{1f7fc}\u3147\ub4a8\u0d98\u85ca\u72fd\u6096\uc45e\u0964'});
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 845 */
+{offset: 845}, {width: 41, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline26 = await device1.createComputePipelineAsync({layout: pipelineLayout10, compute: {module: shaderModule8, entryPoint: 'compute0'}});
+let commandEncoder40 = device1.createCommandEncoder({label: '\ube76\u{1ff7b}\ufa62\u{1fdf3}'});
+let textureView44 = texture20.createView({});
+let externalTexture5 = device1.importExternalTexture({label: '\ue2c0\u{1fdbe}', source: video6, colorSpace: 'srgb'});
+try {
+gpuCanvasContext2.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 51 */
+{offset: 51, bytesPerRow: 808}, {width: 136, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder41 = device1.createCommandEncoder({label: '\udce3\ud805\uf229\u{1f7ba}'});
+let textureView45 = texture18.createView({label: '\u{1fc71}\uf42c\u3547\uf381\u0cd3\u{1fc09}\u{1fb73}\u6d4d', aspect: 'all', baseArrayLayer: 0});
+try {
+buffer8.unmap();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(0)), /* required buffer size: 15 */
+{offset: 15, rowsPerImage: 82}, {width: 95, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline27 = await device1.createComputePipelineAsync({layout: pipelineLayout10, compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}}});
+let commandEncoder42 = device1.createCommandEncoder();
+let commandBuffer11 = commandEncoder37.finish({label: '\u38a6\u{1ff95}\u01f7\u0212\u023b\u{1ff35}\u0bec\u2f32\u{1febb}\uda4e\u{1f855}'});
+let textureView46 = texture17.createView({label: '\u3b72\u4376', format: 'astc-10x5-unorm-srgb', baseMipLevel: 3, mipLevelCount: 1});
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let promise7 = device1.queue.onSubmittedWorkDone();
+let pipeline28 = device1.createComputePipeline({
+  label: '\u8f60\u09a0\u0e05\u3fe9\u5328\ub3a4',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+let bindGroupLayout9 = device1.createBindGroupLayout({
+  label: '\u0b32\u{1fc32}\ufd35\u784e\u0a5f\u{1f8cc}\u0823\u1199\u0f0f\u0973\u0f27',
+  entries: [
+    {
+      binding: 558,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 303,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 775,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder43 = device1.createCommandEncoder({label: '\ue371\uef5d\u2392\uee2a\u4ddd\uff32\u{1fc76}\u{1fc2a}'});
+let textureView47 = texture20.createView({label: '\u93d1\u045d\ue282'});
+let computePassEncoder14 = commandEncoder39.beginComputePass({label: '\u1c94\ub901\ueea6\u9c43\u1321\uaade'});
+let renderBundleEncoder15 = device1.createRenderBundleEncoder({
+  colorFormats: ['bgra8unorm-srgb', 'rg16uint', 'rgb10a2unorm', 'r32sint', 'r32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+try {
+computePassEncoder14.setBindGroup(3, bindGroup5, new Uint32Array(9214), 1790, 0);
+} catch {}
+let pipeline29 = await device1.createComputePipelineAsync({
+  label: '\u128a\u084d\u9370\u0f22',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+let imageData9 = new ImageData(176, 84);
+let commandEncoder44 = device1.createCommandEncoder();
+let renderBundleEncoder16 = device1.createRenderBundleEncoder({
+  label: '\u1bc9\u5784',
+  colorFormats: ['bgra8unorm-srgb', 'rg16uint', 'rgb10a2unorm', 'r32sint', 'r32uint'],
+  depthReadOnly: true,
+});
+let renderBundle26 = renderBundleEncoder14.finish();
+let externalTexture6 = device1.importExternalTexture({label: '\ub981\u0daf', source: video2, colorSpace: 'display-p3'});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup5, new Uint32Array(7810), 424, 0);
+} catch {}
+try {
+renderBundleEncoder15.insertDebugMarker('\u0349');
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb'],
+});
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(809, 80);
+try {
+offscreenCanvas6.getContext('webgpu');
+} catch {}
+document.body.prepend(video0);
+let canvas3 = document.createElement('canvas');
+let imageBitmap11 = await createImageBitmap(offscreenCanvas1);
+let textureView48 = texture17.createView({label: '\u{1fc90}\uc6b0\u0c2e\u0133\udb60\u0384\u9cd8\u5442\u{1fc70}\u63a3\u0b4e', baseMipLevel: 2});
+let computePassEncoder15 = commandEncoder38.beginComputePass({label: '\u{1fcc8}\u2d59\u2036'});
+let externalTexture7 = device1.importExternalTexture({label: '\uea7a\u0294\u{1ff75}\u96f3\u{1fdc7}', source: video4, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder15.setVertexBuffer(9054, undefined, 841423390, 3384372712);
+} catch {}
+try {
+  await device1.popErrorScope();
+} catch {}
+try {
+adapter1.label = '\u77d1\u3ec5\ub981';
+} catch {}
+try {
+  await promise7;
+} catch {}
+document.body.prepend(img5);
+try {
+canvas3.getContext('webgl2');
+} catch {}
+try {
+window.someLabel = externalTexture1.label;
+} catch {}
+let video9 = await videoWithData();
+let texture26 = device1.createTexture({
+  label: '\u{1fd02}\u088a\ud51e\u0d6c\u94b2\u0eee\u{1f89e}\uf63e\u062a\u0740',
+  size: {width: 40, height: 1, depthOrArrayLayers: 92},
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder16 = commandEncoder40.beginComputePass({});
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 160, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 2},
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 752 */
+{offset: 254, bytesPerRow: 35, rowsPerImage: 1}, {width: 2, height: 1, depthOrArrayLayers: 15});
+} catch {}
+try {
+  await promise6;
+} catch {}
+let commandEncoder45 = device1.createCommandEncoder({});
+let querySet21 = device1.createQuerySet({label: '\u{1fafe}\u03ee', type: 'occlusion', count: 3094});
+let texture27 = device1.createTexture({
+  label: '\u0fc3\u0aa1\u9e0d\u58c6\u68b0\uf9e3\u5f8f\u023c\u6394\ufbd5',
+  size: {width: 420, height: 4, depthOrArrayLayers: 1},
+  mipLevelCount: 8,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm-srgb'],
+});
+let computePassEncoder17 = commandEncoder44.beginComputePass({label: '\u0c07\u8c14\u9b92\ue6ef\u0da1'});
+let renderBundle27 = renderBundleEncoder13.finish({label: '\u6e45\u{1f94c}\u83e5'});
+let externalTexture8 = device1.importExternalTexture({label: '\u{1fcdf}\u0bd4\u0afc\ue6fa\u0c6a', source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder16.setPipeline(pipeline26);
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 13, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 3, y: 2 },
+  flipY: false,
+}, {
+  texture: texture27,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline30 = device1.createRenderPipeline({
+  label: '\u0a29\u09e1\u010f\u1429\u20f4',
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb'}, {format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'r32sint'}, {format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 216, attributes: []},
+      {arrayStride: 984, attributes: []},
+      {arrayStride: 564, attributes: [{format: 'float32x4', offset: 0, shaderLocation: 7}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let buffer9 = device1.createBuffer({label: '\u07ab\u5e94\u35e6\u0774\u00fb', size: 44939, usage: GPUBufferUsage.VERTEX});
+try {
+renderBundleEncoder16.setPipeline(pipeline30);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 413 */
+{offset: 413}, {width: 16, height: 1, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let sampler16 = device1.createSampler({
+  label: '\u036d\uff46\u0633\u0ec2\u0396\u95c7\u0f35\ua38d',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 42.35,
+  lodMaxClamp: 98.68,
+});
+try {
+renderBundleEncoder15.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(4, buffer9);
+} catch {}
+let canvas4 = document.createElement('canvas');
+let offscreenCanvas7 = new OffscreenCanvas(29, 1007);
+let imageData10 = new ImageData(152, 164);
+let texture28 = gpuCanvasContext0.getCurrentTexture();
+let externalTexture9 = device1.importExternalTexture({source: video3, colorSpace: 'srgb'});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline27);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup5);
+} catch {}
+let gpuCanvasContext7 = canvas4.getContext('webgpu');
+let texture29 = device1.createTexture({
+  label: '\u9349\uca43',
+  size: [420, 4, 1],
+  mipLevelCount: 3,
+  format: 'r32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder17 = device1.createRenderBundleEncoder({
+  label: '\u0c80\u1d06',
+  colorFormats: ['bgra8unorm-srgb', 'rg16uint', 'rgb10a2unorm', 'r32sint', 'r32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture10 = device1.importExternalTexture({label: '\u0436\u0fae\u45da\uac90\ud3ab\u0845', source: videoFrame3, colorSpace: 'srgb'});
+try {
+buffer9.unmap();
+} catch {}
+document.body.prepend(img10);
+let commandEncoder46 = device1.createCommandEncoder({label: '\u{1fb1c}\u9c16\u031f\u46a3'});
+let commandBuffer12 = commandEncoder45.finish();
+try {
+computePassEncoder15.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(2, bindGroup5);
+} catch {}
+let pipeline31 = device1.createRenderPipeline({
+  label: '\u0fbe\ubf1d\u0432\u0b7b',
+  layout: pipelineLayout10,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rg16uint'}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'r32sint'}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 244,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x4', offset: 60, shaderLocation: 7}],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let gpuCanvasContext8 = offscreenCanvas7.getContext('webgpu');
+let videoFrame7 = new VideoFrame(img5, {timestamp: 0});
+let querySet22 = device1.createQuerySet({label: '\u05bd\u17f3\u{1f857}\uab78\u4c3b\u0306', type: 'occlusion', count: 2088});
+let texture30 = gpuCanvasContext0.getCurrentTexture();
+try {
+renderBundleEncoder17.setIndexBuffer(buffer8, 'uint16', 41950, 28945);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline30);
+} catch {}
+let pipeline32 = await device1.createComputePipelineAsync({
+  label: '\u{1fc8a}\u0815\u8051',
+  layout: 'auto',
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let commandEncoder47 = device1.createCommandEncoder({});
+let textureView49 = texture27.createView({label: '\u0c26\u{1f8ee}\uabc0\u1bfb\u01d2\u0936', dimension: '2d-array', baseMipLevel: 1});
+let externalTexture11 = device1.importExternalTexture({label: '\u0621\u3da7', source: video3, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder15.setBindGroup(3, bindGroup5, []);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(6, buffer9, 0, 22945);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(72)), /* required buffer size: 201 */
+{offset: 201}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let promise8 = device1.createComputePipelineAsync({
+  label: '\u0418\u54ed\u7609\ue3a8\u{1f713}',
+  layout: pipelineLayout11,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+try {
+externalTexture8.label = '\u7d35\u0513';
+} catch {}
+let textureView50 = texture20.createView({dimension: '1d', mipLevelCount: 1, baseArrayLayer: 0});
+let externalTexture12 = device1.importExternalTexture({
+  label: '\ufb2c\u8d5e\u26c1\u0b24\u0f76\u01a4\u0273\u071b\u9b45\ufa61\u0c91',
+  source: videoFrame2,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup5, []);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(0, buffer9, 11664, 18639);
+} catch {}
+let videoFrame8 = new VideoFrame(video9, {timestamp: 0});
+let imageBitmap12 = await createImageBitmap(video3);
+let shaderModule9 = device1.createShaderModule({
+  label: '\u0afc\u{1ff12}\u0364\u{1f992}\u0419\u0c90\ud831\ua247',
+  code: `@group(0) @binding(384)
+var<storage, read_write> n9: array<u32>;
+@group(0) @binding(352)
+var<storage, read_write> local6: array<u32>;
+@group(1) @binding(945)
+var<storage, read_write> function9: array<u32>;
+@group(0) @binding(537)
+var<storage, read_write> global9: array<u32>;
+
+@compute @workgroup_size(3, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(6) f0: u32,
+  @location(0) f1: vec4<f32>,
+  @location(3) f2: vec2<i32>,
+  @location(1) f3: vec4<u32>,
+  @location(4) f4: vec3<u32>,
+  @builtin(sample_mask) f5: u32,
+  @location(2) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(front_facing) a1: bool, @builtin(sample_index) a2: u32, @builtin(sample_mask) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S8 {
+  @location(7) f0: vec2<i32>,
+  @location(12) f1: vec2<u32>,
+  @location(6) f2: i32,
+  @builtin(vertex_index) f3: u32,
+  @location(0) f4: f32,
+  @builtin(instance_index) f5: u32
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec3<u32>, @location(8) a1: f32, @location(13) a2: vec2<u32>, @location(2) a3: vec2<f16>, @location(14) a4: vec2<u32>, @location(15) a5: vec2<i32>, @location(4) a6: vec2<u32>, @location(9) a7: vec2<f32>, @location(1) a8: vec3<f16>, @location(5) a9: vec3<u32>, @location(3) a10: vec3<f16>, @location(10) a11: vec4<u32>, a12: S8) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let textureView51 = texture29.createView({
+  label: '\u9d1e\u0149\u010f\u00f8\u2477\u747e\u1682\u{1fd79}\uf369\u09d0',
+  dimension: '2d-array',
+  mipLevelCount: 2,
+  arrayLayerCount: 1,
+});
+let externalTexture13 = device1.importExternalTexture({label: '\ua5d6\u{1fda6}\ubb1e\u0c2a\u0498\ua6d6\ubd13\u0221', source: videoFrame2});
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline30);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 2,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 248 */
+{offset: 248}, {width: 48, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise9 = device1.createRenderPipelineAsync({
+  label: '\u{1f9fc}\u752d\u{1f610}\u0d6d\u{1fcba}\u096c\uc652',
+  layout: pipelineLayout11,
+  multisample: {mask: 0xe8086226},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'add', srcFactor: 'zero', dstFactor: 'zero'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+}, {format: 'rg16uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r32uint'}],
+},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 44,
+        attributes: [
+          {format: 'float32x2', offset: 0, shaderLocation: 1},
+          {format: 'float16x4', offset: 4, shaderLocation: 3},
+          {format: 'uint8x4', offset: 4, shaderLocation: 10},
+          {format: 'uint32x3', offset: 0, shaderLocation: 5},
+          {format: 'uint8x4', offset: 12, shaderLocation: 4},
+          {format: 'uint32x3', offset: 0, shaderLocation: 11},
+          {format: 'sint16x4', offset: 12, shaderLocation: 6},
+          {format: 'snorm16x4', offset: 8, shaderLocation: 2},
+          {format: 'unorm8x2', offset: 0, shaderLocation: 0},
+          {format: 'uint16x4', offset: 0, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 472,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 256, shaderLocation: 7},
+          {format: 'uint16x2', offset: 36, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 356,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x4', offset: 212, shaderLocation: 8}],
+      },
+      {
+        arrayStride: 664,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x2', offset: 4, shaderLocation: 9}],
+      },
+      {arrayStride: 316, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 412,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 76, shaderLocation: 14},
+          {format: 'sint32x2', offset: 4, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let video10 = await videoWithData();
+let imageData11 = new ImageData(136, 228);
+gc();
+let querySet23 = device1.createQuerySet({label: '\uc4b9\u219c\u0b75', type: 'occlusion', count: 2365});
+let renderBundle28 = renderBundleEncoder16.finish({label: '\u861a\u44fc'});
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let querySet24 = device1.createQuerySet({label: '\uac5f\u2774\u5d70', type: 'occlusion', count: 284});
+let texture31 = device1.createTexture({
+  label: '\u6a20\u0f25\u6615\ueba3\u{1f8dd}',
+  size: [105, 1, 109],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder18 = commandEncoder46.beginComputePass({label: '\u4128\u651d\ua0b2\uf9e3\u98c1\u{1ffec}\u{1fab6}\u35f7'});
+try {
+device1.queue.submit([commandBuffer10, commandBuffer12]);
+} catch {}
+try {
+  await promise5;
+} catch {}
+let imageBitmap13 = await createImageBitmap(offscreenCanvas7);
+let texture32 = device1.createTexture({
+  label: '\u04e9\u{1ffd9}\u034d\u{1f9c4}\u0aa1\u16cb\ub40b\u820a',
+  size: {width: 105, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint'],
+});
+let textureView52 = texture26.createView({label: '\uee4d\u0763\u00af\uf23a\u0de3\uf3d9\u{1f6bd}\u0840', dimension: '3d'});
+let renderBundleEncoder18 = device1.createRenderBundleEncoder({
+  label: '\u3627\u{1f6aa}\u{1fcb0}\u01a2\u07f4\ua226\ua7ee',
+  colorFormats: ['bgra8unorm-srgb', 'rg16uint', 'rgb10a2unorm', 'r32sint', 'r32uint'],
+});
+let sampler17 = device1.createSampler({
+  label: '\u8d78\u{1fdca}\u0b69\u68af\u0747\u0a9c\u0639',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 36.16,
+  lodMaxClamp: 47.01,
+});
+try {
+renderBundleEncoder15.setPipeline(pipeline30);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(7, buffer9, 32404);
+} catch {}
+try {
+commandEncoder43.copyTextureToTexture({
+  texture: texture19,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 420, height: 4, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap9,
+  origin: { x: 2, y: 28 },
+  flipY: false,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 103, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture33 = device0.createTexture({
+  label: '\u4e39\u0e76\uefa0',
+  size: {width: 500, height: 2, depthOrArrayLayers: 302},
+  mipLevelCount: 8,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16float', 'rg16float', 'rg16float'],
+});
+let textureView53 = texture8.createView({mipLevelCount: 1});
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline33 = device0.createRenderPipeline({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'less-equal', depthFailOp: 'invert', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'greater-equal', failOp: 'replace', passOp: 'invert'},
+    stencilReadMask: 3334262611,
+    stencilWriteMask: 121411288,
+    depthBiasSlopeScale: 422.4072751695114,
+    depthBiasClamp: 201.30357451620512,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 30708,
+        attributes: [
+          {format: 'uint32x4', offset: 6172, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 27204, shaderLocation: 6},
+          {format: 'sint32x3', offset: 6884, shaderLocation: 10},
+          {format: 'sint32x4', offset: 23128, shaderLocation: 15},
+          {format: 'float32x3', offset: 10096, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 3968, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 12836,
+        stepMode: 'vertex',
+        attributes: [{format: 'snorm16x2', offset: 32, shaderLocation: 19}],
+      },
+      {arrayStride: 16072, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x4', offset: 16136, shaderLocation: 20}],
+      },
+      {
+        arrayStride: 1020,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x2', offset: 240, shaderLocation: 18}],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+let img11 = await imageWithData(249, 114, '#ca3eca00', '#983855ae');
+try {
+window.someLabel = commandEncoder5.label;
+} catch {}
+let img12 = await imageWithData(246, 243, '#8c6c60c6', '#f8cf029e');
+try {
+adapter1.label = '\u0d38\u0d28\u062d';
+} catch {}
+let bindGroup6 = device1.createBindGroup({
+  label: '\u0f7c\u81a7\u{1fd01}\uafc6\u97be\u{1ff7b}\u1074\u4d6a\ub3e4\u0da7',
+  layout: bindGroupLayout6,
+  entries: [{binding: 190, resource: externalTexture8}, {binding: 635, resource: sampler17}],
+});
+let commandEncoder48 = device1.createCommandEncoder({label: '\u94b5\u{1f612}\ub651\u1fb1\u0dd5\u3f90\u0d67\u79c8\u0946\u4b2d\u05fc'});
+let querySet25 = device1.createQuerySet({type: 'occlusion', count: 1174});
+let texture34 = device1.createTexture({
+  size: {width: 160},
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint'],
+});
+let textureView54 = texture17.createView({
+  label: '\u09ee\u0148\u{1fa1a}\u0dfb\u{1fe14}\u5438\u0445\ub3e6\u6174\u2153\u7c2b',
+  dimension: '2d-array',
+  baseMipLevel: 3,
+  arrayLayerCount: 1,
+});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup6, new Uint32Array(2), 2, 0);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let canvas5 = document.createElement('canvas');
+let buffer10 = device1.createBuffer({label: '\u{1fc8c}\u0c8b', size: 401406, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder49 = device1.createCommandEncoder({});
+try {
+device1.queue.writeBuffer(buffer10, 294216, new DataView(new ArrayBuffer(21748)), 3814, 248);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(48)), /* required buffer size: 308 */
+{offset: 308}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap14 = await createImageBitmap(offscreenCanvas1);
+let gpuCanvasContext9 = canvas5.getContext('webgpu');
+let textureView55 = texture21.createView({label: '\ue930\u5fc9\u1b6b\u8e4a\u255b\u2959\u2534'});
+let renderBundle29 = renderBundleEncoder14.finish({label: '\u{1f709}\u89f5\ua0eb\u0d6f'});
+try {
+computePassEncoder15.dispatchWorkgroups(3, 2, 5);
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline26);
+} catch {}
+try {
+commandEncoder48.copyTextureToBuffer({
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 68 widthInBlocks: 17 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 14020 */
+  offset: 14020,
+  bytesPerRow: 256,
+  buffer: buffer10,
+}, {width: 17, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer10);
+} catch {}
+canvas2.height = 46;
+let commandEncoder50 = device1.createCommandEncoder({});
+let textureView56 = texture25.createView({label: '\u{1fb0b}\uac79\u1b40\u{1f63f}\u{1f849}\u0899', baseMipLevel: 4});
+let renderBundle30 = renderBundleEncoder18.finish({label: '\u012c\u63a3\u9f79\ua0f8\u{1ff8b}\u2abe\ued04\u{1fdb3}'});
+let sampler18 = device1.createSampler({
+  label: '\u7c46\ub4b8',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 67.04,
+  lodMaxClamp: 88.69,
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder14.setPipeline(pipeline25);
+} catch {}
+try {
+buffer8.destroy();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Int32Array(new ArrayBuffer(40)), /* required buffer size: 678 */
+{offset: 678, bytesPerRow: 180}, {width: 37, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img8);
+let offscreenCanvas8 = new OffscreenCanvas(574, 828);
+let sampler19 = device1.createSampler({
+  label: '\u{1fda6}\u0bc5\u1f1f\u6d76\u0fbd',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 75.24,
+  lodMaxClamp: 91.93,
+});
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(1, bindGroup5, new Uint32Array(3195), 2421, 0);
+} catch {}
+try {
+commandEncoder42.copyTextureToBuffer({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 208 widthInBlocks: 52 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10504 */
+  offset: 10296,
+  buffer: buffer10,
+}, {width: 52, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+offscreenCanvas8.getContext('webgl2');
+} catch {}
+let bindGroupLayout10 = device1.createBindGroupLayout({
+  label: '\u080e\uc0ff\u7586',
+  entries: [
+    {
+      binding: 413,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 348,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let texture35 = device1.createTexture({
+  size: [160, 1, 371],
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgb10a2unorm', 'rgb10a2unorm'],
+});
+let textureView57 = texture18.createView({label: '\u7dee\u0e90\u{1fdbe}\u{1f753}\u{1f6e2}\udefc\u09b8\u030e\u01ce'});
+try {
+computePassEncoder18.setPipeline(pipeline25);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+document.body.prepend(video8);
+offscreenCanvas6.width = 2480;
+let videoFrame9 = new VideoFrame(offscreenCanvas1, {timestamp: 0});
+let commandEncoder51 = device1.createCommandEncoder({});
+let commandBuffer13 = commandEncoder42.finish({label: '\u0ef7\ub92d\u2d42\u3ec9\u91cd\u{1fa7a}\u{1f8c5}\u{1fc56}'});
+let textureView58 = texture20.createView({label: '\u{1f9ba}\u0fef\u1200\u2170'});
+let renderBundle31 = renderBundleEncoder16.finish({label: '\u0eeb\ube7a\u{1f7fb}\u0a47\u{1fad6}\u{1fb26}\u9167\u84b0'});
+let externalTexture14 = device1.importExternalTexture({label: '\uedd7\u8535\u7e2e\u0412\u02d3\u0fbc\uc89e', source: video4, colorSpace: 'srgb'});
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline29);
+} catch {}
+try {
+  await device1.popErrorScope();
+} catch {}
+try {
+commandEncoder49.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+commandEncoder49.clearBuffer(buffer10, 100624, 33620);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let video11 = await videoWithData();
+let videoFrame10 = videoFrame8.clone();
+let commandEncoder52 = device1.createCommandEncoder();
+let commandBuffer14 = commandEncoder44.finish({label: '\u{1fc6f}\u29cc\u{1f985}\u{1f74e}\u{1fbc7}\ub095'});
+try {
+computePassEncoder18.setPipeline(pipeline28);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData5,
+  origin: { x: 0, y: 3 },
+  flipY: true,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let canvas6 = document.createElement('canvas');
+let device2 = await adapter1.requestDevice({
+  defaultQueue: {},
+  requiredFeatures: [
+    'depth-clip-control',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+  ],
+  requiredLimits: {
+    maxBindGroups: 9,
+    maxColorAttachmentBytesPerSample: 37,
+    maxVertexAttributes: 20,
+    maxVertexBufferArrayStride: 24562,
+    maxStorageTexturesPerShaderStage: 8,
+    maxStorageBuffersPerShaderStage: 12,
+    maxDynamicStorageBuffersPerPipelineLayout: 60474,
+    maxDynamicUniformBuffersPerPipelineLayout: 37516,
+    maxBindingsPerBindGroup: 6168,
+    maxTextureArrayLayers: 408,
+    maxTextureDimension1D: 8434,
+    maxTextureDimension2D: 11652,
+    maxBindGroupsPlusVertexBuffers: 30,
+    minStorageBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 187676571,
+    maxStorageBufferBindingSize: 203182067,
+    maxUniformBuffersPerShaderStage: 35,
+    maxSampledTexturesPerShaderStage: 21,
+    maxInterStageShaderVariables: 67,
+    maxInterStageShaderComponents: 123,
+    maxSamplersPerShaderStage: 18,
+  },
+});
+let commandEncoder53 = device2.createCommandEncoder({label: '\u{1f715}\u3011\u{1fe0b}\u0355'});
+let texture36 = device2.createTexture({
+  label: '\ubf50\u4961\u527e\ubfa5\uaeae\u659b\u09fd\u0956\u0f54',
+  size: {width: 384, height: 2, depthOrArrayLayers: 254},
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundle32 = renderBundleEncoder16.finish({label: '\u0715\u4e8d\uc667\u0d89\ubde3\u0d90\ub35a\ue1d9'});
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup5, new Uint32Array(5975), 3849, 0);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(3, buffer9, 0, 15836);
+} catch {}
+let pipeline34 = await device1.createRenderPipelineAsync({
+  label: '\u08b3\u0991\ubf7a\u{1f98e}\ua9cc\u9439\u{1fc70}',
+  layout: pipelineLayout10,
+  multisample: {count: 4, mask: 0x8c1481d1},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.GREEN}, {
+  format: 'rg16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'r32uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'equal', failOp: 'replace', depthFailOp: 'replace', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'greater', failOp: 'increment-clamp', depthFailOp: 'increment-wrap', passOp: 'invert'},
+    stencilReadMask: 662090244,
+    stencilWriteMask: 2633870841,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 252,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x3', offset: 28, shaderLocation: 15},
+          {format: 'uint16x2', offset: 36, shaderLocation: 14},
+          {format: 'uint32', offset: 88, shaderLocation: 13},
+          {format: 'uint32x3', offset: 36, shaderLocation: 12},
+          {format: 'uint32x3', offset: 44, shaderLocation: 5},
+          {format: 'unorm10-10-10-2', offset: 12, shaderLocation: 9},
+          {format: 'uint32', offset: 4, shaderLocation: 11},
+          {format: 'unorm16x2', offset: 12, shaderLocation: 8},
+          {format: 'unorm16x4', offset: 64, shaderLocation: 1},
+          {format: 'sint32', offset: 12, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 84,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x3', offset: 20, shaderLocation: 7},
+          {format: 'snorm16x4', offset: 0, shaderLocation: 3},
+          {format: 'float16x2', offset: 12, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 80,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint32x4', offset: 4, shaderLocation: 10}],
+      },
+      {
+        arrayStride: 216,
+        attributes: [
+          {format: 'snorm8x2', offset: 20, shaderLocation: 2},
+          {format: 'uint32x2', offset: 48, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {unclippedDepth: true},
+});
+let textureView59 = texture34.createView({baseArrayLayer: 0});
+let computePassEncoder19 = commandEncoder49.beginComputePass({label: '\u60c9\ua713'});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup5, new Uint32Array(1769), 1085, 0);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline30);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(6548, undefined, 0, 1854233526);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap14,
+  origin: { x: 64, y: 30 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+externalTexture5.label = '\u8346\uacdd\u8553';
+} catch {}
+let buffer11 = device1.createBuffer({label: '\u105d\u0503', size: 240713, usage: GPUBufferUsage.QUERY_RESOLVE});
+let querySet26 = device1.createQuerySet({label: '\ud220\u9e42\ue79a\ud7a3\u00aa\u0ad1\u31d7\ud071\u432c', type: 'occlusion', count: 102});
+let computePassEncoder20 = commandEncoder52.beginComputePass();
+let renderBundle33 = renderBundleEncoder15.finish({label: '\u0d46\u{1f9e7}\u{1fdc6}'});
+let sampler20 = device1.createSampler({
+  label: '\u0074\u0e6a\ufe1b\u0c76\u0552\u1b95\uc361\u6f6e',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 24.99,
+});
+try {
+renderBundleEncoder17.setVertexBuffer(2, buffer9, 0, 130);
+} catch {}
+try {
+commandEncoder47.copyTextureToBuffer({
+  texture: texture17,
+  mipLevel: 2,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 32 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 19776 */
+  offset: 19776,
+  buffer: buffer10,
+}, {width: 20, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder51.copyTextureToTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 160, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise10 = device1.queue.onSubmittedWorkDone();
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 105, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video10,
+  origin: { x: 0, y: 2 },
+  flipY: true,
+}, {
+  texture: texture27,
+  mipLevel: 2,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter2.label = '\u2065\u0d01\u0589\u0572\udabc\u7edc\u0c6a\u9687\u{1fcc5}';
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+try {
+  await promise10;
+} catch {}
+document.body.prepend(img5);
+let img13 = await imageWithData(111, 63, '#b1f7798c', '#4ddfcfee');
+try {
+commandEncoder53.insertDebugMarker('\u011d');
+} catch {}
+let video12 = await videoWithData();
+let promise11 = adapter1.requestAdapterInfo();
+let querySet27 = device2.createQuerySet({
+  label: '\u0ae7\uec70\u2b36\u3abd\u{1f778}\u{1faf9}\u09fe\u0b04\u050f\u9a86\u{1fe19}',
+  type: 'occlusion',
+  count: 2555,
+});
+let renderBundleEncoder19 = device2.createRenderBundleEncoder({
+  label: '\u{1f7fe}\u44d1\u1720\u{1f926}\u71f6\u7b44\uaf70\u7112\u9b05',
+  colorFormats: ['rgba32sint', 'rgb10a2uint', 'rg8unorm'],
+  depthReadOnly: true,
+});
+let renderBundle34 = renderBundleEncoder19.finish({});
+try {
+gpuCanvasContext7.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 4,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Int32Array(new ArrayBuffer(72)), /* required buffer size: 130_198 */
+{offset: 602, bytesPerRow: 316, rowsPerImage: 41}, {width: 9, height: 1, depthOrArrayLayers: 11});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+window.someLabel = textureView11.label;
+} catch {}
+let texture37 = device2.createTexture({
+  size: [768, 5, 1],
+  mipLevelCount: 5,
+  dimension: '2d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let textureView60 = texture37.createView({label: '\uf601\uff6d\uc4ff\u3388\u0b8b\u{1fa89}', dimension: '2d-array', baseMipLevel: 2});
+let computePassEncoder21 = commandEncoder53.beginComputePass({label: '\ud302\uaaf7\u{1f87c}\uf808\ue5ef\u79ad\u{1f992}\u6410\u03ca\u2f4e\u{1fb6e}'});
+try {
+  await promise11;
+} catch {}
+let offscreenCanvas9 = new OffscreenCanvas(754, 153);
+let textureView61 = texture36.createView({label: '\u07c1\uc3d6\ucf7e\u0345', baseMipLevel: 3, mipLevelCount: 5, baseArrayLayer: 0});
+let sampler21 = device2.createSampler({
+  label: '\u0b73\ua884\u09c0\u{1fd16}\u092f\u07ac\u06a5\u0392\u5fea',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 80.45,
+});
+try {
+computePassEncoder21.insertDebugMarker('\u{1f8f6}');
+} catch {}
+gc();
+let imageData12 = new ImageData(16, 220);
+let commandEncoder54 = device1.createCommandEncoder({});
+let texture38 = device1.createTexture({
+  label: '\u0071\u{1fabc}\u2274\u4488\u2db2\u{1f76f}\u0d07',
+  size: [105],
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView62 = texture31.createView({baseMipLevel: 5, baseArrayLayer: 0});
+let sampler22 = device1.createSampler({
+  label: '\u0029\u{1fd2e}\ub824\u17bb\ucfff\ue1ca\u{1f83a}\u6c5c\ua9fe\u{1f673}',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 46.13,
+  lodMaxClamp: 92.12,
+  maxAnisotropy: 2,
+});
+try {
+device1.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 739 */
+{offset: 575}, {width: 41, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let textureView63 = texture37.createView({label: '\u059c\u070e', dimension: '2d-array', baseMipLevel: 3, arrayLayerCount: 1});
+let renderBundle35 = renderBundleEncoder19.finish({label: '\u05ea\u80cb\u0f24\u83ee\u0401\ua677'});
+try {
+device2.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(586), /* required buffer size: 586 */
+{offset: 586}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let offscreenCanvas10 = new OffscreenCanvas(976, 500);
+let video13 = await videoWithData();
+let textureView64 = texture36.createView({label: '\u{1fb39}\u853a', baseMipLevel: 8, arrayLayerCount: 1});
+let gpuCanvasContext10 = offscreenCanvas9.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder55 = device2.createCommandEncoder({label: '\u{1fd9c}\u{1f832}\u{1fef5}\u43dd\u{1fdb4}\u0741\u012b\u{1ffc1}\u{1fb06}\ubfd3\u671b'});
+let texture39 = device2.createTexture({
+  label: '\u12b8\u24b4\u01ea\u0251\u5ea5\u{1fd0d}\uabac\u0fb7\u04ec\uec58\u0e46',
+  size: [160, 48, 94],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba32sint', 'rgba32sint', 'rgba32sint'],
+});
+let renderBundle36 = renderBundleEncoder19.finish({label: '\u07fd\u5285'});
+try {
+device2.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+}, new Int32Array(new ArrayBuffer(64)), /* required buffer size: 359_520 */
+{offset: 168, bytesPerRow: 217, rowsPerImage: 138}, {width: 7, height: 0, depthOrArrayLayers: 13});
+} catch {}
+try {
+querySet25.label = '\u0c57\u4077\u0c7f\u723a\u0cbe\u7160\u7ff8';
+} catch {}
+let texture40 = device1.createTexture({
+  label: '\u{1fa19}\u{1f70e}\ucd2f\ufe53\u6ab1\uef66\u8996',
+  size: {width: 840},
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm'],
+});
+let textureView65 = texture27.createView({dimension: '2d-array', baseMipLevel: 5, mipLevelCount: 2});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 137 */
+{offset: 137}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap15 = await createImageBitmap(imageData4);
+let texture41 = device1.createTexture({
+  label: '\u02f8\u{1f8b1}\u{1fd02}\u{1f6c0}',
+  size: [105, 1, 1],
+  mipLevelCount: 2,
+  format: 'r32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder22 = commandEncoder48.beginComputePass({});
+try {
+computePassEncoder18.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(1, bindGroup5, new Uint32Array(9269), 8978, 0);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(0, buffer9, 1904, 25440);
+} catch {}
+try {
+commandEncoder47.copyTextureToBuffer({
+  texture: texture32,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 52 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 41644 */
+  offset: 41592,
+  buffer: buffer10,
+}, {width: 13, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder47.clearBuffer(buffer10, 81312, 288136);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+device1.queue.submit([commandBuffer11]);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let querySet28 = device2.createQuerySet({label: '\u7651\u{1f9a1}\ue43b\u0b99\u3b31', type: 'occlusion', count: 902});
+let textureView66 = texture37.createView({
+  label: '\u{1f70b}\u07cb\u00f2\u833f\u0f0a\u19ad\ued0f\u03ae\u4c3b\u0396',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+});
+let renderBundle37 = renderBundleEncoder19.finish({label: '\u0de8\u{1ffaf}\u{1ffeb}\u48ba\u005b'});
+let externalTexture15 = device2.importExternalTexture({
+  label: '\u{1fbfc}\u03f0\u0c41\u3862\u{1fa1c}\u9934\u28a9\u5d29\u0534',
+  source: videoFrame3,
+  colorSpace: 'srgb',
+});
+try {
+texture37.destroy();
+} catch {}
+try {
+commandEncoder55.copyTextureToTexture({
+  texture: texture39,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 46, y: 3, z: 7},
+  aspect: 'all',
+},
+{width: 13, height: 4, depthOrArrayLayers: 4});
+} catch {}
+let videoFrame11 = new VideoFrame(img4, {timestamp: 0});
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline30);
+} catch {}
+try {
+commandEncoder38.copyTextureToBuffer({
+  texture: texture19,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 29992 */
+  offset: 29992,
+  buffer: buffer10,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 994 */
+{offset: 994}, {width: 138, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise12 = device1.createComputePipelineAsync({
+  label: '\u{1fa05}\u0659\uf9b6\uf8b8\u02ee\u3459\u048f\u9300\uf78d\u03af\u{1ffd4}',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+let buffer12 = device1.createBuffer({
+  label: '\u987e\u06d4\u03bd\u02d1\u{1f71f}\uf1b6\u07e2\ufef9\u5b92\u072a',
+  size: 157528,
+  usage: GPUBufferUsage.INDEX,
+});
+let commandEncoder56 = device1.createCommandEncoder({label: '\u098e\u7e11\uf355\u039b\u000e\u{1faf5}\u5e98\u4ad3\u{1fee5}\u{1fa4d}\u60ff'});
+let textureView67 = texture30.createView({label: '\uf113\u0228\u{1f813}\u05b8\u0152\u{1fceb}\u231b\u10c5\u6251', dimension: '2d-array'});
+try {
+computePassEncoder22.setBindGroup(3, bindGroup5, new Uint32Array(6221), 2866, 0);
+} catch {}
+try {
+renderBundleEncoder17.drawIndexed(18, 33);
+} catch {}
+try {
+commandEncoder34.copyTextureToTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 176, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture27,
+  mipLevel: 2,
+  origin: {x: 28, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer10, 32060, new DataView(new ArrayBuffer(16791)), 13276, 752);
+} catch {}
+let commandEncoder57 = device1.createCommandEncoder({});
+let texture42 = device1.createTexture({
+  label: '\u2503\u3efa\ueb2e\u1e16\uf7b4\ued39\u9d20\u{1ffdc}\ud249\ud4a9',
+  size: [210],
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint', 'r32uint'],
+});
+let computePassEncoder23 = commandEncoder54.beginComputePass();
+try {
+renderBundleEncoder17.setPipeline(pipeline30);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(2, buffer9, 0);
+} catch {}
+try {
+commandEncoder41.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 112 widthInBlocks: 112 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 100112 */
+  offset: 100000,
+  buffer: buffer10,
+}, {width: 112, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder41.clearBuffer(buffer10, 62916, 45128);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder57.resolveQuerySet(querySet26, 25, 7, buffer11, 48384);
+} catch {}
+let imageData13 = new ImageData(112, 188);
+let renderBundle38 = renderBundleEncoder17.finish({label: '\u65a4\u04ac\u{1f74e}\ud1d8'});
+try {
+computePassEncoder20.setBindGroup(2, bindGroup5, []);
+} catch {}
+try {
+commandEncoder38.copyTextureToTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 160, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder43.resolveQuerySet(querySet24, 223, 30, buffer11, 74496);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise13 = device1.createComputePipelineAsync({
+  label: '\u5829\u0caf\u{1f9fe}\u08b3\u4330\u{1fcaf}',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext11 = canvas6.getContext('webgpu');
+let imageBitmap16 = await createImageBitmap(imageBitmap11);
+let textureView68 = texture39.createView({label: '\u6a8d\u539b\u01df\u09b3', dimension: '3d', mipLevelCount: 1});
+let renderBundleEncoder20 = device2.createRenderBundleEncoder({
+  label: '\u04a6\u0e2f\u47ed\u0d03\u891b\u{1f916}\u{1ffcb}\u{1fe38}\u{1fa89}\uddd3\u0728',
+  colorFormats: ['rgba32sint', 'rgb10a2uint', 'rg8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle39 = renderBundleEncoder19.finish({label: '\uaff5\ud393\u20bf\u042a\uabf1\uce13\u536b\ua3cb\u0ea1'});
+try {
+device2.queue.writeTexture({
+  texture: texture39,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(40)), /* required buffer size: 406_764 */
+{offset: 302, bytesPerRow: 298, rowsPerImage: 151}, {width: 18, height: 5, depthOrArrayLayers: 10});
+} catch {}
+let commandEncoder58 = device1.createCommandEncoder({label: '\u3e47\u{1ffdb}\u0123'});
+let querySet29 = device1.createQuerySet({label: '\u{1ff19}\u044f\u1be5\u320f\u104f\u9d15\u04e5\ud61d', type: 'occlusion', count: 2363});
+let texture43 = device1.createTexture({
+  label: '\u0f65\u092f\u0cc9\ue5b1\u4641\u9b7a\ubc82\u{1fadc}',
+  size: [80],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r32sint'],
+});
+let textureView69 = texture28.createView({label: '\u0be3\u413e\u61dd\u023e\ua683\u{1ff2f}'});
+let computePassEncoder24 = commandEncoder35.beginComputePass({label: '\u0c60\u736f\u0644\u{1f859}\u0f4d\uab63\ue6c2\u39e2\u{1fb5a}'});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup5, new Uint32Array(9577), 1041, 0);
+} catch {}
+let pipeline35 = device1.createComputePipeline({
+  label: '\u0620\u5e88\u565a\u667a\udbf7',
+  layout: pipelineLayout11,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+let videoFrame12 = new VideoFrame(video4, {timestamp: 0});
+let offscreenCanvas11 = new OffscreenCanvas(468, 1022);
+let buffer13 = device2.createBuffer({
+  label: '\u740e\u03b5\u6732\u06ed\ubdfe\u5973\uafc2',
+  size: 38233,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let querySet30 = device2.createQuerySet({label: '\u5064\u1734\ua534\u{1f736}\ub4db', type: 'occlusion', count: 1194});
+let commandBuffer15 = commandEncoder55.finish();
+let texture44 = device2.createTexture({
+  label: '\u{1fb58}\u{1fb04}\u0a14\u{1f762}\u01a1',
+  size: {width: 580, height: 1, depthOrArrayLayers: 48},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView70 = texture36.createView({baseMipLevel: 2, mipLevelCount: 5});
+try {
+buffer13.destroy();
+} catch {}
+let canvas7 = document.createElement('canvas');
+let imageBitmap17 = await createImageBitmap(imageBitmap16);
+let querySet31 = device1.createQuerySet({label: '\u1178\u31cd\u050d\u{1ff99}\ufdfd\ube2c\u0f4b\u3cbb', type: 'occlusion', count: 1337});
+let textureView71 = texture18.createView({
+  label: '\u07c8\u{1f9c5}\ub95e\uf15a\u50e8\u1009\u{1f70d}\u9570\u{1fe4a}\ud3ac\ub349',
+  baseArrayLayer: 0,
+});
+let computePassEncoder25 = commandEncoder56.beginComputePass({label: '\uc63c\u7af0\u00af\u1cd0\u2657\u0364\uf6d2\ua2b1\u86ed\ucf20\u4f2d'});
+let renderBundleEncoder21 = device1.createRenderBundleEncoder({
+  label: '\u00ae\u23e1\uc699',
+  colorFormats: ['bgra8unorm-srgb', 'rg16uint', 'rgb10a2unorm', 'r32sint', 'r32uint'],
+  stencilReadOnly: true,
+});
+let sampler23 = device1.createSampler({
+  label: '\u{1fe20}\u5f2f\udec7\ub95b',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 88.98,
+  lodMaxClamp: 94.35,
+  maxAnisotropy: 3,
+});
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup6, []);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder34.copyTextureToBuffer({
+  texture: texture19,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 24556 */
+  offset: 24556,
+  buffer: buffer10,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder38.resolveQuerySet(querySet25, 1126, 10, buffer11, 229888);
+} catch {}
+try {
+device1.queue.submit([commandBuffer14]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer10, 68196, new DataView(new ArrayBuffer(57393)), 20618, 728);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas5,
+  origin: { x: 366, y: 38 },
+  flipY: true,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline36 = await promise12;
+let pipeline37 = device1.createRenderPipeline({
+  label: '\u0e88\u5023\u3641',
+  layout: pipelineLayout11,
+  multisample: {count: 4, mask: 0x38a3471f},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'src-alpha'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rg16uint', writeMask: 0}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r32uint', writeMask: GPUColorWrite.ALPHA}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-clamp', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'increment-clamp', passOp: 'decrement-wrap'},
+    stencilReadMask: 293953499,
+    stencilWriteMask: 1756822366,
+    depthBiasSlopeScale: 0.0,
+    depthBiasClamp: 879.5553685561042,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 912, shaderLocation: 1},
+          {format: 'uint32x4', offset: 660, shaderLocation: 5},
+          {format: 'uint32x2', offset: 56, shaderLocation: 12},
+          {format: 'uint32x3', offset: 804, shaderLocation: 13},
+          {format: 'uint16x2', offset: 648, shaderLocation: 11},
+          {format: 'uint32x2', offset: 128, shaderLocation: 14},
+          {format: 'float32x4', offset: 76, shaderLocation: 2},
+          {format: 'unorm8x4', offset: 28, shaderLocation: 0},
+          {format: 'sint8x2', offset: 206, shaderLocation: 6},
+          {format: 'uint32x4', offset: 0, shaderLocation: 4},
+          {format: 'sint16x4', offset: 52, shaderLocation: 7},
+          {format: 'snorm8x4', offset: 372, shaderLocation: 3},
+          {format: 'unorm8x4', offset: 124, shaderLocation: 9},
+          {format: 'float32', offset: 160, shaderLocation: 8},
+          {format: 'sint16x2', offset: 836, shaderLocation: 15},
+          {format: 'uint16x4', offset: 760, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw'},
+});
+let bindGroupLayout11 = device1.createBindGroupLayout({label: '\ufcd8\ueb5c\u0c7a\u0312\u337c\ua079', entries: []});
+let commandEncoder59 = device1.createCommandEncoder({label: '\u44b7\u{1f958}\udf7b\u1387\u522b\u087e'});
+let querySet32 = device1.createQuerySet({label: '\uf273\u05f9\uadb0\u7407\u8c4b\u4cc4\u6090', type: 'occlusion', count: 1997});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer12, 'uint16', 28074, 124768);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline30);
+} catch {}
+let pipeline38 = await device1.createRenderPipelineAsync({
+  label: '\u2a81\u4d66\u0569\u{1f981}\ucabc\u0a41',
+  layout: pipelineLayout10,
+  multisample: {mask: 0xb872a169},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg16uint', writeMask: 0}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r32sint'}, {format: 'r32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'not-equal', failOp: 'increment-wrap', depthFailOp: 'invert', passOp: 'replace'},
+    stencilBack: {compare: 'never', failOp: 'increment-clamp', depthFailOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilReadMask: 2682238896,
+    stencilWriteMask: 338726135,
+    depthBias: 1856260255,
+    depthBiasSlopeScale: 561.6745616738608,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 488,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 36, shaderLocation: 8},
+          {format: 'uint16x4', offset: 188, shaderLocation: 11},
+          {format: 'uint32x4', offset: 20, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 212,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 8, shaderLocation: 14},
+          {format: 'uint8x2', offset: 92, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 152,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 4, shaderLocation: 0},
+          {format: 'sint32x3', offset: 16, shaderLocation: 7},
+          {format: 'uint8x2', offset: 0, shaderLocation: 5},
+          {format: 'float32x3', offset: 48, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 16, shaderLocation: 1},
+          {format: 'float16x4', offset: 12, shaderLocation: 2},
+          {format: 'sint16x2', offset: 4, shaderLocation: 6},
+          {format: 'unorm16x4', offset: 60, shaderLocation: 3},
+          {format: 'uint16x2', offset: 0, shaderLocation: 4},
+          {format: 'uint32x4', offset: 96, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 176,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint8x4', offset: 36, shaderLocation: 15}],
+      },
+    ],
+  },
+});
+let img14 = await imageWithData(248, 122, '#ffc9792d', '#a01e63a2');
+let video14 = await videoWithData();
+let shaderModule10 = device1.createShaderModule({
+  code: `@group(0) @binding(352)
+var<storage, read_write> local7: array<u32>;
+@group(1) @binding(791)
+var<storage, read_write> field12: array<u32>;
+@group(0) @binding(537)
+var<storage, read_write> n10: array<u32>;
+@group(1) @binding(945)
+var<storage, read_write> type8: array<u32>;
+@group(0) @binding(384)
+var<storage, read_write> field13: array<u32>;
+
+@compute @workgroup_size(4, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(1) f1: vec4<u32>,
+  @location(3) f2: vec3<i32>,
+  @location(4) f3: u32,
+  @location(2) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(6) f87: vec3<u32>,
+  @location(11) f88: i32,
+  @location(15) f89: vec3<f32>,
+  @builtin(position) f90: vec4<f32>,
+  @location(12) f91: vec4<i32>,
+  @location(0) f92: vec3<f16>,
+  @location(13) f93: vec4<i32>,
+  @location(1) f94: vec2<f32>,
+  @location(9) f95: vec4<u32>,
+  @location(2) f96: vec2<u32>,
+  @location(5) f97: vec4<f32>,
+  @location(7) f98: i32,
+  @location(10) f99: vec3<i32>,
+  @location(3) f100: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(13) a0: vec3<u32>, @location(8) a1: f32, @location(4) a2: vec3<u32>, @location(9) a3: vec3<f32>, @location(14) a4: vec4<u32>, @location(10) a5: vec3<i32>, @location(5) a6: vec4<u32>, @location(1) a7: vec3<f32>, @location(11) a8: vec2<f16>, @location(3) a9: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let renderBundle40 = renderBundleEncoder16.finish();
+try {
+computePassEncoder19.setBindGroup(2, bindGroup5, new Uint32Array(6396), 502, 0);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline30);
+} catch {}
+try {
+commandEncoder58.clearBuffer(buffer10, 274096, 90952);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder57.insertDebugMarker('\u5438');
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas5,
+  origin: { x: 0, y: 12 },
+  flipY: true,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+try {
+canvas7.getContext('bitmaprenderer');
+} catch {}
+try {
+computePassEncoder21.end();
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(9984, undefined, 4291544672, 33539);
+} catch {}
+try {
+commandEncoder53.clearBuffer(buffer13, 6176, 9596);
+dissociateBuffer(device2, buffer13);
+} catch {}
+try {
+renderBundleEncoder20.pushDebugGroup('\u0e7b');
+} catch {}
+try {
+commandEncoder53.insertDebugMarker('\ufcf2');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture44,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(72), /* required buffer size: 505 */
+{offset: 505, rowsPerImage: 178}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let canvas8 = document.createElement('canvas');
+let textureView72 = texture34.createView({label: '\u585a\u0b24', baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder26 = commandEncoder59.beginComputePass({label: '\ub845\u95e5\u{1ffeb}\u0657\u1384'});
+let renderBundleEncoder22 = device1.createRenderBundleEncoder({
+  label: '\u1dc2\u{1fd0f}\uedeb\u869a\u07bf\ue827\udc6f\ufec6',
+  colorFormats: ['bgra8unorm-srgb', 'rg16uint', 'rgb10a2unorm', 'r32sint', 'r32uint'],
+});
+try {
+computePassEncoder23.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer12, 'uint32', 10576, 94560);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(2, buffer9, 0, 6950);
+} catch {}
+try {
+commandEncoder50.resolveQuerySet(querySet22, 137, 454, buffer11, 4096);
+} catch {}
+let texture45 = gpuCanvasContext6.getCurrentTexture();
+let textureView73 = texture39.createView({
+  label: '\u421f\u{1f871}\u{1f99f}\u06a4\u{1ffc1}\ubf10\u05d2\uce1c\u8d51\u{1f608}\u000f',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+});
+try {
+commandEncoder53.copyTextureToTexture({
+  texture: texture39,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture39,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 12, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 1_005 */
+{offset: 993}, {width: 3, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder60 = device1.createCommandEncoder({});
+let querySet33 = device1.createQuerySet({label: '\u{1fcfd}\u29ae\u7af6\u8a89', type: 'occlusion', count: 1956});
+let texture46 = device1.createTexture({
+  label: '\u1688\u9bd0\u0dbd\u{1f936}\u7aad\u{1fe98}\u{1ffc1}\u{1f899}',
+  size: [105],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+commandEncoder38.resolveQuerySet(querySet16, 677, 44, buffer11, 99840);
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let querySet34 = device2.createQuerySet({label: '\u36a3\u{1f79c}\u4364\u{1f67f}', type: 'occlusion', count: 256});
+let sampler24 = device2.createSampler({
+  label: '\uf635\ub7d9\uf342\u6507',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 56.25,
+  lodMaxClamp: 62.74,
+  maxAnisotropy: 2,
+});
+try {
+renderBundleEncoder20.setVertexBuffer(9270, undefined, 1960410211, 895999988);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let img15 = await imageWithData(291, 24, '#e5eb2867', '#3d7344a3');
+let imageData14 = new ImageData(152, 180);
+let texture47 = device2.createTexture({
+  label: '\u092d\u{1f800}',
+  size: {width: 40, height: 12, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  sampleCount: 1,
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder27 = commandEncoder53.beginComputePass({});
+try {
+renderBundleEncoder20.setVertexBuffer(156, undefined, 0);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.destroy();
+} catch {}
+let img16 = await imageWithData(86, 147, '#a3a031a2', '#30cbedf3');
+let bindGroup7 = device1.createBindGroup({
+  label: '\ueb25\ua8c7\u82f7\u8a92\udf86\u{1f661}\u1ca5\u0ccc\u{1fc6f}',
+  layout: bindGroupLayout6,
+  entries: [{binding: 190, resource: externalTexture8}, {binding: 635, resource: sampler20}],
+});
+let commandEncoder61 = device1.createCommandEncoder({label: '\u0997\u1944\u0389\udb71\u42e6\u{1f9d6}\ub489\u{1f79c}'});
+let texture48 = device1.createTexture({
+  size: [105],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView74 = texture17.createView({
+  label: '\u{1fb90}\u06f3\u4e02\u0475\u0f83\u{1f7d5}\u9825\u7759\u{1fb3f}\u{1fb51}',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+  mipLevelCount: 2,
+});
+let renderBundleEncoder23 = device1.createRenderBundleEncoder({
+  label: '\ud624\u4c2c\uc5f5\u{1ff54}\ua572\uc41f\u{1fef8}\u6948\u39ec\udbb8\ub33b',
+  colorFormats: ['bgra8unorm-srgb', 'rg16uint', 'rgb10a2unorm', 'r32sint', 'r32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(6, buffer9, 9720, 12679);
+} catch {}
+try {
+commandEncoder43.resolveQuerySet(querySet21, 1255, 305, buffer11, 12288);
+} catch {}
+let promise14 = device1.queue.onSubmittedWorkDone();
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas2,
+  origin: { x: 88, y: 0 },
+  flipY: true,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img17 = await imageWithData(204, 102, '#37dd9f5d', '#c6d76543');
+try {
+  await promise14;
+} catch {}
+try {
+offscreenCanvas11.getContext('webgpu');
+} catch {}
+let bindGroupLayout12 = device2.createBindGroupLayout({
+  label: '\u01c9\u{1f61b}\ude4b\u55cb\u{1fd3f}\u719a\u1e98\ufb41',
+  entries: [
+    {
+      binding: 3356,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 1243,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let imageBitmap18 = await createImageBitmap(videoFrame10);
+let commandEncoder62 = device0.createCommandEncoder({label: '\u2eaa\uf36d\u0eb9\u03c3\u013a\uf120\u0185\ue3df\u{1f96b}\u829d\u3d23'});
+let textureView75 = texture15.createView({
+  label: '\u0f17\udfe9\u06e0\u77c4\u8db3\u8dae\u2ba5\u{1f664}\u7f99\u0125',
+  format: 'rgba32sint',
+  baseArrayLayer: 9,
+  arrayLayerCount: 2,
+});
+let renderBundle41 = renderBundleEncoder5.finish({label: '\u{1fb75}\u0d27\u04fc\u6c1c\ua58d\u{1fc72}\u{1f617}\u2280\u0e63\u0329'});
+try {
+commandEncoder62.copyBufferToTexture({
+  /* bytesInLastRow: 172 widthInBlocks: 43 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1548 */
+  offset: 1376,
+  bytesPerRow: 256,
+  rowsPerImage: 130,
+  buffer: buffer2,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 43, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline39 = await device0.createComputePipelineAsync({
+  label: '\ucbe0\ub489\u0c70\u{1f62b}\u6f43\u0e47\u0d11\u046d',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+let pipeline40 = device0.createRenderPipeline({
+  label: '\u0e03\u22f6\u08ea\u0060\u2ebb\u13d5\u{1fd7b}\u25a6\u58ff\udba4\ub60d',
+  layout: pipelineLayout4,
+  multisample: {mask: 0xb661ab51},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 14224,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'snorm8x4', offset: 1708, shaderLocation: 19},
+          {format: 'sint8x4', offset: 4188, shaderLocation: 10},
+          {format: 'unorm16x2', offset: 1504, shaderLocation: 0},
+          {format: 'float32', offset: 4436, shaderLocation: 6},
+          {format: 'uint8x4', offset: 1160, shaderLocation: 20},
+          {format: 'float32', offset: 1340, shaderLocation: 18},
+          {format: 'uint8x4', offset: 7120, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 8612,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x2', offset: 2828, shaderLocation: 15}],
+      },
+    ],
+  },
+});
+try {
+adapter1.label = '\u{1f9d1}\u{1f752}\u1522\u0da0\ub64d\u88cd\u92dd\u6a57';
+} catch {}
+let querySet35 = device1.createQuerySet({label: '\u0443\u0485\u{1fb2a}\ufbb0\uec48\u0aee\u0bc6', type: 'occlusion', count: 581});
+let texture49 = device1.createTexture({
+  label: '\u0a02\u{1fc76}',
+  size: [210, 2, 1],
+  mipLevelCount: 5,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint'],
+});
+let textureView76 = texture40.createView({format: 'bgra8unorm'});
+let computePassEncoder28 = commandEncoder57.beginComputePass({label: '\u78d8\u{1f93f}\u2b69\u6381\uee11\u0e2f\u037d\u5f37\u07ea\ua1fc'});
+let externalTexture16 = device1.importExternalTexture({label: '\u790b\uef3d\u08d6', source: video14, colorSpace: 'srgb'});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(3, buffer9, 25240, 13193);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer10, 221356, new Float32Array(18002), 16183, 452);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 6},
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 701_770 */
+{offset: 10, bytesPerRow: 240, rowsPerImage: 68}, {width: 23, height: 0, depthOrArrayLayers: 44});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData6,
+  origin: { x: 5, y: 46 },
+  flipY: true,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas4.width = 182;
+let commandEncoder63 = device1.createCommandEncoder();
+let renderBundle42 = renderBundleEncoder13.finish({label: '\u147d\u0ff5\u4111\uaf7d\u{1f6d6}\uabcd\udbae\u623c\u0b13'});
+let externalTexture17 = device1.importExternalTexture({label: '\u3ce7\u7ceb\u03c3', source: videoFrame2, colorSpace: 'display-p3'});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup6, new Uint32Array(130), 75, 0);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline30);
+} catch {}
+try {
+commandEncoder61.clearBuffer(buffer10, 215252, 67468);
+dissociateBuffer(device1, buffer10);
+} catch {}
+let externalTexture18 = device1.importExternalTexture({source: video13, colorSpace: 'srgb'});
+try {
+renderBundleEncoder22.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+commandEncoder47.clearBuffer(buffer10, 49108, 190256);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder34.resolveQuerySet(querySet33, 1585, 330, buffer11, 115456);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 2,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 563 */
+{offset: 563}, {width: 35, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext12 = offscreenCanvas10.getContext('webgpu');
+try {
+canvas8.getContext('webgl');
+} catch {}
+let querySet36 = device1.createQuerySet({label: '\u1ee9\u07a5\uc9f4', type: 'occlusion', count: 3068});
+let computePassEncoder29 = commandEncoder43.beginComputePass({label: '\u58d7\u6a67\u0699\u081e\u{1ffcf}'});
+let renderBundle43 = renderBundleEncoder16.finish({label: '\uc7ac\ud7f0\u0b15\ue564\ue133\u99c0'});
+try {
+renderBundleEncoder21.setIndexBuffer(buffer8, 'uint16', 24116, 23143);
+} catch {}
+try {
+commandEncoder58.copyTextureToBuffer({
+  texture: texture32,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 36692 */
+  offset: 36692,
+  bytesPerRow: 512,
+  rowsPerImage: 126,
+  buffer: buffer10,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder58.pushDebugGroup('\uf212');
+} catch {}
+let pipeline41 = device1.createRenderPipeline({
+  layout: pipelineLayout10,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'one-minus-src'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'r32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r32uint'}],
+},
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 184,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 40, shaderLocation: 1},
+          {format: 'uint32x3', offset: 40, shaderLocation: 4},
+          {format: 'sint32x2', offset: 68, shaderLocation: 10},
+          {format: 'float32x3', offset: 80, shaderLocation: 8},
+          {format: 'float16x2', offset: 32, shaderLocation: 11},
+          {format: 'float32', offset: 12, shaderLocation: 9},
+          {format: 'uint8x2', offset: 14, shaderLocation: 3},
+          {format: 'uint8x4', offset: 8, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 168,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x2', offset: 4, shaderLocation: 14}, {format: 'uint32', offset: 8, shaderLocation: 5}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+document.body.prepend(canvas7);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let canvas9 = document.createElement('canvas');
+let video15 = await videoWithData();
+offscreenCanvas4.height = 1311;
+let textureView77 = texture48.createView({arrayLayerCount: 1});
+let renderBundleEncoder24 = device1.createRenderBundleEncoder({
+  label: '\u3e7b\udd58\u410a\u{1f8e4}\u0829\u{1f8b0}\u051d\u7431',
+  colorFormats: ['bgra8unorm-srgb', 'rg16uint', 'rgb10a2unorm', 'r32sint', 'r32uint'],
+  stencilReadOnly: true,
+});
+let renderBundle44 = renderBundleEncoder15.finish({label: '\u{1feea}\u02b5\u21df\ub82b'});
+let sampler25 = device1.createSampler({
+  label: '\ue543\ud9cf\u0a7a\u1fa3\u{1f7ff}\uf8d5',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 8.408,
+  lodMaxClamp: 29.50,
+});
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+device1.pushErrorScope('validation');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  alphaMode: 'opaque',
+});
+} catch {}
+let textureView78 = texture38.createView({label: '\ua58f\u{1f8c4}\udf14\u2833\u270d\u090b', dimension: '1d'});
+let renderBundleEncoder25 = device1.createRenderBundleEncoder({
+  label: '\u412f\ub406\u{1f958}\u0845\udedc\ud3bd\u{1fbd3}\u7c54\u{1febf}',
+  colorFormats: ['bgra8unorm-srgb', 'rg16uint', 'rgb10a2unorm', 'r32sint', 'r32uint'],
+  stencilReadOnly: true,
+});
+let sampler26 = device1.createSampler({
+  label: '\ufa97\u{1f88b}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 55.74,
+  lodMaxClamp: 89.05,
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder22.setPipeline(pipeline30);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(5820, undefined, 0, 272150250);
+} catch {}
+let promise15 = device1.createRenderPipelineAsync({
+  label: '\ue1dc\uf51c\u30fd\ua595',
+  layout: pipelineLayout11,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb'}, {format: 'rg16uint'}, {format: 'rgb10a2unorm', writeMask: 0}, {format: 'r32sint'}, {format: 'r32uint'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'less', depthFailOp: 'zero', passOp: 'replace'},
+    stencilBack: {
+      compare: 'not-equal',
+      failOp: 'decrement-clamp',
+      depthFailOp: 'increment-wrap',
+      passOp: 'decrement-wrap',
+    },
+    stencilReadMask: 3470592329,
+    stencilWriteMask: 2909075547,
+    depthBiasClamp: 104.57671460397412,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 72, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 2048,
+        stepMode: 'vertex',
+        attributes: [{format: 'snorm8x4', offset: 52, shaderLocation: 7}],
+      },
+    ],
+  },
+});
+let video16 = await videoWithData();
+offscreenCanvas0.width = 29;
+let video17 = await videoWithData();
+let imageData15 = new ImageData(188, 132);
+let gpuCanvasContext13 = canvas9.getContext('webgpu');
+try {
+adapter2.label = '\u{1fd37}\ua4f3\u4941\u{1fa7f}\u{1f697}\u0f38\ub413\u0269';
+} catch {}
+try {
+device0.queue.label = '\u00a9\u{1feae}\u0fde\u{1f978}\uae0d';
+} catch {}
+try {
+externalTexture1.label = '\u0549\u6a47\u{1f722}\u2f6b\u05e4\u{1faf7}\u020b';
+} catch {}
+try {
+commandEncoder55.label = '\uea0b\ud99f\ud8e0\ube9d\u3dbb\u4895\u049b\u215e\u93bd\u03e6';
+} catch {}
+try {
+texture45.label = '\uf35b\u0877\u0f72\u0df0\u{1fd4a}\u1484';
+} catch {}
+let videoFrame13 = new VideoFrame(offscreenCanvas1, {timestamp: 0});
+let commandEncoder64 = device1.createCommandEncoder({label: '\u{1f742}\u{1fc3c}\ub4ad\u{1f861}\u5959'});
+let texture50 = device1.createTexture({
+  label: '\u{1fffe}\u00b9\u47a2\u{1fe2e}\u{1feeb}\u0725\u6c51',
+  size: [420],
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint', 'rg16uint'],
+});
+let computePassEncoder30 = commandEncoder47.beginComputePass({label: '\u6abf\u4a8d\u8db2\u{1fc2e}'});
+try {
+renderBundleEncoder23.setVertexBuffer(1, buffer9, 21704, 5104);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline42 = await device1.createComputePipelineAsync({
+  label: '\uf36f\u7d99\u{1fcab}\ua951\u0c37\ubc10\u4149\u3515',
+  layout: 'auto',
+  compute: {module: shaderModule10, entryPoint: 'compute0'},
+});
+let imageData16 = new ImageData(108, 84);
+let texture51 = device1.createTexture({
+  label: '\u90a0\u042a',
+  size: {width: 80, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler27 = device1.createSampler({
+  label: '\u0feb\u0df5\u05eb\ua28f\ue4a0\uf8dc\u06b2',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 72.98,
+  lodMaxClamp: 75.09,
+});
+try {
+buffer8.unmap();
+} catch {}
+try {
+commandEncoder50.resolveQuerySet(querySet24, 13, 143, buffer11, 152064);
+} catch {}
+try {
+commandEncoder58.popDebugGroup();
+} catch {}
+try {
+device1.queue.writeBuffer(buffer10, 66108, new Int16Array(23619), 12570, 516);
+} catch {}
+let pipeline43 = await promise8;
+let img18 = await imageWithData(69, 50, '#5f30e483', '#06af46a6');
+let bindGroupLayout13 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 232,
+      visibility: 0,
+      storageTexture: { format: 'rgba16float', access: 'write-only', viewDimension: '2d' },
+    },
+    {binding: 473, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder65 = device1.createCommandEncoder({label: '\u{1fbba}\u{1fd0f}'});
+let computePassEncoder31 = commandEncoder65.beginComputePass({label: '\ua1b0\uf7a9\u2f03\u{1ffbb}\ube9c\u0988\u0951\u0cf2'});
+let externalTexture19 = device1.importExternalTexture({label: '\u80c2\u8512\u7b12\u{1f938}\u09aa\u0502\u08c4', source: videoFrame5, colorSpace: 'display-p3'});
+try {
+computePassEncoder26.setBindGroup(1, bindGroup5, new Uint32Array(4801), 176, 0);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline30);
+} catch {}
+try {
+commandEncoder51.copyTextureToBuffer({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 268 widthInBlocks: 67 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 17092 */
+  offset: 17092,
+  buffer: buffer10,
+}, {width: 67, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder60.clearBuffer(buffer10, 239104, 111224);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder63.resolveQuerySet(querySet16, 739, 258, buffer11, 94976);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 186 */
+{offset: 186}, {width: 30, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas5,
+  origin: { x: 7, y: 5 },
+  flipY: false,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline44 = await device1.createComputePipelineAsync({
+  label: '\u0f51\u{1f925}\u{1f9f0}\ud145\ue278',
+  layout: pipelineLayout11,
+  compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}},
+});
+let pipeline45 = await promise9;
+let buffer14 = device1.createBuffer({label: '\u0a83\u7a14\u978b', size: 350412, usage: GPUBufferUsage.UNIFORM});
+let commandEncoder66 = device1.createCommandEncoder();
+let renderBundle45 = renderBundleEncoder14.finish();
+let sampler28 = device1.createSampler({
+  label: '\u079f\u00fc\u014e\u0c58\ud11e\uf427\u{1fca1}',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 58.60,
+  lodMaxClamp: 99.55,
+});
+try {
+renderBundleEncoder22.draw(178, 135, 470_282_821, 1_000_985_956);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline45);
+} catch {}
+document.body.prepend(video9);
+let imageBitmap19 = await createImageBitmap(imageData2);
+let imageData17 = new ImageData(4, 204);
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+let offscreenCanvas12 = new OffscreenCanvas(61, 127);
+let bindGroupLayout14 = device1.createBindGroupLayout({
+  entries: [
+    {binding: 675, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 251, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let commandEncoder67 = device1.createCommandEncoder({label: '\uefa4\u32eb\u{1fa0b}\u{1fcd2}\u4b5c\u5b84'});
+try {
+computePassEncoder16.setPipeline(pipeline27);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+  await buffer10.mapAsync(GPUMapMode.READ, 0, 242052);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(72), /* required buffer size: 11_041 */
+{offset: 833, bytesPerRow: 232, rowsPerImage: 11}, {width: 0, height: 1, depthOrArrayLayers: 5});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 52, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap19,
+  origin: { x: 1, y: 72 },
+  flipY: true,
+}, {
+  texture: texture27,
+  mipLevel: 3,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise16 = device1.createComputePipelineAsync({layout: pipelineLayout10, compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}}});
+let pipeline46 = await promise15;
+let buffer15 = device1.createBuffer({
+  label: '\uede8\u7806\u{1f7f6}\ud860\uaa73',
+  size: 154365,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder68 = device1.createCommandEncoder({label: '\u{1f74b}\u7bf1\u0aa2\u0ff1\ucf0e\u16cf'});
+let querySet37 = device1.createQuerySet({
+  label: '\u0b0c\u08c3\u098e\u{1fae4}\u0e81\u7d89\u{1f7c8}\u9b57\u0acc\u36b2',
+  type: 'occlusion',
+  count: 3123,
+});
+try {
+computePassEncoder23.setPipeline(pipeline43);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(0, bindGroup5, []);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline45);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video9,
+  origin: { x: 1, y: 3 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline47 = device1.createComputePipeline({
+  label: '\u2387\u{1faf4}\ua2a6\u0d4d\u{1fbf5}\uf159\u75b7',
+  layout: pipelineLayout11,
+  compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}},
+});
+let pipeline48 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.GREEN}, {format: 'rg16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'r32uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'not-equal', depthFailOp: 'increment-clamp', passOp: 'increment-clamp'},
+    stencilReadMask: 2474844323,
+    depthBias: -1848006837,
+    depthBiasSlopeScale: 488.01810805856917,
+  },
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'uint8x4', offset: 100, shaderLocation: 13},
+          {format: 'snorm8x4', offset: 744, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 28, shaderLocation: 9},
+          {format: 'snorm16x4', offset: 672, shaderLocation: 1},
+          {format: 'uint32x2', offset: 424, shaderLocation: 3},
+          {format: 'snorm8x4', offset: 316, shaderLocation: 8},
+          {format: 'sint32x2', offset: 1012, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 152,
+        attributes: [{format: 'uint32', offset: 12, shaderLocation: 5}, {format: 'uint32x4', offset: 24, shaderLocation: 4}],
+      },
+      {arrayStride: 236, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 300,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x4', offset: 124, shaderLocation: 14}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front'},
+});
+let pipelineLayout12 = device1.createPipelineLayout({
+  label: '\ucbb0\u{1f89e}\u0c45\u{1f715}\u0e00\u0bcf',
+  bindGroupLayouts: [bindGroupLayout8, bindGroupLayout11],
+});
+let textureView79 = texture38.createView({label: '\u{1ffbc}\u6e52\u0ab6\u00c8\ua9a9\u{1fc71}\u045c\u9223'});
+let sampler29 = device1.createSampler({
+  label: '\uf1df\u05ee\u{1f647}\u1fec\u3705\u8f1a\u2ccd\uc252\u{1f779}\u3b6d\u054a',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 43.57,
+  lodMaxClamp: 91.98,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder31.end();
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(0, buffer9, 12824, 6017);
+} catch {}
+try {
+commandEncoder58.resolveQuerySet(querySet20, 15, 66, buffer11, 213248);
+} catch {}
+let pipeline49 = device1.createRenderPipeline({
+  layout: pipelineLayout11,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-src-alpha', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rg16uint'}, {format: 'rgb10a2unorm'}, {format: 'r32sint', writeMask: GPUColorWrite.RED}, {format: 'r32uint'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    stencilFront: {compare: 'equal', failOp: 'replace', depthFailOp: 'decrement-clamp', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'invert'},
+    stencilReadMask: 4114155299,
+    depthBiasSlopeScale: 798.713253782863,
+    depthBiasClamp: 580.8306106060887,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 80,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm8x2', offset: 2, shaderLocation: 2},
+          {format: 'uint8x2', offset: 26, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 304,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 8, shaderLocation: 9},
+          {format: 'sint16x4', offset: 76, shaderLocation: 7},
+          {format: 'float32x2', offset: 76, shaderLocation: 0},
+          {format: 'sint8x4', offset: 28, shaderLocation: 6},
+          {format: 'uint16x4', offset: 28, shaderLocation: 5},
+          {format: 'snorm16x2', offset: 16, shaderLocation: 8},
+          {format: 'float32', offset: 68, shaderLocation: 1},
+          {format: 'uint32', offset: 16, shaderLocation: 12},
+          {format: 'uint16x2', offset: 0, shaderLocation: 10},
+          {format: 'uint32x2', offset: 72, shaderLocation: 11},
+          {format: 'sint32x3', offset: 44, shaderLocation: 15},
+        ],
+      },
+      {arrayStride: 188, attributes: [{format: 'uint16x2', offset: 128, shaderLocation: 14}]},
+      {arrayStride: 172, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 548,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 8, shaderLocation: 3},
+          {format: 'uint32x3', offset: 36, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+let commandEncoder69 = device1.createCommandEncoder({label: '\u07fa\ufcdd\u2c08\u199c\uc97a\u04e0\u{1f882}\ua302\u{1f98e}'});
+let renderBundleEncoder26 = device1.createRenderBundleEncoder({
+  label: '\u{1fe08}\u5b83\u{1f824}\u0ceb\u{1fec5}\u6ef4\u7966\ud9d3\u5ab7\u71a5',
+  colorFormats: ['bgra8unorm-srgb', 'rg16uint', 'rgb10a2unorm', 'r32sint', 'r32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler30 = device1.createSampler({
+  label: '\u{1ff85}\u{1fde8}\u01ad\u67f4\uf382\ua464\u615c\u017c\u4fae',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 57.98,
+  lodMaxClamp: 96.96,
+  maxAnisotropy: 9,
+});
+try {
+device1.pushErrorScope('validation');
+} catch {}
+let promise17 = device1.queue.onSubmittedWorkDone();
+let pipeline50 = await device1.createRenderPipelineAsync({
+  label: '\u214e\u7aaf\u7ce9\u{1fe05}\u8f73',
+  layout: pipelineLayout12,
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.GREEN}, {format: 'rg16uint', writeMask: 0}, {format: 'rgb10a2unorm'}, {format: 'r32sint'}, {format: 'r32uint', writeMask: GPUColorWrite.ALL}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'less', failOp: 'invert', depthFailOp: 'increment-wrap', passOp: 'invert'},
+    stencilReadMask: 2798415651,
+    stencilWriteMask: 2292722208,
+    depthBiasSlopeScale: 682.2444223086911,
+    depthBiasClamp: 83.26863082421565,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [{arrayStride: 592, attributes: [{format: 'unorm16x2', offset: 12, shaderLocation: 7}]}],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: true},
+});
+let imageBitmap20 = await createImageBitmap(imageData13);
+let bindGroup8 = device1.createBindGroup({
+  label: '\udc80\u{1f93b}',
+  layout: bindGroupLayout6,
+  entries: [{binding: 190, resource: externalTexture10}, {binding: 635, resource: sampler28}],
+});
+let textureView80 = texture43.createView({label: '\u749f\u0c78\u07df\u65b6\uc7ec\u0746\u{1fe7b}\u2a30\u{1f84a}'});
+try {
+renderBundleEncoder21.setVertexBuffer(2, buffer9, 0, 21630);
+} catch {}
+try {
+commandEncoder60.resolveQuerySet(querySet16, 745, 56, buffer11, 164608);
+} catch {}
+let promise18 = device1.queue.onSubmittedWorkDone();
+let offscreenCanvas13 = new OffscreenCanvas(704, 339);
+try {
+offscreenCanvas12.getContext('webgl2');
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+gc();
+let offscreenCanvas14 = new OffscreenCanvas(26, 705);
+let videoFrame14 = new VideoFrame(img4, {timestamp: 0});
+let imageBitmap21 = await createImageBitmap(videoFrame2);
+let commandEncoder70 = device1.createCommandEncoder({label: '\ucd0c\u0090'});
+let textureView81 = texture46.createView({
+  label: '\u38df\u3352\u0af5\u{1fab9}\u20a6\u{1f7fc}\u9cec\u{1f711}\uab77\u51b7\u{1fd79}',
+  aspect: 'all',
+});
+let computePassEncoder32 = commandEncoder70.beginComputePass({label: '\u788e\u03df\u0fe0'});
+try {
+renderBundleEncoder21.draw(342, 78, 729_811_280, 1_563_351_768);
+} catch {}
+try {
+renderBundleEncoder21.drawIndexed(109, 190, 3_016_454_400, 80_631_683, 336_477_405);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline45);
+} catch {}
+try {
+texture29.destroy();
+} catch {}
+try {
+  await buffer15.mapAsync(GPUMapMode.WRITE, 19776, 59764);
+} catch {}
+try {
+commandEncoder50.copyBufferToBuffer(buffer15, 6192, buffer10, 396340, 2612);
+dissociateBuffer(device1, buffer15);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas4,
+  origin: { x: 10, y: 23 },
+  flipY: true,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext14 = offscreenCanvas14.getContext('webgpu');
+document.body.prepend(video14);
+let gpuCanvasContext15 = offscreenCanvas13.getContext('webgpu');
+let bindGroupLayout15 = device1.createBindGroupLayout({
+  label: '\u0f5e\u0f66\u06a5\u8b90\u08f1\u027d\u96e8\ue3b0\u3ba6',
+  entries: [
+    {binding: 903, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 408,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let buffer16 = device1.createBuffer({
+  label: '\udc5d\u{1fa20}\u{1f6e3}\u06a6',
+  size: 419720,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE,
+});
+let commandBuffer16 = commandEncoder58.finish({label: '\u8aae\u9481\u0ba9\u{1fd7e}\uae9b\u1d2d\u0b50'});
+let renderBundleEncoder27 = device1.createRenderBundleEncoder({
+  label: '\u0a2d\u8c8e\u250c',
+  colorFormats: ['bgra8unorm-srgb', 'rg16uint', 'rgb10a2unorm', 'r32sint', 'r32uint'],
+  depthReadOnly: true,
+});
+let renderBundle46 = renderBundleEncoder16.finish({label: '\u037e\u0744\u6e05\u{1f790}\u0ec2\u9a72\u0dbf'});
+try {
+computePassEncoder26.setBindGroup(2, bindGroup7, new Uint32Array(4111), 3272, 0);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup5, new Uint32Array(2907), 1743, 0);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline45);
+} catch {}
+try {
+buffer10.destroy();
+} catch {}
+try {
+commandEncoder63.copyTextureToBuffer({
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 116 widthInBlocks: 29 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 26936 */
+  offset: 26936,
+  bytesPerRow: 256,
+  buffer: buffer10,
+}, {width: 29, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder67.clearBuffer(buffer10, 67948, 72060);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(55), /* required buffer size: 55 */
+{offset: 55}, {width: 2, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 3, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img3,
+  origin: { x: 22, y: 29 },
+  flipY: false,
+}, {
+  texture: texture27,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout16 = device2.createBindGroupLayout({
+  label: '\u16b8\u76df\u0d95\u036f\u6e38\uddba\uc463\udc85\u3f6b\u0347',
+  entries: [
+    {
+      binding: 3888,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 4729, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 5710,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let texture52 = gpuCanvasContext1.getCurrentTexture();
+let textureView82 = texture45.createView({label: '\u0feb\uacd9\u17a5\ube65\u088a\u{1fde8}', dimension: '2d-array', format: 'bgra8unorm-srgb'});
+let bindGroupLayout17 = device1.createBindGroupLayout({
+  label: '\u1ff6\u0efb\u{1f933}\ub744\u8042\u{1ffc2}\u43c9\u{1fa33}\u3218',
+  entries: [
+    {
+      binding: 467,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 167,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32float', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+let pipelineLayout13 = device1.createPipelineLayout({label: '\u{1fb91}\u07c6\ueebb', bindGroupLayouts: [bindGroupLayout9]});
+let computePassEncoder33 = commandEncoder66.beginComputePass({label: '\u15b5\u0433\u04ca\u4c3f\u5725\u0f8f\ub5a6\u{1f8a9}\u0dae\u{1ffe1}'});
+try {
+renderBundleEncoder25.setBindGroup(2, bindGroup6, []);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(0, buffer9, 0, 1534);
+} catch {}
+let arrayBuffer0 = buffer15.getMappedRange(19776, 55080);
+try {
+commandEncoder41.copyBufferToBuffer(buffer15, 42452, buffer10, 331656, 60716);
+dissociateBuffer(device1, buffer15);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer0), /* required buffer size: 918 */
+{offset: 854, rowsPerImage: 256}, {width: 16, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData3,
+  origin: { x: 3, y: 6 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline51 = device1.createComputePipeline({
+  label: '\ufded\u0a14\u548c',
+  layout: pipelineLayout13,
+  compute: {module: shaderModule10, entryPoint: 'compute0'},
+});
+let offscreenCanvas15 = new OffscreenCanvas(911, 621);
+try {
+offscreenCanvas15.getContext('bitmaprenderer');
+} catch {}
+try {
+  await promise17;
+} catch {}
+gc();
+let canvas10 = document.createElement('canvas');
+let querySet38 = device1.createQuerySet({
+  label: '\uee85\u4852\u{1ff31}\u2793\u{1fc3c}\u{1f6c4}\u{1fcd3}\ud4d2\u8929\ub4a6\u663f',
+  type: 'occlusion',
+  count: 3814,
+});
+let computePassEncoder34 = commandEncoder64.beginComputePass();
+let renderBundle47 = renderBundleEncoder25.finish();
+try {
+renderBundleEncoder23.setVertexBuffer(3, buffer9, 5344, 30677);
+} catch {}
+try {
+commandEncoder50.resolveQuerySet(querySet16, 193, 393, buffer16, 180736);
+} catch {}
+try {
+device1.queue.submit([commandBuffer16]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer0), /* required buffer size: 785 */
+{offset: 785, rowsPerImage: 285}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+bindGroup5.label = '\uaf31\ucca4\u299c\u7abd\u{1f6a8}\ub6ca\u{1facb}';
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline30);
+} catch {}
+try {
+commandEncoder60.copyBufferToBuffer(buffer15, 111952, buffer10, 3584, 18304);
+dissociateBuffer(device1, buffer15);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder69.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 77 widthInBlocks: 77 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 3209 */
+  offset: 3132,
+  buffer: buffer16,
+}, {width: 77, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+renderBundleEncoder27.insertDebugMarker('\ufe26');
+} catch {}
+document.body.prepend(canvas1);
+let imageBitmap22 = await createImageBitmap(imageBitmap3);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+canvas5.height = 407;
+let imageData18 = new ImageData(156, 236);
+let imageBitmap23 = await createImageBitmap(video5);
+let texture53 = device1.createTexture({
+  label: '\u76ac\u3f0b\u27f1\u{1f934}\u07e0\ufa3a\u00c9',
+  size: {width: 420, height: 4, depthOrArrayLayers: 104},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm'],
+});
+let textureView83 = texture51.createView({baseMipLevel: 1});
+let computePassEncoder35 = commandEncoder69.beginComputePass();
+try {
+renderBundleEncoder26.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+commandEncoder63.copyTextureToBuffer({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 109 widthInBlocks: 109 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 14044 */
+  offset: 14044,
+  rowsPerImage: 116,
+  buffer: buffer16,
+}, {width: 109, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer16);
+} catch {}
+let pipeline52 = device1.createRenderPipeline({
+  label: '\u{1fb32}\u094f\u0e00\uf479\u{1f969}\u0320\u{1f8fb}\u0631',
+  layout: pipelineLayout11,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'src-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rg16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r32uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {failOp: 'decrement-wrap', depthFailOp: 'invert', passOp: 'zero'},
+    stencilBack: {compare: 'less-equal', failOp: 'zero', passOp: 'zero'},
+    stencilReadMask: 3117021149,
+    stencilWriteMask: 3064340880,
+    depthBias: 0,
+    depthBiasSlopeScale: 56.34979870926321,
+    depthBiasClamp: 203.36611101206836,
+  },
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 272,
+        attributes: [
+          {format: 'unorm8x4', offset: 60, shaderLocation: 9},
+          {format: 'uint8x2', offset: 72, shaderLocation: 13},
+          {format: 'uint32x3', offset: 16, shaderLocation: 14},
+          {format: 'sint32', offset: 88, shaderLocation: 10},
+          {format: 'unorm8x2', offset: 78, shaderLocation: 11},
+          {format: 'uint32', offset: 20, shaderLocation: 4},
+          {format: 'float32x2', offset: 12, shaderLocation: 1},
+          {format: 'uint16x2', offset: 100, shaderLocation: 3},
+          {format: 'uint8x4', offset: 84, shaderLocation: 5},
+          {format: 'float32x2', offset: 264, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+let imageBitmap24 = await createImageBitmap(video15);
+let gpuCanvasContext16 = canvas10.getContext('webgpu');
+let video18 = await videoWithData();
+try {
+  await promise18;
+} catch {}
+let offscreenCanvas16 = new OffscreenCanvas(419, 779);
+let img19 = await imageWithData(140, 58, '#664d60ae', '#dcb484c7');
+let commandEncoder71 = device1.createCommandEncoder({});
+let computePassEncoder36 = commandEncoder68.beginComputePass();
+try {
+computePassEncoder23.end();
+} catch {}
+try {
+computePassEncoder29.setPipeline(pipeline44);
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(buffer15, 27452, buffer10, 296356, 67964);
+dissociateBuffer(device1, buffer15);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder38.copyTextureToBuffer({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 264 widthInBlocks: 66 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 860 */
+  offset: 860,
+  rowsPerImage: 6,
+  buffer: buffer16,
+}, {width: 66, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+commandEncoder51.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 38},
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 10});
+} catch {}
+try {
+commandEncoder63.resolveQuerySet(querySet18, 647, 203, buffer11, 202496);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas2,
+  origin: { x: 0, y: 3 },
+  flipY: true,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u4541\u0f09\u{1fa16}\u{1fc62}\u01c4\ub96e\u0ee4\u{1ffe2}\udfd3';
+} catch {}
+try {
+offscreenCanvas16.getContext('webgl');
+} catch {}
+try {
+externalTexture8.label = '\u5875\u008d\u1a9d\u07f0\ua06b\ucfe6';
+} catch {}
+let bindGroupLayout18 = pipeline35.getBindGroupLayout(0);
+let textureView84 = texture29.createView({
+  label: '\u{1f82c}\u{1fc52}\u0692\u9da9\u0a65\u09a1\u8b05\u1d80\u3ef7\u0e8a',
+  baseMipLevel: 1,
+  baseArrayLayer: 0,
+  arrayLayerCount: 1,
+});
+let computePassEncoder37 = commandEncoder41.beginComputePass({label: '\u{1f629}\u4a81\u{1fd8a}\u{1f97a}\uc9d2\u85e0\u{1fffe}\u{1fdd0}\u{1f785}\u{1f8e0}'});
+let sampler31 = device1.createSampler({
+  label: '\uef4a\u0d59\u0885\u{1fbf3}\u{1f840}\u{1fe8b}\u075d',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 87.22,
+  lodMaxClamp: 91.01,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder22.setPipeline(pipeline29);
+} catch {}
+try {
+commandEncoder61.clearBuffer(buffer16, 98636);
+dissociateBuffer(device1, buffer16);
+} catch {}
+let promise19 = device1.createComputePipelineAsync({
+  label: '\ueafc\u2cb2\u0b52',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+let video19 = await videoWithData();
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+try {
+externalTexture1.label = '\uad90\u0c5e\u9c7c\u{1f77e}\u1334\u8d2f\u2044\ue64a\uecf1';
+} catch {}
+video15.width = 76;
+let bindGroupLayout19 = device1.createBindGroupLayout({
+  label: '\ubebe\u8fdd\u4621',
+  entries: [
+    {
+      binding: 964,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let externalTexture20 = device1.importExternalTexture({label: '\ue1a2\ud6e0\u05c3', source: video2, colorSpace: 'srgb'});
+try {
+renderBundleEncoder23.setPipeline(pipeline45);
+} catch {}
+try {
+commandEncoder60.clearBuffer(buffer16);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer16, 36984, new Float32Array(60151));
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout20 = device1.createBindGroupLayout({
+  label: '\ue848\u1086\u8f3c\u{1f71b}\u0924\ucfa8',
+  entries: [
+    {binding: 932, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 839,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 931,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: true },
+    },
+  ],
+});
+let texture54 = device1.createTexture({
+  size: [80],
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView85 = texture53.createView({label: '\u{1f9e9}\u075b\u0e78\u6a82\uec41', dimension: '3d', format: 'bgra8unorm', baseMipLevel: 3});
+let externalTexture21 = device1.importExternalTexture({
+  label: '\u5f24\u{1f8db}\u00ef\uca0a\u293e\u0bb8\u1c42\u784d\u0c15',
+  source: videoFrame13,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder16.dispatchWorkgroups(2, 1, 5);
+} catch {}
+try {
+buffer14.destroy();
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(buffer15, 131780, buffer16, 171400, 13100);
+dissociateBuffer(device1, buffer15);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise20 = device1.queue.onSubmittedWorkDone();
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame14,
+  origin: { x: 0, y: 26 },
+  flipY: false,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video8.width = 216;
+try {
+  await promise20;
+} catch {}
+let bindGroupLayout21 = device1.createBindGroupLayout({
+  label: '\u{1f8af}\ucc23\uaf8c\udfae',
+  entries: [
+    {binding: 232, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 198,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 173,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let commandEncoder72 = device1.createCommandEncoder({label: '\u{1f841}\u{1fcaa}\ub22d'});
+let textureView86 = texture48.createView({label: '\u6dff\u02a9\u0fe3\u{1f91a}', dimension: '1d'});
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline32);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline45);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 32 */
+{offset: 32}, {width: 11, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline53 = device1.createComputePipeline({
+  label: '\u{1fc3d}\u0f4e\u48a4\u7af4',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule8, entryPoint: 'compute0'},
+});
+let renderBundleEncoder28 = device2.createRenderBundleEncoder({
+  label: '\u6b48\uf970\u{1f9fa}\u0728\u0a7d\u{1f9f6}',
+  colorFormats: ['rgba32sint', 'rgb10a2uint', 'rg8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video15,
+  origin: { x: 5, y: 2 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle48 = renderBundleEncoder15.finish({});
+try {
+renderBundleEncoder27.setPipeline(pipeline45);
+} catch {}
+try {
+commandEncoder50.copyBufferToBuffer(buffer15, 105176, buffer16, 211396, 21008);
+dissociateBuffer(device1, buffer15);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+commandEncoder50.clearBuffer(buffer10, 194004, 132004);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 240 */
+{offset: 240}, {width: 20, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle49 = renderBundleEncoder24.finish();
+let externalTexture22 = device1.importExternalTexture({source: videoFrame3, colorSpace: 'srgb'});
+try {
+computePassEncoder34.end();
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer12, 'uint16', 66034, 56808);
+} catch {}
+let arrayBuffer1 = buffer15.getMappedRange(77048, 848);
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+offscreenCanvas14.width = 578;
+try {
+window.someLabel = externalTexture8.label;
+} catch {}
+let pipelineLayout14 = device1.createPipelineLayout({label: '\u4ccd\u{1fbb6}', bindGroupLayouts: []});
+let computePassEncoder38 = commandEncoder65.beginComputePass({label: '\u6da8\u0175\u5968\ua3f5\u0575'});
+try {
+renderBundleEncoder26.setBindGroup(3, bindGroup5, new Uint32Array(8465), 3973, 0);
+} catch {}
+try {
+commandEncoder63.clearBuffer(buffer16);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 7},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 1_857_197 */
+{offset: 397, bytesPerRow: 176, rowsPerImage: 211}, {width: 9, height: 0, depthOrArrayLayers: 51});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline54 = device1.createComputePipeline({
+  label: '\u796b\u{1f783}\uacbf\u3b24\u3638\u3b02\u05b9',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule9, entryPoint: 'compute0'},
+});
+let pipeline55 = device1.createRenderPipeline({
+  label: '\u260d\u0aae\uaac2\u{1fc6f}\u7f10\ue309\u8256\u05de\u9d00',
+  layout: pipelineLayout11,
+  multisample: {mask: 0xcd523604},
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'rg16uint', writeMask: 0}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALPHA}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r32uint'}],
+},
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [{arrayStride: 500, attributes: [{format: 'snorm16x2', offset: 192, shaderLocation: 7}]}],
+  },
+});
+let video20 = await videoWithData();
+let pipelineLayout15 = device1.createPipelineLayout({label: '\u07c7\u0860', bindGroupLayouts: []});
+let texture55 = device1.createTexture({
+  label: '\u0583\u216b\uef48\u8084\u94a9\ua26d\u0373\u083e\u9d95\u7075\u88ca',
+  size: [1250, 6, 1],
+  mipLevelCount: 5,
+  dimension: '2d',
+  format: 'astc-10x6-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['astc-10x6-unorm', 'astc-10x6-unorm'],
+});
+let renderBundleEncoder29 = device1.createRenderBundleEncoder({
+  colorFormats: ['bgra8unorm-srgb', 'rg16uint', 'rgb10a2unorm', 'r32sint', 'r32uint'],
+  stencilReadOnly: true,
+});
+let sampler32 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 4.171,
+  lodMaxClamp: 54.44,
+});
+try {
+computePassEncoder30.setPipeline(pipeline42);
+} catch {}
+let pipeline56 = await device1.createRenderPipelineAsync({
+  label: '\u9354\u40a9\u90cb\ub1e0',
+  layout: pipelineLayout13,
+  multisample: {count: 1},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'one-minus-src'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'zero'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rg16uint', writeMask: 0}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'less', failOp: 'increment-clamp', depthFailOp: 'increment-clamp', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'decrement-clamp'},
+    stencilReadMask: 4294967295,
+    stencilWriteMask: 678520575,
+    depthBiasSlopeScale: 390.59277089545054,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 196,
+        attributes: [
+          {format: 'uint32x3', offset: 56, shaderLocation: 10},
+          {format: 'sint16x4', offset: 12, shaderLocation: 6},
+          {format: 'uint16x2', offset: 4, shaderLocation: 14},
+          {format: 'unorm16x4', offset: 40, shaderLocation: 0},
+          {format: 'float16x2', offset: 16, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 40, shaderLocation: 2},
+          {format: 'uint32x2', offset: 28, shaderLocation: 4},
+          {format: 'sint16x2', offset: 0, shaderLocation: 7},
+          {format: 'uint32x3', offset: 12, shaderLocation: 12},
+          {format: 'unorm16x2', offset: 0, shaderLocation: 3},
+          {format: 'sint32x4', offset: 44, shaderLocation: 15},
+          {format: 'uint32x3', offset: 108, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 324,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 28, shaderLocation: 13},
+          {format: 'unorm8x2', offset: 0, shaderLocation: 1},
+          {format: 'uint32x4', offset: 20, shaderLocation: 5},
+        ],
+      },
+      {arrayStride: 36, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 996,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 524, shaderLocation: 8}],
+      },
+    ],
+  },
+});
+let canvas11 = document.createElement('canvas');
+try {
+canvas11.getContext('webgl');
+} catch {}
+let commandEncoder73 = device1.createCommandEncoder({label: '\u0a44\ubd2d'});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline35);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(3, buffer9, 12696, 8753);
+} catch {}
+try {
+commandEncoder60.clearBuffer(buffer10, 109264, 162012);
+dissociateBuffer(device1, buffer10);
+} catch {}
+let imageData19 = new ImageData(132, 168);
+let bindGroupLayout22 = device1.createBindGroupLayout({label: '\u0eec\u1e00\ueec3\u047d\u{1fad3}\u{1f769}\ua0df\u0b9e', entries: []});
+let commandEncoder74 = device1.createCommandEncoder({label: '\u{1f972}\ua3ba\u013b\u0ab8\u0711\u01c9\u6b94\u7ccd'});
+let querySet39 = device1.createQuerySet({type: 'occlusion', count: 3340});
+let computePassEncoder39 = commandEncoder73.beginComputePass({label: '\u11af\u5067\u{1f677}\ud669\u05be\ue3fa\udbc4\u{1f66a}\u4545\u81b6\u{1fc62}'});
+try {
+renderBundleEncoder21.setPipeline(pipeline45);
+} catch {}
+try {
+buffer11.destroy();
+} catch {}
+try {
+commandEncoder72.copyBufferToBuffer(buffer15, 6100, buffer16, 6896, 23088);
+dissociateBuffer(device1, buffer15);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+commandEncoder64.copyTextureToBuffer({
+  texture: texture49,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 50600 */
+  offset: 50600,
+  buffer: buffer16,
+}, {width: 7, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+commandEncoder34.copyTextureToTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture53,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 51, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder74.clearBuffer(buffer10, 391572, 3704);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer16, 298600, new BigUint64Array(34116), 13865, 812);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 3, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap22,
+  origin: { x: 327, y: 2 },
+  flipY: false,
+}, {
+  texture: texture27,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule11 = device0.createShaderModule({
+  label: '\u{1fc3f}\u088a\u079d',
+  code: `@group(1) @binding(3048)
+var<storage, read_write> function10: array<u32>;
+@group(3) @binding(4222)
+var<storage, read_write> global10: array<u32>;
+@group(0) @binding(1928)
+var<storage, read_write> function11: array<u32>;
+@group(1) @binding(1928)
+var<storage, read_write> function12: array<u32>;
+@group(2) @binding(3048)
+var<storage, read_write> parameter6: array<u32>;
+@group(5) @binding(1928)
+var<storage, read_write> type9: array<u32>;
+@group(2) @binding(1928)
+var<storage, read_write> local8: array<u32>;
+@group(0) @binding(3048)
+var<storage, read_write> parameter7: array<u32>;
+
+@compute @workgroup_size(1, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S9 {
+  @location(22) f0: vec2<u32>,
+  @builtin(position) f1: vec4<f32>,
+  @location(4) f2: vec4<u32>,
+  @location(0) f3: f16,
+  @location(16) f4: f32,
+  @location(18) f5: vec3<u32>,
+  @location(29) f6: vec4<f32>,
+  @location(11) f7: u32,
+  @location(38) f8: u32,
+  @location(3) f9: vec2<i32>,
+  @location(33) f10: vec3<f32>,
+  @location(6) f11: vec4<i32>,
+  @location(43) f12: vec2<i32>,
+  @location(26) f13: f16,
+  @location(19) f14: vec3<u32>,
+  @location(32) f15: vec3<u32>,
+  @location(37) f16: vec4<u32>,
+  @location(2) f17: vec2<i32>,
+  @builtin(sample_mask) f18: u32,
+  @location(31) f19: vec4<u32>,
+  @location(41) f20: vec4<u32>,
+  @location(28) f21: vec3<i32>
+}
+struct FragmentOutput0 {
+  @location(7) f0: vec4<f32>,
+  @location(0) f1: vec4<i32>,
+  @location(5) f2: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(15) a0: vec4<f16>, @location(5) a1: vec3<f16>, @location(30) a2: vec2<u32>, @location(10) a3: vec2<u32>, @location(35) a4: vec2<f32>, a5: S9, @location(36) a6: vec2<u32>, @builtin(front_facing) a7: bool, @builtin(sample_index) a8: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(10) f101: vec2<u32>,
+  @location(5) f102: vec3<f16>,
+  @location(28) f103: vec3<i32>,
+  @location(22) f104: vec2<u32>,
+  @location(33) f105: vec3<f32>,
+  @location(35) f106: vec2<f32>,
+  @location(26) f107: f16,
+  @location(43) f108: vec2<i32>,
+  @location(37) f109: vec4<u32>,
+  @location(3) f110: vec2<i32>,
+  @location(4) f111: vec4<u32>,
+  @location(31) f112: vec4<u32>,
+  @location(0) f113: f16,
+  @location(15) f114: vec4<f16>,
+  @location(36) f115: vec2<u32>,
+  @location(2) f116: vec2<i32>,
+  @location(41) f117: vec4<u32>,
+  @builtin(position) f118: vec4<f32>,
+  @location(29) f119: vec4<f32>,
+  @location(38) f120: u32,
+  @location(6) f121: vec4<i32>,
+  @location(11) f122: u32,
+  @location(32) f123: vec3<u32>,
+  @location(19) f124: vec3<u32>,
+  @location(16) f125: f32,
+  @location(30) f126: vec2<u32>,
+  @location(18) f127: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(20) a0: vec4<f16>, @location(1) a1: f16, @location(6) a2: i32, @location(14) a3: vec2<i32>, @location(8) a4: vec2<i32>, @location(9) a5: i32, @location(18) a6: vec4<f16>, @location(4) a7: vec2<f32>, @location(15) a8: vec2<u32>, @location(5) a9: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let commandEncoder75 = device0.createCommandEncoder({label: '\u3c8a\u0525\ufd09\u544f\u2f6a'});
+let textureView87 = texture8.createView({label: '\u023c\u{1f690}\u0352'});
+let renderBundle50 = renderBundleEncoder2.finish({label: '\u7556\u77ec'});
+let externalTexture23 = device0.importExternalTexture({
+  label: '\u84e5\u5146\u{1f77e}\uc3fc\u2a13\u{1fd4f}\ua90d\u{1f86c}\u{1f7a5}',
+  source: videoFrame12,
+  colorSpace: 'display-p3',
+});
+try {
+texture3.destroy();
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let pipeline57 = await device0.createRenderPipelineAsync({
+  label: '\u6f77\u7f57\u0f20\u0fd9\u0788\u{1f6ed}',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0x38dc8d5e},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint', writeMask: 0}, {format: 'r8sint', writeMask: 0}, {
+  format: 'rg8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'rgba32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2644,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 620, shaderLocation: 7},
+          {format: 'float32x4', offset: 328, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 186, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 11444,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 4640, shaderLocation: 6},
+          {format: 'uint32x4', offset: 1780, shaderLocation: 12},
+          {format: 'float16x4', offset: 2820, shaderLocation: 9},
+          {format: 'sint8x4', offset: 3076, shaderLocation: 5},
+          {format: 'unorm8x4', offset: 1392, shaderLocation: 4},
+          {format: 'uint32', offset: 1328, shaderLocation: 20},
+          {format: 'sint8x4', offset: 332, shaderLocation: 2},
+          {format: 'uint16x4', offset: 2104, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 5256, shaderLocation: 11},
+          {format: 'snorm8x2', offset: 1010, shaderLocation: 0},
+          {format: 'unorm16x4', offset: 280, shaderLocation: 8},
+          {format: 'uint32', offset: 1704, shaderLocation: 13},
+          {format: 'float32x2', offset: 860, shaderLocation: 16},
+          {format: 'snorm8x2', offset: 1920, shaderLocation: 17},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'none',
+  unclippedDepth: true,
+},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageBitmap25 = await createImageBitmap(video11);
+let img20 = await imageWithData(131, 91, '#a0484365', '#1b8fad43');
+try {
+textureView25.label = '\u2347\u04f5\ub858';
+} catch {}
+offscreenCanvas3.height = 71;
+let imageBitmap26 = await createImageBitmap(video12);
+document.body.prepend(canvas4);
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+canvas1.width = 69;
+let commandEncoder76 = device1.createCommandEncoder({label: '\u0505\uf94c\u2845\u044d\u21ab\u91ad\u{1feb0}\uf253\u604a'});
+let textureView88 = texture22.createView({baseMipLevel: 4, arrayLayerCount: 1});
+let computePassEncoder40 = commandEncoder56.beginComputePass({});
+let renderBundle51 = renderBundleEncoder25.finish();
+let sampler33 = device1.createSampler({
+  label: '\ue574\uf9dd\u0073\u1c6c\ueff5\ub780\u0660\u{1fe24}',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 91.10,
+  lodMaxClamp: 93.01,
+  maxAnisotropy: 13,
+});
+try {
+renderBundleEncoder23.setVertexBuffer(2, buffer9);
+} catch {}
+try {
+texture41.destroy();
+} catch {}
+try {
+commandEncoder72.clearBuffer(buffer10, 174692, 142552);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder76.resolveQuerySet(querySet22, 807, 670, buffer16, 210432);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(946), /* required buffer size: 946 */
+{offset: 946}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap5,
+  origin: { x: 32, y: 2 },
+  flipY: false,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise21 = device1.createRenderPipelineAsync({
+  label: '\u{1fba3}\u{1fde1}\u3ef3\u0195\u7b7c\ud91d\u8bf3\ufbd1\u5d4d\u05d5',
+  layout: pipelineLayout11,
+  multisample: {count: 4, mask: 0xffffffff, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALPHA}, {format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'r32sint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r32uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'greater', depthFailOp: 'increment-wrap', passOp: 'replace'},
+    stencilBack: {compare: 'never', depthFailOp: 'decrement-clamp', passOp: 'replace'},
+    stencilReadMask: 3104720038,
+    stencilWriteMask: 3225860379,
+    depthBiasSlopeScale: 0.0,
+    depthBiasClamp: 995.7071825970156,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 120,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x4', offset: 0, shaderLocation: 7}],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'none',
+  unclippedDepth: true,
+},
+});
+let bindGroupLayout23 = device1.createBindGroupLayout({
+  label: '\u{1f8fa}\u8ff7\u{1f7ac}\u0d4e\uc6ad\u{1fe30}\u9734\u6bb8\u0315\u27ab',
+  entries: [
+    {
+      binding: 202,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 3,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let renderBundleEncoder30 = device1.createRenderBundleEncoder({
+  label: '\u860f\u0a16\ub9aa\u7d4e\u0000\u{1fb5a}\u267c',
+  colorFormats: ['bgra8unorm-srgb', 'rg16uint', 'rgb10a2unorm', 'r32sint', 'r32uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle52 = renderBundleEncoder26.finish({});
+try {
+renderBundleEncoder21.setPipeline(pipeline55);
+} catch {}
+try {
+commandEncoder63.copyTextureToTexture({
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 26, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 27},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer0), /* required buffer size: 372_976 */
+{offset: 172, bytesPerRow: 108, rowsPerImage: 29}, {width: 24, height: 1, depthOrArrayLayers: 120});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(canvas1);
+let video21 = await videoWithData();
+let promise22 = adapter2.requestAdapterInfo();
+let shaderModule12 = device1.createShaderModule({
+  label: '\u5764\u{1fab2}\u9b31\u{1f8d7}\ufb57\ua35f\u04cf\ud348\u10a0\u40d2',
+  code: `@group(1) @binding(945)
+var<storage, read_write> parameter8: array<u32>;
+@group(0) @binding(384)
+var<storage, read_write> n11: array<u32>;
+@group(1) @binding(791)
+var<storage, read_write> type10: array<u32>;
+@group(0) @binding(352)
+var<storage, read_write> type11: array<u32>;
+@group(0) @binding(537)
+var<storage, read_write> function13: array<u32>;
+
+@compute @workgroup_size(7, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(4) f1: vec3<u32>,
+  @location(1) f2: vec3<u32>,
+  @location(2) f3: vec4<f32>,
+  @builtin(sample_mask) f4: u32,
+  @location(3) f5: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(7) a0: vec4<f16>, @location(5) a1: vec3<i32>, @location(3) a2: vec2<f16>, @location(12) a3: i32, @location(14) a4: vec4<f32>, @location(4) a5: vec2<u32>, @location(8) a6: f16, @location(1) a7: f16, @location(13) a8: f32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(3) f128: vec2<f16>,
+  @location(6) f129: vec4<f32>,
+  @location(12) f130: i32,
+  @location(13) f131: f32,
+  @location(11) f132: vec2<i32>,
+  @location(8) f133: f16,
+  @location(10) f134: vec3<u32>,
+  @location(5) f135: vec3<i32>,
+  @builtin(position) f136: vec4<f32>,
+  @location(4) f137: vec2<u32>,
+  @location(1) f138: f16,
+  @location(7) f139: vec4<f16>,
+  @location(15) f140: vec3<f16>,
+  @location(14) f141: vec4<f32>,
+  @location(2) f142: vec3<f16>,
+  @location(0) f143: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(12) a0: f32, @location(2) a1: vec4<i32>, @location(8) a2: vec2<u32>, @location(3) a3: f16, @location(11) a4: vec4<f16>, @location(15) a5: vec3<f16>, @location(14) a6: vec4<i32>, @location(9) a7: vec2<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout24 = device1.createBindGroupLayout({
+  entries: [
+    {binding: 652, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 794, visibility: 0, buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false }},
+  ],
+});
+let texture56 = device1.createTexture({
+  label: '\uccd1\uc5ae\u7a95',
+  size: [840],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView89 = texture42.createView({});
+try {
+renderBundleEncoder30.setBindGroup(3, bindGroup5, new Uint32Array(5507), 2737, 0);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer8, 'uint16');
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(5, buffer9, 42744, 826);
+} catch {}
+try {
+commandEncoder63.copyTextureToBuffer({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 108 widthInBlocks: 27 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 18628 */
+  offset: 18520,
+  buffer: buffer10,
+}, {width: 27, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas0,
+  origin: { x: 0, y: 171 },
+  flipY: true,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline58 = await promise16;
+let imageBitmap27 = await createImageBitmap(videoFrame7);
+let commandEncoder77 = device1.createCommandEncoder({label: '\u6c79\u0187'});
+let texture57 = device1.createTexture({
+  label: '\u02bb\u{1fbba}\ua4aa\u0f62\u2bb9\u22d0\u0cbf\u0113\u4738\uc112\u0ab3',
+  size: [320],
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+});
+let externalTexture24 = device1.importExternalTexture({label: '\uf8f7\u0623', source: video16, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder29.setPipeline(pipeline55);
+} catch {}
+try {
+commandEncoder54.resolveQuerySet(querySet37, 936, 1980, buffer16, 180736);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer13]);
+} catch {}
+let promise23 = device1.createComputePipelineAsync({
+  label: '\uf4a2\u088d\uab24\u8aed',
+  layout: pipelineLayout12,
+  compute: {module: shaderModule10, entryPoint: 'compute0'},
+});
+offscreenCanvas13.height = 400;
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+video6.width = 289;
+video5.width = 284;
+let imageBitmap28 = await createImageBitmap(img7);
+let textureView90 = texture48.createView({dimension: '1d'});
+let renderBundleEncoder31 = device1.createRenderBundleEncoder({
+  label: '\ucc0a\u{1fe62}\u0f83\u09a1\ubd53\u7375\u7ba9\u3896\u521d\u34e6',
+  colorFormats: ['bgra8unorm-srgb', 'rg16uint', 'rgb10a2unorm', 'r32sint', 'r32uint'],
+});
+let renderBundle53 = renderBundleEncoder17.finish({});
+let sampler34 = device1.createSampler({
+  label: '\u0270\ub9f1\u0138\u0815\u0326\u8bfb\u{1fead}\ub0ff\u05e7\u0d4d',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.47,
+  compare: 'not-equal',
+  maxAnisotropy: 7,
+});
+try {
+commandEncoder71.copyBufferToBuffer(buffer15, 25532, buffer10, 295228, 17388);
+dissociateBuffer(device1, buffer15);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 105, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 23, y: 28 },
+  flipY: false,
+}, {
+  texture: texture27,
+  mipLevel: 2,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline59 = await promise21;
+let pipelineLayout16 = device1.createPipelineLayout({
+  label: '\u79db\ud7d2\u01f8\u{1ffa9}\u0296\u{1f6fe}\uaf20\ua744\u0c7b\u382c',
+  bindGroupLayouts: [bindGroupLayout23, bindGroupLayout23],
+});
+let textureView91 = texture46.createView({label: '\u8977\u7b3b\u08cc\u{1fc13}', dimension: '1d'});
+let renderBundle54 = renderBundleEncoder23.finish({label: '\u{1f71b}\uc7ff\u05d3\u{1f870}\ua594\u0b73'});
+try {
+computePassEncoder20.pushDebugGroup('\u{1fa43}');
+} catch {}
+let canvas12 = document.createElement('canvas');
+try {
+device1.label = '\u7365\u03f1\u507a\ucebf\u{1f7b4}\u{1f8b2}\u5c09\u{1fda8}\ua79b\u0380\ufa84';
+} catch {}
+let querySet40 = device1.createQuerySet({label: '\u3dd9\ub26e\u0b9f\u83d1\u9657\u0799\u0828', type: 'occlusion', count: 2733});
+let textureView92 = texture21.createView({label: '\u2fbf\u63ef\uec49\u0144'});
+try {
+commandEncoder63.copyBufferToBuffer(buffer15, 129700, buffer16, 64480, 23112);
+dissociateBuffer(device1, buffer15);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 139, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer1), /* required buffer size: 389 */
+{offset: 389}, {width: 78, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise24 = device1.createRenderPipelineAsync({
+  label: '\u{1f8e6}\u207e\uff78\ufed0\u941d\ufe9d\u{1fbe5}\u08f9',
+  layout: pipelineLayout16,
+  fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'dst', dstFactor: 'src'},
+    alpha: {operation: 'subtract', srcFactor: 'one', dstFactor: 'one-minus-src'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rg16uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'dst-alpha'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r32uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'not-equal', failOp: 'decrement-clamp', depthFailOp: 'decrement-wrap', passOp: 'replace'},
+    stencilBack: {failOp: 'invert', depthFailOp: 'increment-clamp'},
+    stencilReadMask: 3640738748,
+    depthBias: -1775262250,
+    depthBiasSlopeScale: 589.0133372257633,
+    depthBiasClamp: 658.1695206423176,
+  },
+  vertex: {
+    module: shaderModule12,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 680, attributes: []},
+      {
+        arrayStride: 500,
+        attributes: [
+          {format: 'sint32', offset: 116, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 122, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 320,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x4', offset: 8, shaderLocation: 15}],
+      },
+      {
+        arrayStride: 144,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 24, shaderLocation: 2},
+          {format: 'uint16x4', offset: 44, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 48, shaderLocation: 11},
+          {format: 'unorm16x2', offset: 32, shaderLocation: 9},
+          {format: 'float32x4', offset: 0, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'front', unclippedDepth: true},
+});
+let imageData20 = new ImageData(132, 72);
+try {
+adapter0.label = '\u067e\u{1f868}\u99cc\uda83\u1792\u0d9a\u3411\u6094\u{1f668}\u9746';
+} catch {}
+try {
+computePassEncoder33.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+computePassEncoder14.dispatchWorkgroups(3);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder29.setPipeline(pipeline55);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder34.copyTextureToTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture53,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 9},
+  aspect: 'all',
+},
+{width: 38, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder20.popDebugGroup();
+} catch {}
+let commandEncoder78 = device1.createCommandEncoder({label: '\u2c77\u0767\u0ea3\u4856\u0904\u0e04\u{1fed4}\u3654'});
+let texture58 = device1.createTexture({
+  label: '\u0a84\u0458\ub575\u7d63\u0d30\u7f0f\u0f1c\u4226\u9927\u00ed',
+  size: {width: 210},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView93 = texture29.createView({
+  label: '\ub799\u0378\u0785\u4f71\u00be\u{1f9f5}\u01c6\u59aa\u9a06\u7cc7\uf823',
+  dimension: '2d-array',
+});
+let renderBundle55 = renderBundleEncoder29.finish({});
+let sampler35 = device1.createSampler({
+  label: '\u{1fd32}\ucc23\u100d\u0d49\u0ac0\u220a\u0f79',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 18.49,
+  lodMaxClamp: 56.85,
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+computePassEncoder32.setPipeline(pipeline53);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(3689, undefined, 0);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 105, height: 1, depthOrArrayLayers: 26}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 70, y: 12 },
+  flipY: true,
+}, {
+  texture: texture53,
+  mipLevel: 2,
+  origin: {x: 4, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 42, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas1.width = 74;
+let offscreenCanvas17 = new OffscreenCanvas(585, 659);
+let buffer17 = device2.createBuffer({size: 258692, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView94 = texture52.createView({
+  label: '\u0759\u72b4\ub7c2\u3a4f\ub17c\u{1fb89}\u{1f97c}\u{1fa93}\u4b74\u3c25',
+  dimension: '2d-array',
+  format: 'bgra8unorm-srgb',
+});
+let texture59 = device1.createTexture({
+  label: '\u9c68\u03bf\uba7f\u0ca8\u1963\u7036\u{1fa82}',
+  size: [160, 1, 371],
+  mipLevelCount: 5,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16uint', 'rg16uint'],
+});
+let textureView95 = texture31.createView({baseMipLevel: 1, mipLevelCount: 1, arrayLayerCount: 1});
+let externalTexture25 = device1.importExternalTexture({source: videoFrame9});
+try {
+renderBundleEncoder27.setIndexBuffer(buffer8, 'uint16', 20358, 42152);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline45);
+} catch {}
+let imageBitmap29 = await createImageBitmap(canvas7);
+let gpuCanvasContext17 = offscreenCanvas17.getContext('webgpu');
+try {
+adapter1.label = '\u9236\uceb2\ua52f\u6fc5\u0b2e\u0885\ud3ad\u{1fb49}';
+} catch {}
+let gpuCanvasContext18 = canvas12.getContext('webgpu');
+try {
+  await promise22;
+} catch {}
+offscreenCanvas7.width = 218;
+let canvas13 = document.createElement('canvas');
+let gpuCanvasContext19 = canvas13.getContext('webgpu');
+gc();
+try {
+renderBundle31.label = '\u1e17\u5db8\ub506\u{1fd09}\u4e53\u3c61\u92ae\u{1fe0e}\u0357\u05c6\u0efc';
+} catch {}
+let texture60 = device1.createTexture({
+  size: {width: 40, height: 1, depthOrArrayLayers: 92},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb'],
+});
+let textureView96 = texture30.createView({label: '\u277d\u0121\u{1f941}\u0206', dimension: '2d-array'});
+let computePassEncoder41 = commandEncoder54.beginComputePass({label: '\ubc59\ud2df\u{1f6e8}\u0578\u06d8\u62df\u8958\ue0b1\u0dab\u{1f77c}\ua9ab'});
+try {
+computePassEncoder22.dispatchWorkgroups(4, 3);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline45);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(0, buffer9, 0, 14412);
+} catch {}
+try {
+commandEncoder71.copyBufferToBuffer(buffer15, 134320, buffer16, 97164, 5704);
+dissociateBuffer(device1, buffer15);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+commandEncoder34.clearBuffer(buffer16);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm', 'rgba8unorm'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let commandEncoder79 = device1.createCommandEncoder({label: '\u05c1\ufa4d\u0e4f\u{1f912}'});
+let textureView97 = texture55.createView({label: '\u0942\uc22f\u04eb\u{1fc38}\ue9a5', baseMipLevel: 2, mipLevelCount: 1});
+let sampler36 = device1.createSampler({
+  label: '\u{1fbc6}\udc6a\ud071\u1fc4\ufea1\u0a3e\u2556\u{1fb23}\u{1fa29}\u00cc',
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 89.26,
+  lodMaxClamp: 95.93,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder20.setPipeline(pipeline54);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline55);
+} catch {}
+try {
+commandEncoder38.copyTextureToBuffer({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 292 widthInBlocks: 73 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 35144 */
+  offset: 34852,
+  buffer: buffer16,
+}, {width: 73, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline60 = await promise19;
+let pipeline61 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout11,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r32sint', writeMask: GPUColorWrite.ALL}, {format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 104,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 20, shaderLocation: 3},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 44, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 8, shaderLocation: 2},
+          {format: 'sint32x3', offset: 0, shaderLocation: 15},
+          {format: 'sint32x3', offset: 4, shaderLocation: 7},
+          {format: 'float32x4', offset: 0, shaderLocation: 0},
+          {format: 'uint32x3', offset: 28, shaderLocation: 12},
+          {format: 'uint8x2', offset: 0, shaderLocation: 5},
+          {format: 'uint32x2', offset: 4, shaderLocation: 11},
+          {format: 'snorm16x2', offset: 72, shaderLocation: 9},
+          {format: 'sint8x4', offset: 32, shaderLocation: 6},
+          {format: 'uint32', offset: 20, shaderLocation: 14},
+          {format: 'uint32x2', offset: 8, shaderLocation: 13},
+          {format: 'uint16x2', offset: 0, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 836,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint16x2', offset: 36, shaderLocation: 10}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+try {
+device1.destroy();
+} catch {}
+let img21 = await imageWithData(250, 212, '#77cd2a32', '#524c9f7e');
+try {
+externalTexture10.label = '\u079c\u0710\u{1fade}\ufb6a\u{1f7a4}\u0d09\u{1fbc8}\u5f03\u4059\u0370\u06a6';
+} catch {}
+try {
+externalTexture24.label = '\u0698\u05a4\u3fb9\u809f\u0333\u10f7\u1b06\u4aa4\u0260\u8d64\u0e10';
+} catch {}
+let adapter3 = await navigator.gpu.requestAdapter({});
+let imageData21 = new ImageData(192, 60);
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+let offscreenCanvas18 = new OffscreenCanvas(223, 816);
+let video22 = await videoWithData();
+let offscreenCanvas19 = new OffscreenCanvas(667, 123);
+let querySet41 = device0.createQuerySet({label: '\ua11d\u0dad\ubf21\u794f\u{1fc82}', type: 'occlusion', count: 713});
+let textureView98 = texture9.createView({label: '\uea7f\u0c0f\u47b3\u08d6\u052d', baseMipLevel: 4, arrayLayerCount: 1});
+let renderBundle56 = renderBundleEncoder0.finish({label: '\u143b\u{1f798}\u{1f614}\u038b\ub15c\u{1f7b8}\ud386\u03d2'});
+let sampler37 = device0.createSampler({
+  label: '\u5041\u47b9\u3173\u{1ff27}\u0263\uddb9\u0176\u3b57\uae77\u101e\uda07',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 56.79,
+  lodMaxClamp: 74.04,
+});
+let externalTexture26 = device0.importExternalTexture({label: '\u5be0\u0b5e\u095f\u5ed7\u17a1\uaac2\u4473\u0346\u9b42', source: video15});
+try {
+renderBundleEncoder6.setPipeline(pipeline11);
+} catch {}
+try {
+commandEncoder11.clearBuffer(buffer0, 37712, 44196);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 43588, new Int16Array(15318));
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(80)), /* required buffer size: 24 */
+{offset: 24, bytesPerRow: 113}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let video23 = await videoWithData();
+let imageBitmap30 = await createImageBitmap(img21);
+try {
+offscreenCanvas19.getContext('webgpu');
+} catch {}
+let imageBitmap31 = await createImageBitmap(imageBitmap17);
+let textureView99 = texture47.createView({label: '\u0ebb\u{1f87f}\ua370', dimension: '2d-array', baseMipLevel: 5, baseArrayLayer: 0});
+let sampler38 = device2.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 20.64,
+  lodMaxClamp: 85.10,
+});
+try {
+device2.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 3},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer1), /* required buffer size: 2_911_822 */
+{offset: 958, bytesPerRow: 447, rowsPerImage: 176}, {width: 70, height: 0, depthOrArrayLayers: 38});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img21,
+  origin: { x: 29, y: 20 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas14 = document.createElement('canvas');
+let offscreenCanvas20 = new OffscreenCanvas(823, 361);
+try {
+offscreenCanvas20.getContext('bitmaprenderer');
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+video22.height = 118;
+let video24 = await videoWithData();
+let img22 = await imageWithData(63, 254, '#0422afc6', '#29080160');
+gc();
+let imageBitmap32 = await createImageBitmap(videoFrame14);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+offscreenCanvas4.width = 282;
+let gpuCanvasContext20 = canvas14.getContext('webgpu');
+let gpuCanvasContext21 = offscreenCanvas18.getContext('webgpu');
+let offscreenCanvas21 = new OffscreenCanvas(350, 51);
+try {
+offscreenCanvas21.getContext('webgpu');
+} catch {}
+let pipelineLayout17 = device2.createPipelineLayout({
+  label: '\u{1fd99}\uc5bb\u6e8e\u{1f7d6}\u0a72\u0d88\u0c86\uc790\ue3bb\ufeda\ud3a3',
+  bindGroupLayouts: [],
+});
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+gc();
+let img23 = await imageWithData(114, 272, '#1009b144', '#1057246c');
+let imageData22 = new ImageData(152, 116);
+try {
+window.someLabel = texture50.label;
+} catch {}
+let commandEncoder80 = device0.createCommandEncoder({});
+try {
+renderBundleEncoder10.setVertexBuffer(7, buffer4, 0, 12848);
+} catch {}
+try {
+commandEncoder30.copyBufferToBuffer(buffer3, 764, buffer0, 84552, 13092);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+commandEncoder24.copyTextureToBuffer({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 288 widthInBlocks: 18 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 5760 */
+  offset: 5472,
+  buffer: buffer5,
+}, {width: 18, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer5, 8036, new BigUint64Array(22869), 4258, 1408);
+} catch {}
+let pipeline62 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}}});
+offscreenCanvas21.width = 506;
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let imageBitmap33 = await createImageBitmap(videoFrame0);
+let canvas15 = document.createElement('canvas');
+let img24 = await imageWithData(3, 121, '#1ef20f17', '#faabe80a');
+canvas12.width = 182;
+try {
+adapter2.label = '\u{1fe40}\u{1f9e8}\u0ce2\u61ce\uc150\uadec\ub912\ufafa\u0821';
+} catch {}
+canvas11.width = 530;
+gc();
+let gpuCanvasContext22 = canvas15.getContext('webgpu');
+let textureView100 = texture47.createView({label: '\u07ec\u{1f97d}\ufe40', baseMipLevel: 2, mipLevelCount: 2});
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+renderBundleEncoder20.insertDebugMarker('\u3acd');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 6,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 792 */
+{offset: 792, bytesPerRow: 119}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let imageData23 = new ImageData(192, 192);
+let video25 = await videoWithData();
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend(video4);
+let imageData24 = new ImageData(28, 64);
+let bindGroupLayout25 = device0.createBindGroupLayout({
+  label: '\u1482\u027f\u9c58\u{1f728}\u4a2a\u{1fa6a}\ub76e',
+  entries: [
+    {
+      binding: 4640,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 4630,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 408,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let commandBuffer17 = commandEncoder11.finish({label: '\ud5a1\u7b06\u{1f8c4}\u01bf'});
+let texture61 = device0.createTexture({
+  size: [4000, 16, 302],
+  mipLevelCount: 5,
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let texture62 = gpuCanvasContext6.getCurrentTexture();
+let textureView101 = texture4.createView({label: '\u03a2\u3c0f\u3d2d\u{1fa80}', mipLevelCount: 3});
+let renderBundleEncoder32 = device0.createRenderBundleEncoder({
+  label: '\u6aaa\u0217\u{1fda5}\u07de',
+  colorFormats: ['rg8uint', 'r8sint', 'rg8sint', 'rg16float', 'rgba32sint'],
+  stencilReadOnly: true,
+});
+let renderBundle57 = renderBundleEncoder1.finish({label: '\u6fb2\u06ca\u709a\u8715\u{1f8f6}\ud12d\u89a7'});
+try {
+renderBundleEncoder9.setPipeline(pipeline11);
+} catch {}
+let promise25 = buffer5.mapAsync(GPUMapMode.READ, 38768);
+try {
+device0.queue.submit([commandBuffer1, commandBuffer17]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 44, new Float32Array(3093), 2552, 220);
+} catch {}
+let texture63 = device2.createTexture({
+  size: [96, 1, 1],
+  mipLevelCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let externalTexture27 = device2.importExternalTexture({
+  label: '\u9ed9\u{1f99d}\uaba4\u017b\u{1fba6}\u0e86\ud14d\u7519',
+  source: videoFrame4,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder20.setVertexBuffer(7427, undefined, 1793234892, 2059012806);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer0), /* required buffer size: 949 */
+{offset: 949}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video4,
+  origin: { x: 2, y: 0 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img24);
+let canvas16 = document.createElement('canvas');
+document.body.prepend(canvas1);
+let img25 = await imageWithData(10, 7, '#91b7ee0d', '#5594c876');
+try {
+  await promise25;
+} catch {}
+let offscreenCanvas22 = new OffscreenCanvas(900, 856);
+let imageData25 = new ImageData(28, 200);
+try {
+canvas16.getContext('webgl');
+} catch {}
+let gpuCanvasContext23 = offscreenCanvas22.getContext('webgpu');
+let imageBitmap34 = await createImageBitmap(video23);
+let imageBitmap35 = await createImageBitmap(imageBitmap31);
+let imageBitmap36 = await createImageBitmap(imageData10);
+try {
+externalTexture19.label = '\u8540\u01f9\u37ab\u1c2c\u0169\ud0b6\ua9ff';
+} catch {}
+offscreenCanvas9.width = 1456;
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let offscreenCanvas23 = new OffscreenCanvas(735, 717);
+canvas9.width = 989;
+try {
+offscreenCanvas23.getContext('webgpu');
+} catch {}
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+let imageData26 = new ImageData(236, 216);
+try {
+adapter1.label = '\ua866\u037b\u61c7\u{1fa1e}\u0f90\u0924\u{1f83b}\u{1fcd3}\u70e5\u0e30';
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let img26 = await imageWithData(149, 233, '#66ece9fe', '#eca0ada4');
+try {
+texture63.label = '\u{1f818}\u0d31\u00be\u{1f73a}';
+} catch {}
+canvas3.height = 417;
+gc();
+let img27 = await imageWithData(38, 199, '#aab81cca', '#2213ece0');
+let videoFrame15 = new VideoFrame(imageBitmap18, {timestamp: 0});
+document.body.prepend(video19);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+gc();
+let canvas17 = document.createElement('canvas');
+let gpuCanvasContext24 = canvas17.getContext('webgpu');
+let imageBitmap37 = await createImageBitmap(offscreenCanvas17);
+let videoFrame16 = new VideoFrame(videoFrame9, {timestamp: 0});
+let img28 = await imageWithData(268, 52, '#132eb220', '#e57b2749');
+let imageBitmap38 = await createImageBitmap(videoFrame6);
+let adapter4 = await navigator.gpu.requestAdapter({});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let videoFrame17 = new VideoFrame(videoFrame10, {timestamp: 0});
+let imageBitmap39 = await createImageBitmap(offscreenCanvas4);
+let imageBitmap40 = await createImageBitmap(img9);
+let canvas18 = document.createElement('canvas');
+let canvas19 = document.createElement('canvas');
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let promise26 = adapter1.requestAdapterInfo();
+document.body.prepend(video12);
+try {
+canvas19.getContext('webgl2');
+} catch {}
+let gpuCanvasContext25 = canvas18.getContext('webgpu');
+offscreenCanvas13.height = 241;
+let videoFrame18 = new VideoFrame(video18, {timestamp: 0});
+video8.height = 223;
+let video26 = await videoWithData();
+let commandEncoder81 = device1.createCommandEncoder({label: '\u00ae\u4cea\u5fa9\u0d28\u{1f84e}\u054d\u79c4\udf8b\u2c2e\u08f2\u01a4'});
+let commandBuffer18 = commandEncoder71.finish({label: '\ue306\ubaff\u{1fafd}\u{1f865}'});
+let computePassEncoder42 = commandEncoder38.beginComputePass({label: '\u0191\ub86a\u9d3e\u8fb3\u062e\u1bb3\u02b5\u{1fc16}\u0a55\u00e8\u07cd'});
+let renderBundleEncoder33 = device1.createRenderBundleEncoder({
+  label: '\u205a\u6c06\u48a7\u2d01\u{1f60f}',
+  colorFormats: ['bgra8unorm-srgb', 'rg16uint', 'rgb10a2unorm', 'r32sint', 'r32uint'],
+  stencilReadOnly: true,
+});
+let externalTexture28 = device1.importExternalTexture({source: videoFrame17});
+try {
+computePassEncoder37.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder33.setPipeline(pipeline55);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let videoFrame19 = new VideoFrame(canvas2, {timestamp: 0});
+try {
+  await promise26;
+} catch {}
+let video27 = await videoWithData();
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let imageData27 = new ImageData(176, 144);
+canvas2.width = 753;
+let img29 = await imageWithData(254, 157, '#c1bd3ed8', '#e85493eb');
+let buffer18 = device0.createBuffer({
+  label: '\u8c8b\ua23a\ucad3\u0715\u833e',
+  size: 368602,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder82 = device0.createCommandEncoder({label: '\ub4fc\u{1f9b3}\u0637\u00a2\u1d53\uf627\u{1f848}\u5e49'});
+let textureView102 = texture15.createView({label: '\uce2d\ue6ff', dimension: '2d', format: 'rgba32sint', baseArrayLayer: 8});
+let renderBundle58 = renderBundleEncoder7.finish({label: '\uf7be\u04a5\u659b\ua8fa\ud782\u4901'});
+try {
+renderBundleEncoder9.setPipeline(pipeline17);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(2, buffer4, 23488, 16115);
+} catch {}
+try {
+commandEncoder22.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 9, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 572 widthInBlocks: 143 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 63040 */
+  offset: 63040,
+  bytesPerRow: 1024,
+  rowsPerImage: 28,
+  buffer: buffer0,
+}, {width: 143, height: 11, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer0);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let adapter5 = await navigator.gpu.requestAdapter({});
+let imageBitmap41 = await createImageBitmap(imageBitmap9);
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let videoFrame20 = new VideoFrame(videoFrame18, {timestamp: 0});
+let bindGroupLayout26 = device1.createBindGroupLayout({
+  label: '\u{1fce1}\u00b8\u033d\ucb73',
+  entries: [
+    {
+      binding: 764,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 207,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 176,
+      visibility: 0,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let commandEncoder83 = device1.createCommandEncoder({label: '\udbdf\u02be\u04ca\u07a6\u0126\u3ff9\u0e21\u0178\u0c5f\u39cd'});
+let textureView103 = texture18.createView({label: '\ue79e\u0225\u{1fcda}\u90ac\u{1fc95}', format: 'r8uint', baseArrayLayer: 0});
+let sampler39 = device1.createSampler({
+  label: '\u086d\u9ac9\u054e\u0236\u{1f6d0}\uf45c',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 53.86,
+  lodMaxClamp: 56.62,
+});
+try {
+commandEncoder78.copyBufferToBuffer(buffer15, 38584, buffer16, 353808, 49148);
+dissociateBuffer(device1, buffer15);
+dissociateBuffer(device1, buffer16);
+} catch {}
+try {
+gpuCanvasContext24.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline63 = await promise24;
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let adapter6 = await navigator.gpu.requestAdapter({powerPreference: 'low-power'});
+let commandEncoder84 = device2.createCommandEncoder({label: '\u73a6\u0c4f\u0f96'});
+let computePassEncoder43 = commandEncoder84.beginComputePass();
+let renderBundleEncoder34 = device2.createRenderBundleEncoder({
+  label: '\uf5cd\u5dc1\u1503\u{1fafe}\u5b52\u0f3d\u0763\u{1fa89}',
+  colorFormats: ['rgba32sint', 'rgb10a2uint', 'rg8unorm'],
+  stencilReadOnly: true,
+});
+try {
+device2.queue.writeTexture({
+  texture: texture47,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 162 */
+{offset: 162}, {width: 4, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+canvas7.width = 2375;
+let canvas20 = document.createElement('canvas');
+try {
+adapter1.label = '\ubf0f\u0668\u6e7d\ub19e\uc6ad\u8468\u{1f798}\u005e\u0c81';
+} catch {}
+try {
+  await adapter5.requestAdapterInfo();
+} catch {}
+gc();
+let imageData28 = new ImageData(28, 16);
+let imageData29 = new ImageData(232, 32);
+video19.height = 48;
+video21.height = 58;
+document.body.prepend(video5);
+gc();
+try {
+canvas20.getContext('webgl');
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let offscreenCanvas24 = new OffscreenCanvas(202, 760);
+let imageData30 = new ImageData(36, 48);
+try {
+offscreenCanvas24.getContext('2d');
+} catch {}
+let img30 = await imageWithData(164, 199, '#43099267', '#78c58e1c');
+offscreenCanvas15.height = 570;
+try {
+window.someLabel = device0.label;
+} catch {}
+gc();
+let canvas21 = document.createElement('canvas');
+let video28 = await videoWithData();
+let gpuCanvasContext26 = canvas21.getContext('webgpu');
+try {
+gpuCanvasContext20.unconfigure();
+} catch {}
+let img31 = await imageWithData(150, 69, '#95721659', '#96630035');
+video14.width = 64;
+let videoFrame21 = new VideoFrame(imageBitmap0, {timestamp: 0});
+let video29 = await videoWithData();
+let promise27 = adapter2.requestAdapterInfo();
+let offscreenCanvas25 = new OffscreenCanvas(889, 711);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let offscreenCanvas26 = new OffscreenCanvas(916, 190);
+let imageBitmap42 = await createImageBitmap(img18);
+try {
+renderBundleEncoder10.label = '\u1a34\u558c\u5ab9\u7ce4\uf48a\u6b30\u0a7c';
+} catch {}
+document.body.prepend(video14);
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+let imageBitmap43 = await createImageBitmap(videoFrame5);
+try {
+  await promise27;
+} catch {}
+let imageBitmap44 = await createImageBitmap(offscreenCanvas6);
+let videoFrame22 = new VideoFrame(imageBitmap0, {timestamp: 0});
+let videoFrame23 = new VideoFrame(imageBitmap44, {timestamp: 0});
+try {
+adapter4.label = '\u{1fe2d}\u{1ffc7}\u02d0\u922b';
+} catch {}
+offscreenCanvas24.height = 714;
+try {
+  await adapter6.requestAdapterInfo();
+} catch {}
+let gpuCanvasContext27 = offscreenCanvas25.getContext('webgpu');
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let promise28 = adapter0.requestAdapterInfo();
+let imageBitmap45 = await createImageBitmap(videoFrame15);
+let videoFrame24 = videoFrame12.clone();
+let gpuCanvasContext28 = offscreenCanvas26.getContext('webgpu');
+document.body.prepend(img24);
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let imageBitmap46 = await createImageBitmap(imageBitmap32);
+let videoFrame25 = new VideoFrame(img24, {timestamp: 0});
+try {
+window.someLabel = externalTexture15.label;
+} catch {}
+let commandEncoder85 = device2.createCommandEncoder({});
+let texture64 = device2.createTexture({
+  label: '\u275d\u{1f9c4}\u5c3e\u0413\u{1fe68}\u0c4f\u{1fed2}',
+  size: [290, 1, 292],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgb10a2uint'],
+});
+let texture65 = gpuCanvasContext6.getCurrentTexture();
+let textureView104 = texture45.createView({label: '\u043b\u6420'});
+let renderBundle59 = renderBundleEncoder19.finish({label: '\u883e\u{1f6d9}\u7003\u35dd'});
+let externalTexture29 = device2.importExternalTexture({
+  label: '\u0bf0\u0c6b\ud990\u{1f74e}\u9b63\u2b7a\u{1fe3a}\udc50\u{1f690}\u{1f643}\u321b',
+  source: video16,
+  colorSpace: 'display-p3',
+});
+try {
+gpuCanvasContext23.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let img32 = await imageWithData(34, 5, '#3aa06bc4', '#86500726');
+let video30 = await videoWithData();
+try {
+adapter0.label = '\u0592\u0243\u0020';
+} catch {}
+gc();
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+try {
+  await promise28;
+} catch {}
+try {
+window.someLabel = externalTexture21.label;
+} catch {}
+offscreenCanvas18.height = 243;
+let video31 = await videoWithData();
+let video32 = await videoWithData();
+let img33 = await imageWithData(282, 65, '#875f3025', '#ae08135c');
+offscreenCanvas4.width = 933;
+let bindGroupLayout27 = device2.createBindGroupLayout({label: '\u09b9\u06eb\u6f33', entries: []});
+let commandEncoder86 = device2.createCommandEncoder({label: '\udc8e\u{1faf2}\u086b\uaf77\u2dfc\ue3f6\u7c15\u3328\u0cbf'});
+let texture66 = device2.createTexture({
+  size: {width: 290, height: 1, depthOrArrayLayers: 140},
+  mipLevelCount: 6,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['depth16unorm'],
+});
+let textureView105 = texture47.createView({format: 'rg32float', baseMipLevel: 1, mipLevelCount: 3});
+try {
+device2.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder86.copyTextureToTexture({
+  texture: texture39,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 7},
+  aspect: 'all',
+},
+{
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 49, y: 14, z: 3},
+  aspect: 'all',
+},
+{width: 68, height: 7, depthOrArrayLayers: 25});
+} catch {}
+document.body.prepend(img11);
+let imageData31 = new ImageData(228, 64);
+try {
+computePassEncoder26.label = '\u{1f664}\ud86e\ud4d8\u052d\u0917';
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend(video20);
+let imageBitmap47 = await createImageBitmap(imageBitmap23);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let canvas22 = document.createElement('canvas');
+let adapter7 = await navigator.gpu.requestAdapter({powerPreference: 'low-power'});
+let imageBitmap48 = await createImageBitmap(video24);
+let querySet42 = device1.createQuerySet({label: '\u6c2c\u0288\u0190\u0624\ua583', type: 'occlusion', count: 1631});
+let renderBundle60 = renderBundleEncoder17.finish({});
+let sampler40 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 65.55,
+  lodMaxClamp: 79.83,
+});
+try {
+computePassEncoder32.setPipeline(pipeline36);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(2, buffer9, 0, 42025);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer16, 14176, new DataView(new ArrayBuffer(61000)));
+} catch {}
+try {
+canvas22.getContext('webgl2');
+} catch {}
+let buffer19 = device0.createBuffer({
+  label: '\u0db4\u21c1\u5dc8\u{1f785}',
+  size: 1515,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let querySet43 = device0.createQuerySet({label: '\u7754\u0250\ua902\ud6f2\u79ce', type: 'occlusion', count: 2729});
+let textureView106 = texture61.createView({
+  label: '\ub4b0\ua57d\u{1fb49}\uab47',
+  dimension: '2d',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 205,
+});
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({
+  label: '\u8194\u0da5\u29d7\u{1fa48}\u7efb\u503e\u97d3',
+  colorFormats: ['rg8uint', 'r8sint', 'rg8sint', 'rg16float', 'rgba32sint'],
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder5.setBindGroup(7, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline24);
+} catch {}
+try {
+commandEncoder29.copyBufferToBuffer(buffer1, 11912, buffer5, 118208, 1100);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer5);
+} catch {}
+let imageBitmap49 = await createImageBitmap(canvas6);
+let computePassEncoder44 = commandEncoder86.beginComputePass({label: '\u6195\ua496\u{1f651}\u6878'});
+let renderBundle61 = renderBundleEncoder34.finish({label: '\u{1fada}\u037a\u2c84'});
+try {
+commandEncoder85.copyBufferToBuffer(buffer17, 23456, buffer13, 16276, 2376);
+dissociateBuffer(device2, buffer17);
+dissociateBuffer(device2, buffer13);
+} catch {}
+try {
+adapter5.label = '\ua0d9\u{1f95a}\u6295';
+} catch {}
+offscreenCanvas2.height = 489;
+let imageBitmap50 = await createImageBitmap(imageBitmap8);
+document.body.prepend(video30);
+let bindGroupLayout28 = device1.createBindGroupLayout({
+  label: '\u{1fda6}\u{1fd4f}\u99f7\u{1feab}\u{1fd1b}\ud5b0',
+  entries: [
+    {binding: 679, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 116,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 643,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let texture67 = device1.createTexture({
+  label: '\u{1f6f2}\u71ca\u0504\u0546\u08da\u032a\u0fb0\u{1f693}',
+  size: [420, 4, 1],
+  mipLevelCount: 3,
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint'],
+});
+let textureView107 = texture59.createView({
+  label: '\ud190\u0053\u55ba\u{1fbce}\u00c2\u{1ffc5}\ud1ea',
+  aspect: 'all',
+  baseMipLevel: 4,
+  mipLevelCount: 1,
+});
+let sampler41 = device1.createSampler({
+  label: '\u{1f695}\u{1fc96}\u5d36\u{1f861}\u{1fd6f}\u8e34\u{1ff2e}\u7cfa\ub483\u03fe',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 69.99,
+  lodMaxClamp: 71.68,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder33.setPipeline(pipeline45);
+} catch {}
+let arrayBuffer2 = buffer15.getMappedRange(75304, 1260);
+try {
+commandEncoder50.copyTextureToTexture({
+  texture: texture59,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 58},
+  aspect: 'all',
+},
+{
+  texture: texture25,
+  mipLevel: 3,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 76, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder78.clearBuffer(buffer16, 199240, 33728);
+dissociateBuffer(device1, buffer16);
+} catch {}
+let img34 = await imageWithData(132, 267, '#daf9caae', '#5f41c277');
+let imageBitmap51 = await createImageBitmap(canvas17);
+let videoFrame26 = new VideoFrame(imageBitmap17, {timestamp: 0});
+try {
+adapter5.label = '\u7a42\u5318\ufc4b\u04a8';
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let canvas23 = document.createElement('canvas');
+gc();
+try {
+canvas23.getContext('webgl2');
+} catch {}
+let commandEncoder87 = device1.createCommandEncoder({label: '\u3393\u{1f86e}\udaf5\uf28c'});
+let commandBuffer19 = commandEncoder74.finish({label: '\u{1fa1e}\u{1fa9a}\u0964\u208e\u0c4b\u372e\u{1ff44}\ufde5\u1ff8'});
+let textureView108 = texture31.createView({label: '\u0053\ud821\u3eda', baseMipLevel: 3, mipLevelCount: 1, arrayLayerCount: 1});
+let renderBundleEncoder36 = device1.createRenderBundleEncoder({
+  label: '\u6ecf\ubd9b\u445e',
+  colorFormats: ['bgra8unorm-srgb', 'rg16uint', 'rgb10a2unorm', 'r32sint', 'r32uint'],
+  sampleCount: 1,
+});
+try {
+computePassEncoder24.setBindGroup(1, bindGroup6, new Uint32Array(7535), 6383, 0);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline45);
+} catch {}
+try {
+commandEncoder77.copyTextureToBuffer({
+  texture: texture19,
+  mipLevel: 2,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 14140 */
+  offset: 14140,
+  buffer: buffer10,
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer10);
+} catch {}
+let img35 = await imageWithData(240, 299, '#d1b5cb2d', '#0b09370c');
+let img36 = await imageWithData(148, 82, '#c0ed07d3', '#691b432d');
+let video33 = await videoWithData();
+let adapter8 = await navigator.gpu.requestAdapter({powerPreference: 'low-power'});
+let video34 = await videoWithData();
+try {
+gpuCanvasContext23.unconfigure();
+} catch {}
+let video35 = await videoWithData();
+let imageBitmap52 = await createImageBitmap(imageData22);
+try {
+window.someLabel = externalTexture7.label;
+} catch {}
+document.body.prepend(canvas16);
+try {
+gpuCanvasContext21.unconfigure();
+} catch {}
+gc();
+let imageData32 = new ImageData(4, 176);
+try {
+adapter3.label = '\u{1f777}\uc634\u9632\u803c';
+} catch {}
+let texture68 = device0.createTexture({
+  label: '\u420c\u{1f74b}\u{1f77c}\ue68b\u{1f9d0}\u01b5',
+  size: [900],
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32sint', 'rgba32sint'],
+});
+let textureView109 = texture16.createView({label: '\u45d5\uaf5b\u0da6\u{1fed6}\u04b2\u0511', aspect: 'all'});
+let externalTexture30 = device0.importExternalTexture({
+  label: '\u9e80\u3096\u{1fbf2}\u049e\ue022\u331a\u4177\u0273',
+  source: videoFrame16,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder6.setPipeline(pipeline24);
+} catch {}
+try {
+commandEncoder8.copyBufferToBuffer(buffer2, 242680, buffer5, 328, 103352);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer5);
+} catch {}
+let pipeline64 = device0.createRenderPipeline({
+  label: '\u090e\u08d4\u455c\ud987\u0a4f\uad05\u40c8\u{1fb05}',
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8uint'}, {format: 'r8sint', writeMask: 0}, {format: 'rg8sint', writeMask: 0}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.GREEN,
+}, {format: 'rgba32sint', writeMask: GPUColorWrite.ALL}],
+},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 7760,
+        attributes: [
+          {format: 'float16x4', offset: 2172, shaderLocation: 14},
+          {format: 'sint32x3', offset: 184, shaderLocation: 0},
+          {format: 'uint8x2', offset: 158, shaderLocation: 6},
+          {format: 'sint32', offset: 4040, shaderLocation: 8},
+          {format: 'uint16x4', offset: 2308, shaderLocation: 9},
+          {format: 'uint32x2', offset: 604, shaderLocation: 10},
+          {format: 'sint8x2', offset: 2650, shaderLocation: 18},
+          {format: 'snorm16x4', offset: 240, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 660, shaderLocation: 13},
+          {format: 'uint32x2', offset: 504, shaderLocation: 16},
+          {format: 'unorm16x4', offset: 2796, shaderLocation: 5},
+          {format: 'float32x4', offset: 1108, shaderLocation: 2},
+          {format: 'float16x2', offset: 3520, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 8728,
+        attributes: [
+          {format: 'sint32x3', offset: 3020, shaderLocation: 12},
+          {format: 'sint8x4', offset: 1676, shaderLocation: 20},
+          {format: 'float32x4', offset: 1348, shaderLocation: 11},
+          {format: 'snorm8x2', offset: 416, shaderLocation: 15},
+          {format: 'sint16x4', offset: 1040, shaderLocation: 17},
+          {format: 'snorm16x4', offset: 3576, shaderLocation: 3},
+          {format: 'snorm16x2', offset: 664, shaderLocation: 19},
+          {format: 'unorm16x4', offset: 1124, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+});
+canvas17.width = 634;
+let offscreenCanvas27 = new OffscreenCanvas(252, 343);
+document.body.prepend(video17);
+canvas12.width = 1756;
+let imageBitmap53 = await createImageBitmap(imageBitmap38);
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -88,10 +88,11 @@ public:
 
     ~RenderBundleEncoder();
 
-    void draw(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t firstInstance);
-    void drawIndexed(uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex, int32_t baseVertex, uint32_t firstInstance);
-    void drawIndexedIndirect(Buffer& indirectBuffer, uint64_t indirectOffset);
-    void drawIndirect(Buffer& indirectBuffer, uint64_t indirectOffset);
+    enum FinalizeRenderCommand { };
+    FinalizeRenderCommand draw(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t firstInstance);
+    FinalizeRenderCommand drawIndexed(uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex, int32_t baseVertex, uint32_t firstInstance);
+    FinalizeRenderCommand drawIndexedIndirect(Buffer& indirectBuffer, uint64_t indirectOffset);
+    FinalizeRenderCommand drawIndirect(Buffer& indirectBuffer, uint64_t indirectOffset);
     Ref<RenderBundle> finish(const WGPURenderBundleDescriptor&);
     void insertDebugMarker(String&& markerLabel);
     void popDebugGroup();
@@ -126,7 +127,8 @@ private:
     void addResource(RenderBundle::ResourcesContainer*, id<MTLResource>, MTLRenderStages, const BindGroupEntryUsageData::Resource&);
     void addResource(RenderBundle::ResourcesContainer*, id<MTLResource>, MTLRenderStages);
     bool icbNeedsToBeSplit(const RenderPipeline& a, const RenderPipeline& b);
-    void finalizeRenderCommand(MTLIndirectCommandType);
+    FinalizeRenderCommand finalizeRenderCommand(MTLIndirectCommandType);
+    FinalizeRenderCommand finalizeRenderCommand();
     bool validToEncodeCommand() const;
     bool returnIfEncodingIsFinished(NSString* errorString);
     bool runIndexBufferValidation(uint32_t firstInstance, uint32_t instanceCount);


### PR DESCRIPTION
#### 82200c87c9e07fb76d09b6f228d736a9088b9ea5
<pre>
[WebGPU] RenderBundleEncoder::drawIndexed does not check for the buffer being destroyed
<a href="https://bugs.webkit.org/show_bug.cgi?id=275167">https://bugs.webkit.org/show_bug.cgi?id=275167</a>
&lt;radar://129227496&gt;

Reviewed by Tadeu Zagallo.

drawIndexed call was allowing destroyed buffer to be passed to Metal,
which resulted in a size mismatch as the destroyed buffer has a length of 1.

We can not simply return early without incrementing the command count however
since then when replay occurs in the bundle, the commands will not all be removed.

Ensure this doesn&apos;t occur which avoids replaying the incorrect commands on the next
frame.

* LayoutTests/fast/webgpu/regression/fuzz-275167-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/fuzz-275167.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::draw):
(WebGPU::RenderBundleEncoder::finalizeRenderCommand):
(WebGPU::RenderBundleEncoder::drawIndexed):
(WebGPU::RenderBundleEncoder::drawIndexedIndirect):
(WebGPU::RenderBundleEncoder::drawIndirect):

Canonical link: <a href="https://commits.webkit.org/279878@main">https://commits.webkit.org/279878@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fee93090b362148bc62d67066af641bc2ce4c56f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57881 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5334 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5337 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44221 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3590 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25347 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28959 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4621 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3474 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50709 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4837 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59471 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29834 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4976 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51644 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30983 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47377 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51074 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12043 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31962 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30771 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->