### PR TITLE
[visionOS] no VP8 or VP9 available in visionOS VM.

### DIFF
--- a/LayoutTests/media/vp9.html
+++ b/LayoutTests/media/vp9.html
@@ -1,4 +1,4 @@
-<html> <!-- webkit-test-runner [ VP9SWDecoderEnabledOnBattery=true ] -->
+<html> <!-- webkit-test-runner [ SWDecoderAlwaysEnabled=true ] -->
 <body>
 <script src="../resources/testharness.js"></script>
 <script src="../resources/testharnessreport.js"></script>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5502,6 +5502,18 @@ SKAttributionEnabled:
     WebKit:
       default: true
 
+SWVPDecodersAlwaysEnabled:
+  type: bool
+  status: internal
+  category: media
+  humanReadableName: "Always enable VPx software decoders"
+  humanReadableDescription: "Always enable VPx software decoders"
+  webcoreBinding: none
+  condition: ENABLE(VP9)
+  defaultValue:
+    WebKit:
+      default: false
+
 SafeBrowsingEnabled:
   type: bool
   status: embedder
@@ -7049,18 +7061,6 @@ VP9DecoderEnabled:
       default: false
     WebKit:
       default: true
-
-VP9SWDecoderEnabledOnBattery:
-  type: bool
-  status: internal
-  category: media
-  humanReadableName: "VP9 SW decoder on battery"
-  humanReadableDescription: "Enable VP9 SW decoder on battery"
-  webcoreBinding: none
-  condition: ENABLE(VP9)
-  defaultValue:
-    WebKit:
-      default: false
 
 VerifyWindowOpenUserGestureFromUIProcess:
   type: bool

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -31,6 +31,9 @@
 #include "Logging.h"
 #include "NowPlayingInfo.h"
 #include "PlatformMediaSession.h"
+#if PLATFORM(COCOA)
+#include "VP9UtilitiesCocoa.h"
+#endif
 
 namespace WebCore {
 
@@ -59,7 +62,7 @@ bool PlatformMediaSessionManager::s_useSCContentSharingPicker;
 #if ENABLE(VP9)
 bool PlatformMediaSessionManager::m_vp9DecoderEnabled;
 bool PlatformMediaSessionManager::m_vp8DecoderEnabled;
-bool PlatformMediaSessionManager::m_vp9SWDecoderEnabled;
+bool PlatformMediaSessionManager::m_swVPDecodersAlwaysEnabled;
 #endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)
@@ -813,14 +816,17 @@ bool PlatformMediaSessionManager::shouldEnableVP8Decoder()
     return m_vp8DecoderEnabled;
 }
 
-void PlatformMediaSessionManager::setShouldEnableVP9SWDecoder(bool vp9SWDecoderEnabled)
+void PlatformMediaSessionManager::setSWVPDecodersAlwaysEnabled(bool swVPDecodersAlwaysEnabled)
 {
-    m_vp9SWDecoderEnabled = vp9SWDecoderEnabled;
+    m_swVPDecodersAlwaysEnabled = swVPDecodersAlwaysEnabled;
+#if PLATFORM(COCOA)
+    VP9TestingOverrides::singleton().setSWVPDecodersAlwaysEnabled(swVPDecodersAlwaysEnabled);
+#endif
 }
 
-bool PlatformMediaSessionManager::shouldEnableVP9SWDecoder()
+bool PlatformMediaSessionManager::swVPDecodersAlwaysEnabled()
 {
-    return m_vp9SWDecoderEnabled;
+    return m_swVPDecodersAlwaysEnabled;
 }
 #endif // ENABLE(VP9)
 

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
@@ -74,8 +74,8 @@ public:
     WEBCORE_EXPORT static bool shouldEnableVP9Decoder();
     WEBCORE_EXPORT static void setShouldEnableVP8Decoder(bool);
     WEBCORE_EXPORT static bool shouldEnableVP8Decoder();
