### PR TITLE
CSS transition on SVG inside href fails when link already visited

### DIFF
--- a/LayoutTests/transitions/svg-visited-fill-expected.html
+++ b/LayoutTests/transitions/svg-visited-fill-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      a .svg1 {
+        fill: rgb(100, 100, 0);
+      }
+      a .svg2 {
+        fill: rgb(100, 0, 100);
+      }
+    </style>
+  </head>
+  <body onload="test()">
+    <a href="">
+      <svg class="svg1" height="24" width="24" viewBox="0 0 24 24">
+          <rect width="200" height="100" x="10" y="10"/>
+      </svg>
+      <svg class="svg2" height="24" width="24" viewBox="0 0 24 24">
+          <rect width="200" height="100" x="10" y="10"/>
+      </svg>
+    </a>
+  </body>
+</html>

--- a/LayoutTests/transitions/svg-visited-fill.html
+++ b/LayoutTests/transitions/svg-visited-fill.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      a.transition .svg1 {
+        fill: rgb(0, 200, 0);
+      }
+      a.transition:visited .svg2 {
+        fill: rgb(0, 0, 200);
+      }
+      .svg1, .svg2 {
+        transition: fill 100s steps(2, jump-start);
+        fill: rgb(200, 0, 0);
+      }
+    </style>
+  </head>
+  <body onload="test()">
+    <a href="">
+      <svg class="svg1" height="24" width="24" viewBox="0 0 24 24">
+          <rect width="200" height="100" x="10" y="10"/>
+      </svg>
+      <svg class="svg2" height="24" width="24" viewBox="0 0 24 24">
+          <rect width="200" height="100" x="10" y="10"/>
+      </svg>
+    </a>
+    <script>
+    function test() {
+        document.querySelector("a").classList.add("transition");
+    }
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1650,16 +1650,22 @@ public:
     inline SVGRenderStyle& accessSVGStyle();
 
     inline SVGPaintType fillPaintType() const;
-    inline StyleColor fillPaintColor() const;
+    inline SVGPaintType visitedFillPaintType() const;
+    inline const StyleColor& fillPaintColor() const;
+    inline const StyleColor& visitedFillPaintColor() const;
     inline void setFillPaintColor(const StyleColor&);
+    inline void setVisitedFillPaintColor(const StyleColor&);
     inline void setHasExplicitlySetColor(bool);
     inline bool hasExplicitlySetColor() const;
     inline float fillOpacity() const;
     inline void setFillOpacity(float);
 
     inline SVGPaintType strokePaintType() const;
-    inline StyleColor strokePaintColor() const;
+    inline SVGPaintType visitedStrokePaintType() const;
+    inline const StyleColor& strokePaintColor() const;
+    inline const StyleColor& visitedStrokePaintColor() const;
     inline void setStrokePaintColor(const StyleColor&);
+    inline void setVisitedStrokePaintColor(const StyleColor&);
     inline float strokeOpacity() const;
     inline void setStrokeOpacity(float);
     inline Vector<SVGLengthValue> strokeDashArray() const;

--- a/Source/WebCore/rendering/style/SVGRenderStyle.h
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.h
@@ -109,9 +109,9 @@ public:
     void setY(const Length&);
     void setD(RefPtr<BasicShapePath>&&);
     void setFillOpacity(float);
-    void setFillPaint(SVGPaintType, const StyleColor&, const String& uri, bool applyToRegularStyle = true, bool applyToVisitedLinkStyle = false);
+    void setFillPaint(SVGPaintType, const StyleColor&, const String& uri, bool applyToRegularStyle, bool applyToVisitedLinkStyle);
     void setStrokeOpacity(float);
-    void setStrokePaint(SVGPaintType, const StyleColor&, const String& uri, bool applyToRegularStyle = true, bool applyToVisitedLinkStyle = false);
+    void setStrokePaint(SVGPaintType, const StyleColor&, const String& uri, bool applyToRegularStyle, bool applyToVisitedLinkStyle);
 
     void setStrokeDashArray(const Vector<SVGLengthValue>&);
     void setStrokeDashOffset(const Length&);
@@ -247,8 +247,10 @@ inline const Length& RenderStyle::cx() const { return svgStyle().cx(); }
 inline const Length& RenderStyle::cy() const { return svgStyle().cy(); }
 inline BasicShapePath* RenderStyle::d() const { return svgStyle().d(); }
 inline float RenderStyle::fillOpacity() const { return svgStyle().fillOpacity(); }
-inline StyleColor RenderStyle::fillPaintColor() const { return svgStyle().fillPaintColor(); }
+inline const StyleColor& RenderStyle::fillPaintColor() const { return svgStyle().fillPaintColor(); }
+inline const StyleColor& RenderStyle::visitedFillPaintColor() const { return svgStyle().visitedLinkFillPaintColor(); }
 inline SVGPaintType RenderStyle::fillPaintType() const { return svgStyle().fillPaintType(); }
+inline SVGPaintType RenderStyle::visitedFillPaintType() const { return svgStyle().visitedLinkFillPaintType(); }
 inline const StyleColor& RenderStyle::floodColor() const { return svgStyle().floodColor(); }
 inline float RenderStyle::floodOpacity() const { return svgStyle().floodOpacity(); }
 inline bool RenderStyle::hasExplicitlySetStrokeWidth() const { return m_rareInheritedData->hasSetStrokeWidth; }
