### PR TITLE
Remove some unused WebPageGroup code

### DIFF
--- a/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/Inspector/socket/RemoteInspectorProtocolHandler.cpp
@@ -31,6 +31,7 @@
 #include "APIContentWorld.h"
 #include "APILoaderClient.h"
 #include "APINavigation.h"
+#include "APIPageConfiguration.h"
 #include "PageLoadState.h"
 #include "WebPageGroup.h"
 #include "WebPageProxy.h"
@@ -188,7 +189,7 @@ void RemoteInspectorProtocolHandler::platformStartTask(WebPageProxy& pageProxy, 
 
     // Setup target postMessage listener
     auto handler = WebScriptMessageHandler::create(makeUnique<ScriptMessageClient>(*this), "inspector"_s, API::ContentWorld::pageContentWorld());
-    pageProxy.pageGroup().userContentController().addUserScriptMessageHandler(handler.get());
+    pageProxy.configuration().userContentController().addUserScriptMessageHandler(handler.get());
 
     // Setup loader client to get notified of page load
     m_page.setLoaderClient(makeUnique<LoaderClient>([this] {

--- a/Source/WebKit/UIProcess/WebPageGroup.h
+++ b/Source/WebKit/UIProcess/WebPageGroup.h
@@ -38,37 +38,23 @@ namespace WebKit {
 
 class WebPreferences;
 class WebPageProxy;
-class WebUserContentControllerProxy;
 
 class WebPageGroup : public API::ObjectImpl<API::Object::Type::PageGroup>, public CanMakeWeakPtr<WebPageGroup> {
 public:
     explicit WebPageGroup(const String& identifier = { });
     static Ref<WebPageGroup> create(const String& identifier = { });
 
-    static WebPageGroup* get(PageGroupIdentifier);
-    static void forEach(Function<void(WebPageGroup&)>&&);
-
     virtual ~WebPageGroup();
-
-    void addPage(WebPageProxy&);
-    void removePage(WebPageProxy&);
 
     PageGroupIdentifier pageGroupID() const { return m_data.pageGroupID; }
 
     const WebPageGroupData& data() const { return m_data; }
 
-    void setPreferences(WebPreferences*);
     WebPreferences& preferences() const;
-    Ref<WebPreferences> protectedPreferences() const;
-
-    WebUserContentControllerProxy& userContentController();
-    Ref<WebUserContentControllerProxy> protectedUserContentController();
 
 private:
     WebPageGroupData m_data;
     RefPtr<WebPreferences> m_preferences;
-    Ref<WebUserContentControllerProxy> m_userContentController;
-    WeakHashSet<WebPageProxy> m_pages;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -732,7 +732,6 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
     WebProcessPool::statistics().wkPageCount++;
 
     protectedPreferences()->addPage(*this);
-    protectedPageGroup()->addPage(*this);
 
 #if ENABLE(WK_WEB_EXTENSIONS)
     if (RefPtr webExtensionController = this->webExtensionController())
@@ -808,7 +807,6 @@ WebPageProxy::~WebPageProxy()
 
     Ref preferences = this->preferences();
     preferences->removePage(*this);
-    protectedPageGroup()->removePage(*this);
 
 #ifndef NDEBUG
     webPageProxyCounter.decrement();

--- a/Source/WebKit/WebProcess/WebPage/WebPageGroupProxy.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageGroupProxy.cpp
@@ -50,4 +50,9 @@ WebPageGroupProxy::~WebPageGroupProxy()
 {
 }
 
+WebCore::PageGroup* WebPageGroupProxy::corePageGroup() const
+{
+    return m_pageGroup.get();
+}
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebPageGroupProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageGroupProxy.h
@@ -46,14 +46,13 @@ public:
     const String& identifier() const { return m_data.identifier; }
     PageGroupIdentifier pageGroupID() const { return m_data.pageGroupID; }
     // Namespace IDs for local storage namespaces are currently equivalent to web page group IDs.
-    StorageNamespaceIdentifier localStorageNamespaceIdentifier() const { return ObjectIdentifier<StorageNamespaceIdentifierType>(pageGroupID().toUInt64()); }
-    WebCore::PageGroup* corePageGroup() const { return m_pageGroup; }
+    WebCore::PageGroup* corePageGroup() const;
 
 private:
     WebPageGroupProxy(const WebPageGroupData&);
 
     WebPageGroupData m_data;
-    WebCore::PageGroup* m_pageGroup;
+    WeakPtr<WebCore::PageGroup> m_pageGroup;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1033,21 +1033,6 @@ void WebProcess::removeWebFrame(FrameIdentifier frameID, std::optional<WebPagePr
     parentProcessConnection()->send(Messages::WebProcessProxy::DidDestroyFrame(frameID, *pageID), 0);
 }
 
-WebPageGroupProxy* WebProcess::webPageGroup(PageGroup* pageGroup)
-{
-    for (auto& page : m_pageGroupMap.values()) {
-        if (page->corePageGroup() == pageGroup)
-            return page.get();
-    }
-
-    return 0;
-}
-
-WebPageGroupProxy* WebProcess::webPageGroup(PageGroupIdentifier pageGroupID)
-{
-    return m_pageGroupMap.get(pageGroupID);
-}
-
 WebPageGroupProxy* WebProcess::webPageGroup(const WebPageGroupData& pageGroupData)
 {
     auto result = m_pageGroupMap.add(pageGroupData.pageGroupID, nullptr);

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -227,8 +227,6 @@ public:
     void addWebFrame(WebCore::FrameIdentifier, WebFrame*);
     void removeWebFrame(WebCore::FrameIdentifier, std::optional<WebPageProxyIdentifier>);
 
-    WebPageGroupProxy* webPageGroup(WebCore::PageGroup*);
-    WebPageGroupProxy* webPageGroup(PageGroupIdentifier);
     WebPageGroupProxy* webPageGroup(const WebPageGroupData&);
 
     uint64_t userGestureTokenIdentifier(std::optional<WebCore::PageIdentifier>, RefPtr<WebCore::UserGestureToken>);


### PR DESCRIPTION
#### 12485a2a6bd767a77e2191ce28cf4bf8aa87f052
<pre>
Remove some unused WebPageGroup code
<a href="https://bugs.webkit.org/show_bug.cgi?id=275216">https://bugs.webkit.org/show_bug.cgi?id=275216</a>
<a href="https://rdar.apple.com/129354155">rdar://129354155</a>

Reviewed by Brady Eidson.

And use a smart pointer instead of a raw pointer for the WebCore::PageGroup.

* Source/WebKit/UIProcess/WebPageGroup.cpp:
(WebKit::WebPageGroup::WebPageGroup):
(WebKit::WebPageGroup::get): Deleted.
(WebKit::WebPageGroup::forEach): Deleted.
(WebKit::WebPageGroup::addPage): Deleted.
(WebKit::WebPageGroup::removePage): Deleted.
(WebKit::WebPageGroup::setPreferences): Deleted.
(WebKit::WebPageGroup::protectedPreferences const): Deleted.
(WebKit::WebPageGroup::userContentController): Deleted.
(WebKit::WebPageGroup::protectedUserContentController): Deleted.
* Source/WebKit/UIProcess/WebPageGroup.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::~WebPageProxy):
* Source/WebKit/WebProcess/WebPage/WebPageGroupProxy.cpp:
(WebKit::WebPageGroupProxy::corePageGroup const):
* Source/WebKit/WebProcess/WebPage/WebPageGroupProxy.h:
(WebKit::WebPageGroupProxy::localStorageNamespaceIdentifier const): Deleted.
(WebKit::WebPageGroupProxy::corePageGroup const): Deleted.
* Source/WebKit/WebProcess/WebProcess.cpp:
* Source/WebKit/WebProcess/WebProcess.h:

Canonical link: <a href="https://commits.webkit.org/279830@main">https://commits.webkit.org/279830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbdbac4d53eccf6f8ce4e3781b83ccfa68927ee2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54524 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57802 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5256 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5259 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44154 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3525 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56620 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32085 "Found 60 new test failures: accessibility/accessibility-node-reparent.html accessibility/ancestor-computation.html accessibility/announcement-notification.html accessibility/aria-braillelabel.html accessibility/aria-brailleroledescription.html accessibility/aria-checked-mixed-value.html accessibility/aria-current-state-changed-notification.html accessibility/aria-current.html accessibility/aria-describedby-on-input.html accessibility/aria-description.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47217 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25282 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28882 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html ... (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3397 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50722 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4759 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59393 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29756 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4921 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51578 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30904 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47304 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50949 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31886 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8086 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30694 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->