### PR TITLE
Block connections to 0.0.0.0

### DIFF
--- a/LayoutTests/http/tests/media/video-error-all-zero-address-blocked-expected.txt
+++ b/LayoutTests/http/tests/media/video-error-all-zero-address-blocked-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: Not allowed to use restricted network host "0.0.0.0": http://0.0.0.0:8000/media/resources/test.mp4
+PASS Received error
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Test passes if loading video is not successful

--- a/LayoutTests/http/tests/media/video-error-all-zero-address-blocked.html
+++ b/LayoutTests/http/tests/media/video-error-all-zero-address-blocked.html
@@ -1,0 +1,27 @@
+<head>
+    <script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<p>Test passes if loading video is not successful</p>
+<script>
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsText();
+    }
+
+    const video = document.createElement("video");
+    video.src = "http://0.0.0.0:8000/media/resources/test.mp4";
+    video.onerror = (e) => {
+        testPassed("Received error");
+        testRunner.notifyDone();
+    }
+    video.onopen = (e) => {
+        testFailed("Received open");
+        testRunner.notifyDone();
+    }
+    video.onmessage = (e) => {
+        testFailed("Received message");
+        testRunner.notifyDone();
+    }
+</script>
+</body>

--- a/LayoutTests/http/tests/security/block-iframe-to-all-zero-address-expected.txt
+++ b/LayoutTests/http/tests/security/block-iframe-to-all-zero-address-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: Not allowed to use restricted network host "0.0.0.0": http://0.0.0.0:8000/security/resources/target.html
+
+This attempts to load an iframe from the all-zeroes address, which should be blocked.

--- a/LayoutTests/http/tests/security/block-iframe-to-all-zero-address.html
+++ b/LayoutTests/http/tests/security/block-iframe-to-all-zero-address.html
@@ -1,0 +1,11 @@
+<html>
+<body>
+<iframe src="http://0.0.0.0:8000/security/resources/target.html"></iframe></br>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+    }
+</script>
+<p>This attempts to load an iframe from the all-zeroes address, which should be blocked.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/block-popup-to-all-zero-address-expected.txt
+++ b/LayoutTests/http/tests/security/block-popup-to-all-zero-address-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: Not allowed to use restricted network host "0.0.0.0": http://0.0.0.0:8000/security/resources/target.html
+This attempts to load an iframe from the all-zeroes address, which should be blocked.

--- a/LayoutTests/http/tests/security/block-popup-to-all-zero-address.html
+++ b/LayoutTests/http/tests/security/block-popup-to-all-zero-address.html
@@ -1,0 +1,12 @@
+<html>
+<body>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+    }
+    window.open("http://0.0.0.0:8000/security/resources/target.html");
+
+</script>
+<p>This attempts to load an iframe from the all-zeroes address, which should be blocked.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/redirect-BLOCKED-to-all-zero-address-expected.txt
+++ b/LayoutTests/http/tests/security/redirect-BLOCKED-to-all-zero-address-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: Not allowed to use restricted network host "0.0.0.0": http://0.0.0.0:8000/security/resources/file-redirect-target.html
+
+This attempts to open a redirect link to the all-zeroes address, which should be blocked.

--- a/LayoutTests/http/tests/security/redirect-BLOCKED-to-all-zero-address.html
+++ b/LayoutTests/http/tests/security/redirect-BLOCKED-to-all-zero-address.html
@@ -1,0 +1,11 @@
+<html>
+<body>
+<iframe src="http://127.0.0.1:8000/resources/redirect.py?url=http://0.0.0.0:8000/security/resources/file-redirect-target.html"></iframe></br>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+    }
+</script>
+<p>This attempts to open a redirect link to the all-zeroes address, which should be blocked.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/websocket/connection-to-all-zero-address-blocked-expected.txt
+++ b/LayoutTests/http/tests/websocket/connection-to-all-zero-address-blocked-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: WebSocket address 0.0.0.0 blocked
+PASS successfullyParsed is true
+
+TEST COMPLETE
+PASS Received error
+Test passes if websocket connection is not successful

