### PR TITLE
[WebGPU] index buffer set on GPURenderPassEncoder can be garbage collected in a surprising fashion

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_275195-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_275195-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: no validation error
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_275195.html
+++ b/LayoutTests/fast/webgpu/regression/repro_275195.html
@@ -1,0 +1,59 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let code = `
+@vertex
+fn v() -> @builtin(position) vec4f {
+  return vec4();
+}
+
+@fragment
+fn f() -> @location(0) vec4f {
+  return vec4();
+}
+`;
+    let module = device.createShaderModule({code});
+    let pipeline = device.createRenderPipeline({
+      layout: device.createPipelineLayout({bindGroupLayouts: []}),
+      vertex: {
+        module,
+        buffers: [],
+      },
+      fragment: {module, targets: [{format: 'bgra8unorm'}]},
+      primitive: {topology: 'point-list'},
+    });
+    globalThis.keep = pipeline;
+
+    let texture = device.createTexture({format: 'bgra8unorm', size: [1], usage: GPUTextureUsage.RENDER_ATTACHMENT});
+    let commandEncoder = device.createCommandEncoder();
+    let renderPassEncoder = commandEncoder.beginRenderPass({
+      colorAttachments: [{
+        view: texture.createView(),
+        clearValue: [0, 0, 0, 0],
+        loadOp: 'clear', storeOp: 'store',
+      }],
+    });
+    let indexBuffer = device.createBuffer({usage: GPUBufferUsage.INDEX, size: 4});
+    renderPassEncoder.setPipeline(pipeline);
+    renderPassEncoder.setIndexBuffer(indexBuffer, 'uint16');
+    await 0;
+    GCController.collect();
+    renderPassEncoder.drawIndexed(1);
+    renderPassEncoder.end();
+    device.queue.submit([commandEncoder.finish()]);
+    await device.queue.onSubmittedWorkDone();
+    let error = await device.popErrorScope();
+    if (error) {
+      log('validation error');
+      log(error.message);
+    } else {
+      log('no validation error');
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/LayoutTests/fast/webgpu/regression/repro_275195b-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_275195b-expected.txt
@@ -1,0 +1,7 @@
+CONSOLE MESSAGE: [object GPUBuffer]
+CONSOLE MESSAGE: no validation error
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_275195b.html
+++ b/LayoutTests/fast/webgpu/regression/repro_275195b.html
@@ -1,0 +1,60 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+    device.pushErrorScope('validation');
+    let code = `
+@vertex
+fn v() -> @builtin(position) vec4f {
+  return vec4();
+}
+
+@fragment
+fn f() -> @location(0) vec4f {
+  return vec4();
+}
+`;
+    let module = device.createShaderModule({code});
+    let pipeline = device.createRenderPipeline({
+      layout: device.createPipelineLayout({bindGroupLayouts: []}),
+      vertex: {
+        module,
+        buffers: [],
+      },
+      fragment: {module, targets: [{format: 'bgra8unorm'}]},
+      primitive: {topology: 'point-list'},
+    });
+    globalThis.keep = pipeline;
+
+    let texture = device.createTexture({format: 'bgra8unorm', size: [1], usage: GPUTextureUsage.RENDER_ATTACHMENT});
+    let commandEncoder = device.createCommandEncoder();
+    let renderPassEncoder = commandEncoder.beginRenderPass({
+      colorAttachments: [{
+        view: texture.createView(),
+        clearValue: [0, 0, 0, 0],
+        loadOp: 'clear', storeOp: 'store',
+      }],
+    });
+    let indexBuffer = device.createBuffer({usage: GPUBufferUsage.INDEX, size: 4});
+    renderPassEncoder.setPipeline(pipeline);
+    renderPassEncoder.setIndexBuffer(indexBuffer, 'uint16');
+    await 0;
+    GCController.collect();
+    renderPassEncoder.drawIndexed(1);
+    renderPassEncoder.end();
+    device.queue.submit([commandEncoder.finish()]);
+    await device.queue.onSubmittedWorkDone();
+    log(indexBuffer);
+    let error = await device.popErrorScope();
+    if (error) {
+      log('validation error');
+      log(error.message);
+    } else {
+      log('no validation error');
+    }
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -140,7 +140,7 @@ private:
     std::pair<uint32_t, uint32_t> computeMininumVertexInstanceCount() const;
 
     const Ref<Device> m_device;
-    WeakPtr<Buffer> m_indexBuffer;
+    RefPtr<Buffer> m_indexBuffer;
     MTLIndexType m_indexType { MTLIndexTypeUInt16 };
     NSUInteger m_indexBufferOffset { 0 };
     NSUInteger m_indexBufferSize { 0 };

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -994,7 +994,7 @@ void RenderBundleEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& gro
 void RenderBundleEncoder::setIndexBuffer(Buffer& buffer, WGPUIndexFormat format, uint64_t offset, uint64_t size)
 {
     RETURN_IF_FINISHED();
-    m_indexBuffer = buffer;
+    m_indexBuffer = &buffer;
     RELEASE_ASSERT(m_indexBuffer);
     m_indexType = format == WGPUIndexFormat_Uint32 ? MTLIndexTypeUInt32 : MTLIndexTypeUInt16;
     m_indexBufferOffset = offset;

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -82,7 +82,7 @@ public:
     void pushDebugGroup(String&& groupLabel);
     void setBindGroup(uint32_t groupIndex, const BindGroup&, uint32_t dynamicOffsetCount, const uint32_t* dynamicOffsets);
     void setBlendConstant(const WGPUColor&);
-    void setIndexBuffer(const Buffer&, WGPUIndexFormat, uint64_t offset, uint64_t size);
+    void setIndexBuffer(Buffer&, WGPUIndexFormat, uint64_t offset, uint64_t size);
     void setPipeline(const RenderPipeline&);
     void setScissorRect(uint32_t x, uint32_t y, uint32_t width, uint32_t height);
     void setStencilReference(uint32_t);
@@ -140,7 +140,7 @@ private:
     };
 
     const Ref<Device> m_device;
-    WeakPtr<Buffer> m_indexBuffer;
+    RefPtr<Buffer> m_indexBuffer;
     MTLIndexType m_indexType { MTLIndexTypeUInt16 };
     NSUInteger m_indexBufferOffset { 0 };
     NSUInteger m_indexBufferSize { 0 };

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -1074,7 +1074,7 @@ void RenderPassEncoder::setBlendConstant(const WGPUColor& color)
     [renderCommandEncoder() setBlendColorRed:color.r green:color.g blue:color.b alpha:color.a];
 }
 
