### PR TITLE
In in-window mode, missing PIP when minimizing safari

### DIFF
--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -210,7 +210,7 @@ void FullscreenManager::requestFullscreenForElement(Ref<Element>&& element, RefP
 
         // Don't allow fullscreen if document is hidden.
         auto document = protectedDocument();
-        if (document->hidden()) {
+        if (document->hidden() && mode != HTMLMediaElementEnums::VideoFullscreenModeInWindow) {
             ERROR_LOG(identifier, "task - document hidden; failing.");
             failedPreflights(WTFMove(element), WTFMove(promise));
             completionHandler(false);
@@ -272,7 +272,7 @@ void FullscreenManager::requestFullscreenForElement(Ref<Element>&& element, RefP
             }
 
             auto page = this->page();
-            if (!page || this->document().hidden() || m_pendingFullscreenElement != element.ptr() || !element->isConnected()) {
+            if (!page || (this->document().hidden() && mode != HTMLMediaElementEnums::VideoFullscreenModeInWindow) || m_pendingFullscreenElement != element.ptr() || !element->isConnected()) {
                 ERROR_LOG(identifier, "task - page, document, or element mismatch; failing.");
                 failedPreflights(WTFMove(element), WTFMove(promise));
                 completionHandler(false);

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -7171,7 +7171,7 @@ void HTMLMediaElement::enterFullscreen(VideoFullscreenMode mode)
         if (isContextStopped())
             return;
 
-        if (document().hidden()) {
+        if (document().hidden() && mode != HTMLMediaElementEnums::VideoFullscreenModePictureInPicture) {
             ALWAYS_LOG(logIdentifier, " returning because document is hidden");
             m_changingVideoFullscreenMode = false;
             return;

--- a/Source/WebCore/platform/cocoa/VideoPresentationModel.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModel.h
@@ -128,6 +128,7 @@ public:
     virtual void willExitPictureInPicture() { }
     virtual void didExitPictureInPicture() { }
     virtual void setPlayerIdentifier(std::optional<MediaPlayerIdentifier>) { }
+    virtual void documentVisibilityChanged(bool) { }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
@@ -114,10 +114,12 @@ private:
     void didExitPictureInPicture() final;
 
     static std::span<const AtomString> observedEventNames();
+    static std::span<const AtomString> documentObservedEventNames();
     const AtomString& eventNameAll();
     friend class VideoListener;
     void updateForEventName(const AtomString&);
     void cleanVideoListeners();
+    void documentVisibilityChanged();
 
     Ref<VideoListener> m_videoListener;
     RefPtr<HTMLVideoElement> m_videoElement;
@@ -125,6 +127,7 @@ private:
     bool m_isListening { false };
     HashSet<CheckedPtr<VideoPresentationModelClient>> m_clients;
     bool m_hasVideo { false };
+    bool m_documentIsVisible { true };
     FloatSize m_videoDimensions;
     FloatRect m_videoFrame;
     Vector<RefPtr<TextTrack>> m_legibleTracksForMenu;

--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
@@ -80,6 +80,8 @@ void VideoPresentationModelVideoElement::cleanVideoListeners()
         return;
     for (auto& eventName : observedEventNames())
         m_videoElement->removeEventListener(eventName, m_videoListener, false);
+    for (auto& eventName : documentObservedEventNames())
+        m_videoElement->document().removeEventListener(eventName, m_videoListener, false);
 }
 
 void VideoPresentationModelVideoElement::setVideoElement(HTMLVideoElement* videoElement)
@@ -101,6 +103,8 @@ void VideoPresentationModelVideoElement::setVideoElement(HTMLVideoElement* video
     if (m_videoElement) {
         for (auto& eventName : observedEventNames())
             m_videoElement->addEventListener(eventName, m_videoListener, false);
+        for (auto& eventName : documentObservedEventNames())
+            m_videoElement->document().addEventListener(eventName, m_videoListener, false);
         m_isListening = true;
     }
 
@@ -119,6 +123,9 @@ void VideoPresentationModelVideoElement::updateForEventName(const WTF::AtomStrin
         setHasVideo(m_videoElement);
         setVideoDimensions(m_videoElement ? FloatSize(m_videoElement->videoWidth(), m_videoElement->videoHeight()) : FloatSize());
     }
+
+    if (all || eventName == eventNames().visibilitychangeEvent)
+        documentVisibilityChanged();
 
     if (all
         || eventName == eventNames().loadedmetadataEvent || eventName == eventNames().loadstartEvent) {
@@ -139,6 +146,21 @@ void VideoPresentationModelVideoElement::updateForEventName(const WTF::AtomStrin
             return std::nullopt;
         }());
     }
+}
+
+void VideoPresentationModelVideoElement::documentVisibilityChanged()
+{
+    if (!m_videoElement)
+        return;
+
+    bool isDocumentVisible = !m_videoElement->document().hidden();
+
+    if (isDocumentVisible == m_documentIsVisible)
+        return;
+
+    m_documentIsVisible = isDocumentVisible;
+    for (auto& client : copyToVector(m_clients))
+        client->documentVisibilityChanged(m_documentIsVisible);
 }
 
 void VideoPresentationModelVideoElement::willExitFullscreen()
@@ -242,6 +264,12 @@ void VideoPresentationModelVideoElement::setVideoLayerGravity(MediaPlayer::Video
 std::span<const AtomString> VideoPresentationModelVideoElement::observedEventNames()
 {
     static NeverDestroyed names = std::array { eventNames().resizeEvent, eventNames().loadstartEvent, eventNames().loadedmetadataEvent };
+    return names.get();
+}
+
+std::span<const AtomString> VideoPresentationModelVideoElement::documentObservedEventNames()
+{
+    static NeverDestroyed names = std::array { eventNames().visibilitychangeEvent };
     return names.get();
 }
 

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
@@ -104,6 +104,7 @@ public:
     WEBCORE_EXPORT void requestHideAndExitPiP();
 
     std::optional<MediaPlayerIdentifier> playerIdentifier() const { return m_playerIdentifier; }
+    WEBCORE_EXPORT void documentVisibilityChanged(bool) final;
 
 #if !RELEASE_LOG_DISABLED
     const void* logIdentifier() const;
@@ -120,12 +121,15 @@ private:
     uint32_t ptrCountWithoutThreadCheck() const final { return CanMakeCheckedPtr::ptrCountWithoutThreadCheck(); }
     void incrementPtrCount() const final { CanMakeCheckedPtr::incrementPtrCount(); }
     void decrementPtrCount() const final { CanMakeCheckedPtr::decrementPtrCount(); }
+    void setDocumentBecameVisibleCallback(Function<void()>&& callback) { m_documentBecameVisibleCallback = WTFMove(callback); }
 
     Ref<PlaybackSessionInterfaceMac> m_playbackSessionInterface;
     std::optional<MediaPlayerIdentifier> m_playerIdentifier;
     ThreadSafeWeakPtr<VideoPresentationModel> m_videoPresentationModel;
     HTMLMediaElementEnums::VideoFullscreenMode m_mode { HTMLMediaElementEnums::VideoFullscreenModeNone };
     RetainPtr<WebVideoPresentationInterfaceMacObjC> m_webVideoPresentationInterfaceObjC;
+    bool m_documentIsVisible { true };
+    Function<void()> m_documentBecameVisibleCallback;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -228,6 +228,7 @@ private:
     void setInlineRect(PlaybackSessionContextIdentifier, const WebCore::FloatRect& inlineRect, bool visible);
     void setHasVideoContentLayer(PlaybackSessionContextIdentifier, bool value);
     void setHasVideo(PlaybackSessionContextIdentifier, bool);
+    void setDocumentVisibility(PlaybackSessionContextIdentifier, bool);
     void setVideoDimensions(PlaybackSessionContextIdentifier, const WebCore::FloatSize&);
     void enterFullscreen(PlaybackSessionContextIdentifier);
     void exitFullscreen(PlaybackSessionContextIdentifier, WebCore::FloatRect finalRect, CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in
@@ -23,6 +23,7 @@
 #if ENABLE(VIDEO_PRESENTATION_MODE)
 messages -> VideoPresentationManagerProxy {
     SetHasVideo(WebKit::PlaybackSessionContextIdentifier contextId, bool hasVideo)
+    SetDocumentVisibility(WebKit::PlaybackSessionContextIdentifier contextId, bool isDocumentVisible)
     SetVideoDimensions(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::FloatSize videoDimensions)
     SetupFullscreenWithID(WebKit::PlaybackSessionContextIdentifier contextId, WebKit::LayerHostingContextID videoLayerID, WebCore::FloatRect screenRect, WebCore::FloatSize initialSize, WebCore::FloatSize videoDimensions, float hostingScaleFactor, WebCore::MediaPlayerEnums::VideoFullscreenMode videoFullscreenMode, bool allowsPictureInPicture, bool standby, bool blocksReturnToFullscreenFromPictureInPicture)
     SetPlayerIdentifier(WebKit::PlaybackSessionContextIdentifier contextId, std::optional<WebCore::MediaPlayerIdentifier> playerIdentifier)

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -943,6 +943,15 @@ void VideoPresentationManagerProxy::setHasVideo(PlaybackSessionContextIdentifier
         interface->hasVideoChanged(hasVideo);
 }
 
+void VideoPresentationManagerProxy::setDocumentVisibility(PlaybackSessionContextIdentifier contextId, bool isDocumentVisible)
+{
+    if (m_mockVideoPresentationModeEnabled)
+        return;
+
+    if (auto* interface = findInterface(contextId))
+        interface->documentVisibilityChanged(isDocumentVisible);
+}
+
 void VideoPresentationManagerProxy::setVideoDimensions(PlaybackSessionContextIdentifier contextId, const FloatSize& videoDimensions)
 {
     auto& [model, interface] = ensureModelAndInterface(contextId);

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -103,6 +103,7 @@ public:
 private:
     // VideoPresentationModelClient
     void hasVideoChanged(bool) override;
+    void documentVisibilityChanged(bool) override;
 
     // CheckedPtr interface
     uint32_t ptrCount() const final { return CanMakeCheckedPtr::ptrCount(); }
@@ -178,6 +179,7 @@ protected:
 
     // Interface to VideoPresentationInterfaceContext
     void hasVideoChanged(PlaybackSessionContextIdentifier, bool hasVideo);
+    void documentVisibilityChanged(PlaybackSessionContextIdentifier, bool isDocumentVisible);
     void videoDimensionsChanged(PlaybackSessionContextIdentifier, const WebCore::FloatSize&);
     void setPlayerIdentifier(PlaybackSessionContextIdentifier, std::optional<WebCore::MediaPlayerIdentifier>);
 

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -116,6 +116,12 @@ void VideoPresentationInterfaceContext::hasVideoChanged(bool hasVideo)
         m_manager->hasVideoChanged(m_contextId, hasVideo);
 }
 
+void VideoPresentationInterfaceContext::documentVisibilityChanged(bool isDocumentVisible)
+{
+    if (m_manager)
+        m_manager->documentVisibilityChanged(m_contextId, isDocumentVisible);
+}
+
 void VideoPresentationInterfaceContext::videoDimensionsChanged(const FloatSize& videoDimensions)
 {
     if (m_manager)
@@ -519,6 +525,12 @@ void VideoPresentationManager::hasVideoChanged(PlaybackSessionContextIdentifier 
 {
     if (m_page)
         m_page->send(Messages::VideoPresentationManagerProxy::SetHasVideo(contextId, hasVideo));
+}
+
+void VideoPresentationManager::documentVisibilityChanged(PlaybackSessionContextIdentifier contextId, bool isDocumentVisibile)
+{
+    if (m_page)
+        m_page->send(Messages::VideoPresentationManagerProxy::SetDocumentVisibility(contextId, isDocumentVisibile));
 }
 
 void VideoPresentationManager::videoDimensionsChanged(PlaybackSessionContextIdentifier contextId, const FloatSize& videoDimensions)


### PR DESCRIPTION
#### 2cc2b7b1a74870711aa5ffcac1ac77d890e95b6a
<pre>
In in-window mode, missing PIP when minimizing safari
<a href="https://bugs.webkit.org/show_bug.cgi?id=275182">https://bugs.webkit.org/show_bug.cgi?id=275182</a>
<a href="https://rdar.apple.com/124376686">rdar://124376686</a>

Reviewed by Jer Noble.

Currently when a window is in in-window mode and the safari window
is minimized, safari asks webkit to toggle PIP, but this does
not successfully occur. This is because currently we return early
from HTMLMediaElement::enterFullscreen if the document hidden.
This check has been changed to not return early if the document is
the new mode is PIP.

The above change revealed that we do not successfully return to
in-window mode when the window is maximized again, or when the
PIP return button is clicked.

To fix the case where the window is maximized but the video
does not return to in-window, this patch has us no longer return early
from FullscreenManager::requestFullscreenForElement when the document
is hidden but the new mode is in-window.

To fix the case where the the return button is clicked on the PIP
window and the video does not return to in-window, this patch has
VideoPresentationInterfaceMac wait for the document to become
visible before beginning to exit PIP. To facilitate this,
VideoPresentationModelVideoElement now listens to
visibilitychangeEvent from Document and propagates the information
to VideoPresentationInterfaceMac.

* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::requestFullscreenForElement):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::enterFullscreen):
* Source/WebCore/platform/cocoa/VideoPresentationModel.h:
(WebCore::VideoPresentationModelClient::documentVisibilityChanged):
* Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h:
* Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm:
(WebCore::VideoPresentationModelVideoElement::setVideoElement):
(WebCore::VideoPresentationModelVideoElement::updateForEventName):
(WebCore::VideoPresentationModelVideoElement::documentVisibilityChanged):
(WebCore::VideoPresentationModelVideoElement::documentObservedEventNames):
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h:
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm:
(WebCore::VideoPresentationInterfaceMac::requestHideAndExitPiP):
(WebCore::VideoPresentationInterfaceMac::documentVisibilityChanged):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::setDocumentVisibility):
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationInterfaceContext::documentVisibilityChanged):
(WebKit::VideoPresentationManager::documentVisibilityChanged):

Canonical link: <a href="https://commits.webkit.org/279877@main">https://commits.webkit.org/279877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b8767f19cc35ec1fb34be49dfa5b5fd116ed467

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33974 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7127 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57836 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5289 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56857 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41513 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5291 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44187 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3556 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56650 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32122 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47250 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25309 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28918 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4580 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3429 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50678 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4796 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59426 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29788 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4944 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51611 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30938 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47336 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50986 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31916 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8110 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30726 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->