### PR TITLE
[WGSL] Cannot access fields of PackedVec3

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -467,6 +467,8 @@ Packing RewriteGlobalVariables::getPacking(AST::FieldAccessExpression& expressio
     auto* baseType = expression.base().inferredType();
     if (auto* referenceType = std::get_if<Types::Reference>(baseType))
         baseType = referenceType->element;
+    if (auto* pointerType = std::get_if<Types::Pointer>(baseType))
+        baseType = pointerType->element;
     if (std::holds_alternative<Types::Vector>(*baseType))
         return Packing::Unpacked;
     ASSERT(std::holds_alternative<Types::Struct>(*baseType));

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -197,16 +197,23 @@ void FunctionDefinitionWriter::emitNecessaryHelpers()
         {
             IndentationScope scope(m_indent);
             m_stringBuilder.append(
-                m_indent, "packed_vec<T, 3> vec3;\n"_s,
+                m_indent, "T x;\n"_s,
+                m_indent, "T y;\n"_s,
+                m_indent, "T z;\n"_s,
                 m_indent, "uint8_t __padding[sizeof(T)];\n"_s,
                 m_indent, "\n"_s,
-                m_indent, "PackedVec3() : vec3() { }\n"_s,
+                m_indent, "PackedVec3() { }\n"_s,
                 m_indent, "\n"_s,
-                m_indent, "PackedVec3(packed_vec<T, 3> v) : vec3(v) { }\n"_s,
+                m_indent, "PackedVec3(packed_vec<T, 3> v) : x(v.x), y(v.y), z(v.z) { }\n"_s,
                 m_indent, "\n"_s,
-                m_indent, "operator packed_vec<T, 3>() { return vec3; }\n"_s,
+                m_indent, "operator vec<T, 3>() { return vec<T, 3>(x, y, z); }\n"_s,
+                m_indent, "operator packed_vec<T, 3>() { return packed_vec<T, 3>(x, y, z); }\n"_s,
                 m_indent, "\n"_s,
-                m_indent, "operator float3() { return as_type<vec<float, 3>>(vec<T, 3>(vec3)); }\n"_s
+                m_indent, "T operator[](int i) const { return i ? i == 2 ? z : y : x; }\n"_s,
+                m_indent, "device T& operator[](int i) device { return i ? i == 2 ? z : y : x; }\n"_s,
+                m_indent, "constant T& operator[](int i) constant { return i ? i == 2 ? z : y : x; }\n"_s,
+                m_indent, "thread T& operator[](int i) thread { return i ? i == 2 ? z : y : x; }\n"_s,
+                m_indent, "threadgroup T& operator[](int i) threadgroup { return i ? i == 2 ? z : y : x; }\n"_s
             );
         }
         m_stringBuilder.append(m_indent, "};\n\n"_s);

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -103,8 +103,8 @@ inline std::variant<PrepareResult, Error> prepareImpl(ShaderModule& shaderModule
         HashMap<String, Reflection::EntryPointInformation> entryPoints;
 
         RUN_PASS(mangleNames, shaderModule);
-        RUN_PASS(rewritePointers, shaderModule);
         RUN_PASS(insertBoundsChecks, shaderModule);
+        RUN_PASS(rewritePointers, shaderModule);
         RUN_PASS(rewriteEntryPoints, shaderModule, pipelineLayouts);
         CHECK_PASS(rewriteGlobalVariables, shaderModule, pipelineLayouts, entryPoints);
 

--- a/Source/WebGPU/WGSL/tests/valid/array-vec3.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/array-vec3.wgsl
@@ -1,0 +1,30 @@
+// RUN: %metal-compile main
+
+@group(0) @binding(0) var<storage, read_write> un: array<vec3f, 1>;
+
+@vertex
+fn main() -> @builtin(position) vec4f {
+  {
+    let x = un[0].x;
+    let y = un[0][1];
+    un[0].x = x;
+    un[0][1] = y;
+  }
+
+  {
+    var v = un[0];
+    let x = v.x;
+    let y = v[1];
+    v.x = x;
+    v[1] = y;
+  }
+
+  {
+    let v = &un[0];
+    let x = v.x;
+    let y = v[1];
+    v.x = x;
+    v[1] = y;
+  }
+  return vec4();
+}


### PR DESCRIPTION
#### 8c16f89f981dd428c469acdcadca90666bf0e67f
<pre>
[WGSL] Cannot access fields of PackedVec3
<a href="https://bugs.webkit.org/show_bug.cgi?id=275175">https://bugs.webkit.org/show_bug.cgi?id=275175</a>
<a href="https://rdar.apple.com/129052933">rdar://129052933</a>

Reviewed by Mike Wyrzykowski.

The current implementation of PackedVec3 wraps a packed_vec&lt;T, 3&gt;, but it doesn&apos;t
provide any means to access the components of the vector. Change it so it matches
the vec/packed_vec interface by having x/y/z members and implementing a subscript
operator.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::getPacking):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::emitNecessaryHelpers):
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::prepareImpl):

Canonical link: <a href="https://commits.webkit.org/279808@main">https://commits.webkit.org/279808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f704ce42736c172beb688058996e972999d223c4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33823 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57692 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5144 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5107 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44062 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3444 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56507 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31967 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47119 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25199 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28774 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3287 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50568 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4660 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59283 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29633 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4778 "Found 1 new test failure: inspector/unit-tests/test-harness-evaluate-in-page.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51487 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30791 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47213 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50854 "Found 3 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11956 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31768 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30583 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->