### PR TITLE
[InteractionRegions] Highlight container instead of shape when it can improve visibility

### DIFF
--- a/LayoutTests/interaction-region/svg-luminance-expected.txt
+++ b/LayoutTests/interaction-region/svg-luminance-expected.txt
@@ -1,0 +1,47 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (guard (30.50,30) width=40 height=43),
+        (guard (30.27,24.53) width=21.33 height=36),
+        (interaction (30.27,34.53) width=21.33 height=16)
+        (clipPath move to (1.20,0), add line to (20.13,0), add curve to (20.80,0) (21.33,0.54) (21.33,1.20), add line to (21.33,14.80), add curve to (21.33,15.46) (20.80,16) (20.13,16), add line to (1.20,16), add curve to (0.54,16) (0,15.46) (0,14.80), add line to (0,1.20), add curve to (0,0.54) (0.54,0) (1.20,0), close subpath),
+        (guard (147,30) width=40 height=43),
+        (guard (147.27,24.53) width=21.33 height=36),
+        (interaction (147.27,34.53) width=21.33 height=16)
+        (clipPath move to (1.20,0), add line to (20.13,0), add curve to (20.80,0) (21.33,0.54) (21.33,1.20), add line to (21.33,14.80), add curve to (21.33,15.46) (20.80,16) (20.13,16), add line to (1.20,16), add curve to (0.54,16) (0,15.46) (0,14.80), add line to (0,1.20), add curve to (0,0.54) (0.54,0) (1.20,0), close subpath),
+        (interaction (263.50,30) width=40 height=43)
+        (cornerRadius 8.00),
+        (interaction (380,30) width=40 height=43)
+        (cornerRadius 8.00),
+        (interaction (496.50,30) width=40 height=43)
+        (cornerRadius 8.00),
+        (guard (613,30) width=40 height=43),
+        (guard (613.27,24.53) width=21.33 height=36),
+        (interaction (613.27,34.53) width=21.33 height=16)
+        (clipPath move to (1.20,0), add line to (20.13,0), add curve to (20.80,0) (21.33,0.54) (21.33,1.20), add line to (21.33,14.80), add curve to (21.33,15.46) (20.80,16) (20.13,16), add line to (1.20,16), add curve to (0.54,16) (0,15.46) (0,14.80), add line to (0,1.20), add curve to (0,0.54) (0.54,0) (1.20,0), close subpath),
+        (interaction (699.50,0) width=100 height=103)
+        (cornerRadius 8.00),
+        (guard (0.50,119) width=100 height=103),
+        (interaction (0.67,130.33) width=53.33 height=40)
+        (clipPath move to (3,0), add line to (50.33,0), add curve to (51.99,0) (53.33,1.34) (53.33,3), add line to (53.33,37), add curve to (53.33,38.66) (51.99,40) (50.33,40), add line to (3,40), add curve to (1.34,40) (0,38.66) (0,37), add line to (0,3), add curve to (0,1.34) (1.34,0) (3,0), close subpath),
+        (guard (127,129) width=80 height=83),
+        (interaction (127.53,138.07) width=42.67 height=32)
+        (clipPath move to (2.40,0), add line to (40.27,0), add curve to (41.59,0) (42.67,1.07) (42.67,2.40), add line to (42.67,29.60), add curve to (42.67,30.93) (41.59,32) (40.27,32), add line to (2.40,32), add curve to (1.07,32) (0,30.93) (0,29.60), add line to (0,2.40), add curve to (0,1.07) (1.07,0) (2.40,0), close subpath),
+        (guard (243.50,129) width=80 height=83),
+        (interaction (243.53,138.07) width=42.67 height=32)
+        (clipPath move to (2.40,0), add line to (40.27,0), add curve to (41.59,0) (42.67,1.07) (42.67,2.40), add line to (42.67,29.60), add curve to (42.67,30.93) (41.59,32) (40.27,32), add line to (2.40,32), add curve to (1.07,32) (0,30.93) (0,29.60), add line to (0,2.40), add curve to (0,1.07) (1.07,0) (2.40,0), close subpath)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/svg-luminance.html
+++ b/LayoutTests/interaction-region/svg-luminance.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+    #test {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+        gap: 1rem;
+        font-family: -apple-system;
+    }
+    section {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(0, 0, 0, 0.7);
+        min-height: 100px;
+    }
+    button {
+        appearance: none;
+        border: none;
+        background: transparent;
+        padding: 0;
+    }
+    svg {
+        color: black;
+    }
+</style>
+<body>
+<div id="test">
+    <section>
+        <button>
+            <svg viewBox="0 0 1500 1200" version="1.1" width="40" height="40" xmlns="http://www.w3.org/2000/svg">
+                <defs>
+                    <radialGradient id="myGradient">
+                        <stop offset="10%" stop-color="gold" />
+                        <stop offset="95%" stop-color="red" />
+                    </radialGradient>
+                </defs>
+                <rect x="10" y="20" width="800" height="600"  rx="45" ry="45" fill="url(#myGradient)" />
+            </svg>
+        </button>
+    </section>
+    <section>
+        <button>
+            <svg viewBox="0 0 1500 1200" version="1.1" width="40" height="40" xmlns="http://www.w3.org/2000/svg">
+                <rect x="10" y="20" width="800" height="600"  rx="45" ry="45" fill="red" />
+            </svg>
+        </button>
+    </section>
+    <section>
+        <button>
+            <svg viewBox="0 0 1500 1200" version="1.1" width="40" height="40" xmlns="http://www.w3.org/2000/svg">
+                <rect x="10" y="20" width="800" height="600"  rx="45" ry="45" fill="black" />
+            </svg>
+        </button>
+    </section>
+    <section>
+        <button>
+            <svg viewBox="0 0 1500 1200" version="1.1" width="40" height="40" xmlns="http://www.w3.org/2000/svg">
+                <rect x="10" y="20" width="800" height="600"  rx="45" ry="45" fill="white" />
+            </svg>
+        </button>
+    </section>
+    <section>
+        <button>
+            <svg viewBox="0 0 1500 1200" version="1.1" width="40" height="40" xmlns="http://www.w3.org/2000/svg">
+                <rect x="10" y="20" width="800" height="600"  rx="45" ry="45" fill="currentcolor" />
+            </svg>
+        </button>
+    </section>
+    <section>
+        <button>
+            <svg style="color:green;" viewBox="0 0 1500 1200" version="1.1" width="40" height="40" xmlns="http://www.w3.org/2000/svg">
+                <rect x="10" y="20" width="800" height="600"  rx="45" ry="45" fill="currentcolor" />
+            </svg>
+        </button>
+    </section>
+    <section>
+        <button>
+            <svg viewBox="0 0 1500 1200" version="1.1" width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+                <rect x="10" y="20" width="600" height="400"  rx="45" ry="45" fill="white" />
+            </svg>
+        </button>
+    </section>
+    <section>
+        <button>
+            <svg viewBox="0 0 1500 1200" version="1.1" width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+                <rect x="10" y="20" width="800" height="600"  rx="45" ry="45" fill="white" />
+            </svg>
+        </button>
+    </section>
+    <section>
+        <button>
+            <svg viewBox="0 0 1500 1200" version="1.1" width="80" height="80" xmlns="http://www.w3.org/2000/svg">
+                <rect x="10" y="20" width="800" height="600"  rx="45" ry="45" fill="black" />
+            </svg>
+        </button>
+    </section>
+    <section>
+        <button>
+            <svg viewBox="0 0 1500 1200" version="1.1" width="80" height="80" xmlns="http://www.w3.org/2000/svg">
+                <rect x="10" y="20" width="800" height="600"  rx="45" ry="45" fill="white" />
+            </svg>
+        </button>
+    </section>
+</div>
+<pre id="results"></pre>
+<script>
+document.body.addEventListener("click", function(e) {
+    console.log(e, "event delegation");
+});
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (!window.internals)
+       return;
+
+   results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+   document.getElementById('test').remove();
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -257,6 +257,27 @@ bool EventRegionContext::shouldConsolidateInteractionRegion(RenderObject& render
     return false;
 }
 
