### PR TITLE
Local WebKit builds don't use locally-built WebKit process extensions

### DIFF
--- a/Source/WebKit/Shared/Cocoa/DefaultWebBrowserChecks.mm
+++ b/Source/WebKit/Shared/Cocoa/DefaultWebBrowserChecks.mm
@@ -68,13 +68,19 @@ static bool isInWebKitChildProcess()
 
     static dispatch_once_t once;
     dispatch_once(&once, ^{
+#if USE(EXTENSIONKIT)
+        isInSubProcess |= WTF::processHasEntitlement("com.apple.developer.web-browser-engine.networking"_s)
+            || WTF::processHasEntitlement("com.apple.developer.web-browser-engine.rendering"_s)
+            || WTF::processHasEntitlement("com.apple.developer.web-browser-engine.webcontent"_s);
+#else
         NSString *bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
         isInSubProcess = [bundleIdentifier hasPrefix:@"com.apple.WebKit.WebContent"]
             || [bundleIdentifier hasPrefix:@"com.apple.WebKit.Networking"]
             || [bundleIdentifier hasPrefix:@"com.apple.WebKit.GPU"];
 #if ENABLE(MODEL_PROCESS)
         isInSubProcess = isInSubProcess || [bundleIdentifier hasPrefix:@"com.apple.WebKit.Model"];
-#endif
+#endif // ENABLE(MODEL_PROCESS)
+#endif // USE(EXTENSIONKIT)
     });
 
     return isInSubProcess;

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -126,6 +126,19 @@ static void launchWithExtensionKitFallback(ProcessLauncher& processLauncher, Pro
 }
 #endif // USE(LEGACY_EXTENSIONKIT_SPI)
 
+#if !USE(LEGACY_EXTENSIONKIT_SPI)
+static bool hasExtensionInAppBundle(NSString *name)
+{
+#if PLATFORM(IOS_SIMULATOR)
+    NSString *path = [[NSBundle mainBundle] pathForResource:name ofType:@"appex" inDirectory:@"Extensions"];
+    return !!path;
+#else
+    UNUSED_PARAM(name);
+    return false;
+#endif
+}
+#endif // !USE(LEGACY_EXTENSIONKIT_SPI)
+
 static void launchWithExtensionKit(ProcessLauncher& processLauncher, ProcessLauncher::ProcessType processType, ProcessLauncher::Client* client, WTF::Function<void(ThreadSafeWeakPtr<ProcessLauncher> weakProcessLauncher, ExtensionProcess&& process, ASCIILiteral name, NSError *error)>&& handler)
 {
 #if USE(LEGACY_EXTENSIONKIT_SPI)
@@ -138,21 +151,30 @@ static void launchWithExtensionKit(ProcessLauncher& processLauncher, ProcessLaun
         auto block = makeBlockPtr([handler = WTFMove(handler), weakProcessLauncher = ThreadSafeWeakPtr { processLauncher }, name = name](BEWebContentProcess *_Nullable process, NSError *_Nullable error) {
             handler(WTFMove(weakProcessLauncher), process, name, error);
         });
-        [BEWebContentProcess webContentProcessWithBundleID:identifier.get() interruptionHandler: ^{ } completion:block.get()];
+        if (hasExtensionInAppBundle(@"WebContentExtension"))
+            [BEWebContentProcess webContentProcessWithInterruptionHandler:^{ } completion:block.get()];
+        else
+            [BEWebContentProcess webContentProcessWithBundleID:identifier.get() interruptionHandler:^{ } completion:block.get()];
         break;
     }
     case ProcessLauncher::ProcessType::Network: {
         auto block = makeBlockPtr([handler = WTFMove(handler), weakProcessLauncher = ThreadSafeWeakPtr { processLauncher }, name = name](BENetworkingProcess *_Nullable process, NSError *_Nullable error) {
             handler(WTFMove(weakProcessLauncher), process, name, error);
         });
-        [BENetworkingProcess networkProcessWithBundleID:identifier.get() interruptionHandler: ^{ } completion:block.get()];
+        if (hasExtensionInAppBundle(@"NetworkingExtension"))
+            [BENetworkingProcess networkProcessWithInterruptionHandler:^{ } completion:block.get()];
+        else
+            [BENetworkingProcess networkProcessWithBundleID:identifier.get() interruptionHandler:^{ } completion:block.get()];
         break;
     }
     case ProcessLauncher::ProcessType::GPU: {
         auto block = makeBlockPtr([handler = WTFMove(handler), weakProcessLauncher = ThreadSafeWeakPtr { processLauncher }, name = name](BERenderingProcess *_Nullable process, NSError *_Nullable error) {
             handler(WTFMove(weakProcessLauncher), process, name, error);
         });
-        [BERenderingProcess renderingProcessWithBundleID:identifier.get() interruptionHandler: ^{ } completion:block.get()];
+        if (hasExtensionInAppBundle(@"GPUExtension"))
+            [BERenderingProcess renderingProcessWithInterruptionHandler:^{ } completion:block.get()];
+        else
+            [BERenderingProcess renderingProcessWithBundleID:identifier.get() interruptionHandler:^{ } completion:block.get()];
         break;
     }
     }

