### PR TITLE
Vary whether to left or right align PGM allocations.

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
@@ -70,6 +70,13 @@ struct pas_pgm_storage {
     uint16_t mem_to_waste;
     uint16_t page_size;
 
+    /*
+     * Alignment direction within the allocated page, if right_align true then
+     * aligned up to "upper_guard page" so could catch overflow
+     * else left_aligned and will start after "lower_guard page" to catch underflow
+     */
+    bool right_align;
+
     pas_large_heap* large_heap;
 };
 

--- a/Source/bmalloc/libpas/src/libpas/pas_report_crash_pgm_report.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_report_crash_pgm_report.h
@@ -45,12 +45,13 @@ extern "C" {
 typedef void *(*crash_reporter_memory_reader_t)(task_t task, vm_address_t address, size_t size);
 
 /* Crash Report Version number. This must be in sync between ReportCrash and libpas to generate a report. */
-const unsigned pas_crash_report_version = 1;
+const unsigned pas_crash_report_version = 2;
 
 /* Report sent back to the ReportCrash process. */
 typedef struct {
     const char *error_type;
     const char *confidence;
+    const char *alignment;
     vm_address_t fault_address;
     size_t allocation_size;
 } pas_report_crash_pgm_report;

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.h
@@ -66,6 +66,7 @@ PAS_BEGIN_EXTERN_C;
 #define PAS_NEVER_INLINE __PAS_NEVER_INLINE
 #define PAS_NO_RETURN __PAS_NO_RETURN
 #define PAS_USED __attribute__((used))
+#define PAS_WARN_UNUSED_RETURN __attribute__((__warn_unused_result__))
 
 #define PAS_COLD /* FIXME: Need some way of triggering cold CC. */
 


### PR DESCRIPTION
#### a2ce7711e418202bd84ca34e529cad3f9f05850e
<pre>
Vary whether to left or right align PGM allocations.
<a href="https://bugs.webkit.org/show_bug.cgi?id=266581">https://bugs.webkit.org/show_bug.cgi?id=266581</a>
<a href="https://rdar.apple.com/107954062">rdar://107954062</a>.

Reviewed by David Kilzer.

Large heap PGM allocations are right aligned to catch overflows by default.
Added the left alignment with random decision in order to catch underflows with equal probability.

* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
(pas_probabilistic_guard_malloc_allocate): Added random decision for left or right alignment.
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h: Added flag in meta data to keep track of alignment for given heap.
/Source/bmalloc/libpas/src/libpas/pas_report_crash.c: Modified the crash reporting based on alignment.
/Source/bmalloc/libpas/src/libpas/pas_report_crash_pgm_report.h: Added alignment info.

Canonical link: <a href="https://commits.webkit.org/279892@main">https://commits.webkit.org/279892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81498458e045f357c32d91d322344b336b3ce1e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54809 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58087 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5540 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5556 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44390 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3747 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56904 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32370 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47483 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25514 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29159 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4819 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3681 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/48176 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50988 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59677 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/54314 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30057 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51813 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31198 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47564 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51230 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32208 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/66610 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8122 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30986 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12692 "Passed tests") | 
<!--EWS-Status-Bubble-End-->