### PR TITLE
Cleanup LocalFrameViewLayoutContext calls to document

### DIFF
--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -170,13 +170,13 @@ void LocalFrameViewLayoutContext::layout()
 void LocalFrameViewLayoutContext::performLayout()
 {
     Ref frame = this->frame();
-    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!frame->document()->inRenderTreeUpdate());
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!document()->inRenderTreeUpdate());
     ASSERT(LayoutDisallowedScope::isLayoutAllowed());
     ASSERT(!view().isPainting());
     ASSERT(frame->view() == &view());
-    ASSERT(frame->document());
-    ASSERT(frame->document()->backForwardCacheState() == Document::NotInBackForwardCache
-        || frame->document()->backForwardCacheState() == Document::AboutToEnterBackForwardCache);
+    ASSERT(document());
+    ASSERT(document()->backForwardCacheState() == Document::NotInBackForwardCache
+        || document()->backForwardCacheState() == Document::AboutToEnterBackForwardCache);
     if (!canPerformLayout()) {
         LOG(Layout, "  is not allowed, bailing");
         return;
@@ -202,7 +202,7 @@ void LocalFrameViewLayoutContext::performLayout()
     {
         SetForScope layoutPhase(m_layoutPhase, LayoutPhase::InPreLayout);
 
-        if (!frame->document()->isResolvingContainerQueriesForSelfOrAncestor()) {
+        if (!document()->isResolvingContainerQueriesForSelfOrAncestor()) {
             // If this is a new top-level layout and there are any remaining tasks from the previous layout, finish them now.
             if (!isLayoutNested() && m_postLayoutTaskTimer.isActive())
                 runPostLayoutTasks();
@@ -279,7 +279,7 @@ void LocalFrameViewLayoutContext::runOrScheduleAsynchronousTasks()
     if (m_postLayoutTaskTimer.isActive())
         return;
 
-    if (frame().document()->isResolvingContainerQueries()) {
+    if (document()->isResolvingContainerQueries()) {
         // We are doing layout from style resolution to resolve container queries.
         m_postLayoutTaskTimer.startOneShot(0_s);
         return;
@@ -348,7 +348,7 @@ void LocalFrameViewLayoutContext::setNeedsLayoutAfterViewConfigurationChange()
     }
 
     if (auto* renderView = this->renderView()) {
-        ASSERT(!frame().document()->inHitTesting());
+        ASSERT(document()->inHitTesting());
         renderView->setNeedsLayout();
         scheduleLayout();
     }
@@ -371,7 +371,7 @@ void LocalFrameViewLayoutContext::scheduleLayout()
     // FIXME: We should assert the page is not in the back/forward cache, but that is causing
     // too many false assertions. See <rdar://problem/7218118>.
     ASSERT(frame().view() == &view());
-    if (!frame().document())
+    if (!document())
         return;
 
     if (subtreeLayoutRoot())
@@ -380,14 +380,14 @@ void LocalFrameViewLayoutContext::scheduleLayout()
     if (isLayoutPending())
         return;
 
-    if (!isLayoutSchedulingEnabled() || !frame().document()->shouldScheduleLayout())
+    if (!isLayoutSchedulingEnabled() || !document()->shouldScheduleLayout())
         return;
     if (!needsLayout())
         return;
 
 #if !LOG_DISABLED
-    if (!frame().document()->ownerElement())
-        LOG(Layout, "LocalFrameView %p layout timer scheduled at %.3fs", this, frame().document()->timeSinceDocumentCreation().value());
+    if (!document()->ownerElement())
+        LOG(Layout, "LocalFrameView %p layout timer scheduled at %.3fs", this, document()->timeSinceDocumentCreation().value());
 #endif
 
     InspectorInstrumentation::didInvalidateLayout(protectedFrame());
@@ -403,8 +403,8 @@ void LocalFrameViewLayoutContext::unscheduleLayout()
         return;
 
 #if !LOG_DISABLED
-    if (!frame().document()->ownerElement())
-        LOG_WITH_STREAM(Layout, stream << "LocalFrameViewLayoutContext for LocalFrameView " << frame().view() << " layout timer unscheduled at " << frame().document()->timeSinceDocumentCreation().value());
+    if (!document()->ownerElement())
+        LOG_WITH_STREAM(Layout, stream << "LocalFrameViewLayoutContext for LocalFrameView " << frame().view() << " layout timer unscheduled at " << document()->timeSinceDocumentCreation().value());
 #endif
 
     m_layoutTimer.stop();
@@ -467,8 +467,8 @@ void LocalFrameViewLayoutContext::scheduleSubtreeLayout(RenderElement& layoutRoo
 void LocalFrameViewLayoutContext::layoutTimerFired()
 {
 #if !LOG_DISABLED
-    if (!frame().document()->ownerElement())
-        LOG_WITH_STREAM(Layout, stream << "LocalFrameViewLayoutContext for LocalFrameView " << frame().view() << " layout timer fired at " << frame().document()->timeSinceDocumentCreation().value());
+    if (!document()->ownerElement())
+        LOG_WITH_STREAM(Layout, stream << "LocalFrameViewLayoutContext for LocalFrameView " << frame().view() << " layout timer fired at " << document()->timeSinceDocumentCreation().value());
 #endif
     layout();
 }
@@ -498,7 +498,7 @@ bool LocalFrameViewLayoutContext::canPerformLayout() const
     if (view().isPainting())
         return false;
 
-    if (!subtreeLayoutRoot() && !frame().document()->renderView())
+    if (!subtreeLayoutRoot() && !document()->renderView())
         return false;
 
     return true;
@@ -530,7 +530,7 @@ void LocalFrameViewLayoutContext::applyTextSizingIfNeeded(RenderElement& layoutR
 void LocalFrameViewLayoutContext::updateStyleForLayout()
 {
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
-    Ref document = *frame().document();
+    Ref document = *this->document();
 
     // FIXME: This shouldn't be necessary, but see rdar://problem/36670246.
     if (!document->styleScope().resolverIfExists())


### PR DESCRIPTION
#### 00c73058f19ed9d0be94742a782d49d72ca69ee2
<pre>
Cleanup LocalFrameViewLayoutContext calls to document
<a href="https://bugs.webkit.org/show_bug.cgi?id=275181">https://bugs.webkit.org/show_bug.cgi?id=275181</a>
<a href="https://rdar.apple.com/129301712">rdar://129301712</a>

Reviewed by Simon Fraser.

We already have a document accessor defined in LocalFrameViewLayoutContext.
At some points we call the accessor and at some points we call frame().document().

I think we can unify the behavior and let the compiler decide to inline it.

* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::performLayout):
(WebCore::LocalFrameViewLayoutContext::runOrScheduleAsynchronousTasks):
(WebCore::LocalFrameViewLayoutContext::setNeedsLayoutAfterViewConfigurationChange):
(WebCore::LocalFrameViewLayoutContext::scheduleLayout):
(WebCore::LocalFrameViewLayoutContext::unscheduleLayout):
(WebCore::LocalFrameViewLayoutContext::layoutTimerFired):
(WebCore::LocalFrameViewLayoutContext::canPerformLayout const):
(WebCore::LocalFrameViewLayoutContext::updateStyleForLayout):

Canonical link: <a href="https://commits.webkit.org/279760@main">https://commits.webkit.org/279760@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f365c9492e27a4abc16bc02cbe06d5f03ebfe0c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57703 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5155 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56726 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5130 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44070 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3453 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56518 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/31981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47127 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25207 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/28784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4459 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3298 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4673 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59294 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/29645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/4791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/51496 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/30802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47221 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50866 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11878 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/31779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30594 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->