+void EventRegionContext::convertGuardContainersToInterationIfNeeded(float minimumCornerRadius)
+{
+    for (auto& region : m_interactionRegions) {
+        if (region.type != InteractionRegion::Type::Guard)
+            continue;
+
+        if (!m_discoveredRegionsByElement.contains(region.elementIdentifier)) {
+            auto rectForTracking = enclosingIntRect(region.rectInLayerCoordinates);
+            if (!m_interactionRectsAndContentHints.contains(rectForTracking)) {
+                region.type = InteractionRegion::Type::Interaction;
+                region.cornerRadius = minimumCornerRadius;
+
+                m_interactionRectsAndContentHints.add(rectForTracking, region.contentHint);
+                Vector<InteractionRegion, 1> discoveredRegions;
+                discoveredRegions.append(region);
+                m_discoveredRegionsByElement.add(region.elementIdentifier, discoveredRegions);
+            }
+        }
+    }
+}
+
 void EventRegionContext::shrinkWrapInteractionRegions()
 {
     for (size_t i = 0; i < m_interactionRegions.size(); ++i) {
@@ -357,8 +378,9 @@ void EventRegionContext::removeSuperfluousInteractionRegions()
     });
 }
 
-void EventRegionContext::copyInteractionRegionsToEventRegion()
+void EventRegionContext::copyInteractionRegionsToEventRegion(float minimumCornerRadius)
 {
+    convertGuardContainersToInterationIfNeeded(minimumCornerRadius);
     removeSuperfluousInteractionRegions();
     shrinkWrapInteractionRegions();
     m_eventRegion.appendInteractionRegions(m_interactionRegions);

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -62,9 +62,10 @@ public:
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     void uniteInteractionRegions(RenderObject&, const FloatRect&, const FloatSize&, const std::optional<AffineTransform>&);
     bool shouldConsolidateInteractionRegion(RenderObject&, const IntRect&, const ElementIdentifier&);
+    void convertGuardContainersToInterationIfNeeded(float minimumCornerRadius);
     void removeSuperfluousInteractionRegions();
     void shrinkWrapInteractionRegions();
-    void copyInteractionRegionsToEventRegion();
+    void copyInteractionRegionsToEventRegion(float minimumCornerRadius);
 #endif
 
 private:

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1975,7 +1975,7 @@ void RenderLayerBacking::updateEventRegion()
             eventRegionContext.unite(FloatRoundedRect(FloatRect({ }, graphicsLayer->size())), renderer(), renderer().style());
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-        eventRegionContext.copyInteractionRegionsToEventRegion();
+        eventRegionContext.copyInteractionRegionsToEventRegion(renderer().document().settings().interactionRegionMinimumCornerRadius());
 #endif
         graphicsLayer->setEventRegion(WTFMove(eventRegion));
     };