-    WEBCORE_EXPORT static void setShouldEnableVP9SWDecoder(bool);
-    WEBCORE_EXPORT static bool shouldEnableVP9SWDecoder();
+    WEBCORE_EXPORT static void setSWVPDecodersAlwaysEnabled(bool);
+    WEBCORE_EXPORT static bool swVPDecodersAlwaysEnabled();
 #endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)
@@ -278,7 +278,7 @@ private:
 #if ENABLE(VP9)
     static bool m_vp9DecoderEnabled;
     static bool m_vp8DecoderEnabled;
-    static bool m_vp9SWDecoderEnabled;
+    static bool m_swVPDecodersAlwaysEnabled;
 #endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -74,10 +74,11 @@ void MediaSessionManagerCocoa::ensureCodecsRegistered()
     dispatch_once(&onceToken, ^{
         if (shouldEnableVP9Decoder())
             registerSupplementalVP9Decoder();
-        if (shouldEnableVP8Decoder())
-            registerWebKitVP8Decoder();
-        if (shouldEnableVP9SWDecoder())
+        if (swVPDecodersAlwaysEnabled()) {
             registerWebKitVP9Decoder();
+            registerWebKitVP8Decoder();
+        } else if (shouldEnableVP8Decoder())
+            registerWebKitVP8Decoder();
     });
 #endif
 }

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h
@@ -74,20 +74,24 @@ public:
     static VP9TestingOverrides& singleton();
 
     void setHardwareDecoderDisabled(std::optional<bool>&&);
-    std::optional<bool> hardwareDecoderDisabled() { return m_hardwareDecoderDisabled; }
+    std::optional<bool> hardwareDecoderDisabled() const { return m_hardwareDecoderDisabled; }
     
     void setVP9DecoderDisabled(std::optional<bool>&&);
-    std::optional<bool> vp9DecoderDisabled() { return m_vp9DecoderDisabled; }
+    std::optional<bool> vp9DecoderDisabled() const { return m_vp9DecoderDisabled; }
 
     void setVP9ScreenSizeAndScale(std::optional<ScreenDataOverrides>&&);
-    std::optional<ScreenDataOverrides> vp9ScreenSizeAndScale()  { return m_screenSizeAndScale; }
+    std::optional<ScreenDataOverrides> vp9ScreenSizeAndScale() const { return m_screenSizeAndScale; }
 
     void setConfigurationChangedCallback(std::function<void(bool)>&&);
     void resetOverridesToDefaultValues();
 
+    void setSWVPDecodersAlwaysEnabled(bool);
+    bool swVPDecodersAlwaysEnabled() const { return m_swVPDecodersAlwaysEnabled; }
+
 private:
     std::optional<bool> m_hardwareDecoderDisabled;
     std::optional<bool> m_vp9DecoderDisabled;
+    bool m_swVPDecodersAlwaysEnabled { false };
     std::optional<ScreenDataOverrides> m_screenSizeAndScale;
     Function<void(bool)> m_configurationChangedCallback;
 };

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
@@ -70,6 +70,12 @@ void VP9TestingOverrides::setVP9DecoderDisabled(std::optional<bool>&& disabled)
         m_configurationChangedCallback(false);
 }
 
+void VP9TestingOverrides::setSWVPDecodersAlwaysEnabled(bool enabled)
+{
+    m_swVPDecodersAlwaysEnabled = enabled;
+    // We don't call the configurationChangedCallback to prevent unnecessarily starting the GPU process.
+}
+
 void VP9TestingOverrides::setVP9ScreenSizeAndScale(std::optional<ScreenDataOverrides>&& overrides)
 {
     m_screenSizeAndScale = WTFMove(overrides);
@@ -138,10 +144,15 @@ void registerSupplementalVP9Decoder()
         softLink_VideoToolbox_VTRegisterSupplementalVideoDecoderIfAvailable(kCMVideoCodecType_VP9);
 }
 