--- a/Tools/WebKitTestRunner/Configurations/WebKitTestRunnerApp-iOS.entitlements
+++ b/Tools/WebKitTestRunner/Configurations/WebKitTestRunnerApp-iOS.entitlements
@@ -14,5 +14,9 @@
 	<true/>
 	<key>com.apple.runningboard.launch_extensions</key>
 	<true/>
+	<key>com.apple.developer.web-browser</key>
+	<true/>
+	<key>com.apple.developer.web-browser-engine.host</key>
+	<true/>
 </dict>
 </plist>

--- a/Tools/WebKitTestRunner/Configurations/WebKitTestRunnerApp.xcconfig
+++ b/Tools/WebKitTestRunner/Configurations/WebKitTestRunnerApp.xcconfig
@@ -37,9 +37,11 @@ STRIP_STYLE = debugging;
 
 SKIP_INSTALL[sdk=macosx*] = YES;
 
-EXCLUDED_SOURCE_FILE_NAMES[sdk=macosx*] = ios/* AppDelegate.m;
-EXCLUDED_SOURCE_FILE_NAMES[sdk=appletv*] = ios/Launch.storyboard;
-EXCLUDED_SOURCE_FILE_NAMES[sdk=watch*] = ios/Launch.storyboard;
+EXCLUDED_SOURCE_FILE_NAMES[config=Production] = $(inherited) *.appex
+EXCLUDED_SOURCE_FILE_NAMES[sdk=macosx*] = $(inherited) ios/* AppDelegate.m *.appex;
+EXCLUDED_SOURCE_FILE_NAMES[sdk=appletv*] = $(inherited) ios/Launch.storyboard *.appex;
+EXCLUDED_SOURCE_FILE_NAMES[sdk=watch*] = $(inherited) ios/Launch.storyboard *.appex;
+EXCLUDED_SOURCE_FILE_NAMES[sdk=xr*] = $(inherited) *.appex;
 
 TARGETED_DEVICE_FAMILY = 1,2,4,7;
 
@@ -47,3 +49,5 @@ CODE_SIGN_ENTITLEMENTS[sdk=iphone*] = Configurations/WebKitTestRunnerApp-iOS.ent
 CODE_SIGN_ENTITLEMENTS[sdk=appletv*] = Configurations/WebKitTestRunnerApp-watchOS.entitlements;
 CODE_SIGN_ENTITLEMENTS[sdk=watch*] = Configurations/WebKitTestRunnerApp-watchOS.entitlements;
 CODE_SIGN_ENTITLEMENTS[sdk=xr*] = Configurations/WebKitTestRunnerApp-iOS.entitlements;
+
+APPLY_RULES_IN_COPY_FILES = YES;

--- a/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
+++ b/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
@@ -162,6 +162,9 @@
 		E132AA3A17CD5F1000611DF0 /* WebKitTestRunnerDraggingInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = E132AA3817CD5F1000611DF0 /* WebKitTestRunnerDraggingInfo.mm */; };
 		E132AA3D17CE776F00611DF0 /* WebKitTestRunnerEvent.mm in Sources */ = {isa = PBXBuildFile; fileRef = E132AA3B17CE776F00611DF0 /* WebKitTestRunnerEvent.mm */; };
 		E1C642C617CBCD4C00D66A3C /* WebKitTestRunnerPasteboard.mm in Sources */ = {isa = PBXBuildFile; fileRef = E1C642C417CBCD4C00D66A3C /* WebKitTestRunnerPasteboard.mm */; };