@@ -2008,7 +2008,7 @@ void RenderLayerBacking::updateEventRegion()
         paintIntoLayer(&graphicsLayer, nullContext, dirtyRect, { }, &eventRegionContext);
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-        eventRegionContext.copyInteractionRegionsToEventRegion();
+        eventRegionContext.copyInteractionRegionsToEventRegion(renderer().document().settings().interactionRegionMinimumCornerRadius());
 #endif
         eventRegion.translate(toIntSize(roundedIntPoint(layerOffset)));
         graphicsLayer.setEventRegion(WTFMove(eventRegion));

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2536,7 +2536,7 @@ void RenderLayerCompositor::updateScrollLayerClipping()
         auto eventRegionContext = eventRegion.makeContext();
         eventRegionContext.unite(FloatRoundedRect(FloatRect({ }, layerSize)), m_renderView, RenderStyle::defaultStyle());
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-        eventRegionContext.copyInteractionRegionsToEventRegion();
+        eventRegionContext.copyInteractionRegionsToEventRegion(renderer().document().settings().interactionRegionMinimumCornerRadius());
 #endif
         m_clipLayer->setEventRegion(WTFMove(eventRegion));
     }


### PR DESCRIPTION
#### 16668679e31ce64c7c8cee5d7d64e2c4b7587400
<pre>
[InteractionRegions] Highlight container instead of shape when it can improve visibility
<a href="https://bugs.webkit.org/show_bug.cgi?id=275208">https://bugs.webkit.org/show_bug.cgi?id=275208</a>
&lt;<a href="https://rdar.apple.com/128509643">rdar://128509643</a>&gt;

Reviewed by Simon Fraser.

Detect cases where the highlight doesn&apos;t work well (small shapes with
very high or very low luminance) and fallback to highlighting their
containers instead.

In order to do so we go over Guards and convert them to Interactions if
the Interaction they&apos;re guarding doesn&apos;t exist.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::usesFillColorWithExtremeLuminance):
New function to detect fill colors that won&apos;t work well.
(WebCore::interactionRegionForRenderedRegion):
Don&apos;t generate an Interaction when it won&apos;t be visible enough and a
container is available.

* Source/WebCore/rendering/EventRegion.h:
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::convertGuardContainersToInterationIfNeeded):
New method to convert Guards to Interactions when needed. It needs to
know the minimum corner radius to apply it.
Guards containers have &quot;transparent&quot; style so it&apos;s always safe to add.
(WebCore::EventRegionContext::copyInteractionRegionsToEventRegion):
Call the new method.

* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateEventRegion):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateScrollLayerClipping):
Pass the minimum corner radius setting down.

* LayoutTests/interaction-region/svg-luminance-expected.txt: Added.
* LayoutTests/interaction-region/svg-luminance.html: Added.
Add new tests to cover this change.

Canonical link: <a href="https://commits.webkit.org/279859@main">https://commits.webkit.org/279859@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cb69dad432a481ce5532c3f61289b2e64c23cb7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58042 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5495 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57064 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5508 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44354 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3711 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56858 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32323 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47441 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25478 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29113 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4779 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3636 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50891 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59632 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30009 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5141 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51777 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31151 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51179 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12027 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32158 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30938 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->