### PR TITLE
After closing a modal <dialog>, elements can be z-ordered incorrectly

### DIFF
--- a/LayoutTests/fast/layers/layer-order-after-top-layer-expected.html
+++ b/LayoutTests/fast/layers/layer-order-after-top-layer-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <style>
+        .above {
+            position: absolute;
+            left: 20px;
+            top: 20px;
+            width: 400px;
+            height: 300px;
+            padding: 0;
+            margin: 0;
+            background-color: Canvas;
+            color: white;
+            background-color: green;
+        }
+    </style>
+</head>
+<body>
+    <div class="above"></div>
+</body>
+</html>

--- a/LayoutTests/fast/layers/layer-order-after-top-layer.html
+++ b/LayoutTests/fast/layers/layer-order-after-top-layer.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+    <style>
+        
+        dialog, .above {
+            position: absolute;
+            left: 20px;
+            top: 20px;
+            width: 400px;
+            height: 300px;
+            background-color: red;
+            border: none;
+            display: block;
+            padding: 0;
+            margin: 0;
+        }
+
+        dialog {
+            background-color: red;
+            display: block;
+            padding: 0;
+            margin: 0;
+        }
+        
+        .above {
+            position: absolute;
+            left: 20px;
+            top: 20px;
+            width: 400px;
+            height: 300px;
+            padding: 0;
+            margin: 0;
+            background-color: Canvas;
+            color: white;
+            background-color: green;
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        window.addEventListener('load', async () => {
+            document.querySelector("dialog").showModal();
+            await UIHelper.renderingUpdate();
+            document.querySelector("dialog").close();
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, false);        
+    </script>
+</head>
+<body>
+    <dialog></dialog>
+    <div class="above"></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -4032,7 +4032,8 @@ void RenderLayer::establishesTopLayerDidChange()
 {
     if (auto* parentLayer = renderer().layerParent()) {
         setIsNormalFlowOnly(shouldBeNormalFlowOnly());
-        parentLayer->addChild(*this);
+        auto* beforeChild = renderer().layerNextSibling(*parentLayer);
+        parentLayer->addChild(*this, beforeChild);
     }
 }
 


### PR DESCRIPTION
#### 4fef6aeb87184c720ade5901d11df721a966e345
<pre>
After closing a modal &lt;dialog&gt;, elements can be z-ordered incorrectly
<a href="https://bugs.webkit.org/show_bug.cgi?id=275188">https://bugs.webkit.org/show_bug.cgi?id=275188</a>
<a href="https://rdar.apple.com/128899243">rdar://128899243</a>

Reviewed by Antti Koivisto.

When adding or removing an element from the top layer (e.g. for dialog or popups),
`RenderLayer::establishesTopLayerDidChange()` is called. This called `parentLayer-&gt;addChild()`
which re-parents the RenderLayer, but it always appended it to the end of the list. This would
cause adjacent `position:absolute` elements to z-order incorrectly when closing a modal dialog.

* LayoutTests/fast/layers/layer-order-after-top-layer-expected.html: Added.
* LayoutTests/fast/layers/layer-order-after-top-layer.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::establishesTopLayerDidChange):

Canonical link: <a href="https://commits.webkit.org/279785@main">https://commits.webkit.org/279785@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f694946039099c6f2eba79bdccd9c524f72e98f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54551 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33968 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7121 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57828 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5285 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56853 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41508 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5286 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44183 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3552 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56646 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/32119 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47244 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25305 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/28915 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4575 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3423 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4790 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59422 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/29784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/4939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/51604 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30934 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47328 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/50977 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11922 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/31912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/30722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->