@@ -263,7 +265,9 @@ inline void RenderStyle::setCx(Length&& cx) { accessSVGStyle().setCx(WTFMove(cx)
 inline void RenderStyle::setCy(Length&& cy) { accessSVGStyle().setCy(WTFMove(cy)); }
 inline void RenderStyle::setD(RefPtr<BasicShapePath>&& d) { accessSVGStyle().setD(WTFMove(d)); }
 inline void RenderStyle::setFillOpacity(float f) { accessSVGStyle().setFillOpacity(f); }
-inline void RenderStyle::setFillPaintColor(const StyleColor& color) { accessSVGStyle().setFillPaint(SVGPaintType::RGBColor, color, emptyString()); }
+inline void RenderStyle::setFillPaintColor(const StyleColor& color) { accessSVGStyle().setFillPaint(SVGPaintType::RGBColor, color, emptyString(), true, false); }
+inline void RenderStyle::setVisitedFillPaintColor(const StyleColor& color) { accessSVGStyle().setFillPaint(SVGPaintType::RGBColor, color, emptyString(), false, true); }
+
 inline void RenderStyle::setFloodColor(const StyleColor& c) { accessSVGStyle().setFloodColor(c); }
 inline void RenderStyle::setFloodOpacity(float f) { accessSVGStyle().setFloodOpacity(f); }
 inline void RenderStyle::setKerning(SVGLengthValue k) { accessSVGStyle().setKerning(k); }
@@ -276,7 +280,8 @@ inline void RenderStyle::setStopOpacity(float f) { accessSVGStyle().setStopOpaci
 inline void RenderStyle::setStrokeDashArray(Vector<SVGLengthValue> array) { accessSVGStyle().setStrokeDashArray(array); }
 inline void RenderStyle::setStrokeDashOffset(Length&& d) { accessSVGStyle().setStrokeDashOffset(WTFMove(d)); }
 inline void RenderStyle::setStrokeOpacity(float f) { accessSVGStyle().setStrokeOpacity(f); }
-inline void RenderStyle::setStrokePaintColor(const StyleColor& color) { accessSVGStyle().setStrokePaint(SVGPaintType::RGBColor, color, emptyString()); }
+inline void RenderStyle::setStrokePaintColor(const StyleColor& color) { accessSVGStyle().setStrokePaint(SVGPaintType::RGBColor, color, emptyString(), true, false); }
+inline void RenderStyle::setVisitedStrokePaintColor(const StyleColor& color) { accessSVGStyle().setStrokePaint(SVGPaintType::RGBColor, color, emptyString(), false, true); }
 inline void RenderStyle::setX(Length&& x) { accessSVGStyle().setX(WTFMove(x)); }
 inline void RenderStyle::setY(Length&& y) { accessSVGStyle().setY(WTFMove(y)); }
 inline const StyleColor& RenderStyle::stopColor() const { return svgStyle().stopColor(); }
@@ -284,8 +289,10 @@ inline float RenderStyle::stopOpacity() const { return svgStyle().stopOpacity();
 inline Vector<SVGLengthValue> RenderStyle::strokeDashArray() const { return svgStyle().strokeDashArray(); }
 inline const Length& RenderStyle::strokeDashOffset() const { return svgStyle().strokeDashOffset(); }
 inline float RenderStyle::strokeOpacity() const { return svgStyle().strokeOpacity(); }
-inline StyleColor RenderStyle::strokePaintColor() const { return svgStyle().strokePaintColor(); }
+inline const StyleColor& RenderStyle::strokePaintColor() const { return svgStyle().strokePaintColor(); }
+inline const StyleColor& RenderStyle::visitedStrokePaintColor() const { return svgStyle().visitedLinkStrokePaintColor(); }
 inline SVGPaintType RenderStyle::strokePaintType() const { return svgStyle().strokePaintType(); }
+inline SVGPaintType RenderStyle::visitedStrokePaintType() const { return svgStyle().visitedLinkStrokePaintType(); }
 inline const Length& RenderStyle::strokeWidth() const { return m_rareInheritedData->strokeWidth; }
 inline const Length& RenderStyle::x() const { return svgStyle().x(); }
 inline const Length& RenderStyle::y() const { return svgStyle().y(); }


### PR DESCRIPTION
#### 969e1262811073faa52aa31cbceea18ef64183d8
<pre>
CSS transition on SVG inside href fails when link already visited
<a href="https://bugs.webkit.org/show_bug.cgi?id=267515">https://bugs.webkit.org/show_bug.cgi?id=267515</a>
<a href="https://rdar.apple.com/121015467">rdar://121015467</a>

Reviewed by Antoine Quint.

* LayoutTests/transitions/svg-visited-fill-expected.html: Added.
* LayoutTests/transitions/svg-visited-fill.html: Added.
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::PropertyWrapperVisitedAffectedSVGPaint::PropertyWrapperVisitedAffectedSVGPaint):
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):

Add an animation property wrapper for visited-affected fill/stroke similar to other color properties and use it.

* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/SVGRenderStyle.h:
(WebCore::RenderStyle::fillPaintColor const):
(WebCore::RenderStyle::visitedFillPaintColor const):
(WebCore::RenderStyle::visitedFillPaintType const):
(WebCore::RenderStyle::setFillPaintColor):
(WebCore::RenderStyle::setVisitedFillPaintColor):
(WebCore::RenderStyle::setStrokePaintColor):
(WebCore::RenderStyle::setVisitedStrokePaintColor):
(WebCore::RenderStyle::strokePaintColor const):
(WebCore::RenderStyle::visitedStrokePaintColor const):
(WebCore::RenderStyle::visitedStrokePaintType const):

Expose some helpers for the property wrapper.

Canonical link: <a href="https://commits.webkit.org/279807@main">https://commits.webkit.org/279807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc4192a79223c1e65c62f296bd40eb7a588b9e34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34027 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7185 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57889 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5342 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56910 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5345 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44230 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3597 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56703 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32172 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47302 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25356 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28969 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4633 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3482 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4849 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59479 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29843 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4985 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51652 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30991 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47388 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51029 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11947 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31970 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30779 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->