+static bool isSWDecodersAlwaysEnabled()
+{
+    return VP9TestingOverrides::singleton().swVPDecodersAlwaysEnabled();
+}
+
 bool isVP9DecoderAvailable()
 {
-    if (auto disabledForTesting = VP9TestingOverrides::singleton().vp9DecoderDisabled())
-        return !*disabledForTesting;
+    if (isSWDecodersAlwaysEnabled())
+        return true;
 
 #if PLATFORM(IOS) || PLATFORM(VISION)
     return canLoad_VideoToolbox_VTIsHardwareDecodeSupported() && VTIsHardwareDecodeSupported(kCMVideoCodecType_VP9);
@@ -154,6 +165,8 @@ bool isVP9DecoderAvailable()
 
 bool isVP8DecoderAvailable()
 {
+    if (isSWDecodersAlwaysEnabled())
+        return true;
     if (!VideoToolboxLibrary(true))
         return false;
     return noErr == VTSelectAndCreateVideoDecoderInstance('vp08', kCFAllocatorDefault, nullptr, nullptr);
@@ -187,6 +200,9 @@ static bool isVP9CodecConfigurationRecordSupported(const VPCodecConfigurationRec
     // HW & SW VP9 Decoders support up to Level 6:
     if (codecConfiguration.level > VPConfigurationLevel::Level_6)
         return false;
+
+    if (isSWDecodersAlwaysEnabled())
+        return true;
 
     // Hardware decoders are always available.
     if (vp9HardwareDecoderAvailable())
@@ -314,6 +330,11 @@ std::optional<MediaCapabilitiesInfo> computeVPParameters(const VideoConfiguratio
     // FIXME: Add a lookup table for device-to-capabilities. For now, assume that the SW VP9
     // decoder can support 4K @ 30.
     info.smooth = isVPSoftwareDecoderSmooth(videoConfiguration);
+
+    if (isSWDecodersAlwaysEnabled()) {
+        info.supported = true;
+        return info;
+    }
 
     // For wall-powered devices, always report VP9 as supported, even if not powerEfficient.
     if (!systemHasBattery()) {

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -360,12 +360,19 @@ void GPUProcess::updateGPUProcessPreferences(GPUProcessPreferences&& preferences
         }
 #endif
     }
-    if (updatePreference(m_preferences.vp9SWDecoderEnabled, preferences.vp9SWDecoderEnabled)) {
-        PlatformMediaSessionManager::setShouldEnableVP9SWDecoder(*m_preferences.vp9SWDecoderEnabled);
+    if (preferences.swVPDecodersAlwaysEnabled != std::exchange(m_preferences.swVPDecodersAlwaysEnabled, preferences.swVPDecodersAlwaysEnabled)) {
+        PlatformMediaSessionManager::setSWVPDecodersAlwaysEnabled(m_preferences.swVPDecodersAlwaysEnabled);
 #if PLATFORM(COCOA)
-        if (!m_haveEnabledVP9SWDecoder && *m_preferences.vp9SWDecoderEnabled) {
-            m_haveEnabledVP9SWDecoder = true;
-            WebCore::registerWebKitVP9Decoder();
+        if (!m_haveEnabledSWVPDecoders && m_preferences.swVPDecodersAlwaysEnabled) {
+            m_haveEnabledSWVPDecoders = true;
+            if (!m_haveEnabledVP9Decoder) {
+                WebCore::registerWebKitVP9Decoder();
+                m_haveEnabledVP9Decoder = true;
+            }
+            if (!m_haveEnabledVP8Decoder) {
+                WebCore::registerWebKitVP8Decoder();
+                m_haveEnabledVP8Decoder = true;
+            }
         }
 #endif
     }

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -244,7 +244,7 @@ private:
 #if ENABLE(VP9) && PLATFORM(COCOA)
     bool m_haveEnabledVP8Decoder { false };
     bool m_haveEnabledVP9Decoder { false };
-    bool m_haveEnabledVP9SWDecoder { false };
+    bool m_haveEnabledSWVPDecoders { false };
 #endif
 
 };

--- a/Source/WebKit/GPUProcess/GPUProcessPreferences.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcessPreferences.cpp
@@ -81,14 +81,10 @@ void GPUProcessPreferences::copyEnabledWebPreferences(const WebPreferences& webP
 #if ENABLE(VP9)
     if (webPreferences.vp8DecoderEnabled())
         vp8DecoderEnabled = true;
-    if (webPreferences.vp9DecoderEnabled()) {
+    if (webPreferences.vp9DecoderEnabled())
         vp9DecoderEnabled = true;
-#if PLATFORM(COCOA)
-        if (!WebCore::systemHasBattery() || webPreferences.vp9SWDecoderEnabledOnBattery())
-            vp9SWDecoderEnabled = true;
-#endif
-
-    }
+    if (webPreferences.sWVPDecodersAlwaysEnabled())
+        swVPDecodersAlwaysEnabled = true;
 #endif
 }
 

--- a/Source/WebKit/GPUProcess/GPUProcessPreferences.h
+++ b/Source/WebKit/GPUProcess/GPUProcessPreferences.h
@@ -75,7 +75,7 @@ struct GPUProcessPreferences {
 #if ENABLE(VP9)
     std::optional<bool> vp8DecoderEnabled;
     std::optional<bool> vp9DecoderEnabled;
-    std::optional<bool> vp9SWDecoderEnabled;
+    bool swVPDecodersAlwaysEnabled { false };
 #endif
 };
 

--- a/Source/WebKit/GPUProcess/GPUProcessPreferences.serialization.in
+++ b/Source/WebKit/GPUProcess/GPUProcessPreferences.serialization.in
@@ -53,7 +53,7 @@ struct WebKit::GPUProcessPreferences {
 #if ENABLE(VP9)
     std::optional<bool> vp8DecoderEnabled;
     std::optional<bool> vp9DecoderEnabled;
-    std::optional<bool> vp9SWDecoderEnabled;
+    bool swVPDecodersAlwaysEnabled;
 #endif
 };
 

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -289,7 +289,6 @@ struct WebPageCreationParameters {
 #endif
     bool shouldEnableVP8Decoder { false };
     bool shouldEnableVP9Decoder { false };
-    bool shouldEnableVP9SWDecoder { false };
 #if ENABLE(APP_BOUND_DOMAINS)
     bool limitsNavigationsToAppBoundDomains { false };
 #endif

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -217,7 +217,6 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
 #endif
     bool shouldEnableVP8Decoder;
     bool shouldEnableVP9Decoder;
-    bool shouldEnableVP9SWDecoder;
 #if ENABLE(APP_BOUND_DOMAINS)
     bool limitsNavigationsToAppBoundDomains;
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10442,8 +10442,6 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
 #if ENABLE(VP9) && PLATFORM(COCOA)
     // FIXME: This is also being passed over the to WebProcess via the PreferencesStore.
     parameters.shouldEnableVP8Decoder = preferences().vp8DecoderEnabled();
-    // FIXME: This is also being passed over the to WebProcess via the PreferencesStore.
-    parameters.shouldEnableVP9SWDecoder = preferences().vp9DecoderEnabled() && (!WebCore::systemHasBattery() || preferences().vp9SWDecoderEnabledOnBattery());
 #endif
     parameters.shouldCaptureDisplayInUIProcess = m_process->processPool().configuration().shouldCaptureDisplayInUIProcess();
     parameters.shouldCaptureDisplayInGPUProcess = preferences().useGPUProcessForDisplayCapture();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1031,7 +1031,6 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 #if ENABLE(VP9)
     PlatformMediaSessionManager::setShouldEnableVP8Decoder(parameters.shouldEnableVP8Decoder);
     PlatformMediaSessionManager::setShouldEnableVP9Decoder(parameters.shouldEnableVP9Decoder);
-    PlatformMediaSessionManager::setShouldEnableVP9SWDecoder(parameters.shouldEnableVP9SWDecoder);
 #endif
 
     m_page->setCanUseCredentialStorage(parameters.canUseCredentialStorage);
@@ -4819,6 +4818,10 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
 
 #if ENABLE(OPUS)
     PlatformMediaSessionManager::setOpusDecoderEnabled(DeprecatedGlobalSettings::opusDecoderEnabled());
+#endif
+
+#if ENABLE(VP9)
+    PlatformMediaSessionManager::setSWVPDecodersAlwaysEnabled(store.getBoolValueForKey(WebPreferencesKey::sWVPDecodersAlwaysEnabledKey()));
 #endif
 
     // FIXME: This should be automated by adding a new field in WebPreferences*.yaml


### PR DESCRIPTION
#### 77966f5b8e272f8b790a223fc21c036dcf857b1c
<pre>
[visionOS] no VP8 or VP9 available in visionOS VM.
<a href="https://bugs.webkit.org/show_bug.cgi?id=275204">https://bugs.webkit.org/show_bug.cgi?id=275204</a>
<a href="https://rdar.apple.com/129329733">rdar://129329733</a>

Reviewed by Youenn Fablet.

VP8 and VP9 codecs are currently not available on visionOS VM making testing difficult.
The actual hardware has HW acceleration for VP9 and VP8 is available in VideoToolbox.

We add an internal web preference to always enable software decoders.
On machines with no VP8/VP9 decoder we will fallback on the WebCoreDecompressionSession and
the WebRTC software decoders.

There&apos;s no current testing infrastructure for this configuration.
The underlying bug is tracked under
<a href="https://rdar.apple.com/129329733">rdar://129329733</a>

* LayoutTests/media/vp9.html: rename preference.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::setSWDecoderAlwaysEnabled):
(WebCore::PlatformMediaSessionManager::swDecoderAlwaysEnabled):
(WebCore::PlatformMediaSessionManager::setShouldEnableVP9SWDecoder): Deleted.
(WebCore::PlatformMediaSessionManager::shouldEnableVP9SWDecoder): Deleted.
* Source/WebCore/platform/audio/PlatformMediaSessionManager.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::ensureCodecsRegistered):
* Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.h:
* Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm:
(WebCore::VP9TestingOverrides::setSWDecoderAlwaysEnabled):
(WebCore::isSWDecoderAlwaysEnabled):
(WebCore::isVP9DecoderAvailable):
(WebCore::isVP8DecoderAvailable):
(WebCore::isVP9CodecConfigurationRecordSupported):
(WebCore::computeVPParameters):
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::updateGPUProcessPreferences):
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/GPUProcessPreferences.cpp:
(WebKit::GPUProcessPreferences::copyEnabledWebPreferences):
* Source/WebKit/GPUProcess/GPUProcessPreferences.h:
* Source/WebKit/GPUProcess/GPUProcessPreferences.serialization.in:
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_unifiedTextReplacementController):

Canonical link: <a href="https://commits.webkit.org/279806@main">https://commits.webkit.org/279806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/350c90d790c0e66ff8baa8ab0a8e73bb83edddd9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54610 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57891 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5344 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56912 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5347 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44229 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3600 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56705 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32174 "Found 60 new test failures: accessibility/accessibility-node-reparent.html accessibility/ancestor-computation.html accessibility/announcement-notification.html accessibility/aria-braillelabel.html accessibility/aria-brailleroledescription.html accessibility/aria-checked-mixed-value.html accessibility/aria-current-state-changed-notification.html accessibility/aria-current.html accessibility/aria-describedby-on-input.html accessibility/aria-description.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47301 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25355 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28978 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4632 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3484 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/47975 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4848 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59481 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/54117 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29845 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4987 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51653 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30993 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47387 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51030 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11954 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31973 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/66414 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30781 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12663 "Passed tests") | 
<!--EWS-Status-Bubble-End-->