### PR TITLE
GNOME Discourse page loads forever

### DIFF
--- a/Source/WebKit/UIProcess/PageLoadState.cpp
+++ b/Source/WebKit/UIProcess/PageLoadState.cpp
@@ -448,6 +448,11 @@ void PageLoadState::didFinishProgress(const Transaction::Token& token)
 {
     ASSERT_UNUSED(token, &token.m_pageLoadState == this);
     m_uncommittedState.estimatedProgress = 1;
+
+    // We want PageLoadState::isLoading to return false after loading finishes,
+    // but it won't if there is still a pending API request. It should probably
+    // be cleared prior to this point, but that doesn't always happen.
+    clearPendingAPIRequest(token);
 }
 
 void PageLoadState::setNetworkRequestsInProgress(const Transaction::Token& token, bool networkRequestsInProgress)


### PR DESCRIPTION
#### 72cca2fb140344953f94956bf32ec87f7f551d17
<pre>
GNOME Discourse page loads forever
<a href="https://bugs.webkit.org/show_bug.cgi?id=274727">https://bugs.webkit.org/show_bug.cgi?id=274727</a>

Reviewed by NOBODY (OOPS!).

The problem here is the load actually finishes, but PageLoadState
doesn&apos;t know it has finished because PageLoadState::isLoading always
returns true if there is a pending API request URL. It has to, because
otherwise it would return false immediately after starting a load,
because the default state is Finished.

Normally the pending API request gets unset before the load finishes,
but if it doesn&apos;t, then WebKit will get stuck in the isLoading state.

This fix doesn&apos;t feel particularly satisfying. We should probably also
add a test for this, but I don&apos;t know which conditions trigger the bug.
It requires restoring a page from session state, but that is not
sufficient.

* Source/WebKit/UIProcess/PageLoadState.cpp:
(WebKit::PageLoadState::didFinishProgress):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72cca2fb140344953f94956bf32ec87f7f551d17

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33828 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/6980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57696 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5148 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41361 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5115 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3446 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56511 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/31975 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47123 "Found 1 new API test failure: TestWebKitAPI.SafeBrowsing.WKWebViewGoBackIFrame (failure)") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28779 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3291 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50613 "Found 1 new API test failure: TestWebKitAPI.SafeBrowsing.WKWebViewGoBackIFrame (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59287 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29637 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4776 "Found 1 new test failure: imported/w3c/web-platform-tests/wasm/jsapi/constructor/instantiate.any.worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51490 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30795 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47217 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50859 "Found 6 new API test failures: /WebKitGTK/TestSSL:/webkit/WebKitWebView/load-failed-with-tls-errors, /WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/active-uri, /WebKitGTK/TestLoaderClient:/webkit/WebKitWebView/is-loading, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme, /WebKitGTK/TestAuthentication:/webkit/Authentication/authentication-storage, /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31772 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30587 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->