-void RenderPassEncoder::setIndexBuffer(const Buffer& buffer, WGPUIndexFormat format, uint64_t offset, uint64_t size)
+void RenderPassEncoder::setIndexBuffer(Buffer& buffer, WGPUIndexFormat format, uint64_t offset, uint64_t size)
 {
     RETURN_IF_FINISHED();
     if (!isValidToUseWith(buffer, *this)) {
@@ -1097,7 +1097,7 @@ void RenderPassEncoder::setIndexBuffer(const Buffer& buffer, WGPUIndexFormat for
         return;
     }
 
-    m_indexBuffer = buffer;
+    m_indexBuffer = &buffer;
     m_indexBufferSize = size;
     m_indexType = format == WGPUIndexFormat_Uint32 ? MTLIndexTypeUInt32 : MTLIndexTypeUInt16;
     m_indexBufferOffset = offset;


### PR DESCRIPTION
#### 3caf6eb7624dcf98778238644a78775400d29dab
<pre>
[WebGPU] index buffer set on GPURenderPassEncoder can be garbage collected in a surprising fashion
<a href="https://bugs.webkit.org/show_bug.cgi?id=275195">https://bugs.webkit.org/show_bug.cgi?id=275195</a>
&lt;radar://129272040&gt;

Reviewed by Dan Glastonbury.

We should hold a RefPtr and not a WeakPtr since a GC which occurs in the middle
of an encoder can result in the pipeline&apos;s ref count reaching zero.

There is not a risk of a retain cycle as the *Encoders are not retained by
any other objects.

* LayoutTests/fast/webgpu/regression/repro_275195-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_275195.html: Added.
* LayoutTests/fast/webgpu/regression/repro_275195b-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_275195b.html: Added.
* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::setIndexBuffer):
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::setIndexBuffer):

Canonical link: <a href="https://commits.webkit.org/279800@main">https://commits.webkit.org/279800@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06338d970b410d3ae5e58ddc8c5a1b6bf34320c4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7028 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57743 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5195 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5185 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44100 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3479 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56559 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32014 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47169 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25236 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28812 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4498 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3338 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50624 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4712 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59334 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29689 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4864 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51524 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30842 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47258 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50894 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11930 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31820 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30635 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->