### PR TITLE
[WebGPU] GPURenderPipeline can surprisingly be garbage collected

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_275194-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_275194-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: no validation error
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_275194.html
+++ b/LayoutTests/fast/webgpu/regression/repro_275194.html
@@ -1,0 +1,56 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let code = `
+@vertex
+fn v() -> @builtin(position) vec4f {
+  return vec4();
+}
+
+@fragment
+fn f() -> @location(0) vec4f {
+  return vec4();
+}
+`;
+    let module = device.createShaderModule({code});
+    let pipeline = device.createRenderPipeline({
+      layout: device.createPipelineLayout({bindGroupLayouts: []}),
+      vertex: {
+        module,
+        buffers: [],
+      },
+      fragment: {module, targets: [{format: 'bgra8unorm'}]},
+      primitive: {topology: 'point-list'},
+    });
+
+    let texture = device.createTexture({format: 'bgra8unorm', size: [1], usage: GPUTextureUsage.RENDER_ATTACHMENT});
+    let commandEncoder = device.createCommandEncoder();
+    let renderPassEncoder = commandEncoder.beginRenderPass({
+      colorAttachments: [{
+        view: texture.createView(),
+        clearValue: [0, 0, 0, 0],
+        loadOp: 'clear', storeOp: 'store',
+      }],
+    });
+    renderPassEncoder.setPipeline(pipeline);
+    await 0;
+    globalThis.GCController?.collect();
+    renderPassEncoder.draw(1);
+    renderPassEncoder.end();
+    device.queue.submit([commandEncoder.finish()]);
+    await device.queue.onSubmittedWorkDone();
+    let error = await device.popErrorScope();
+    if (error) {
+      log('validation error');
+      log(error.message);
+    } else {
+      log('no validation error');
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/LayoutTests/fast/webgpu/regression/repro_275194b-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_275194b-expected.txt
@@ -1,0 +1,7 @@
+CONSOLE MESSAGE: [object GPURenderPipeline]
+CONSOLE MESSAGE: no validation error
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_275194b.html
+++ b/LayoutTests/fast/webgpu/regression/repro_275194b.html
@@ -1,0 +1,57 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let code = `
+@vertex
+fn v() -> @builtin(position) vec4f {
+  return vec4();
+}
+
+@fragment
+fn f() -> @location(0) vec4f {
+  return vec4();
+}
+`;
+    let module = device.createShaderModule({code});
+    let pipeline = device.createRenderPipeline({
+      layout: device.createPipelineLayout({bindGroupLayouts: []}),
+      vertex: {
+        module,
+        buffers: [],
+      },
+      fragment: {module, targets: [{format: 'bgra8unorm'}]},
+      primitive: {topology: 'point-list'},
+    });
+
+    let texture = device.createTexture({format: 'bgra8unorm', size: [1], usage: GPUTextureUsage.RENDER_ATTACHMENT});
+    let commandEncoder = device.createCommandEncoder();
+    let renderPassEncoder = commandEncoder.beginRenderPass({
+      colorAttachments: [{
+        view: texture.createView(),
+        clearValue: [0, 0, 0, 0],
+        loadOp: 'clear', storeOp: 'store',
+      }],
+    });
+    renderPassEncoder.setPipeline(pipeline);
+    await 0;
+    globalThis.GCController?.collect();
+    renderPassEncoder.draw(1);
+    renderPassEncoder.end();
+    device.queue.submit([commandEncoder.finish()]);
+    await device.queue.onSubmittedWorkDone();
+    log(pipeline);
+    let error = await device.popErrorScope();
+    if (error) {
+      log('validation error');
+      log(error.message);
+    } else {
+      log('no validation error');
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.h
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.h
@@ -99,7 +99,7 @@ private:
     const Ref<Device> m_device;
     MTLSize m_threadsPerThreadgroup;
     Vector<uint32_t> m_computeDynamicOffsets;
-    WeakPtr<const ComputePipeline> m_pipeline;
+    RefPtr<const ComputePipeline> m_pipeline;
     Ref<CommandEncoder> m_parentEncoder;
     HashMap<uint32_t, Vector<uint32_t>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroupDynamicOffsets;
     HashMap<uint32_t, Vector<const BindableResources*>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroupResources;

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -144,7 +144,7 @@ private:
     MTLIndexType m_indexType { MTLIndexTypeUInt16 };
     NSUInteger m_indexBufferOffset { 0 };
     NSUInteger m_indexBufferSize { 0 };
-    WeakPtr<RenderPipeline> m_pipeline;
+    RefPtr<const RenderPipeline> m_pipeline;
     uint32_t m_maxVertexBufferSlot { 0 };
     uint32_t m_maxBindGroupSlot { 0 };
     using UtilizedBufferIndicesContainer = HashMap<uint32_t, uint64_t, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -144,7 +144,7 @@ private:
     MTLIndexType m_indexType { MTLIndexTypeUInt16 };
     NSUInteger m_indexBufferOffset { 0 };
     NSUInteger m_indexBufferSize { 0 };
-    WeakPtr<RenderPipeline> m_pipeline;
+    RefPtr<const RenderPipeline> m_pipeline;
     uint32_t m_maxVertexBufferSlot { 0 };
     uint32_t m_maxBindGroupSlot { 0 };
     MTLPrimitiveType m_primitiveType { MTLPrimitiveTypeTriangle };


### PR DESCRIPTION
#### d4f3388e87ebc7b5a89352a0a80446ade8249bec
<pre>
[WebGPU] GPURenderPipeline can surprisingly be garbage collected
<a href="https://bugs.webkit.org/show_bug.cgi?id=275194">https://bugs.webkit.org/show_bug.cgi?id=275194</a>
&lt;radar://129271876&gt;

Reviewed by Dan Glastonbury.

We should hold a RefPtr and not a WeakPtr since a GC which occurs in the middle
of an encoder can result in the pipeline&apos;s ref count reaching zero.

There is not a risk of a retain cycle as the *Encoders are not retained by
any other objects.

* LayoutTests/fast/webgpu/regression/repro_275194-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_275194.html: Added.
* LayoutTests/fast/webgpu/regression/repro_275194b-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_275194b.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/ComputePassEncoder.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.h:

Canonical link: <a href="https://commits.webkit.org/279795@main">https://commits.webkit.org/279795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27deb3c137b4997665dcef65b64e2dce4f5e7609

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54463 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7027 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57742 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5194 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5184 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44105 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3478 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56558 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32011 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47167 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25241 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-17-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4496 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3337 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4710 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59333 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29690 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4863 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51523 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30841 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47256 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50893 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11929 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31819 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30634 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->