--- a/LayoutTests/http/tests/websocket/connection-to-all-zero-address-blocked.html
+++ b/LayoutTests/http/tests/websocket/connection-to-all-zero-address-blocked.html
@@ -1,0 +1,26 @@
+<head>
+    <script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<p>Test passes if websocket connection is not successful</p>
+<script>
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsText();
+    }
+
+    const socket = new WebSocket("ws://0.0.0.0:8880");
+    socket.onerror = (e) => {
+        testPassed("Received error");
+        testRunner.notifyDone();
+    }
+    socket.onopen = (e) => {
+        testFailed("Received open");
+        testRunner.notifyDone();
+    }
+    socket.onmessage = (e) => {
+        testFailed("Received message");
+        testRunner.notifyDone();
+    }
+</script>
+</body>

--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -910,6 +910,12 @@ http/tests/websocket/tests/hybi/multiple-connections-limit.html [ Skip ] # Timeo
 # Timeout on local PC
 http/tests/websocket/tests/hybi/frame-lengths.html [ Pass Timeout ]
 
+# Connections need additional validation
+http/tests/security/block-iframe-to-all-zero-address.html [ Failure ]
+http/tests/security/block-popup-to-all-zero-address.html [ Failure ]
+http/tests/security/redirect-BLOCKED-to-all-zero-address.html [ Failure ]
+http/tests/websocket/connection-to-all-zero-address-blocked.html [ Failure ]
+
 # Failure on Buildbot
 http/tests/websocket/tests/hybi/inspector/binary.html [ Pass Failure ]
 

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -36,6 +36,7 @@
 
 #if ENABLE(WEB_RTC)
 
+#include "DNS.h"
 #include "Document.h"
 #include "Event.h"
 #include "EventNames.h"