+		E372BC362C08E29C006DFE67 /* NetworkingExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = E372BC352C08E29C006DFE67 /* NetworkingExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		E372BC382C08EB01006DFE67 /* GPUExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = E372BC372C08EB01006DFE67 /* GPUExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		E372BC3A2C08F323006DFE67 /* WebContentExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = E372BC392C08F323006DFE67 /* WebContentExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		F4010B7E24DA205300A876E2 /* PoseAsClass.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4010B7C24DA204800A876E2 /* PoseAsClass.mm */; };
 		F415C22C27AF52D30028F505 /* UIPasteboardConsistencyEnforcer.h in Headers */ = {isa = PBXBuildFile; fileRef = F415C22A27AF52D30028F505 /* UIPasteboardConsistencyEnforcer.h */; };
 		F415C23527AF5B390028F505 /* UIPasteboardConsistencyEnforcer.mm in Sources */ = {isa = PBXBuildFile; fileRef = F415C22B27AF52D30028F505 /* UIPasteboardConsistencyEnforcer.mm */; };
@@ -173,6 +176,22 @@
 		F4C3578C20E8444600FA0748 /* LayoutTestSpellChecker.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4C3578A20E8444000FA0748 /* LayoutTestSpellChecker.mm */; };
 		F4FED324235823A3003C139C /* NSPasteboardAdditions.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4FED3222358215E003C139C /* NSPasteboardAdditions.mm */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXBuildRule section */
