### PR TITLE
[WebGPU] runClearEncoder can fail validation when depth-stencil texture is destroyed

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-275225-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-275225-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-275225.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-275225.html
@@ -1,0 +1,14847 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ */
+function pseudoSubmit(device) {
+  for (let i = 0; i < 63; i++) {
+    device.createCommandEncoder();
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  label: '\u0f2d\u0d27\u08fe\u0825\u037e\u0c0f\u8131\u801e',
+  defaultQueue: {label: '\u71d4\u{1fc67}\u{1fb08}\u063c\u1ef0\u4de9\u1e4f'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 6,
+    maxColorAttachmentBytesPerSample: 57,
+    maxVertexBufferArrayStride: 51445,
+    maxStorageTexturesPerShaderStage: 30,
+    maxStorageBuffersPerShaderStage: 17,
+    maxDynamicStorageBuffersPerPipelineLayout: 39295,
+    maxDynamicUniformBuffersPerPipelineLayout: 25561,
+    maxBindingsPerBindGroup: 9072,
+    maxTextureArrayLayers: 1358,
+    maxTextureDimension1D: 8702,
+    maxTextureDimension2D: 11986,
+    maxBindGroupsPlusVertexBuffers: 29,
+    minUniformBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 76052655,
+    maxStorageBufferBindingSize: 149083284,
+    maxUniformBuffersPerShaderStage: 25,
+    maxInterStageShaderVariables: 113,
+    maxInterStageShaderComponents: 102,
+    maxSamplersPerShaderStage: 19,
+  },
+});
+let img0 = await imageWithData(73, 27, '#ec3fff77', '#fa027e8f');
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\u14e9\u{1f632}\u0f21\ub1b8\ubbfa\udef7',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+});
+let commandEncoder0 = device0.createCommandEncoder({});
+let commandBuffer0 = commandEncoder0.finish();
+let renderBundle0 = renderBundleEncoder0.finish({label: '\uba2f\u{1fa0c}\ub793\u4f3d'});
+let imageBitmap0 = await createImageBitmap(img0);
+let commandEncoder1 = device0.createCommandEncoder({label: '\u{1f8a0}\u00d5\ufba3\ub7d2\u4f00\uce98\u31fc\ucdfc\uc2c4\u0235\u06d8'});
+let querySet0 = device0.createQuerySet({label: '\u1c0b\u1c0d\u{1fd11}', type: 'occlusion', count: 1596});
+let texture0 = device0.createTexture({
+  label: '\uca64\u07ca\u057a\u4599\u0765',
+  size: {width: 384, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['depth24plus-stencil8', 'depth24plus-stencil8'],
+});
+let textureView0 = texture0.createView({
+  label: '\uefec\u733d\ua642',
+  dimension: '2d-array',
+  aspect: 'depth-only',
+  baseMipLevel: 0,
+  mipLevelCount: 2,
+  baseArrayLayer: 0,
+});
+let computePassEncoder0 = commandEncoder1.beginComputePass({label: '\ub7a1\u8d4c\u5d4b'});
+let commandEncoder2 = device0.createCommandEncoder({label: '\u3f75\u95b1'});
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 1340});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let img1 = await imageWithData(295, 228, '#426158f8', '#46a83bfe');
+let videoFrame0 = new VideoFrame(img1, {timestamp: 0});
+let sampler0 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMaxClamp: 99.17,
+  maxAnisotropy: 1,
+});
+let promise0 = device0.queue.onSubmittedWorkDone();
+let commandEncoder3 = device0.createCommandEncoder({label: '\ue1bb\u6fa7'});
+let texture1 = device0.createTexture({
+  size: {width: 768, height: 1, depthOrArrayLayers: 989},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle1 = renderBundleEncoder0.finish({});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 3,
+  origin: {x: 38, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 2_132_032 */
+{offset: 232, bytesPerRow: 132, rowsPerImage: 190}, {width: 13, height: 0, depthOrArrayLayers: 86});
+} catch {}
+let commandBuffer1 = commandEncoder2.finish({});
+let img2 = await imageWithData(273, 59, '#e452aff9', '#cca6c405');
+let videoFrame1 = new VideoFrame(img1, {timestamp: 0});
+let commandEncoder4 = device0.createCommandEncoder({label: '\u{1febe}\uace8\u3e32\ub33c'});
+let renderBundle2 = renderBundleEncoder0.finish({label: '\u6e34\u{1f94d}\u0144\u{1fcf2}\ub750\u747a\ud2c1\uc39f'});
+let sampler1 = device0.createSampler({
+  label: '\u0986\u0ca6\u{1f9b0}\u{1f896}\udb56\ue609\ue384\ua663\u06bb',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 21.03,
+  maxAnisotropy: 2,
+});
+let externalTexture0 = device0.importExternalTexture({label: '\u0a47\u608d\u{1fc7b}\u0817\u0f4e\u0317', source: videoFrame1});
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder4.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 3,
+  origin: {x: 33, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 2,
+  origin: {x: 13, y: 0, z: 4},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 26});
+} catch {}
+let querySet2 = device0.createQuerySet({label: '\u0583\u44e6\uc53d\u3e36\u0dab\u2413\u1f8c\u0ad4\u06ee\u7a1b', type: 'occlusion', count: 123});
+let commandBuffer2 = commandEncoder4.finish({label: '\u0f12\uff5e\ufa2f\u0510\ufa48\ucb21\u050d\u2f3f\u4ab1\u73c5\u7843'});
+let computePassEncoder1 = commandEncoder3.beginComputePass({label: '\u00b6\u7286\u{1f760}\u{1ff96}\u0f11\u79f3\udc92'});
+let renderBundle3 = renderBundleEncoder0.finish({label: '\u{1f794}\u0266\u{1ff65}'});
+let externalTexture1 = device0.importExternalTexture({label: '\u8423\ucbdf\u{1fd3e}\ue9b9', source: videoFrame0, colorSpace: 'display-p3'});
+let textureView1 = texture1.createView({label: '\u0311\u{1f737}\u93f8\u5c49\u0b33\u09a7\u12a9\u01b3', baseMipLevel: 3, baseArrayLayer: 0});
+let renderBundle4 = renderBundleEncoder0.finish();
+let promise1 = device0.queue.onSubmittedWorkDone();
+let canvas0 = document.createElement('canvas');
+let imageData0 = new ImageData(72, 180);
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder5 = device0.createCommandEncoder({label: '\uc7e4\u94d0'});
+let texture2 = device0.createTexture({
+  size: {width: 192, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['depth24plus-stencil8'],
+});
+let textureView2 = texture1.createView({label: '\uf7db\u8196\u{1f9a3}\u046a\u14fc\u56bc\u{1ff21}', mipLevelCount: 3});
+let canvas1 = document.createElement('canvas');
+let buffer0 = device0.createBuffer({
+  label: '\u9fcc\u09d0\u0866\u761f\u510c\u{1fc66}\ub664\u2445\u7230\ueb3d\u990c',
+  size: 5352,
+  usage: GPUBufferUsage.INDEX,
+  mappedAtCreation: true,
+});
+let commandEncoder6 = device0.createCommandEncoder();
+let texture3 = device0.createTexture({
+  label: '\u0b30\ub696\u08ab\u5062\u2344\u{1fdfb}',
+  size: [1680, 12, 1207],
+  mipLevelCount: 11,
+  format: 'astc-12x12-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView3 = texture2.createView({
+  label: '\u7f9d\u{1f633}\u0649\uc758',
+  dimension: '2d',
+  aspect: 'stencil-only',
+  baseMipLevel: 1,
+  mipLevelCount: 3,
+});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  label: '\ub8e2\u287d\u{1feeb}\u{1fa7a}\u{1fc7c}\u0d28\u0d98',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+});
+try {
+renderBundleEncoder1.setIndexBuffer(buffer0, 'uint16', 2944, 1288);
+} catch {}
+let textureView4 = texture3.createView({dimension: '2d', baseMipLevel: 10, baseArrayLayer: 1038});
+let renderBundle5 = renderBundleEncoder0.finish({label: '\u{1fee3}\u14c6\u6d8d\u4239'});
+try {
+renderBundleEncoder1.insertDebugMarker('\uf05f');
+} catch {}
+try {
+adapter0.label = '\u{1fe41}\u4912';
+} catch {}
+let texture4 = device0.createTexture({
+  label: '\u02f5\u025b\u23e7\u{1fcf1}\u04ef\uddd3\u{1ff86}\u087b',
+  size: [1460, 5, 1],
+  mipLevelCount: 5,
+  format: 'astc-10x5-unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['astc-10x5-unorm', 'astc-10x5-unorm-srgb'],
+});
+let textureView5 = texture1.createView({
+  label: '\uf283\uf441\u0604\u254a\u{1fbf0}\u18ee\u0d3f\u{1ffc1}\u0f0a\u8655',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+});
+let renderBundle6 = renderBundleEncoder1.finish();
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+let querySet3 = device0.createQuerySet({label: '\u{1f86f}\uec15\u5f27\u23a9\u779a', type: 'occlusion', count: 3576});
+let texture5 = device0.createTexture({
+  label: '\u4758\u{1fccb}\u6889\u5951\u7c2a\uef9c\ua4b0\u3549',
+  size: [384, 1, 1],
+  mipLevelCount: 6,
+  dimension: '2d',
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let gpuCanvasContext1 = canvas1.getContext('webgpu');
+let video0 = await videoWithData();
+let buffer1 = device0.createBuffer({
+  label: '\u1b20\u{1f669}\u6375\u04f9\u0844\ub7e8\u0331\u444b',
+  size: 299344,
+  usage: GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let textureView6 = texture2.createView({mipLevelCount: 4});
+let externalTexture2 = device0.importExternalTexture({label: '\u0443\u060d\uf209', source: video0, colorSpace: 'srgb'});
+let texture6 = device0.createTexture({
+  size: [96, 1, 372],
+  mipLevelCount: 3,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint', 'rgba8uint'],
+});
+let textureView7 = texture1.createView({label: '\uf906\u0a4e\u073f\uf204\u305f\ucb28\u5cdc', baseMipLevel: 2, mipLevelCount: 1});
+try {
+commandEncoder6.insertDebugMarker('\u8955');
+} catch {}
+document.body.prepend(img2);
+let imageData1 = new ImageData(52, 24);
+let commandEncoder7 = device0.createCommandEncoder({label: '\u0cc1\u1612\u7e46\ufea7\u{1fd46}\ud042\u325b'});
+let texture7 = device0.createTexture({
+  size: [768, 1, 334],
+  mipLevelCount: 7,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32uint', 'rgba32uint', 'rgba32uint'],
+});
+let computePassEncoder2 = commandEncoder7.beginComputePass();
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  label: '\u2a7f\u0fff\ucccd\u{1f99f}\u{1f78d}\u{1faf7}\u2ef1\u0d2a\ue7db',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+});
+let buffer2 = device0.createBuffer({size: 80637, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let commandEncoder8 = device0.createCommandEncoder({label: '\u{1fd5f}\u71a9\u{1f8de}\u0d79\u6b60\u{1fab6}\ufcfd\ud607\u{1fc55}'});
+let externalTexture3 = device0.importExternalTexture({label: '\ubd15\u3ab7\u0570', source: video0, colorSpace: 'display-p3'});
+try {
+commandEncoder6.insertDebugMarker('\u0441');
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+let querySet4 = device0.createQuerySet({label: '\u3a55\u0e3d\u5c28', type: 'occlusion', count: 2097});
+try {
+computePassEncoder2.end();
+} catch {}
+document.body.prepend(video0);
+let commandEncoder9 = device0.createCommandEncoder();
+try {
+commandEncoder7.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 5,
+  origin: {x: 1, y: 0, z: 11},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder10 = device0.createCommandEncoder({label: '\u9611\u{1f680}\u5f8b\u{1f78f}\u{1f893}\u06c4'});
+let textureView8 = texture1.createView({label: '\u{1f9df}\ubd41\u{1fbdd}\u9922\u09c6\ucb00', baseMipLevel: 3});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+});
+try {
+commandEncoder10.clearBuffer(buffer2, 50172, 3152);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+computePassEncoder0.insertDebugMarker('\uc0fb');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 5612, new DataView(new ArrayBuffer(62097)), 13941, 33656);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 2},
+  aspect: 'all',
+}, new ArrayBuffer(10_624_184), /* required buffer size: 10_624_184 */
+{offset: 824, bytesPerRow: 5267, rowsPerImage: 144}, {width: 318, height: 1, depthOrArrayLayers: 15});
+} catch {}
+try {
+  await promise0;
+} catch {}
+let img3 = await imageWithData(143, 259, '#3c6f9c13', '#3e9f3725');
+let commandEncoder11 = device0.createCommandEncoder({label: '\udcc9\u695c\u8d68'});
+let texture8 = device0.createTexture({
+  size: {width: 192, height: 1, depthOrArrayLayers: 1758},
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba8uint', 'rgba8uint', 'rgba8uint'],
+});
+try {
+commandEncoder7.clearBuffer(buffer2, 41184, 9608);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 2380, new Float32Array(19475), 14271, 688);
+} catch {}
+canvas1.height = 1260;
+let imageData2 = new ImageData(240, 220);
+let texture9 = device0.createTexture({
+  label: '\ubd7d\ufcc2\u{1fa0f}\u037a\ub00b\u0c4b\uf6d4\u04c8\u{1f733}',
+  size: [768, 1, 526],
+  mipLevelCount: 3,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32uint', 'rgba32uint', 'rgba32uint'],
+});
+let externalTexture4 = device0.importExternalTexture({label: '\u{1f665}\u{1f831}\u01bd\u0ce4\u1750\u{1fa82}', source: video0, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder3.setVertexBuffer(6167, undefined);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder10.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 358},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+adapter0.label = '\u00cd\u46f7\u9a3c\u072d\u2bab\u7d45\u0af9\u0385\u{1f732}\u0db2';
+} catch {}
+let bindGroupLayout0 = device0.createBindGroupLayout({label: '\u027c\u7605\uca7c', entries: []});
+let pipelineLayout0 = device0.createPipelineLayout({
+  label: '\u{1f6c8}\u01b0\u9aec\u0820\u483e\u4fd5\u0450\ucbe2\u{1fc9b}\u{1fa58}\ua206',
+  bindGroupLayouts: [],
+});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\uf50f\u{1fef1}',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture5 = device0.importExternalTexture({
+  label: '\u{1f889}\u{1fd5c}\uc326\uff03\u9b82\ud173\u4275\ud559\u027a\u095f\ub51f',
+  source: videoFrame0,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint16', 3738, 535);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(4664, undefined, 0, 688769773);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+let videoFrame2 = new VideoFrame(canvas1, {timestamp: 0});
+let buffer3 = device0.createBuffer({label: '\u9c42\ud71b\u0df0', size: 380747, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let querySet5 = device0.createQuerySet({label: '\u243b\ua9a9\u{1f7b4}\u09a9\u0192\u054e\u00b6', type: 'occlusion', count: 199});
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+gc();
+let offscreenCanvas0 = new OffscreenCanvas(415, 459);
+try {
+externalTexture4.label = '\udabd\u737e\uf5d4\u0bd2\u0086\u0cac\u09e0\u0c76';
+} catch {}
+let commandBuffer3 = commandEncoder10.finish({});
+let textureView9 = texture1.createView({baseMipLevel: 2, mipLevelCount: 1});
+let computePassEncoder3 = commandEncoder11.beginComputePass({});
+let renderBundle7 = renderBundleEncoder3.finish();
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 34},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 212, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 449_735 */
+{offset: 583, bytesPerRow: 128, rowsPerImage: 121}, {width: 0, height: 1, depthOrArrayLayers: 30});
+} catch {}
+try {
+offscreenCanvas0.getContext('bitmaprenderer');
+} catch {}
+let bindGroup0 = device0.createBindGroup({label: '\u{1f64f}\u04c7\u0ab8\u{1fe40}\u38b5', layout: bindGroupLayout0, entries: []});
+let commandEncoder12 = device0.createCommandEncoder({label: '\u221f\u0d41\u{1f64d}\u{1fafd}\u1526\ud8ed\udccf\ue1eb\u{1fe63}'});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  label: '\u{1f807}\u0f43',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+});
+let renderBundle8 = renderBundleEncoder5.finish({});
+let externalTexture6 = device0.importExternalTexture({source: videoFrame2, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder2.setBindGroup(5, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(5264, undefined, 2984295791, 632396385);
+} catch {}
+try {
+device0.queue.submit([commandBuffer3, commandBuffer0]);
+} catch {}
+let imageBitmap1 = await createImageBitmap(videoFrame2);
+let commandEncoder13 = device0.createCommandEncoder({});
+let querySet6 = device0.createQuerySet({label: '\u01aa\uafdb\u765b\u9f6f\u3d2d\u4bc5', type: 'occlusion', count: 893});
+try {
+commandEncoder12.clearBuffer(buffer2, 66996, 11452);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 46},
+  aspect: 'all',
+}, new ArrayBuffer(9_962_081), /* required buffer size: 9_962_081 */
+{offset: 693, bytesPerRow: 557, rowsPerImage: 263}, {width: 20, height: 0, depthOrArrayLayers: 69});
+} catch {}
+try {
+  await promise2;
+} catch {}
+let commandEncoder14 = device0.createCommandEncoder({label: '\u{1fa45}\ufa7b'});
+let querySet7 = device0.createQuerySet({label: '\u0038\u{1fe8a}\u059c\u069a\ua338\u0970', type: 'occlusion', count: 1643});
+let texture10 = device0.createTexture({
+  label: '\u026f\u5d05\ucd10\u16e3\u{1fbdd}\u88d8\u72c7\u0702\u0874',
+  size: {width: 192, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({
+  label: '\u4ac1\uc381',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: false,
+});
+try {
+commandEncoder7.copyTextureToBuffer({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 192 widthInBlocks: 192 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1204 */
+  offset: 1204,
+  buffer: buffer3,
+}, {width: 192, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+let bindGroup1 = device0.createBindGroup({
+  label: '\u043e\u{1fe62}\u04b6\u0c60\u290f\u07f7\u0c95\u08b1\u{1fa00}\u028c',
+  layout: bindGroupLayout0,
+  entries: [],
+});
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 83});
+let textureView10 = texture3.createView({
+  label: '\u0f78\u0a96\u0283',
+  format: 'astc-12x12-unorm',
+  baseMipLevel: 2,
+  mipLevelCount: 4,
+  baseArrayLayer: 137,
+  arrayLayerCount: 200,
+});
+let computePassEncoder4 = commandEncoder13.beginComputePass({label: '\u9ce1\u{1f7ee}\u614e\u8626\u0f1b\u505f'});
+let renderBundle9 = renderBundleEncoder5.finish({label: '\uf867\u{1f7b1}\uc604\u2b88\u4b0d\u{1f631}\u{1f7a1}\u{1fd75}'});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup0, new Uint32Array(4829), 4145, 0);
+} catch {}
+let arrayBuffer0 = buffer0.getMappedRange();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+video0.height = 51;
+let commandEncoder15 = device0.createCommandEncoder({});
+let textureView11 = texture6.createView({
+  label: '\u93b4\u0f21\uf74f\uc060',
+  aspect: 'all',
+  baseMipLevel: 2,
+  baseArrayLayer: 246,
+  arrayLayerCount: 36,
+});
+let computePassEncoder5 = commandEncoder5.beginComputePass({});
+let sampler2 = device0.createSampler({
+  label: '\u2694\u055b\u0f8f\u4f29\u2f72\u0050\u9796\u0d63\u{1fdc5}\u048c',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 32.16,
+  lodMaxClamp: 51.82,
+  compare: 'less-equal',
+  maxAnisotropy: 15,
+});
+try {
+renderBundleEncoder4.setBindGroup(4, bindGroup1, new Uint32Array(327), 61, 0);
+} catch {}
+let textureView12 = texture8.createView({label: '\u{1fdff}\u6770\u0069\u6f6b\ub7ae\uff90\u81fd\u09d0\u{1f702}\u9677\u{1f80d}'});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\u0edb\u{1fb4c}',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup0, new Uint32Array(3312), 1811, 0);
+} catch {}
+try {
+commandEncoder12.copyTextureToTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 357, y: 0, z: 18},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 69, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder7.clearBuffer(buffer3, 30212, 126744);
+dissociateBuffer(device0, buffer3);
+} catch {}
+canvas0.width = 1953;
+let pipelineLayout1 = device0.createPipelineLayout({
+  label: '\ua1cc\u{1f84e}',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0],
+});
+let buffer4 = device0.createBuffer({
+  label: '\u0cae\u{1f9ed}\ua78a\u7c0f\u{1f669}\u0f9a\u4ce7\u6381',
+  size: 43918,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder16 = device0.createCommandEncoder({label: '\u{1f6a1}\u0f68\u1019\u{1fbdc}\u1490\u08b2\u{1ff24}\u{1f6e2}\u0516\u030f\u{1fb04}'});
+let externalTexture7 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder2.setBindGroup(3, bindGroup1, new Uint32Array(4413), 1555, 0);
+} catch {}
+try {
+commandEncoder16.copyTextureToBuffer({
+  texture: texture10,
+  mipLevel: 1,
+  origin: {x: 44, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 304 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 992 */
+  offset: 992,
+  rowsPerImage: 58,
+  buffer: buffer2,
+}, {width: 19, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder7.clearBuffer(buffer4, 13516, 14584);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 318 */
+{offset: 318}, {width: 77, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let commandEncoder17 = device0.createCommandEncoder({});
+try {
+commandEncoder6.clearBuffer(buffer2, 21108, 17564);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 9848, new Float32Array(24351), 21509, 104);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData3 = new ImageData(104, 248);
+let renderBundle10 = renderBundleEncoder5.finish({label: '\u10e9\u05b6'});
+let externalTexture8 = device0.importExternalTexture({label: '\u5827\uc563\u0bed\u9582\udd3e\u0170', source: videoFrame0, colorSpace: 'srgb'});
+try {
+renderBundleEncoder4.setVertexBuffer(9721, undefined, 0, 1697368195);
+} catch {}
+try {
+commandEncoder16.copyTextureToBuffer({
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 24 widthInBlocks: 24 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 16524 */
+  offset: 16500,
+  buffer: buffer3,
+}, {width: 24, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 79780, new Int16Array(36217), 32919, 1024);
+} catch {}
+let video1 = await videoWithData();
+let commandEncoder18 = device0.createCommandEncoder({label: '\u88a3\u021b\u840d\u09ef\u{1fe55}\u2936'});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  label: '\u359a\u08fb\u076b\u3eae\u080d\u0de8\u64ed\u0bc0\u96e1',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler3 = device0.createSampler({
+  label: '\u0843\uce81\u0b68\u0f38\u{1fdd9}\u909a\u63b3\u0150\u{1f9f1}\u083b',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 22.98,
+  maxAnisotropy: 1,
+});
+try {
+commandEncoder18.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 1,
+  origin: {x: 28, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 26, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder14.clearBuffer(buffer2, 62608, 10736);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let bindGroupLayout1 = device0.createBindGroupLayout({label: '\u0646\uf2d6\u6799', entries: []});
+let textureView13 = texture1.createView({label: '\u46ff\u00dc', baseMipLevel: 2, baseArrayLayer: 0, arrayLayerCount: 1});
+let computePassEncoder6 = commandEncoder16.beginComputePass({label: '\ub89d\u4284\uc1e1\u6673\u7766\u{1fa0d}'});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: false,
+  stencilReadOnly: false,
+});
+let renderBundle11 = renderBundleEncoder8.finish({});
+try {
+computePassEncoder3.setBindGroup(3, bindGroup1, new Uint32Array(592), 585, 0);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer0, 'uint16', 5118, 124);
+} catch {}
+try {
+commandEncoder18.copyTextureToBuffer({
+  texture: texture10,
+  mipLevel: 2,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 272 widthInBlocks: 17 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 9856 */
+  offset: 9856,
+  rowsPerImage: 124,
+  buffer: buffer2,
+}, {width: 17, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 9,
+  origin: {x: 0, y: 0, z: 181},
+  aspect: 'all',
+}, new ArrayBuffer(4_000_006), /* required buffer size: 4_000_006 */
+{offset: 10, bytesPerRow: 91, rowsPerImage: 222}, {width: 0, height: 0, depthOrArrayLayers: 199});
+} catch {}
+let texture11 = device0.createTexture({
+  size: [384, 1, 1148],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle12 = renderBundleEncoder6.finish({label: '\ua20c\ud719\u6e80\u079e\u{1f96c}\ud15b\u4a0b\u{1fb74}\u{1fefb}\ue0b2'});
+try {
+renderBundleEncoder9.setBindGroup(4, bindGroup1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 22436, new Int16Array(64664), 47472, 7972);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 61},
+  aspect: 'all',
+}, new ArrayBuffer(339_169), /* required buffer size: 339_169 */
+{offset: 419, bytesPerRow: 271, rowsPerImage: 50}, {width: 4, height: 0, depthOrArrayLayers: 26});
+} catch {}
+let adapter1 = await navigator.gpu.requestAdapter();
+let textureView14 = texture7.createView({
+  label: '\u{1f659}\u02e2\ub19b\ub343',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 4,
+  baseArrayLayer: 285,
+});
+let computePassEncoder7 = commandEncoder15.beginComputePass({label: '\u45da\u03fd\ua892\ue520\u0cd2\ucde5\ue47e\u{1f679}\u087c\uf5a7\u4dee'});
+try {
+renderBundleEncoder2.setIndexBuffer(buffer0, 'uint16', 1360);
+} catch {}
+try {
+commandEncoder9.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 259, y: 0, z: 228},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 10},
+  aspect: 'all',
+},
+{width: 34, height: 1, depthOrArrayLayers: 34});
+} catch {}
+try {
+computePassEncoder1.insertDebugMarker('\u{1f995}');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 4},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 12_774_392 */
+{offset: 692, bytesPerRow: 498, rowsPerImage: 150}, {width: 68, height: 0, depthOrArrayLayers: 172});
+} catch {}
+let commandEncoder19 = device0.createCommandEncoder({label: '\u4b92\uc571'});
+let externalTexture9 = device0.importExternalTexture({
+  label: '\u1486\u{1ffc1}\ua385\u5733\ud358\u{1fc4b}\u08c6\u0313',
+  source: videoFrame2,
+  colorSpace: 'srgb',
+});
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 3,
+  origin: {x: 18, y: 0, z: 3},
+  aspect: 'all',
+}, new ArrayBuffer(440_050), /* required buffer size: 440_050 */
+{offset: 170, bytesPerRow: 302, rowsPerImage: 16}, {width: 42, height: 1, depthOrArrayLayers: 92});
+} catch {}
+let texture12 = device0.createTexture({
+  label: '\u04bc\u0ca6\u{1f948}\u1c4a',
+  size: [384, 1, 110],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba32uint'],
+});
+let textureView15 = texture8.createView({label: '\u29f9\u02cf\u0abc\u{1fa4b}\ua72e\u{1fe32}\ua558\uec2b\u0696\u068a\u2f48'});
+let computePassEncoder8 = commandEncoder6.beginComputePass();
+let renderBundle13 = renderBundleEncoder6.finish({label: '\u738c\u07ea\ue4a5\ub8e5\uabe3'});
+try {
+commandEncoder19.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 37008 */
+  offset: 37008,
+  bytesPerRow: 0,
+  rowsPerImage: 19,
+  buffer: buffer2,
+}, {width: 0, height: 0, depthOrArrayLayers: 239});
+dissociateBuffer(device0, buffer2);
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+  label: '\u{1feac}\u457e\u0232\u{1fe43}\u533a\u63ca\uf61c\uc164',
+  layout: bindGroupLayout0,
+  entries: [],
+});
+let pipelineLayout2 = device0.createPipelineLayout({
+  label: '\uc5d2\u{1ff77}\u68ea\u0c9c\u010f\uc0cf\u378d\uf1b0\u0a06\u0351',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout1, bindGroupLayout1, bindGroupLayout1],
+});
+let querySet9 = device0.createQuerySet({
+  label: '\u0b6c\ue1a7\u9238\ub67d\ude37\u{1f7d4}\u{1f7c9}\u{1f67c}\u5a4b',
+  type: 'occlusion',
+  count: 575,
+});
+let computePassEncoder9 = commandEncoder9.beginComputePass({label: '\uee98\u5095\u019e\u{1f730}\u0fef\u{1f9a3}\u{1f63e}'});
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder19.clearBuffer(buffer3, 270432, 32584);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(new ArrayBuffer(64)), /* required buffer size: 985 */
+{offset: 985}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video0);
+let bindGroupLayout2 = device0.createBindGroupLayout({entries: []});
+let querySet10 = device0.createQuerySet({label: '\uf263\u92db\ub048\u48f4\u0141', type: 'occlusion', count: 220});
+try {
+renderBundleEncoder2.setBindGroup(4, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer0, 'uint32', 3680, 1385);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let canvas2 = document.createElement('canvas');
+let imageData4 = new ImageData(104, 224);
+let querySet11 = device0.createQuerySet({label: '\u2bdb\u4332\u0f59\u02b7\ud13b', type: 'occlusion', count: 400});
+let computePassEncoder10 = commandEncoder18.beginComputePass({label: '\uf53b\u{1fb7f}\u3a7e\u{1fc97}\uf5b8\uf037\u073c'});
+try {
+texture11.destroy();
+} catch {}
+try {
+commandEncoder17.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 243, y: 0, z: 17},
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 92},
+  aspect: 'all',
+},
+{width: 74, height: 1, depthOrArrayLayers: 802});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 6488, new Float32Array(61572), 8111, 1016);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroup3 = device0.createBindGroup({
+  label: '\u5043\u0c13\u{1f66c}\u0ad5\uf521\ua7cf\u{1f78b}\u0cd6\u{1f7a2}',
+  layout: bindGroupLayout2,
+  entries: [],
+});
+let commandEncoder20 = device0.createCommandEncoder({label: '\u{1fdb5}\u0736'});
+let textureView16 = texture5.createView({
+  label: '\u{1feb1}\u691b\u{1fcde}\u{1f9e0}\u512a\u550b',
+  dimension: '2d-array',
+  aspect: 'depth-only',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  label: '\u022c\u82ac\u{1fd7b}\uf4c2',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle14 = renderBundleEncoder0.finish({});
+try {
+renderBundleEncoder2.setVertexBuffer(5551, undefined);
+} catch {}
+try {
+computePassEncoder7.insertDebugMarker('\u{1faca}');
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise3;
+} catch {}
+let imageBitmap2 = await createImageBitmap(canvas1);
+let promise4 = adapter1.requestAdapterInfo();
+let commandEncoder21 = device0.createCommandEncoder({});
+let texture13 = device0.createTexture({
+  label: '\u{1fe8d}\u395a\u058a\u1531\uc17c\u32b3\u{1f95c}\ub97b\ub5e1\u09ea\u0ae9',
+  size: [384, 1, 556],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgba32uint'],
+});
+let sampler4 = device0.createSampler({
+  label: '\u00fb\u{1fa08}\u4ccb\ud1e1',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 43.00,
+  lodMaxClamp: 58.60,
+});
+try {
+renderBundleEncoder7.setBindGroup(4, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(1443, undefined, 2923812688, 961471040);
+} catch {}
+try {
+commandEncoder17.copyTextureToBuffer({
+  texture: texture2,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 12 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 4544 */
+  offset: 4544,
+  buffer: buffer2,
+}, {width: 12, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder21.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 297},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 2,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 52, height: 0, depthOrArrayLayers: 245});
+} catch {}
+document.body.prepend(img3);
+let commandEncoder22 = device0.createCommandEncoder();
+let externalTexture10 = device0.importExternalTexture({label: '\uef5f\u0764\u{1fef8}', source: videoFrame1});
+try {
+renderBundleEncoder10.setBindGroup(4, bindGroup3);
+} catch {}
+try {
+  await buffer2.mapAsync(GPUMapMode.READ, 0, 4536);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 15692, new Float32Array(31335), 1442, 812);
+} catch {}
+let bindGroup4 = device0.createBindGroup({label: '\u9eef\u641b', layout: bindGroupLayout1, entries: []});
+let computePassEncoder11 = commandEncoder17.beginComputePass();
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({
+  label: '\ub08b\u0fc7\u{1fbda}\udab4',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+});
+let externalTexture11 = device0.importExternalTexture({
+  label: '\u0139\u66c9\u7b66\ua6a0\u00c7\u068f\u6fe1\u{1ffa2}\ua27f',
+  source: videoFrame2,
+  colorSpace: 'srgb',
+});
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 8},
+  aspect: 'all',
+}, new Int32Array(new ArrayBuffer(56)), /* required buffer size: 3_000_414 */
+{offset: 669, bytesPerRow: 2551, rowsPerImage: 5}, {width: 145, height: 1, depthOrArrayLayers: 236});
+} catch {}
+try {
+window.someLabel = externalTexture5.label;
+} catch {}
+let commandEncoder23 = device0.createCommandEncoder({});
+let textureView17 = texture6.createView({
+  label: '\u15cf\u{1fc9a}\uedc7\u0cd1\u55c2\u0edd',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 174,
+  arrayLayerCount: 17,
+});
+try {
+computePassEncoder8.setBindGroup(5, bindGroup1);
+} catch {}
+try {
+computePassEncoder6.insertDebugMarker('\ucf29');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 121568, new Float32Array(39488), 15843, 6600);
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 3456,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '1d' },
+    },
+    {binding: 7180, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+  ],
+});
+let textureView18 = texture10.createView({label: '\ucafc\u9d9d\u{1fa38}\u9ba7\u050a\u069a\u06a9\u{1fbfc}', baseMipLevel: 2, mipLevelCount: 1});
+let externalTexture12 = device0.importExternalTexture({label: '\u23d9\ueb5c\u6535', source: video1, colorSpace: 'display-p3'});
+try {
+device0.queue.writeBuffer(buffer3, 2564, new BigUint64Array(62447), 37675, 2596);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 9_809_968 */
+{offset: 688, bytesPerRow: 520, rowsPerImage: 131}, {width: 71, height: 0, depthOrArrayLayers: 145});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise1;
+} catch {}
+document.body.prepend(canvas0);
+let bindGroupLayout4 = device0.createBindGroupLayout({label: '\u0f18\u0d9e\u07c4\u{1ff57}\u43d3\u{1fac6}', entries: []});
+let buffer5 = device0.createBuffer({
+  label: '\u06ef\u5698\u0caa\u09b6\u0070\u9482\ucef3\u06c1\uaee9\ud52f',
+  size: 257593,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+});
+let texture14 = device0.createTexture({
+  label: '\u34fe\u59ba\u9fe2',
+  size: {width: 384, height: 1, depthOrArrayLayers: 689},
+  mipLevelCount: 4,
+  dimension: '2d',
+  format: 'depth24plus',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['depth24plus', 'depth24plus'],
+});
+let computePassEncoder12 = commandEncoder23.beginComputePass({label: '\u{1fe1c}\u04af'});
+try {
+renderBundleEncoder7.setBindGroup(4, bindGroup3, new Uint32Array(5317), 2909, 0);
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise5;
+} catch {}
+document.body.prepend(img0);
+video0.width = 260;
+let commandEncoder24 = device0.createCommandEncoder({label: '\u{1fcd8}\u{1ff49}\ud7af\u8d42\u0a65\u{1fd02}'});
+let commandBuffer4 = commandEncoder14.finish({label: '\u57fb\ue7a8\uf2fc\u0915\u09f2\u94eb\u0e9c\ud4a9\ua48a\u07b9\u{1f987}'});
+try {
+renderBundleEncoder9.setVertexBuffer(2092, undefined, 0, 3434850009);
+} catch {}
+try {
+commandEncoder24.copyTextureToBuffer({
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 24 widthInBlocks: 24 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 136 */
+  offset: 136,
+  buffer: buffer3,
+}, {width: 24, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+  await promise4;
+} catch {}
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  label: '\ufd86\u{1f7ab}\ua34e\u0e27\u9f53\u053c\u{1fc30}\u651e',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+});
+let externalTexture13 = device0.importExternalTexture({
+  label: '\u34d2\ufa57\u{1ff04}\u0592\u251e\u40ed\ue151\ub939\u{1fa10}\u0aff\ua40d',
+  source: videoFrame1,
+  colorSpace: 'srgb',
+});
+try {
+  await buffer1.mapAsync(GPUMapMode.READ);
+} catch {}
+try {
+commandEncoder22.clearBuffer(buffer4, 39020, 4816);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 2568, new Int16Array(32432), 20511, 272);
+} catch {}
+let canvas3 = document.createElement('canvas');
+let commandEncoder25 = device0.createCommandEncoder({label: '\uf40d\uf74f\u{1fd88}\u0236\u6a83'});
+let textureView19 = texture13.createView({
+  label: '\ud926\u{1fa80}\u05c1\u0153\u8a0a\u532b\u{1ff3c}\u04df\u6d18\ub7ca\u0da4',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+});
+let sampler5 = device0.createSampler({
+  label: '\u040c\u{1fe54}\u{1fec6}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 99.61,
+});
+try {
+commandEncoder22.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 48, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture12,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 71, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder7.clearBuffer(buffer2, 30428, 8456);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup5 = device0.createBindGroup({
+  label: '\uc8a6\u0f47\u06d4\u{1f939}\u08d9\u93d8\uc16b\u{1fafe}',
+  layout: bindGroupLayout4,
+  entries: [],
+});
+let textureView20 = texture12.createView({
+  label: '\uffd8\u0052\u0574\ua604\u{1f7ee}\uc67d\ud989\u8d67\udb83\uf00c',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+let sampler6 = device0.createSampler({
+  label: '\ucb4d\ud68b\ua40d\u8032\u555d\u4c14\u1f0e',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 20.57,
+  lodMaxClamp: 35.44,
+  compare: 'greater',
+});
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+querySet9.destroy();
+} catch {}
+gc();
+let imageData5 = new ImageData(48, 156);
+let renderPassEncoder0 = commandEncoder25.beginRenderPass({
+  label: '\u0dec\u78b9\ub9e7\u05f6\u0628\u6232\u58e7\ua6ad\u3a9e\uf473',
+  colorAttachments: [{
+  view: textureView8,
+  depthSlice: 79,
+  clearValue: { r: -267.5, g: -771.8, b: -79.06, a: 161.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {
+  view: textureView20,
+  depthSlice: 6,
+  clearValue: { r: 447.2, g: 559.4, b: 487.5, a: 19.34, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView16, depthClearValue: -8.312897388300122, depthReadOnly: true, stencilReadOnly: true},
+  occlusionQuerySet: querySet8,
+  maxDrawCount: 12623643,
+});
+try {
+renderBundleEncoder12.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+commandEncoder12.clearBuffer(buffer2, 11024, 39976);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder19.pushDebugGroup('\u05c8');
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder({label: '\u{1fbfe}\u0e3f\u656e\u964c\ub705\u00b7\u{1ff5c}\u07f9'});
+let commandBuffer5 = commandEncoder7.finish({label: '\uf878\u907e\u513c\u499c'});
+let renderBundle15 = renderBundleEncoder12.finish({});
+let externalTexture14 = device0.importExternalTexture({label: '\u0764\u{1fcb1}\u00af\u01ae\u{1f6d3}\u0965\u{1f648}', source: videoFrame1, colorSpace: 'srgb'});
+try {
+renderPassEncoder0.beginOcclusionQuery(38);
+} catch {}
+try {
+renderPassEncoder0.setViewport(51.30, 0.8929, 9.032, 0.00427, 0.3352, 0.5098);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(2930, undefined, 251531794, 1139472300);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer0), /* required buffer size: 181 */
+{offset: 181}, {width: 144, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder27 = device0.createCommandEncoder({});
+let texture15 = device0.createTexture({
+  label: '\u2b57\u{1fd96}\u0d75\uf28a\ufdfc\u09d3',
+  size: [384, 1, 1],
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder1 = commandEncoder8.beginRenderPass({
+  colorAttachments: [{
+  view: textureView8,
+  depthSlice: 20,
+  clearValue: { r: -874.5, g: 660.3, b: 841.1, a: 720.1, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView20,
+  depthSlice: 20,
+  clearValue: { r: 730.6, g: 598.1, b: -834.2, a: 689.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView16,
+    depthClearValue: 0.5376252898758146,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'discard',
+    stencilClearValue: 27118,
+  },
+  occlusionQuerySet: querySet9,
+  maxDrawCount: 821764449,
+});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  label: '\ud0f0\u3463\u0c99\ue774\u995f\u0560\u0875\u0a1e\u2667',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder1.beginOcclusionQuery(15);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setViewport(15.52, 0.5065, 37.29, 0.3035, 0.8805, 0.9159);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(4395, undefined, 127833017, 4112231926);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder24.pushDebugGroup('\u199d');
+} catch {}
+try {
+commandEncoder12.insertDebugMarker('\u06b8');
+} catch {}
+try {
+renderBundleEncoder13.insertDebugMarker('\u05c7');
+} catch {}
+let gpuCanvasContext2 = canvas2.getContext('webgpu');
+let commandEncoder28 = device0.createCommandEncoder();
+let textureView21 = texture3.createView({
+  label: '\u0a5b\uc7a2',
+  aspect: 'all',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 797,
+  arrayLayerCount: 269,
+});
+let computePassEncoder13 = commandEncoder21.beginComputePass({});
+let renderPassEncoder2 = commandEncoder12.beginRenderPass({
+  label: '\u0deb\u{1fa43}\u004d\u4f23\uabf9\uea85\u00a4',
+  colorAttachments: [{
+  view: textureView1,
+  depthSlice: 44,
+  clearValue: { r: -451.2, g: 486.0, b: 27.09, a: 222.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {
+  view: textureView20,
+  depthSlice: 25,
+  clearValue: { r: -924.0, g: -682.0, b: 58.43, a: -60.55, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {view: textureView16, depthLoadOp: 'load', depthStoreOp: 'discard'},
+  occlusionQuerySet: querySet3,
+  maxDrawCount: 81256825,
+});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(4, bindGroup5, new Uint32Array(4678), 4070, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 295.8, g: -283.1, b: 199.4, a: -870.2, });
+} catch {}
+try {
+renderPassEncoder2.setViewport(93.92, 0.8902, 1.827, 0.03956, 0.02746, 0.7747);
+} catch {}
+try {
+commandEncoder20.copyTextureToTexture({
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 23, y: 0, z: 9},
+  aspect: 'all',
+},
+{
+  texture: texture13,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 4},
+  aspect: 'all',
+},
+{width: 43, height: 1, depthOrArrayLayers: 37});
+} catch {}
+try {
+renderBundleEncoder13.insertDebugMarker('\u7261');
+} catch {}
+let buffer6 = device0.createBuffer({
+  label: '\ue5ca\ue0d3\u79a0\u08fb\ub634\uc32c\u4c2e\u8a98',
+  size: 92039,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder29 = device0.createCommandEncoder({label: '\uf607\u64a9\u012c\uc876\ubbe1\ud42e\u0313\uac0c\u185c\u0327'});
+let textureView22 = texture10.createView({
+  label: '\u{1fbee}\u5ac8\u1b91\u0a48\uebe8\u0273\ucfa6\u08e8\u{1f70b}\u5ee4',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+  baseArrayLayer: 0,
+});
+let computePassEncoder14 = commandEncoder29.beginComputePass({label: '\u95d2\u8e75\u0ca5\u5136\u0242\u0f95\u{1fbba}\ubf8a\u2802'});
+let renderPassEncoder3 = commandEncoder24.beginRenderPass({
+  label: '\ua9ed\u4f62\u{1fffc}\u09d9\u0294\u{1fc2f}\uc649\u4cd7\u04ae\u{1fe11}',
+  colorAttachments: [{
+  view: textureView8,
+  depthSlice: 45,
+  clearValue: { r: 132.8, g: -97.78, b: 421.3, a: 379.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {
+  view: textureView20,
+  depthSlice: 13,
+  clearValue: { r: -907.2, g: -597.1, b: 26.93, a: 570.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView16,
+    depthClearValue: 0.614494305404919,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'discard',
+    stencilReadOnly: true,
+  },
+  maxDrawCount: 709641380,
+});
+try {
+renderPassEncoder1.setBlendConstant({ r: 796.7, g: 570.6, b: -192.6, a: -13.27, });
+} catch {}
+try {
+renderPassEncoder1.setViewport(7.955, 0.5412, 11.09, 0.2993, 0.9008, 0.9325);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer0, 'uint16', 2438);
+} catch {}
+let gpuCanvasContext3 = canvas3.getContext('webgpu');
+let bindGroup6 = device0.createBindGroup({layout: bindGroupLayout1, entries: []});
+let buffer7 = device0.createBuffer({
+  label: '\u0978\u237f\u06bf\u2e76\u98fe\u0010\u{1f6ae}',
+  size: 389472,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: false,
+});
+let commandEncoder30 = device0.createCommandEncoder({});
+let querySet12 = device0.createQuerySet({
+  label: '\u0aac\u{1fb1d}\u0288\u{1fc02}\u{1f9e8}\u032c\u15cc\u018d\u3d1c\u4dec\u0fc6',
+  type: 'occlusion',
+  count: 1675,
+});
+let textureView23 = texture1.createView({
+  label: '\u5300\ud0cf\u3b95\u076f\u2b4a\u{1fd3f}\u0909\u00a6\u{1f879}\u{1f74a}\u09f1',
+  baseMipLevel: 3,
+});
+let renderPassEncoder4 = commandEncoder20.beginRenderPass({
+  label: '\u0283\u4ace\u{1fc5a}\u98a3\u07bd\u270e\u0dd8\u0404\u05c8\u6e73\uf4f9',
+  colorAttachments: [{
+  view: textureView23,
+  depthSlice: 12,
+  clearValue: { r: 739.2, g: -134.2, b: 780.7, a: 71.99, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView20,
+  depthSlice: 1,
+  clearValue: { r: -348.2, g: 222.2, b: -193.2, a: 917.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView16,
+    depthClearValue: -4.174821359740914,
+    depthReadOnly: true,
+    stencilClearValue: 14543,
+    stencilReadOnly: true,
+  },
+  maxDrawCount: 908998212,
+});
+let renderBundle16 = renderBundleEncoder11.finish({label: '\u0759\u{1fe61}\u{1fc1e}\u{1fcb2}\u066e\u8d89\u2993\u00df\u4bf4\u01c7\u{1f9d9}'});
+try {
+renderPassEncoder4.setVertexBuffer(9839, undefined);
+} catch {}
+let promise6 = buffer6.mapAsync(GPUMapMode.READ, 10528, 80420);
+try {
+commandEncoder19.copyBufferToBuffer(buffer7, 173708, buffer2, 42552, 12724);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder30.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 2,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 24},
+  aspect: 'all',
+}, new Float32Array(new ArrayBuffer(72)), /* required buffer size: 2_089_368 */
+{offset: 876, bytesPerRow: 138, rowsPerImage: 47}, {width: 26, height: 0, depthOrArrayLayers: 323});
+} catch {}
+let texture16 = device0.createTexture({
+  label: '\u{1f64f}\u5574\u264e\u352a\ufa4b\u00ea',
+  size: {width: 9530, height: 8, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  sampleCount: 1,
+  format: 'astc-10x8-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView24 = texture15.createView({label: '\u{1fa11}\u0b21\u4c67', dimension: '2d'});
+let renderPassEncoder5 = commandEncoder19.beginRenderPass({
+  label: '\u{1faca}\u13f6\u0811\u5fb9\u026e\u075c\u9817\u0026\u8d78\ua6a3\u20aa',
+  colorAttachments: [{
+  view: textureView8,
+  depthSlice: 26,
+  clearValue: { r: 311.3, g: 192.0, b: 925.1, a: -122.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView20,
+  depthSlice: 17,
+  clearValue: { r: 766.2, g: -279.0, b: -175.1, a: 95.49, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView16,
+    depthClearValue: 0.9433583120702781,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'store',
+    depthReadOnly: false,
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet12,
+  maxDrawCount: 297958471,
+});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({
+  label: '\ue613\u567a\u06e2\u0a24',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture15 = device0.importExternalTexture({source: video1, colorSpace: 'display-p3'});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup1, new Uint32Array(222), 118, 0);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(40, 1, 33, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer5, 'uint16', 81898, 42503);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  label: '\u0594\u0167',
+  entries: [
+    {binding: 2349, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 1984, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'filtering' }},
+    {binding: 5759, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+  ],
+});
+let textureView25 = texture6.createView({label: '\u2ad7\u{1f607}\u0e7e\u45fb\u4d8b\u01be', baseArrayLayer: 169, arrayLayerCount: 118});
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setViewport(44.73, 0.5692, 46.68, 0.3710, 0.8419, 0.8551);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer0, 'uint32', 3048, 2074);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(8455, undefined, 0);
+} catch {}
+try {
+renderPassEncoder2.insertDebugMarker('\uf786');
+} catch {}
+document.body.prepend(canvas3);
+gc();
+let imageBitmap3 = await createImageBitmap(imageBitmap0);
+let querySet13 = device0.createQuerySet({label: '\u0025\u009d\u9788\u54e5\ue50c', type: 'occlusion', count: 1018});
+let externalTexture16 = device0.importExternalTexture({label: '\uf8bc\ue9bc', source: videoFrame1, colorSpace: 'display-p3'});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup4, new Uint32Array(8744), 3961, 0);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer5, 'uint32', 113592, 70688);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(1, bindGroup0, new Uint32Array(1061), 573, 0);
+} catch {}
+try {
+window.someLabel = texture15.label;
+} catch {}
+let commandEncoder31 = device0.createCommandEncoder({label: '\u{1f925}\u0c8d\u0289\u29b1\ua6fb\ucf05'});
+let textureView26 = texture12.createView({
+  label: '\u031a\ud169\u0911\u71d4\ucdbb\u{1f617}\u6749\u0c4b\u0968\u831b\u0224',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+});
+let renderPassEncoder6 = commandEncoder28.beginRenderPass({
+  label: '\u{1ffe5}\u0e14\u0b67\ud876\ue90a',
+  colorAttachments: [{view: textureView23, depthSlice: 11, loadOp: 'load', storeOp: 'store'}, {
+  view: textureView20,
+  depthSlice: 0,
+  clearValue: { r: -43.86, g: 734.1, b: -4.552, a: -620.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView16,
+    depthClearValue: 0.6744484791866846,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'store',
+    stencilClearValue: 40696,
+    stencilReadOnly: true,
+  },
+  occlusionQuerySet: querySet13,
+  maxDrawCount: 21963085,
+});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({
+  label: '\u7f39\u20e2\uc8dd\u9de5\u0cf7\u2050\u{1fbf6}\u{1f6c3}\u2313',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder1.setBindGroup(4, bindGroup6);
+} catch {}
+try {
+commandEncoder30.copyBufferToBuffer(buffer7, 136072, buffer4, 12784, 5452);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder30.copyTextureToBuffer({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 192 widthInBlocks: 192 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 17612 */
+  offset: 17612,
+  buffer: buffer4,
+}, {width: 192, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 2148, new Float32Array(43530), 40748, 424);
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let commandBuffer6 = commandEncoder26.finish({label: '\uf6e3\u0d50\u9833\u91fa\ue90f\u364f\uad33\u81f2\u0024\ub3bb\u{1f834}'});
+let computePassEncoder15 = commandEncoder31.beginComputePass({});
+let renderBundle17 = renderBundleEncoder12.finish({label: '\u30db\u{1fa52}\u{1fb54}\u4432'});
+try {
+renderPassEncoder0.setScissorRect(79, 1, 15, 0);
+} catch {}
+try {
+commandEncoder30.copyTextureToBuffer({
+  texture: texture2,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 12 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 29700 */
+  offset: 29700,
+  buffer: buffer4,
+}, {width: 12, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder27.clearBuffer(buffer6, 53432, 3028);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+computePassEncoder3.insertDebugMarker('\udabb');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 118080, new Float32Array(37142), 9638, 1012);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 370},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 43_860_488 */
+{offset: 224, bytesPerRow: 430, rowsPerImage: 136}, {width: 66, height: 1, depthOrArrayLayers: 751});
+} catch {}
+let commandEncoder32 = device0.createCommandEncoder({label: '\u0d11\u0c52\u{1f770}'});
+let sampler7 = device0.createSampler({
+  label: '\u904c\u{1f87a}\u{1f786}\u0549',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 86.77,
+  lodMaxClamp: 96.25,
+  compare: 'less',
+});
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(3868);
+} catch {}
+try {
+commandEncoder27.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 24},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 376 widthInBlocks: 94 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 286896 */
+  offset: 13112,
+  bytesPerRow: 512,
+  rowsPerImage: 267,
+  buffer: buffer3,
+}, {width: 94, height: 1, depthOrArrayLayers: 3});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 294},
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 57_743_641 */
+{offset: 181, bytesPerRow: 378, rowsPerImage: 268}, {width: 45, height: 1, depthOrArrayLayers: 571});
+} catch {}
+let imageData6 = new ImageData(88, 100);
+let bindGroupLayout6 = device0.createBindGroupLayout({label: '\u{1f760}\ub4c1\u{1f63f}\u8c71\uf07a\u0e9c\u06a7\u7219\u{1f689}\u0f2e', entries: []});
+let computePassEncoder16 = commandEncoder22.beginComputePass({label: '\u70c9\u463f\u{1fd78}\u0aaf\u93e9\u{1fa28}\uf475\u0a10'});
+let renderPassEncoder7 = commandEncoder32.beginRenderPass({
+  label: '\u{1fa1f}\ueafe\u71bf',
+  colorAttachments: [{
+  view: textureView1,
+  depthSlice: 105,
+  clearValue: { r: 465.4, g: 889.9, b: -329.1, a: 294.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {
+  view: textureView20,
+  depthSlice: 12,
+  clearValue: { r: -759.7, g: 234.4, b: 145.2, a: 635.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView16,
+    depthClearValue: 0.8744435853356745,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'discard',
+  },
+  occlusionQuerySet: querySet6,
+});
+let renderBundle18 = renderBundleEncoder15.finish();
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setViewport(23.33, 0.4138, 61.32, 0.4511, 0.06814, 0.1441);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup5);
+} catch {}
+let promise8 = device0.popErrorScope();
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder33 = device0.createCommandEncoder({label: '\ub2bb\ud111\uf7a9\ued05\ube92\u093f\u{1f827}\u0ed8'});
+let texture17 = device0.createTexture({
+  label: '\u16c7\u0a7a',
+  size: {width: 384, height: 1, depthOrArrayLayers: 918},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView27 = texture17.createView({
+  label: '\u80f2\u91eb\u0d13\u0bf9\u{1ffe3}\u0c03\uf5f5\u391a',
+  dimension: '2d',
+  aspect: 'stencil-only',
+  baseArrayLayer: 109,
+});
+let renderPassEncoder8 = commandEncoder27.beginRenderPass({
+  label: '\u16b0\u7e2b',
+  colorAttachments: [{
+  view: textureView23,
+  depthSlice: 74,
+  clearValue: { r: 583.0, g: -962.5, b: 493.5, a: 681.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView20,
+  depthSlice: 12,
+  clearValue: { r: 30.19, g: 870.9, b: 561.5, a: 927.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView16, depthLoadOp: 'load', depthStoreOp: 'discard', stencilClearValue: 38384},
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 1188595571,
+});
+let sampler8 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 74.32,
+  maxAnisotropy: 13,
+});
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup1, new Uint32Array(8109), 2832, 0);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(520);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(24, 1, 31, 0);
+} catch {}
+try {
+renderPassEncoder0.setViewport(44.42, 0.6359, 47.35, 0.1318, 0.4056, 0.6331);
+} catch {}
+try {
+commandEncoder30.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 34, y: 0, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture13,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 24},
+  aspect: 'all',
+},
+{width: 86, height: 1, depthOrArrayLayers: 241});
+} catch {}
+try {
+commandEncoder30.clearBuffer(buffer6, 16004, 43396);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let bindGroupLayout7 = device0.createBindGroupLayout({label: '\u0ee0\u1753\ueaba', entries: []});
+let commandEncoder34 = device0.createCommandEncoder({label: '\u0105\u{1f87d}\u013e\u01d9'});
+let computePassEncoder17 = commandEncoder30.beginComputePass({});
+try {
+renderPassEncoder2.setStencilReference(2292);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(2776, undefined);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 13, y: 0, z: 93},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 44_006_265 */
+{offset: 187, bytesPerRow: 1393, rowsPerImage: 162}, {width: 302, height: 1, depthOrArrayLayers: 196});
+} catch {}
+canvas3.width = 787;
+let offscreenCanvas1 = new OffscreenCanvas(755, 317);
+try {
+offscreenCanvas1.getContext('webgl');
+} catch {}
+let buffer8 = device0.createBuffer({label: '\uc4c2\u8446\u68be', size: 301523, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE});
+let texture18 = device0.createTexture({
+  label: '\u012e\u1332\u399b\u0e8e\ud3d9\u{1f64b}\u070d\u4ec1',
+  size: {width: 96, height: 1, depthOrArrayLayers: 1894},
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8uint'],
+});
+let renderPassEncoder9 = commandEncoder33.beginRenderPass({
+  label: '\u06e0\u0e6c\u0323\ubacb',
+  colorAttachments: [{view: textureView23, depthSlice: 109, loadOp: 'clear', storeOp: 'store'}, {
+  view: textureView20,
+  depthSlice: 16,
+  clearValue: { r: 47.87, g: -759.1, b: -955.6, a: -337.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView16,
+    depthClearValue: -1.0845238428444066,
+    depthReadOnly: true,
+    stencilClearValue: 2288,
+    stencilReadOnly: true,
+  },
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 700396831,
+});
+let renderBundle19 = renderBundleEncoder9.finish({});
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder13.insertDebugMarker('\u0f0e');
+} catch {}
+let pipelineLayout3 = device0.createPipelineLayout({
+  label: '\u{1f655}\u{1f84d}\u7c51\u49bb\u1f16',
+  bindGroupLayouts: [bindGroupLayout5, bindGroupLayout2],
+});
+let commandEncoder35 = device0.createCommandEncoder({});
+let querySet14 = device0.createQuerySet({label: '\u{1fc6a}\u0d16\ue8ed\u7708\ub01f\uad0b', type: 'occlusion', count: 159});
+let textureView28 = texture2.createView({
+  label: '\u060d\u07d8\u09ae\u22b6\u3ce1\u1fe6\u4f55\uf410\u{1f77a}\u03f1\u1804',
+  aspect: 'stencil-only',
+  mipLevelCount: 2,
+});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  label: '\uc3d5\u{1ff34}\u{1fcdb}',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler9 = device0.createSampler({
+  label: '\u{1ff87}\u3fab\u2c92\ub945',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 72.57,
+  lodMaxClamp: 81.34,
+  compare: 'less',
+  maxAnisotropy: 18,
+});
+let externalTexture17 = device0.importExternalTexture({
+  label: '\u050f\u9a73\u{1fe85}\uca0d\uef77\u0bab\uce96\u3e39\u034d\u4de2\u{1f9f7}',
+  source: video0,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder7.beginOcclusionQuery(784);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(4, bindGroup2);
+} catch {}
+let bindGroupLayout8 = device0.createBindGroupLayout({label: '\u038e\u0cca\u{1fd68}\u{1f784}\u013b\ubd8f\u{1fbf5}\u445c', entries: []});
+let textureView29 = texture4.createView({
+  label: '\u{1f7d1}\ud048\u86f8\u5a48\ueabb\u066b\u0b2f',
+  dimension: '2d-array',
+  aspect: 'all',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let renderPassEncoder10 = commandEncoder35.beginRenderPass({
+  colorAttachments: [{
+  view: textureView1,
+  depthSlice: 49,
+  clearValue: { r: 206.1, g: 948.7, b: -124.2, a: -293.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView20,
+  depthSlice: 3,
+  clearValue: { r: 450.7, g: -825.8, b: 441.6, a: -716.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView16, depthClearValue: -6.684709066125965, depthReadOnly: true},
+  occlusionQuerySet: querySet6,
+});
+let externalTexture18 = device0.importExternalTexture({
+  label: '\u06fc\uebc5\u29f9\u0405\u6d6c\ue3fc\u{1fde4}\ua819\u{1faa5}',
+  source: videoFrame1,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder0.setStencilReference(2912);
+} catch {}
+try {
+querySet9.destroy();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 34224, new BigUint64Array(32363), 11144, 9664);
+} catch {}
+let imageData7 = new ImageData(164, 148);
+let commandEncoder36 = device0.createCommandEncoder({label: '\uee28\u0439\u{1feb0}\u03eb\u903a\uaf1f\u6ece\ud9d4\u{1ff6b}\uf731'});
+let sampler10 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 1.778,
+  lodMaxClamp: 43.02,
+});
+let externalTexture19 = device0.importExternalTexture({label: '\u0246\u0c98\ub17f\u0d26\u500d\u4d99\u0b21\udde8', source: videoFrame2});
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(8154, undefined, 2665455584, 56239652);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(7394, undefined, 0, 210768747);
+} catch {}
+try {
+commandEncoder34.copyBufferToBuffer(buffer8, 135748, buffer4, 27132, 15536);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 356},
+  aspect: 'stencil-only',
+}, new Uint32Array(new ArrayBuffer(40)), /* required buffer size: 8_955_571 */
+{offset: 966, bytesPerRow: 451, rowsPerImage: 209}, {width: 192, height: 0, depthOrArrayLayers: 96});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let videoFrame3 = new VideoFrame(img2, {timestamp: 0});
+let bindGroup7 = device0.createBindGroup({layout: bindGroupLayout2, entries: []});
+let commandEncoder37 = device0.createCommandEncoder({});
+let textureView30 = texture10.createView({label: '\u{1f893}\u665c\uf0b3\u{1f825}\u{1ff1d}\uecda\uc75b\uc97c', aspect: 'all', mipLevelCount: 3});
+let renderPassEncoder11 = commandEncoder37.beginRenderPass({
+  label: '\u0f84\u005c\u05ea\u027a\u{1fe63}',
+  colorAttachments: [{
+  view: textureView1,
+  depthSlice: 13,
+  clearValue: { r: -233.2, g: -803.2, b: -227.5, a: 859.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {view: textureView20, depthSlice: 19, loadOp: 'load', storeOp: 'discard'}],
+  depthStencilAttachment: {view: textureView16, depthClearValue: 0.901793818242141, depthLoadOp: 'clear', depthStoreOp: 'store'},
+  occlusionQuerySet: querySet10,
+  maxDrawCount: 506983037,
+});
+try {
+renderPassEncoder3.setBindGroup(4, bindGroup6, []);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup7, new Uint32Array(9777), 8896, 0);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: 966.5, g: -464.8, b: 758.3, a: 130.4, });
+} catch {}
+let texture19 = device0.createTexture({
+  size: {width: 384, height: 1, depthOrArrayLayers: 1281},
+  mipLevelCount: 9,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderPassEncoder12 = commandEncoder31.beginRenderPass({
+  label: '\u{1f6be}\u5f0c\u44ef\u0c9e',
+  colorAttachments: [{
+  view: textureView8,
+  depthSlice: 30,
+  clearValue: { r: -421.3, g: -331.4, b: -529.8, a: 456.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {
+  view: textureView20,
+  depthSlice: 12,
+  clearValue: { r: -135.8, g: -989.5, b: 904.3, a: 814.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView16,
+    depthClearValue: 0.7587993388728931,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'store',
+    stencilReadOnly: true,
+  },
+  maxDrawCount: 1128099669,
+});
+try {
+renderPassEncoder7.setBlendConstant({ r: -87.82, g: 881.8, b: 265.2, a: 882.4, });
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer0, 'uint32', 2804, 1480);
+} catch {}
+let bindGroupLayout9 = device0.createBindGroupLayout({label: '\u6693\u0c8f\u29fd\u0668\ud738', entries: []});
+let buffer9 = device0.createBuffer({label: '\u88cb\u0221', size: 340236, usage: GPUBufferUsage.UNIFORM, mappedAtCreation: true});
+let commandEncoder38 = device0.createCommandEncoder();
+let texture20 = device0.createTexture({
+  label: '\uaee4\u0bd2\u14e0\u{1f694}\u0b80\u{1f8b5}\u057a\u6578\u0932',
+  size: {width: 768, height: 1, depthOrArrayLayers: 558},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint', 'rgba8uint'],
+});
+let computePassEncoder18 = commandEncoder38.beginComputePass({label: '\u05d7\u96fe\u78fd\u7091\u0bb9\ud727'});
+try {
+computePassEncoder5.setBindGroup(5, bindGroup5, new Uint32Array(8478), 7805, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer5, 'uint16', 72368, 10662);
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let sampler11 = device0.createSampler({
+  label: '\ud92f\ua7c1',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 58.22,
+  lodMaxClamp: 96.14,
+});
+let externalTexture20 = device0.importExternalTexture({source: video0});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup1, new Uint32Array(9461), 1093, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup6, new Uint32Array(6109), 1297, 0);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant({ r: 310.4, g: -95.82, b: 891.2, a: -704.9, });
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(13, 1, 46, 0);
+} catch {}
+try {
+renderPassEncoder5.setStencilReference(1125);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3425, undefined, 0, 3067009993);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(1, bindGroup2, []);
+} catch {}
+try {
+commandEncoder36.clearBuffer(buffer4, 22480, 9432);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 1052, new DataView(new ArrayBuffer(50276)), 40408, 1948);
+} catch {}
+let commandEncoder39 = device0.createCommandEncoder({label: '\u34f6\u09f4\u0a0c\uc45d'});
+let textureView31 = texture14.createView({label: '\u0f31\u{1ffed}\u{1fde2}\u0b6d', dimension: '2d', baseMipLevel: 3, baseArrayLayer: 540});
+let renderBundle20 = renderBundleEncoder9.finish({label: '\u0e76\u0052\ud404\u20b4\u1dc1\ucba4\u0f6a\u{1f8ae}'});
+let sampler12 = device0.createSampler({
+  label: '\u0110\u0a78\u{1fb51}\u48e0\u3211\ubf09',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 94.13,
+  lodMaxClamp: 99.27,
+  compare: 'not-equal',
+});
+try {
+renderPassEncoder2.setStencilReference(2507);
+} catch {}
+try {
+commandEncoder39.copyBufferToTexture({
+  /* bytesInLastRow: 96 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 24960 */
+  offset: 24960,
+  rowsPerImage: 296,
+  buffer: buffer7,
+}, {
+  texture: texture10,
+  mipLevel: 2,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let textureView32 = texture2.createView({
+  label: '\ue725\u{1ffdc}\u08ac\u1f32\u0eaf\u{1f9c5}\u0dae\u{1f800}\u2e68',
+  dimension: '2d-array',
+  baseMipLevel: 3,
+  arrayLayerCount: 1,
+});
+let computePassEncoder19 = commandEncoder36.beginComputePass({label: '\u01d8\u0cb8\u0345'});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture21 = device0.importExternalTexture({
+  label: '\ua93c\u{1fef6}\u0e58\u{1fb94}\u23a0\u9e0e\u{1f60f}\u{1ffb6}',
+  source: video1,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder6.setBindGroup(4, bindGroup0, new Uint32Array(9058), 7087, 0);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(1441);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant({ r: 218.2, g: -28.53, b: -587.5, a: -351.3, });
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(3667);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 194, y: 0, z: 321},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer0), /* required buffer size: 8_988_004 */
+{offset: 100, bytesPerRow: 1494, rowsPerImage: 47}, {width: 301, height: 0, depthOrArrayLayers: 129});
+} catch {}
+let texture21 = device0.createTexture({
+  label: '\u0620\u0b35\u0369\u0a98\uec49\u{1fa44}',
+  size: [768, 1, 1],
+  mipLevelCount: 3,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder8.beginOcclusionQuery(729);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer5, 'uint16');
+} catch {}
+try {
+commandEncoder39.copyBufferToBuffer(buffer7, 172512, buffer6, 85412, 4956);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder34.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 1,
+  origin: {x: 37, y: 0, z: 140},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 47},
+  aspect: 'all',
+},
+{width: 14, height: 1, depthOrArrayLayers: 14});
+} catch {}
+let bindGroup8 = device0.createBindGroup({label: '\u2874\u{1f942}\u{1f8bf}\u{1f8ef}\u{1fd4a}\ue4a7', layout: bindGroupLayout9, entries: []});
+let commandEncoder40 = device0.createCommandEncoder({label: '\u09c2\u05c2\u{1f90b}\u0858\u6b5a\u0b77'});
+let texture22 = device0.createTexture({
+  label: '\u87d6\u{1fb65}\u0467\u0a11\u9747',
+  size: {width: 96},
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let externalTexture22 = device0.importExternalTexture({label: '\u{1f80d}\u0342\u4b53\u7fcd\uba8e', source: video1, colorSpace: 'display-p3'});
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({colorFormats: ['rgba8uint', 'rgba32uint'], depthStencilFormat: 'depth24plus-stencil8', sampleCount: 1});
+try {
+renderPassEncoder3.setBlendConstant({ r: -818.2, g: 742.0, b: 730.7, a: -971.7, });
+} catch {}
+try {
+commandEncoder40.copyBufferToTexture({
+  /* bytesInLastRow: 656 widthInBlocks: 41 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 144064 */
+  offset: 8240,
+  bytesPerRow: 768,
+  rowsPerImage: 16,
+  buffer: buffer8,
+}, {
+  texture: texture12,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 41, height: 1, depthOrArrayLayers: 12});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder34.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 57, y: 0, z: 29},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 75, y: 0, z: 131},
+  aspect: 'all',
+},
+{width: 12, height: 1, depthOrArrayLayers: 214});
+} catch {}
+try {
+  await promise8;
+} catch {}
+gc();
+let shaderModule0 = device0.createShaderModule({
+  label: '\uee7d\u35b2\uad3e\u{1fdfd}\ue85b\u{1fa9e}\u0e03\u8dea\u{1f753}',
+  code: `@group(0) @binding(1984)
+var<storage, read_write> n0: array<u32>;
+@group(0) @binding(5759)
+var<storage, read_write> parameter0: array<u32>;
+
+@compute @workgroup_size(5, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(6) f0: vec3<u32>,
+  @location(1) f1: vec4<u32>,
+  @location(2) f2: vec2<i32>,
+  @location(0) f3: vec4<u32>,
+  @builtin(frag_depth) f4: f32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S0 {
+  @location(15) f0: vec3<i32>,
+  @location(2) f1: vec3<f32>,
+  @location(14) f2: vec4<i32>,
+  @location(1) f3: vec4<i32>,
+  @location(6) f4: i32,
+  @location(0) f5: u32,
+  @location(7) f6: i32,
+  @location(5) f7: vec3<f32>,
+  @builtin(vertex_index) f8: u32,
+  @location(8) f9: vec4<i32>,
+  @location(3) f10: vec3<u32>,
+  @location(11) f11: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(13) a0: vec2<i32>, @location(12) a1: f32, @location(10) a2: f16, @location(4) a3: vec4<f16>, @builtin(instance_index) a4: u32, a5: S0, @location(9) a6: vec4<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup9 = device0.createBindGroup({
+  label: '\u{1faed}\u01ae\ue3b1\u2bd8\uf23b\u07e5\u{1f7b7}\uaa77\ud0bc',
+  layout: bindGroupLayout0,
+  entries: [],
+});
+let commandEncoder41 = device0.createCommandEncoder({});
+let renderPassEncoder13 = commandEncoder34.beginRenderPass({
+  label: '\uf4fa\u0058\ub338\u7304\udace\u{1fead}\u{1ff42}\uae28\u36b1',
+  colorAttachments: [{view: textureView1, depthSlice: 100, loadOp: 'clear', storeOp: 'discard'}, {
+  view: textureView20,
+  depthSlice: 25,
+  clearValue: { r: -851.3, g: 9.730, b: 929.9, a: -336.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView16,
+    depthClearValue: 0.724848232797074,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'store',
+    stencilClearValue: 9187,
+  },
+  occlusionQuerySet: querySet7,
+  maxDrawCount: 1147610864,
+});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({
+  label: '\u4c51\u51f2\u353d',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+});
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant({ r: 116.5, g: 74.60, b: 144.2, a: 252.0, });
+} catch {}
+try {
+renderPassEncoder3.setViewport(21.91, 0.7136, 63.67, 0.2338, 0.5572, 0.6292);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup5, []);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(6442, undefined, 0, 2855686680);
+} catch {}
+try {
+commandEncoder41.copyBufferToBuffer(buffer8, 246596, buffer6, 85092, 4184);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 7052, new Int16Array(9363), 9226, 12);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 113},
+  aspect: 'stencil-only',
+}, new BigUint64Array(arrayBuffer0), /* required buffer size: 14_065 */
+{offset: 499, bytesPerRow: 357, rowsPerImage: 2}, {width: 192, height: 0, depthOrArrayLayers: 20});
+} catch {}
+document.body.prepend(video0);
+let videoFrame4 = new VideoFrame(canvas0, {timestamp: 0});
+let externalTexture23 = device0.importExternalTexture({label: '\u3901\ue849\u{1fd20}\u5a7b\u09c0\u0cda\u0f44', source: videoFrame1});
+try {
+renderPassEncoder5.beginOcclusionQuery(1447);
+} catch {}
+try {
+renderPassEncoder3.setViewport(57.08, 0.6018, 16.21, 0.1213, 0.9561, 0.9573);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(8515, undefined, 0, 1903817080);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 2,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 271_990 */
+{offset: 434, bytesPerRow: 282, rowsPerImage: 37}, {width: 17, height: 1, depthOrArrayLayers: 27});
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+let pipeline0 = await device0.createRenderPipelineAsync({
+  label: '\u{1fad7}\u0e00\u0545\u0dd1\u024b\u07c4\ubc01\ub7cc\u0525\u0e71\u11ad',
+  layout: pipelineLayout2,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'equal', failOp: 'increment-clamp', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilBack: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'decrement-clamp', passOp: 'increment-wrap'},
+    stencilReadMask: 3266747667,
+    stencilWriteMask: 448606302,
+    depthBias: -1644514667,
+    depthBiasSlopeScale: 818.8474614149058,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3176,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 252, shaderLocation: 1},
+          {format: 'uint8x4', offset: 632, shaderLocation: 0},
+          {format: 'float16x2', offset: 960, shaderLocation: 11},
+          {format: 'unorm8x2', offset: 878, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 22660,
+        attributes: [
+          {format: 'sint32x2', offset: 3948, shaderLocation: 13},
+          {format: 'sint32', offset: 3428, shaderLocation: 15},
+          {format: 'sint32', offset: 1920, shaderLocation: 6},
+          {format: 'float32', offset: 5656, shaderLocation: 10},
+          {format: 'sint16x2', offset: 4748, shaderLocation: 14},
+          {format: 'uint32', offset: 4688, shaderLocation: 9},
+          {format: 'uint32', offset: 7212, shaderLocation: 3},
+          {format: 'snorm8x4', offset: 152, shaderLocation: 5},
+          {format: 'float16x2', offset: 2056, shaderLocation: 12},
+          {format: 'float32x3', offset: 912, shaderLocation: 4},
+          {format: 'sint8x4', offset: 2536, shaderLocation: 7},
+          {format: 'sint8x4', offset: 1456, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', unclippedDepth: true},
+});
+canvas3.width = 975;
+let shaderModule1 = device0.createShaderModule({
+  label: '\u{1f89f}\u06a5\u3ae8\uc02f\u0d04',
+  code: `@group(0) @binding(2349)
+var<storage, read_write> n1: array<u32>;
+@group(0) @binding(1984)
+var<storage, read_write> parameter1: array<u32>;
+@group(0) @binding(5759)
+var<storage, read_write> local0: array<u32>;
+
+@compute @workgroup_size(4, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<u32>,
+  @builtin(frag_depth) f1: f32,
+  @builtin(sample_mask) f2: u32,
+  @location(0) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(7) a0: vec3<i32>, @location(4) a1: u32, @location(15) a2: vec4<u32>, @builtin(instance_index) a3: u32, @location(12) a4: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandBuffer7 = commandEncoder40.finish();
+let texture23 = device0.createTexture({
+  label: '\u{1fe37}\u4f8a\u0045\ue093\u2730\uffb7\ueed4',
+  size: [384],
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView33 = texture15.createView({dimension: '2d'});
+let computePassEncoder20 = commandEncoder41.beginComputePass();
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder4.setViewport(12.53, 0.3458, 56.56, 0.2814, 0.9134, 0.9495);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer0, 'uint16', 442);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(8074, undefined, 0, 148138477);
+} catch {}
+try {
+commandEncoder39.copyBufferToBuffer(buffer8, 223712, buffer2, 51356, 3256);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder39.copyTextureToTexture({
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 10, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 22, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline1 = await device0.createRenderPipelineAsync({
+  label: '\u8ecd\u0394\u17c6\u4365\u23d3\uc4d2\u8d08\u074f\u33de\u{1f6ca}',
+  layout: pipelineLayout3,
+  multisample: {},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: 0}, {format: 'rgba32uint'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'greater', failOp: 'invert', depthFailOp: 'invert', passOp: 'invert'},
+    stencilReadMask: 1791019856,
+    stencilWriteMask: 1935676532,
+    depthBiasClamp: 28.433323266466147,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {arrayStride: 4688, stepMode: 'instance', attributes: []},
+      {arrayStride: 15592, attributes: []},
+      {
+        arrayStride: 4552,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 368, shaderLocation: 15},
+          {format: 'uint16x2', offset: 304, shaderLocation: 4},
+          {format: 'sint32x3', offset: 2244, shaderLocation: 7},
+          {format: 'sint32x2', offset: 100, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back'},
+});
+let textureView34 = texture22.createView({label: '\uf749\u60a4\u{1f8fe}\u581d\u{1fa88}\u2578\ua033\u2c38\u749c\u0574'});
+try {
+renderPassEncoder9.setVertexBuffer(2227, undefined, 429917302, 1453607508);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+document.body.prepend(img3);
+let canvas4 = document.createElement('canvas');
+let commandEncoder42 = device0.createCommandEncoder();
+let querySet15 = device0.createQuerySet({type: 'occlusion', count: 2275});
+let texture24 = device0.createTexture({
+  label: '\u0818\u29b4\u{1f9f2}\u0c3a',
+  size: {width: 192, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  sampleCount: 1,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView35 = texture7.createView({
+  label: '\u9765\ufa79\u6f97\u106a\uecc0\u4e26\u80d2\u507d',
+  dimension: '2d',
+  baseMipLevel: 4,
+  mipLevelCount: 2,
+  baseArrayLayer: 73,
+});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({
+  label: '\ue90c\u0ad9\u1318\u03ed\u0e9f\uec29\u3aaf\u0aff\u{1f794}',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: false,
+});
+let renderBundle21 = renderBundleEncoder20.finish({label: '\u{1f9bc}\ucbd1\u0c1b\u8798\ufdfd\u{1fb9f}\u22bf\u28c5'});
+let externalTexture24 = device0.importExternalTexture({label: '\u08fb\ue5fc\udde5\u2219\u0457', source: video1, colorSpace: 'srgb'});
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup6, []);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(2512);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2710, undefined, 309221317, 3022882668);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+commandEncoder39.copyTextureToBuffer({
+  texture: texture21,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 192 widthInBlocks: 192 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 26908 */
+  offset: 26716,
+  buffer: buffer4,
+}, {width: 192, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer4);
+} catch {}
+let imageData8 = new ImageData(56, 144);
+let texture25 = device0.createTexture({
+  label: '\u6d13\ue92d\u{1f907}\u0eba\u{1fe28}\u271a\u0400\u0916\uc79e',
+  size: {width: 384, height: 1, depthOrArrayLayers: 157},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint'],
+});
+try {
+renderPassEncoder0.beginOcclusionQuery(63);
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(2944);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer0, 'uint32');
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(4, bindGroup7, new Uint32Array(8617), 6296, 0);
+} catch {}
+try {
+commandEncoder42.copyBufferToBuffer(buffer8, 32956, buffer3, 212852, 162836);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder42.clearBuffer(buffer6, 17360, 2988);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let gpuCanvasContext4 = canvas4.getContext('webgpu');
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let bindGroup10 = device0.createBindGroup({label: '\u1452\ufeca\u{1f68f}\u{1feb2}\u8326\u{1fbda}', layout: bindGroupLayout8, entries: []});
+let computePassEncoder21 = commandEncoder39.beginComputePass({label: '\ube47\u09c4\u0f9d\u9d32'});
+try {
+renderPassEncoder5.setViewport(31.25, 0.8814, 33.71, 0.05822, 0.01106, 0.7938);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup9, []);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder42.copyBufferToTexture({
+  /* bytesInLastRow: 6432 widthInBlocks: 402 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 33344 */
+  offset: 26912,
+  buffer: buffer8,
+}, {
+  texture: texture16,
+  mipLevel: 1,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4020, height: 8, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer8);
+} catch {}
+let commandEncoder43 = device0.createCommandEncoder({});
+let texture26 = device0.createTexture({
+  label: '\u0a0b\u07fe\u3b74\u8814\u8981\uc59b',
+  size: {width: 96, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['depth24plus-stencil8', 'depth24plus-stencil8'],
+});
+let textureView36 = texture10.createView({label: '\ua693\uc846\u{1f828}\u0257\ue974', dimension: '2d-array', baseMipLevel: 2});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({
+  label: '\u0419\u0827\u{1ff46}\u5d12\u039e\u{1fcc2}\uff14',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+let externalTexture25 = device0.importExternalTexture({label: '\u0b8c\u5e76', source: video0});
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(42);
+} catch {}
+let arrayBuffer1 = buffer2.getMappedRange(3760, 0);
+try {
+buffer3.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 1856, new BigUint64Array(59668), 33437, 1264);
+} catch {}
+try {
+  await promise6;
+} catch {}
+let img4 = await imageWithData(190, 85, '#31508bec', '#9eb434f7');
+try {
+window.someLabel = externalTexture21.label;
+} catch {}
+try {
+window.someLabel = renderBundle14.label;
+} catch {}
+let textureView37 = texture12.createView({label: '\u{1ffb3}\u3625\ue990\u04ea\uac87\u1f80', baseMipLevel: 3});
+let computePassEncoder22 = commandEncoder43.beginComputePass({label: '\uc7ff\u{1f9fd}\u{1fe41}\u{1f9f8}\u006e'});
+try {
+renderPassEncoder5.setViewport(93.91, 0.07051, 1.328, 0.3140, 0.6333, 0.6408);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer5, 'uint16', 153850, 59297);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(5, bindGroup4, new Uint32Array(9764), 1203, 0);
+} catch {}
+try {
+commandEncoder42.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 20552 */
+  offset: 20532,
+  buffer: buffer8,
+}, {
+  texture: texture25,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder42.clearBuffer(buffer6, 31828, 24804);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.submit([commandBuffer6, commandBuffer5]);
+} catch {}
+let querySet16 = device0.createQuerySet({label: '\u{1fba2}\u7a49\u{1f683}\uae55\u{1f611}\u058e\u021a', type: 'occlusion', count: 3977});
+let commandBuffer8 = commandEncoder42.finish({label: '\u1cf7\u{1f729}\ucdf6\ufd9e\u0e56'});
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder3.setViewport(2.452, 0.1146, 17.31, 0.6256, 0.1866, 0.6274);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(4, bindGroup3);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(8431, undefined, 0, 3917837758);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let arrayBuffer2 = buffer2.getMappedRange(3768, 188);
+try {
+computePassEncoder3.insertDebugMarker('\u{1fe69}');
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  label: '\u0401\u0c4e\u6724\u1475\ue413\u{1f885}\u4be3\uce89\u0da7',
+  entries: [
+    {
+      binding: 8636,
+      visibility: 0,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d' },
+    },
+    {binding: 6981, visibility: 0, externalTexture: {}},
+  ],
+});
+let commandEncoder44 = device0.createCommandEncoder({});
+let textureView38 = texture24.createView({
+  label: '\u0237\u0ac5\u0db1\u{1f6cf}\uea15\ucf50\u0a1d\u{1f892}\ufaec',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+});
+let renderBundle22 = renderBundleEncoder17.finish({label: '\u0f6a\ue23c\u0720\u{1f681}\ue106\uca6d\u174c\ue854\uba69'});
+let sampler13 = device0.createSampler({
+  label: '\u6501\u7423\u02f4\u04e6\u00c3\uefed',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 53.24,
+  lodMaxClamp: 64.07,
+  maxAnisotropy: 2,
+});
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+let querySet17 = device0.createQuerySet({label: '\u3a99\u1703\u092d\u070e\u7a98\u510f\u77c5\u{1f984}', type: 'occlusion', count: 3679});
+let textureView39 = texture4.createView({format: 'astc-10x5-unorm-srgb', mipLevelCount: 4});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+});
+let renderBundle23 = renderBundleEncoder8.finish();
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup2, new Uint32Array(1038), 199, 0);
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(96, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder3.setViewport(74.26, 0.9327, 4.127, 0.02868, 0.03948, 0.5594);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(5, bindGroup1, new Uint32Array(3104), 2954, 0);
+} catch {}
+try {
+commandEncoder44.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 43208 */
+  offset: 43208,
+  bytesPerRow: 0,
+  rowsPerImage: 277,
+  buffer: buffer8,
+}, {
+  texture: texture25,
+  mipLevel: 3,
+  origin: {x: 6, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 11});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+renderPassEncoder3.insertDebugMarker('\u{1fe58}');
+} catch {}
+let imageData9 = new ImageData(64, 240);
+let bindGroup11 = device0.createBindGroup({
+  label: '\u7666\u{1fae7}\u{1f84d}\ud25e\u{1f72d}\u0893\u02cf\u{1fa9a}\ucb77\u3754\u084d',
+  layout: bindGroupLayout8,
+  entries: [],
+});
+let commandEncoder45 = device0.createCommandEncoder({label: '\u{1f618}\ucbf1'});
+try {
+renderPassEncoder3.setVertexBuffer(4660, undefined);
+} catch {}
+try {
+commandEncoder45.copyBufferToTexture({
+  /* bytesInLastRow: 256 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 13392 */
+  offset: 13392,
+  buffer: buffer8,
+}, {
+  texture: texture10,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 16, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder45.insertDebugMarker('\u028b');
+} catch {}
+try {
+renderPassEncoder2.insertDebugMarker('\u0e82');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 209156, new DataView(new ArrayBuffer(58329)), 56154, 760);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+document.body.prepend(video1);
+let bindGroupLayout11 = device0.createBindGroupLayout({label: '\u0010\u0aad\u5936\u59f6\u{1fc95}\u67da\u0eec\u0c93\ue50b\ua9d4', entries: []});
+let commandEncoder46 = device0.createCommandEncoder();
+let texture27 = device0.createTexture({
+  label: '\u{1fc83}\u02d4',
+  size: [192, 1, 858],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32uint'],
+});
+let textureView40 = texture5.createView({
+  label: '\u0e8f\u{1ff21}\u{1fa3a}\u{1fdcf}\u{1fac2}\u56fc\uc3b7',
+  dimension: '2d-array',
+  aspect: 'depth-only',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(13, 1, 79, 0);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(1574);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(9832, undefined, 773233943, 545617166);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline1);
+} catch {}
+try {
+texture18.destroy();
+} catch {}
+try {
+commandEncoder45.clearBuffer(buffer3, 238360, 46460);
+dissociateBuffer(device0, buffer3);
+} catch {}
+document.body.prepend(video1);
+let texture28 = device0.createTexture({
+  label: '\u{1f7c8}\u{1fc96}\u362f\u7152\uedef\ua733\u{1faa6}\u96b6\u0a87\u007b\ucf0e',
+  size: {width: 96, height: 1, depthOrArrayLayers: 940},
+  mipLevelCount: 6,
+  dimension: '2d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint', 'rgba8uint'],
+});
+let texture29 = gpuCanvasContext0.getCurrentTexture();
+let renderBundle24 = renderBundleEncoder11.finish({label: '\u0d02\u84e5\ub6e8\u0af3\u0f06\u75d1\u4f3f\u449b\u{1f739}\u4524\u{1f65d}'});
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder44.copyBufferToTexture({
+  /* bytesInLastRow: 892 widthInBlocks: 223 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 16440 */
+  offset: 16440,
+  buffer: buffer8,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 223, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer8);
+} catch {}
+let canvas5 = document.createElement('canvas');
+let pipelineLayout4 = device0.createPipelineLayout({
+  label: '\u26fd\ud461\u391c\u{1fbdb}\u{1fac0}\u0978\u7c25\u{1fb43}',
+  bindGroupLayouts: [bindGroupLayout4, bindGroupLayout5],
+});
+let commandEncoder47 = device0.createCommandEncoder({label: '\u{1fb3a}\u896c\ue650\u6edb\u09c9\u0e74'});
+let querySet18 = device0.createQuerySet({label: '\u0919\u0a68', type: 'occlusion', count: 1411});
+let texture30 = gpuCanvasContext0.getCurrentTexture();
+let textureView41 = texture6.createView({label: '\u092f\u7a08\ub4e7\u0f83', baseMipLevel: 2, baseArrayLayer: 27, arrayLayerCount: 138});
+let renderBundle25 = renderBundleEncoder5.finish({});
+try {
+renderPassEncoder0.setBlendConstant({ r: -753.2, g: 216.2, b: -748.1, a: -294.3, });
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(10, 1, 69, 0);
+} catch {}
+try {
+renderPassEncoder1.setViewport(57.31, 0.9791, 9.367, 0.01542, 0.3268, 0.4451);
+} catch {}
+try {
+  await buffer4.mapAsync(GPUMapMode.READ, 6672, 18344);
+} catch {}
+try {
+commandEncoder45.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 1,
+  origin: {x: 23, y: 0, z: 41},
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 311, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer7]);
+} catch {}
+let commandEncoder48 = device0.createCommandEncoder({});
+let textureView42 = texture10.createView({label: '\ubcdf\u51a3\u9f9f\u0f37\u{1f824}\u0ff8\u0b1d\u{1f8c2}\u95a1\u0734\u0194'});
+let renderBundle26 = renderBundleEncoder12.finish({label: '\u88bb\u908c\ube86\ueb45\u0d1c\u58ca\u{1fac6}\u0875\uf8cc'});
+let sampler14 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  lodMinClamp: 80.82,
+  lodMaxClamp: 83.56,
+});
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(29);
+} catch {}
+try {
+renderPassEncoder10.setViewport(46.80, 0.8032, 4.670, 0.1288, 0.6619, 0.8777);
+} catch {}
+try {
+commandEncoder46.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 58, y: 0, z: 238},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 154, y: 0, z: 226},
+  aspect: 'all',
+},
+{width: 45, height: 0, depthOrArrayLayers: 449});
+} catch {}
+let promise11 = device0.createComputePipelineAsync({layout: pipelineLayout2, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+let bindGroupLayout12 = pipeline0.getBindGroupLayout(1);
+let commandBuffer9 = commandEncoder47.finish();
+let renderPassEncoder14 = commandEncoder45.beginRenderPass({
+  label: '\uc97d\ue963\u{1fe14}',
+  colorAttachments: [{
+  view: textureView8,
+  depthSlice: 97,
+  clearValue: { r: 914.4, g: -887.5, b: -439.2, a: -993.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView20,
+  depthSlice: 23,
+  clearValue: { r: -44.10, g: 482.6, b: -358.9, a: -139.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {view: textureView16, depthLoadOp: 'load', depthStoreOp: 'discard', stencilReadOnly: true},
+  occlusionQuerySet: querySet12,
+  maxDrawCount: 954573930,
+});
+let externalTexture26 = device0.importExternalTexture({label: '\u3264\u6747\u{1f7b9}\u005e\u00d6\ue4e5\u{1fce0}\udb5d', source: video1});
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(5, bindGroup8, []);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline1);
+} catch {}
+let arrayBuffer3 = buffer2.getMappedRange(2480, 1132);
+try {
+commandEncoder48.copyBufferToBuffer(buffer8, 20224, buffer6, 74296, 1276);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder48.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 6},
+  aspect: 'all',
+},
+{
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 105, y: 0, z: 63},
+  aspect: 'all',
+},
+{width: 381, height: 0, depthOrArrayLayers: 143});
+} catch {}
+document.body.prepend(video1);
+let offscreenCanvas2 = new OffscreenCanvas(222, 32);
+try {
+offscreenCanvas2.getContext('bitmaprenderer');
+} catch {}
+let bindGroupLayout13 = device0.createBindGroupLayout({
+  label: '\u{1ff28}\u0bcc\u5aa7\u{1f7d2}\uecbb\u{1fdd8}\uaf0b\u8a75\u1bb8',
+  entries: [
+    {binding: 4888, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 7531, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder49 = device0.createCommandEncoder({label: '\u0693\u{1fdfd}\u{1fa7b}\u{1fd51}\u28e4\u6046\u0607\uf5f9\u1a65\u4d7b\u79f9'});
+let renderPassEncoder15 = commandEncoder44.beginRenderPass({
+  label: '\u89f2\u0217\u0079\u7238\u0fd8',
+  colorAttachments: [{
+  view: textureView23,
+  depthSlice: 60,
+  clearValue: { r: -339.8, g: 301.8, b: 97.03, a: -404.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {view: textureView20, depthSlice: 22, loadOp: 'clear', storeOp: 'store'}],
+  depthStencilAttachment: {
+    view: textureView16,
+    depthClearValue: 0.1857097818733312,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'discard',
+    stencilClearValue: 54039,
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet12,
+  maxDrawCount: 449207869,
+});
+let sampler15 = device0.createSampler({
+  label: '\u7f4a\u{1f79a}\u6aee\u0716\uceb1\uf723\u0def\ud867\u09cf\ub02c\u82ca',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 77.62,
+  lodMaxClamp: 79.74,
+  maxAnisotropy: 18,
+});
+try {
+renderBundleEncoder7.setVertexBuffer(9427, undefined, 4043661154, 181761141);
+} catch {}
+try {
+commandEncoder46.copyTextureToBuffer({
+  texture: texture2,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 24 widthInBlocks: 24 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 152 */
+  offset: 152,
+  buffer: buffer3,
+}, {width: 24, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline2 = device0.createComputePipeline({
+  label: '\u4953\ufc87\u9338\u2707\u0783\u0420\uaa0b',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule1, entryPoint: 'compute0'},
+});
+gc();
+let videoFrame5 = new VideoFrame(canvas4, {timestamp: 0});
+try {
+canvas5.getContext('2d');
+} catch {}
+let textureView43 = texture24.createView({label: '\udfe6\u{1f87a}\u0932\u0912\u0246\u9ef5\u9084\u072a', format: 'rgba8uint', baseMipLevel: 4});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({
+  label: '\u354b\u23bc\u436e\ue9c0\u0296\u03ab',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let externalTexture27 = device0.importExternalTexture({label: '\uc9ab\u882a\u0fb1\u9b7d', source: videoFrame4, colorSpace: 'srgb'});
+try {
+computePassEncoder0.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(2504, undefined, 27015929, 4101343707);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(5, bindGroup11, new Uint32Array(8673), 5236, 0);
+} catch {}
+try {
+commandEncoder48.copyTextureToTexture({
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 160, y: 0, z: 203},
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 49, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 22, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 40456, new Float32Array(7624), 2850, 672);
+} catch {}
+let promise12 = device0.createRenderPipelineAsync({
+  label: '\ub9b4\u9a00\ue839\u949e\u0aa7',
+  layout: pipelineLayout3,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'equal', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilBack: {compare: 'less-equal', failOp: 'increment-clamp', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilReadMask: 1792448512,
+    stencilWriteMask: 990566929,
+    depthBias: 1648372020,
+    depthBiasSlopeScale: 331.93452739777314,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 19796,
+        attributes: [
+          {format: 'sint16x2', offset: 5724, shaderLocation: 7},
+          {format: 'sint8x2', offset: 422, shaderLocation: 12},
+          {format: 'uint32', offset: 792, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 13520, stepMode: 'instance', attributes: []},
+      {arrayStride: 13420, stepMode: 'instance', attributes: []},
+      {arrayStride: 10516, attributes: []},
+      {arrayStride: 13340, attributes: []},
+      {arrayStride: 23464, attributes: [{format: 'uint32x2', offset: 9132, shaderLocation: 15}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw'},
+});
+let bindGroup12 = device0.createBindGroup({layout: bindGroupLayout11, entries: []});
+let commandEncoder50 = device0.createCommandEncoder({});
+let texture31 = device0.createTexture({
+  label: '\u{1fb2c}\u{1fa59}',
+  size: [192, 1, 1],
+  mipLevelCount: 8,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle27 = renderBundleEncoder2.finish();
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: 209.0, g: 575.4, b: 982.8, a: 468.6, });
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline1);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+let texture32 = device0.createTexture({
+  label: '\u6afe\u{1f8e8}\u01fd\u5d3d\ua3b4\u0b11\uf246\u2d52',
+  size: {width: 768, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView44 = texture6.createView({
+  label: '\u0aae\u5df0\ua7ab\u0aed\u5780\u{1f7fc}\u0e8f',
+  baseMipLevel: 2,
+  baseArrayLayer: 73,
+  arrayLayerCount: 232,
+});
+let externalTexture28 = device0.importExternalTexture({label: '\u23ca\u0820', source: videoFrame5, colorSpace: 'display-p3'});
+try {
+computePassEncoder8.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(747);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer0, 'uint32', 5324, 2);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup3, new Uint32Array(6814), 3236, 0);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(2127, undefined, 0, 2662863480);
+} catch {}
+try {
+querySet14.destroy();
+} catch {}
+let video2 = await videoWithData();
+let querySet19 = device0.createQuerySet({label: '\u{1f95b}\u68b8\u0208\u3b49\ue280\ud778', type: 'occlusion', count: 881});
+let texture33 = device0.createTexture({
+  label: '\u87f0\u25af\u{1ffc9}\u000b\u6b72\u2af7\uce12\u{1feed}\u3a97\u{1fc6d}',
+  size: [768, 1, 539],
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['depth24plus-stencil8', 'depth24plus-stencil8', 'depth24plus-stencil8'],
+});
+let textureView45 = texture4.createView({label: '\ue1fc\u782f', aspect: 'all', format: 'astc-10x5-unorm', baseMipLevel: 2, mipLevelCount: 1});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle28 = renderBundleEncoder4.finish({label: '\u383d\ueffc\uabaa\u0527\uf0ca\u3622'});
+try {
+renderPassEncoder14.setBlendConstant({ r: 680.1, g: -701.1, b: -152.4, a: 758.3, });
+} catch {}
+try {
+renderPassEncoder15.setScissorRect(7, 0, 38, 0);
+} catch {}
+let pipeline3 = device0.createComputePipeline({layout: pipelineLayout2, compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}}});
+let img5 = await imageWithData(229, 83, '#2b654a17', '#72cb65f0');
+let commandBuffer10 = commandEncoder48.finish({label: '\ue1d9\ua7cf\u{1f623}\u0d04'});
+let textureView46 = texture11.createView({label: '\u6c73\u0ebe\u{1fc31}\u635b\u{1f65a}\u5914\u{1fd2a}\u3c23', aspect: 'all', baseMipLevel: 3});
+let computePassEncoder23 = commandEncoder46.beginComputePass();
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({
+  label: '\u{1f914}\u452c',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+});
+let sampler16 = device0.createSampler({
+  label: '\u{1f970}\u9034\u9c02\udb65\uddd0\u5ce1\u7b3a\u{1f7c9}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 39.51,
+  lodMaxClamp: 91.25,
+});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setViewport(2.884, 0.1108, 54.45, 0.6186, 0.5571, 0.9924);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1995, undefined, 0, 2570619361);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(1143, undefined, 256869889);
+} catch {}
+try {
+  await buffer7.mapAsync(GPUMapMode.READ | GPUMapMode.WRITE, 369056, 14924);
+} catch {}
+try {
+commandEncoder49.copyBufferToBuffer(buffer8, 35540, buffer2, 41700, 26856);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder50.copyBufferToTexture({
+  /* bytesInLastRow: 1236 widthInBlocks: 309 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 17740 */
+  offset: 16504,
+  buffer: buffer8,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 309, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder50.copyTextureToBuffer({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 64 widthInBlocks: 16 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10788 */
+  offset: 10788,
+  buffer: buffer3,
+}, {width: 16, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder50.clearBuffer(buffer3, 273068, 21024);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 143072, new BigUint64Array(12388), 3385, 1368);
+} catch {}
+let bindGroupLayout14 = device0.createBindGroupLayout({label: '\u9130\u082a\u{1f8ac}\ufe10\u0276\ua6bd\u0ca1\u{1fe0d}\u6464\u{1ff63}\ue954', entries: []});
+let textureView47 = texture12.createView({
+  label: '\u03a1\ud673\ub450\ub9b3\u8978\ua265\u0c87\u0d2b\ud559\u2eff\u05c6',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let computePassEncoder24 = commandEncoder50.beginComputePass({label: '\u0e4d\u{1f773}\u91ff\u1497\u{1fbac}\u0011\u{1fb8a}\u{1f899}\u4742'});
+let renderPassEncoder16 = commandEncoder49.beginRenderPass({
+  label: '\u0d85\u{1f6ba}\u0419\u05c6\u014b',
+  colorAttachments: [{
+  view: textureView23,
+  depthSlice: 102,
+  clearValue: { r: 981.3, g: 876.9, b: 368.5, a: 145.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {view: textureView47, depthSlice: 4, loadOp: 'load', storeOp: 'discard'}],
+  depthStencilAttachment: {
+    view: textureView16,
+    depthClearValue: 0.099035361570323,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'discard',
+    stencilReadOnly: true,
+  },
+  occlusionQuerySet: querySet11,
+});
+let renderBundle29 = renderBundleEncoder5.finish({label: '\u1ce0\ua43e\u978e\u{1f8ae}\u{1f908}\ua375'});
+let sampler17 = device0.createSampler({
+  label: '\u3c89\u0f38\u0639\u4ce0\u8bd6\u024a\u384f',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 52.95,
+  lodMaxClamp: 57.11,
+});
+try {
+renderPassEncoder12.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: -321.9, g: -697.5, b: 25.00, a: 186.2, });
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(34, 0, 29, 1);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(1525);
+} catch {}
+try {
+renderPassEncoder0.setViewport(7.928, 0.1399, 63.80, 0.3718, 0.05917, 0.1466);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(9777, undefined, 1165849113);
+} catch {}
+try {
+computePassEncoder1.pushDebugGroup('\u556b');
+} catch {}
+let bindGroup13 = device0.createBindGroup({layout: bindGroupLayout4, entries: []});
+let pipelineLayout5 = device0.createPipelineLayout({
+  label: '\uce2a\u03c9\u896b\u{1f9b5}\u0e91\u5a8b',
+  bindGroupLayouts: [bindGroupLayout10, bindGroupLayout3, bindGroupLayout14, bindGroupLayout7, bindGroupLayout8],
+});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(1169);
+} catch {}
+document.body.prepend(video2);
+let textureView48 = texture23.createView({
+  label: '\u87d5\uc8dc\u{1f81a}\u02bc\u{1fac3}\u2453\uda23\u7ff5\u{1f783}\ubff9\u76a7',
+  dimension: '1d',
+  aspect: 'all',
+  format: 'rgba8uint',
+});
+let renderBundle30 = renderBundleEncoder12.finish({label: '\ud54e\u070c\u58cb\u{1ff2b}\ue6f7\u1941\ua514\uc425'});
+let sampler18 = device0.createSampler({
+  label: '\uf1bf\u{1f6bb}\u{1f972}\u4024\u058b',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 20.82,
+  lodMaxClamp: 71.23,
+  compare: 'equal',
+});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup11, new Uint32Array(2928), 360, 0);
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder15.setBlendConstant({ r: -334.0, g: 436.2, b: 967.0, a: 622.2, });
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(67, 1, 12, 0);
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(1171);
+} catch {}
+try {
+  await buffer3.mapAsync(GPUMapMode.READ, 262464, 4536);
+} catch {}
+let textureView49 = texture11.createView({baseMipLevel: 3, arrayLayerCount: 1});
+let sampler19 = device0.createSampler({
+  label: '\u0981\uaec1\u08b5\ud5d2\u03c3\ube37\uf88e\u0681',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 70.34,
+  lodMaxClamp: 84.06,
+  compare: 'greater-equal',
+  maxAnisotropy: 1,
+});
+let externalTexture29 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup10, new Uint32Array(5667), 1400, 0);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 456.5, g: -331.1, b: 342.1, a: 653.8, });
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(85, 1, 4, 0);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer5, 'uint16', 221804, 9800);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 23},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 4_302_811 */
+{offset: 91, bytesPerRow: 747, rowsPerImage: 192}, {width: 169, height: 0, depthOrArrayLayers: 31});
+} catch {}
+let promise13 = device0.createComputePipelineAsync({
+  label: '\u{1f632}\u2f18\u6868\u0af6\ue9a0\u7d57\ucbe8\u4a7e\u0af8',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let texture34 = device0.createTexture({
+  size: [768, 1, 1],
+  mipLevelCount: 9,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView50 = texture33.createView({label: '\u9aaf\u{1f632}\u5fb0\u9d5e', aspect: 'stencil-only', baseArrayLayer: 530, arrayLayerCount: 8});
+let renderBundle31 = renderBundleEncoder1.finish({label: '\u0e3e\u0561\u{1f9cd}\u3ce1\u08bd\u{1f806}\u{1f685}\u0b89\u{1f918}\u{1ff42}\u0ae7'});
+try {
+renderPassEncoder14.setIndexBuffer(buffer0, 'uint16', 422, 2157);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(1, bindGroup9, new Uint32Array(1413), 387, 0);
+} catch {}
+try {
+renderBundleEncoder23.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(5224, undefined);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 3,
+  origin: {x: 14, y: 0, z: 4},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer3), /* required buffer size: 3_474_828 */
+{offset: 453, bytesPerRow: 545, rowsPerImage: 255}, {width: 23, height: 0, depthOrArrayLayers: 26});
+} catch {}
+let commandEncoder51 = device0.createCommandEncoder({});
+let texture35 = device0.createTexture({
+  label: '\u{1fca9}\u07a3\u0b90\u06b1\uebc7',
+  size: {width: 768, height: 1, depthOrArrayLayers: 1203},
+  mipLevelCount: 6,
+  sampleCount: 1,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView51 = texture27.createView({label: '\u0f9b\u20db\uabdf\u418d\u27ea\u2fe3\u9f49\u0652\u0b22\u0eb6'});
+let renderPassEncoder17 = commandEncoder51.beginRenderPass({
+  label: '\u2b1f\uc81e\u{1fd0a}',
+  colorAttachments: [{
+  view: textureView7,
+  depthSlice: 77,
+  clearValue: { r: -615.9, g: -262.5, b: 3.878, a: -30.54, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {
+  view: textureView51,
+  depthSlice: 786,
+  clearValue: { r: 173.1, g: 277.7, b: 260.7, a: -443.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView40, depthClearValue: -4.291602583985439, depthLoadOp: 'load', depthStoreOp: 'discard'},
+});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+});
+try {
+renderPassEncoder16.setBlendConstant({ r: 955.8, g: 563.3, b: 224.1, a: 831.6, });
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(404);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(8232, undefined, 0, 1105548332);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(5, bindGroup3);
+} catch {}
+try {
+buffer1.destroy();
+} catch {}
+let pipeline4 = await promise11;
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise10;
+} catch {}
+let commandEncoder52 = device0.createCommandEncoder({label: '\u{1ffae}\u8ce3\u7b66\u18ca\u{1fe70}\u0e64\u22fd\u{1ffc8}\u{1f878}\u10c2'});
+let textureView52 = texture7.createView({dimension: '2d', baseMipLevel: 3, mipLevelCount: 2, baseArrayLayer: 25});
+let externalTexture30 = device0.importExternalTexture({
+  label: '\u{1f652}\ua941\u0bc0\u{1ffa2}\u2a6b\u23bc\u05c8\uc0a8\uc4a9\u0d12\u9e09',
+  source: videoFrame5,
+});
+try {
+renderPassEncoder8.setIndexBuffer(buffer0, 'uint16', 2404, 2868);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup2, new Uint32Array(3277), 2504, 0);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroupLayout15 = device0.createBindGroupLayout({
+  label: '\u0729\u{1f725}\u{1fd25}\u095b\ued0b',
+  entries: [
+    {
+      binding: 5330,
+      visibility: 0,
+      storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let commandEncoder53 = device0.createCommandEncoder({label: '\u2bcc\u476d\u{1fe9c}'});
+let renderBundle32 = renderBundleEncoder19.finish({});
+try {
+commandEncoder53.clearBuffer(buffer2, 76320, 2316);
+dissociateBuffer(device0, buffer2);
+} catch {}
+canvas4.width = 2;
+let video3 = await videoWithData();
+let shaderModule2 = device0.createShaderModule({
+  label: '\u8f40\u2889\u2445\u{1ff20}\u{1f8e9}\ubed7\u0793\u0b3c\u{1fe58}',
+  code: `@group(0) @binding(2349)
+var<storage, read_write> local1: array<u32>;
+@group(0) @binding(1984)
+var<storage, read_write> type0: array<u32>;
+@group(0) @binding(5759)
+var<storage, read_write> field0: array<u32>;
+
+@compute @workgroup_size(3, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(1) f1: vec4<u32>,
+  @location(3) f2: vec3<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S1 {
+  @location(10) f0: vec3<f16>,
+  @location(9) f1: f32,
+  @location(13) f2: f32,
+  @location(14) f3: vec2<f32>,
+  @builtin(instance_index) f4: u32,
+  @location(4) f5: vec3<u32>,
+  @location(6) f6: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec4<f16>, @location(11) a1: vec4<f32>, @location(1) a2: vec4<f16>, @location(15) a3: vec3<f16>, @location(0) a4: vec4<f32>, @location(2) a5: vec4<u32>, @location(12) a6: u32, a7: S1, @location(5) a8: vec4<i32>, @location(3) a9: vec3<f32>, @location(8) a10: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup14 = device0.createBindGroup({
+  label: '\u{1fbbd}\u0eb1\u{1fea8}\u0102\ud862\u{1fe87}\u2731\u02bd\u1200\uada6',
+  layout: bindGroupLayout5,
+  entries: [
+    {binding: 5759, resource: sampler19},
+    {binding: 2349, resource: externalTexture27},
+    {binding: 1984, resource: sampler1},
+  ],
+});
+let pipelineLayout6 = device0.createPipelineLayout({label: '\u{1f994}\u{1fa80}\ua2c2\u1ddb\u165d\u{1f85f}', bindGroupLayouts: []});
+let querySet20 = device0.createQuerySet({type: 'occlusion', count: 718});
+let commandBuffer11 = commandEncoder53.finish({label: '\u0d12\u{1fb6e}\u0618\ue6da\u05cf'});
+try {
+computePassEncoder22.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(36, 1, 23, 0);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(123);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(4, bindGroup7, new Uint32Array(7491), 7387, 0);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer5, 'uint32', 95404);
+} catch {}
+let video4 = await videoWithData();
+let buffer10 = device0.createBuffer({
+  label: '\u3590\u05ff\u{1ff88}\u{1fffe}\u0b10\u52bb\u0a14\u02d6',
+  size: 399352,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder54 = device0.createCommandEncoder({label: '\u7975\u000f'});
+let computePassEncoder25 = commandEncoder54.beginComputePass({label: '\u{1ff12}\u0ad5\u37ed\u5cab'});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({
+  label: '\u{1fb21}\uc2bf\u82b3\u0f09\u{1f716}\u{1fccc}',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+});
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup14, new Uint32Array(9106), 4070, 0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer0, 'uint16', 3110, 46);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(4, buffer10, 0);
+} catch {}
+try {
+commandEncoder52.clearBuffer(buffer3, 62908, 220836);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline5 = await promise13;
+try {
+  await promise9;
+} catch {}
+let imageBitmap4 = await createImageBitmap(imageData0);
+let sampler20 = device0.createSampler({
+  label: '\uea17\u0a0e\u9162\u04d7\u0b98\u{1f763}\u{1fa95}',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 99.42,
+  lodMaxClamp: 99.52,
+  maxAnisotropy: 5,
+});
+try {
+renderPassEncoder3.setStencilReference(1491);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer0, 'uint32', 772);
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+commandEncoder52.copyBufferToBuffer(buffer8, 7732, buffer3, 326468, 15224);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+renderPassEncoder8.insertDebugMarker('\uf177');
+} catch {}
+try {
+window.someLabel = bindGroupLayout10.label;
+} catch {}
+let bindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 3191,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32float', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 1109,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let texture36 = device0.createTexture({
+  label: '\u0436\u0992\u9e65\u723a\u0cde\u6af3\u076d\u{1fa2c}\u9627\u1a38\u0cdd',
+  size: {width: 384},
+  dimension: '1d',
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let renderPassEncoder18 = commandEncoder52.beginRenderPass({
+  label: '\u28ce\u6750\uf69c\u{1f975}\ud5fa\u807d\u266a\u06e9\u04b0',
+  colorAttachments: [{
+  view: textureView7,
+  depthSlice: 207,
+  clearValue: { r: -241.7, g: 16.38, b: -894.4, a: 966.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {
+  view: textureView51,
+  depthSlice: 208,
+  clearValue: { r: -268.6, g: 476.8, b: -433.2, a: -199.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView40,
+    depthClearValue: 9.069114182836397,
+    depthLoadOp: 'load',
+    depthStoreOp: 'store',
+    stencilClearValue: 54490,
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet12,
+  maxDrawCount: 470501947,
+});
+try {
+renderPassEncoder18.beginOcclusionQuery(679);
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(2, 1, 7, 0);
+} catch {}
+try {
+renderPassEncoder18.setViewport(160.8, 0.9667, 2.453, 0.02926, 0.6252, 0.6614);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(new ArrayBuffer(48)), /* required buffer size: 492 */
+{offset: 492, bytesPerRow: 1365}, {width: 310, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline6 = device0.createComputePipeline({
+  label: '\u{1fcc2}\ue1c6\u99d0',
+  layout: 'auto',
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let textureView53 = texture29.createView({label: '\ue439\u{1fbea}', dimension: '2d-array', format: 'bgra8unorm'});
+try {
+renderPassEncoder12.setVertexBuffer(0, buffer10);
+} catch {}
+try {
+device0.queue.submit([commandBuffer11, commandBuffer4]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer1), /* required buffer size: 381_894 */
+{offset: 610, bytesPerRow: 1242, rowsPerImage: 153}, {width: 77, height: 1, depthOrArrayLayers: 3});
+} catch {}
+let promise14 = device0.queue.onSubmittedWorkDone();
+let pipeline7 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule1, entryPoint: 'compute0'}});
+let textureView54 = texture35.createView({
+  label: '\ub812\u{1fa07}\ubeab\ucec1\u065a\u{1fd9e}\u3970\u0d81',
+  baseMipLevel: 2,
+  baseArrayLayer: 66,
+  arrayLayerCount: 928,
+});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({
+  label: '\ue2fa\u0b6f\u3eb0\u042b\u033d\ua5d2\uc573\uae85\u{1fbd3}\u0b49\uac16',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+});
+try {
+computePassEncoder8.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(5, bindGroup5);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(231);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(37, 0, 58, 0);
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(296);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(0, buffer10, 169468, 93294);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageBitmap5 = await createImageBitmap(img5);
+let shaderModule3 = device0.createShaderModule({
+  code: `@group(0) @binding(1984)
+var<storage, read_write> type1: array<u32>;
+@group(0) @binding(2349)
+var<storage, read_write> type2: array<u32>;
+@group(0) @binding(5759)
+var<storage, read_write> global0: array<u32>;
+
+@compute @workgroup_size(4, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S3 {
+  @location(6) f0: vec2<u32>,
+  @location(98) f1: vec4<f32>,
+  @location(90) f2: vec3<u32>,
+  @builtin(front_facing) f3: bool,
+  @location(103) f4: vec2<i32>,
+  @builtin(sample_mask) f5: u32,
+  @location(22) f6: vec4<i32>,
+  @location(21) f7: vec2<i32>,
+  @location(92) f8: vec3<i32>,
+  @location(1) f9: vec4<u32>,
+  @location(64) f10: vec2<u32>,
+  @location(63) f11: f16,
+  @location(35) f12: vec3<u32>,
+  @location(87) f13: vec4<f32>,
+  @location(101) f14: vec3<f16>,
+  @location(52) f15: vec2<f16>,
+  @location(111) f16: u32,
+  @location(37) f17: vec2<f16>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<u32>,
+  @location(0) f1: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(16) a0: i32, @location(31) a1: u32, @location(7) a2: vec2<f32>, @location(110) a3: u32, @location(105) a4: vec2<i32>, @builtin(position) a5: vec4<f32>, @location(94) a6: vec4<f32>, @location(27) a7: vec3<f16>, @location(47) a8: vec3<i32>, @location(40) a9: vec2<i32>, @builtin(sample_index) a10: u32, @location(69) a11: vec4<i32>, @location(23) a12: vec3<i32>, @location(66) a13: vec4<u32>, @location(80) a14: vec2<u32>, @location(81) a15: vec3<f32>, a16: S3, @location(18) a17: vec4<f32>, @location(59) a18: vec4<f32>, @location(36) a19: vec2<f32>, @location(26) a20: vec2<f16>, @location(60) a21: i32, @location(28) a22: vec3<i32>, @location(41) a23: i32, @location(5) a24: vec4<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S2 {
+  @location(4) f0: u32,
+  @location(5) f1: f32,
+  @location(14) f2: vec4<f16>,
+  @location(15) f3: f32
+}
+struct VertexOutput0 {
+  @location(80) f0: vec2<u32>,
+  @location(94) f1: vec4<f32>,
+  @location(87) f2: vec4<f32>,
+  @location(21) f3: vec2<i32>,
+  @location(6) f4: vec2<u32>,
+  @location(40) f5: vec2<i32>,
+  @location(101) f6: vec3<f16>,
+  @location(81) f7: vec3<f32>,
+  @location(37) f8: vec2<f16>,
+  @location(36) f9: vec2<f32>,
+  @location(28) f10: vec3<i32>,
+  @location(5) f11: vec4<i32>,
+  @location(27) f12: vec3<f16>,
+  @location(105) f13: vec2<i32>,
+  @location(1) f14: vec4<u32>,
+  @location(31) f15: u32,
+  @location(98) f16: vec4<f32>,
+  @location(92) f17: vec3<i32>,
+  @location(60) f18: i32,
+  @location(52) f19: vec2<f16>,
+  @location(22) f20: vec4<i32>,
+  @location(47) f21: vec3<i32>,
+  @location(18) f22: vec4<f32>,
+  @location(41) f23: i32,
+  @location(7) f24: vec2<f32>,
+  @location(63) f25: f16,
+  @location(64) f26: vec2<u32>,
+  @location(35) f27: vec3<u32>,
+  @location(111) f28: u32,
+  @location(69) f29: vec4<i32>,
+  @location(23) f30: vec3<i32>,
+  @location(103) f31: vec2<i32>,
+  @location(16) f32: i32,
+  @location(59) f33: vec4<f32>,
+  @location(66) f34: vec4<u32>,
+  @location(110) f35: u32,
+  @location(26) f36: vec2<f16>,
+  @location(90) f37: vec3<u32>,
+  @builtin(position) f38: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec4<f32>, @location(0) a1: f16, @location(11) a2: vec4<i32>, @location(1) a3: vec4<i32>, @location(3) a4: vec4<f16>, @location(8) a5: vec3<f16>, @location(2) a6: i32, a7: S2, @location(9) a8: f32, @location(10) a9: vec3<f16>, @location(13) a10: vec2<i32>, @location(12) a11: vec4<f16>, @location(6) a12: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+});
+let commandEncoder55 = device0.createCommandEncoder({label: '\u{1fc67}\u4fa5\uf2c2\u0556\ue429\u36ae'});
+let textureView55 = texture36.createView({label: '\u0906\uc4e9\u{1fda0}\u{1f652}\u0b18\u{1fbde}\u2b70\u05a5\u0d2c', baseArrayLayer: 0});
+let computePassEncoder26 = commandEncoder55.beginComputePass({label: '\uefc4\u{1f699}\u0dcc\ud9bd\u03f3\uc525'});
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(972);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(3, buffer10, 112816, 251800);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(2, buffer10, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let video5 = await videoWithData();
+let querySet21 = device0.createQuerySet({label: '\u07d3\u0d3f\u{1ff83}\udefb\u0db5\u{1f750}\uc609', type: 'occlusion', count: 1700});
+let textureView56 = texture19.createView({
+  label: '\u6004\u0f9a\uac20\u065b\u{1f77a}\u087c\u0778',
+  dimension: '2d',
+  baseMipLevel: 7,
+  mipLevelCount: 1,
+  baseArrayLayer: 519,
+});
+try {
+renderPassEncoder3.setScissorRect(23, 0, 70, 0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer0, 'uint16', 3784, 494);
+} catch {}
+try {
+renderBundleEncoder29.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(1907, undefined, 0, 757983823);
+} catch {}
+let pipeline8 = await device0.createRenderPipelineAsync({
+  label: '\u2721\uadab',
+  layout: pipelineLayout3,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint'}, {format: 'rgba32uint'}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 4164,
+        attributes: [
+          {format: 'sint32x2', offset: 1780, shaderLocation: 13},
+          {format: 'unorm16x2', offset: 2492, shaderLocation: 3},
+          {format: 'sint16x2', offset: 204, shaderLocation: 2},
+          {format: 'unorm16x2', offset: 744, shaderLocation: 8},
+          {format: 'sint8x4', offset: 496, shaderLocation: 1},
+          {format: 'snorm8x4', offset: 124, shaderLocation: 14},
+          {format: 'float32x2', offset: 1592, shaderLocation: 10},
+          {format: 'uint16x2', offset: 48, shaderLocation: 4},
+          {format: 'float32x2', offset: 1612, shaderLocation: 15},
+          {format: 'snorm8x4', offset: 1152, shaderLocation: 0},
+          {format: 'sint32', offset: 1256, shaderLocation: 11},
+          {format: 'snorm16x4', offset: 8, shaderLocation: 7},
+          {format: 'float16x4', offset: 4, shaderLocation: 5},
+          {format: 'uint16x2', offset: 648, shaderLocation: 6},
+          {format: 'unorm16x4', offset: 164, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 6120,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 1096, shaderLocation: 12}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'back'},
+});
+let textureView57 = texture17.createView({label: '\u05d3\u0ffe\ufb63', dimension: '2d', aspect: 'stencil-only', baseArrayLayer: 198});
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({
+  label: '\u0c0e\u99af\u0b7e\ub157\u316b\u0799\udcc9\u280f\ufc07\u966a\u9c49',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+});
+let renderBundle33 = renderBundleEncoder4.finish({label: '\u1971\u531d\ua752\u5515\u16d6'});
+let externalTexture31 = device0.importExternalTexture({source: videoFrame4, colorSpace: 'srgb'});
+try {
+renderPassEncoder18.setIndexBuffer(buffer0, 'uint16', 3556);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(5, bindGroup1);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+  await promise14;
+} catch {}
+gc();
+let bindGroup15 = device0.createBindGroup({
+  label: '\ubf3b\uac93\u1b6f\u{1f8a8}\u{1ff31}\u{1f626}\u{1fdcb}\u0267\u31d5\u{1f7b4}\uad64',
+  layout: bindGroupLayout6,
+  entries: [],
+});
+let texture37 = device0.createTexture({
+  label: '\ub4ec\u{1feaa}\u{1fed8}\u{1fc26}\u56f8\ud9c8\u891a\u0293',
+  size: {width: 96, height: 1, depthOrArrayLayers: 1246},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint'],
+});
+let textureView58 = texture16.createView({label: '\u538c\u093b\u{1f975}\u{1f62a}', dimension: '2d', baseMipLevel: 2, mipLevelCount: 1});
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer0, 'uint16');
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(6, buffer10, 0, 75041);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer0, 'uint16', 5080, 227);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 71, y: 0, z: 26},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 503_432 */
+{offset: 462, bytesPerRow: 202, rowsPerImage: 131}, {width: 48, height: 1, depthOrArrayLayers: 20});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(21, 1, 45, 0);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(632);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(6, buffer10, 0, 203899);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(2, buffer10, 0, 329830);
+} catch {}
+let commandEncoder56 = device0.createCommandEncoder();
+let computePassEncoder27 = commandEncoder56.beginComputePass({label: '\u0a21\u0be2\uee63\u02bc\u6e5c\ubee4\u8e97\uf7c2\u0ee7\uc940'});
+let sampler21 = device0.createSampler({
+  label: '\u36d5\ueff2',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 73.20,
+  lodMaxClamp: 99.84,
+  compare: 'not-equal',
+  maxAnisotropy: 14,
+});
+try {
+renderPassEncoder15.beginOcclusionQuery(136);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(36, 0, 11, 1);
+} catch {}
+try {
+renderPassEncoder9.setViewport(9.011, 0.5825, 75.81, 0.3137, 0.5211, 0.7683);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(7, buffer10, 260816, 44338);
+} catch {}
+let pipeline9 = device0.createComputePipeline({
+  label: '\u123b\u6f55\u0969\u{1fec8}\u0cbd',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(canvas3);
+let bindGroupLayout17 = device0.createBindGroupLayout({label: '\u600d\u{1f65b}\u71ba\u6f1b\u0587\u078d\u5d6a\u{1fbde}\u{1fac2}\u{1ff0b}', entries: []});
+let textureView59 = texture34.createView({
+  label: '\u6649\uc032\u69da\uf563\u0ed2\u9c5b',
+  dimension: '2d-array',
+  aspect: 'depth-only',
+  baseMipLevel: 3,
+  mipLevelCount: 2,
+  arrayLayerCount: 1,
+});
+let renderBundle34 = renderBundleEncoder7.finish();
+let sampler22 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 28.27,
+  lodMaxClamp: 44.98,
+});
+let externalTexture32 = device0.importExternalTexture({label: '\uaffa\u{1fb58}\u0c1c\u{1feec}', source: videoFrame3});
+try {
+renderPassEncoder15.setVertexBuffer(2, buffer10, 0, 35215);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(3, buffer10);
+} catch {}
+canvas5.height = 1009;
+let bindGroupLayout18 = device0.createBindGroupLayout({
+  label: '\u{1f61f}\u09c8\ua0b3\u86c5\u4391',
+  entries: [
+    {binding: 8736, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 3674,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 3383,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let commandEncoder57 = device0.createCommandEncoder({label: '\u{1fe52}\ubb6c\u{1fb84}\u4c6d\u{1fc98}\u{1fc99}\u{1ff7c}\u0161\u143a\ucd01'});
+let commandBuffer12 = commandEncoder57.finish({});
+let textureView60 = texture4.createView({dimension: '2d-array', format: 'astc-10x5-unorm', baseMipLevel: 3, mipLevelCount: 1});
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({
+  label: '\ue97c\u4f1b\u6c4b\u2c26\u{1fd66}\u8287\u{1f747}\u04a1',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+});
+let externalTexture33 = device0.importExternalTexture({source: videoFrame1});
+try {
+renderPassEncoder2.beginOcclusionQuery(3050);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(4, buffer10, 0, 290819);
+} catch {}
+let pipeline10 = device0.createComputePipeline({
+  label: '\u268f\udcca\u2108\ucb1a',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipeline11 = await device0.createRenderPipelineAsync({
+  label: '\u088a\u{1f87c}\ue8d2\uc8d9\ua695',
+  layout: pipelineLayout3,
+  multisample: {},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rgba32uint'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'invert', depthFailOp: 'invert', passOp: 'replace'},
+    stencilBack: {compare: 'never', failOp: 'increment-clamp', depthFailOp: 'decrement-wrap', passOp: 'replace'},
+    stencilReadMask: 1091304889,
+    stencilWriteMask: 859802922,
+    depthBias: 75436362,
+    depthBiasSlopeScale: -65.18904710018924,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3784,
+        attributes: [
+          {format: 'sint16x4', offset: 404, shaderLocation: 12},
+          {format: 'uint8x2', offset: 854, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 3904,
+        attributes: [
+          {format: 'sint16x4', offset: 76, shaderLocation: 7},
+          {format: 'uint32x2', offset: 112, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', unclippedDepth: true},
+});
+let querySet22 = device0.createQuerySet({
+  label: '\uc708\u0f26\u0954\u{1fb4d}\u4c19\u40af\uca51\u0f15\u07d4\u3c7d\u0501',
+  type: 'occlusion',
+  count: 141,
+});
+let textureView61 = texture10.createView({
+  label: '\u{1fc4c}\u045c\u{1f613}\u{1f863}\u0fb2\u{1f88b}\u{1f8b0}\u0ab4',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+try {
+renderPassEncoder3.setBindGroup(4, bindGroup9);
+} catch {}
+try {
+renderPassEncoder4.end();
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(3, buffer10, 0, 65270);
+} catch {}
+let bindGroup16 = device0.createBindGroup({
+  label: '\u0382\u01b4\u0674\u4464\ua683\u3eb1\ue5b4\u3a3d',
+  layout: bindGroupLayout13,
+  entries: [{binding: 7531, resource: externalTexture6}, {binding: 4888, resource: externalTexture5}],
+});
+let commandEncoder58 = device0.createCommandEncoder({});
+let commandBuffer13 = commandEncoder58.finish({label: '\u0da9\u006f\u0be3\u0ce9\u3656\ud183\u{1faf5}'});
+let texture38 = device0.createTexture({
+  label: '\u8ec6\uad5d\u111f\u{1fdbf}\u8270\u{1f949}',
+  size: [384, 1, 1],
+  mipLevelCount: 7,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView62 = texture14.createView({dimension: '2d', aspect: 'depth-only', baseMipLevel: 0, baseArrayLayer: 408});
+let renderBundleEncoder32 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder9.setStencilReference(1637);
+} catch {}
+try {
+computePassEncoder1.popDebugGroup();
+} catch {}
+let pipeline12 = await device0.createComputePipelineAsync({
+  label: '\u0eb8\u6611\ue3a0\u{1f822}\u{1fc64}\u3e35\u0f74\u0e4d\u{1f90d}',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder59 = device0.createCommandEncoder({label: '\u0e3c\ufb89\uae4b\u{1fe6e}\u{1fc81}\u8075\uee75\u91a7\u{1f93f}'});
+let texture39 = device0.createTexture({
+  label: '\udec7\u{1ff77}',
+  size: [96, 1, 100],
+  mipLevelCount: 3,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['depth24plus-stencil8', 'depth24plus-stencil8'],
+});
+let textureView63 = texture30.createView({label: '\u6d64\u{1f741}', aspect: 'all', format: 'bgra8unorm', baseArrayLayer: 0, arrayLayerCount: 1});
+let renderPassEncoder19 = commandEncoder59.beginRenderPass({
+  colorAttachments: [{
+  view: textureView23,
+  depthSlice: 31,
+  clearValue: { r: -169.1, g: -732.2, b: -894.0, a: -393.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {
+  view: textureView47,
+  depthSlice: 18,
+  clearValue: { r: 190.3, g: 406.8, b: -186.9, a: 148.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView16,
+    depthClearValue: 0.9493688157444581,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'discard',
+  },
+  maxDrawCount: 402195802,
+});
+try {
+renderPassEncoder1.setBlendConstant({ r: 564.4, g: 674.9, b: 716.8, a: -399.8, });
+} catch {}
+let commandEncoder60 = device0.createCommandEncoder({label: '\uf5e3\u01d8\u{1fcc0}'});
+let renderPassEncoder20 = commandEncoder60.beginRenderPass({
+  colorAttachments: [{
+  view: textureView8,
+  depthSlice: 67,
+  clearValue: { r: 147.7, g: 118.5, b: 732.2, a: 674.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView47,
+  depthSlice: 19,
+  clearValue: { r: -771.9, g: 1.204, b: 3.253, a: -510.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView16, depthClearValue: 1.7235514622818613, depthReadOnly: true},
+  occlusionQuerySet: querySet15,
+  maxDrawCount: 532054168,
+});
+let sampler23 = device0.createSampler({
+  label: '\u0656\u9403\u052e\u95a5\u1856',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 96.45,
+  lodMaxClamp: 99.72,
+});
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup1, new Uint32Array(2475), 732, 0);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 601.0, g: 312.0, b: -765.0, a: 213.1, });
+} catch {}
+try {
+renderPassEncoder7.setViewport(28.41, 0.9063, 50.44, 0.09042, 0.8178, 0.8348);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(5, bindGroup0);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise15 = device0.createRenderPipelineAsync({
+  label: '\u0b68\u1a8f\u{1fdd9}\u{1f6e0}\uf736\u{1febc}\uec22\u0d64\u72fc\u5881\u073f',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba32uint'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {failOp: 'invert', depthFailOp: 'replace', passOp: 'replace'},
+    stencilBack: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilReadMask: 4259187224,
+    stencilWriteMask: 1131545927,
+    depthBias: 585799582,
+    depthBiasSlopeScale: 337.3177470124004,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4796,
+        attributes: [
+          {format: 'sint32x2', offset: 836, shaderLocation: 8},
+          {format: 'float32x3', offset: 364, shaderLocation: 4},
+          {format: 'sint32x4', offset: 60, shaderLocation: 1},
+          {format: 'float32x2', offset: 492, shaderLocation: 5},
+          {format: 'sint16x4', offset: 1600, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 5016,
+        attributes: [
+          {format: 'sint16x4', offset: 2348, shaderLocation: 15},
+          {format: 'unorm8x2', offset: 1652, shaderLocation: 2},
+          {format: 'uint16x4', offset: 624, shaderLocation: 0},
+          {format: 'snorm8x4', offset: 412, shaderLocation: 10},
+          {format: 'uint16x2', offset: 1028, shaderLocation: 3},
+        ],
+      },
+      {arrayStride: 208, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 48092,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 4072, shaderLocation: 11},
+          {format: 'sint32x4', offset: 320, shaderLocation: 14},
+          {format: 'uint8x4', offset: 9364, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 14488, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 4532,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint8x2', offset: 412, shaderLocation: 6},
+          {format: 'sint8x2', offset: 314, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', unclippedDepth: true},
+});
+let bindGroupLayout19 = device0.createBindGroupLayout({
+  label: '\u3f85\u{1fcf4}\u90e3\ud953\u{1fecb}\u{1ffe6}\u03b5',
+  entries: [
+    {
+      binding: 4967,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {binding: 5986, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+  ],
+});
+let texture40 = device0.createTexture({
+  size: {width: 192, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['depth24plus-stencil8'],
+});
+let textureView64 = texture24.createView({label: '\u8f40\ue284\u0351\u03a9\ufa84\ub286\u0f48\u{1fcb5}\u0a09', baseMipLevel: 4});
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder17.insertDebugMarker('\u{1f994}');
+} catch {}
+let pipeline13 = await device0.createRenderPipelineAsync({
+  label: '\u{1f9c4}\uf1f1\u0b7e\u1452\u5fee',
+  layout: pipelineLayout4,
+  multisample: {mask: 0xc4d06729},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba8uint', writeMask: 0}, {format: 'rgba32uint'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {failOp: 'increment-wrap', depthFailOp: 'increment-wrap'},
+    stencilBack: {compare: 'never', failOp: 'decrement-wrap'},
+    stencilReadMask: 1050367168,
+    stencilWriteMask: 3783368638,
+    depthBias: -1725449388,
+    depthBiasSlopeScale: 50.45994562649949,
+    depthBiasClamp: 762.2895701404397,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 7332,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 1560, shaderLocation: 7},
+          {format: 'uint8x2', offset: 798, shaderLocation: 9},
+          {format: 'sint32x4', offset: 748, shaderLocation: 6},
+          {format: 'uint32x4', offset: 680, shaderLocation: 3},
+          {format: 'sint8x2', offset: 252, shaderLocation: 15},
+          {format: 'float32x3', offset: 188, shaderLocation: 2},
+          {format: 'uint32x4', offset: 1116, shaderLocation: 0},
+          {format: 'sint8x4', offset: 1356, shaderLocation: 8},
+          {format: 'sint32', offset: 1296, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 3260, shaderLocation: 12},
+          {format: 'float32x2', offset: 1580, shaderLocation: 5},
+          {format: 'snorm16x2', offset: 1168, shaderLocation: 10},
+          {format: 'float32x2', offset: 896, shaderLocation: 11},
+          {format: 'snorm16x4', offset: 1036, shaderLocation: 4},
+          {format: 'sint32x2', offset: 72, shaderLocation: 14},
+        ],
+      },
+      {arrayStride: 812, attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 2160, stepMode: 'instance', attributes: []},
+      {arrayStride: 2904, attributes: [{format: 'sint16x4', offset: 160, shaderLocation: 13}]},
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'none'},
+});
+let videoFrame6 = new VideoFrame(img5, {timestamp: 0});
+let bindGroup17 = device0.createBindGroup({label: '\u{1fbaf}\u0c05\u4103\u9aa7\u0b97\u{1f681}', layout: bindGroupLayout12, entries: []});
+let commandEncoder61 = device0.createCommandEncoder({label: '\ud03b\u{1f75f}\u0670\u3a19'});
+let querySet23 = device0.createQuerySet({label: '\ucb89\u1ff6\u{1fc9c}\u{1f835}\u07a5\u{1f6fe}', type: 'occlusion', count: 1100});
+let renderPassEncoder21 = commandEncoder61.beginRenderPass({
+  label: '\u{1fb23}\u3b9f\ucfd2\u7286\ubae5\uf5f9\u0559',
+  colorAttachments: [{
+  view: textureView9,
+  depthSlice: 11,
+  clearValue: { r: -850.6, g: 407.1, b: -823.4, a: 665.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {view: textureView51, depthSlice: 815, loadOp: 'clear', storeOp: 'discard'}],
+  depthStencilAttachment: {
+    view: textureView40,
+    depthClearValue: -3.576114430893629,
+    depthReadOnly: true,
+    stencilClearValue: 35269,
+  },
+  occlusionQuerySet: querySet5,
+});
+let externalTexture34 = device0.importExternalTexture({label: '\u76fb\u5812\u6bb5\u4a52', source: video4, colorSpace: 'srgb'});
+try {
+renderPassEncoder0.setScissorRect(3, 1, 28, 0);
+} catch {}
+try {
+renderPassEncoder13.setStencilReference(1158);
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(video1);
+let commandEncoder62 = device0.createCommandEncoder({label: '\u05aa\u84fd\u0060\u03c2\ue672\uface\u0a91\u{1fbbb}'});
+let texture41 = device0.createTexture({
+  label: '\u666c\u{1fe58}\u{1fc9d}\u1886\u5921',
+  size: {width: 192},
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32uint', 'rgba32uint', 'rgba32uint'],
+});
+let renderBundleEncoder33 = device0.createRenderBundleEncoder({
+  label: '\u0762\u24d5\ub6bc\u03bb',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+let externalTexture35 = device0.importExternalTexture({label: '\u0020\u7882', source: videoFrame6});
+try {
+computePassEncoder23.setBindGroup(4, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(6, buffer10, 0, 386367);
+} catch {}
+try {
+commandEncoder62.clearBuffer(buffer3, 165056, 85096);
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline14 = device0.createComputePipeline({
+  label: '\u403d\u{1faf6}\ud502\u19ed\u9b2e\u5f1e\ub0cd\u1646\u5a0f',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let promise17 = adapter1.requestAdapterInfo();
+let commandEncoder63 = device0.createCommandEncoder();
+let textureView65 = texture21.createView({
+  label: '\u{1fba7}\u07f7\u8961\u02ac\u{1fe69}\u0d43\ub117\u7aa6\u{1f885}',
+  aspect: 'stencil-only',
+  mipLevelCount: 2,
+});
+try {
+computePassEncoder16.setBindGroup(4, bindGroup2, new Uint32Array(5721), 336, 0);
+} catch {}
+try {
+renderPassEncoder11.end();
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(18);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(0, buffer10, 193940, 139271);
+} catch {}
+try {
+commandEncoder63.resolveQuerySet(querySet12, 198, 893, buffer10, 208384);
+} catch {}
+try {
+renderPassEncoder8.insertDebugMarker('\u099a');
+} catch {}
+let pipeline15 = await device0.createComputePipelineAsync({
+  label: '\ue8be\uf4bc\ua395\u{1fc57}\u029d\u0d85\u{1f959}\u7cac\uac10',
+  layout: 'auto',
+  compute: {module: shaderModule1, entryPoint: 'compute0'},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let pipelineLayout7 = device0.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder64 = device0.createCommandEncoder({});
+let commandBuffer14 = commandEncoder63.finish({label: '\u3b38\u0d95\uaeb2\u{1fa2a}'});
+let texture42 = gpuCanvasContext2.getCurrentTexture();
+let textureView66 = texture36.createView({format: 'rg11b10ufloat', arrayLayerCount: 1});
+let renderPassEncoder22 = commandEncoder62.beginRenderPass({
+  label: '\u{1fa4e}\u3c23\u52a6',
+  colorAttachments: [{
+  view: textureView23,
+  depthSlice: 41,
+  clearValue: { r: -371.3, g: 783.4, b: 63.31, a: -74.50, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {view: textureView47, depthSlice: 23, loadOp: 'load', storeOp: 'store'}],
+  depthStencilAttachment: {view: textureView16, depthReadOnly: true, stencilClearValue: 2806},
+  occlusionQuerySet: querySet12,
+  maxDrawCount: 1219883506,
+});
+try {
+renderBundleEncoder33.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(5, buffer10, 219928, 55093);
+} catch {}
+try {
+commandEncoder64.clearBuffer(buffer6, 71500, 19540);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+  await promise7;
+} catch {}
+let device1 = await adapter1.requestDevice({
+  label: '\uc6a4\u{1f76d}\u{1ff77}\ufdb7\u{1f6f7}\u062c\u{1f621}\ucfed\u0038\uf069\u3b36',
+  defaultQueue: {},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 10,
+    maxColorAttachmentBytesPerSample: 33,
+    maxVertexAttributes: 25,
+    maxVertexBufferArrayStride: 49516,
+    maxStorageTexturesPerShaderStage: 8,
+    maxStorageBuffersPerShaderStage: 37,
+    maxDynamicStorageBuffersPerPipelineLayout: 1760,
+    maxDynamicUniformBuffersPerPipelineLayout: 33661,
+    maxBindingsPerBindGroup: 6572,
+    maxTextureArrayLayers: 531,
+    maxTextureDimension1D: 8205,
+    maxTextureDimension2D: 11962,
+    maxVertexBuffers: 9,
+    maxBindGroupsPlusVertexBuffers: 28,
+    minStorageBufferOffsetAlignment: 128,
+    minUniformBufferOffsetAlignment: 64,
+    maxUniformBufferBindingSize: 260019346,
+    maxStorageBufferBindingSize: 267512154,
+    maxUniformBuffersPerShaderStage: 27,
+    maxSampledTexturesPerShaderStage: 40,
+    maxInterStageShaderVariables: 78,
+    maxInterStageShaderComponents: 101,
+    maxSamplersPerShaderStage: 19,
+  },
+});
+let bindGroup18 = device0.createBindGroup({label: '\u0833\u68e3\ua38c\ua37c', layout: bindGroupLayout14, entries: []});
+let commandEncoder65 = device0.createCommandEncoder({label: '\u{1fb82}\u0429'});
+let texture43 = device0.createTexture({
+  label: '\u351c\u0f48\u3937\u47cf\ub07d\u5735',
+  size: [768, 1, 1],
+  mipLevelCount: 5,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32uint', 'rgba32uint'],
+});
+let renderPassEncoder23 = commandEncoder64.beginRenderPass({
+  colorAttachments: [{
+  view: textureView23,
+  depthSlice: 103,
+  clearValue: { r: -181.8, g: -240.4, b: -479.3, a: -921.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {view: textureView47, depthSlice: 24, loadOp: 'clear', storeOp: 'store'}],
+  depthStencilAttachment: {view: textureView16, depthReadOnly: true, stencilClearValue: 6187},
+  occlusionQuerySet: querySet22,
+  maxDrawCount: 613219880,
+});
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup15, new Uint32Array(2732), 939, 0);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(1229);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(3, buffer10, 267656, 88706);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder65.clearBuffer(buffer2, 45948, 32424);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 48, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer3), /* required buffer size: 713 */
+{offset: 713}, {width: 165, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let imageBitmap6 = await createImageBitmap(canvas1);
+let buffer11 = device0.createBuffer({
+  label: '\uc469\u85a6\u6eb9\u0dde\ue917\ub7c7\u00eb\u0768\u0b89\u039c\ue85e',
+  size: 94606,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX,
+});
+let commandEncoder66 = device0.createCommandEncoder({label: '\u91f4\u5b4e\u{1fd2a}\u003b\uc1d4\u0fff\u4e0d\u2d1e\u096b\u00b4\u1ec4'});
+let querySet24 = device0.createQuerySet({label: '\u4799\ucad8\ubce5\uf33d\u022c\u{1f838}\udf7e\ueb48', type: 'occlusion', count: 2630});
+let renderPassEncoder24 = commandEncoder65.beginRenderPass({
+  label: '\u6c66\u{1f644}\u7523\u{1fed5}\u{1feb9}\ucb33\u3387\u0426',
+  colorAttachments: [{
+  view: textureView9,
+  depthSlice: 32,
+  clearValue: { r: -589.5, g: -454.5, b: 543.0, a: 505.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView51,
+  depthSlice: 277,
+  clearValue: { r: -755.8, g: 444.8, b: -601.2, a: -53.41, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {view: textureView40, depthLoadOp: 'load', depthStoreOp: 'store', depthReadOnly: false},
+  maxDrawCount: 584629887,
+});
+try {
+renderPassEncoder21.beginOcclusionQuery(63);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(67, 0, 11, 1);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(4, buffer10, 172708);
+} catch {}
+try {
+commandEncoder66.resolveQuerySet(querySet14, 40, 27, buffer10, 352512);
+} catch {}
+try {
+device0.queue.submit([commandBuffer8, commandBuffer1, commandBuffer13]);
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(432, 513);
+try {
+offscreenCanvas3.getContext('2d');
+} catch {}
+let commandEncoder67 = device1.createCommandEncoder({label: '\u{1f88a}\u140d\u03ea\ub2a7'});
+let computePassEncoder28 = commandEncoder67.beginComputePass({});
+let texture44 = gpuCanvasContext3.getCurrentTexture();
+let textureView67 = texture44.createView({label: '\u{1f98c}\u{1ff5e}\u5c7d\u0137\u8e5d', format: 'bgra8unorm-srgb'});
+let renderBundleEncoder35 = device1.createRenderBundleEncoder({
+  label: '\ucb21\uc004\u{1f953}\u1255\ud950\ud144\u{1ff2f}\u{1f6d7}\u{1fe46}\uf0e0',
+  colorFormats: ['rg32uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+let sampler24 = device1.createSampler({
+  label: '\uad39\u4d91\u0684\u0982\u{1fe69}\u4391\u5528\u909e\u7c29\u9793',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 11.01,
+  compare: 'greater-equal',
+});
+let renderBundleEncoder36 = device1.createRenderBundleEncoder({colorFormats: ['rg32uint'], sampleCount: 4, stencilReadOnly: true});
+let renderBundle35 = renderBundleEncoder35.finish({label: '\u6c69\u076f\uf0c7\u{1fe1a}\ua748\u{1fe6e}\u5df2\uf14b\uca02\ua935\u8d2c'});
+let sampler25 = device1.createSampler({
+  label: '\u{1fdf5}\u0002',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 65.99,
+  lodMaxClamp: 79.94,
+  compare: 'never',
+  maxAnisotropy: 9,
+});
+let externalTexture36 = device1.importExternalTexture({label: '\u7674\u{1fa8e}\u{1fbec}', source: video2, colorSpace: 'display-p3'});
+let img6 = await imageWithData(212, 23, '#e4b0fe34', '#8db85f06');
+let commandEncoder68 = device0.createCommandEncoder({label: '\u072b\u{1f9e8}\u{1fd69}\u7ffd\u{1f6e3}\u054c\udd30\u08d7\u071e\u{1f74b}\u9c23'});
+let renderBundle36 = renderBundleEncoder18.finish({label: '\u0228\u9054\u{1fdc0}\u06fd\u230d\uacf8'});
+try {
+renderPassEncoder5.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer10, 0, 209617);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup7);
+} catch {}
+let pipeline16 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let texture45 = device1.createTexture({
+  size: [778, 4, 1],
+  mipLevelCount: 9,
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg32uint', 'rg32uint', 'rg32uint'],
+});
+let textureView68 = texture45.createView({
+  label: '\u7208\u9bfb\u02e3\u4ccf\u0a1b\u{1feed}\ua760\u140f\uc95f\u8ca1\ub7d1',
+  dimension: '2d-array',
+  baseMipLevel: 4,
+});
+let renderBundle37 = renderBundleEncoder36.finish({});
+let bindGroup19 = device0.createBindGroup({layout: bindGroupLayout12, entries: []});
+let commandEncoder69 = device0.createCommandEncoder({label: '\u056b\u63b8\u0ad1\u1b0f'});
+let renderPassEncoder25 = commandEncoder69.beginRenderPass({
+  colorAttachments: [{view: textureView23, depthSlice: 62, loadOp: 'load', storeOp: 'discard'}, {
+  view: textureView20,
+  depthSlice: 16,
+  clearValue: { r: 837.5, g: -181.9, b: 176.6, a: -480.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView16,
+    depthLoadOp: 'load',
+    depthStoreOp: 'discard',
+    stencilClearValue: 56652,
+    stencilReadOnly: true,
+  },
+  occlusionQuerySet: querySet18,
+  maxDrawCount: 362905160,
+});
+let renderBundleEncoder37 = device0.createRenderBundleEncoder({
+  label: '\u0e37\u0c15\u584b\u{1f66b}',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(81, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder14.setViewport(34.60, 0.9595, 56.88, 0.00533, 0.4845, 0.7011);
+} catch {}
+try {
+  await buffer3.mapAsync(GPUMapMode.READ, 0, 359532);
+} catch {}
+try {
+commandEncoder66.copyBufferToBuffer(buffer8, 153244, buffer6, 21860, 9116);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder66.copyBufferToTexture({
+  /* bytesInLastRow: 156 widthInBlocks: 39 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 316 */
+  offset: 316,
+  rowsPerImage: 204,
+  buffer: buffer8,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 39, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder66.copyTextureToTexture({
+  texture: texture40,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture40,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 24, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise17;
+} catch {}
+let renderBundle38 = renderBundleEncoder35.finish({label: '\u{1ff5d}\u80aa\u{1fab7}\u0bbd\u0e17\ue1fb\u86fa\u08b9\u3714'});
+try {
+computePassEncoder28.pushDebugGroup('\u05d3');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+document.body.prepend(video3);
+let querySet25 = device0.createQuerySet({label: '\u0d26\u00df\u82c1\ub064\u02ad\u0bca\u0e7b\u0cf6\u01bf', type: 'occlusion', count: 2561});
+let texture46 = device0.createTexture({
+  label: '\u0b17\u259d\ue3b2\u0c29\u{1f623}\u5172\u462b\u{1fc32}\u{1fce1}\ua229\u0363',
+  size: [192, 1, 1],
+  mipLevelCount: 8,
+  sampleCount: 1,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder29 = commandEncoder68.beginComputePass({label: '\u7590\ud99b\u93fc\u59c1'});
+let renderBundle39 = renderBundleEncoder14.finish({label: '\uea3d\u{1f976}\u2782\u85c8\ud6af\u0149\u0b52\ua5fe'});
+let sampler26 = device0.createSampler({
+  label: '\u55cc\u4f8e\u0f61\uefc3\ue17f\u0c27\u{1feaa}\u{1fb9e}\u{1fe7f}',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 66.43,
+  lodMaxClamp: 82.32,
+  maxAnisotropy: 3,
+});
+try {
+renderPassEncoder3.setScissorRect(29, 0, 41, 1);
+} catch {}
+try {
+renderPassEncoder7.setViewport(47.48, 0.7672, 31.62, 0.2114, 0.2915, 0.9914);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer5, 'uint32', 169368, 72115);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer5, 'uint16', 42702, 176248);
+} catch {}
+try {
+commandEncoder66.copyBufferToBuffer(buffer8, 224100, buffer11, 62612, 7512);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder66.clearBuffer(buffer4, 27884, 9316);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.submit([commandBuffer10, commandBuffer14]);
+} catch {}
+try {
+adapter0.label = '\u6546\u{1ff8f}\ufc89';
+} catch {}
+let renderPassEncoder26 = commandEncoder66.beginRenderPass({
+  label: '\u{1f998}\u51bb\u280e\u07a5\u021c',
+  colorAttachments: [{
+  view: textureView8,
+  depthSlice: 42,
+  clearValue: { r: 294.7, g: -428.1, b: -730.8, a: 733.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {
+  view: textureView47,
+  depthSlice: 18,
+  clearValue: { r: 312.2, g: -891.7, b: -761.0, a: -171.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView16,
+    depthClearValue: 0.4206945563333988,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'store',
+    stencilReadOnly: true,
+  },
+  occlusionQuerySet: querySet18,
+});
+try {
+computePassEncoder3.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder19.setViewport(19.65, 0.09571, 54.60, 0.5831, 0.6177, 0.7349);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer0, 'uint16', 4248, 251);
+} catch {}
+try {
+buffer5.destroy();
+} catch {}
+let promise18 = adapter1.requestAdapterInfo();
+let bindGroupLayout20 = device0.createBindGroupLayout({
+  label: '\u{1fbac}\ue346\u{1f6ee}\ua481\ue249\u{1fa33}\u{1fbef}\u{1fb20}\u{1f7a8}\u1198\u7c72',
+  entries: [
+    {
+      binding: 2318,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {binding: 768, visibility: 0, sampler: { type: 'non-filtering' }},
+    {
+      binding: 7650,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer12 = device0.createBuffer({label: '\u{1fbaf}\ud0b9\u5097\u0925\u1cf6\u{1f760}', size: 78318, usage: GPUBufferUsage.INDEX});
+let texture47 = device0.createTexture({
+  label: '\u{1fc48}\ufca3\ub55f\u0599\u8859\ub4d0\u0c98\u{1ff60}\uea0b\u935e',
+  size: [192],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32uint', 'rgba32uint'],
+});
+let textureView69 = texture13.createView({baseMipLevel: 1, mipLevelCount: 2});
+let renderBundleEncoder38 = device0.createRenderBundleEncoder({
+  label: '\u0be7\u56fe\u3928\ufdab\u04a4\u4279\ueb8b\uaa12',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder12.setBlendConstant({ r: -986.7, g: 476.2, b: 393.4, a: -956.2, });
+} catch {}
+let promise19 = device0.createRenderPipelineAsync({
+  label: '\u080a\u1883\ua396\ua441\u{1fe39}',
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 6272,
+        attributes: [
+          {format: 'float32', offset: 588, shaderLocation: 15},
+          {format: 'snorm16x2', offset: 1324, shaderLocation: 8},
+          {format: 'sint16x4', offset: 248, shaderLocation: 2},
+          {format: 'sint32x4', offset: 848, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm16x4', offset: 43096, shaderLocation: 9},
+          {format: 'sint32', offset: 8208, shaderLocation: 13},
+          {format: 'uint32x2', offset: 9144, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 944, shaderLocation: 7},
+          {format: 'uint32', offset: 1500, shaderLocation: 6},
+          {format: 'unorm10-10-10-2', offset: 104, shaderLocation: 3},
+          {format: 'snorm16x2', offset: 14416, shaderLocation: 5},
+          {format: 'sint16x4', offset: 12604, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 6412, shaderLocation: 10},
+          {format: 'unorm16x4', offset: 4856, shaderLocation: 14},
+          {format: 'snorm16x4', offset: 3524, shaderLocation: 12},
+          {format: 'float32', offset: 13800, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+let videoFrame7 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let commandEncoder70 = device0.createCommandEncoder({label: '\u68ee\u6ac3\u0373\ubfe3\u0698\u08f2\ue45c\u08c0\u0233\ubad9\u093f'});
+let texture48 = device0.createTexture({
+  label: '\u{1fa69}\u8c5f\u{1fca6}\u0d7e\u038e\uc797\u0ab2\ue8f4',
+  size: [192],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32uint'],
+});
+let renderBundleEncoder39 = device0.createRenderBundleEncoder({
+  label: '\u{1fdbe}\u4160',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: false,
+  stencilReadOnly: false,
+});
+let renderBundle40 = renderBundleEncoder13.finish({label: '\u0a5f\u43df\uaf71\uf770\u{1fa51}\u818a'});
+try {
+computePassEncoder26.end();
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer11, 'uint32');
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(1025, undefined);
+} catch {}
+try {
+commandEncoder70.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 17616 */
+  offset: 17616,
+  buffer: buffer8,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder55.clearBuffer(buffer11, 62904, 5596);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+renderPassEncoder0.pushDebugGroup('\uf4c6');
+} catch {}
+try {
+renderPassEncoder0.popDebugGroup();
+} catch {}
+let pipeline17 = device0.createComputePipeline({
+  label: '\u7249\u71e7\u{1fe8f}',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let commandBuffer15 = commandEncoder55.finish({});
+let externalTexture37 = device0.importExternalTexture({label: '\u{1f83c}\u{1fb10}\u2186\u99e9\u2918\u64c8\u{1f93b}', source: videoFrame6});
+try {
+renderPassEncoder13.setBlendConstant({ r: 97.60, g: -295.7, b: 63.91, a: -953.9, });
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(0, buffer10);
+} catch {}
+try {
+commandEncoder70.copyTextureToTexture({
+  texture: texture21,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 192, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderBundleEncoder29.insertDebugMarker('\u0703');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 12364, new DataView(new ArrayBuffer(21619)), 20322, 140);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 206},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer2), /* required buffer size: 17_483_592 */
+{offset: 372, bytesPerRow: 2369, rowsPerImage: 205}, {width: 1572, height: 0, depthOrArrayLayers: 37});
+} catch {}
+let video6 = await videoWithData();
+let commandEncoder71 = device1.createCommandEncoder({label: '\u0d4f\u9017\u010c'});
+let commandBuffer16 = commandEncoder71.finish({label: '\u02a9\u{1f998}\ud8d3\u7cfb\u0ff2\u67d7'});
+let renderBundle41 = renderBundleEncoder36.finish({label: '\u6ea4\u0d45\u0728\u{1f67c}\u793f\u{1f8e2}\u0a66\u{1f81e}'});
+let sampler27 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 44.37,
+  lodMaxClamp: 47.32,
+  maxAnisotropy: 15,
+});
+gc();
+let img7 = await imageWithData(93, 226, '#6ca30bda', '#6400ad71');
+let video7 = await videoWithData();
+let commandEncoder72 = device1.createCommandEncoder({label: '\u5f1a\u063a\u{1fd95}\u131b'});
+let commandBuffer17 = commandEncoder72.finish({label: '\uab5d\u0239'});
+let sampler28 = device1.createSampler({
+  label: '\u741b\u44f4\uc3c4\u1f8f\u78bb\u7fb8\u1c67',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 62.16,
+  lodMaxClamp: 81.24,
+  maxAnisotropy: 19,
+});
+document.body.prepend(img6);
+try {
+adapter1.label = '\u0642\u96d7\u0ae1\ucff9\u0c5f\u091f\u0d81\u64c8';
+} catch {}
+let textureView70 = texture44.createView({dimension: '2d-array', mipLevelCount: 1});
+let renderBundle42 = renderBundleEncoder36.finish();
+let promise20 = device1.queue.onSubmittedWorkDone();
+try {
+device1.destroy();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let textureView71 = texture13.createView({baseMipLevel: 1, mipLevelCount: 2});
+let renderBundleEncoder40 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+});
+let sampler29 = device0.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 57.61,
+  lodMaxClamp: 67.77,
+});
+try {
+computePassEncoder12.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder15.setBlendConstant({ r: -420.6, g: -930.7, b: 711.8, a: -127.4, });
+} catch {}
+try {
+renderPassEncoder15.setViewport(62.16, 0.7434, 7.658, 0.05201, 0.4741, 0.5579);
+} catch {}
+let promise21 = buffer4.mapAsync(GPUMapMode.READ, 37456, 1960);
+try {
+commandEncoder70.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 360 widthInBlocks: 90 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 13284 */
+  offset: 996,
+  bytesPerRow: 768,
+  rowsPerImage: 4,
+  buffer: buffer11,
+}, {width: 90, height: 0, depthOrArrayLayers: 5});
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder70.clearBuffer(buffer3, 146152, 106340);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 11696, new Int16Array(13105), 10824, 68);
+} catch {}
+let computePassEncoder30 = commandEncoder70.beginComputePass({label: '\uee72\u3c86\u02cb\u0d12\u0a5c\u{1f769}\u{1fb2f}'});
+let renderBundle43 = renderBundleEncoder25.finish({});
+let externalTexture38 = device0.importExternalTexture({
+  label: '\u{1fe22}\u80e1\u0f6c\ud404\u{1ff79}\ue113\u{1fe92}\u9b57\u7147\u5d1e\u0fea',
+  source: video5,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(77, 0, 16, 1);
+} catch {}
+try {
+renderPassEncoder18.setViewport(141.5, 0.5398, 46.60, 0.4552, 0.9226, 0.9509);
+} catch {}
+try {
+renderBundleEncoder39.setVertexBuffer(4, buffer10, 0);
+} catch {}
+let pipeline18 = device0.createRenderPipeline({
+  label: '\u{1ff80}\u5a9e\u{1f78e}\u{1fdc0}\u6a13\u259a\u{1fe7d}',
+  layout: pipelineLayout5,
+  multisample: {mask: 0x326f243a},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba32uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater', failOp: 'decrement-clamp', depthFailOp: 'increment-wrap', passOp: 'keep'},
+    stencilBack: {compare: 'less', failOp: 'keep', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilReadMask: 1941988981,
+    stencilWriteMask: 3231177172,
+    depthBiasClamp: 301.40039020428793,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 18144,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 1188, shaderLocation: 7},
+          {format: 'uint16x4', offset: 5236, shaderLocation: 0},
+          {format: 'snorm8x4', offset: 1280, shaderLocation: 12},
+          {format: 'sint32x4', offset: 11100, shaderLocation: 6},
+          {format: 'float32', offset: 3916, shaderLocation: 4},
+          {format: 'sint32', offset: 6144, shaderLocation: 8},
+          {format: 'unorm8x2', offset: 2542, shaderLocation: 11},
+          {format: 'sint32', offset: 15780, shaderLocation: 14},
+          {format: 'uint16x4', offset: 3276, shaderLocation: 3},
+          {format: 'float16x4', offset: 7640, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 18324,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x4', offset: 1200, shaderLocation: 15}],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 17792, shaderLocation: 10},
+          {format: 'sint16x4', offset: 19656, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 4456, attributes: []},
+      {
+        arrayStride: 28308,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint16x2', offset: 2712, shaderLocation: 9}],
+      },
+      {arrayStride: 0, attributes: [{format: 'float16x2', offset: 11176, shaderLocation: 5}]},
+      {
+        arrayStride: 1636,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x3', offset: 400, shaderLocation: 13}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+canvas2.width = 159;
+try {
+renderPassEncoder0.setStencilReference(722);
+} catch {}
+try {
+renderPassEncoder20.setViewport(44.39, 0.8760, 8.123, 0.07685, 0.6913, 0.9824);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer12, 'uint32', 57560, 15176);
+} catch {}
+try {
+renderBundleEncoder34.setIndexBuffer(buffer11, 'uint16', 63512, 3677);
+} catch {}
+let imageBitmap7 = await createImageBitmap(video7);
+let videoFrame8 = new VideoFrame(offscreenCanvas3, {timestamp: 0});
+canvas2.height = 2544;
+let textureView72 = texture39.createView({
+  label: '\ue49a\uc66a\u0c0b\u6014\u{1fdd3}\u0872\u{1f9ef}\u02b6\u7e02\u19d1',
+  aspect: 'depth-only',
+  format: 'depth24plus',
+  baseMipLevel: 1,
+  baseArrayLayer: 61,
+  arrayLayerCount: 33,
+});
+try {
+computePassEncoder17.setBindGroup(4, bindGroup13, new Uint32Array(9138), 3791, 0);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(5, bindGroup18, new Uint32Array(6179), 2211, 0);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(6406, undefined, 0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+  await promise18;
+} catch {}
+gc();
+let videoFrame9 = new VideoFrame(canvas0, {timestamp: 0});
+let textureView73 = texture26.createView({
+  label: '\u4c66\u0810\u04c8\u4af8\u0162\u0ae0\u98d5\u0a70',
+  dimension: '2d-array',
+  aspect: 'depth-only',
+  mipLevelCount: 3,
+});
+try {
+computePassEncoder4.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup11, new Uint32Array(6418), 1366, 0);
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant({ r: -220.4, g: -786.1, b: 109.0, a: 436.2, });
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(89, 0, 95, 0);
+} catch {}
+try {
+renderPassEncoder20.setViewport(19.03, 0.7009, 0.9903, 0.1608, 0.7008, 0.9238);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer10);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(2, bindGroup18, []);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 12824, new Int16Array(60694), 32687, 4528);
+} catch {}
+let pipeline19 = await device0.createComputePipelineAsync({
+  label: '\u{1fa35}\ue686\u0196\u067a\udf1b\u{1f98a}\u0823\ub4b4\u010f\u0d46\u{1fbf3}',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise20;
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  label: '\u{1fdf3}\u{1fa4a}',
+  code: `@group(1) @binding(7180)
+var<storage, read_write> function0: array<u32>;
+
+@compute @workgroup_size(2, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S5 {
+  @builtin(front_facing) f0: bool,
+  @builtin(position) f1: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<u32>,
+  @location(7) f1: vec4<f32>,
+  @location(0) f2: vec4<u32>,
+  @builtin(frag_depth) f3: f32,
+  @location(4) f4: vec3<f32>
+}
+
+@fragment
+fn fragment0(a0: S5, @builtin(sample_index) a1: u32, @builtin(sample_mask) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S4 {
+  @location(1) f0: vec4<f32>,
+  @location(0) f1: vec4<u32>,
+  @location(3) f2: f16,
+  @location(8) f3: vec3<f32>,
+  @location(15) f4: vec2<f32>,
+  @builtin(vertex_index) f5: u32,
+  @location(11) f6: vec3<u32>,
+  @builtin(instance_index) f7: u32
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec4<f32>, @location(13) a1: vec3<u32>, @location(5) a2: vec3<f16>, @location(10) a3: u32, @location(2) a4: vec3<i32>, @location(14) a5: u32, @location(4) a6: vec4<f32>, @location(12) a7: vec4<f32>, @location(9) a8: vec3<u32>, @location(6) a9: vec4<i32>, a10: S4) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup20 = device0.createBindGroup({
+  label: '\ub923\u{1fb05}\u0d4b\u0092\ued0e\u32e7\u{1fad9}\u0e53',
+  layout: bindGroupLayout8,
+  entries: [],
+});
+let commandEncoder73 = device0.createCommandEncoder({label: '\u{1f66a}\u{1fe64}\u{1fc7c}\u03ba\ubc3a\ube4f\u0e9c\u09a7\ubdee\u0fc3\u{1f9ca}'});
+let texture49 = device0.createTexture({
+  label: '\u37f4\u{1ff61}\u97f1\u0ba6\u{1fe3f}\u33f9\u{1f68a}\u71c9\u8e9b\u{1ffd6}',
+  size: {width: 384, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 9,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let renderPassEncoder27 = commandEncoder73.beginRenderPass({
+  label: '\u06da\u{1fd4c}',
+  colorAttachments: [{
+  view: textureView23,
+  depthSlice: 8,
+  clearValue: { r: 78.63, g: 449.7, b: 331.0, a: 488.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView47,
+  depthSlice: 23,
+  clearValue: { r: 119.1, g: 713.1, b: -952.5, a: 542.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView16,
+    depthLoadOp: 'load',
+    depthStoreOp: 'discard',
+    stencilClearValue: 62403,
+    stencilReadOnly: false,
+  },
+  maxDrawCount: 1149939471,
+});
+let sampler30 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 75.50,
+  lodMaxClamp: 93.05,
+  compare: 'always',
+});
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(31, 0, 6, 1);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer11, 'uint16', 43850, 11442);
+} catch {}
+try {
+renderBundleEncoder28.setPipeline(pipeline1);
+} catch {}
+try {
+querySet24.destroy();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise22 = device0.queue.onSubmittedWorkDone();
+let canvas6 = document.createElement('canvas');
+let bindGroupLayout21 = device0.createBindGroupLayout({entries: []});
+let textureView74 = texture27.createView({label: '\u09d7\u4c25\uf0b2\u094f'});
+let externalTexture39 = device0.importExternalTexture({label: '\u4ec9\u{1fd49}', source: videoFrame8, colorSpace: 'srgb'});
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder39.setVertexBuffer(7, buffer10);
+} catch {}
+try {
+commandEncoder54.copyBufferToBuffer(buffer11, 6720, buffer4, 6096, 1180);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder54.copyBufferToTexture({
+  /* bytesInLastRow: 6 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 18388 */
+  offset: 18388,
+  buffer: buffer11,
+}, {
+  texture: texture34,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {width: 6, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+computePassEncoder22.insertDebugMarker('\u827b');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline20 = device0.createComputePipeline({
+  label: '\u4457\u029f\u{1fda1}\u935d\uaa19\u0b29\u2437\u2018\u0c27',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+video5.width = 110;
+let texture50 = device0.createTexture({
+  label: '\u{1fdaf}\u2b11\u6259\u0970\u{1f628}\u7d63\u{1fae5}\u7fa4',
+  size: {width: 768, height: 1, depthOrArrayLayers: 277},
+  mipLevelCount: 10,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView75 = texture21.createView({label: '\u{1fb37}\u041b\u005f', aspect: 'depth-only', mipLevelCount: 2});
+let computePassEncoder31 = commandEncoder54.beginComputePass({label: '\u031e\u372e\u{1f6c3}\ue636\u{1f9e2}\u{1fda3}\u{1fcb7}\u{1f977}'});
+try {
+renderPassEncoder8.beginOcclusionQuery(639);
+} catch {}
+try {
+renderPassEncoder15.setBlendConstant({ r: -199.0, g: 809.6, b: 788.3, a: -682.4, });
+} catch {}
+try {
+renderBundleEncoder33.setPipeline(pipeline13);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 12840, new BigUint64Array(30683), 30197, 48);
+} catch {}
+let pipeline21 = device0.createRenderPipeline({
+  label: '\u0a91\ud254\u{1f813}\u1883\u324c\u50ad\uc4ac',
+  layout: pipelineLayout5,
+  multisample: {},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'equal', failOp: 'decrement-clamp', depthFailOp: 'replace', passOp: 'increment-clamp'},
+    stencilBack: {
+      compare: 'not-equal',
+      failOp: 'decrement-clamp',
+      depthFailOp: 'increment-wrap',
+      passOp: 'decrement-wrap',
+    },
+    stencilReadMask: 1315347339,
+    stencilWriteMask: 1790950178,
+    depthBias: 0,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 9952, attributes: []},
+      {arrayStride: 208, stepMode: 'instance', attributes: []},
+      {arrayStride: 5612, attributes: []},
+      {
+        arrayStride: 14640,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x4', offset: 2428, shaderLocation: 7}],
+      },
+      {
+        arrayStride: 4960,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 764, shaderLocation: 12},
+          {format: 'uint32', offset: 560, shaderLocation: 4},
+          {format: 'uint8x4', offset: 1324, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let videoFrame10 = new VideoFrame(img0, {timestamp: 0});
+let texture51 = device0.createTexture({
+  label: '\u4960\u089d',
+  size: [192, 1, 1],
+  mipLevelCount: 2,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView76 = texture10.createView({label: '\u{1f724}\u9956\ueb2c\u0833\ud87f\uc6a7\u03cf\u8170', dimension: '2d-array', baseMipLevel: 2});
+let renderBundle44 = renderBundleEncoder11.finish({label: '\u16fe\u{1fdf3}'});
+try {
+computePassEncoder12.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(4, bindGroup15);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer11, 'uint16', 43046, 21504);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(1, buffer10, 178232, 165748);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(5, bindGroup20, new Uint32Array(493), 101, 0);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(2143, undefined, 1999334166, 997254803);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer15]);
+} catch {}
+let pipeline22 = device0.createComputePipeline({
+  label: '\u92ed\u2740\u{1f912}\u{1ffaf}',
+  layout: 'auto',
+  compute: {module: shaderModule1, entryPoint: 'compute0'},
+});
+try {
+  await promise22;
+} catch {}
+let textureView77 = texture14.createView({dimension: '2d', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 125});
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder25.setScissorRect(50, 1, 13, 0);
+} catch {}
+try {
+computePassEncoder10.insertDebugMarker('\u86d0');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer3), /* required buffer size: 316 */
+{offset: 316}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise21;
+} catch {}
+let texture52 = device0.createTexture({
+  size: {width: 96, height: 1, depthOrArrayLayers: 741},
+  mipLevelCount: 5,
+  sampleCount: 1,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder41 = device0.createRenderBundleEncoder({
+  label: '\u1fa9\uc2c6',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+});
+let sampler31 = device0.createSampler({
+  label: '\u7270\u07e8\u9800\udb35\u05c4\u0c2f',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 28.28,
+});
+try {
+renderPassEncoder10.setStencilReference(1209);
+} catch {}
+try {
+renderPassEncoder19.setViewport(51.81, 0.6186, 14.63, 0.3770, 0.8903, 0.9978);
+} catch {}
+let pipeline23 = device0.createRenderPipeline({
+  label: '\u{1f8ab}\u04b9\ubc1e\u933f\u{1fb5a}\u5680\u5481\u6c74\uabd5',
+  layout: pipelineLayout6,
+  multisample: {count: 4, mask: 0x71674661},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint'}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'equal', depthFailOp: 'increment-wrap', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'not-equal', failOp: 'invert', passOp: 'replace'},
+    depthBias: -1986049405,
+    depthBiasSlopeScale: 628.4954949898379,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 492,
+        attributes: [
+          {format: 'float32x4', offset: 32, shaderLocation: 8},
+          {format: 'unorm8x2', offset: 56, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 108, shaderLocation: 15},
+          {format: 'unorm10-10-10-2', offset: 56, shaderLocation: 13},
+          {format: 'unorm8x2', offset: 20, shaderLocation: 11},
+          {format: 'snorm16x2', offset: 80, shaderLocation: 14},
+          {format: 'snorm8x4', offset: 36, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 212,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 68, shaderLocation: 9},
+          {format: 'sint16x2', offset: 48, shaderLocation: 5},
+          {format: 'uint8x4', offset: 12, shaderLocation: 4},
+          {format: 'snorm16x4', offset: 20, shaderLocation: 3},
+          {format: 'float16x2', offset: 12, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 5140,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 1700, shaderLocation: 0},
+          {format: 'float32x3', offset: 1852, shaderLocation: 10},
+          {format: 'uint8x4', offset: 1740, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 3588,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint32x2', offset: 496, shaderLocation: 12}],
+      },
+    ],
+  },
+});
+let buffer13 = device0.createBuffer({
+  label: '\u0ca7\u0b27\u{1ff70}\u1460\ucbb1',
+  size: 32491,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let textureView78 = texture46.createView({
+  label: '\ub4ea\ua794\u9a71\u032d',
+  dimension: '2d-array',
+  format: 'depth24plus-stencil8',
+  baseMipLevel: 6,
+});
+let sampler32 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 18.89,
+  maxAnisotropy: 17,
+});
+let externalTexture40 = device0.importExternalTexture({source: videoFrame5});
+try {
+computePassEncoder14.setBindGroup(5, bindGroup4);
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(1335);
+} catch {}
+try {
+renderPassEncoder25.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder17.setScissorRect(37, 1, 91, 0);
+} catch {}
+try {
+querySet19.destroy();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'stencil-only',
+}, arrayBuffer2, /* required buffer size: 10_812_850 */
+{offset: 320, bytesPerRow: 802, rowsPerImage: 221}, {width: 768, height: 1, depthOrArrayLayers: 62});
+} catch {}
+let pipeline24 = device0.createRenderPipeline({
+  label: '\u{1f66a}\u624b\u92cb\u0eac\u143c\u{1fc07}\u946f\u3204\u08ea',
+  layout: pipelineLayout3,
+  multisample: {mask: 0x6415391c},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater', failOp: 'increment-wrap', depthFailOp: 'increment-clamp', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'invert', passOp: 'invert'},
+    stencilReadMask: 1241197144,
+    stencilWriteMask: 3722789353,
+    depthBias: -1804362115,
+    depthBiasSlopeScale: -37.912985905102104,
+    depthBiasClamp: 677.1879302672892,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 11036,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x2', offset: 2424, shaderLocation: 7}],
+      },
+      {
+        arrayStride: 364,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint8x4', offset: 16, shaderLocation: 4},
+          {format: 'uint32x2', offset: 12, shaderLocation: 15},
+          {format: 'sint32x2', offset: 28, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', unclippedDepth: true},
+});
+let gpuCanvasContext5 = canvas6.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let sampler33 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 73.43,
+  lodMaxClamp: 87.68,
+  compare: 'less-equal',
+});
+try {
+renderPassEncoder20.beginOcclusionQuery(1147);
+} catch {}
+try {
+renderPassEncoder19.setViewport(63.16, 0.2846, 0.1764, 0.5396, 0.4993, 0.9522);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb'],
+});
+} catch {}
+let commandEncoder74 = device0.createCommandEncoder({label: '\u7a64\u{1faae}\u0d73\u{1ff41}\u{1fee6}\u{1ff21}\ue257\u0311\uc82c\u09a4\u843c'});
+let renderBundle45 = renderBundleEncoder2.finish({label: '\u2d78\u0da0\u{1fb1d}\ud611\u858b\u{1fe7b}\udae4\u0a9a\ud0fc'});
+let sampler34 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 43.41,
+  lodMaxClamp: 92.57,
+});
+try {
+renderPassEncoder25.beginOcclusionQuery(1365);
+} catch {}
+try {
+commandEncoder74.copyBufferToBuffer(buffer11, 47024, buffer4, 13360, 14440);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let imageBitmap8 = await createImageBitmap(img0);
+let commandBuffer18 = commandEncoder74.finish();
+let textureView79 = texture42.createView({label: '\u9af8\u084e\u02c5', format: 'bgra8unorm-srgb'});
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup10, new Uint32Array(5489), 4542, 0);
+} catch {}
+try {
+renderPassEncoder19.executeBundles([]);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm-srgb'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageBitmap9 = await createImageBitmap(imageBitmap0);
+let commandEncoder75 = device0.createCommandEncoder({});
+let texture53 = device0.createTexture({
+  label: '\u87f0\uc897\u{1f65f}\u0093\u40dd\u44c5\u{1f9dc}\ubc68\u71c4\u0d47\u{1f98d}',
+  size: [1278, 5, 1358],
+  mipLevelCount: 6,
+  format: 'astc-6x5-unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['astc-6x5-unorm', 'astc-6x5-unorm'],
+});
+try {
+computePassEncoder10.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(5, bindGroup6, new Uint32Array(4416), 3263, 0);
+} catch {}
+try {
+renderPassEncoder26.setBlendConstant({ r: 229.3, g: 723.6, b: -123.0, a: -321.4, });
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, buffer10, 0, 3563);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, arrayBuffer0, /* required buffer size: 97 */
+{offset: 97}, {width: 192, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline25 = device0.createRenderPipeline({
+  label: '\ue972\ud92b\u0eb3\u0c12\u{1f6d7}\u9972\uc5fa\u89b8',
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba8uint'}, {format: 'rgba32uint'}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4892,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 1020, shaderLocation: 7},
+          {format: 'unorm16x4', offset: 296, shaderLocation: 13},
+          {format: 'uint8x4', offset: 236, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 21040,
+        attributes: [
+          {format: 'uint32', offset: 2052, shaderLocation: 12},
+          {format: 'unorm16x4', offset: 456, shaderLocation: 3},
+          {format: 'unorm16x4', offset: 724, shaderLocation: 15},
+          {format: 'unorm16x2', offset: 2124, shaderLocation: 14},
+          {format: 'float32x2', offset: 3960, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 5292,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 2256, shaderLocation: 11},
+          {format: 'uint32', offset: 216, shaderLocation: 2},
+          {format: 'sint16x2', offset: 504, shaderLocation: 5},
+          {format: 'unorm8x4', offset: 4, shaderLocation: 6},
+          {format: 'float16x2', offset: 512, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 7560,
+        attributes: [
+          {format: 'float16x2', offset: 1260, shaderLocation: 10},
+          {format: 'float16x4', offset: 256, shaderLocation: 9},
+        ],
+      },
+      {arrayStride: 15224, attributes: [{format: 'snorm16x2', offset: 4664, shaderLocation: 0}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let commandEncoder76 = device0.createCommandEncoder({});
+let commandBuffer19 = commandEncoder75.finish({});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup0, new Uint32Array(8054), 223, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer0, 'uint32');
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(0, buffer10);
+} catch {}
+let arrayBuffer4 = buffer7.getMappedRange(369056, 3364);
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 107, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 769 */
+{offset: 769, bytesPerRow: 7542}, {width: 469, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline26 = device0.createComputePipeline({
+  label: '\u934d\udc6c\ubbac',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule2, entryPoint: 'compute0'},
+});
+let offscreenCanvas4 = new OffscreenCanvas(441, 722);
+let querySet26 = device0.createQuerySet({label: '\u0ef4\u40c2\u2896\ub8bd\u292f', type: 'occlusion', count: 3248});
+let texture54 = gpuCanvasContext3.getCurrentTexture();
+let renderPassEncoder28 = commandEncoder76.beginRenderPass({
+  label: '\u0a69\ueda6',
+  colorAttachments: [{
+  view: textureView9,
+  depthSlice: 56,
+  clearValue: { r: 966.3, g: -366.0, b: 824.8, a: 109.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {
+  view: textureView74,
+  depthSlice: 729,
+  clearValue: { r: -924.5, g: -907.9, b: -332.7, a: -297.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView40,
+    depthClearValue: 0.535662001008983,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'discard',
+    depthReadOnly: false,
+  },
+  maxDrawCount: 1161473754,
+});
+let renderBundle46 = renderBundleEncoder7.finish({label: '\u07ea\ub1d8\u{1fdcb}\u9adb\u{1fffa}\u{1f7b9}\u{1f8bd}\u0e4d\u02f1\u9f41'});
+let externalTexture41 = device0.importExternalTexture({label: '\u1328\ud06b\u57e3\udfac\u03bd', source: video4, colorSpace: 'display-p3'});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup6, new Uint32Array(5499), 5014, 0);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(2, buffer10, 0, 207178);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 9},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 10_904_176 */
+{offset: 176, bytesPerRow: 1450, rowsPerImage: 94}, {width: 303, height: 0, depthOrArrayLayers: 81});
+} catch {}
+let commandEncoder77 = device0.createCommandEncoder({label: '\u0bff\u{1fb7f}\ua1f9\u{1ff40}\u01c0\u902d\u0fd9\u0144\u0120\u0619'});
+let renderPassEncoder29 = commandEncoder77.beginRenderPass({
+  colorAttachments: [{
+  view: textureView5,
+  depthSlice: 197,
+  clearValue: { r: -761.9, g: -547.8, b: -827.3, a: -992.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView51,
+  depthSlice: 115,
+  clearValue: { r: -781.2, g: 960.4, b: 731.6, a: -986.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView77, depthLoadOp: 'load', depthStoreOp: 'store', stencilClearValue: 57744},
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 1100720484,
+});
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder27.setViewport(81.02, 0.06061, 7.857, 0.9041, 0.1991, 0.3203);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, arrayBuffer0, /* required buffer size: 106 */
+{offset: 106, rowsPerImage: 38}, {width: 12, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline27 = device0.createRenderPipeline({
+  label: '\u9a97\u{1fbe8}\u0468\u0a82\u0876\u02af\u0933',
+  layout: pipelineLayout2,
+  multisample: {count: 4, mask: 0x31ca5550},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba32uint'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'greater', failOp: 'invert', depthFailOp: 'decrement-clamp'},
+    stencilBack: {compare: 'never', depthFailOp: 'decrement-clamp', passOp: 'increment-wrap'},
+    stencilReadMask: 617311899,
+    stencilWriteMask: 1502965415,
+    depthBias: -1783854277,
+    depthBiasSlopeScale: 920.8758793471097,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 1724,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 164, shaderLocation: 9},
+          {format: 'unorm8x2', offset: 432, shaderLocation: 10},
+          {format: 'unorm16x2', offset: 248, shaderLocation: 7},
+          {format: 'unorm8x4', offset: 160, shaderLocation: 5},
+          {format: 'sint32', offset: 748, shaderLocation: 2},
+          {format: 'snorm8x2', offset: 402, shaderLocation: 12},
+          {format: 'uint32', offset: 176, shaderLocation: 4},
+          {format: 'float32x2', offset: 872, shaderLocation: 14},
+          {format: 'float32', offset: 328, shaderLocation: 3},
+          {format: 'sint16x2', offset: 344, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 304, shaderLocation: 8},
+          {format: 'unorm16x4', offset: 28, shaderLocation: 0},
+          {format: 'sint8x4', offset: 40, shaderLocation: 13},
+          {format: 'sint32x3', offset: 16, shaderLocation: 1},
+          {format: 'float32', offset: 188, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 16148,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint32x2', offset: 1940, shaderLocation: 6}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: true},
+});
+gc();
+document.body.prepend(canvas3);
+let videoFrame11 = videoFrame3.clone();
+let bindGroupLayout22 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 1587,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let texture55 = device0.createTexture({
+  size: [384, 1, 1],
+  mipLevelCount: 4,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba32uint', 'rgba32uint', 'rgba32uint'],
+});
+let externalTexture42 = device0.importExternalTexture({label: '\u0808\u{1fafd}\uc981\u1e0d\udac1\u07e2\u2081\u{1fd46}', source: video7});
+try {
+computePassEncoder0.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(961), /* required buffer size: 961 */
+{offset: 961, bytesPerRow: 1031}, {width: 47, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise16;
+} catch {}
+document.body.prepend(video6);
+canvas0.width = 9;
+try {
+offscreenCanvas4.getContext('webgl');
+} catch {}
+let querySet27 = device0.createQuerySet({label: '\ub589\u0127\u{1ff8c}\u{1f8eb}', type: 'occlusion', count: 3620});
+let renderBundleEncoder42 = device0.createRenderBundleEncoder({
+  label: '\ucd54\uaf60\u{1f7a1}',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+});
+let externalTexture43 = device0.importExternalTexture({source: videoFrame2, colorSpace: 'display-p3'});
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(5, bindGroup10);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup9, new Uint32Array(471), 425, 0);
+} catch {}
+try {
+renderPassEncoder19.end();
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(3, buffer10, 283968, 80672);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer0), /* required buffer size: 184 */
+{offset: 184}, {width: 95, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder78 = device0.createCommandEncoder();
+let textureView80 = texture33.createView({
+  label: '\u{1f941}\u05d5\u8015\u0b5b\u9a5b\u0fd1\u1ab6\u02c7\u0dde\u04c0\ub8ac',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 197,
+  arrayLayerCount: 243,
+});
+let renderBundle47 = renderBundleEncoder27.finish({label: '\u7a7e\u0f77\ue694\u05f8\u0d81\uf2aa\u1e50\u{1f96f}'});
+try {
+computePassEncoder11.setBindGroup(5, bindGroup12, new Uint32Array(1316), 1205, 0);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(791);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder15.setBlendConstant({ r: -817.2, g: -581.0, b: 542.8, a: 57.33, });
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(2, bindGroup20, new Uint32Array(396), 326, 0);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(6, buffer10, 378212, 4133);
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer3, 228256, 34648);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder23.resolveQuerySet(querySet20, 341, 295, buffer10, 93440);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(610, 1002);
+let commandEncoder79 = device0.createCommandEncoder({label: '\u024c\u796d\u{1ffcf}\u31a5'});
+let commandBuffer20 = commandEncoder78.finish({label: '\ue4cb\u64d2\ud028\u0c32\u01aa\u0063\u5a55\u{1fda0}\u0c0b\u{1fd64}'});
+let renderPassEncoder30 = commandEncoder79.beginRenderPass({
+  label: '\u{1f9ba}\u61cb',
+  colorAttachments: [{view: textureView5, depthSlice: 84, loadOp: 'clear', storeOp: 'store'}, {
+  view: textureView51,
+  depthSlice: 736,
+  clearValue: { r: -886.3, g: 427.4, b: 509.7, a: -811.5, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView40,
+    depthClearValue: 4.491245033967475,
+    depthLoadOp: 'load',
+    depthStoreOp: 'discard',
+    depthReadOnly: false,
+  },
+  occlusionQuerySet: querySet20,
+  maxDrawCount: 625451748,
+});
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder20.setScissorRect(60, 0, 31, 1);
+} catch {}
+try {
+renderPassEncoder9.setViewport(46.84, 0.7522, 9.068, 0.1009, 0.1487, 0.7059);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer10, 0, 99570);
+} catch {}
+try {
+commandEncoder23.copyBufferToBuffer(buffer11, 38956, buffer2, 72312, 5980);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer6, 14260, 28572);
+dissociateBuffer(device0, buffer6);
+} catch {}
+document.body.prepend(canvas5);
+gc();
+canvas6.width = 229;
+let gpuCanvasContext6 = offscreenCanvas5.getContext('webgpu');
+let adapter2 = await navigator.gpu.requestAdapter({});
+let texture56 = device0.createTexture({
+  size: {width: 192, height: 1, depthOrArrayLayers: 1259},
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView81 = texture13.createView({label: '\u8e52\ud8d5\u{1fdeb}\ueb2e', mipLevelCount: 3});
+let computePassEncoder32 = commandEncoder23.beginComputePass({});
+try {
+computePassEncoder3.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup8, new Uint32Array(1923), 254, 0);
+} catch {}
+try {
+renderPassEncoder25.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(21, 0, 12, 0);
+} catch {}
+try {
+renderPassEncoder20.setStencilReference(2974);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(7, buffer10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer2), /* required buffer size: 509 */
+{offset: 509, bytesPerRow: 717}, {width: 39, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline28 = await device0.createRenderPipelineAsync({
+  label: '\u0872\u{1fc39}\u{1fd5a}\u{1f777}\ubb7b',
+  layout: pipelineLayout7,
+  multisample: {mask: 0x41528887},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'equal', failOp: 'replace', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'equal', failOp: 'decrement-clamp', depthFailOp: 'keep'},
+    stencilReadMask: 738551038,
+    depthBias: -314671190,
+    depthBiasSlopeScale: 396.5371963331091,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 15832,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 4292, shaderLocation: 9},
+          {format: 'float32x2', offset: 1572, shaderLocation: 3},
+          {format: 'uint16x2', offset: 3760, shaderLocation: 14},
+          {format: 'float32x2', offset: 4216, shaderLocation: 5},
+          {format: 'snorm8x2', offset: 874, shaderLocation: 7},
+          {format: 'uint8x2', offset: 1376, shaderLocation: 10},
+          {format: 'unorm10-10-10-2', offset: 1816, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 7448,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x3', offset: 824, shaderLocation: 6},
+          {format: 'float32x4', offset: 1692, shaderLocation: 1},
+          {format: 'unorm16x4', offset: 72, shaderLocation: 15},
+          {format: 'uint8x2', offset: 538, shaderLocation: 0},
+          {format: 'float32x3', offset: 1852, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 540, shaderLocation: 12},
+          {format: 'uint32x2', offset: 36, shaderLocation: 13},
+          {format: 'uint16x4', offset: 188, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 14376,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x4', offset: 7808, shaderLocation: 2}],
+      },
+    ],
+  },
+});
+offscreenCanvas2.width = 202;
+let querySet28 = device0.createQuerySet({
+  label: '\u9ac4\u{1f641}\u03d3\uce53\u{1fd25}\u06fa\u722c\u9ba3\u{1ff65}\u583e\u4f3c',
+  type: 'occlusion',
+  count: 1922,
+});
+let texture57 = device0.createTexture({
+  label: '\u13d1\ubb9e\u{1f6f1}\u3c17\ue93b\u7a13\u{1fd16}',
+  size: [384, 1, 1048],
+  mipLevelCount: 4,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32uint', 'rgba32uint'],
+});
+let texture58 = gpuCanvasContext3.getCurrentTexture();
+let textureView82 = texture31.createView({label: '\u051d\u6c3a\u0fa2\uddb9\u{1ff4c}\u470c\u0f8c', baseMipLevel: 5, mipLevelCount: 1});
+let sampler35 = device0.createSampler({
+  label: '\u{1f60d}\u5912\u902e\u{1fab9}\u109f',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 55.02,
+  lodMaxClamp: 81.43,
+  compare: 'never',
+});
+let externalTexture44 = device0.importExternalTexture({
+  label: '\u0fbd\u8636\u06d9\ud9d5\u00b2\ufd02\u{1f9dd}\u7f68\u4112\u0959',
+  source: video7,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup0, new Uint32Array(1220), 408, 0);
+} catch {}
+try {
+renderPassEncoder17.setScissorRect(110, 1, 23, 0);
+} catch {}
+let querySet29 = device0.createQuerySet({label: '\uf8d3\ubdb0\u09d7\u469a\u{1fd8e}\u0a86\u64ce\u202e\u3a95', type: 'occlusion', count: 1815});
+let texture59 = device0.createTexture({
+  size: {width: 96, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['depth24plus-stencil8', 'depth24plus-stencil8', 'depth24plus-stencil8'],
+});
+let texture60 = gpuCanvasContext1.getCurrentTexture();
+let textureView83 = texture39.createView({dimension: '2d', baseMipLevel: 2, mipLevelCount: 1, baseArrayLayer: 88, arrayLayerCount: 1});
+let renderBundleEncoder43 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+});
+try {
+renderPassEncoder24.setStencilReference(3802);
+} catch {}
+try {
+renderBundleEncoder22.insertDebugMarker('\uae1a');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 637 */
+{offset: 637, rowsPerImage: 86}, {width: 237, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline29 = device0.createComputePipeline({
+  label: '\u2a59\u0c0b\ubdbb\u{1fd15}\u049f\u034e\u75a0\u2a14\u81ce\ud9d6',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule3, entryPoint: 'compute0'},
+});
+let promise23 = adapter1.requestAdapterInfo();
+let bindGroup21 = device0.createBindGroup({label: '\udcec\ubd06\u08ce\u4f1a\ua55a\u2770', layout: bindGroupLayout6, entries: []});
+let commandEncoder80 = device0.createCommandEncoder({});
+let commandBuffer21 = commandEncoder80.finish({label: '\ua4b5\u045e\u{1ff4f}\ub273\u6fb8\u0aae\u72a4\u0ca5\u01be\u84d0'});
+let texture61 = device0.createTexture({
+  label: '\u64de\u3f1b\u5351\u33d0\uf199\u{1fbd9}\u43a2\udf8a\u66f8\u{1fadb}',
+  size: {width: 768, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 8,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView84 = texture7.createView({
+  label: '\u67d4\u03e5\u4b96\u89b6\u1db5\u0489\u58c4\u{1fa17}\u06ba\u022c',
+  dimension: '2d',
+  baseMipLevel: 5,
+  mipLevelCount: 1,
+  baseArrayLayer: 275,
+});
+let renderBundle48 = renderBundleEncoder24.finish({label: '\u59d5\ua6f0\u0aaf\u{1f879}\uf833\uc138'});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup21, []);
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(1121);
+} catch {}
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder30.setViewport(66.89, 0.2419, 70.80, 0.5171, 0.4325, 0.7611);
+} catch {}
+let video8 = await videoWithData();
+try {
+  await promise23;
+} catch {}
+let imageBitmap10 = await createImageBitmap(videoFrame4);
+let bindGroupLayout23 = device0.createBindGroupLayout({
+  label: '\u9cbe\u7ad4\u{1f6c8}\u{1f745}\u{1fc34}\u{1fdd5}\ub8eb\u34c1\u3dbf',
+  entries: [
+    {
+      binding: 5821,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 3764, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder81 = device0.createCommandEncoder({label: '\u4f5d\u1688'});
+let texture62 = device0.createTexture({
+  label: '\u06ef\u2bd8\u16a4\u93b2\u{1f95a}\u{1f66a}\u{1fa13}\u649a\u{1f7f7}\ua701\uabc1',
+  size: [96],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32uint'],
+});
+let renderPassEncoder31 = commandEncoder81.beginRenderPass({
+  colorAttachments: [{view: textureView23, depthSlice: 26, loadOp: 'load', storeOp: 'discard'}, {
+  view: textureView47,
+  depthSlice: 21,
+  clearValue: { r: 866.5, g: -928.2, b: -749.3, a: 632.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView16,
+    depthClearValue: -9.51389733552703,
+    depthLoadOp: 'load',
+    depthStoreOp: 'discard',
+    stencilClearValue: 23623,
+    stencilReadOnly: true,
+  },
+  occlusionQuerySet: querySet27,
+  maxDrawCount: 634962857,
+});
+let externalTexture45 = device0.importExternalTexture({source: video4, colorSpace: 'display-p3'});
+try {
+computePassEncoder4.setPipeline(pipeline29);
+} catch {}
+try {
+renderPassEncoder30.setStencilReference(1846);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+renderBundleEncoder33.setPipeline(pipeline24);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(2, buffer10, 322456, 4828);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let adapter3 = await navigator.gpu.requestAdapter();
+let querySet30 = device0.createQuerySet({label: '\u6678\u41d0\u770b\u0b13\u1174\u8feb', type: 'occlusion', count: 2827});
+let texture63 = device0.createTexture({
+  label: '\ue330\u3234\u0fc9\u0ebc\ub4dc\u{1f96d}\u6426\u05d7\u667b\u{1f942}\u0340',
+  size: [96, 1, 1],
+  mipLevelCount: 5,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView85 = texture24.createView({label: '\u0f88\u{1fa58}\ud6f2', dimension: '2d-array', aspect: 'all', baseMipLevel: 3, mipLevelCount: 1});
+let sampler36 = device0.createSampler({
+  label: '\u{1fd65}\u{1f618}\u{1ff1e}\u1652\ub8ba\u{1f6de}\u{1f853}\u24f2\u{1f9a2}\u1033\u{1f9f6}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 0.04470,
+  lodMaxClamp: 14.10,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder25.beginOcclusionQuery(327);
+} catch {}
+try {
+renderPassEncoder21.setViewport(132.3, 0.09043, 34.17, 0.2551, 0.8065, 0.8860);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(5, bindGroup0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Int32Array(new ArrayBuffer(56)), /* required buffer size: 804 */
+{offset: 804}, {width: 16, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline30 = device0.createComputePipeline({layout: pipelineLayout1, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+let pipeline31 = device0.createRenderPipeline({
+  label: '\uc0be\u1cd5',
+  layout: pipelineLayout6,
+  multisample: {count: 4, mask: 0xe51ee526},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rgba32uint'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'greater-equal', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'less-equal', failOp: 'increment-clamp', depthFailOp: 'replace', passOp: 'increment-wrap'},
+    stencilReadMask: 75988663,
+    depthBiasSlopeScale: 204.24221604770014,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 2052, attributes: []},
+      {arrayStride: 30212, attributes: [{format: 'uint16x4', offset: 2304, shaderLocation: 15}]},
+      {
+        arrayStride: 10392,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 1220, shaderLocation: 4},
+          {format: 'sint32x3', offset: 600, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 6676, stepMode: 'vertex', attributes: []},
+      {arrayStride: 144, attributes: [{format: 'sint16x2', offset: 8, shaderLocation: 7}]},
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', unclippedDepth: true},
+});
+let buffer14 = device0.createBuffer({
+  label: '\ucfbc\u87b5\uc2f7\u0c33\u07d5\u0b58\u047a',
+  size: 34229,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let externalTexture46 = device0.importExternalTexture({
+  label: '\u8d93\u0665\ue2c8\u1c39\u{1fc43}\u05ba\u{1ff8d}\u98d5\ua38c\u770d',
+  source: video4,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder22.beginOcclusionQuery(1262);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder21.setBlendConstant({ r: 477.4, g: 898.4, b: -264.3, a: -604.3, });
+} catch {}
+try {
+renderPassEncoder25.setVertexBuffer(1, buffer10, 0, 325495);
+} catch {}
+let bindGroup22 = device0.createBindGroup({
+  layout: bindGroupLayout13,
+  entries: [{binding: 7531, resource: externalTexture3}, {binding: 4888, resource: externalTexture41}],
+});
+let commandEncoder82 = device0.createCommandEncoder({label: '\u808f\u{1ffc6}\u3f6a\u0189\u090c\ud8ba\u60b9'});
+let commandBuffer22 = commandEncoder82.finish({label: '\u0621\ue4ff\u1559\u2805\u07df\u0d80'});
+let texture64 = device0.createTexture({
+  label: '\u{1f7bb}\u0330\u54c7\uce3a\ubdb3\u001d\ubfaa',
+  size: {width: 768},
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder20.setBindGroup(4, bindGroup21);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder22.setBlendConstant({ r: 610.0, g: -159.1, b: 444.7, a: -446.5, });
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+let promise24 = buffer13.mapAsync(GPUMapMode.WRITE, 25208, 6436);
+try {
+device0.queue.submit([commandBuffer18]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 3,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(new ArrayBuffer(0)), /* required buffer size: 530_936 */
+{offset: 670, bytesPerRow: 805, rowsPerImage: 94}, {width: 36, height: 1, depthOrArrayLayers: 8});
+} catch {}
+let querySet31 = device0.createQuerySet({
+  label: '\u2bb3\u{1faa3}\u{1ff3c}\u{1fb1d}\ue47a\u37e7\u5249\u{1fd2d}\uad76\u{1fdc4}',
+  type: 'occlusion',
+  count: 3442,
+});
+let texture65 = device0.createTexture({size: [768, 1, 1100], format: 'depth24plus-stencil8', usage: GPUTextureUsage.COPY_SRC, viewFormats: []});
+let renderBundle49 = renderBundleEncoder14.finish({label: '\u{1fe05}\u0de6\u5f74\u9368'});
+try {
+renderPassEncoder8.setStencilReference(3617);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(0, buffer14);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(0, bindGroup17);
+} catch {}
+let pipeline32 = await device0.createComputePipelineAsync({
+  label: '\u{1fb1a}\u16f4\uaf75\u{1fd4f}\u4887\u95e8',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let imageBitmap11 = await createImageBitmap(imageData3);
+let bindGroup23 = device0.createBindGroup({layout: bindGroupLayout6, entries: []});
+let commandEncoder83 = device0.createCommandEncoder({label: '\uc141\ub26a\u9438\ua27f\u845c\u6679'});
+let querySet32 = device0.createQuerySet({label: '\u01f9\u5f74\u32ee\u{1fa77}\u0405\ue091', type: 'occlusion', count: 1472});
+let commandBuffer23 = commandEncoder83.finish({label: '\ub478\u0699\u{1f6d7}\u9366\u{1f6dd}\u1621\u2dc6'});
+let sampler37 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 39.47,
+});
+try {
+computePassEncoder17.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(4, bindGroup11);
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(1641);
+} catch {}
+try {
+renderPassEncoder25.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer11, 'uint32', 14032, 17478);
+} catch {}
+try {
+renderPassEncoder29.insertDebugMarker('\u04ef');
+} catch {}
+let pipeline33 = await device0.createComputePipelineAsync({
+  label: '\uae11\u0844\u6ab1\u941d',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let offscreenCanvas6 = new OffscreenCanvas(38, 157);
+let videoFrame12 = new VideoFrame(imageBitmap2, {timestamp: 0});
+try {
+offscreenCanvas6.getContext('bitmaprenderer');
+} catch {}
+offscreenCanvas4.width = 421;
+let commandEncoder84 = device0.createCommandEncoder({label: '\u0084\u0269'});
+let commandBuffer24 = commandEncoder84.finish({});
+let texture66 = device0.createTexture({
+  label: '\u2ab7\uf926\u3a6a\u{1fd03}\u{1ff98}\u0c0f\ua478\uca92',
+  size: {width: 192, height: 1, depthOrArrayLayers: 1415},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder30.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(5, bindGroup0, new Uint32Array(9042), 8678, 0);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: -705.8, g: -628.8, b: 671.1, a: -453.6, });
+} catch {}
+try {
+renderPassEncoder7.insertDebugMarker('\ue79e');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 1,
+  origin: {x: 780, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer4), /* required buffer size: 291 */
+{offset: 291}, {width: 1460, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas7 = new OffscreenCanvas(243, 852);
+let commandEncoder85 = device0.createCommandEncoder({label: '\ud339\u{1fa6a}\ub2e3\u18e9\u6603\u28fd\u5f9c\ue40c'});
+let textureView86 = texture23.createView({label: '\u026e\u{1f7d8}\u861b\u5f4c\ua549\u010a', format: 'rgba8uint'});
+let renderPassEncoder32 = commandEncoder85.beginRenderPass({
+  label: '\u0c6e\u{1faa8}\u{1fed1}\u0dd0\u{1fa9d}\u{1f923}\uc412\u3d2e\u0ff3',
+  colorAttachments: [{
+  view: textureView9,
+  depthSlice: 178,
+  clearValue: { r: -159.6, g: 612.4, b: -166.4, a: -857.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {
+  view: textureView51,
+  depthSlice: 516,
+  clearValue: { r: 881.7, g: -897.3, b: -792.6, a: 570.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView40,
+    depthClearValue: 0.8433030662618384,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'store',
+    depthReadOnly: false,
+    stencilClearValue: 60204,
+    stencilReadOnly: false,
+  },
+  maxDrawCount: 178031558,
+});
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup16, new Uint32Array(6747), 6454, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 13, y: 133 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas8 = new OffscreenCanvas(810, 666);
+let bindGroupLayout24 = device0.createBindGroupLayout({
+  label: '\u{1f9f3}\u{1f7f4}\ua7f9\u82b1\u8ab4\u{1f7d3}',
+  entries: [
+    {
+      binding: 5016,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 1712,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let texture67 = device0.createTexture({
+  label: '\u{1fd62}\u59df\u0a17\u0c16',
+  size: [96],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder44 = device0.createRenderBundleEncoder({
+  label: '\u{1fa22}\u0657\u4b8c',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+});
+try {
+computePassEncoder30.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder20.setBlendConstant({ r: -929.4, g: -661.7, b: -69.62, a: 266.8, });
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer12, 'uint32', 38836, 20165);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(1, buffer10, 0, 912);
+} catch {}
+let gpuCanvasContext7 = offscreenCanvas7.getContext('webgpu');
+document.body.prepend(video5);
+video8.width = 277;
+try {
+renderPassEncoder31.setBindGroup(3, bindGroup22, new Uint32Array(4693), 1877, 0);
+} catch {}
+try {
+renderPassEncoder13.end();
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(4040);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer3), /* required buffer size: 966 */
+{offset: 962}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img5,
+  origin: { x: 1, y: 6 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img1);
+try {
+offscreenCanvas8.getContext('webgl2');
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+gc();
+let commandEncoder86 = device0.createCommandEncoder({label: '\u1896\u7cd7\u7ce5\uf218\u0262'});
+let textureView87 = texture28.createView({
+  label: '\u203c\u{1fe70}\u26e3\uc4b5\u8436\u637e\u5a63\ua268\ucd63\u0a62',
+  baseMipLevel: 4,
+  mipLevelCount: 1,
+  baseArrayLayer: 775,
+  arrayLayerCount: 18,
+});
+let renderPassEncoder33 = commandEncoder86.beginRenderPass({
+  label: '\u5b3e\udbd6\u08f9\u8053\u0ec5\u1c6c\u{1f6d5}\u{1f93e}\u{1ff02}\u{1f704}',
+  colorAttachments: [{
+  view: textureView9,
+  depthSlice: 173,
+  clearValue: { r: 669.9, g: -527.3, b: 285.5, a: 74.34, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView51,
+  depthSlice: 85,
+  clearValue: { r: 568.0, g: 274.0, b: 603.4, a: 472.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView40, depthReadOnly: true, stencilReadOnly: true},
+  occlusionQuerySet: querySet8,
+  maxDrawCount: 1093412818,
+});
+try {
+renderPassEncoder18.beginOcclusionQuery(1363);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder29.setScissorRect(96, 0, 34, 1);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer5, 'uint16');
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer14, 4900);
+} catch {}
+let pipeline34 = device0.createComputePipeline({layout: pipelineLayout2, compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}}});
+let bindGroupLayout25 = device0.createBindGroupLayout({entries: []});
+let textureView88 = texture35.createView({baseMipLevel: 4, baseArrayLayer: 497, arrayLayerCount: 68});
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup19, new Uint32Array(5782), 4736, 0);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(366);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer12, 'uint32', 24920, 23129);
+} catch {}
+try {
+renderBundleEncoder10.insertDebugMarker('\ue937');
+} catch {}
+let offscreenCanvas9 = new OffscreenCanvas(990, 736);
+let bindGroupLayout26 = pipeline21.getBindGroupLayout(3);
+let textureView89 = texture7.createView({
+  label: '\uf782\u047d\u76b9\u036f\u474a\uff03\u86fb\ufb61',
+  dimension: '2d',
+  baseMipLevel: 5,
+  baseArrayLayer: 69,
+});
+try {
+renderPassEncoder14.setViewport(54.15, 0.7683, 17.85, 0.2153, 0.4221, 0.6198);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(3, buffer14, 25508);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroupLayout27 = device0.createBindGroupLayout({
+  label: '\ubf4f\u07c6\u0313\uf272\ua0f7',
+  entries: [
+    {
+      binding: 6772,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let pipelineLayout8 = device0.createPipelineLayout({
+  label: '\u4b32\u0ccc\u0e48\ub74c\u0449\uca9e',
+  bindGroupLayouts: [bindGroupLayout15, bindGroupLayout22, bindGroupLayout0],
+});
+let commandEncoder87 = device0.createCommandEncoder({});
+let textureView90 = texture55.createView({baseMipLevel: 2, mipLevelCount: 1});
+let renderBundle50 = renderBundleEncoder3.finish({});
+let externalTexture47 = device0.importExternalTexture({label: '\u{1fa5c}\u0563\u36d9\u1e56\u9a12\u{1f622}', source: video3, colorSpace: 'srgb'});
+try {
+computePassEncoder18.setPipeline(pipeline30);
+} catch {}
+try {
+renderPassEncoder20.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer12, 'uint32', 69068, 1779);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(4, buffer14);
+} catch {}
+let arrayBuffer5 = buffer4.getMappedRange(37744, 68);
+try {
+commandEncoder87.copyTextureToBuffer({
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1680 widthInBlocks: 105 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2656 */
+  offset: 2656,
+  buffer: buffer11,
+}, {width: 105, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+offscreenCanvas9.getContext('webgl');
+} catch {}
+let bindGroup24 = device0.createBindGroup({layout: bindGroupLayout6, entries: []});
+let buffer15 = device0.createBuffer({
+  label: '\u{1fcc6}\u{1f9b6}\u0634\u2578\u7ab9',
+  size: 104700,
+  usage: GPUBufferUsage.COPY_SRC,
+  mappedAtCreation: true,
+});
+let querySet33 = device0.createQuerySet({label: '\u501c\u0f65\udc6e\u{1ff0f}\ue13e', type: 'occlusion', count: 4063});
+let externalTexture48 = device0.importExternalTexture({label: '\ucd1b\u{1f929}\uee88\u0f0e\u{1fecd}', source: video6, colorSpace: 'srgb'});
+try {
+renderPassEncoder20.beginOcclusionQuery(2154);
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(1071);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer10, 236688, 68263);
+} catch {}
+let arrayBuffer6 = buffer0.getMappedRange(5352, 0);
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 15},
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 170_717 */
+{offset: 241, bytesPerRow: 1658, rowsPerImage: 17}, {width: 85, height: 1, depthOrArrayLayers: 7});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 0, y: 4 },
+  flipY: true,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline35 = device0.createComputePipeline({layout: pipelineLayout5, compute: {module: shaderModule4, entryPoint: 'compute0'}});
+let pipeline36 = device0.createRenderPipeline({
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'equal', depthFailOp: 'increment-clamp', passOp: 'replace'},
+    stencilBack: {failOp: 'increment-clamp', depthFailOp: 'decrement-wrap', passOp: 'increment-wrap'},
+    stencilReadMask: 1135337360,
+    stencilWriteMask: 271208190,
+    depthBias: -1414439251,
+    depthBiasClamp: 531.7085111378403,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 12192, stepMode: 'instance', attributes: []},
+      {arrayStride: 2464, attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 252, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 6804,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x3', offset: 1108, shaderLocation: 7}],
+      },
+      {
+        arrayStride: 2444,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 76, shaderLocation: 4},
+          {format: 'sint8x4', offset: 116, shaderLocation: 12},
+          {format: 'uint32x2', offset: 124, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'front', unclippedDepth: true},
+});
+canvas4.height = 555;
+let buffer16 = device0.createBuffer({
+  label: '\u{1fa37}\u0b81\ud345\u{1fa26}\ued82\uecf5\u138e\ufc30\u6ace\u{1fa90}\u8aa9',
+  size: 143914,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder88 = device0.createCommandEncoder({label: '\u{1f64f}\ueb9d\u{1fc3f}'});
+let textureView91 = texture30.createView({
+  label: '\ud12d\u01d5\u2f62\u0832\u3735\u{1fcec}\ue705\ub660\u{1ff97}\u9de8\u03ad',
+  dimension: '2d-array',
+});
+let renderBundle51 = renderBundleEncoder20.finish({label: '\u0e4c\u3da5\u0db5\u{1f835}\u0a4a\u{1fc0c}\u{1f73a}'});
+try {
+renderPassEncoder3.setScissorRect(84, 0, 8, 0);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(2, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(1, buffer14, 33136, 345);
+} catch {}
+try {
+commandEncoder87.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 13308 */
+  offset: 13308,
+  buffer: buffer11,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder87.copyTextureToBuffer({
+  texture: texture2,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 48 widthInBlocks: 48 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1692 */
+  offset: 1692,
+  buffer: buffer16,
+}, {width: 48, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+  await promise24;
+} catch {}
+let offscreenCanvas10 = new OffscreenCanvas(951, 386);
+let videoFrame13 = new VideoFrame(imageBitmap5, {timestamp: 0});
+try {
+offscreenCanvas10.getContext('bitmaprenderer');
+} catch {}
+let textureView92 = texture26.createView({
+  label: '\u099e\u569b\u218e\u4584\ud067\uc2a0\u0016\u04c9\u{1fd9d}',
+  dimension: '2d-array',
+  aspect: 'depth-only',
+  baseMipLevel: 1,
+});
+let sampler38 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 67.03,
+  maxAnisotropy: 5,
+});
+let externalTexture49 = device0.importExternalTexture({source: videoFrame13, colorSpace: 'display-p3'});
+try {
+renderPassEncoder17.setBlendConstant({ r: 336.5, g: 643.7, b: -191.1, a: 703.9, });
+} catch {}
+try {
+renderPassEncoder29.setStencilReference(888);
+} catch {}
+try {
+commandEncoder87.copyTextureToTexture({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 96, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder88.resolveQuerySet(querySet2, 97, 22, buffer10, 260096);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas11 = new OffscreenCanvas(775, 641);
+let commandEncoder89 = device0.createCommandEncoder({label: '\u4fab\u03d5\uc28c\u0697\uf6e2\u{1f6f3}\u3c31\u{1f64b}\u80f1\uc5c8\ub654'});
+let renderPassEncoder34 = commandEncoder89.beginRenderPass({
+  label: '\ub859\u{1fb7e}\u04b7\u20e6\u428f\u0d63',
+  colorAttachments: [{view: textureView1, depthSlice: 89, loadOp: 'load', storeOp: 'store'}, {
+  view: textureView20,
+  depthSlice: 6,
+  clearValue: { r: 648.7, g: 515.8, b: -487.2, a: 945.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView16, depthReadOnly: true, stencilReadOnly: false},
+  occlusionQuerySet: querySet4,
+  maxDrawCount: 1161510460,
+});
+try {
+computePassEncoder27.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder33.setViewport(91.70, 0.4540, 31.18, 0.1488, 0.7849, 0.8037);
+} catch {}
+try {
+commandEncoder87.clearBuffer(buffer6, 4288, 74560);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let canvas7 = document.createElement('canvas');
+gc();
+let video9 = await videoWithData();
+let texture68 = device0.createTexture({
+  label: '\u4f94\u3eef\uf046\u{1ff90}',
+  size: [192, 1, 18],
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba8uint', 'rgba8uint', 'rgba8uint'],
+});
+let texture69 = gpuCanvasContext4.getCurrentTexture();
+let textureView93 = texture69.createView({label: '\u0eb0\u{1f823}\u1d58\u{1fcf4}\u06c6\u0dca\u9727\u2796'});
+let externalTexture50 = device0.importExternalTexture({
+  label: '\uaa23\u75f2\u0795\u0b18\u{1ffed}\u833a\u{1f94c}\u{1faae}\u75c4',
+  source: videoFrame9,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: 926.6, g: 385.7, b: 445.6, a: 76.45, });
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(50, 0, 35, 0);
+} catch {}
+try {
+commandEncoder87.copyBufferToBuffer(buffer11, 68704, buffer3, 176828, 18300);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder87.copyTextureToTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 96, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder88.clearBuffer(buffer11, 37328, 30544);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap11,
+  origin: { x: 21, y: 6 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder33 = commandEncoder87.beginComputePass({label: '\u4ceb\u085d\u0ab2\u49be'});
+let renderPassEncoder35 = commandEncoder88.beginRenderPass({
+  colorAttachments: [{
+  view: textureView9,
+  depthSlice: 133,
+  clearValue: { r: 30.06, g: -54.47, b: -542.8, a: -74.57, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView51,
+  depthSlice: 406,
+  clearValue: { r: 171.6, g: 668.0, b: -153.3, a: -115.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView40,
+    depthClearValue: 0.47068776204502427,
+    depthLoadOp: 'load',
+    depthStoreOp: 'store',
+    stencilClearValue: 48542,
+  },
+  occlusionQuerySet: querySet10,
+  maxDrawCount: 295929720,
+});
+let renderBundleEncoder45 = device0.createRenderBundleEncoder({
+  label: '\u0b85\u{1fb67}\uf671\u057f\u{1f8db}\u{1f9e5}',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle52 = renderBundleEncoder29.finish({label: '\u55ab\u7799'});
+try {
+renderPassEncoder21.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(167, 0, 21, 1);
+} catch {}
+try {
+renderPassEncoder23.setViewport(94.17, 0.5369, 1.519, 0.3562, 0.7526, 0.7906);
+} catch {}
+let gpuCanvasContext8 = offscreenCanvas11.getContext('webgpu');
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let promise25 = adapter2.requestDevice({
+  label: '\u00db\u04aa\ud697\u1440\u0906\ua1ac',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+  ],
+  requiredLimits: {
+    maxBindGroups: 6,
+    maxColorAttachmentBytesPerSample: 33,
+    maxVertexAttributes: 26,
+    maxVertexBufferArrayStride: 51364,
+    maxStorageTexturesPerShaderStage: 28,
+    maxStorageBuffersPerShaderStage: 38,
+    maxDynamicStorageBuffersPerPipelineLayout: 36699,
+    maxDynamicUniformBuffersPerPipelineLayout: 11390,
+    maxBindingsPerBindGroup: 6461,
+    maxTextureArrayLayers: 778,
+    maxTextureDimension1D: 10175,
+    maxTextureDimension2D: 9885,
+    maxVertexBuffers: 10,
+    maxBindGroupsPlusVertexBuffers: 30,
+    minStorageBufferOffsetAlignment: 128,
+    minUniformBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 258806083,
+    maxStorageBufferBindingSize: 163954911,
+    maxUniformBuffersPerShaderStage: 44,
+    maxSampledTexturesPerShaderStage: 39,
+    maxInterStageShaderVariables: 32,
+    maxInterStageShaderComponents: 83,
+    maxSamplersPerShaderStage: 16,
+  },
+});
+try {
+externalTexture43.label = '\u6e2a\u022d\u6027\u0a14\u808f';
+} catch {}
+let buffer17 = device0.createBuffer({
+  label: '\u99ba\u{1fbaf}\u{1f6af}\u62bf\u4309\u9bed\u0985',
+  size: 543239,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let renderBundleEncoder46 = device0.createRenderBundleEncoder({
+  label: '\u09d3\u0c98\ud1ca\u{1fd40}\u0d31\uf0a0\u04ab',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: false,
+});
+let sampler39 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 57.93,
+  lodMaxClamp: 93.32,
+  compare: 'equal',
+});
+let externalTexture51 = device0.importExternalTexture({label: '\u0040\ub07c', source: video4, colorSpace: 'display-p3'});
+try {
+computePassEncoder16.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(6, buffer14, 0, 15793);
+} catch {}
+let promise26 = device0.createComputePipelineAsync({
+  label: '\u0a2b\u{1f9aa}\u05d9\u8f90',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder90 = device0.createCommandEncoder({label: '\u1b1d\u2d33\u2f2a\u5dfd'});
+let querySet34 = device0.createQuerySet({label: '\u0baf\u{1fb24}\u03c7\ue89c\u02e5\u8d98\u0ed3', type: 'occlusion', count: 4036});
+let texture70 = device0.createTexture({
+  label: '\u{1fad4}\u0b77\u0394\u{1fdf4}\u4eaa',
+  size: {width: 768, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 9,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView94 = texture13.createView({label: '\u04f5\u4617\u607c\u6e40\ub9d1\u0a28\u666c', baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder34 = commandEncoder90.beginComputePass();
+let renderBundleEncoder47 = device0.createRenderBundleEncoder({
+  label: '\u{1feae}\u02bc\u13ba\u{1f639}',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder0.dispatchWorkgroups(2, 1, 3);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(1, bindGroup0, new Uint32Array(7617), 2990, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas7,
+  origin: { x: 26, y: 4 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline37 = await device0.createComputePipelineAsync({
+  label: '\u00f7\u3a16\u{1f65d}\uc631\u4707\u0a54\u1f5f\uea9f\u4e72\u3d7c',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let offscreenCanvas12 = new OffscreenCanvas(682, 658);
+let textureView95 = texture0.createView({
+  label: '\u{1faec}\u0b25\u54e2\u2efa\ue3b9',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  baseMipLevel: 2,
+});
+let renderBundleEncoder48 = device0.createRenderBundleEncoder({
+  label: '\u2281\u4336\u03b6\u0fe0\u0cb1\ued55\u8c59\u0edd\uc94c',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder13.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer12, 'uint32', 77968, 193);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline11);
+} catch {}
+let pipeline38 = device0.createComputePipeline({layout: pipelineLayout8, compute: {module: shaderModule2, entryPoint: 'compute0'}});
+video1.height = 200;
+let offscreenCanvas13 = new OffscreenCanvas(961, 162);
+try {
+offscreenCanvas12.getContext('2d');
+} catch {}
+try {
+externalTexture47.label = '\u0ced\u1883';
+} catch {}
+let textureView96 = texture47.createView({label: '\u2e3d\u{1ff36}\u5395\u{1fec1}\uefcd\ub6f3\u{1f8e3}\u{1f7e4}\ue54e'});
+try {
+renderPassEncoder33.beginOcclusionQuery(17);
+} catch {}
+try {
+renderPassEncoder22.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder31.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder12.setViewport(10.26, 0.8769, 37.27, 0.07949, 0.5669, 0.8922);
+} catch {}
+let promise27 = device0.popErrorScope();
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 5,
+  origin: {x: 1, y: 0, z: 76},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 13_153_794 */
+{offset: 850, bytesPerRow: 401, rowsPerImage: 200}, {width: 9, height: 1, depthOrArrayLayers: 165});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext9 = offscreenCanvas13.getContext('webgpu');
+let offscreenCanvas14 = new OffscreenCanvas(411, 963);
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+let gpuCanvasContext10 = offscreenCanvas14.getContext('webgpu');
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let bindGroup25 = device0.createBindGroup({label: '\u696c\u0f1f\u35c4\ub11d\u3e3a', layout: bindGroupLayout14, entries: []});
+let buffer18 = device0.createBuffer({
+  label: '\uc110\u91bd\u{1fdbd}\u{1fdc9}\u{1fd70}\u1441\ue2b6\u{1fc6f}\u{1ff73}\uab6e\ud309',
+  size: 75951,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let renderBundleEncoder49 = device0.createRenderBundleEncoder({
+  label: '\u{1fe52}\u020f\u{1fbdc}\u5195\u{1f8bf}\u4e4a\u{1fefb}\u800f\u7ffc\u0c87\u2127',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderPassEncoder30.setStencilReference(3492);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer14, 'uint32');
+} catch {}
+try {
+renderBundleEncoder23.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder47.setIndexBuffer(buffer12, 'uint32');
+} catch {}
+try {
+renderBundleEncoder28.setPipeline(pipeline13);
+} catch {}
+try {
+device0.queue.submit([commandBuffer22, commandBuffer23]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas14,
+  origin: { x: 88, y: 47 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout28 = device0.createBindGroupLayout({
+  label: '\u03a2\uc28f\u0337\uf228\u216e\u5cba\u51b9',
+  entries: [
+    {binding: 768, visibility: 0, externalTexture: {}},
+    {
+      binding: 6080,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 5634,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder91 = device0.createCommandEncoder({label: '\u8ee3\u{1ff34}'});
+let texture71 = device0.createTexture({
+  label: '\u0ea9\u9b36',
+  size: {width: 768, height: 1, depthOrArrayLayers: 213},
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView97 = texture37.createView({
+  label: '\u{1fb5e}\u{1f7d1}\u237a\u{1fcd1}\u8d74\u1dc5\uaaf9\uc8f9\u082e\u7287',
+  baseMipLevel: 3,
+  baseArrayLayer: 0,
+});
+try {
+computePassEncoder22.setBindGroup(3, bindGroup24, new Uint32Array(6704), 2910, 0);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder30.beginOcclusionQuery(91);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+try {
+commandEncoder91.copyBufferToBuffer(buffer11, 33540, buffer3, 225148, 28328);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img6,
+  origin: { x: 87, y: 12 },
+  flipY: true,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundle35.label = '\u0ade\ubab2\ufcc2';
+} catch {}
+gc();
+let textureView98 = texture34.createView({
+  label: '\u751a\u3198\ufddf\u01e8',
+  dimension: '2d',
+  aspect: 'depth-only',
+  baseMipLevel: 4,
+  mipLevelCount: 1,
+});
+let externalTexture52 = device0.importExternalTexture({label: '\u8fb5\u0f90', source: video9, colorSpace: 'srgb'});
+try {
+renderPassEncoder25.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setViewport(13.83, 0.4909, 10.71, 0.2031, 0.3786, 0.6859);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder91.copyBufferToBuffer(buffer11, 85132, buffer3, 314268, 2608);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder91.clearBuffer(buffer6, 47224, 25672);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder91.resolveQuerySet(querySet25, 1094, 476, buffer10, 178688);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new ArrayBuffer(550), /* required buffer size: 550 */
+{offset: 550}, {width: 192, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline39 = device0.createComputePipeline({
+  label: '\u1428\u{1fd25}\u743f\u5e14\u4d9b\u2be9',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+let canvas8 = document.createElement('canvas');
+gc();
+let promise28 = adapter3.requestDevice({
+  label: '\uce2c\uf631\u6272\u{1fd90}\u44be\u809d\u041f\uebf7\u{1fa7a}',
+  defaultQueue: {label: '\u0d02\u00f8\u000a\u4178\u{1f89f}\u058e\ubecd'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxColorAttachmentBytesPerSample: 61,
+    maxVertexAttributes: 25,
+    maxVertexBufferArrayStride: 63197,
+    maxStorageTexturesPerShaderStage: 42,
+    maxStorageBuffersPerShaderStage: 39,
+    maxDynamicStorageBuffersPerPipelineLayout: 25623,
+    maxDynamicUniformBuffersPerPipelineLayout: 28042,
+    maxBindingsPerBindGroup: 6938,
+    maxTextureArrayLayers: 656,
+    maxTextureDimension1D: 9876,
+    maxTextureDimension2D: 14429,
+    maxBindGroupsPlusVertexBuffers: 29,
+    minStorageBufferOffsetAlignment: 32,
+    maxUniformBufferBindingSize: 11490742,
+    maxStorageBufferBindingSize: 169823108,
+    maxUniformBuffersPerShaderStage: 13,
+    maxSampledTexturesPerShaderStage: 41,
+    maxInterStageShaderVariables: 99,
+    maxInterStageShaderComponents: 94,
+    maxSamplersPerShaderStage: 19,
+  },
+});
+let videoFrame14 = new VideoFrame(imageBitmap7, {timestamp: 0});
+let img8 = await imageWithData(102, 146, '#815706f4', '#f1fadd88');
+try {
+canvas7.getContext('webgpu');
+} catch {}
+let bindGroup26 = device0.createBindGroup({
+  label: '\uc5e3\u{1fa55}\ud5fa\u03b2\u{1fb10}',
+  layout: bindGroupLayout13,
+  entries: [{binding: 4888, resource: externalTexture21}, {binding: 7531, resource: externalTexture37}],
+});
+let querySet35 = device0.createQuerySet({type: 'occlusion', count: 3029});
+let renderBundle53 = renderBundleEncoder0.finish({label: '\ub85f\ub987\u6b75\u1d4f\u0f9a\u786f\u96c8\u084f\ua4d9\u0373'});
+let externalTexture53 = device0.importExternalTexture({
+  label: '\u03bb\ud77a\ucdf2\u02e7\u01b8\u267e\u{1fd20}\u6567',
+  source: video2,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder18.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(1746);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(1, buffer10, 273448);
+} catch {}
+try {
+commandEncoder91.copyTextureToTexture({
+  texture: texture43,
+  mipLevel: 1,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 77, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder91.resolveQuerySet(querySet34, 864, 2889, buffer10, 205056);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 309 */
+{offset: 309}, {width: 118, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap12 = await createImageBitmap(videoFrame8);
+let imageData10 = new ImageData(168, 188);
+try {
+  await promise27;
+} catch {}
+let querySet36 = device1.createQuerySet({label: '\u2454\ucd76\u{1fb16}\u0b39\u02b1\u756f\ubb96', type: 'occlusion', count: 2414});
+let renderBundleEncoder50 = device1.createRenderBundleEncoder({colorFormats: ['rg32uint'], sampleCount: 4, stencilReadOnly: true});
+let sampler40 = device1.createSampler({
+  label: '\ub9e5\u6429\u{1fc32}\u{1f781}\u{1f764}\u0888\u671d\uf74c\u{1f983}\ua311',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 76.49,
+  lodMaxClamp: 82.10,
+  maxAnisotropy: 9,
+});
+try {
+device1.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 6,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 799 */
+{offset: 799, bytesPerRow: 266}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let canvas9 = document.createElement('canvas');
+let commandEncoder92 = device0.createCommandEncoder({label: '\ub664\u0f50\ue422'});
+let querySet37 = device0.createQuerySet({
+  label: '\u64a8\u0bf9\u0942\u2396\uf807\u8c63\u{1f7e5}\u{1fb0c}\u{1f995}\u0ac2',
+  type: 'occlusion',
+  count: 2945,
+});
+let renderPassEncoder36 = commandEncoder91.beginRenderPass({
+  colorAttachments: [{
+  view: textureView8,
+  depthSlice: 80,
+  clearValue: { r: -997.8, g: -935.9, b: -103.7, a: -169.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {
+  view: textureView90,
+  clearValue: { r: 336.8, g: -597.5, b: 657.1, a: 822.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView16,
+    depthClearValue: -5.174025248959482,
+    depthReadOnly: true,
+    stencilClearValue: 27289,
+    stencilReadOnly: false,
+  },
+  maxDrawCount: 174550619,
+});
+try {
+commandEncoder92.copyBufferToTexture({
+  /* bytesInLastRow: 1184 widthInBlocks: 74 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1488 */
+  offset: 304,
+  buffer: buffer8,
+}, {
+  texture: texture10,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 74, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder92.copyTextureToTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 428},
+  aspect: 'all',
+},
+{
+  texture: texture59,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 24, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer1), /* required buffer size: 821 */
+{offset: 821}, {width: 7, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline40 = device0.createRenderPipeline({
+  label: '\u7914\uf382\u{1fad2}\u5acb\u8d11',
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    stencilFront: {compare: 'not-equal', depthFailOp: 'keep', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'greater', failOp: 'increment-wrap', depthFailOp: 'invert', passOp: 'invert'},
+    stencilWriteMask: 1373684677,
+    depthBiasClamp: 510.79951148705027,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 1080,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint16x4', offset: 116, shaderLocation: 11},
+          {format: 'unorm10-10-10-2', offset: 12, shaderLocation: 1},
+          {format: 'float32x4', offset: 228, shaderLocation: 7},
+          {format: 'sint32x3', offset: 52, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 3756,
+        attributes: [
+          {format: 'uint32x2', offset: 1024, shaderLocation: 14},
+          {format: 'sint32', offset: 356, shaderLocation: 2},
+          {format: 'float32', offset: 1524, shaderLocation: 15},
+          {format: 'unorm8x4', offset: 1188, shaderLocation: 3},
+          {format: 'float32', offset: 328, shaderLocation: 4},
+          {format: 'uint32x4', offset: 84, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 1980,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 308, shaderLocation: 5},
+          {format: 'uint32x2', offset: 724, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 3124,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 0, shaderLocation: 8},
+          {format: 'uint8x2', offset: 168, shaderLocation: 13},
+          {format: 'float16x2', offset: 300, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 18788, attributes: [{format: 'uint32x4', offset: 868, shaderLocation: 9}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let querySet38 = device0.createQuerySet({label: '\u{1fcaa}\uda32\u{1f7ca}\u51a7\u0f15\ubda7\u0b1a\u8975', type: 'occlusion', count: 56});
+let texture72 = device0.createTexture({
+  label: '\u08d6\u010c\u3680\u1ab2\u06ac\uc45b\u079a\ud62c\u0eeb\u{1f756}',
+  size: [192, 1, 1508],
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture73 = gpuCanvasContext1.getCurrentTexture();
+let renderPassEncoder37 = commandEncoder92.beginRenderPass({
+  label: '\u9bdc\u07ed\u0f0a\u0021\u00c3\u0a33\u3efb\ub0a6\ua7a5',
+  colorAttachments: [{view: textureView8, depthSlice: 83, loadOp: 'load', storeOp: 'discard'}, {
+  view: textureView90,
+  clearValue: { r: -866.4, g: 248.3, b: 493.5, a: -769.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView16,
+    depthClearValue: 0.7790586779917351,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'store',
+    depthReadOnly: false,
+    stencilClearValue: 23524,
+    stencilReadOnly: true,
+  },
+  occlusionQuerySet: querySet37,
+  maxDrawCount: 388044579,
+});
+let renderBundleEncoder51 = device0.createRenderBundleEncoder({
+  label: '\u{1f981}\u4ee7\u0920\u{1fe7f}\u{1f67d}\u{1fc79}\uc1f2\u7c8e',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler41 = device0.createSampler({
+  label: '\u1cef\u7023\u0b41\u{1fc56}',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 64.86,
+  lodMaxClamp: 97.26,
+});
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+let promise29 = device0.queue.onSubmittedWorkDone();
+let offscreenCanvas15 = new OffscreenCanvas(166, 139);
+let imageBitmap13 = await createImageBitmap(videoFrame13);
+try {
+renderPassEncoder37.setVertexBuffer(1, buffer14, 5952, 16873);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer0, 'uint16', 5270, 56);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 192, new Float32Array(11530), 6065, 1212);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData8,
+  origin: { x: 6, y: 38 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas10 = document.createElement('canvas');
+let externalTexture54 = device0.importExternalTexture({
+  label: '\u0829\u673a\ud136\u{1fdcc}\u0de4\u{1fc2b}\u9519\u{1fa9e}\ufd0d',
+  source: video1,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder45.setIndexBuffer(buffer0, 'uint32', 2716, 2267);
+} catch {}
+let arrayBuffer7 = buffer15.getMappedRange(9264);
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 871 */
+{offset: 871}, {width: 21, height: 0, depthOrArrayLayers: 1});
+} catch {}
+gc();
+let imageData11 = new ImageData(68, 36);
+try {
+canvas10.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder93 = device0.createCommandEncoder({label: '\u3309\u4b03\ud98e\u0137\u{1fdb7}\u0b5a\u{1ff3c}\u{1fc1d}\u6433\u842a'});
+let texture74 = device0.createTexture({
+  label: '\u0741\u7096\ufc4d\u0a32\u{1fe79}\u{1facc}',
+  size: [768],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32uint', 'rgba32uint', 'rgba32uint'],
+});
+let renderBundle54 = renderBundleEncoder18.finish({label: '\u{1fe36}\u001e\ub659\ub0d6\u0208\u614e\u5447\ue0ff\u022b\u{1fa09}\u03dd'});
+try {
+renderPassEncoder35.beginOcclusionQuery(14);
+} catch {}
+try {
+renderPassEncoder31.setBlendConstant({ r: 738.0, g: -750.0, b: -170.8, a: 102.5, });
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(0, buffer14);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(4, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(3, buffer10, 111544);
+} catch {}
+try {
+commandEncoder93.copyBufferToBuffer(buffer13, 22888, buffer4, 38480, 5308);
+dissociateBuffer(device0, buffer13);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder93.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1096 */
+  offset: 1092,
+  bytesPerRow: 512,
+  buffer: buffer17,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer17);
+} catch {}
+try {
+commandEncoder93.copyTextureToBuffer({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 192 widthInBlocks: 192 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 39648 */
+  offset: 39648,
+  buffer: buffer11,
+}, {width: 192, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer11);
+} catch {}
+let offscreenCanvas16 = new OffscreenCanvas(164, 893);
+let videoFrame15 = new VideoFrame(offscreenCanvas13, {timestamp: 0});
+let commandEncoder94 = device0.createCommandEncoder();
+let commandBuffer25 = commandEncoder93.finish({label: '\u24ea\u{1fc0a}\ub420\u0c57\u0334\uc40d\uc10f\u93b0\u8d20'});
+let textureView99 = texture15.createView({label: '\u0a5c\u0dec', aspect: 'all', format: 'rgba8uint'});
+let renderBundle55 = renderBundleEncoder41.finish({label: '\u0d1c\u0e08\u859b\u1e7b\ufe4c\u{1ffbe}\u845a\ubaa7\u6906'});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup25, new Uint32Array(1643), 722, 0);
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder36.setBindGroup(4, bindGroup24);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder35.setBlendConstant({ r: -662.2, g: -69.11, b: 198.6, a: -951.8, });
+} catch {}
+try {
+renderPassEncoder23.insertDebugMarker('\u0dc6');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap6,
+  origin: { x: 28, y: 543 },
+  flipY: true,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData12 = new ImageData(116, 68);
+try {
+canvas9.getContext('webgl');
+} catch {}
+let videoFrame16 = new VideoFrame(imageBitmap0, {timestamp: 0});
+let buffer19 = device0.createBuffer({
+  label: '\u{1f850}\ud738\u9926\u0666\u0b94\u0244\uacf8\u0f51\u{1f792}\uf8f8',
+  size: 81717,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder95 = device0.createCommandEncoder({label: '\u0adf\u{1ffaa}\u09b0\u{1f70b}\u{1fe01}\u0455'});
+let textureView100 = texture21.createView({dimension: '2d', aspect: 'depth-only', baseMipLevel: 0});
+let renderPassEncoder38 = commandEncoder95.beginRenderPass({
+  label: '\u38ef\ua945\u091a',
+  colorAttachments: [{view: textureView7, depthSlice: 89, loadOp: 'load', storeOp: 'discard'}, {
+  view: textureView51,
+  depthSlice: 755,
+  clearValue: { r: 653.5, g: -497.7, b: -208.8, a: 388.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {view: textureView77, depthReadOnly: true, stencilReadOnly: false},
+  occlusionQuerySet: querySet22,
+  maxDrawCount: 332750034,
+});
+let externalTexture55 = device0.importExternalTexture({label: '\u9720\u03f3\u{1f8c0}\u52b8', source: videoFrame0});
+try {
+computePassEncoder33.setBindGroup(3, bindGroup4, new Uint32Array(5103), 845, 0);
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline33);
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(84, 1, 8, 0);
+} catch {}
+let promise30 = buffer17.mapAsync(GPUMapMode.WRITE, 518224, 4256);
+try {
+commandEncoder94.copyBufferToBuffer(buffer13, 23340, buffer6, 18552, 3660);
+dissociateBuffer(device0, buffer13);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder94.copyTextureToTexture({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder94.resolveQuerySet(querySet6, 758, 106, buffer10, 332288);
+} catch {}
+let pipeline41 = await device0.createRenderPipelineAsync({
+  label: '\u070a\u0b9c\u{1fddd}\u40e1\u{1fce6}',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'decrement-clamp', depthFailOp: 'decrement-wrap', passOp: 'zero'},
+    stencilBack: {compare: 'never', failOp: 'replace', passOp: 'invert'},
+    stencilReadMask: 861170132,
+    stencilWriteMask: 1928280177,
+    depthBiasClamp: 683.3489259121342,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 11404,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 300, shaderLocation: 7},
+          {format: 'uint32x3', offset: 2924, shaderLocation: 4},
+          {format: 'uint32x4', offset: 164, shaderLocation: 15},
+          {format: 'sint32x2', offset: 184, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'front'},
+});
+try {
+  await promise30;
+} catch {}
+let texture75 = device0.createTexture({
+  label: '\u2435\u27f2\udb61\u5f95\u9b6c',
+  size: {width: 384, height: 1, depthOrArrayLayers: 197},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint'],
+});
+let renderPassEncoder39 = commandEncoder94.beginRenderPass({
+  label: '\u787a\uf799\uc6f2\u9d28\uf1d7',
+  colorAttachments: [{
+  view: textureView23,
+  depthSlice: 103,
+  clearValue: { r: 532.9, g: 228.2, b: 776.5, a: 985.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {
+  view: textureView90,
+  clearValue: { r: 608.1, g: -273.0, b: 613.0, a: -284.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView16,
+    depthClearValue: 0.29130265349532436,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'store',
+    depthReadOnly: false,
+    stencilClearValue: 3912,
+  },
+});
+let renderBundleEncoder52 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+let renderBundle56 = renderBundleEncoder49.finish({label: '\u9724\u0885\u6c76\uf680\u0a87\u6681\u{1f96b}\u99c2\u345f'});
+let externalTexture56 = device0.importExternalTexture({label: '\u{1fa84}\u061c\ud3d0', source: video6});
+try {
+computePassEncoder19.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder16.beginOcclusionQuery(346);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+let pipeline42 = device0.createComputePipeline({
+  label: '\u{1f664}\u59c8\u27b6\u092e\u014d\ued56\u016c\u{1f95b}\u{1fbbf}\u{1f79c}',
+  layout: 'auto',
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+let pipeline43 = await promise12;
+let externalTexture57 = device0.importExternalTexture({label: '\u2b8b\u0665\ua2bb\u{1f715}\u0db5', source: videoFrame6, colorSpace: 'display-p3'});
+try {
+renderPassEncoder10.end();
+} catch {}
+try {
+renderPassEncoder34.setStencilReference(3068);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer0, 'uint32', 1460, 1172);
+} catch {}
+let textureView101 = texture48.createView({label: '\u0398\uc47d\u36c7\u23d7\u{1f84d}\u6f00\u384a\u0973\ufb7b\u5aa2\u0816', mipLevelCount: 1});
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(3, bindGroup22, new Uint32Array(4518), 3345, 0);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(6, buffer10, 57488, 181442);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 57648, new DataView(new ArrayBuffer(21331)), 8624, 536);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 69},
+  aspect: 'stencil-only',
+}, arrayBuffer5, /* required buffer size: 10_574_348 */
+{offset: 548, bytesPerRow: 666, rowsPerImage: 162}, {width: 384, height: 1, depthOrArrayLayers: 99});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let imageBitmap14 = await createImageBitmap(offscreenCanvas6);
+let imageData13 = new ImageData(116, 16);
+let gpuCanvasContext11 = canvas8.getContext('webgpu');
+let imageData14 = new ImageData(8, 12);
+let gpuCanvasContext12 = offscreenCanvas16.getContext('webgpu');
+try {
+  await promise29;
+} catch {}
+let commandEncoder96 = device0.createCommandEncoder({});
+let textureView102 = texture61.createView({
+  label: '\u{1fde2}\u643f\ufbff\u31f6\uffed\ud7e2\u{1fa8e}\u0417',
+  aspect: 'stencil-only',
+  baseMipLevel: 5,
+  mipLevelCount: 2,
+});
+try {
+computePassEncoder20.setPipeline(pipeline32);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder24.setStencilReference(2294);
+} catch {}
+try {
+renderPassEncoder30.setViewport(36.33, 0.6455, 132.4, 0.1507, 0.7968, 0.9508);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer10, 317484, 42953);
+} catch {}
+let promise31 = device0.popErrorScope();
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let imageBitmap15 = await createImageBitmap(imageBitmap12);
+let commandEncoder97 = device0.createCommandEncoder({});
+let querySet39 = device0.createQuerySet({label: '\u067e\u0b2f', type: 'occlusion', count: 2419});
+let renderBundleEncoder53 = device0.createRenderBundleEncoder({
+  label: '\u0446\u09ed\uc127\u639e\ua10f\u1a25',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+});
+try {
+commandEncoder96.copyBufferToBuffer(buffer7, 164844, buffer11, 53820, 23396);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder96.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 3,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 20132 */
+  offset: 20132,
+  bytesPerRow: 0,
+  rowsPerImage: 140,
+  buffer: buffer11,
+}, {width: 0, height: 1, depthOrArrayLayers: 108});
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer9, commandBuffer19]);
+} catch {}
+let bindGroup27 = device0.createBindGroup({label: '\u{1f61f}\u{1f932}\u0cdd\u{1f74b}\u031d\u0473\u0b3a', layout: bindGroupLayout7, entries: []});
+let textureView103 = texture69.createView({
+  label: '\u{1fdd1}\u{1fbc0}\u7d29\u0605\u0d35\u0109\u8876\ub844\u{1fe1a}\u{1ff4e}\u0c22',
+  arrayLayerCount: 1,
+});
+let externalTexture58 = device0.importExternalTexture({label: '\u{1f787}\u{1ff80}', source: video7, colorSpace: 'srgb'});
+try {
+computePassEncoder10.end();
+} catch {}
+try {
+renderPassEncoder27.setBlendConstant({ r: 840.1, g: -434.9, b: 503.9, a: 745.9, });
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(3, bindGroup3, new Uint32Array(3469), 1533, 0);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(6, buffer10, 148932, 215140);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer2), /* required buffer size: 75 */
+{offset: 55}, {width: 5, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let computePassEncoder35 = commandEncoder18.beginComputePass({label: '\u3cc8\u7df2\u8e63\u6fda\u06a5\u007c\u{1fda1}\u{1ff84}\ucb4a\ue4f7\ua001'});
+let renderPassEncoder40 = commandEncoder96.beginRenderPass({
+  label: '\u{1f986}\ua398\u{1f9c9}\u491d\u{1fa8e}\u{1fddf}\u{1f7aa}\u{1f696}\u07b6',
+  colorAttachments: [{
+  view: textureView9,
+  depthSlice: 71,
+  clearValue: { r: -353.2, g: 855.8, b: -426.5, a: 148.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}, {
+  view: textureView74,
+  depthSlice: 666,
+  clearValue: { r: 934.6, g: 434.2, b: 762.1, a: 787.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  depthStencilAttachment: {
+    view: textureView40,
+    depthClearValue: 0.7135503837772972,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'store',
+    stencilClearValue: 10046,
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet29,
+});
+let sampler42 = device0.createSampler({
+  label: '\ue03c\udb41\uacf2',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 6.666,
+  lodMaxClamp: 79.89,
+  maxAnisotropy: 8,
+});
+try {
+renderPassEncoder33.setIndexBuffer(buffer12, 'uint32', 196, 27262);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup25, []);
+} catch {}
+try {
+commandEncoder97.clearBuffer(buffer18, 27868, 34472);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline44 = await device0.createRenderPipelineAsync({
+  label: '\u0fac\ua77e\u4dc0\u{1fb8f}',
+  layout: pipelineLayout2,
+  multisample: {mask: 0x65bd9a15},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: 0}, {
+  format: 'rgba32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 42140,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32x4', offset: 388, shaderLocation: 12},
+          {format: 'uint8x4', offset: 9636, shaderLocation: 6},
+          {format: 'float32x2', offset: 4148, shaderLocation: 7},
+          {format: 'sint32x4', offset: 28472, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 1200, shaderLocation: 10},
+          {format: 'unorm16x4', offset: 11036, shaderLocation: 0},
+          {format: 'sint32', offset: 19680, shaderLocation: 2},
+          {format: 'unorm8x4', offset: 14880, shaderLocation: 8},
+          {format: 'uint32x2', offset: 10448, shaderLocation: 4},
+          {format: 'sint8x2', offset: 17034, shaderLocation: 13},
+          {format: 'float16x2', offset: 3580, shaderLocation: 14},
+          {format: 'sint32x2', offset: 1224, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 16, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 7280,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 916, shaderLocation: 3},
+          {format: 'snorm8x4', offset: 1192, shaderLocation: 15},
+        ],
+      },
+      {arrayStride: 3908, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 12904,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x4', offset: 20, shaderLocation: 9}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+let gpuCanvasContext13 = offscreenCanvas15.getContext('webgpu');
+let imageData15 = new ImageData(204, 180);
+let renderBundleEncoder54 = device1.createRenderBundleEncoder({
+  label: '\u60cf\u0a0a\ue6b7\u02af\u{1f78b}',
+  colorFormats: ['rg32uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let videoFrame17 = new VideoFrame(offscreenCanvas2, {timestamp: 0});
+try {
+  await promise31;
+} catch {}
+let bindGroup28 = device0.createBindGroup({layout: bindGroupLayout25, entries: []});
+let texture76 = device0.createTexture({
+  size: [192, 1, 1],
+  mipLevelCount: 3,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder20.dispatchWorkgroups(5, 3, 2);
+} catch {}
+try {
+renderPassEncoder30.setStencilReference(3987);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer11, 'uint16', 79620, 10508);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(7, buffer14);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder97.copyBufferToTexture({
+  /* bytesInLastRow: 1808 widthInBlocks: 113 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3264 */
+  offset: 1456,
+  rowsPerImage: 171,
+  buffer: buffer8,
+}, {
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 121, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 113, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder97.resolveQuerySet(querySet33, 278, 2091, buffer10, 283136);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(arrayBuffer5), /* required buffer size: 275 */
+{offset: 275}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame18 = new VideoFrame(canvas2, {timestamp: 0});
+let video10 = await videoWithData();
+let bindGroupLayout29 = device0.createBindGroupLayout({
+  label: '\u069f\u{1fce9}\u0e7c\u18a3',
+  entries: [
+    {
+      binding: 5137,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let bindGroup29 = device0.createBindGroup({
+  label: '\ufa83\u235a\ue05b\udf78\ube1f',
+  layout: bindGroupLayout19,
+  entries: [{binding: 5986, resource: sampler17}, {binding: 4967, resource: {buffer: buffer9, offset: 256128}}],
+});
+let commandEncoder98 = device0.createCommandEncoder({label: '\u8e39\u17d9\u05b5\u0880'});
+let texture77 = device0.createTexture({
+  label: '\u016d\u{1fd8a}\u2d07\u4fae\u0c52\u0274\u0496\udd28',
+  size: [768, 1, 1],
+  mipLevelCount: 10,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['astc-12x10-unorm'],
+});
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder31.setViewport(20.48, 0.3816, 38.83, 0.5100, 0.1031, 0.3752);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(3, buffer10);
+} catch {}
+try {
+commandEncoder98.copyBufferToTexture({
+  /* bytesInLastRow: 1304 widthInBlocks: 326 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 30284 */
+  offset: 30284,
+  buffer: buffer11,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 326, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder98.resolveQuerySet(querySet18, 1016, 120, buffer10, 339200);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData13,
+  origin: { x: 23, y: 6 },
+  flipY: false,
+}, {
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline45 = device0.createRenderPipeline({
+  label: '\uece5\u{1fe23}\u0bc2\u0864',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint'}, {format: 'rgba32uint', writeMask: GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'snorm16x4', offset: 2892, shaderLocation: 9},
+          {format: 'snorm8x2', offset: 568, shaderLocation: 14},
+          {format: 'sint32x4', offset: 2992, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 3892, shaderLocation: 6},
+          {format: 'unorm16x4', offset: 22132, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 12156, shaderLocation: 15},
+          {format: 'float16x4', offset: 7968, shaderLocation: 11},
+          {format: 'unorm10-10-10-2', offset: 4372, shaderLocation: 7},
+          {format: 'unorm10-10-10-2', offset: 7132, shaderLocation: 0},
+          {format: 'float32', offset: 6732, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 4964, shaderLocation: 13},
+          {format: 'uint32x3', offset: 1260, shaderLocation: 12},
+          {format: 'uint32x4', offset: 12824, shaderLocation: 2},
+          {format: 'float16x4', offset: 9588, shaderLocation: 3},
+          {format: 'uint8x4', offset: 3720, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 14744,
+        stepMode: 'vertex',
+        attributes: [{format: 'float32', offset: 2976, shaderLocation: 10}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', unclippedDepth: true},
+});
+let texture78 = device0.createTexture({
+  label: '\u0762\ua05b\u3cea\u0210\u{1fd8e}\u0cc6',
+  size: {width: 384, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+renderPassEncoder28.setIndexBuffer(buffer5, 'uint32');
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(0, bindGroup20, new Uint32Array(2437), 1342, 0);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(2, buffer10);
+} catch {}
+let pipeline46 = await device0.createRenderPipelineAsync({
+  label: '\u0364\u{1fb3c}\u07f8\u0aac\ud7e4\u8eca\u8d01\u087f\u0658\u{1fab3}',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint'}, {format: 'rgba32uint'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-wrap', depthFailOp: 'invert'},
+    stencilBack: {compare: 'less-equal', failOp: 'decrement-wrap', depthFailOp: 'replace', passOp: 'replace'},
+    stencilReadMask: 2741361091,
+    stencilWriteMask: 891567079,
+    depthBias: -935354961,
+    depthBiasClamp: 188.8072054517047,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 20828,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 300, shaderLocation: 3},
+          {format: 'float32x3', offset: 4908, shaderLocation: 10},
+          {format: 'sint16x4', offset: 10224, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 4976, shaderLocation: 11},
+          {format: 'float32x4', offset: 1216, shaderLocation: 2},
+          {format: 'uint32x2', offset: 3564, shaderLocation: 9},
+          {format: 'sint16x2', offset: 9052, shaderLocation: 15},
+          {format: 'uint32x4', offset: 1944, shaderLocation: 0},
+          {format: 'sint16x2', offset: 2752, shaderLocation: 13},
+          {format: 'unorm8x2', offset: 2402, shaderLocation: 12},
+          {format: 'sint32x4', offset: 5280, shaderLocation: 7},
+          {format: 'float16x4', offset: 2972, shaderLocation: 4},
+          {format: 'float16x4', offset: 1868, shaderLocation: 5},
+          {format: 'sint8x4', offset: 1904, shaderLocation: 1},
+          {format: 'sint32x2', offset: 1468, shaderLocation: 6},
+          {format: 'sint8x2', offset: 2364, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+let querySet40 = device0.createQuerySet({
+  label: '\ue258\u0d57\u{1fb11}\u8227\u2a9f\u8d45\u{1f659}\u91b0\ue9ca\u7169\u463c',
+  type: 'occlusion',
+  count: 2531,
+});
+let textureView104 = texture70.createView({
+  label: '\u55cd\u0d51\u07fd\u496b\ub63d\ud3cf\u9bca\u4372\u3891\u556a\u0128',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  baseMipLevel: 8,
+  mipLevelCount: 1,
+});
+let computePassEncoder36 = commandEncoder98.beginComputePass({label: '\u{1f7da}\uf387\u02c9'});
+try {
+computePassEncoder32.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder20.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder37.setStencilReference(741);
+} catch {}
+try {
+commandEncoder97.copyBufferToBuffer(buffer11, 91188, buffer3, 241936, 2420);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+commandEncoder97.resolveQuerySet(querySet8, 55, 6, buffer10, 289792);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let video11 = await videoWithData();
+try {
+window.someLabel = textureView64.label;
+} catch {}
+let querySet41 = device0.createQuerySet({label: '\uab5e\u0581\u7904\u{1fa9c}', type: 'occlusion', count: 2711});
+let computePassEncoder37 = commandEncoder97.beginComputePass({label: '\u978a\u27bf\u8d40\u4ec6\u0364\u93c0\u0665\u{1f8b9}\ud3eb'});
+let renderBundle57 = renderBundleEncoder29.finish({label: '\uaf01\u0b1d\u7fd9'});
+let sampler43 = device0.createSampler({
+  label: '\ua56e\ua025\u314e\uda52\ue70b\u1961\u{1f6a2}\uf355\u2b8f\u{1fd35}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 74.05,
+  lodMaxClamp: 83.49,
+  maxAnisotropy: 14,
+});
+try {
+renderPassEncoder22.setBindGroup(5, bindGroup10);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(2, bindGroup20, new Uint32Array(8549), 295, 0);
+} catch {}
+try {
+renderPassEncoder25.end();
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(40, 1, 16, 0);
+} catch {}
+try {
+renderPassEncoder15.setStencilReference(2365);
+} catch {}
+try {
+renderPassEncoder24.setViewport(16.53, 0.7665, 169.9, 0.06137, 0.9123, 0.9601);
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer12, 'uint16', 58864);
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(0, bindGroup13, new Uint32Array(5333), 3617, 0);
+} catch {}
+try {
+renderBundleEncoder51.setVertexBuffer(5, buffer14);
+} catch {}
+let arrayBuffer8 = buffer7.getMappedRange(372424, 7800);
+try {
+device0.queue.writeTexture({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 45, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 2_100 */
+{offset: 788, rowsPerImage: 230}, {width: 82, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas9,
+  origin: { x: 6, y: 14 },
+  flipY: false,
+}, {
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout30 = device0.createBindGroupLayout({
+  label: '\u9bfd\u2020\u{1fd8d}\u{1fca4}\u6607\u4edb\u8856\u9f89\u00f4\u7344\u0dbb',
+  entries: [
+    {binding: 552, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 489,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let textureView105 = texture33.createView({
+  label: '\u{1ffc6}\u8c10\u09a0\u43ca\u2687\u7c68',
+  dimension: '2d',
+  aspect: 'stencil-only',
+  mipLevelCount: 2,
+  baseArrayLayer: 128,
+});
+let renderBundle58 = renderBundleEncoder47.finish({label: '\u{1fbca}\u{1f7bb}'});
+let externalTexture59 = device0.importExternalTexture({label: '\u9c87\u{1f6c9}\u{1fb20}\u6f8d', source: videoFrame7, colorSpace: 'display-p3'});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup15, new Uint32Array(6117), 2570, 0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(4, bindGroup0);
+} catch {}
+try {
+renderPassEncoder33.setIndexBuffer(buffer12, 'uint32', 24308, 41577);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(1, buffer10);
+} catch {}
+try {
+computePassEncoder13.insertDebugMarker('\u0bb2');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 21, y: 1 },
+  flipY: true,
+}, {
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline47 = await device0.createComputePipelineAsync({
+  label: '\u{1f738}\uce41\u3df8\u6aaf',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let pipeline48 = device0.createRenderPipeline({
+  layout: 'auto',
+  multisample: {mask: 0xd2fedfb4},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint'}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'less-equal', failOp: 'invert', depthFailOp: 'decrement-wrap', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'not-equal', failOp: 'zero', depthFailOp: 'invert', passOp: 'decrement-wrap'},
+    stencilReadMask: 950011062,
+    stencilWriteMask: 71949254,
+    depthBias: -1478360059,
+    depthBiasSlopeScale: 133.4210843060679,
+    depthBiasClamp: 39.768125487800546,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 540,
+        attributes: [
+          {format: 'sint16x2', offset: 96, shaderLocation: 14},
+          {format: 'uint8x4', offset: 84, shaderLocation: 9},
+          {format: 'sint32x2', offset: 136, shaderLocation: 1},
+          {format: 'sint16x2', offset: 64, shaderLocation: 6},
+          {format: 'sint16x2', offset: 24, shaderLocation: 15},
+          {format: 'float16x4', offset: 192, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 116, shaderLocation: 2},
+          {format: 'sint8x4', offset: 60, shaderLocation: 7},
+          {format: 'unorm10-10-10-2', offset: 136, shaderLocation: 12},
+          {format: 'sint16x4', offset: 0, shaderLocation: 13},
+          {format: 'unorm8x2', offset: 18, shaderLocation: 4},
+          {format: 'uint8x2', offset: 50, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 2656, shaderLocation: 5},
+          {format: 'uint32', offset: 1036, shaderLocation: 0},
+          {format: 'sint16x2', offset: 716, shaderLocation: 8},
+          {format: 'float32x2', offset: 13072, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+canvas0.height = 162;
+let canvas11 = document.createElement('canvas');
+let commandEncoder99 = device0.createCommandEncoder();
+let renderBundleEncoder55 = device0.createRenderBundleEncoder({
+  label: '\uc9a3\u{1fcf8}\u40c3\u35d8\u{1ff17}\u{1f6f6}',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true,
+});
+let sampler44 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 34.28,
+  lodMaxClamp: 45.55,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder5.dispatchWorkgroups(1, 2);
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(757);
+} catch {}
+try {
+renderPassEncoder40.setBlendConstant({ r: 910.7, g: 900.3, b: -254.9, a: -699.3, });
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame14,
+  origin: { x: 0, y: 2 },
+  flipY: false,
+}, {
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView106 = texture56.createView({dimension: '2d', aspect: 'depth-only', baseArrayLayer: 550});
+let renderPassEncoder41 = commandEncoder99.beginRenderPass({
+  colorAttachments: [{
+  view: textureView1,
+  depthSlice: 119,
+  clearValue: { r: -945.2, g: -270.5, b: 813.9, a: 355.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView90,
+  clearValue: { r: 503.8, g: -854.4, b: 430.2, a: -545.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView16,
+    depthClearValue: -1.7296469104552301,
+    depthLoadOp: 'load',
+    depthStoreOp: 'store',
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet41,
+  maxDrawCount: 809822776,
+});
+try {
+renderPassEncoder1.setBlendConstant({ r: -809.7, g: -439.1, b: -107.3, a: 485.6, });
+} catch {}
+try {
+renderPassEncoder29.setStencilReference(545);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer12, 'uint32', 47532, 28351);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(5, buffer10, 392292, 440);
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(4, buffer14, 2108, 29372);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas8,
+  origin: { x: 424, y: 13 },
+  flipY: true,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline49 = device0.createComputePipeline({
+  label: '\u3c5b\uaf45\u1a85\u{1f6e3}\u0253\u016e\u746d\u020f\ua3c9',
+  layout: 'auto',
+  compute: {module: shaderModule1, entryPoint: 'compute0'},
+});
+let offscreenCanvas17 = new OffscreenCanvas(747, 476);
+try {
+offscreenCanvas17.getContext('webgl');
+} catch {}
+gc();
+let video12 = await videoWithData();
+let textureView107 = texture3.createView({
+  label: '\u{1f7a2}\u088a\u0e70\u2271\u9992\uca05\ue981\u0a67',
+  dimension: '2d',
+  baseMipLevel: 0,
+  mipLevelCount: 5,
+  baseArrayLayer: 640,
+});
+try {
+computePassEncoder33.end();
+} catch {}
+try {
+renderPassEncoder23.beginOcclusionQuery(13);
+} catch {}
+try {
+renderPassEncoder20.setScissorRect(78, 1, 17, 0);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer14, 'uint16', 12934, 8509);
+} catch {}
+try {
+commandEncoder87.copyBufferToBuffer(buffer17, 424556, buffer18, 17924, 8836);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder87.copyTextureToBuffer({
+  texture: texture49,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 12 widthInBlocks: 12 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 19336 */
+  offset: 19324,
+  buffer: buffer18,
+}, {width: 12, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture43,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 369 */
+{offset: 369, bytesPerRow: 5651}, {width: 340, height: 0, depthOrArrayLayers: 0});
+} catch {}
+canvas8.width = 26;
+let canvas12 = document.createElement('canvas');
+let commandEncoder100 = device0.createCommandEncoder({label: '\u{1fa68}\u{1fe03}\u{1fe63}\u9d76\u0f4f\ub457\uebd4\u07fb\u90f6'});
+try {
+computePassEncoder20.dispatchWorkgroups(5, 1);
+} catch {}
+try {
+computePassEncoder35.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder28.setBlendConstant({ r: 347.2, g: 833.0, b: -953.6, a: 770.0, });
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(2, buffer10, 0, 35068);
+} catch {}
+try {
+renderBundleEncoder46.setPipeline(pipeline24);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(3, buffer10, 0, 121824);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new Uint32Array(arrayBuffer5), /* required buffer size: 268 */
+{offset: 268, bytesPerRow: 162, rowsPerImage: 159}, {width: 96, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline50 = await promise26;
+let imageData16 = new ImageData(196, 212);
+let bindGroup30 = device0.createBindGroup({label: '\u4b91\u0ae3\u9677', layout: bindGroupLayout4, entries: []});
+let textureView108 = texture17.createView({
+  label: '\u{1fec6}\u{1ffa7}\ua966\u96cd\u51c8',
+  dimension: '2d-array',
+  aspect: 'depth-only',
+  format: 'depth24plus',
+  mipLevelCount: 1,
+  baseArrayLayer: 594,
+  arrayLayerCount: 140,
+});
+try {
+renderPassEncoder23.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(4, bindGroup22, new Uint32Array(3316), 2491, 0);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder100.copyBufferToBuffer(buffer15, 22496, buffer18, 15156, 53724);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder87.copyTextureToTexture({
+  texture: texture43,
+  mipLevel: 1,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture13,
+  mipLevel: 2,
+  origin: {x: 12, y: 0, z: 31},
+  aspect: 'all',
+},
+{width: 47, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let promise32 = device0.createComputePipelineAsync({
+  label: '\u98bf\u1921\u862b\u76ec\u002c\ucd1f\uab46\u0e66\ube90\u{1fa6b}',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let textureView109 = texture59.createView({label: '\u004e\u{1f700}\u0f25\uaf05\uf875', dimension: '2d-array', baseMipLevel: 2});
+let externalTexture60 = device0.importExternalTexture({source: videoFrame7});
+try {
+renderPassEncoder30.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(0, bindGroup27, new Uint32Array(7221), 3498, 0);
+} catch {}
+let pipeline51 = device0.createComputePipeline({
+  label: '\u4114\u{1f92d}\u04b1\u{1feea}\u{1faa0}\u{1f982}\u{1f832}\uf918',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let pipeline52 = device0.createRenderPipeline({
+  label: '\u4a48\ua6c1\u4aac\u07e5\u60b0\u083a\uc305\u62fd\u0e10\u04a8\udd5c',
+  layout: pipelineLayout1,
+  multisample: {count: 4, mask: 0xe21835bd},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.GREEN}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'less-equal', failOp: 'decrement-clamp', depthFailOp: 'decrement-clamp', passOp: 'replace'},
+    stencilBack: {compare: 'never', failOp: 'replace', depthFailOp: 'invert', passOp: 'replace'},
+    stencilReadMask: 3096801570,
+    stencilWriteMask: 1343231538,
+    depthBiasSlopeScale: 179.17852797821683,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 18900,
+        attributes: [
+          {format: 'uint32x2', offset: 1780, shaderLocation: 4},
+          {format: 'sint32x3', offset: 820, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 380,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x4', offset: 0, shaderLocation: 12}],
+      },
+      {arrayStride: 1868, attributes: []},
+      {
+        arrayStride: 13464,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x4', offset: 2132, shaderLocation: 15}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw', unclippedDepth: true},
+});
+let bindGroup31 = device0.createBindGroup({
+  label: '\uad2e\u4a5c\ue189\u2f4c\ued85\ud82f\u{1ff0c}\u06c1\u5b62\u1a7c',
+  layout: bindGroupLayout19,
+  entries: [
+    {binding: 4967, resource: {buffer: buffer9, offset: 218752, size: 76968}},
+    {binding: 5986, resource: sampler17},
+  ],
+});
+let commandEncoder101 = device0.createCommandEncoder({label: '\u025b\u3d2a\u{1f850}\uf637\u0f47\ue2f0\u{1f8cb}\u683d'});
+let querySet42 = device0.createQuerySet({
+  label: '\u31d9\u{1fbef}\u02d7\u{1f8a8}\u{1f934}\u2b2c\u5947\ucca0\u59a5\u{1f8fb}',
+  type: 'occlusion',
+  count: 3832,
+});
+let texture79 = device0.createTexture({
+  label: '\u0448\u1120\u06dd',
+  size: [768, 1, 254],
+  mipLevelCount: 10,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderBundle59 = renderBundleEncoder16.finish();
+try {
+computePassEncoder0.dispatchWorkgroups(1, 2, 1);
+} catch {}
+try {
+renderPassEncoder33.setScissorRect(129, 0, 35, 0);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(6, buffer14, 9296, 23973);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(4, bindGroup13);
+} catch {}
+try {
+commandEncoder100.copyBufferToBuffer(buffer15, 76148, buffer4, 28896, 9924);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let pipeline53 = await promise32;
+let gpuCanvasContext14 = canvas12.getContext('webgpu');
+canvas12.width = 1;
+let img9 = await imageWithData(94, 251, '#d6a69867', '#656f7ab3');
+document.body.prepend(video12);
+try {
+device1.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer8), /* required buffer size: 315 */
+{offset: 315}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+video0.width = 298;
+let imageBitmap16 = await createImageBitmap(canvas9);
+let renderBundle60 = renderBundleEncoder36.finish({label: '\u{1fa7b}\u68c7\u02df\u0f04\u9b9b\u53b8\u67c1'});
+let externalTexture61 = device1.importExternalTexture({
+  label: '\u0038\u0e8e\u04d3\u0e83\ua29e\uef6f\u114a\u{1f63d}',
+  source: videoFrame5,
+  colorSpace: 'display-p3',
+});
+try {
+device1.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 6,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 116 */
+{offset: 116}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder102 = device0.createCommandEncoder({label: '\uef2b\ud243\u{1ff9c}\uec7f'});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+renderPassEncoder20.setBlendConstant({ r: -996.6, g: -36.28, b: -236.2, a: -345.4, });
+} catch {}
+try {
+renderPassEncoder39.setStencilReference(4093);
+} catch {}
+try {
+renderPassEncoder27.setViewport(92.10, 0.5320, 3.563, 0.3108, 0.1422, 0.3832);
+} catch {}
+try {
+commandEncoder87.copyBufferToBuffer(buffer8, 281760, buffer2, 26972, 12496);
+dissociateBuffer(device0, buffer8);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 16464, new DataView(new ArrayBuffer(14355)), 1309, 1828);
+} catch {}
+let imageBitmap17 = await createImageBitmap(canvas4);
+let bindGroup32 = device0.createBindGroup({label: '\u1894\u{1f7cf}', layout: bindGroupLayout17, entries: []});
+let texture80 = device0.createTexture({
+  size: {width: 192, height: 1, depthOrArrayLayers: 297},
+  mipLevelCount: 8,
+  sampleCount: 1,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['depth24plus-stencil8', 'depth24plus-stencil8'],
+});
+let textureView110 = texture37.createView({label: '\u05db\uab55\u4ce4\u052c\u04f4\u0b14\u0ccf\ud788\u9730', baseMipLevel: 6});
+let renderBundleEncoder56 = device0.createRenderBundleEncoder({
+  label: '\uf302\u0c9d\u0312',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder21.setPipeline(pipeline35);
+} catch {}
+try {
+renderPassEncoder16.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder26.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder31.setScissorRect(28, 0, 63, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer8, /* required buffer size: 3_152 */
+{offset: 352}, {width: 175, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 49, y: 15 },
+  flipY: true,
+}, {
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+gc();
+let commandEncoder103 = device0.createCommandEncoder({});
+let commandBuffer26 = commandEncoder102.finish({label: '\u0688\u0b84\u3e39\ucc8f\u74cb\u981b\u7bbe\uf303\u0e36'});
+let renderBundle61 = renderBundleEncoder26.finish();
+try {
+renderPassEncoder41.beginOcclusionQuery(1330);
+} catch {}
+try {
+renderPassEncoder37.setStencilReference(977);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer0, 'uint16', 4866, 371);
+} catch {}
+try {
+commandEncoder103.copyTextureToTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 96, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline54 = device0.createComputePipeline({
+  label: '\u0249\ua5ca\u89cf\u0ba4\u1864\u05d5\u03f9\u4cf0',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule3, entryPoint: 'compute0'},
+});
+let canvas13 = document.createElement('canvas');
+let video13 = await videoWithData();
+let bindGroupLayout31 = device0.createBindGroupLayout({
+  label: '\u56c0\u{1fdb7}\u9801\ue9fb\u{1fbb4}\u01d4\u{1fc25}\u{1fb98}',
+  entries: [
+    {
+      binding: 2257,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16uint', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 9054,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {binding: 1705, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+  ],
+});
+let textureView111 = texture32.createView({
+  label: '\u3f2b\uacdb\u0c80\u678b\uead0\ue03a\u0a4c\u0168\u2234\u26ed',
+  dimension: '2d',
+  aspect: 'all',
+  format: 'rgba32uint',
+  baseMipLevel: 2,
+  arrayLayerCount: 1,
+});
+try {
+computePassEncoder4.setPipeline(pipeline29);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+renderPassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder33.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder27.setBlendConstant({ r: -582.9, g: -714.0, b: -826.7, a: -930.8, });
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(2, bindGroup2, new Uint32Array(5651), 4271, 0);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(4, buffer10, 0, 265172);
+} catch {}
+try {
+commandEncoder87.copyTextureToTexture({
+  texture: texture49,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 45, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline55 = await device0.createComputePipelineAsync({layout: pipelineLayout6, compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}}});
+let canvas14 = document.createElement('canvas');
+let bindGroup33 = device0.createBindGroup({
+  label: '\u3b4e\uf4a3\u{1fae4}\u006b\u{1f8f5}\u2ca8',
+  layout: bindGroupLayout30,
+  entries: [{binding: 552, resource: externalTexture35}, {binding: 489, resource: sampler7}],
+});
+let querySet43 = device0.createQuerySet({label: '\u86fc\u{1fbe0}\u05cd\u027a\u{1fa5c}\u{1ffc9}', type: 'occlusion', count: 3430});
+let texture81 = device0.createTexture({
+  label: '\u00a4\u{1fc99}\u56d8\u087e\u{1f83f}\u4122',
+  size: [768],
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint', 'rgba8uint'],
+});
+let texture82 = gpuCanvasContext5.getCurrentTexture();
+let textureView112 = texture50.createView({
+  label: '\u53ff\u{1f6c8}\u{1fac0}\u942b\u{1fa00}\u3c31\u{1fd64}\u{1fc99}\u8383',
+  dimension: '2d',
+  mipLevelCount: 5,
+  baseArrayLayer: 77,
+});
+try {
+renderPassEncoder21.setScissorRect(133, 0, 57, 1);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(4, buffer10, 0, 356189);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(4, buffer14, 30200, 3410);
+} catch {}
+try {
+commandEncoder101.copyTextureToBuffer({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 16208 */
+  offset: 16208,
+  rowsPerImage: 52,
+  buffer: buffer11,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline56 = device0.createRenderPipeline({
+  label: '\u3921\u{1f7a0}',
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: 0}, {format: 'rgba32uint'}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 14588,
+        stepMode: 'vertex',
+        attributes: [{format: 'unorm16x2', offset: 1420, shaderLocation: 14}],
+      },
+      {
+        arrayStride: 3984,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 368, shaderLocation: 7},
+          {format: 'float32', offset: 920, shaderLocation: 15},
+          {format: 'unorm8x2', offset: 278, shaderLocation: 1},
+          {format: 'unorm8x4', offset: 1588, shaderLocation: 0},
+          {format: 'float16x2', offset: 1096, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 1196, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 800, shaderLocation: 9},
+          {format: 'float32x4', offset: 1028, shaderLocation: 10},
+          {format: 'snorm16x2', offset: 1368, shaderLocation: 3},
+          {format: 'sint8x4', offset: 3476, shaderLocation: 5},
+          {format: 'uint32x3', offset: 1100, shaderLocation: 12},
+          {format: 'float16x4', offset: 548, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 10296,
+        attributes: [
+          {format: 'uint32x4', offset: 216, shaderLocation: 4},
+          {format: 'uint32x2', offset: 920, shaderLocation: 2},
+          {format: 'unorm16x4', offset: 2840, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+});
+try {
+window.someLabel = externalTexture17.label;
+} catch {}
+let bindGroupLayout32 = device0.createBindGroupLayout({
+  label: '\u0618\u043c\u98cd\u0791\u9684\u0711',
+  entries: [
+    {
+      binding: 8582,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '2d' },
+    },
+    {binding: 3358, visibility: 0, sampler: { type: 'non-filtering' }},
+  ],
+});
+let commandEncoder104 = device0.createCommandEncoder({label: '\u56a4\u{1fb8c}\u283e'});
+let querySet44 = device0.createQuerySet({type: 'occlusion', count: 1181});
+let textureView113 = texture43.createView({baseMipLevel: 2, mipLevelCount: 2, baseArrayLayer: 0});
+try {
+renderPassEncoder1.setScissorRect(93, 1, 1, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(40), /* required buffer size: 301 */
+{offset: 301}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView114 = texture25.createView({label: '\ub7c5\u43eb', mipLevelCount: 3});
+let renderBundle62 = renderBundleEncoder4.finish({label: '\u4a94\u23f7'});
+let sampler45 = device0.createSampler({
+  label: '\u{1f892}\ubc84\u3dc7',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 89.30,
+  lodMaxClamp: 90.06,
+  compare: 'always',
+});
+try {
+renderBundleEncoder39.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(2, buffer14, 3352, 30771);
+} catch {}
+try {
+commandEncoder87.copyBufferToTexture({
+  /* bytesInLastRow: 1056 widthInBlocks: 66 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 114464 */
+  offset: 5888,
+  bytesPerRow: 1280,
+  rowsPerImage: 14,
+  buffer: buffer8,
+}, {
+  texture: texture3,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 162},
+  aspect: 'all',
+}, {width: 792, height: 12, depthOrArrayLayers: 7});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder87.clearBuffer(buffer18, 63396, 2188);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 19896, new Int16Array(49277), 22654, 6908);
+} catch {}
+let videoFrame19 = videoFrame9.clone();
+let imageData17 = new ImageData(128, 140);
+let bindGroup34 = device0.createBindGroup({label: '\ude49\u0ee6\uf6a9\u061f\u8492', layout: bindGroupLayout1, entries: []});
+let texture83 = device0.createTexture({
+  label: '\u0baf\u{1fba0}\u8147\ubb76',
+  size: {width: 384, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'r32uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint', 'r32uint', 'r32uint'],
+});
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+renderPassEncoder26.beginOcclusionQuery(675);
+} catch {}
+try {
+renderPassEncoder34.executeBundles([]);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer19, 'uint32', 73168, 7210);
+} catch {}
+let arrayBuffer9 = buffer4.getMappedRange(37816, 1388);
+try {
+commandEncoder100.clearBuffer(buffer6, 32020, 41032);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas10,
+  origin: { x: 22, y: 15 },
+  flipY: false,
+}, {
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext15 = canvas13.getContext('webgpu');
+let imageData18 = new ImageData(24, 244);
+try {
+canvas11.getContext('webgpu');
+} catch {}
+document.body.prepend(img1);
+let imageData19 = new ImageData(64, 92);
+let renderBundleEncoder57 = device1.createRenderBundleEncoder({colorFormats: ['rg32uint'], sampleCount: 4, depthReadOnly: true});
+let sampler46 = device1.createSampler({
+  label: '\u009e\u{1fe1f}\u3253\ue011\ue75a\ud27f\u32c3\u8912',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 31.74,
+  lodMaxClamp: 57.24,
+});
+let externalTexture62 = device1.importExternalTexture({source: videoFrame7, colorSpace: 'display-p3'});
+let commandEncoder105 = device0.createCommandEncoder({label: '\u{1fdc8}\u093b\ua7cb\u441b'});
+let commandBuffer27 = commandEncoder101.finish({label: '\u7b8e\u{1fcd3}\u5897\u2bd2'});
+let renderPassEncoder42 = commandEncoder104.beginRenderPass({
+  label: '\u5095\u03d0\u0f48\u{1fcd9}\u{1ff34}',
+  colorAttachments: [{
+  view: textureView7,
+  depthSlice: 72,
+  clearValue: { r: 508.5, g: 987.6, b: 852.7, a: -229.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}, {
+  view: textureView74,
+  depthSlice: 175,
+  clearValue: { r: 697.9, g: -791.6, b: -167.2, a: -485.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView77,
+    depthClearValue: -5.965466990514683,
+    depthLoadOp: 'load',
+    depthStoreOp: 'discard',
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet32,
+});
+try {
+computePassEncoder31.setBindGroup(2, bindGroup31, new Uint32Array(9835), 7327, 1);
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -379.7, g: 619.9, b: -614.8, a: 90.07, });
+} catch {}
+try {
+renderPassEncoder24.setScissorRect(144, 1, 22, 0);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(3659);
+} catch {}
+try {
+commandEncoder87.copyTextureToTexture({
+  texture: texture46,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 67, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.submit([commandBuffer25, commandBuffer12]);
+} catch {}
+let bindGroup35 = device0.createBindGroup({label: '\u45d7\u0422\ue521\u48b4\u3a08', layout: bindGroupLayout7, entries: []});
+let textureView115 = texture61.createView({label: '\u3c97\uf722', format: 'depth24plus-stencil8', baseMipLevel: 4, mipLevelCount: 3});
+try {
+renderPassEncoder33.setBindGroup(4, bindGroup21, new Uint32Array(8722), 8346, 0);
+} catch {}
+try {
+renderPassEncoder31.setBlendConstant({ r: -989.2, g: 401.3, b: -784.2, a: 145.1, });
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(1, bindGroup32, []);
+} catch {}
+try {
+commandEncoder103.copyTextureToTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 8140, new Int16Array(59404), 42021, 44);
+} catch {}
+let pipeline57 = device0.createComputePipeline({
+  label: '\u5701\uc202\ucbcd',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule2, entryPoint: 'compute0'},
+});
+let img10 = await imageWithData(35, 140, '#a661fe1f', '#22ba994d');
+let gpuCanvasContext16 = canvas14.getContext('webgpu');
+let texture84 = device0.createTexture({
+  size: [192, 1, 1],
+  mipLevelCount: 8,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['depth24plus-stencil8', 'depth24plus-stencil8'],
+});
+let textureView116 = texture32.createView({label: '\u817d\u0251\u03b6\ud455\u7ee0\ua991\u08b3\u{1ff22}\uc5dd', mipLevelCount: 2});
+let sampler47 = device0.createSampler({
+  label: '\u{1f717}\u0c1d',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 29.02,
+  lodMaxClamp: 59.81,
+  compare: 'always',
+});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+computePassEncoder35.setBindGroup(0, bindGroup8, new Uint32Array(6961), 5936, 0);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+renderPassEncoder42.setIndexBuffer(buffer19, 'uint32', 34200);
+} catch {}
+video4.height = 271;
+let bindGroupLayout33 = device0.createBindGroupLayout({
+  label: '\u979d\u039b\u{1f768}\u{1f89d}\u1bc0\uf3d6',
+  entries: [
+    {
+      binding: 5660,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 2282,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 50646263, hasDynamicOffset: false },
+    },
+    {
+      binding: 3586,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let renderBundleEncoder58 = device0.createRenderBundleEncoder({
+  label: '\u{1fbd4}\udc68\u5a4b\u6e1b\u33a6\u08bb\u0b95\u99a2\u54f5\u0815',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+});
+let sampler48 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 67.19,
+  lodMaxClamp: 84.03,
+});
+try {
+computePassEncoder29.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder56.setBindGroup(3, bindGroup29, [0]);
+} catch {}
+try {
+commandEncoder100.copyBufferToTexture({
+  /* bytesInLastRow: 2368 widthInBlocks: 148 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 61808 */
+  offset: 61808,
+  buffer: buffer11,
+}, {
+  texture: texture32,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 148, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+commandEncoder87.copyTextureToTexture({
+  texture: texture63,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder103.resolveQuerySet(querySet39, 1387, 184, buffer10, 20736);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img5,
+  origin: { x: 84, y: 33 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup36 = device0.createBindGroup({layout: bindGroupLayout8, entries: []});
+let commandEncoder106 = device0.createCommandEncoder();
+let textureView117 = texture48.createView({label: '\ud9b7\ucf64\u07ec', format: 'rgba32uint'});
+try {
+renderPassEncoder36.setVertexBuffer(5, buffer14, 3084, 26663);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+commandEncoder87.copyTextureToBuffer({
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 23192 */
+  offset: 23192,
+  buffer: buffer16,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder103.clearBuffer(buffer2, 17416, 54892);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 11432, new BigUint64Array(28409), 20741, 924);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 4},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 310_233 */
+{offset: 473, bytesPerRow: 121, rowsPerImage: 32}, {width: 17, height: 0, depthOrArrayLayers: 81});
+} catch {}
+offscreenCanvas15.height = 26;
+let pipelineLayout9 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout23, bindGroupLayout8, bindGroupLayout16]});
+let textureView118 = texture78.createView({label: '\ua369\u94a3\u1fef', aspect: 'depth-only', format: 'depth24plus'});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+computePassEncoder20.setBindGroup(2, bindGroup34, new Uint32Array(8282), 149, 0);
+} catch {}
+try {
+computePassEncoder5.dispatchWorkgroups(2, 2, 4);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(2, bindGroup29, [0]);
+} catch {}
+try {
+renderPassEncoder21.beginOcclusionQuery(187);
+} catch {}
+try {
+renderPassEncoder41.setStencilReference(2610);
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(2, buffer10, 75680, 293826);
+} catch {}
+try {
+renderBundleEncoder53.setPipeline(pipeline11);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let promise33 = buffer18.mapAsync(GPUMapMode.READ, 58472, 13244);
+try {
+commandEncoder105.copyBufferToBuffer(buffer17, 339776, buffer3, 105016, 14924);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 16},
+  aspect: 'all',
+}, arrayBuffer9, /* required buffer size: 14_625_715 */
+{offset: 715, bytesPerRow: 325, rowsPerImage: 125}, {width: 48, height: 0, depthOrArrayLayers: 361});
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+try {
+  await promise33;
+} catch {}
+let shaderModule5 = device0.createShaderModule({
+  label: '\u{1fb0b}\u08c7\u06c5\u4a2c\u{1fcb6}\uc79a\u{1ff77}\u{1fc78}',
+  code: `@group(0) @binding(5330)
+var<storage, read_write> field1: array<u32>;
+@group(1) @binding(1587)
+var<storage, read_write> function1: array<u32>;
+
+@compute @workgroup_size(4, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S7 {
+  @builtin(sample_index) f0: u32,
+  @builtin(front_facing) f1: bool,
+  @builtin(sample_mask) f2: u32
+}
+struct FragmentOutput0 {
+  @location(3) f0: vec2<f32>,
+  @location(0) f1: vec4<u32>,
+  @location(1) f2: vec4<u32>,
+  @builtin(frag_depth) f3: f32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, a1: S7) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S6 {
+  @builtin(vertex_index) f0: u32,
+  @location(4) f1: i32,
+  @location(8) f2: f32,
+  @location(12) f3: vec4<u32>,
+  @location(14) f4: vec4<f32>,
+  @location(3) f5: vec2<u32>,
+  @location(15) f6: vec2<f16>,
+  @location(0) f7: vec2<f16>,
+  @location(2) f8: i32,
+  @location(1) f9: f32,
+  @location(7) f10: vec4<f32>,
+  @location(11) f11: vec4<f32>,
+  @location(5) f12: f32,
+  @location(9) f13: i32,
+  @location(13) f14: vec3<f16>,
+  @builtin(instance_index) f15: u32
+}
+
+@vertex
+fn vertex0(a0: S6, @location(10) a1: vec2<f32>, @location(6) a2: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture85 = device0.createTexture({
+  label: '\ueb08\u03aa\u038a\u0383\u5a07\u0cb2\u0ed7\u{1f64f}\u{1f86a}\u8383',
+  size: {width: 384, height: 1, depthOrArrayLayers: 689},
+  mipLevelCount: 8,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['depth24plus-stencil8', 'depth24plus-stencil8'],
+});
+let renderBundle63 = renderBundleEncoder34.finish({label: '\u{1f9dd}\uc9d3\u2ca0\u8345\ua039\u030f\u08bc\u4412\u0dab\u0620'});
+let sampler49 = device0.createSampler({
+  label: '\ub7fe\u87d4\u6cb2\u77e9\u1341\u0042\ue16d\ue236',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 42.37,
+  lodMaxClamp: 80.42,
+});
+try {
+computePassEncoder37.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder23.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -465.6, g: -595.8, b: 461.8, a: -330.3, });
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(127, 0, 34, 0);
+} catch {}
+try {
+renderPassEncoder31.setStencilReference(1463);
+} catch {}
+try {
+commandEncoder105.resolveQuerySet(querySet8, 12, 55, buffer10, 233984);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 3,
+  origin: {x: 72, y: 0, z: 6},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer5), /* required buffer size: 257_890 */
+{offset: 146, bytesPerRow: 280, rowsPerImage: 40}, {width: 108, height: 12, depthOrArrayLayers: 24});
+} catch {}
+let pipeline58 = await device0.createComputePipelineAsync({
+  label: '\u000a\u{1f89d}\u0a40\u06f3\u0bb0\uc23b\u79a4\u{1fc3f}\u050f\ud4c0\u0d97',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+video1.height = 175;
+let bindGroupLayout34 = device0.createBindGroupLayout({label: '\uc22d\u{1fafa}\u08c9\u{1ff1a}\uc33a', entries: []});
+let bindGroup37 = device0.createBindGroup({label: '\u{1f63d}\u04e9\u05cf\u{1fbdc}\u{1fbed}', layout: bindGroupLayout25, entries: []});
+let commandEncoder107 = device0.createCommandEncoder({label: '\u43db\u15cb\u{1fda0}\u01fc\u411d\u{1f704}\u47de\u{1fc4f}'});
+let querySet45 = device0.createQuerySet({
+  label: '\u245b\u6eb1\ue4a9\uf985\u970f\udb62\u{1f8c9}\uaba7\u{1ff4d}\ue79f',
+  type: 'occlusion',
+  count: 1410,
+});
+let textureView119 = texture81.createView({label: '\u72d6\u7bb6\u19ea\u{1f8a2}\u8ada\u7809\u03b5\u47b3'});
+let computePassEncoder38 = commandEncoder100.beginComputePass({label: '\u{1f72a}\u03a3\u{1fb15}\uc2d5\uc8af\u0295\uc811'});
+try {
+computePassEncoder21.setPipeline(pipeline50);
+} catch {}
+try {
+renderPassEncoder40.setStencilReference(3443);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer14, 5460, 9541);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline13);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 453 */
+{offset: 453}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video8,
+  origin: { x: 3, y: 3 },
+  flipY: true,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline59 = await device0.createComputePipelineAsync({
+  label: '\u{1f9a8}\u{1fa0b}\u{1f8e9}\u07c9\u00e3\ue7ac',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule1, entryPoint: 'compute0'},
+});
+let querySet46 = device0.createQuerySet({type: 'occlusion', count: 1768});
+let computePassEncoder39 = commandEncoder105.beginComputePass({label: '\u5e69\u0890\u48d6\ue6cc\u0704\u85ee\u1acb\uacda'});
+let renderBundleEncoder59 = device0.createRenderBundleEncoder({
+  label: '\u04e2\u{1fb61}\u003f\u8ffc\u46c3\u1fd6\ua751\u{1fb20}',
+  colorFormats: ['rgba32uint', 'bgra8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder8.setScissorRect(26, 0, 67, 0);
+} catch {}
+try {
+texture66.destroy();
+} catch {}
+try {
+commandEncoder107.copyBufferToBuffer(buffer11, 61172, buffer6, 76788, 13828);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder107.copyTextureToTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout35 = device0.createBindGroupLayout({
+  label: '\u0f96\uf8c3\u80f9\u0d35\u8ae8\u3537\u{1f7d1}',
+  entries: [{binding: 4914, visibility: GPUShaderStage.COMPUTE, externalTexture: {}}],
+});
+let querySet47 = device0.createQuerySet({label: '\u136e\u0c81\uc1ce\u2488\u0cc2\u{1ff4f}\u{1ffeb}', type: 'occlusion', count: 1602});
+let computePassEncoder40 = commandEncoder106.beginComputePass({});
+try {
+computePassEncoder40.end();
+} catch {}
+try {
+renderPassEncoder31.setBindGroup(2, bindGroup31, new Uint32Array(3755), 249, 1);
+} catch {}
+try {
+renderPassEncoder31.beginOcclusionQuery(183);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder103.copyBufferToBuffer(buffer13, 1104, buffer3, 279852, 8320);
+dissociateBuffer(device0, buffer13);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline60 = await device0.createComputePipelineAsync({
+  label: '\u3857\ua006\u6111\uf93c\u1765',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let imageData20 = new ImageData(240, 132);
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let promise34 = adapter1.requestAdapterInfo();
+let offscreenCanvas18 = new OffscreenCanvas(1016, 451);
+try {
+offscreenCanvas18.getContext('webgl2');
+} catch {}
+let renderPassEncoder43 = commandEncoder106.beginRenderPass({
+  label: '\u5bce\udf8a\ua9ed\uac57\u{1faf2}\ud420\uac06',
+  colorAttachments: [{
+  view: textureView8,
+  depthSlice: 53,
+  clearValue: { r: -500.4, g: -963.4, b: 973.2, a: 893.2, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView47,
+  depthSlice: 18,
+  clearValue: { r: -719.1, g: -808.7, b: -961.6, a: 667.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView16,
+    depthClearValue: 0.9076180691399914,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'store',
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet17,
+  maxDrawCount: 997545696,
+});
+let renderBundleEncoder60 = device0.createRenderBundleEncoder({
+  label: '\u{1fb7c}\ufcda\u1b20',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true,
+});
+let sampler50 = device0.createSampler({
+  label: '\u060e\ueaee\u{1fa1f}\u09ff\u25e4',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 30.90,
+  lodMaxClamp: 65.74,
+  maxAnisotropy: 6,
+});
+try {
+renderPassEncoder37.beginOcclusionQuery(2117);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(2229);
+} catch {}
+try {
+renderPassEncoder32.setViewport(2.938, 0.6880, 102.9, 0.03036, 0.01346, 0.8094);
+} catch {}
+try {
+commandEncoder107.copyTextureToBuffer({
+  texture: texture34,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 3 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 30963 */
+  offset: 30960,
+  bytesPerRow: 256,
+  buffer: buffer16,
+}, {width: 3, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder87.copyTextureToTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 192, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder107.clearBuffer(buffer16, 115292, 5708);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder103.resolveQuerySet(querySet0, 124, 1442, buffer10, 182528);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img0);
+offscreenCanvas14.height = 1286;
+let imageData21 = new ImageData(128, 176);
+let commandEncoder108 = device0.createCommandEncoder({label: '\u013a\ufadd\u7b9b'});
+let texture86 = device0.createTexture({
+  label: '\u86e1\uea11\u0a5a\u879c',
+  size: [768, 1, 163],
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let computePassEncoder41 = commandEncoder103.beginComputePass();
+let renderPassEncoder44 = commandEncoder108.beginRenderPass({
+  label: '\uaff4\u038d\u22c8\u2445\u{1ffac}\u{1f669}\u{1f86d}',
+  colorAttachments: [{
+  view: textureView5,
+  depthSlice: 82,
+  clearValue: { r: -607.6, g: -472.0, b: -670.8, a: 791.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView74,
+  depthSlice: 528,
+  clearValue: { r: -569.8, g: 666.2, b: 353.2, a: 189.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {view: textureView106, depthReadOnly: true, stencilClearValue: 9615},
+  occlusionQuerySet: querySet25,
+  maxDrawCount: 96213791,
+});
+try {
+renderPassEncoder36.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+renderPassEncoder9.setViewport(48.80, 0.4315, 3.082, 0.2797, 0.2608, 0.9375);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(6, buffer14, 6716, 5558);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline13);
+} catch {}
+let arrayBuffer10 = buffer2.getMappedRange(448, 1748);
+try {
+commandEncoder87.copyBufferToBuffer(buffer7, 269052, buffer3, 98580, 76380);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 13204, new DataView(new ArrayBuffer(18537)), 7585, 92);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 5},
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(64)), /* required buffer size: 17_311_409 */
+{offset: 838, bytesPerRow: 317, rowsPerImage: 203}, {width: 38, height: 1, depthOrArrayLayers: 270});
+} catch {}
+let pipeline61 = device0.createRenderPipeline({
+  label: '\u04eb\u0dad\u97ba\u6ea6\uc599',
+  layout: 'auto',
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'always', failOp: 'increment-wrap', depthFailOp: 'increment-wrap', passOp: 'invert'},
+    stencilBack: {compare: 'greater-equal', depthFailOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilReadMask: 2971810824,
+    stencilWriteMask: 349516567,
+    depthBias: 2067768607,
+    depthBiasSlopeScale: -73.84162924454174,
+    depthBiasClamp: -46.58353679951005,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3080,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 260, shaderLocation: 8},
+          {format: 'float32', offset: 0, shaderLocation: 10},
+          {format: 'sint32x4', offset: 1292, shaderLocation: 1},
+          {format: 'snorm8x4', offset: 84, shaderLocation: 3},
+          {format: 'float16x2', offset: 596, shaderLocation: 0},
+          {format: 'uint16x2', offset: 520, shaderLocation: 6},
+          {format: 'unorm16x2', offset: 780, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 12640, shaderLocation: 2},
+          {format: 'uint32x4', offset: 2164, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x4', offset: 5948, shaderLocation: 13}],
+      },
+      {
+        arrayStride: 10308,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 3140, shaderLocation: 5},
+          {format: 'snorm8x2', offset: 2784, shaderLocation: 15},
+          {format: 'unorm10-10-10-2', offset: 5428, shaderLocation: 12},
+          {format: 'float32x4', offset: 24, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 9940,
+        attributes: [
+          {format: 'snorm16x4', offset: 2244, shaderLocation: 7},
+          {format: 'sint32', offset: 6328, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+});
+try {
+  await promise34;
+} catch {}
+let textureView120 = texture75.createView({mipLevelCount: 3});
+try {
+computePassEncoder20.dispatchWorkgroups(2, 2, 2);
+} catch {}
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder31.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder28.setScissorRect(22, 1, 42, 0);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer14, 'uint16', 10180);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(4, buffer14, 23420, 6903);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+commandEncoder1.copyBufferToBuffer(buffer7, 152096, buffer6, 24376, 23124);
+dissociateBuffer(device0, buffer7);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder87.clearBuffer(buffer16, 106068, 4924);
+dissociateBuffer(device0, buffer16);
+} catch {}
+let pipeline62 = await device0.createRenderPipelineAsync({
+  label: '\u{1f736}\u{1fce4}\u93cb\u9ec0\ua922\u{1fb96}\u0a26\u{1fc45}\u{1f8a7}\u0aa0',
+  layout: pipelineLayout3,
+  multisample: {count: 4, mask: 0x38e034c5},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rgba32uint'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'less-equal', depthFailOp: 'invert', passOp: 'zero'},
+    stencilBack: {
+      compare: 'not-equal',
+      failOp: 'increment-clamp',
+      depthFailOp: 'increment-clamp',
+      passOp: 'decrement-wrap',
+    },
+    stencilReadMask: 618453136,
+    stencilWriteMask: 260275468,
+    depthBias: 1590087227,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 540,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 56, shaderLocation: 7},
+          {format: 'float32', offset: 36, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 48, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 300, shaderLocation: 15},
+          {format: 'sint8x2', offset: 4, shaderLocation: 9},
+          {format: 'unorm8x2', offset: 24, shaderLocation: 5},
+          {format: 'uint16x4', offset: 56, shaderLocation: 3},
+          {format: 'unorm16x2', offset: 40, shaderLocation: 10},
+          {format: 'float32x4', offset: 120, shaderLocation: 6},
+          {format: 'sint16x2', offset: 460, shaderLocation: 4},
+          {format: 'float16x4', offset: 160, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 34020,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 7676, shaderLocation: 2},
+          {format: 'uint32', offset: 27708, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 1964,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x4', offset: 572, shaderLocation: 11}],
+      },
+      {
+        arrayStride: 15152,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 1756, shaderLocation: 8},
+          {format: 'float16x2', offset: 11672, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'cw'},
+});
+gc();
+let img11 = await imageWithData(218, 125, '#ec23ba78', '#cfa15813');
+let bindGroup38 = device0.createBindGroup({
+  label: '\u{1f722}\u{1fa50}',
+  layout: bindGroupLayout30,
+  entries: [{binding: 489, resource: sampler45}, {binding: 552, resource: externalTexture10}],
+});
+let buffer20 = device0.createBuffer({size: 237089, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let querySet48 = device0.createQuerySet({
+  label: '\ude47\ucb0d\ucb86\u07fe\u050a\u0483\u0625\u{1fcdd}\u{1fc81}\uacfd',
+  type: 'occlusion',
+  count: 557,
+});
+let renderPassEncoder45 = commandEncoder107.beginRenderPass({
+  colorAttachments: [{
+  view: textureView9,
+  depthSlice: 98,
+  clearValue: { r: -602.4, g: 434.4, b: 707.1, a: 375.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}, {
+  view: textureView74,
+  depthSlice: 316,
+  clearValue: { r: -405.9, g: 717.3, b: -136.3, a: -140.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView40,
+    depthClearValue: 0.2512542302781907,
+    depthLoadOp: 'clear',
+    depthStoreOp: 'discard',
+    stencilClearValue: 55865,
+    stencilReadOnly: true,
+  },
+  occlusionQuerySet: querySet29,
+  maxDrawCount: 263852623,
+});
+let renderBundle64 = renderBundleEncoder52.finish();
+try {
+renderPassEncoder37.setBindGroup(3, bindGroup34, new Uint32Array(7950), 3035, 0);
+} catch {}
+try {
+renderPassEncoder39.end();
+} catch {}
+try {
+renderPassEncoder42.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder40.setIndexBuffer(buffer12, 'uint16', 57542, 13226);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(1, buffer10);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline28);
+} catch {}
+try {
+computePassEncoder5.pushDebugGroup('\u6a6b');
+} catch {}
+try {
+computePassEncoder5.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext16.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float'],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer20, 13420, new DataView(new ArrayBuffer(5697)), 5600, 20);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, arrayBuffer6, /* required buffer size: 694 */
+{offset: 694}, {width: 192, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline63 = await device0.createComputePipelineAsync({layout: pipelineLayout2, compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}}});
+let imageBitmap18 = await createImageBitmap(canvas6);
+let commandEncoder109 = device0.createCommandEncoder({label: '\u6cfa\u249e\u04f4\u6abf\u093b\u{1fbdb}\u0b49'});
+let querySet49 = device0.createQuerySet({label: '\u73a9\ud191\u{1fb69}\u2830\u4640\uc045\u{1fc4d}\u{1f895}', type: 'occlusion', count: 2868});
+let textureView121 = texture31.createView({
+  label: '\uabbf\u045a\u0dd9\u08e7\u{1f818}\u5462',
+  dimension: '2d-array',
+  aspect: 'depth-only',
+  baseMipLevel: 7,
+});
+let renderPassEncoder46 = commandEncoder109.beginRenderPass({
+  label: '\u{1f864}\u{1ff65}\u31d1\u0139\u1413\u{1ff52}\ub99e\ua2ba\u37c7',
+  colorAttachments: [{
+  view: textureView23,
+  depthSlice: 59,
+  clearValue: { r: -279.1, g: 445.4, b: 204.8, a: -297.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}, {
+  view: textureView20,
+  depthSlice: 19,
+  clearValue: { r: -16.42, g: 672.0, b: 409.7, a: 168.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView16,
+    depthClearValue: -1.1989794886340412,
+    depthLoadOp: 'load',
+    depthStoreOp: 'store',
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet46,
+  maxDrawCount: 778659560,
+});
+try {
+renderPassEncoder44.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder53.setBindGroup(1, bindGroup24);
+} catch {}
+try {
+commandEncoder87.copyBufferToBuffer(buffer17, 82176, buffer18, 69360, 5992);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder1.copyTextureToTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 87},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 192, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder87.clearBuffer(buffer16, 82428, 48424);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 368, y: 1 },
+  flipY: false,
+}, {
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+let texture87 = device0.createTexture({
+  label: '\u{1ff13}\u02a5\u{1fa19}\ud4d9\u{1ffb0}',
+  size: {width: 96, height: 1, depthOrArrayLayers: 1},
+  dimension: '2d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder42 = commandEncoder87.beginComputePass({label: '\u8e38\u{1ff0d}\u04a8\ub26d\u{1f847}\u0399\u1789\u2d9d\u5a94'});
+let externalTexture63 = device0.importExternalTexture({label: '\u{1f8c7}\u{1fc32}\u36ab\u{1f8aa}\u1038\u046b', source: videoFrame10, colorSpace: 'srgb'});
+try {
+renderPassEncoder42.beginOcclusionQuery(50);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(4, buffer14, 29516, 738);
+} catch {}
+try {
+device0.queue.submit([commandBuffer26, commandBuffer21]);
+} catch {}
+document.body.prepend(canvas12);
+let commandBuffer28 = commandEncoder1.finish({});
+let sampler51 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 23.60,
+  lodMaxClamp: 64.85,
+  maxAnisotropy: 8,
+});
+let externalTexture64 = device0.importExternalTexture({
+  label: '\u{1fe92}\u{1fb9c}\u07c3\u0359\u{1fd98}\u6df6\u006e\u770e\u9eac\u3cd8',
+  source: videoFrame7,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder38.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline28);
+} catch {}
+document.body.prepend(canvas2);
+let bindGroup39 = device0.createBindGroup({
+  label: '\ue7b5\u8cc4\uc2d0\u250b\u0049\u0b59\u0f0d\u{1f8af}\u0c0a\u9b05\u{1f9fd}',
+  layout: bindGroupLayout1,
+  entries: [],
+});
+let buffer21 = device0.createBuffer({size: 174285, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let querySet50 = device0.createQuerySet({
+  label: '\uf59b\u83b6\u0f25\u1764\u09d7\u1816\u02fe\u0341\u{1f857}\u{1f6eb}',
+  type: 'occlusion',
+  count: 3951,
+});
+let externalTexture65 = device0.importExternalTexture({label: '\u0b4f\u{1f7a3}\u034e', source: videoFrame7, colorSpace: 'srgb'});
+try {
+renderPassEncoder23.beginOcclusionQuery(109);
+} catch {}
+try {
+renderPassEncoder35.setBlendConstant({ r: 193.1, g: -85.28, b: 275.9, a: -292.1, });
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder45.setIndexBuffer(buffer19, 'uint16', 78630, 1170);
+} catch {}
+let pipeline64 = await device0.createRenderPipelineAsync({
+  label: '\u{1f6d2}\ub17b\ubabc',
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rgba32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'equal', failOp: 'invert', depthFailOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'zero', passOp: 'increment-clamp'},
+    stencilReadMask: 4294967295,
+    stencilWriteMask: 2176674009,
+    depthBias: -1430802827,
+    depthBiasSlopeScale: 468.7141129516865,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4008,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 1244, shaderLocation: 7},
+          {format: 'float32x4', offset: 52, shaderLocation: 10},
+          {format: 'float32x3', offset: 16, shaderLocation: 1},
+          {format: 'float32x3', offset: 336, shaderLocation: 15},
+          {format: 'snorm8x4', offset: 364, shaderLocation: 8},
+          {format: 'unorm8x4', offset: 416, shaderLocation: 13},
+          {format: 'uint32x2', offset: 2560, shaderLocation: 12},
+          {format: 'sint32x4', offset: 352, shaderLocation: 9},
+          {format: 'snorm8x4', offset: 1236, shaderLocation: 6},
+          {format: 'uint32x3', offset: 424, shaderLocation: 3},
+          {format: 'unorm8x2', offset: 32, shaderLocation: 11},
+          {format: 'unorm16x2', offset: 712, shaderLocation: 0},
+          {format: 'unorm8x2', offset: 1786, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 62, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 25444,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x2', offset: 48, shaderLocation: 4}],
+      },
+      {
+        arrayStride: 1632,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x2', offset: 40, shaderLocation: 2}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-list', cullMode: 'back'},
+});
+let bindGroup40 = device0.createBindGroup({
+  label: '\u8914\u0cf3\u{1f9b0}\ud746\u{1fbd6}\u2828\uc156\u6d4c\u3c0c\u07cd',
+  layout: bindGroupLayout19,
+  entries: [{binding: 5986, resource: sampler23}, {binding: 4967, resource: {buffer: buffer9, offset: 68224}}],
+});
+let querySet51 = device0.createQuerySet({
+  label: '\u{1f864}\u{1ff20}\u{1fa23}\ucca0\u47ec\u{1f670}\u0e85\u6be4\u6e32',
+  type: 'occlusion',
+  count: 1755,
+});
+try {
+renderPassEncoder46.setBindGroup(5, bindGroup27, []);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(1729);
+} catch {}
+try {
+renderPassEncoder41.setViewport(22.92, 0.5180, 45.72, 0.1381, 0.3520, 0.4504);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer14, 'uint32', 26208, 2040);
+} catch {}
+let buffer22 = device0.createBuffer({
+  label: '\u0d40\u7f85',
+  size: 232312,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let renderBundleEncoder61 = device0.createRenderBundleEncoder({
+  label: '\u59e6\u201c\u6e6e\uea20\u0e74\u8f84',
+  colorFormats: ['rgba32uint', 'bgra8unorm'],
+  depthReadOnly: true,
+});
+let sampler52 = device0.createSampler({
+  label: '\u49b7\ue47f\u{1f61f}\u2a6e',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 66.05,
+});
+let externalTexture66 = device0.importExternalTexture({
+  label: '\uf496\ua505\u4c7f\u52db\uac39\ud929\ue16d\ua2fd\u7ea6\u312f\u06c5',
+  source: video13,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder8.setBindGroup(5, bindGroup40, [0]);
+} catch {}
+try {
+renderPassEncoder24.setStencilReference(1415);
+} catch {}
+try {
+renderBundleEncoder32.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(4, bindGroup32, new Uint32Array(5720), 539, 0);
+} catch {}
+let bindGroupLayout36 = device0.createBindGroupLayout({
+  label: '\u0247\u{1fb57}\u03ba\u0747\u2e54\u08a7\u0a62\ubb0e\u0f41\u0e4b',
+  entries: [
+    {
+      binding: 3416,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let querySet52 = device0.createQuerySet({
+  label: '\u6d41\u0f1a\u09fc\ue847\udb02\u{1fd67}\u{1f746}\u{1fbd0}\u3103\ua25a',
+  type: 'occlusion',
+  count: 2780,
+});
+let renderBundle65 = renderBundleEncoder60.finish();
+try {
+computePassEncoder23.setBindGroup(3, bindGroup20, []);
+} catch {}
+try {
+renderPassEncoder41.setBindGroup(0, bindGroup2, new Uint32Array(2313), 1858, 0);
+} catch {}
+try {
+renderPassEncoder31.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder45.setBlendConstant({ r: -621.8, g: -565.3, b: -532.4, a: 156.4, });
+} catch {}
+let imageData22 = new ImageData(56, 12);
+let commandEncoder110 = device0.createCommandEncoder({label: '\u0f4c\u57b0\u0da2\u353f\u16c5\u7f1c\u{1fc3c}\u03bf\u3811\ud0b7'});
+let computePassEncoder43 = commandEncoder110.beginComputePass({});
+let renderBundle66 = renderBundleEncoder61.finish({label: '\u02eb\u0aec\u0f40\u3fc9\ucb75'});
+try {
+renderPassEncoder31.setBlendConstant({ r: -283.7, g: -428.9, b: -458.4, a: -763.9, });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer11, 29060, new DataView(new ArrayBuffer(3333)), 1414, 152);
+} catch {}
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let videoFrame20 = new VideoFrame(img9, {timestamp: 0});
+let textureView122 = texture29.createView({dimension: '2d-array', baseMipLevel: 0, baseArrayLayer: 0});
+let renderBundle67 = renderBundleEncoder61.finish();
+try {
+computePassEncoder27.setPipeline(pipeline32);
+} catch {}
+try {
+renderPassEncoder18.end();
+} catch {}
+try {
+renderPassEncoder37.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder35.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(9379, undefined, 0, 2138194475);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(3, bindGroup38, new Uint32Array(7266), 789, 0);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer5, 'uint32', 57772, 141670);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video4,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap19 = await createImageBitmap(imageData2);
+let promise35 = adapter1.requestAdapterInfo();
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let textureView123 = texture33.createView({
+  label: '\u21aa\u{1fa14}\u0957\u66d8\u06a0\u0ab5\uee67\u{1f7dc}\u0b6c\u2b92',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 284,
+});
+let renderBundleEncoder62 = device0.createRenderBundleEncoder({
+  label: '\u0938\uc8e8\u3da3\u78f6\uf57e\u7815\u8a0e\u{1fb27}\u00f5\u{1f79c}\u3b62',
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle68 = renderBundleEncoder40.finish({label: '\u9f98\uf2f0\u0fa6\u8778\u00cf\u{1f897}'});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder14.setScissorRect(36, 0, 23, 0);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(6, buffer14, 29968, 4237);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(2, bindGroup18, new Uint32Array(5253), 4737, 0);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+  await buffer21.mapAsync(GPUMapMode.WRITE, 0, 1544);
+} catch {}
+try {
+device0.queue.submit([commandBuffer27]);
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+gc();
+let imageData23 = new ImageData(200, 80);
+try {
+device1.queue.label = '\u{1fa44}\u{1fc4f}';
+} catch {}
+let commandEncoder111 = device0.createCommandEncoder();
+let querySet53 = device0.createQuerySet({type: 'occlusion', count: 3913});
+let renderBundle69 = renderBundleEncoder19.finish({});
+try {
+renderPassEncoder42.setIndexBuffer(buffer12, 'uint32', 18464, 26712);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 15352, new Int16Array(16864), 1410, 1084);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture43,
+  mipLevel: 1,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer1), /* required buffer size: 127 */
+{offset: 127, rowsPerImage: 230}, {width: 269, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video10.width = 135;
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+let img12 = await imageWithData(225, 181, '#0e4534ba', '#4e3f7e40');
+let imageBitmap20 = await createImageBitmap(offscreenCanvas0);
+let renderBundleEncoder63 = device0.createRenderBundleEncoder({label: '\u03c0\u1c35', colorFormats: ['rgba32uint', 'bgra8unorm'], stencilReadOnly: true});
+try {
+computePassEncoder9.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(4, bindGroup3);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant({ r: -290.7, g: 149.8, b: 838.1, a: -702.8, });
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(58, 1, 6, 0);
+} catch {}
+try {
+commandEncoder111.copyTextureToBuffer({
+  texture: texture78,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 96 widthInBlocks: 96 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 17072 */
+  offset: 16976,
+  rowsPerImage: 183,
+  buffer: buffer6,
+}, {width: 96, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder111.resolveQuerySet(querySet46, 199, 778, buffer10, 167936);
+} catch {}
+let pipeline65 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout6,
+  multisample: {mask: 0x8220ff43},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'decrement-clamp'},
+    stencilBack: {failOp: 'decrement-clamp', depthFailOp: 'replace', passOp: 'decrement-clamp'},
+    stencilReadMask: 2426238310,
+    stencilWriteMask: 3832548955,
+    depthBias: -1205442405,
+    depthBiasSlopeScale: 565.4813971945647,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 8628, shaderLocation: 5},
+          {format: 'sint32x3', offset: 7340, shaderLocation: 13},
+          {format: 'unorm8x4', offset: 6952, shaderLocation: 3},
+          {format: 'float32', offset: 4876, shaderLocation: 12},
+          {format: 'snorm8x2', offset: 17204, shaderLocation: 9},
+          {format: 'unorm10-10-10-2', offset: 780, shaderLocation: 7},
+          {format: 'uint16x4', offset: 11220, shaderLocation: 4},
+          {format: 'sint8x4', offset: 14872, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 15038, shaderLocation: 10},
+          {format: 'snorm8x4', offset: 28196, shaderLocation: 0},
+          {format: 'sint8x2', offset: 2690, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 376,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 56, shaderLocation: 15},
+          {format: 'sint32x2', offset: 72, shaderLocation: 11},
+          {format: 'uint16x4', offset: 36, shaderLocation: 6},
+          {format: 'unorm16x2', offset: 160, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [{format: 'unorm8x4', offset: 7056, shaderLocation: 8}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+try {
+externalTexture61.label = '\ub99f\u7939\ue2a4\u8ae2\udefc\u8999\u{1fcc5}\u{1fce2}\u{1fc3f}\u1c61';
+} catch {}
+let buffer23 = device1.createBuffer({size: 418214, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let externalTexture67 = device1.importExternalTexture({source: videoFrame11});
+try {
+device1.queue.submit([commandBuffer16]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer5), /* required buffer size: 790 */
+{offset: 790, bytesPerRow: 954}, {width: 118, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+gc();
+let adapter4 = await navigator.gpu.requestAdapter({});
+let shaderModule6 = device0.createShaderModule({
+  code: `@group(0) @binding(5330)
+var<storage, read_write> field2: array<u32>;
+@group(1) @binding(1587)
+var<storage, read_write> n2: array<u32>;
+
+@compute @workgroup_size(1, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S9 {
+  @location(50) f0: vec3<i32>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(0) f1: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(73) a0: vec2<i32>, @location(94) a1: vec3<f32>, @location(63) a2: vec4<f16>, @location(81) a3: i32, @location(75) a4: vec2<f16>, @location(3) a5: vec3<f32>, @location(15) a6: vec3<f32>, @location(96) a7: vec4<f16>, a8: S9, @location(70) a9: vec2<i32>, @location(66) a10: vec4<f32>, @location(9) a11: vec4<f16>, @location(17) a12: vec3<u32>, @location(43) a13: vec2<i32>, @location(58) a14: vec3<i32>, @builtin(position) a15: vec4<f32>, @builtin(front_facing) a16: bool, @location(7) a17: i32, @location(38) a18: f32, @builtin(sample_index) a19: u32, @location(55) a20: i32, @location(46) a21: vec2<f16>, @location(12) a22: vec4<f16>, @location(105) a23: vec3<f16>, @location(6) a24: vec2<u32>, @location(35) a25: vec4<u32>, @location(14) a26: vec3<i32>, @location(5) a27: vec4<i32>, @location(13) a28: f16, @location(76) a29: i32, @location(52) a30: vec2<u32>, @location(68) a31: f16, @location(100) a32: vec3<f16>, @location(31) a33: vec4<f16>, @location(45) a34: vec4<u32>, @location(64) a35: f32, @builtin(sample_mask) a36: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S8 {
+  @location(12) f0: vec2<u32>,
+  @location(5) f1: vec2<u32>,
+  @location(13) f2: vec3<f16>,
+  @location(9) f3: vec3<f16>,
+  @location(3) f4: vec3<i32>,
+  @location(0) f5: u32,
+  @location(7) f6: vec4<f32>,
+  @location(8) f7: vec4<f32>,
+  @location(6) f8: vec4<f32>,
+  @location(2) f9: f16,
+  @location(11) f10: u32,
+  @location(10) f11: vec2<u32>,
+  @location(14) f12: u32,
+  @location(4) f13: i32,
+  @location(1) f14: vec2<f32>
+}
+struct VertexOutput0 {
+  @location(31) f39: vec4<f16>,
+  @location(76) f40: i32,
+  @location(3) f41: vec3<f32>,
+  @location(46) f42: vec2<f16>,
+  @location(14) f43: vec3<i32>,
+  @location(45) f44: vec4<u32>,
+  @location(52) f45: vec2<u32>,
+  @location(70) f46: vec2<i32>,
+  @location(15) f47: vec3<f32>,
+  @builtin(position) f48: vec4<f32>,
+  @location(50) f49: vec3<i32>,
+  @location(73) f50: vec2<i32>,
+  @location(17) f51: vec3<u32>,
+  @location(66) f52: vec4<f32>,
+  @location(68) f53: f16,
+  @location(75) f54: vec2<f16>,
+  @location(81) f55: i32,
+  @location(5) f56: vec4<i32>,
+  @location(64) f57: f32,
+  @location(6) f58: vec2<u32>,
+  @location(100) f59: vec3<f16>,
+  @location(12) f60: vec4<f16>,
+  @location(48) f61: vec3<f32>,
+  @location(63) f62: vec4<f16>,
+  @location(43) f63: vec2<i32>,
+  @location(55) f64: i32,
+  @location(38) f65: f32,
+  @location(58) f66: vec3<i32>,
+  @location(35) f67: vec4<u32>,
+  @location(7) f68: i32,
+  @location(104) f69: vec2<f16>,
+  @location(94) f70: vec3<f32>,
+  @location(96) f71: vec4<f16>,
+  @location(92) f72: vec4<u32>,
+  @location(107) f73: vec3<u32>,
+  @location(9) f74: vec4<f16>,
+  @location(13) f75: f16,
+  @location(105) f76: vec3<f16>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @builtin(vertex_index) a1: u32, a2: S8, @location(15) a3: vec2<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture88 = device0.createTexture({
+  label: '\u8315\u645d\u{1f91c}\u{1fb18}',
+  size: [96, 1, 1356],
+  mipLevelCount: 6,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32uint'],
+});
+let textureView124 = texture85.createView({
+  label: '\ua8dd\u9166\u57f1\uf6fb\u{1f9b6}\u0f36\u9e9c\u09bf\u{1fd95}\ucb8d\u0123',
+  dimension: '2d',
+  aspect: 'stencil-only',
+  baseMipLevel: 3,
+  baseArrayLayer: 247,
+});
+let sampler53 = device0.createSampler({
+  label: '\u{1f80e}\u954d\u4608\u{1fe3e}\ufa81\u{1fa34}\u79ae\u0f08\u3b53',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 25.69,
+  lodMaxClamp: 89.45,
+});
+try {
+computePassEncoder29.setBindGroup(5, bindGroup2);
+} catch {}
+try {
+renderPassEncoder38.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -147.7, g: 673.3, b: 473.3, a: -618.3, });
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(276, undefined, 58839501, 2904115958);
+} catch {}
+try {
+commandEncoder111.copyBufferToTexture({
+  /* bytesInLastRow: 528 widthInBlocks: 33 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 23408 */
+  offset: 23408,
+  buffer: buffer8,
+}, {
+  texture: texture16,
+  mipLevel: 1,
+  origin: {x: 40, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 330, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(1_789), /* required buffer size: 1_789 */
+{offset: 477}, {width: 82, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let renderBundle70 = renderBundleEncoder60.finish({});
+try {
+computePassEncoder16.setBindGroup(4, bindGroup15);
+} catch {}
+try {
+computePassEncoder39.setBindGroup(2, bindGroup11, new Uint32Array(2126), 1455, 0);
+} catch {}
+try {
+renderPassEncoder38.beginOcclusionQuery(10);
+} catch {}
+try {
+renderPassEncoder28.setViewport(57.26, 0.5159, 73.69, 0.3225, 0.2493, 0.7303);
+} catch {}
+try {
+commandEncoder111.copyBufferToBuffer(buffer13, 5580, buffer18, 32112, 17096);
+dissociateBuffer(device0, buffer13);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+renderBundleEncoder55.insertDebugMarker('\u4015');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video13,
+  origin: { x: 2, y: 10 },
+  flipY: true,
+}, {
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline66 = device0.createRenderPipeline({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba32uint'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {failOp: 'decrement-wrap', depthFailOp: 'keep'},
+    stencilBack: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilReadMask: 1326836768,
+    stencilWriteMask: 671712803,
+    depthBiasSlopeScale: 74.7945668660393,
+    depthBiasClamp: 604.2998371784032,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 296,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 168, shaderLocation: 1},
+          {format: 'unorm8x4', offset: 8, shaderLocation: 8},
+          {format: 'sint8x4', offset: 8, shaderLocation: 6},
+          {format: 'snorm16x4', offset: 96, shaderLocation: 12},
+          {format: 'snorm8x2', offset: 40, shaderLocation: 4},
+          {format: 'float32x2', offset: 24, shaderLocation: 7},
+          {format: 'float32x3', offset: 60, shaderLocation: 5},
+          {format: 'unorm10-10-10-2', offset: 8, shaderLocation: 15},
+          {format: 'uint32x4', offset: 48, shaderLocation: 10},
+        ],
+      },
+      {arrayStride: 708, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 1652,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint32x2', offset: 4, shaderLocation: 14},
+          {format: 'uint32x3', offset: 192, shaderLocation: 11},
+          {format: 'uint8x2', offset: 414, shaderLocation: 0},
+          {format: 'unorm16x4', offset: 344, shaderLocation: 3},
+          {format: 'sint32x4', offset: 12, shaderLocation: 2},
+          {format: 'uint16x2', offset: 84, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 768,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x2', offset: 84, shaderLocation: 9}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+let buffer24 = device0.createBuffer({size: 159307, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder112 = device0.createCommandEncoder({label: '\ub9e5\u0151\u4dab\u0dc7\u{1ffbd}\ub097'});
+let texture89 = device0.createTexture({
+  label: '\u8a57\u0a65\ufb83\u14b7\u08a1\u{1fc59}\u6095\ua397\u6f28\u293e\u9f2a',
+  size: [384],
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm-srgb'],
+});
+let textureView125 = texture14.createView({
+  label: '\ubdfe\u0fa7\u669a\u0d0a\u038b\u5f9a\u7c5f\u0eb5',
+  dimension: '2d',
+  aspect: 'depth-only',
+  format: 'depth24plus',
+  baseMipLevel: 3,
+  baseArrayLayer: 544,
+});
+let computePassEncoder44 = commandEncoder111.beginComputePass({label: '\u58b7\u0f1d\u{1f7c9}\ua3ce\u0ded\u1c9e\u4a10\u2ea8\u7e7e'});
+let renderPassEncoder47 = commandEncoder112.beginRenderPass({
+  label: '\uf5b7\uf3a8\u2cce\u05eb\udf73\u{1fd3c}',
+  colorAttachments: [{view: textureView5, depthSlice: 73, loadOp: 'clear', storeOp: 'store'}, {
+  view: textureView51,
+  depthSlice: 767,
+  clearValue: { r: 2.122, g: 889.8, b: 143.8, a: -316.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView106,
+    depthClearValue: 4.095630067850207,
+    depthLoadOp: 'load',
+    depthStoreOp: 'discard',
+    depthReadOnly: false,
+    stencilClearValue: 58665,
+    stencilReadOnly: true,
+  },
+  maxDrawCount: 453157581,
+});
+let externalTexture68 = device0.importExternalTexture({label: '\u1317\u0606\ube64', source: video4});
+try {
+renderPassEncoder46.setBlendConstant({ r: 764.8, g: -408.9, b: -926.1, a: 114.4, });
+} catch {}
+let texture90 = device0.createTexture({
+  size: [192],
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint', 'rgba8uint'],
+});
+try {
+computePassEncoder42.setBindGroup(2, bindGroup34, new Uint32Array(1745), 357, 0);
+} catch {}
+try {
+renderPassEncoder40.setBlendConstant({ r: 210.9, g: -125.7, b: -391.5, a: 557.9, });
+} catch {}
+try {
+renderPassEncoder43.setScissorRect(23, 0, 60, 0);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline13);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 63, y: 3 },
+  flipY: false,
+}, {
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise36 = device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgba32uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1652,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 740, shaderLocation: 15},
+          {format: 'sint32x3', offset: 276, shaderLocation: 2},
+          {format: 'float32x4', offset: 80, shaderLocation: 3},
+          {format: 'snorm8x2', offset: 732, shaderLocation: 12},
+          {format: 'unorm16x4', offset: 144, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 3916,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 20, shaderLocation: 6},
+          {format: 'unorm8x2', offset: 282, shaderLocation: 9},
+          {format: 'sint32x3', offset: 1108, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 160, shaderLocation: 10},
+          {format: 'float16x4', offset: 256, shaderLocation: 14},
+          {format: 'sint8x2', offset: 902, shaderLocation: 1},
+          {format: 'sint32x3', offset: 756, shaderLocation: 13},
+          {format: 'float16x4', offset: 360, shaderLocation: 7},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 6956,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 1220, shaderLocation: 8},
+          {format: 'uint32', offset: 2220, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 2356, attributes: []},
+      {arrayStride: 1500, attributes: [{format: 'unorm16x4', offset: 140, shaderLocation: 5}]},
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+try {
+  await promise35;
+} catch {}
+let shaderModule7 = device0.createShaderModule({
+  label: '\u058a\u4cfd\u2be6\ucb45\u0ba8\u8edc\u{1f7d6}\u32e1',
+  code: `@group(1) @binding(1587)
+var<storage, read_write> parameter2: array<u32>;
+
+@compute @workgroup_size(7, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(3) f1: i32,
+  @location(0) f2: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(3) a1: vec2<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+try {
+computePassEncoder31.setPipeline(pipeline51);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup40, [0]);
+} catch {}
+try {
+renderPassEncoder35.setStencilReference(1382);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 17, y: 2 },
+  flipY: false,
+}, {
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline67 = await promise19;
+try {
+device0.destroy();
+} catch {}
+let imageBitmap21 = await createImageBitmap(offscreenCanvas15);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+gc();
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let img13 = await imageWithData(141, 86, '#f3832863', '#04afe832');
+let canvas15 = document.createElement('canvas');
+let gpuCanvasContext17 = canvas15.getContext('webgpu');
+let offscreenCanvas19 = new OffscreenCanvas(249, 469);
+document.body.prepend(canvas11);
+let videoFrame21 = new VideoFrame(img9, {timestamp: 0});
+let canvas16 = document.createElement('canvas');
+let offscreenCanvas20 = new OffscreenCanvas(379, 532);
+let buffer25 = device1.createBuffer({
+  label: '\u0281\udb9d',
+  size: 32997,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let textureView126 = texture44.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+try {
+renderBundleEncoder54.pushDebugGroup('\u0068');
+} catch {}
+let promise37 = device1.queue.onSubmittedWorkDone();
+try {
+device1.destroy();
+} catch {}
+try {
+offscreenCanvas20.getContext('webgl2');
+} catch {}
+let device2 = await promise25;
+try {
+canvas16.getContext('bitmaprenderer');
+} catch {}
+try {
+  await promise37;
+} catch {}
+try {
+offscreenCanvas19.getContext('webgl');
+} catch {}
+let texture91 = device2.createTexture({
+  label: '\u0b33\u{1f642}\u53a0\ufa91\u86be\u1581',
+  size: [84, 10, 178],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'astc-12x10-unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['astc-12x10-unorm-srgb', 'astc-12x10-unorm', 'astc-12x10-unorm'],
+});
+let externalTexture69 = device2.importExternalTexture({label: '\u010a\u7c4f\u2185\u3a61\u2bf7\u0bb0\u{1f935}', source: video1, colorSpace: 'srgb'});
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder113 = device2.createCommandEncoder({label: '\uf786\ua548\u{1fad0}\u01c0\u0ae8\u85bc'});
+try {
+gpuCanvasContext16.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+});
+} catch {}
+let imageData24 = new ImageData(124, 4);
+let commandEncoder114 = device2.createCommandEncoder({label: '\u{1f7b7}\u26cf\u02ae\ud396\u{1f89a}\u38d0\u0b81\ua1ae\uf836\u0c03'});
+let textureView127 = texture91.createView({label: '\u3ddf\u03c6\u5abd', dimension: '2d', aspect: 'all', mipLevelCount: 1, baseArrayLayer: 118});
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+let offscreenCanvas21 = new OffscreenCanvas(108, 465);
+let textureView128 = texture91.createView({
+  label: '\u{1f87f}\u8515\u{1ffb6}\u{1fec8}\u06ad\u40eb\u{1f72b}\u95c1',
+  dimension: '2d',
+  format: 'astc-12x10-unorm',
+  mipLevelCount: 1,
+  baseArrayLayer: 161,
+});
+let renderBundleEncoder64 = device2.createRenderBundleEncoder({
+  label: '\u7b71\u5c56\u7c08\u8e8a\u{1fe1d}',
+  colorFormats: ['r8unorm'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let video14 = await videoWithData();
+let videoFrame22 = new VideoFrame(offscreenCanvas4, {timestamp: 0});
+try {
+adapter2.label = '\u5e00\ud170\u{1ffd7}\u{1fe76}\u0964\u61e1\u078d\u6690\u0361';
+} catch {}
+try {
+offscreenCanvas21.getContext('2d');
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let commandEncoder115 = device2.createCommandEncoder({label: '\ud534\u04db\uadd7\u9342\ud61b\ua6fc\ud2be\u6162'});
+let textureView129 = texture91.createView({
+  label: '\u739a\ub00d\u{1f80d}\u5f48\u0df9\u0c5e\ud095\u04dc',
+  dimension: '2d',
+  format: 'astc-12x10-unorm-srgb',
+  mipLevelCount: 1,
+  baseArrayLayer: 111,
+});
+let sampler54 = device2.createSampler({
+  label: '\uc2f9\u4ae1\u72a4\u9377\u231f\u{1f74a}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 57.30,
+  lodMaxClamp: 95.81,
+  maxAnisotropy: 13,
+});
+let video15 = await videoWithData();
+try {
+adapter4.label = '\u{1f6b2}\u0eeb\ueb7f\ubb53\u7bfc';
+} catch {}
+try {
+renderBundleEncoder64.setVertexBuffer(1143, undefined, 2437886208);
+} catch {}
+let imageBitmap22 = await createImageBitmap(offscreenCanvas6);
+let textureView130 = texture45.createView({
+  label: '\u090e\u0c0b\ud19b\u789d\u{1fb26}\u7390\u0b7e\u35f2\u2e37',
+  mipLevelCount: 6,
+  baseArrayLayer: 0,
+});
+let renderBundleEncoder65 = device1.createRenderBundleEncoder({label: '\ud76d\u{1fa3b}\u0cfa\ud7b3\u064f\u4447', colorFormats: ['rg32uint'], sampleCount: 4});
+try {
+device1.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(81), /* required buffer size: 81 */
+{offset: 57}, {width: 3, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let textureView131 = texture91.createView({
+  label: '\u0435\u0806',
+  format: 'astc-12x10-unorm',
+  baseMipLevel: 1,
+  baseArrayLayer: 99,
+  arrayLayerCount: 3,
+});
+let sampler55 = device2.createSampler({
+  label: '\u3743\u0682\u0503\u8a22\u52d5\u332c',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 66.17,
+});
+let externalTexture70 = device2.importExternalTexture({
+  label: '\u{1fcec}\u0f61\u020b\u1ebb\u{1fb85}\uda0d\uc078\uec46\u03b5\u1ea7',
+  source: videoFrame2,
+  colorSpace: 'display-p3',
+});
+gc();
+let promise38 = adapter2.requestAdapterInfo();
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+let textureView132 = texture91.createView({label: '\u08d5\u9129\u85b5\u0585\u0cf7\ua46f', dimension: '2d', baseMipLevel: 1, baseArrayLayer: 109});
+let renderBundle71 = renderBundleEncoder64.finish();
+let imageBitmap23 = await createImageBitmap(img3);
+try {
+textureView132.label = '\ud20a\u0464\u6fc7\u5de2\ua7da\u{1fffe}\u07e5\ua408';
+} catch {}
+let renderBundle72 = renderBundleEncoder64.finish({label: '\u508d\u2386\u014d\u{1fd61}'});
+let sampler56 = device2.createSampler({
+  label: '\u9ab0\u1c17',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 69.84,
+  lodMaxClamp: 76.38,
+  maxAnisotropy: 5,
+});
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise38;
+} catch {}
+let imageBitmap24 = await createImageBitmap(imageBitmap20);
+let commandBuffer29 = commandEncoder114.finish();
+let texture92 = device2.createTexture({
+  label: '\u0d47\u0769\u0be9\uceef\u1534\u2220\uca4c\u8d47\u3c4a',
+  size: [32, 1, 106],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let buffer26 = device2.createBuffer({
+  label: '\u040c\u02cf\u03cf\ua606\u0ef1\u0b06',
+  size: 114179,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandBuffer30 = commandEncoder113.finish({});
+let texture93 = device2.createTexture({
+  label: '\ue885\u{1f8a3}\u0692\ubf5c',
+  size: {width: 64, height: 2, depthOrArrayLayers: 1},
+  mipLevelCount: 7,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8unorm'],
+});
+let textureView133 = texture91.createView({label: '\u8397\u2e74\u90e1\u{1f98e}', mipLevelCount: 1, baseArrayLayer: 141, arrayLayerCount: 36});
+try {
+commandEncoder115.pushDebugGroup('\u1040');
+} catch {}
+try {
+commandEncoder115.popDebugGroup();
+} catch {}
+let textureView134 = texture91.createView({dimension: '2d', baseMipLevel: 1, baseArrayLayer: 150});
+let computePassEncoder45 = commandEncoder115.beginComputePass({});
+let renderBundleEncoder66 = device2.createRenderBundleEncoder({label: '\u0d62\u{1f6e2}\u8379\ud7dd', colorFormats: ['r8unorm'], depthReadOnly: true});
+canvas8.height = 1403;
+document.body.prepend(img4);
+video15.height = 80;
+let buffer27 = device2.createBuffer({
+  label: '\uce6c\u50fa\uf137\u{1fab9}',
+  size: 285939,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder116 = device2.createCommandEncoder();
+let renderBundle73 = renderBundleEncoder66.finish({});
+try {
+  await device2.popErrorScope();
+} catch {}
+let img14 = await imageWithData(126, 108, '#f46d9250', '#63087d37');
+let textureView135 = texture91.createView({mipLevelCount: 1, baseArrayLayer: 159, arrayLayerCount: 5});
+let computePassEncoder46 = commandEncoder116.beginComputePass();
+let externalTexture71 = device2.importExternalTexture({source: video9});
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas21,
+  origin: { x: 9, y: 68 },
+  flipY: true,
+}, {
+  texture: texture93,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img10);
+let renderBundleEncoder67 = device2.createRenderBundleEncoder({colorFormats: ['r8unorm'], depthReadOnly: true, stencilReadOnly: true});
+let externalTexture72 = device2.importExternalTexture({label: '\ucbad\u08f3\u{1fd61}\u510f', source: videoFrame21, colorSpace: 'srgb'});
+try {
+device2.queue.writeTexture({
+  texture: texture93,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer10), /* required buffer size: 397 */
+{offset: 397}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas16,
+  origin: { x: 17, y: 0 },
+  flipY: true,
+}, {
+  texture: texture93,
+  mipLevel: 2,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas17 = document.createElement('canvas');
+let canvas18 = document.createElement('canvas');
+try {
+canvas18.getContext('webgl2');
+} catch {}
+let renderBundleEncoder68 = device2.createRenderBundleEncoder({label: '\ub0fe\ub3a4', colorFormats: ['r8unorm']});
+let sampler57 = device2.createSampler({
+  label: '\u0a98\u{1fe33}\u8e4a\u{1fa63}\u18a2\uc628\u9326\u1042\u{1f746}\u0901',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 58.76,
+});
+let externalTexture73 = device2.importExternalTexture({label: '\udd4a\u{1ffa6}\u61d2\u02ed', source: videoFrame19, colorSpace: 'srgb'});
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 4, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData21,
+  origin: { x: 0, y: 33 },
+  flipY: true,
+}, {
+  texture: texture93,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas8);
+let imageBitmap25 = await createImageBitmap(img11);
+try {
+canvas17.getContext('webgl2');
+} catch {}
+canvas1.height = 387;
+let renderBundle74 = renderBundleEncoder64.finish();
+try {
+renderBundleEncoder67.setVertexBuffer(2785, undefined, 0, 2124798094);
+} catch {}
+gc();
+let imageData25 = new ImageData(228, 12);
+let texture94 = device2.createTexture({
+  label: '\u08ac\u{1f66b}\u611b\uce85\u0d1a\uce1d\u{1f92b}\u020d\u3b7e\u0a7f',
+  size: [8],
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device2.pushErrorScope('internal');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture93,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(arrayBuffer5), /* required buffer size: 453 */
+{offset: 453, rowsPerImage: 199}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise39 = navigator.gpu.requestAdapter();
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let imageData26 = new ImageData(92, 212);
+let video16 = await videoWithData();
+let textureView136 = texture92.createView({aspect: 'all', baseMipLevel: 1, mipLevelCount: 2});
+try {
+device2.queue.writeBuffer(buffer27, 23628, new DataView(new ArrayBuffer(44105)), 13268, 7192);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 16, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video12,
+  origin: { x: 1, y: 6 },
+  flipY: false,
+}, {
+  texture: texture93,
+  mipLevel: 2,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.destroy();
+} catch {}
+let offscreenCanvas22 = new OffscreenCanvas(339, 209);
+let adapter5 = await promise39;
+let canvas19 = document.createElement('canvas');
+let img15 = await imageWithData(55, 191, '#b754f314', '#c0246a66');
+let renderBundle75 = renderBundleEncoder64.finish();
+try {
+buffer27.destroy();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video7,
+  origin: { x: 1, y: 2 },
+  flipY: false,
+}, {
+  texture: texture93,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let canvas20 = document.createElement('canvas');
+let video17 = await videoWithData();
+let offscreenCanvas23 = new OffscreenCanvas(222, 697);
+let img16 = await imageWithData(44, 200, '#53a020bc', '#08625a21');
+let gpuCanvasContext18 = canvas20.getContext('webgpu');
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let imageBitmap26 = await createImageBitmap(imageBitmap9);
+document.body.prepend(video3);
+gc();
+let offscreenCanvas24 = new OffscreenCanvas(152, 74);
+try {
+offscreenCanvas23.getContext('webgpu');
+} catch {}
+let videoFrame23 = new VideoFrame(videoFrame9, {timestamp: 0});
+let videoFrame24 = new VideoFrame(video5, {timestamp: 0});
+let gpuCanvasContext19 = offscreenCanvas22.getContext('webgpu');
+let imageData27 = new ImageData(172, 60);
+let img17 = await imageWithData(189, 274, '#eeafcaa4', '#24747d1f');
+let videoFrame25 = new VideoFrame(imageBitmap2, {timestamp: 0});
+document.body.prepend(video8);
+gc();
+let video18 = await videoWithData();
+let videoFrame26 = new VideoFrame(canvas8, {timestamp: 0});
+canvas7.height = 2162;
+video2.width = 48;
+try {
+adapter2.label = '\u{1fb14}\ucc4c\u8589\u{1f772}\u{1fb93}\u7a89\u036a\u48a5';
+} catch {}
+let gpuCanvasContext20 = canvas19.getContext('webgpu');
+let bindGroupLayout37 = device2.createBindGroupLayout({
+  label: '\u{1fe05}\u{1ffaf}',
+  entries: [
+    {binding: 3321, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 6218,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {
+      binding: 5920,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let pipelineLayout10 = device2.createPipelineLayout({
+  label: '\u291e\u81db\u0e10\u2599\u8674\u05ee\u6539\uf1e7\u153f\u{1fe53}',
+  bindGroupLayouts: [bindGroupLayout37, bindGroupLayout37, bindGroupLayout37],
+});
+let commandEncoder117 = device2.createCommandEncoder({label: '\u17b4\u{1f763}\u{1f7b0}\u469f\u{1ffe4}\u41c5\u8022'});
+let canvas21 = document.createElement('canvas');
+let canvas22 = document.createElement('canvas');
+try {
+gpuCanvasContext20.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let imageBitmap27 = await createImageBitmap(video7);
+let commandEncoder118 = device2.createCommandEncoder({label: '\u8add\u0f85\ud37d\u9fec\u{1fc7d}\ub48c'});
+let externalTexture74 = device2.importExternalTexture({
+  label: '\u04fb\u3fab\u0ce1\u44a3\u9422\u7d5e\u{1fd05}\u0410',
+  source: videoFrame21,
+  colorSpace: 'srgb',
+});
+try {
+canvas22.getContext('bitmaprenderer');
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+gc();
+let video19 = await videoWithData();
+let imageData28 = new ImageData(28, 200);
+offscreenCanvas12.width = 299;
+let gpuCanvasContext21 = offscreenCanvas24.getContext('webgpu');
+try {
+gpuCanvasContext19.unconfigure();
+} catch {}
+let img18 = await imageWithData(36, 128, '#853e1210', '#f958adaf');
+let videoFrame27 = new VideoFrame(imageBitmap2, {timestamp: 0});
+let imageBitmap28 = await createImageBitmap(imageBitmap24);
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+try {
+canvas21.getContext('webgpu');
+} catch {}
+document.body.prepend(img17);
+let offscreenCanvas25 = new OffscreenCanvas(448, 915);
+let imageBitmap29 = await createImageBitmap(video13);
+try {
+window.someLabel = externalTexture74.label;
+} catch {}
+let video20 = await videoWithData();
+let bindGroupLayout38 = device1.createBindGroupLayout({label: '\u0ac8\u7a92\ud21f\u0440\ua6d8\u8eac\u{1fb44}\u07b9\u8445\u0ff2\u0bd2', entries: []});
+let texture95 = device1.createTexture({
+  label: '\u{1ff7d}\u02b2\u2ef3\u{1ffd9}\u058a\u7698\u{1f828}\ubb91\u21d7',
+  size: [12, 1, 839],
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32uint', 'rg32uint'],
+});
+let textureView137 = texture45.createView({label: '\u3f88\u{1f9da}\u042d\u{1fd4b}', mipLevelCount: 1});
+let sampler58 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 86.44,
+  lodMaxClamp: 93.32,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder28.popDebugGroup();
+} catch {}
+let video21 = await videoWithData();
+let gpuCanvasContext22 = offscreenCanvas25.getContext('webgpu');
+let canvas23 = document.createElement('canvas');
+try {
+canvas23.getContext('bitmaprenderer');
+} catch {}
+let videoFrame28 = new VideoFrame(img5, {timestamp: 0});
+let promise40 = adapter4.requestAdapterInfo();
+try {
+window.someLabel = commandBuffer16.label;
+} catch {}
+let imageBitmap30 = await createImageBitmap(imageData14);
+document.body.prepend(canvas6);
+let canvas24 = document.createElement('canvas');
+let gpuCanvasContext23 = canvas24.getContext('webgpu');
+try {
+  await promise40;
+} catch {}
+offscreenCanvas22.height = 877;
+document.body.prepend(img12);
+gc();
+let video22 = await videoWithData();
+offscreenCanvas14.height = 847;
+let imageData29 = new ImageData(8, 112);
+let canvas25 = document.createElement('canvas');
+let videoFrame29 = new VideoFrame(videoFrame12, {timestamp: 0});
+let gpuCanvasContext24 = canvas25.getContext('webgpu');
+let imageBitmap31 = await createImageBitmap(videoFrame4);
+let pipelineLayout11 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout15, bindGroupLayout26, bindGroupLayout9, bindGroupLayout25]});
+let textureView138 = texture32.createView({baseMipLevel: 2});
+try {
+renderPassEncoder26.setBindGroup(3, bindGroup40, [0]);
+} catch {}
+try {
+renderPassEncoder22.beginOcclusionQuery(766);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer0, 'uint32');
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(3, buffer10, 126024, 117037);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(5, bindGroup5, new Uint32Array(8920), 1300, 0);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(2, buffer10, 306232, 12480);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 60184, new DataView(new ArrayBuffer(65411)), 17688, 12868);
+} catch {}
+let promise41 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+document.body.prepend(canvas2);
+try {
+window.someLabel = device1.label;
+} catch {}
+try {
+  await promise41;
+} catch {}
+let video23 = await videoWithData();
+let commandEncoder119 = device2.createCommandEncoder({label: '\u0e36\u6abc\u042a\uf2f1\ub0ca\u096d\u{1fbcd}\u06cc'});
+let querySet54 = device2.createQuerySet({label: '\u0b18\u0f71\u0cc1\u9c66\u6823', type: 'occlusion', count: 3507});
+let textureView139 = texture93.createView({
+  label: '\u{1fc31}\ub134\u00a8\uf205\u01db\u{1fede}\u4a3f',
+  dimension: '2d-array',
+  aspect: 'all',
+  baseMipLevel: 4,
+});
+try {
+commandEncoder119.clearBuffer(buffer27, 270188, 1492);
+dissociateBuffer(device2, buffer27);
+} catch {}
+let imageBitmap32 = await createImageBitmap(imageBitmap18);
+video15.width = 164;
+let renderBundleEncoder69 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8uint', 'rgba32uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler59 = device0.createSampler({
+  label: '\udfb9\u1623\u4900\uba83\ufef4\u{1f8b6}\u273a\u6197\u0bd2',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 14.07,
+  lodMaxClamp: 58.05,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder7.setPipeline(pipeline34);
+} catch {}
+try {
+renderPassEncoder17.setBlendConstant({ r: 452.1, g: 762.4, b: -207.3, a: -319.0, });
+} catch {}
+try {
+renderPassEncoder9.setViewport(44.14, 0.4986, 39.06, 0.2527, 0.9633, 0.9817);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer14, 'uint16', 29562, 2172);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(4, buffer14);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer10), /* required buffer size: 42 */
+{offset: 42}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let promise42 = adapter5.requestDevice({
+  requiredLimits: {
+    maxColorAttachmentBytesPerSample: 43,
+    maxVertexAttributes: 26,
+    maxVertexBufferArrayStride: 25142,
+    maxStorageTexturesPerShaderStage: 32,
+    maxStorageBuffersPerShaderStage: 37,
+    maxDynamicStorageBuffersPerPipelineLayout: 56363,
+    maxDynamicUniformBuffersPerPipelineLayout: 58104,
+    maxBindingsPerBindGroup: 4359,
+    maxTextureArrayLayers: 564,
+    maxTextureDimension1D: 13470,
+    maxTextureDimension2D: 14671,
+    maxBindGroupsPlusVertexBuffers: 25,
+    minStorageBufferOffsetAlignment: 128,
+    minUniformBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 172116749,
+    maxStorageBufferBindingSize: 228126809,
+    maxUniformBuffersPerShaderStage: 42,
+    maxSampledTexturesPerShaderStage: 36,
+    maxInterStageShaderVariables: 77,
+    maxInterStageShaderComponents: 76,
+    maxSamplersPerShaderStage: 22,
+  },
+});
+try {
+adapter0.label = '\u{1ff48}\u09d4\u14b9\u0ab9\u0830\u079c\ub6d1\u4e21';
+} catch {}
+let img19 = await imageWithData(71, 130, '#5d6d359c', '#65a40e2e');
+let imageData30 = new ImageData(136, 204);
+gc();
+try {
+window.someLabel = externalTexture35.label;
+} catch {}
+let video24 = await videoWithData();
+try {
+window.someLabel = externalTexture62.label;
+} catch {}
+let imageBitmap33 = await createImageBitmap(img18);
+try {
+window.someLabel = device1.queue.label;
+} catch {}
+document.body.prepend(img10);
+offscreenCanvas11.width = 618;
+let img20 = await imageWithData(17, 42, '#5117099f', '#317b0f7d');
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let videoFrame30 = new VideoFrame(videoFrame14, {timestamp: 0});
+let imageBitmap34 = await createImageBitmap(imageBitmap19);
+try {
+externalTexture74.label = '\u04a6\u464d';
+} catch {}
+offscreenCanvas21.width = 1177;
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+document.body.prepend(img6);
+let canvas26 = document.createElement('canvas');
+canvas10.height = 417;
+try {
+canvas26.getContext('bitmaprenderer');
+} catch {}
+let img21 = await imageWithData(187, 208, '#f2876ab0', '#741a9c26');
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let imageData31 = new ImageData(20, 140);
+let bindGroupLayout39 = device0.createBindGroupLayout({label: '\uedad\u0464\u0604\u26ce\u5a53\ud90d', entries: []});
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer11, 'uint16');
+} catch {}
+try {
+renderBundleEncoder53.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 173, y: 7 },
+  flipY: true,
+}, {
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap35 = await createImageBitmap(imageData29);
+let canvas27 = document.createElement('canvas');
+let img22 = await imageWithData(239, 260, '#196deea5', '#44a37dfd');
+let offscreenCanvas26 = new OffscreenCanvas(536, 4);
+try {
+canvas27.getContext('webgl');
+} catch {}
+try {
+offscreenCanvas26.getContext('bitmaprenderer');
+} catch {}
+video19.height = 173;
+let imageData32 = new ImageData(20, 244);
+try {
+  await adapter3.requestAdapterInfo();
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let canvas28 = document.createElement('canvas');
+try {
+canvas28.getContext('webgpu');
+} catch {}
+try {
+window.someLabel = externalTexture54.label;
+} catch {}
+let canvas29 = document.createElement('canvas');
+try {
+gpuCanvasContext22.unconfigure();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+canvas29.getContext('webgpu');
+} catch {}
+video10.height = 58;
+try {
+pipeline3.label = '\u6a2e\uf554\u0793\u021c\u0e1e\u0bf3\u0958\uc5bd\u03f4\uc5fd';
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let videoFrame31 = new VideoFrame(imageBitmap16, {timestamp: 0});
+gc();
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let img23 = await imageWithData(263, 105, '#57299d63', '#b7f3ffa0');
+video0.height = 2;
+let offscreenCanvas27 = new OffscreenCanvas(576, 630);
+let gpuCanvasContext25 = offscreenCanvas27.getContext('webgpu');
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+let offscreenCanvas28 = new OffscreenCanvas(220, 97);
+let video25 = await videoWithData();
+let gpuCanvasContext26 = offscreenCanvas28.getContext('webgpu');
+try {
+window.someLabel = renderBundleEncoder66.label;
+} catch {}
+let offscreenCanvas29 = new OffscreenCanvas(851, 587);
+let imageData33 = new ImageData(212, 208);
+let canvas30 = document.createElement('canvas');
+gc();
+let img24 = await imageWithData(262, 93, '#16f48189', '#1344f2d2');
+let imageBitmap36 = await createImageBitmap(imageData27);
+let img25 = await imageWithData(78, 21, '#4622a3a1', '#41fb069f');
+let imageData34 = new ImageData(232, 228);
+let gpuCanvasContext27 = offscreenCanvas29.getContext('webgpu');
+let imageBitmap37 = await createImageBitmap(offscreenCanvas0);
+let video26 = await videoWithData();
+let gpuCanvasContext28 = canvas30.getContext('webgpu');
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let video27 = await videoWithData();
+let img26 = await imageWithData(93, 105, '#a4d27caf', '#6e003ac9');
+let imageData35 = new ImageData(220, 144);
+let canvas31 = document.createElement('canvas');
+try {
+canvas31.getContext('2d');
+} catch {}
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+gc();
+let imageData36 = new ImageData(76, 32);
+try {
+  await adapter3.requestAdapterInfo();
+} catch {}
+document.body.prepend(video27);
+let imageBitmap38 = await createImageBitmap(img11);
+offscreenCanvas6.height = 253;
+let imageBitmap39 = await createImageBitmap(canvas23);
+document.body.prepend(canvas15);
+let videoFrame32 = new VideoFrame(canvas14, {timestamp: 0});
+let offscreenCanvas30 = new OffscreenCanvas(961, 685);
+video20.height = 78;
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let imageBitmap40 = await createImageBitmap(videoFrame31);
+let canvas32 = document.createElement('canvas');
+let video28 = await videoWithData();
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let video29 = await videoWithData();
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let img27 = await imageWithData(27, 210, '#80a51ba1', '#95f20561');
+try {
+offscreenCanvas30.getContext('webgl2');
+} catch {}
+try {
+canvas32.getContext('bitmaprenderer');
+} catch {}
+let videoFrame33 = new VideoFrame(video3, {timestamp: 0});
+document.body.prepend(img1);
+let texture96 = device2.createTexture({
+  label: '\u{1fb12}\u3cd2\u35ad\u{1ffc5}\u{1f8d5}\ubcf2\u01c1\ucf6c',
+  size: {width: 8, height: 1, depthOrArrayLayers: 26},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r8unorm'],
+});
+let textureView140 = texture96.createView({
+  label: '\u087c\u8a32\u17e2\u6e13\u0483\u{1fabc}\u{1f832}\u{1fdc1}\u{1f935}',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+let computePassEncoder47 = commandEncoder118.beginComputePass({});
+let renderPassEncoder48 = commandEncoder117.beginRenderPass({
+  label: '\u1cac\u9c51\u0a26\uc7a4\u5c86\u6f5f\u285d\ue212\u0214\u16c9',
+  colorAttachments: [{
+  view: textureView140,
+  depthSlice: 1,
+  clearValue: { r: -844.4, g: -22.54, b: -50.98, a: 387.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet54,
+  maxDrawCount: 303946007,
+});
+let externalTexture75 = device2.importExternalTexture({label: '\u01a7\u4741\u399e\u{1fed7}\u0113\u0dca', source: video25, colorSpace: 'display-p3'});
+try {
+renderPassEncoder48.setBlendConstant({ r: 397.0, g: -21.49, b: -550.0, a: 592.3, });
+} catch {}
+try {
+renderPassEncoder48.setScissorRect(0, 1, 2, 0);
+} catch {}
+let videoFrame34 = videoFrame13.clone();
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+gc();
+let canvas33 = document.createElement('canvas');
+try {
+canvas33.getContext('2d');
+} catch {}
+let canvas34 = document.createElement('canvas');
+let imageBitmap41 = await createImageBitmap(videoFrame26);
+let canvas35 = document.createElement('canvas');
+let offscreenCanvas31 = new OffscreenCanvas(80, 196);
+try {
+sampler27.label = '\u2bbc\ueb31\u6297';
+} catch {}
+document.body.prepend(img22);
+let gpuCanvasContext29 = canvas34.getContext('webgpu');
+let img28 = await imageWithData(84, 185, '#77daa774', '#833a74f6');
+let videoFrame35 = new VideoFrame(offscreenCanvas19, {timestamp: 0});
+gc();
+let imageData37 = new ImageData(72, 212);
+try {
+offscreenCanvas31.getContext('webgpu');
+} catch {}
+let img29 = await imageWithData(197, 222, '#fb0da4ee', '#30059cc5');
+let gpuCanvasContext30 = canvas35.getContext('webgpu');
+let img30 = await imageWithData(163, 39, '#fb920a0f', '#0db01361');
+try {
+gpuCanvasContext20.unconfigure();
+} catch {}
+let video30 = await videoWithData();
+let imageBitmap42 = await createImageBitmap(img2);
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend(video20);
+try {
+gpuCanvasContext27.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let buffer28 = device2.createBuffer({
+  label: '\u9fd2\u04fc\u0159\u{1ff44}\u49c1\u{1f7fb}',
+  size: 443384,
+  usage: GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: true,
+});
+let textureView141 = texture92.createView({label: '\u0530\u{1fd30}\u6c15\u36f8\u{1f82b}\u02b2\u00e6\u{1f65b}', baseMipLevel: 1, mipLevelCount: 1});
+let renderBundleEncoder70 = device2.createRenderBundleEncoder({colorFormats: ['r8unorm']});
+let renderBundle76 = renderBundleEncoder67.finish();
+let externalTexture76 = device2.importExternalTexture({label: '\u0373\u{1f8da}', source: videoFrame27});
+try {
+renderPassEncoder48.setStencilReference(740);
+} catch {}
+try {
+commandEncoder119.copyTextureToBuffer({
+  texture: texture92,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 7506 */
+  offset: 7506,
+  bytesPerRow: 0,
+  rowsPerImage: 264,
+  buffer: buffer27,
+}, {width: 0, height: 1, depthOrArrayLayers: 12});
+dissociateBuffer(device2, buffer27);
+} catch {}
+try {
+commandEncoder119.copyTextureToTexture({
+  texture: texture92,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture93,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder119.resolveQuerySet(querySet54, 2429, 412, buffer28, 19200);
+} catch {}
+let imageBitmap43 = await createImageBitmap(img27);
+try {
+window.someLabel = device1.label;
+} catch {}
+try {
+adapter3.label = '\u0891\u04c1\u0d9d\u{1f9bb}';
+} catch {}
+let imageData38 = new ImageData(28, 184);
+let video31 = await videoWithData();
+let canvas36 = document.createElement('canvas');
+let imageData39 = new ImageData(72, 104);
+try {
+canvas36.getContext('webgl2');
+} catch {}
+try {
+adapter5.label = '\u0467\u5892\u{1f613}';
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let canvas37 = document.createElement('canvas');
+let offscreenCanvas32 = new OffscreenCanvas(573, 850);
+let videoFrame36 = new VideoFrame(img11, {timestamp: 0});
+document.body.prepend(canvas37);
+video30.height = 29;
+gc();
+let adapter6 = await navigator.gpu.requestAdapter({powerPreference: 'high-performance'});
+let gpuCanvasContext31 = offscreenCanvas32.getContext('webgpu');
+try {
+  await adapter6.requestAdapterInfo();
+} catch {}
+let gpuCanvasContext32 = canvas37.getContext('webgpu');
+gc();
+let offscreenCanvas33 = new OffscreenCanvas(375, 702);
+document.body.prepend(video22);
+let canvas38 = document.createElement('canvas');
+let videoFrame37 = new VideoFrame(canvas29, {timestamp: 0});
+try {
+adapter0.label = '\uf73f\ued96\u6f34\u{1fb7f}\u{1fdc2}\u0a14\uf3d2\u{1fc3b}\u01ea\u{1f86a}\u{1f73d}';
+} catch {}
+let videoFrame38 = new VideoFrame(img16, {timestamp: 0});
+let video32 = await videoWithData();
+let imageBitmap44 = await createImageBitmap(canvas28);
+try {
+offscreenCanvas33.getContext('2d');
+} catch {}
+video20.height = 13;
+offscreenCanvas16.height = 1866;
+let imageData40 = new ImageData(188, 204);
+let videoFrame39 = new VideoFrame(videoFrame15, {timestamp: 0});
+document.body.prepend(img15);
+let videoFrame40 = new VideoFrame(imageBitmap10, {timestamp: 0});
+document.body.prepend(video24);
+canvas13.height = 1667;
+try {
+gpuCanvasContext20.unconfigure();
+} catch {}
+gc();
+let imageData41 = new ImageData(212, 28);
+document.body.prepend(video20);
+let gpuCanvasContext33 = canvas38.getContext('webgpu');
+let imageBitmap45 = await createImageBitmap(imageBitmap30);
+try {
+sampler27.label = '\u011c\u0152\u0d8f\u0f4a\uef5c\ucff6\u{1fcf4}\u05c9\u7baf\u0a29\u{1f9ab}';
+} catch {}
+try {
+  await adapter6.requestAdapterInfo();
+} catch {}
+gc();
+let videoFrame41 = new VideoFrame(img6, {timestamp: 0});
+try {
+window.someLabel = renderBundle37.label;
+} catch {}
+video16.height = 234;
+let imageData42 = new ImageData(184, 208);
+let promise43 = adapter2.requestAdapterInfo();
+let canvas39 = document.createElement('canvas');
+try {
+window.someLabel = renderBundleEncoder36.label;
+} catch {}
+document.body.prepend(img12);
+document.body.prepend(img4);
+try {
+  await promise43;
+} catch {}
+let offscreenCanvas34 = new OffscreenCanvas(123, 47);
+let gpuCanvasContext34 = offscreenCanvas34.getContext('webgpu');
+let imageBitmap46 = await createImageBitmap(imageData18);
+try {
+bindGroupLayout17.label = '\u07ca\u22a2\u02d8';
+} catch {}
+try {
+canvas39.getContext('2d');
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+adapter4.label = '\u0427\u3925\u675e\u{1fd59}\u{1fde6}\ud546\u278f\u09b6\u07f1\u{1f93e}';
+} catch {}
+video24.width = 151;
+try {
+gpuCanvasContext19.unconfigure();
+} catch {}
+canvas7.width = 320;
+let offscreenCanvas35 = new OffscreenCanvas(804, 977);
+let gpuCanvasContext35 = offscreenCanvas35.getContext('webgpu');
+let videoFrame42 = new VideoFrame(img7, {timestamp: 0});
+let offscreenCanvas36 = new OffscreenCanvas(684, 6);
+let gpuCanvasContext36 = offscreenCanvas36.getContext('webgpu');
+gc();
+try {
+window.someLabel = device2.label;
+} catch {}
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+let textureView142 = texture95.createView({baseMipLevel: 8});
+let externalTexture77 = device1.importExternalTexture({label: '\u784e\u089e\u01da\ub846\u0df5', source: video21, colorSpace: 'srgb'});
+let offscreenCanvas37 = new OffscreenCanvas(552, 206);
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+let video33 = await videoWithData();
+gc();
+try {
+window.someLabel = externalTexture75.label;
+} catch {}
+let offscreenCanvas38 = new OffscreenCanvas(332, 210);
+let imageData43 = new ImageData(56, 232);
+canvas37.height = 278;
+let commandEncoder120 = device0.createCommandEncoder({label: '\u6487\u0938\u{1fcbd}'});
+let querySet55 = device0.createQuerySet({type: 'occlusion', count: 1888});
+let texture97 = device0.createTexture({
+  label: '\u0647\ud5f8\u0bdf\u505f\u3e0f\u0083\udcb2',
+  size: [192, 1, 243],
+  mipLevelCount: 6,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint'],
+});
+let textureView143 = texture97.createView({label: '\ua148\ua280\u467b\u9bc9\u084e\u0f62\ub76e\ucfc4', aspect: 'all', baseMipLevel: 5});
+let computePassEncoder48 = commandEncoder120.beginComputePass({label: '\u0d56\u8584\u0296\u1d28\ub94e\uff89\uff49\u92e5\u5236\u{1fb1d}\uabc8'});
+let renderBundle77 = renderBundleEncoder3.finish();
+try {
+renderPassEncoder29.setBindGroup(1, bindGroup24, []);
+} catch {}
+try {
+renderPassEncoder42.setVertexBuffer(5, buffer14, 18196, 2847);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 29208, new DataView(new ArrayBuffer(50708)), 12, 10176);
+} catch {}
+let gpuCanvasContext37 = offscreenCanvas37.getContext('webgpu');
+try {
+adapter6.label = '\u0fe7\u{1f7f5}\u6ac0\u0d9d\u20d1\u{1feae}\u{1f615}\u5dd2\u0cac\u9816';
+} catch {}
+canvas16.height = 31;
+try {
+offscreenCanvas38.getContext('webgl');
+} catch {}
+try {
+sampler57.label = '\u1556\u2c57\u029e\ub996\u0f72\u7290\u05c0';
+} catch {}
+try {
+window.someLabel = externalTexture76.label;
+} catch {}
+let offscreenCanvas39 = new OffscreenCanvas(229, 965);
+let textureView144 = texture89.createView({
+  label: '\uf7ec\u010a\u0b69\u{1fbab}\u{1f85d}\u0fc8\u{1f729}',
+  aspect: 'all',
+  format: 'bgra8unorm-srgb',
+});
+let sampler60 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 6.559,
+  lodMaxClamp: 21.07,
+});
+try {
+renderPassEncoder38.setViewport(170.6, 0.6080, 12.61, 0.3109, 0.8904, 0.9740);
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(2, bindGroup24);
+} catch {}
+try {
+renderBundleEncoder69.setVertexBuffer(1, buffer10);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img25,
+  origin: { x: 2, y: 5 },
+  flipY: false,
+}, {
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline68 = device0.createRenderPipeline({
+  layout: 'auto',
+  multisample: {},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: 0}, {format: 'rgba32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 5604,
+        attributes: [
+          {format: 'sint16x4', offset: 352, shaderLocation: 2},
+          {format: 'sint32x2', offset: 972, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 1552, shaderLocation: 8},
+          {format: 'uint32x2', offset: 340, shaderLocation: 6},
+          {format: 'float16x2', offset: 444, shaderLocation: 3},
+          {format: 'snorm8x2', offset: 1888, shaderLocation: 14},
+          {format: 'float16x4', offset: 416, shaderLocation: 0},
+          {format: 'snorm8x2', offset: 772, shaderLocation: 10},
+          {format: 'float16x4', offset: 224, shaderLocation: 12},
+          {format: 'sint16x4', offset: 1112, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 3234, shaderLocation: 9},
+          {format: 'uint16x4', offset: 0, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 3480,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 480, shaderLocation: 5},
+          {format: 'float32x3', offset: 340, shaderLocation: 15},
+        ],
+      },
+      {arrayStride: 7828, attributes: []},
+      {arrayStride: 11544, stepMode: 'instance', attributes: []},
+      {arrayStride: 17276, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 18996,
+        attributes: [
+          {format: 'sint8x4', offset: 1452, shaderLocation: 13},
+          {format: 'unorm16x4', offset: 980, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+});
+document.body.prepend(video18);
+try {
+window.someLabel = pipeline27.label;
+} catch {}
+let offscreenCanvas40 = new OffscreenCanvas(211, 662);
+let img31 = await imageWithData(127, 7, '#0d54b9c0', '#6b8b949d');
+let imageData44 = new ImageData(20, 88);
+try {
+externalTexture64.label = '\ua1cd\u81d0\ua163\u9c2c';
+} catch {}
+let img32 = await imageWithData(179, 126, '#48db35f5', '#f1a84291');
+let gpuCanvasContext38 = offscreenCanvas39.getContext('webgpu');
+let video34 = await videoWithData();
+let commandEncoder121 = device2.createCommandEncoder();
+let textureView145 = texture92.createView({baseMipLevel: 2, mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder49 = commandEncoder121.beginComputePass({label: '\ucadd\uece5'});
+let renderPassEncoder49 = commandEncoder119.beginRenderPass({
+  label: '\u088d\ub358\u0889\u8cf8\u{1f9bf}\uedec\u681d\u0175\u0032\u{1f7db}\u{1fe59}',
+  colorAttachments: [{
+  view: textureView140,
+  depthSlice: 0,
+  clearValue: { r: -920.6, g: 291.9, b: -510.8, a: -673.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 237649022,
+});
+let renderBundle78 = renderBundleEncoder70.finish({label: '\u{1f91e}\u{1ff5b}\u3fa0\u02b6'});
+let videoFrame43 = new VideoFrame(img2, {timestamp: 0});
+try {
+bindGroupLayout38.label = '\uc646\ubdfb\uf621\u0721\uab7b\uee3e\u7d94\u0bf9\u{1fb27}\u078b';
+} catch {}
+let pipelineLayout12 = device1.createPipelineLayout({
+  label: '\u{1f705}\u6c45\ua457\u3faf\u{1feec}\u4e60\u{1f740}\u{1fc49}\uabb0\u{1f862}',
+  bindGroupLayouts: [bindGroupLayout38],
+});
+let commandEncoder122 = device1.createCommandEncoder({label: '\u4aa4\u1d65\ucf00\u{1fda2}\u04c5\u{1f686}\u{1f854}'});
+let textureView146 = texture44.createView({label: '\ua1b1\u{1fb37}\u979e\u7c7f\u193d\u{1f98c}\u3f51\u053e', dimension: '2d-array', aspect: 'all'});
+let computePassEncoder50 = commandEncoder122.beginComputePass({label: '\u{1f8c1}\uc2db'});
+try {
+renderBundleEncoder65.setVertexBuffer(226, undefined, 0, 3417700759);
+} catch {}
+try {
+  await buffer23.mapAsync(GPUMapMode.WRITE, 381376, 4328);
+} catch {}
+canvas9.height = 4;
+let video35 = await videoWithData();
+let gpuCanvasContext39 = offscreenCanvas40.getContext('webgpu');
+canvas24.width = 1616;
+gc();
+let imageBitmap47 = await createImageBitmap(imageBitmap34);
+try {
+adapter5.label = '\ud7af\u{1fdb5}\u0b21';
+} catch {}
+let offscreenCanvas41 = new OffscreenCanvas(117, 962);
+try {
+offscreenCanvas41.getContext('2d');
+} catch {}
+document.body.prepend(canvas6);
+let textureView147 = texture45.createView({label: '\u{1f9af}\u042c', baseMipLevel: 3, mipLevelCount: 3, baseArrayLayer: 0, arrayLayerCount: 1});
+try {
+computePassEncoder50.insertDebugMarker('\u1f04');
+} catch {}
+try {
+renderBundleEncoder54.insertDebugMarker('\u05d0');
+} catch {}
+try {
+gpuCanvasContext29.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+offscreenCanvas40.height = 321;
+gc();
+let imageBitmap48 = await createImageBitmap(img22);
+document.body.prepend(img13);
+try {
+adapter5.label = '\u9f95\ub3c3\u7066';
+} catch {}
+let querySet56 = device0.createQuerySet({label: '\ub2da\u69cc\u9980\ud0b4\u0021\u0f6f\u066a\u01bd\u0337', type: 'occlusion', count: 2538});
+let textureView148 = texture74.createView({label: '\u0282\ud804\u2eee\u423b\ua9ed\u1c0a\u{1f899}\u{1f6b7}\uf63f\u0f44', baseMipLevel: 0});
+let renderBundle79 = renderBundleEncoder11.finish({label: '\u{1ff4d}\u4e4f\u08e3\u06eb\udf39'});
+try {
+renderBundleEncoder69.setBindGroup(4, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder45.setIndexBuffer(buffer5, 'uint16', 60786);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline13);
+} catch {}
+try {
+renderBundleEncoder44.setVertexBuffer(4, buffer10, 0, 172837);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let imageBitmap49 = await createImageBitmap(videoFrame19);
+let img33 = await imageWithData(39, 18, '#0365ee32', '#07cd411e');
+let video36 = await videoWithData();
+let texture98 = device2.createTexture({
+  label: '\u058e\u{1fae2}\u94cc\u{1f941}\u0d95\u{1f90c}\u0f5d\u5b94',
+  size: {width: 32},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8unorm', 'r8unorm', 'r8unorm'],
+});
+let textureView149 = texture91.createView({label: '\u41da\u{1fd93}', mipLevelCount: 1, baseArrayLayer: 162, arrayLayerCount: 5});
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let promise44 = navigator.gpu.requestAdapter({});
+let imageData45 = new ImageData(216, 180);
+let videoFrame44 = new VideoFrame(videoFrame8, {timestamp: 0});
+let imageBitmap50 = await createImageBitmap(video22);
+document.body.prepend(canvas3);
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let imageData46 = new ImageData(36, 252);
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+offscreenCanvas39.width = 168;
+try {
+window.someLabel = querySet49.label;
+} catch {}
+let canvas40 = document.createElement('canvas');
+let videoFrame45 = new VideoFrame(video16, {timestamp: 0});
+try {
+adapter5.label = '\ue7e5\u{1fd63}\u076f\u77a9\u{1ffcf}\u6780\uae9e\u{1f9c1}\u{1fe0c}';
+} catch {}
+let canvas41 = document.createElement('canvas');
+let img34 = await imageWithData(63, 118, '#ce18c9e5', '#81a56691');
+let imageBitmap51 = await createImageBitmap(video4);
+try {
+canvas41.getContext('2d');
+} catch {}
+let video37 = await videoWithData();
+try {
+adapter6.label = '\u{1f853}\ue3cc\u{1fedd}\u5a59\ubb2e\ue041\u70e8\ua475\u{1fb54}\uc518';
+} catch {}
+document.body.prepend(canvas27);
+let gpuCanvasContext40 = canvas40.getContext('webgpu');
+let imageData47 = new ImageData(136, 48);
+let img35 = await imageWithData(277, 196, '#38216c88', '#3cf11750');
+let videoFrame46 = new VideoFrame(video32, {timestamp: 0});
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let commandEncoder123 = device1.createCommandEncoder({label: '\ue591\uaf55\u9508\u0eb9\u08d9\u2b55\u038d'});
+let externalTexture78 = device1.importExternalTexture({label: '\u0718\u3863\u6c0a\uaf44\uda28\u{1fd8f}', source: videoFrame38, colorSpace: 'srgb'});
+try {
+renderBundleEncoder50.insertDebugMarker('\u7420');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 3,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 106 */
+{offset: 106}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+externalTexture8.label = '\u7164\u0916\ub4e9\udf1c\ub409\u3ce9\u0804';
+} catch {}
+canvas5.width = 2155;
+gc();
+let imageBitmap52 = await createImageBitmap(img4);
+try {
+gpuCanvasContext21.unconfigure();
+} catch {}
+let canvas42 = document.createElement('canvas');
+let texture99 = device2.createTexture({
+  label: '\uc289\ua1aa\u0ae9\u113b\u{1f852}\u4a27\ube78\u{1fd30}\u961a\u4639\u0a96',
+  size: [32],
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8unorm'],
+});
+let textureView150 = texture93.createView({label: '\u{1f8b4}\uf35e', dimension: '2d-array', baseMipLevel: 1, mipLevelCount: 3});
+let renderBundle80 = renderBundleEncoder68.finish();
+let sampler61 = device2.createSampler({
+  label: '\u842e\uc69e\u2ce8\ue5b8\u538a',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 7.111,
+  lodMaxClamp: 81.29,
+  maxAnisotropy: 12,
+});
+try {
+renderPassEncoder48.end();
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+let videoFrame47 = new VideoFrame(img18, {timestamp: 0});
+let videoFrame48 = new VideoFrame(imageBitmap50, {timestamp: 0});
+let img36 = await imageWithData(167, 96, '#323608d5', '#fc7189d7');
+offscreenCanvas15.width = 1971;
+let canvas43 = document.createElement('canvas');
+try {
+canvas43.getContext('webgl');
+} catch {}
+let renderBundleEncoder71 = device2.createRenderBundleEncoder({colorFormats: ['r8unorm'], depthReadOnly: true});
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+offscreenCanvas7.height = 262;
+let img37 = await imageWithData(187, 134, '#d86fa999', '#5485cfee');
+let imageData48 = new ImageData(24, 72);
+try {
+canvas42.getContext('webgl');
+} catch {}
+let img38 = await imageWithData(225, 22, '#1ca805e0', '#38eb6a0b');
+let img39 = await imageWithData(83, 252, '#73cf40e2', '#9096486a');
+let bindGroup41 = device1.createBindGroup({label: '\u{1f937}\u0404\u624e\u5e34\u07dc\u40c9', layout: bindGroupLayout38, entries: []});
+let commandEncoder124 = device1.createCommandEncoder();
+let renderBundle81 = renderBundleEncoder50.finish({label: '\u5db2\uf911\uc6da\u22e5\u70a8\u{1fbdd}\u05ff'});
+let externalTexture79 = device1.importExternalTexture({label: '\u070c\u0ea1', source: videoFrame41});
+try {
+renderBundleEncoder65.setBindGroup(5, bindGroup41);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 337 */
+{offset: 337}, {width: 2, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let videoFrame49 = new VideoFrame(videoFrame29, {timestamp: 0});
+gc();
+let imageData49 = new ImageData(116, 16);
+canvas36.height = 2128;
+try {
+window.someLabel = externalTexture70.label;
+} catch {}
+let textureView151 = texture91.createView({
+  label: '\u0c9e\u0fd0\u{1fdb5}\u07ad',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 64,
+});
+let sampler62 = device2.createSampler({
+  label: '\ufd30\u{1fa89}\u0239\u{1ff51}\u0fa5\u087e\u4412\ud499\u352e',
+  addressModeW: 'clamp-to-edge',
+  lodMaxClamp: 85.85,
+});
+let externalTexture80 = device2.importExternalTexture({label: '\u0940\u5718\u8c04\u{1f605}\u{1fbc0}', source: videoFrame33, colorSpace: 'srgb'});
+try {
+gpuCanvasContext39.unconfigure();
+} catch {}
+try {
+adapter5.label = '\ud19e\u581e\ub1ed\u502c\u{1fa26}\u0c28\ufa6f\u9b9b';
+} catch {}
+document.body.prepend(video14);
+let offscreenCanvas42 = new OffscreenCanvas(793, 946);
+let video38 = await videoWithData();
+let canvas44 = document.createElement('canvas');
+let gpuCanvasContext41 = offscreenCanvas42.getContext('webgpu');
+gc();
+let imageData50 = new ImageData(116, 140);
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+let offscreenCanvas43 = new OffscreenCanvas(596, 197);
+let commandEncoder125 = device1.createCommandEncoder({label: '\u05c9\u9760\ua63a\u0f09\u{1fa63}\u{1f6a3}\uae1f'});
+let querySet57 = device1.createQuerySet({type: 'occlusion', count: 1178});
+let texture100 = device1.createTexture({
+  label: '\u0ffb\ua67c\u04e6\u056c\u{1fa85}\u30b2\ueebf\u8bf3\u{1f7ec}\u08d5',
+  size: {width: 540, height: 1, depthOrArrayLayers: 83},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle82 = renderBundleEncoder57.finish({label: '\u7c67\u007c'});
+try {
+device1.queue.writeTexture({
+  texture: texture45,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer8), /* required buffer size: 862 */
+{offset: 862}, {width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext42 = canvas44.getContext('webgpu');
+let offscreenCanvas44 = new OffscreenCanvas(950, 930);
+let imageData51 = new ImageData(200, 100);
+try {
+adapter3.label = '\u{1fe01}\u0470';
+} catch {}
+let gpuCanvasContext43 = offscreenCanvas44.getContext('webgpu');
+try {
+gpuCanvasContext36.unconfigure();
+} catch {}
+try {
+offscreenCanvas43.getContext('webgl');
+} catch {}
+let img40 = await imageWithData(26, 213, '#9fbf5cdd', '#a4ef12de');
+let canvas45 = document.createElement('canvas');
+let video39 = await videoWithData();
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let promise45 = adapter3.requestAdapterInfo();
+let gpuCanvasContext44 = canvas45.getContext('webgpu');
+gc();
+gc();
+let commandBuffer31 = commandEncoder125.finish({label: '\u0a65\u0e4e\u97a9'});
+let videoFrame50 = new VideoFrame(video33, {timestamp: 0});
+let videoFrame51 = new VideoFrame(canvas29, {timestamp: 0});
+let buffer29 = device1.createBuffer({
+  label: '\u8563\u{1fbd1}\uaea3\u5cfa\u06ac\u{1fbee}\u8599\u30c8\ubf82\u48d8',
+  size: 114900,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let querySet58 = device1.createQuerySet({label: '\u0633\u0d58\u0279', type: 'occlusion', count: 921});
+let textureView152 = texture100.createView({
+  label: '\u0a91\u31ba\u58f1\u06a5\ud054\u{1fd26}\u086d\u18c6',
+  baseMipLevel: 2,
+  mipLevelCount: 4,
+  arrayLayerCount: 1,
+});
+let externalTexture81 = device1.importExternalTexture({source: video33});
+try {
+computePassEncoder28.setBindGroup(9, bindGroup41);
+} catch {}
+try {
+renderBundleEncoder65.setVertexBuffer(8, buffer29, 0, 22868);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+try {
+  await promise45;
+} catch {}
+let img41 = await imageWithData(255, 83, '#41d5ebd0', '#606725b1');
+let img42 = await imageWithData(295, 207, '#95154430', '#51a19af2');
+try {
+gpuCanvasContext43.unconfigure();
+} catch {}
+document.body.prepend(video6);
+document.body.prepend(img6);
+let video40 = await videoWithData();
+let device3 = await promise42;
+let imageBitmap53 = await createImageBitmap(videoFrame49);
+let videoFrame52 = new VideoFrame(video33, {timestamp: 0});
+let sampler63 = device3.createSampler({
+  label: '\ub75c\u179f\u{1fb2c}\u{1fe80}\u0550\uded8\ufa26\u5982',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 25.64,
+  lodMaxClamp: 40.71,
+  maxAnisotropy: 13,
+});
+offscreenCanvas22.width = 2525;
+try {
+externalTexture79.label = '\u1a47\ucc20\u3d71';
+} catch {}
+let commandEncoder126 = device3.createCommandEncoder({label: '\u01ca\ub2d7\u{1f8bc}'});
+let querySet59 = device3.createQuerySet({label: '\ue559\u05f8\u{1f967}', type: 'occlusion', count: 3809});
+let sampler64 = device3.createSampler({
+  label: '\u{1fea9}\u04eb\u063f\u{1fbfd}\u99a1\u28c0\ucfec\u0f87',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 47.22,
+  maxAnisotropy: 2,
+});
+let offscreenCanvas45 = new OffscreenCanvas(121, 327);
+gc();
+let imageBitmap54 = await createImageBitmap(video31);
+try {
+offscreenCanvas45.getContext('bitmaprenderer');
+} catch {}
+let buffer30 = device3.createBuffer({label: '\ub00d\u4bc8\u9462', size: 58224, usage: GPUBufferUsage.INDIRECT});
+let commandEncoder127 = device3.createCommandEncoder({label: '\u{1f6ed}\u2788\u{1fc8f}\u08f6\u{1fa06}'});
+let commandBuffer32 = commandEncoder127.finish({label: '\u66f6\u67c6\uc732\u0548\u588c\u0a18\uf80c\u0cb8'});
+let texture101 = device3.createTexture({
+  label: '\u013c\u3e08\u{1faa7}\uae97\uc62d\u{1fef9}\u8d6f',
+  size: [360, 60, 291],
+  mipLevelCount: 2,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView153 = texture101.createView({
+  label: '\u3e1f\u08eb\u08da\u6494\u0cff\u0833\u4fb7\u4608\u0c69\u{1fa65}',
+  dimension: '2d',
+  format: 'rg16sint',
+  baseMipLevel: 1,
+  baseArrayLayer: 156,
+});
+try {
+buffer30.unmap();
+} catch {}
+video37.width = 173;
+let videoFrame53 = new VideoFrame(canvas4, {timestamp: 0});
+canvas6.width = 416;
+let imageData52 = new ImageData(256, 160);
+try {
+adapter4.label = '\ua881\u78b7\ue0f6\ub40e\uef45';
+} catch {}
+let querySet60 = device3.createQuerySet({label: '\u0b37\u07a7\u4df1\u70e0\u065c\u0b19\u{1f863}\u{1f972}\uee6e', type: 'occlusion', count: 3043});
+let texture102 = device3.createTexture({
+  label: '\u6639\u{1fe77}',
+  size: [15, 1, 147],
+  mipLevelCount: 5,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint'],
+});
+let textureView154 = texture102.createView({aspect: 'all', baseMipLevel: 3, arrayLayerCount: 1});
+let img43 = await imageWithData(266, 238, '#2205512e', '#5264f48a');
+let textureView155 = texture102.createView({label: '\u{1ff7f}\ua5a7\u04ed\u0587\u8bff\ub855\u{1fc44}', baseMipLevel: 3, mipLevelCount: 1});
+let externalTexture82 = device3.importExternalTexture({
+  label: '\ua334\u7890\u{1ff9f}\ua6fd\u0561\u8c18\u5260\u0c37\u0921',
+  source: videoFrame23,
+  colorSpace: 'display-p3',
+});
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let bindGroupLayout40 = device1.createBindGroupLayout({
+  label: '\u13a2\u{1fe65}',
+  entries: [
+    {
+      binding: 2721,
+      visibility: 0,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {binding: 563, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {
+      binding: 6513,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16uint', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let commandEncoder128 = device1.createCommandEncoder({});
+let querySet61 = device1.createQuerySet({label: '\ufe05\ue5bc\u6e74\u0e9a\u6588\u{1fd0d}\u0d4e\u7621\u{1f69e}', type: 'occlusion', count: 3066});
+let renderBundle83 = renderBundleEncoder65.finish({label: '\ub165\uef6c\u7ebc'});
+try {
+commandEncoder128.copyBufferToTexture({
+  /* bytesInLastRow: 400 widthInBlocks: 50 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2760 */
+  offset: 2760,
+  buffer: buffer25,
+}, {
+  texture: texture45,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 50, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+window.someLabel = externalTexture58.label;
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder129 = device3.createCommandEncoder({label: '\ufa70\u{1f6b6}\u8ab0\u4355\u0eca\uef07\ud0d9\u{1fb98}'});
+let querySet62 = device3.createQuerySet({type: 'occlusion', count: 1701});
+try {
+device3.queue.writeTexture({
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 33, y: 4, z: 0},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 2_194_538 */
+{offset: 326, bytesPerRow: 588, rowsPerImage: 217}, {width: 96, height: 43, depthOrArrayLayers: 18});
+} catch {}
+let bindGroupLayout41 = device3.createBindGroupLayout({label: '\ud29a\u{1f8e3}\u9a72\u7b6f', entries: []});
+let texture103 = device3.createTexture({
+  label: '\u{1fae9}\uf51c\u0bf7\u094f\ua41c\uf5c4\uf6cf',
+  size: {width: 15, height: 1, depthOrArrayLayers: 452},
+  mipLevelCount: 3,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView156 = texture102.createView({baseMipLevel: 2, mipLevelCount: 1});
+try {
+commandEncoder126.copyTextureToTexture({
+  texture: texture103,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 93},
+  aspect: 'all',
+},
+{
+  texture: texture103,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let canvas46 = document.createElement('canvas');
+try {
+canvas46.getContext('webgl');
+} catch {}
+let pipelineLayout13 = device3.createPipelineLayout({
+  label: '\udcce\u9b11',
+  bindGroupLayouts: [bindGroupLayout41, bindGroupLayout41, bindGroupLayout41, bindGroupLayout41],
+});
+let textureView157 = texture103.createView({dimension: '2d', format: 'rgb10a2unorm', mipLevelCount: 2, baseArrayLayer: 388});
+let externalTexture83 = device3.importExternalTexture({
+  label: '\u0688\u0b12\u{1faf4}\ub8a0\u{1fe9d}\u106e\ua3ce\u51e4\u16bd\u{1fd2c}\u0f62',
+  source: video12,
+  colorSpace: 'srgb',
+});
+try {
+device3.queue.writeTexture({
+  texture: texture103,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 103},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer5), /* required buffer size: 516_030 */
+{offset: 133, bytesPerRow: 243, rowsPerImage: 11}, {width: 2, height: 1, depthOrArrayLayers: 194});
+} catch {}
+document.body.prepend(canvas44);
+let bindGroup42 = device3.createBindGroup({label: '\uf9d5\ub622', layout: bindGroupLayout41, entries: []});
+let textureView158 = texture103.createView({label: '\ue327\u7124', baseMipLevel: 2, baseArrayLayer: 138, arrayLayerCount: 119});
+try {
+commandEncoder126.copyTextureToTexture({
+  texture: texture103,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 9},
+  aspect: 'all',
+},
+{
+  texture: texture103,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup43 = device3.createBindGroup({label: '\u{1fde5}\u33d4\ue13e\u0b15\u0210\udbea\u{1fbe3}', layout: bindGroupLayout41, entries: []});
+let commandEncoder130 = device3.createCommandEncoder({label: '\u78cb\u{1fa92}\u{1fa4b}\u0bf5'});
+let querySet63 = device3.createQuerySet({label: '\ua52d\uc91f\u{1f777}\u37ac\uc905\uc930\u7f82\u00e6', type: 'occlusion', count: 93});
+let textureView159 = texture103.createView({baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 243, arrayLayerCount: 207});
+let renderBundleEncoder72 = device3.createRenderBundleEncoder({
+  label: '\u7ff6\u573f\u0715\u0521\u0758\u0042',
+  colorFormats: ['rgba16sint', undefined, 'rgb10a2unorm', 'rgba32float', 'rg16sint'],
+  stencilReadOnly: true,
+});
+let imageData53 = new ImageData(164, 40);
+let computePassEncoder51 = commandEncoder126.beginComputePass({label: '\u012f\u{1feec}\u09ed'});
+let renderBundle84 = renderBundleEncoder72.finish({label: '\u072b\u0635\u80a7\u0f47\ue843'});
+let externalTexture84 = device3.importExternalTexture({label: '\uf638\u0024', source: video33, colorSpace: 'srgb'});
+try {
+computePassEncoder51.setBindGroup(3, bindGroup43);
+} catch {}
+let promise46 = device3.queue.onSubmittedWorkDone();
+let videoFrame54 = new VideoFrame(img28, {timestamp: 0});
+try {
+  await promise46;
+} catch {}
+let bindGroupLayout42 = device3.createBindGroupLayout({
+  label: '\u333e\u0078\u00d8\uafac\u06ef',
+  entries: [
+    {binding: 630, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 35,
+      visibility: 0,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let querySet64 = device3.createQuerySet({label: '\u51f4\u087e\u6e7a\u{1f9db}\u0344\u9874', type: 'occlusion', count: 1332});
+let textureView160 = texture101.createView({baseMipLevel: 1, baseArrayLayer: 84, arrayLayerCount: 61});
+try {
+commandEncoder129.pushDebugGroup('\u8761');
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture103,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 5},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer6), /* required buffer size: 15_634_405 */
+{offset: 89, bytesPerRow: 244, rowsPerImage: 233}, {width: 4, height: 1, depthOrArrayLayers: 276});
+} catch {}
+try {
+computePassEncoder51.insertDebugMarker('\u0f08');
+} catch {}
+gc();
+let pipelineLayout14 = device1.createPipelineLayout({
+  label: '\u19a3\u{1f97d}\uadef\u15ee\u{1f9cb}\ubc09',
+  bindGroupLayouts: [bindGroupLayout40, bindGroupLayout38],
+});
+let commandEncoder131 = device1.createCommandEncoder();
+let querySet65 = device1.createQuerySet({label: '\ufcb2\u1456\u023f', type: 'occlusion', count: 1719});
+let textureView161 = texture100.createView({label: '\u177f\u{1fffe}\u6115\u{1f62c}', aspect: 'all', format: 'rg32uint', mipLevelCount: 2});
+try {
+renderBundleEncoder54.setVertexBuffer(2, buffer29, 87908, 5468);
+} catch {}
+let img44 = await imageWithData(60, 270, '#7833b421', '#2382f518');
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+let bindGroup44 = device3.createBindGroup({
+  label: '\u67cd\u8b5d\u9cd6\u0deb\u1b05\u5816\ub1b6\u{1fa5d}\uc2c2\u3691\uc280',
+  layout: bindGroupLayout41,
+  entries: [],
+});
+let commandEncoder132 = device3.createCommandEncoder({label: '\u6026\u879f\u3dff'});
+let renderBundleEncoder73 = device3.createRenderBundleEncoder({colorFormats: ['rgba16sint', undefined, 'rgb10a2unorm', 'rgba32float', 'rg16sint']});
+try {
+computePassEncoder51.setBindGroup(3, bindGroup42, new Uint32Array(1568), 879, 0);
+} catch {}
+let commandEncoder133 = device3.createCommandEncoder({label: '\u126e\uefb2\u0e9f\ud8fe\uca23\u4782\u{1f8cd}\u6c51\uda9e\u5ebb'});
+let querySet66 = device3.createQuerySet({label: '\ua118\u1a8c\u64c8', type: 'occlusion', count: 1745});
+let renderBundleEncoder74 = device3.createRenderBundleEncoder({
+  label: '\uf9d1\ud6f0\u0089\u0620\u{1ffdd}\ufa16',
+  colorFormats: ['rgba16sint', undefined, 'rgb10a2unorm', 'rgba32float', 'rg16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle85 = renderBundleEncoder72.finish({label: '\u4e05\u7ad7\ua1e0\u0043'});
+let sampler65 = device3.createSampler({
+  label: '\u49d9\u1fa7\u0704\u6e90\u{1f7c9}\u22ea',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 39.75,
+  lodMaxClamp: 86.00,
+});
+try {
+buffer30.destroy();
+} catch {}
+let bindGroup45 = device3.createBindGroup({layout: bindGroupLayout41, entries: []});
+try {
+computePassEncoder51.end();
+} catch {}
+try {
+renderBundleEncoder73.setBindGroup(2, bindGroup43);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture101,
+  mipLevel: 1,
+  origin: {x: 14, y: 1, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(3_554_057), /* required buffer size: 3_554_057 */
+{offset: 931, bytesPerRow: 571, rowsPerImage: 107}, {width: 91, height: 17, depthOrArrayLayers: 59});
+} catch {}
+let querySet67 = device3.createQuerySet({type: 'occlusion', count: 2100});
+let textureView162 = texture103.createView({
+  label: '\u7953\u{1fb31}\ud0d5\ucd0e\u9fa6\u1e10\u{1fe25}\ufa90\u0f8f\u5282',
+  dimension: '2d',
+  format: 'rgb10a2unorm',
+  mipLevelCount: 2,
+  baseArrayLayer: 153,
+});
+let commandEncoder134 = device3.createCommandEncoder();
+let commandBuffer33 = commandEncoder132.finish({label: '\u624e\u{1f6e0}'});
+let textureView163 = texture103.createView({
+  label: '\u0b64\u0edc\u05c3\ua336\u{1fc1c}\u98cd',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 1,
+  baseArrayLayer: 75,
+});
+try {
+device3.queue.writeTexture({
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 93, y: 1, z: 54},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 894_662 */
+{offset: 183, bytesPerRow: 513, rowsPerImage: 123}, {width: 80, height: 22, depthOrArrayLayers: 15});
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+let bindGroupLayout43 = device3.createBindGroupLayout({
+  label: '\u8636\uc641\u643c\u0680\u6e7b\u30fc\ua3c2\ue9d1\u0a9a\u7b7a',
+  entries: [
+    {
+      binding: 2866,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 1211, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 1013,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16float', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+let buffer31 = device3.createBuffer({
+  label: '\uf0fb\u0f3a\ud19c\udc62\u0d77\u8051\u699a\u{1fbe8}\u{1fe56}\u{1f6ba}',
+  size: 66798,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let renderBundleEncoder75 = device3.createRenderBundleEncoder({
+  label: '\ue51b\u1b83\u5235\u46c8\u{1f765}\ub613\u5bd0\u1308\u{1f89f}\u{1fc13}\u93ba',
+  colorFormats: ['rgba16sint', undefined, 'rgb10a2unorm', 'rgba32float', 'rg16sint'],
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder74.setVertexBuffer(1632, undefined);
+} catch {}
+try {
+buffer30.destroy();
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let video41 = await videoWithData();
+let promise47 = navigator.gpu.requestAdapter({});
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let canvas47 = document.createElement('canvas');
+try {
+canvas47.getContext('webgpu');
+} catch {}
+let offscreenCanvas46 = new OffscreenCanvas(650, 555);
+let buffer32 = device3.createBuffer({
+  label: '\u0788\u{1fb56}\uefed\u1942',
+  size: 116772,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let commandBuffer34 = commandEncoder126.finish({label: '\u{1fc63}\u1369\u53a1\u{1fd77}\ude97'});
+let texture104 = device3.createTexture({
+  label: '\uf764\u19db\u8ba5\ub83f',
+  size: [48],
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2unorm', 'rgb10a2unorm', 'rgb10a2unorm'],
+});
+try {
+buffer30.destroy();
+} catch {}
+try {
+commandEncoder134.copyBufferToBuffer(buffer31, 18328, buffer32, 42548, 11348);
+dissociateBuffer(device3, buffer31);
+dissociateBuffer(device3, buffer32);
+} catch {}
+try {
+commandEncoder129.popDebugGroup();
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+video31.width = 39;
+let commandEncoder135 = device3.createCommandEncoder();
+let textureView164 = texture103.createView({label: '\u5166\u02f2\u{1fa30}\u21b5\uc8d3\u502e\u0c26', dimension: '2d', baseArrayLayer: 268});
+let renderBundleEncoder76 = device3.createRenderBundleEncoder({colorFormats: ['rgba16sint', undefined, 'rgb10a2unorm', 'rgba32float', 'rg16sint']});
+try {
+commandEncoder133.copyTextureToTexture({
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 70},
+  aspect: 'all',
+},
+{
+  texture: texture103,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise48 = device3.queue.onSubmittedWorkDone();
+try {
+  await adapter6.requestAdapterInfo();
+} catch {}
+try {
+offscreenCanvas46.getContext('2d');
+} catch {}
+try {
+  await promise48;
+} catch {}
+let texture105 = device3.createTexture({
+  label: '\ue1f0\u06cf\u{1fe9d}\u0aca\ua899\u085a\u{1fc21}\ud299\u6210\u6f18',
+  size: [96, 20, 445],
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rgb9e5ufloat',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgb9e5ufloat'],
+});
+try {
+renderBundleEncoder75.setBindGroup(2, bindGroup44);
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+offscreenCanvas37.width = 1389;
+let bindGroupLayout44 = device3.createBindGroupLayout({
+  label: '\u7730\ufc8c\uc18d\u9527\u{1fc32}\u{1f805}\u1a16\u{1fd57}',
+  entries: [
+    {
+      binding: 1448,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 3290,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 127930868, hasDynamicOffset: true },
+    },
+    {
+      binding: 3,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let textureView165 = texture104.createView({
+  label: '\u0ddc\u70f0\u0dc5\u{1ff38}\u6278\u0f98\u0934\u0648\uaf4c',
+  format: 'rgb10a2unorm',
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+let renderBundleEncoder77 = device3.createRenderBundleEncoder({
+  label: '\u0629\uf067\u{1fa6b}',
+  colorFormats: ['rgba16sint', undefined, 'rgb10a2unorm', 'rgba32float', 'rg16sint'],
+  depthReadOnly: true,
+});
+let renderBundle86 = renderBundleEncoder72.finish({label: '\u628d\u{1f7c9}'});
+try {
+renderBundleEncoder73.setVertexBuffer(4916, undefined, 0, 2187290001);
+} catch {}
+try {
+renderBundleEncoder75.insertDebugMarker('\u{1f608}');
+} catch {}
+let canvas48 = document.createElement('canvas');
+let commandEncoder136 = device3.createCommandEncoder({label: '\u{1fdc9}\u0f87'});
+let computePassEncoder52 = commandEncoder130.beginComputePass({label: '\u9c2b\u4eb2'});
+let renderBundleEncoder78 = device3.createRenderBundleEncoder({
+  label: '\u{1fff2}\u4cec\u3be7\u004d\u{1fb2e}\u0d54\uafdb\u0e18\u79dd\u4140\u0c42',
+  colorFormats: ['rgba16sint', undefined, 'rgb10a2unorm', 'rgba32float', 'rg16sint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder52.setBindGroup(0, bindGroup45);
+} catch {}
+try {
+computePassEncoder52.setBindGroup(0, bindGroup45, new Uint32Array(3399), 808, 0);
+} catch {}
+try {
+renderBundleEncoder77.setVertexBuffer(7656, undefined, 0, 1789428519);
+} catch {}
+let img45 = await imageWithData(280, 235, '#44f166ba', '#434565f2');
+let gpuCanvasContext45 = canvas48.getContext('webgpu');
+try {
+  await adapter5.requestAdapterInfo();
+} catch {}
+let video42 = await videoWithData();
+let commandEncoder137 = device3.createCommandEncoder();
+let texture106 = device3.createTexture({
+  label: '\u0436\ude7e\u47cb\uc647\ufcfe\u{1f61f}\u0661\ufd8d',
+  size: [360, 60, 291],
+  mipLevelCount: 3,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint'],
+});
+let textureView166 = texture105.createView({label: '\u{1f7fc}\u{1f889}\u34c9\u07d6\ucf8a', aspect: 'all', baseMipLevel: 7});
+let renderBundleEncoder79 = device3.createRenderBundleEncoder({
+  label: '\u0741\u{1f623}\u0d1b\ub932\ube8c\ue065\u0ac4',
+  colorFormats: ['rgba16sint', undefined, 'rgb10a2unorm', 'rgba32float', 'rg16sint'],
+  stencilReadOnly: true,
+});
+let renderBundle87 = renderBundleEncoder73.finish({});
+try {
+commandEncoder134.copyBufferToTexture({
+  /* bytesInLastRow: 152 widthInBlocks: 38 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1012 */
+  offset: 1012,
+  buffer: buffer31,
+}, {
+  texture: texture104,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 38, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device3, buffer31);
+} catch {}
+try {
+device3.queue.submit([commandBuffer33]);
+} catch {}
+let videoFrame55 = new VideoFrame(img14, {timestamp: 0});
+let texture107 = device3.createTexture({
+  label: '\u07e2\u{1ff2a}',
+  size: {width: 15},
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint'],
+});
+let textureView167 = texture102.createView({baseMipLevel: 2, mipLevelCount: 1});
+try {
+computePassEncoder52.setBindGroup(1, bindGroup42);
+} catch {}
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+commandEncoder137.copyBufferToBuffer(buffer31, 15976, buffer32, 54420, 1000);
+dissociateBuffer(device3, buffer31);
+dissociateBuffer(device3, buffer32);
+} catch {}
+canvas14.height = 2889;
+let imageBitmap55 = await createImageBitmap(videoFrame22);
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let img46 = await imageWithData(234, 235, '#98ffff83', '#cfaa3e20');
+document.body.prepend(canvas44);
+gc();
+let textureView168 = texture101.createView({
+  label: '\u0dbe\u0b03\u2e4a\u0ed7\u{1fc9c}\u{1fc7c}\ubad8\ub398',
+  dimension: '2d',
+  baseMipLevel: 1,
+  baseArrayLayer: 80,
+});
+let computePassEncoder53 = commandEncoder136.beginComputePass({label: '\u0d88\u04ef\u{1fefe}\u1ced\u4e08'});
+try {
+computePassEncoder52.setBindGroup(2, bindGroup44, new Uint32Array(1869), 437, 0);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame36.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame40.close();
+videoFrame41.close();
+videoFrame42.close();
+videoFrame43.close();
+videoFrame44.close();
+videoFrame45.close();
+videoFrame46.close();
+videoFrame47.close();
+videoFrame48.close();
+videoFrame49.close();
+videoFrame50.close();
+videoFrame51.close();
+videoFrame52.close();
+videoFrame53.close();
+videoFrame54.close();
+videoFrame55.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -848,10 +848,9 @@ void RenderPassEncoder::endPass()
     bool hasTexturesToClear = m_allColorAttachments.count || m_attachmentsToClear.count || (m_depthStencilAttachmentToClear && (m_clearDepthAttachment || m_clearStencilAttachment));
 
     if ((!issuedDraw || useDiscardTextures) && hasTexturesToClear) {
-        if (m_depthStencilAttachmentToClear && !issuedDraw && !useDiscardTextures) {
-            auto pixelFormat = m_depthStencilAttachmentToClear.pixelFormat;
-            m_clearDepthAttachment = !Device::isStencilOnlyFormat(pixelFormat);
-            m_clearStencilAttachment = pixelFormat == MTLPixelFormatDepth32Float_Stencil8 || pixelFormat == MTLPixelFormatStencil8 || pixelFormat == MTLPixelFormatX32_Stencil8;
+        if (m_depthStencilView && m_depthStencilAttachmentToClear && !issuedDraw && !useDiscardTextures) {
+            m_clearDepthAttachment = Texture::containsDepthAspect(m_depthStencilView->format());
+            m_clearStencilAttachment = Texture::containsStencilAspect(m_depthStencilView->format());
         }
         if (useDiscardTextures)
             endEncoder();


### PR DESCRIPTION
#### c36a992b81f254cf95b15bf20013f0498a604518
<pre>
[WebGPU] runClearEncoder can fail validation when depth-stencil texture is destroyed
<a href="https://bugs.webkit.org/show_bug.cgi?id=275225">https://bugs.webkit.org/show_bug.cgi?id=275225</a>
&lt;radar://129354753&gt;

Reviewed by Dan Glastonbury.

Consulting the MTLTexture&apos;s pixelFormat is incorrect for destroyed textures,
but we already have the WGPUTextureFormat, so we can use that.

* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::endPass):

Canonical link: <a href="https://commits.webkit.org/279816@main">https://commits.webkit.org/279816@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16eefecb6d6d7da1f58b0c2707655d7b19b62123

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57884 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5337 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41562 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5340 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44228 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3593 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56698 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32208 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47297 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25354 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28963 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4627 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3477 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59474 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29837 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4978 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51648 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30986 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47383 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51024 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11971 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31965 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30774 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->