@@ -408,7 +409,7 @@ ExceptionOr<Vector<MediaEndpointConfiguration::IceServerInfo>> RTCPeerConnection
 
             urls.removeAllMatching([&](auto& urlString) {
                 URL url { URL { }, urlString };
-                if (url.path().endsWithIgnoringASCIICase(".local"_s) || !portAllowed(url)) {
+                if (url.path().endsWithIgnoringASCIICase(".local"_s) || !portAllowed(url) || isIPAddressDisallowed(url)) {
                     queueTaskToDispatchEvent(*this, TaskSource::MediaElement, RTCPeerConnectionIceErrorEvent::create(Event::CanBubble::No, Event::IsCancelable::No, { }, { }, WTFMove(urlString), 701, "URL is not allowed"_s));
                     return true;
                 }

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -35,6 +35,7 @@
 #include "Blob.h"
 #include "CloseEvent.h"
 #include "ContentSecurityPolicy.h"
+#include "DNS.h"
 #include "Document.h"
 #include "Event.h"
 #include "EventListener.h"
@@ -257,9 +258,11 @@ ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& pr
 
     contentSecurityPolicy->upgradeInsecureRequestIfNeeded(m_url, ContentSecurityPolicy::InsecureRequestType::Load);
 
-    if (!portAllowed(m_url)) {
+    if (!portAllowed(m_url) || isIPAddressDisallowed(m_url)) {
         String message;
-        if (m_url.port())
+        if (isIPAddressDisallowed(m_url))
+            message = makeString("WebSocket address "_s, m_url.host(), " blocked"_s);
+        else if (m_url.port())
             message = makeString("WebSocket port "_s, m_url.port().value(), " blocked"_s);
         else
             message = "WebSocket without port blocked"_s;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -48,6 +48,7 @@
 #include "ContentSecurityPolicy.h"
 #include "ContentType.h"
 #include "CookieJar.h"
+#include "DNS.h"
 #include "DeprecatedGlobalSettings.h"
 #include "DiagnosticLoggingClient.h"
 #include "DiagnosticLoggingKeys.h"
@@ -2572,12 +2573,16 @@ bool HTMLMediaElement::isSafeToLoadURL(const URL& url, InvalidURLAction actionIf
         return false;
     }
 
-    if (!portAllowed(url)) {
+    if (!portAllowed(url) || isIPAddressDisallowed(url)) {
         if (actionIfInvalid == Complain) {
             if (frame)
                 FrameLoader::reportBlockedLoadFailed(*frame, url);
-            if (shouldLog)
-                ERROR_LOG(LOGIDENTIFIER, url , " was rejected because the port is not allowed");
+            if (shouldLog) {
+                if (isIPAddressDisallowed(url))
+                    ERROR_LOG(LOGIDENTIFIER, url , " was rejected because the address not allowed");
+                else
+                    ERROR_LOG(LOGIDENTIFIER, url , " was rejected because the port is not allowed");
+            }
         }
         return false;
     }

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -41,6 +41,7 @@
 #include "ContentSecurityPolicy.h"
 #include "CrossOriginOpenerPolicy.h"
 #include "CustomHeaderFields.h"
+#include "DNS.h"
 #include "DocumentInlines.h"
 #include "DocumentParser.h"
 #include "DocumentWriter.h"
@@ -696,6 +697,13 @@ void DocumentLoader::willSendRequest(ResourceRequest&& newRequest, const Resourc
         }
         if (!portAllowed(newRequest.url())) {
             DOCUMENTLOADER_RELEASE_LOG("willSendRequest: canceling - redirecting to a URL with a blocked port");
+            if (m_frame)
+                FrameLoader::reportBlockedLoadFailed(*m_frame, newRequest.url());
+            cancelMainResourceLoad(frameLoader()->blockedError(newRequest));
+            return completionHandler(WTFMove(newRequest));
+        }
+        if (isIPAddressDisallowed(newRequest.url())) {
+            DOCUMENTLOADER_RELEASE_LOG("willSendRequest: canceling - redirecting to a URL with a disallowed IP address");
             if (m_frame)
                 FrameLoader::reportBlockedLoadFailed(*m_frame, newRequest.url());
             cancelMainResourceLoad(frameLoader()->blockedError(newRequest));

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -33,6 +33,7 @@
 #include "ApplicationCacheHost.h"
 #include "AuthenticationChallenge.h"
 #include "ContentRuleListResults.h"
+#include "DNS.h"
 #include "DataURLDecoder.h"
 #include "DiagnosticLoggingClient.h"
 #include "DiagnosticLoggingKeys.h"
@@ -161,6 +162,13 @@ void ResourceLoader::init(ResourceRequest&& clientRequest, CompletionHandler<voi
 
     if (!portAllowed(clientRequest.url())) {
         RESOURCELOADER_RELEASE_LOG("init: Cancelling load to a blocked port.");
+        FrameLoader::reportBlockedLoadFailed(*protectedFrame(), clientRequest.url());
+        releaseResources();
+        return completionHandler(false);
+    }
+
+    if (isIPAddressDisallowed(clientRequest.url())) {
+        RESOURCELOADER_RELEASE_LOG("init: Cancelling load to disallowed IP address.");
         FrameLoader::reportBlockedLoadFailed(*protectedFrame(), clientRequest.url());
         releaseResources();
         return completionHandler(false);

--- a/Source/WebCore/loader/SubframeLoader.cpp
+++ b/Source/WebCore/loader/SubframeLoader.cpp
@@ -34,6 +34,7 @@
 #include "SubframeLoader.h"
 
 #include "ContentSecurityPolicy.h"
+#include "DNS.h"
 #include "DiagnosticLoggingClient.h"
 #include "DiagnosticLoggingKeys.h"
 #include "DocumentInlines.h"
@@ -138,7 +139,7 @@ bool FrameLoader::SubframeLoader::pluginIsLoadable(const URL& url)
             return false;
         }
 
-        if (!portAllowed(url)) {
+        if (!portAllowed(url) || isIPAddressDisallowed(url)) {
             FrameLoader::reportBlockedLoadFailed(protectedFrame(), url);
             return false;
         }
@@ -287,7 +288,7 @@ RefPtr<LocalFrame> FrameLoader::SubframeLoader::loadSubframe(HTMLFrameOwnerEleme
         return nullptr;
     }
 
-    if (!portAllowed(url)) {
+    if (!portAllowed(url) || isIPAddressDisallowed(url)) {
         FrameLoader::reportBlockedLoadFailed(frame, url);
         return nullptr;
     }

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -47,6 +47,7 @@
 #include "CookieJar.h"
 #include "CrossOriginAccessControl.h"
 #include "CustomHeaderFields.h"
+#include "DNS.h"
 #include "DateComponents.h"
 #include "DocumentInlines.h"
 #include "DocumentLoader.h"
@@ -1056,6 +1057,12 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
         if (forPreload == ForPreload::No)
             FrameLoader::reportBlockedLoadFailed(frame, url);
         CACHEDRESOURCELOADER_RELEASE_LOG_WITH_FRAME("CachedResourceLoader::requestResource URL has a blocked port", frame.get());
+        return makeUnexpected(frame->checkedLoader()->blockedError(request.resourceRequest()));
+    }
+
+    if (isIPAddressDisallowed(url)) {
+        FrameLoader::reportBlockedLoadFailed(frame, url);
+        CACHEDRESOURCELOADER_RELEASE_LOG_WITH_FRAME("CachedResourceLoader::requestResource URL has a disallowd address", frame.get());
         return makeUnexpected(frame->checkedLoader()->blockedError(request.resourceRequest()));
     }
 

--- a/Source/WebCore/platform/network/DNS.cpp
+++ b/Source/WebCore/platform/network/DNS.cpp
@@ -64,6 +64,14 @@ void stopResolveDNS(uint64_t identifier)
     WebCore::DNSResolveQueue::singleton().stopResolve(identifier);
 }
 
+// FIXME: Temporary fix until we have rdar://63797758
+bool isIPAddressDisallowed(const URL& url)
+{
+    if (auto address = IPAddress::fromString(url.host().toStringWithoutCopying()))
+        return address->containsOnlyZeros();
+    return false;
+}
+
 bool IPAddress::containsOnlyZeros() const
 {
     return std::visit(WTF::makeVisitor([] (const WTF::HashTableEmptyValueType&) {

--- a/Source/WebCore/platform/network/DNS.h
+++ b/Source/WebCore/platform/network/DNS.h
@@ -110,6 +110,7 @@ using DNSCompletionHandler = CompletionHandler<void(DNSAddressesOrError&&)>;
 WEBCORE_EXPORT void prefetchDNS(const String& hostname);
 WEBCORE_EXPORT void resolveDNS(const String& hostname, uint64_t identifier, DNSCompletionHandler&&);
 WEBCORE_EXPORT void stopResolveDNS(uint64_t identifier);
+WEBCORE_EXPORT bool isIPAddressDisallowed(const URL&);
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/network/ResourceHandle.cpp
+++ b/Source/WebCore/platform/network/ResourceHandle.cpp
@@ -27,6 +27,7 @@
 #include "ResourceHandle.h"
 #include "ResourceHandleInternal.h"
 
+#include "DNS.h"
 #include "Logging.h"
 #include "NetworkingContext.h"
 #include "NotImplemented.h"
@@ -85,7 +86,7 @@ ResourceHandle::ResourceHandle(NetworkingContext* context, const ResourceRequest
         return;
     }
 
-    if (!portAllowed(request.url())) {
+    if (!portAllowed(request.url()) || isIPAddressDisallowed(request.url())) {
         scheduleFailure(BlockedFailure);
         return;
     }

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
@@ -93,7 +93,7 @@ NetworkDataTask::NetworkDataTask(NetworkSession& session, NetworkDataTaskClient&
         return;
     }
 
-    if (!portAllowed(requestWithCredentials.url())) {
+    if (!portAllowed(requestWithCredentials.url()) || isIPAddressDisallowed(requestWithCredentials.url())) {
         scheduleFailure(FailureType::Blocked);
         return;
     }


### PR DESCRIPTION
#### e59cd4a4330877f4692ab31caaf5039185e845bf
<pre>
Block connections to 0.0.0.0
<a href="https://bugs.webkit.org/show_bug.cgi?id=275224">https://bugs.webkit.org/show_bug.cgi?id=275224</a>
<a href="https://rdar.apple.com/125913679">rdar://125913679</a>

Reviewed by Alex Christensen.

This patch blocks connections to 0.0.0.0 and [::], as per RFC 6890 [0]. That
spec says that these addresses may only be used as source addresses, not
destinations. Requesting connections to either of these addresses is generally
confusing, and likely not motivated by a good reason.

Coincidentally, Blink seems to be making a similar change [1], and their use
counters are showing below 0.001%. We can&apos;t exactly extrapolate from that, but
it&apos;s a good indicator that this is safe.

[0] <a href="https://www.rfc-editor.org/rfc/rfc6890#section-2.2.3">https://www.rfc-editor.org/rfc/rfc6890#section-2.2.3</a>
[1] <a href="https://groups.google.com/a/chromium.org/g/blink-dev/c/9uymCQNGVgw">https://groups.google.com/a/chromium.org/g/blink-dev/c/9uymCQNGVgw</a>

* LayoutTests/http/tests/media/video-error-all-zero-address-blocked-expected.txt: Added.
* LayoutTests/http/tests/media/video-error-all-zero-address-blocked.html: Added.
* LayoutTests/http/tests/security/block-iframe-to-all-zero-address-expected.txt: Added.
* LayoutTests/http/tests/security/block-iframe-to-all-zero-address.html: Added.
* LayoutTests/http/tests/security/block-popup-to-all-zero-address-expected.txt: Added.
* LayoutTests/http/tests/security/block-popup-to-all-zero-address.html: Added.
* LayoutTests/http/tests/security/redirect-BLOCKED-to-all-zero-address-expected.txt: Added.
* LayoutTests/http/tests/security/redirect-BLOCKED-to-all-zero-address.html: Added.
* LayoutTests/http/tests/websocket/connection-to-all-zero-address-blocked-expected.txt: Added.
* LayoutTests/http/tests/websocket/connection-to-all-zero-address-blocked.html: Added.
* LayoutTests/platform/wincairo/TestExpectations:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::iceServersFromConfiguration):
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::connect):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::isSafeToLoadURL const):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::willSendRequest):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadFrameRequest):
(WebCore::FrameLoader::reportBlockedLoadFailed):
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::init):
* Source/WebCore/loader/SubframeLoader.cpp:
(WebCore::FrameLoader::SubframeLoader::pluginIsLoadable):
(WebCore::FrameLoader::SubframeLoader::loadSubframe):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestResource):
* Source/WebCore/platform/network/DNS.cpp:
(WebCore::isIPAddressDisallowed):
* Source/WebCore/platform/network/DNS.h:
* Source/WebCore/platform/network/ResourceHandle.cpp:
(WebCore::ResourceHandle::ResourceHandle):
* Source/WebKit/NetworkProcess/NetworkDataTask.cpp:
(WebKit::NetworkDataTask::NetworkDataTask):

Canonical link: <a href="https://commits.webkit.org/279835@main">https://commits.webkit.org/279835@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a05c0af490af333f1395c4b80b1895f26f472629

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54665 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57945 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5398 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56966 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5407 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44280 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3647 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56760 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32225 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47346 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25405 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29019 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4680 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3538 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4894 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59535 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29905 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5042 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51703 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47432 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51094 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32043 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8090 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30835 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->