+		E372BC2C2C08C74A006DFE67 /* PBXBuildRule */ = {
+			isa = PBXBuildRule;
+			compilerSpec = com.apple.compilers.proxy.script;
+			filePatterns = "*.appex";
+			fileType = pattern.proxy;
+			inputFiles = (
+			);
+			isEditable = 1;
+			outputFiles = (
+				"$(BUILT_PRODUCTS_DIR)/$(EXTENSIONS_FOLDER_PATH)/$(INPUT_FILE_NAME)",
+			);
+			script = "set -e\n\nDESTINATION_PATH=${BUILT_PRODUCTS_DIR}/WebKitTestRunnerApp.app/Extensions/${INPUT_FILE_NAME}\n\nmkdir -p \"${DESTINATION_PATH}\"\nditto \"${BUILT_PRODUCTS_DIR}/${INPUT_FILE_NAME}\" \"${DESTINATION_PATH}\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleIdentifier ${PRODUCT_BUNDLE_IDENTIFIER}.${INPUT_FILE_BASE}\" \"${DESTINATION_PATH}/Info.plist\"\n\nif [[ ${INPUT_FILE_BASE} == \"WebContentExtension\" ]]; then\n    EXTENSION_POINT_ID=\"com.apple.web-browser-engine.content\"\nelif [[ ${INPUT_FILE_BASE} == \"WebContentCaptivePortalExtension\" ]]; then\n    EXTENSION_POINT_ID=\"com.apple.web-browser-engine.content\"\nfi\n\nif [[ -z \"${EXTENSION_POINT_ID}\" ]]; then\n    exit 0\nfi\n\n/usr/libexec/PlistBuddy -c \"Delete :EXAppExtensionAttributes:EXExtensionPointIdentifier dict\" \"${DESTINATION_PATH}/Info.plist\"\n/usr/libexec/PlistBuddy -c \"Add :EXAppExtensionAttributes:EXExtensionPointIdentifier string ${EXTENSION_POINT_ID}\" \"${DESTINATION_PATH}/Info.plist\"\n";
+		};
+/* End PBXBuildRule section */
 
 /* Begin PBXContainerItemProxy section */
 		A115CCB91B9D76BF00E89159 /* PBXContainerItemProxy */ = {
@@ -229,6 +248,19 @@
 				2E34C90018B68808000067BB /* WebKitTestRunnerInjectedBundle.bundle in Copy Plug-Ins */,
 			);
 			name = "Copy Plug-Ins";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E372BC342C08E22D006DFE67 /* Embed Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(EXTENSIONS_FOLDER_PATH)";
+			dstSubfolderSpec = 16;
+			files = (
+				E372BC382C08EB01006DFE67 /* GPUExtension.appex in Embed Extensions */,
+				E372BC362C08E29C006DFE67 /* NetworkingExtension.appex in Embed Extensions */,
+				E372BC3A2C08F323006DFE67 /* WebContentExtension.appex in Embed Extensions */,
+			);
+			name = "Embed Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -442,6 +474,9 @@
 		E1BA671D1742DA5A00C20251 /* Carbon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Carbon.framework; path = System/Library/Frameworks/Carbon.framework; sourceTree = SDKROOT; };
 		E1C642C417CBCD4C00D66A3C /* WebKitTestRunnerPasteboard.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebKitTestRunnerPasteboard.mm; sourceTree = "<group>"; };
 		E1C642C517CBCD4C00D66A3C /* WebKitTestRunnerPasteboard.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebKitTestRunnerPasteboard.h; sourceTree = "<group>"; };
+		E372BC352C08E29C006DFE67 /* NetworkingExtension.appex */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.extensionkit-extension"; path = NetworkingExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		E372BC372C08EB01006DFE67 /* GPUExtension.appex */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.extensionkit-extension"; path = GPUExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		E372BC392C08F323006DFE67 /* WebContentExtension.appex */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.extensionkit-extension"; path = WebContentExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4010B7C24DA204800A876E2 /* PoseAsClass.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = PoseAsClass.mm; path = ../TestRunnerShared/cocoa/PoseAsClass.mm; sourceTree = "<group>"; };
 		F4010B7D24DA204800A876E2 /* PoseAsClass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PoseAsClass.h; path = ../TestRunnerShared/cocoa/PoseAsClass.h; sourceTree = "<group>"; };
 		F415C22A27AF52D30028F505 /* UIPasteboardConsistencyEnforcer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UIPasteboardConsistencyEnforcer.h; sourceTree = "<group>"; };
@@ -503,6 +538,9 @@
 		08FB7794FE84155DC02AAC07 /* WebKitTestRunner */ = {
 			isa = PBXGroup;
 			children = (
+				E372BC392C08F323006DFE67 /* WebContentExtension.appex */,
+				E372BC372C08EB01006DFE67 /* GPUExtension.appex */,
+				E372BC352C08E29C006DFE67 /* NetworkingExtension.appex */,
 				49AEEF692407278200C87E4C /* Info.plist */,
 				BC952EC511F3C10F003398B4 /* DerivedSources.make */,
 				2EE52CEA1890A9A80010ED21 /* WebKitTestRunnerApp-Info.plist */,
@@ -1037,8 +1075,10 @@
 				2EE52CDD1890A9A80010ED21 /* Frameworks */,
 				2EE52CDE1890A9A80010ED21 /* Resources */,
 				CEC209031D36E36A00261596 /* Copy Plug-Ins */,
+				E372BC342C08E22D006DFE67 /* Embed Extensions */,
 			);
 			buildRules = (
+				E372BC2C2C08C74A006DFE67 /* PBXBuildRule */,
 			);
 			dependencies = (
 				A18510361B9ADE6D00744AEB /* PBXTargetDependency */,


### PR DESCRIPTION
#### 52f67b99e6e8949eb858922e818472f4a3089625
<pre>
Local WebKit builds don&apos;t use locally-built WebKit process extensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=273550">https://bugs.webkit.org/show_bug.cgi?id=273550</a>
<a href="https://rdar.apple.com/125726458">rdar://125726458</a>

Reviewed by Elliott Williams.

When locally built WebKit extensions are installed in the app bundle, these extensions
will be launched instead of the system extensions when launching said app. This patch
adds a build step that copies extensions to WebKitTestRunner app bundle.

* Source/WebKit/Shared/Cocoa/DefaultWebBrowserChecks.mm:
(WebKit::isInWebKitChildProcess):
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::hasExtensionInAppBundle):
(WebKit::launchWithExtensionKit):
* Tools/Scripts/webkitpy/port/device_port.py:
(DevicePort._install_extensions):
(DevicePort._install):
* Tools/WebKitTestRunner/Configurations/WebKitTestRunnerApp.xcconfig:
* Tools/WebKitTestRunner/Configurations/WebKitTestRunnerApp-iOS.entitlements:
* Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/279946@main">https://commits.webkit.org/279946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a058e344cb91706c8d64c6fee50b6c969f05891c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58260 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5713 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57282 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5745 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44529 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3887 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32525 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47636 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25655 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4980 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3854 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59851 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30249 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5357 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51951 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31379 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47712 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51390 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32400 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8142 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31170 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->