### PR TITLE
REGRESSION (iOS 17.5): Method call silently fails since iOS 17.5/ MacOS 14.5 after a warmup period

### DIFF
--- a/JSTests/stress/ftl-uint32-array-out-of-bounds.js
+++ b/JSTests/stress/ftl-uint32-array-out-of-bounds.js
@@ -1,0 +1,111 @@
+globalThis.console ??= {};
+console.log ??= print;
+
+var cb;
+globalThis.setInterval ||= function setInterval(cb, ms) {
+  function iter() {
+    setTimeout(iter, ms);
+    cb && cb();
+  }
+
+  setTimeout(iter, ms);
+};
+
+setInterval(() => {
+  cb && cb();
+}, 16);
+
+function requestAnimationFrame(callback) {
+  cb = callback;
+}
+
+function copyFromSrcToTgt({
+  count,
+  size,
+  srcBuffer,
+  srcOffset,
+  srcStride,
+  tgtBuffer,
+  tgtOffset,
+  tgtStride,
+}) {
+  const source_buffer = new Uint32Array(srcBuffer, srcOffset);
+  const target_buffer = new Uint32Array(tgtBuffer, tgtOffset);
+
+  for (let v = 0; v < count; v++) {
+    const src_base = (v * srcStride) / 4;
+    const tgt_base = (v * tgtStride) / 4;
+    for (let k = 0; k < size / 4; k++) {
+      target_buffer[tgt_base + k] = source_buffer[src_base + k];
+    }
+  }
+}
+let buffersNotAligned = [];
+for (let i = 0; i < 500; i++) {
+  let typedBuffer = new Float32Array(i % 2 === 0 ? 900 : 810);
+  typedBuffer.fill(i + 1);
+  buffersNotAligned.push(typedBuffer);
+}
+
+let buffersAligned = [];
+for (let i = 0; i < 500; i++) {
+  let typedBuffer = new Float32Array(900);
+  typedBuffer.fill(i + 1);
+  buffersAligned.push(typedBuffer);
+}
+let success = 0;
+let fail = 0;
+function doCopyOperation(buffers) {
+  for (let i = 0; i < buffers.length; i += 2) {
+    let buffer1 = buffers[i];
+    let buffer2 = buffers[i + 1];
+    let dstBuffer = new Float32Array(
+      2 * Math.max(buffer1.length, buffer2.length)
+    );
+    copyFromSrcToTgt({
+      count: buffer1.length / 3,
+      size: 3 * 4, // byte size of 3 float 32
+      srcBuffer: buffer1.buffer,
+      tgtBuffer: dstBuffer.buffer,
+      srcOffset: 0,
+      srcStride: 12,
+      tgtOffset: 0,
+      tgtStride: 24,
+    });
+    copyFromSrcToTgt({
+      // This is a deliberate mistake so that we can go out of bound for buffer2, which should yield undefined values
+      // using buffer2.length instead fixes the problem but the sample has been made to showcase the issue
+      // Going out of bound works fine on Win, Linux and Android, was also working fine on MacOS before 14.5 and iOS before 17.5
+      // It also works fine on current MacOS and iOS for a period
+      count: buffer1.length / 3,
+      size: 3 * 4, // byte size of 3 float 32
+      srcBuffer: buffer2.buffer,
+      tgtBuffer: dstBuffer.buffer,
+      srcOffset: 0,
+      srcStride: 12,
+      tgtOffset: 12,
+      tgtStride: 24,
+    });
+    if (dstBuffer[0] === 0) {
+      fail++;
+    } else {
+      success++;
+    }
+  }
+}
+function doOperation() {
+  // This fails after a warm up period
+  doCopyOperation(buffersNotAligned);
+  // This should always work, but also starts failing after a warm up period, if the previous line is commented, this never fails
+  doCopyOperation(buffersAligned);
+  if (success > 1e3 || fail > 1e3) {
+    if (fail) {
+        print("FAILED");
+        quit(1);
+    } else
+        quit(0);
+    return;
+  }
+  requestAnimationFrame(doOperation);
+}
+requestAnimationFrame(doOperation);


### PR DESCRIPTION
#### 8f9d6d2b9c5f0ab9c31ff1f9f6fe42cbb67311d4
<pre>
REGRESSION (iOS 17.5): Method call silently fails since iOS 17.5/ MacOS 14.5 after a warmup period
<a href="https://bugs.webkit.org/show_bug.cgi?id=275160">https://bugs.webkit.org/show_bug.cgi?id=275160</a>
<a href="https://rdar.apple.com/129303210">rdar://129303210</a>

Reviewed by Yijia Huang and Keith Miller.

When FTL is handling OutOfBounds Uint32Array access, it should wrap the results to double when we do not have speculations.

* JSTests/stress/ftl-uint32-array-out-of-bounds.js: Added.
(iter):
(globalThis.setInterval):
(setInterval):
(requestAnimationFrame):
(copyFromSrcToTgt):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileGetByValImpl):

Canonical link: <a href="https://commits.webkit.org/279790@main">https://commits.webkit.org/279790@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f1b2dfeb6658bf6d1563da91892c8ae6582886f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/33973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57835 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5288 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5290 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44186 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3554 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56649 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32120 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47247 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25308 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28916 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4577 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3428 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/47919 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59425 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/54060 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29787 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4942 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51608 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30937 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47333 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/50988 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31915 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/66358 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8073 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30725 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12643 "Passed tests") | 
<!--EWS-Status-Bubble-End-->