### PR TITLE
[WebGPU] Destroyed Device leads to validation errors in render pipeline

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-275228-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-275228-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it does not crash

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-275228.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-275228.html
@@ -1,0 +1,26146 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ */
+function pseudoSubmit(device) {
+  for (let i = 0; i < 63; i++) {
+    device.createCommandEncoder();
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let adapter1 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  label: '\u0e57\u8b39\u4893\u94ea\u448a\u2e22',
+  requiredLimits: {
+    maxBindGroups: 7,
+    maxColorAttachmentBytesPerSample: 39,
+    maxVertexAttributes: 28,
+    maxVertexBufferArrayStride: 7360,
+    maxStorageTexturesPerShaderStage: 16,
+    maxStorageBuffersPerShaderStage: 29,
+    maxDynamicStorageBuffersPerPipelineLayout: 15794,
+    maxDynamicUniformBuffersPerPipelineLayout: 52821,
+    maxBindingsPerBindGroup: 7533,
+    maxTextureArrayLayers: 1875,
+    maxTextureDimension1D: 12371,
+    maxTextureDimension2D: 15317,
+    maxVertexBuffers: 9,
+    maxBindGroupsPlusVertexBuffers: 30,
+    minStorageBufferOffsetAlignment: 128,
+    minUniformBufferOffsetAlignment: 32,
+    maxUniformBufferBindingSize: 648583,
+    maxStorageBufferBindingSize: 258274943,
+    maxUniformBuffersPerShaderStage: 25,
+    maxSampledTexturesPerShaderStage: 36,
+    maxInterStageShaderVariables: 40,
+    maxInterStageShaderComponents: 120,
+    maxSamplersPerShaderStage: 18,
+  },
+});
+let commandEncoder0 = device0.createCommandEncoder({label: '\uee7d\ub9a3\u2bf9\u80dd\u0d75'});
+let sampler0 = device0.createSampler({
+  label: '\u500f\u092f\u8e8e\u01f6\u0f1a\u0097\u0ab1\u3ab4\u0470\u0c1e\u{1f7e7}',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 15.71,
+});
+let commandEncoder1 = device0.createCommandEncoder({});
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 505});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb', 'r8unorm', 'r16sint', 'r8sint', 'rgba32float'], sampleCount: 1});
+let renderBundle0 = renderBundleEncoder0.finish({label: '\u{1f637}\uba3e\u{1fbb0}\u{1f657}\u{1fc0f}\u0179\u9d47\udbbf\u065a\u716d'});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({label: '\u8637\uffd9\u7521', colorFormats: ['rgba8sint', 'rg16float'], stencilReadOnly: true});
+try {
+renderBundleEncoder1.setVertexBuffer(5749, undefined, 3837762152, 105261034);
+} catch {}
+let commandEncoder2 = device0.createCommandEncoder({label: '\u021d\ufd07'});
+let renderBundle1 = renderBundleEncoder0.finish();
+let bindGroupLayout0 = device0.createBindGroupLayout({label: '\u0393\u55fc\u{1f6cd}', entries: []});
+let bindGroup0 = device0.createBindGroup({label: '\u737b\ue24c\u8cab', layout: bindGroupLayout0, entries: []});
+let buffer0 = device0.createBuffer({size: 21700, usage: GPUBufferUsage.VERTEX});
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  label: '\u3d65\u897f\u04e0\u{1ffaf}',
+  entries: [
+    {
+      binding: 281,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 4360,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+  ],
+});
+let querySet1 = device0.createQuerySet({
+  label: '\u4694\u3444\ua06c\u0499\u{1fe03}\ud7dd\ua088\u0e06\u{1f803}\u0e16\uf563',
+  type: 'occlusion',
+  count: 1550,
+});
+let computePassEncoder0 = commandEncoder1.beginComputePass({label: '\u{1fc06}\u134c\u51fa\u{1f95e}\u5b07\u0804\u715f\u0e3e\u2ebc'});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(2, buffer0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let canvas0 = document.createElement('canvas');
+let img0 = await imageWithData(258, 275, '#c7c60163', '#1dc86a7e');
+let bindGroup1 = device0.createBindGroup({
+  label: '\ue152\u8b91\ue68f\u8ae2\u065d\ue489\u1619\u{1f8d4}\u0a83\u0b45\u044a',
+  layout: bindGroupLayout0,
+  entries: [],
+});
+let pipelineLayout0 = device0.createPipelineLayout({
+  label: '\u911d\u0f1f\u70fd\u{1fe21}\u9377\u0a4a\u0ad5\u{1faa5}\u8519',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout0, bindGroupLayout1],
+});
+let computePassEncoder1 = commandEncoder2.beginComputePass();
+try {
+renderBundleEncoder1.setVertexBuffer(7, buffer0, 0, 9382);
+} catch {}
+try {
+canvas0.getContext('webgl');
+} catch {}
+let commandEncoder3 = device0.createCommandEncoder();
+let computePassEncoder2 = commandEncoder3.beginComputePass({label: '\u45a6\uca0a\u{1f65b}\u{1fb69}\u9cd7\u00a2\u0672\u1d60'});
+let sampler1 = device0.createSampler({
+  label: '\u0556\u0e71\u4ab1\u4b7b\u0a4e\u9aa3\u{1fb6b}',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 13.36,
+  maxAnisotropy: 19,
+});
+let commandEncoder4 = device0.createCommandEncoder({label: '\u{1fe89}\ua06d\ua96c\u{1f8d3}\u2dc5\u67b3\u342d\u1bf8\u523a\ude3e'});
+try {
+renderBundleEncoder1.setVertexBuffer(0, buffer0, 0, 7973);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+  label: '\u{1f6e8}\u0f45\u{1f687}\u1e3f',
+  code: `@group(2) @binding(4360)
+var<storage, read_write> global0: array<u32>;
+@group(2) @binding(281)
+var<storage, read_write> type0: array<u32>;
+@group(0) @binding(281)
+var<storage, read_write> parameter0: array<u32>;
+@group(0) @binding(4360)
+var<storage, read_write> local0: array<u32>;
+
+@compute @workgroup_size(6, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(7) f0: vec4<f32>,
+  @location(0) f1: vec4<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S0 {
+  @location(8) f0: f32,
+  @location(2) f1: vec3<i32>,
+  @location(21) f2: vec3<u32>,
+  @location(10) f3: f32,
+  @location(1) f4: vec3<f32>,
+  @location(14) f5: vec3<f32>,
+  @builtin(vertex_index) f6: u32,
+  @builtin(instance_index) f7: u32,
+  @location(4) f8: i32,
+  @location(18) f9: f16,
+  @location(23) f10: vec2<i32>,
+  @location(19) f11: vec3<f32>,
+  @location(24) f12: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(25) a0: vec2<f32>, @location(16) a1: vec4<f32>, @location(0) a2: vec2<f32>, @location(15) a3: f32, @location(13) a4: vec3<f16>, @location(22) a5: f16, a6: S0, @location(6) a7: vec2<u32>, @location(20) a8: i32, @location(12) a9: vec4<f32>, @location(5) a10: vec3<f32>, @location(7) a11: vec3<f32>, @location(26) a12: i32, @location(17) a13: vec3<u32>, @location(27) a14: u32, @location(11) a15: vec2<i32>, @location(3) a16: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let pipelineLayout1 = device0.createPipelineLayout({
+  label: '\u8f6d\ue833\u803b\u0541\ua142\u0bc8\u9b4e\u{1fde9}\u89fc',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout1, bindGroupLayout0],
+});
+let renderBundle2 = renderBundleEncoder1.finish({label: '\u{1f8d7}\u{1f709}'});
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline0 = await device0.createComputePipelineAsync({
+  label: '\u{1f857}\u8cf0\udf34\ub9fa\ue30c\u0a93\u145c\u608c\u6ac9\u8620\u{1f976}',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let offscreenCanvas0 = new OffscreenCanvas(865, 932);
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 102});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup0, []);
+} catch {}
+try {
+computePassEncoder1.setPipeline(pipeline0);
+} catch {}
+offscreenCanvas0.height = 1424;
+let promise0 = adapter0.requestAdapterInfo();
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  label: '\u0ce4\u35bc\u{1fb7e}',
+  entries: [
+    {
+      binding: 3007,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+try {
+computePassEncoder2.pushDebugGroup('\u0bd6');
+} catch {}
+let promise1 = adapter1.requestDevice({
+  label: '\u0a5a\u2bc9\u152a\u{1fc8e}',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+  ],
+  requiredLimits: {
+    maxBindGroups: 10,
+    maxColorAttachmentBytesPerSample: 59,
+    maxVertexAttributes: 27,
+    maxVertexBufferArrayStride: 59190,
+    maxStorageTexturesPerShaderStage: 7,
+    maxStorageBuffersPerShaderStage: 20,
+    maxDynamicStorageBuffersPerPipelineLayout: 21163,
+    maxDynamicUniformBuffersPerPipelineLayout: 19508,
+    maxBindingsPerBindGroup: 7036,
+    maxTextureArrayLayers: 845,
+    maxTextureDimension1D: 13944,
+    maxTextureDimension2D: 10421,
+    maxVertexBuffers: 9,
+    maxBindGroupsPlusVertexBuffers: 29,
+    minStorageBufferOffsetAlignment: 32,
+    minUniformBufferOffsetAlignment: 64,
+    maxUniformBufferBindingSize: 71415600,
+    maxStorageBufferBindingSize: 140963253,
+    maxUniformBuffersPerShaderStage: 27,
+    maxSampledTexturesPerShaderStage: 22,
+    maxInterStageShaderVariables: 118,
+    maxInterStageShaderComponents: 71,
+    maxSamplersPerShaderStage: 22,
+  },
+});
+try {
+offscreenCanvas0.getContext('webgl2');
+} catch {}
+let pipelineLayout2 = device0.createPipelineLayout({
+  label: '\u09cd\u102e\u10c4\u{1f7f1}\ua158\uc130\u099b',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0, bindGroupLayout1],
+});
+let buffer1 = device0.createBuffer({size: 651712, usage: GPUBufferUsage.INDEX});
+let commandEncoder5 = device0.createCommandEncoder({label: '\u0dd9\uad4c\u00c1\u0114\u7b83'});
+let texture0 = device0.createTexture({
+  label: '\u{1f8ad}\u8298\u24c6\uc694\udaac\u57f3\u05e5\u8de8\u6de9\u8123\uf687',
+  size: {width: 658},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint', 'rg16float']});
+let sampler2 = device0.createSampler({
+  label: '\u378b\u{1fa4a}\u{1fe0d}\u{1f753}\u{1f84c}\u0edb\ua0a3\u00d5\u9a33\ue020',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 70.98,
+  lodMaxClamp: 96.87,
+});
+try {
+computePassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(9362, undefined);
+} catch {}
+try {
+commandEncoder0.insertDebugMarker('\u01c1');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 408 */
+{offset: 408}, {width: 481, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = device0.label;
+} catch {}
+let textureView0 = texture0.createView({});
+let computePassEncoder3 = commandEncoder0.beginComputePass({label: '\u{1ff8b}\u{1fc5d}\u7aff\u{1fb14}\u0f26'});
+try {
+  await promise0;
+} catch {}
+document.body.prepend(img0);
+let shaderModule1 = device0.createShaderModule({
+  label: '\u4f28\u6b3a\u97b4\u2879\u715d\uaf83\ud8e2\ub16c\u{1fcf5}\u0719\u1c06',
+  code: `@group(2) @binding(4360)
+var<storage, read_write> type1: array<u32>;
+@group(2) @binding(281)
+var<storage, read_write> local1: array<u32>;
+
+@compute @workgroup_size(1, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S1 {
+  @location(9) f0: f32,
+  @location(36) f1: vec2<f16>,
+  @builtin(sample_index) f2: u32,
+  @location(13) f3: vec2<f32>,
+  @location(3) f4: vec3<f16>,
+  @location(2) f5: f32,
+  @builtin(front_facing) f6: bool,
+  @location(16) f7: f32,
+  @location(19) f8: vec2<f16>,
+  @location(26) f9: vec3<f32>,
+  @location(20) f10: vec4<u32>,
+  @location(39) f11: vec2<i32>,
+  @location(0) f12: vec4<f16>,
+  @location(28) f13: f16,
+  @location(38) f14: f32,
+  @location(29) f15: vec3<i32>,
+  @builtin(sample_mask) f16: u32,
+  @location(24) f17: vec2<i32>,
+  @location(31) f18: vec2<f32>,
+  @location(33) f19: vec4<u32>,
+  @location(1) f20: f16,
+  @location(7) f21: vec2<f16>,
+  @location(6) f22: f32,
+  @location(22) f23: vec3<i32>,
+  @location(4) f24: vec3<u32>,
+  @location(11) f25: vec2<f16>,
+  @location(25) f26: vec3<f16>,
+  @location(8) f27: vec4<i32>,
+  @location(18) f28: vec2<f16>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(3) f1: vec3<i32>,
+  @builtin(sample_mask) f2: u32,
+  @location(1) f3: vec4<f32>,
+  @location(4) f4: vec4<f32>,
+  @location(5) f5: vec4<f32>,
+  @location(2) f6: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(23) a0: vec4<f32>, a1: S1, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(26) f0: vec3<f32>,
+  @location(4) f1: vec3<u32>,
+  @location(9) f2: f32,
+  @location(0) f3: vec4<f16>,
+  @builtin(position) f4: vec4<f32>,
+  @location(13) f5: vec2<f32>,
+  @location(2) f6: f32,
+  @location(3) f7: vec3<f16>,
+  @location(16) f8: f32,
+  @location(20) f9: vec4<u32>,
+  @location(6) f10: f32,
+  @location(7) f11: vec2<f16>,
+  @location(11) f12: vec2<f16>,
+  @location(28) f13: f16,
+  @location(25) f14: vec3<f16>,
+  @location(24) f15: vec2<i32>,
+  @location(31) f16: vec2<f32>,
+  @location(39) f17: vec2<i32>,
+  @location(19) f18: vec2<f16>,
+  @location(38) f19: f32,
+  @location(8) f20: vec4<i32>,
+  @location(18) f21: vec2<f16>,
+  @location(33) f22: vec4<u32>,
+  @location(22) f23: vec3<i32>,
+  @location(1) f24: f16,
+  @location(29) f25: vec3<i32>,
+  @location(23) f26: vec4<f32>,
+  @location(36) f27: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(25) a0: vec4<u32>, @location(22) a1: vec3<u32>, @location(4) a2: vec3<i32>, @builtin(vertex_index) a3: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup2 = device0.createBindGroup({label: '\u142a\u0351\uce3d\u077c\uf3cc\u0e51\u{1feac}\u09ff', layout: bindGroupLayout0, entries: []});
+try {
+renderBundleEncoder2.setVertexBuffer(0, buffer0);
+} catch {}
+try {
+computePassEncoder3.pushDebugGroup('\u{1f657}');
+} catch {}
+let bindGroup3 = device0.createBindGroup({label: '\u0693\u0af9', layout: bindGroupLayout0, entries: []});
+let textureView1 = texture0.createView({label: '\ubbbf\u{1fe96}\u0446\ub919\u41e2\u{1fc29}\u009a\u91e5\u0377'});
+try {
+computePassEncoder1.setPipeline(pipeline0);
+} catch {}
+let pipeline1 = await device0.createRenderPipelineAsync({
+  label: '\u065d\u09e3\u07c6\u0ea8',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba8unorm-srgb'}, {format: 'r8unorm', writeMask: 0}, {
+  format: 'r16sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8sint'}, {format: 'rgba32float', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {failOp: 'increment-clamp', depthFailOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'less', failOp: 'invert', depthFailOp: 'invert'},
+    stencilReadMask: 211282578,
+    stencilWriteMask: 502902865,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 636,
+        attributes: [
+          {format: 'uint32', offset: 48, shaderLocation: 25},
+          {format: 'uint32x2', offset: 80, shaderLocation: 22},
+          {format: 'sint32x4', offset: 108, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw'},
+});
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let texture1 = device0.createTexture({
+  label: '\u0ffc\u0060\ua4dc\uc059\ueebf\u249f\u{1fea8}\uc758',
+  size: [480],
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r8sint'],
+});
+try {
+renderBundleEncoder2.setVertexBuffer(3, buffer0, 0, 15546);
+} catch {}
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 1862});
+let textureView2 = texture1.createView({label: '\udb5d\u039a\u{1fad2}\u{1f8de}\u0be0\u{1f745}\u7437', dimension: '1d'});
+try {
+computePassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(7, buffer0, 0, 622);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline2 = await device0.createComputePipelineAsync({layout: pipelineLayout0, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+let commandEncoder6 = device0.createCommandEncoder({label: '\u0c82\ueb07\uaa64\u0a6c\u{1ff5f}\u{1fb8e}\u0c58\u{1f78b}\u{1fd4d}\u0a09'});
+let textureView3 = texture0.createView({label: '\u0ea7\u9836\u6827\u50a2\u2601'});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup1);
+} catch {}
+let imageData0 = new ImageData(200, 108);
+let commandBuffer0 = commandEncoder6.finish({label: '\uf7b5\u{1f693}\ub857\udab3\u5c4f\u013e\u03de\uf7d1\u41fa'});
+let textureView4 = texture0.createView({label: '\u{1fd67}\u02c2\u{1fa2a}\u0e4c\u0aac\u0334\u5f50\u0d02\u{1f860}', aspect: 'all'});
+try {
+computePassEncoder1.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(6, bindGroup0, new Uint32Array(96), 39, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let pipeline3 = device0.createComputePipeline({
+  label: '\u6f03\u0d24\u{1ff49}\uf2da\uac9c',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let bindGroupLayout3 = pipeline3.getBindGroupLayout(0);
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 3450});
+let renderBundle3 = renderBundleEncoder1.finish({label: '\u{1f7d4}\u{1f888}\ueb29\ua952\ucb56\ubc93\u8317\ufc61'});
+try {
+computePassEncoder2.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(1, buffer0, 0, 20864);
+} catch {}
+let textureView5 = texture1.createView({});
+let computePassEncoder4 = commandEncoder1.beginComputePass({label: '\u{1fa94}\u0d08\ua33c\u{1f81e}\u59aa\u{1f96b}\u217b\u{1f8f5}'});
+let pipeline4 = device0.createRenderPipeline({
+  label: '\u0985\u8a7b\ued3a\u034e',
+  layout: pipelineLayout2,
+  multisample: {count: 4, mask: 0x7e6dd13a},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8unorm', writeMask: 0}, {format: 'r16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r8sint', writeMask: GPUColorWrite.GREEN}, {format: 'rgba32float', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1196,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32', offset: 120, shaderLocation: 22}],
+      },
+      {arrayStride: 568, attributes: []},
+      {
+        arrayStride: 776,
+        attributes: [
+          {format: 'uint16x2', offset: 180, shaderLocation: 25},
+          {format: 'sint32x3', offset: 84, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'front'},
+});
+let offscreenCanvas1 = new OffscreenCanvas(906, 514);
+let imageBitmap0 = await createImageBitmap(canvas0);
+let imageData1 = new ImageData(100, 156);
+let commandBuffer1 = commandEncoder5.finish({});
+let texture2 = device0.createTexture({
+  label: '\ub736\u{1f83c}\u{1fca1}',
+  size: [329, 10, 1],
+  mipLevelCount: 1,
+  sampleCount: 4,
+  dimension: '2d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+});
+let textureView6 = texture2.createView({label: '\u95f9\u4d54\ue43a'});
+let commandEncoder7 = device0.createCommandEncoder({label: '\u{1fed6}\uf3ca'});
+let computePassEncoder5 = commandEncoder7.beginComputePass({label: '\ue356\u{1f9a3}\u97b2'});
+try {
+renderBundleEncoder2.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+commandEncoder4.insertDebugMarker('\u8def');
+} catch {}
+try {
+offscreenCanvas1.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder();
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 478});
+let texture3 = device0.createTexture({
+  label: '\u1237\u2541\u{1fc18}\uc63b\u{1fc4a}',
+  size: [480],
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle4 = renderBundleEncoder2.finish();
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  label: '\u9341\u531e\u0304\uf393\u7e50',
+  entries: [
+    {
+      binding: 6934,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 154814051, hasDynamicOffset: true },
+    },
+    {binding: 2330, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let texture4 = device0.createTexture({
+  label: '\u{1ff88}\ud968\u01b3\u5672\uc130\ucc5a\u0b53\u0b81',
+  size: {width: 60, height: 4, depthOrArrayLayers: 265},
+  mipLevelCount: 2,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView7 = texture0.createView({label: '\u09aa\u0fc7\ubd19\u5652\u060d'});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  label: '\u0707\ud9a2\u031d\u3d98\u{1fded}\u0425\uc6be\u09ad\ud75a',
+  colorFormats: ['rg16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder3.setIndexBuffer(buffer1, 'uint32', 234548, 365288);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(4, buffer0, 0, 10272);
+} catch {}
+let pipeline5 = device0.createComputePipeline({
+  label: '\u4083\u6a26\u88c3\u{1fe41}\u{1f926}\ub779\u0e3e\u099b\u0196',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let buffer2 = device0.createBuffer({
+  label: '\u9779\u{1f695}\u17f9\u0123\u94a1\u0137\u9eba\u6c5c\ue091\u099d',
+  size: 14312,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let querySet6 = device0.createQuerySet({
+  label: '\u8aa0\u{1f9eb}\u02b7\u0795\u{1fe78}\u01d9\u{1f953}\ue9fe\u2aed\u8f44',
+  type: 'occlusion',
+  count: 3849,
+});
+let computePassEncoder6 = commandEncoder8.beginComputePass({label: '\u{1f743}\u5afa\u080b'});
+let renderBundle5 = renderBundleEncoder0.finish({label: '\u01f1\u{1fe84}\u012c\u{1fa56}\u31a1\u7fdc'});
+document.body.prepend(img0);
+let textureView8 = texture2.createView({format: 'rgba8unorm'});
+let computePassEncoder7 = commandEncoder4.beginComputePass();
+try {
+renderBundleEncoder3.setBindGroup(1, bindGroup0);
+} catch {}
+let textureView9 = texture0.createView({label: '\u05a0\u388c\u{1fad4}\ue448\u0c38\u777d\u037e\u504c', format: 'r16sint'});
+try {
+computePassEncoder7.setPipeline(pipeline3);
+} catch {}
+let pipelineLayout3 = device0.createPipelineLayout({label: '\uadcf\u881a\u35af', bindGroupLayouts: [bindGroupLayout4]});
+let commandEncoder9 = device0.createCommandEncoder({label: '\ua03f\u{1fd22}\ueec9\u{1f6d8}\u976f\u{1fd12}'});
+let texture5 = device0.createTexture({
+  label: '\ucb64\u389b\u{1fea0}\u{1f6a4}\u96a0\u069a\u052c\ua302',
+  size: {width: 240, height: 16, depthOrArrayLayers: 1514},
+  mipLevelCount: 8,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16float'],
+});
+let renderBundle6 = renderBundleEncoder0.finish({});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup2, new Uint32Array(5751), 4920, 0);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(6, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(3, buffer0, 0, 20664);
+} catch {}
+let arrayBuffer0 = buffer2.getMappedRange();
+let pipeline6 = device0.createComputePipeline({
+  label: '\u44b7\ua40d\u{1f80d}\u076d\ua15b\ueacd\u0971',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipeline7 = device0.createRenderPipeline({
+  layout: pipelineLayout2,
+  multisample: {mask: 0xe44d5067},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALL}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'r16sint'}, {format: 'r8sint', writeMask: GPUColorWrite.BLUE}, {format: 'rgba32float'}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 1316,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 36, shaderLocation: 25},
+          {format: 'sint16x2', offset: 60, shaderLocation: 4},
+          {format: 'uint32x3', offset: 312, shaderLocation: 22},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'ccw', cullMode: 'front'},
+});
+let img1 = await imageWithData(66, 239, '#563e992c', '#0b3e6765');
+let videoFrame0 = new VideoFrame(imageBitmap0, {timestamp: 0});
+let textureView10 = texture2.createView({label: '\u{1ff93}\u00df', baseMipLevel: 0});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\u{1f923}\u{1fdb5}\u1553\u05c1\u0732\ua5f5\u95ed\u4d44\u{1fc58}\u02a2\u{1f726}',
+  colorFormats: ['rgba8sint', 'rg16float'],
+  stencilReadOnly: true,
+});
+let renderBundle7 = renderBundleEncoder3.finish({label: '\ud7e2\uf44d\u8786\u035c\uf436'});
+try {
+computePassEncoder1.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(6, bindGroup0, new Uint32Array(7916), 29, 0);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(4, buffer0, 9480, 3654);
+} catch {}
+try {
+buffer1.destroy();
+} catch {}
+try {
+computePassEncoder2.popDebugGroup();
+} catch {}
+try {
+commandEncoder9.insertDebugMarker('\ucbad');
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(new ArrayBuffer(64)), /* required buffer size: 2_055 */
+{offset: 935}, {width: 560, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline8 = device0.createComputePipeline({
+  label: '\u0d6f\uf418\u26d2\uc95c\ue9ad\u07f7\uc702\u0618\u9081\uad1f',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let textureView11 = texture1.createView({label: '\u0837\u08a7'});
+try {
+buffer2.destroy();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 194 */
+{offset: 194}, {width: 363, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline9 = device0.createRenderPipeline({
+  label: '\uc4a6\u020a\ua17c\uc01b\u{1f7d2}\u{1ff4f}\u0b1b\u{1fec1}\u{1fe91}\u{1fad1}\u473f',
+  layout: pipelineLayout1,
+  multisample: {count: 4, mask: 0x58fe2adf},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'r8unorm', writeMask: 0}, {format: 'r16sint', writeMask: GPUColorWrite.ALL}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgba32float', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 808, stepMode: 'instance', attributes: []},
+      {arrayStride: 308, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 760,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint32', offset: 112, shaderLocation: 4}],
+      },
+      {
+        arrayStride: 2480,
+        attributes: [
+          {format: 'uint8x2', offset: 414, shaderLocation: 25},
+          {format: 'uint32x3', offset: 1252, shaderLocation: 22},
+        ],
+      },
+    ],
+  },
+});
+let buffer3 = device0.createBuffer({
+  label: '\u4543\u{1f689}\ubfe4\u{1fd9d}\u03a4\u52d3\u09f5\u{1fc93}\u{1f923}\u974e\u{1fc79}',
+  size: 396716,
+  usage: GPUBufferUsage.INDIRECT,
+  mappedAtCreation: true,
+});
+let commandEncoder10 = device0.createCommandEncoder({label: '\u0b3e\u06f5'});
+let querySet7 = device0.createQuerySet({label: '\u239f\u631b\u4e0d\u06b7\ubbcf\ua0be', type: 'occlusion', count: 1492});
+let commandBuffer2 = commandEncoder10.finish({});
+let texture6 = device0.createTexture({
+  label: '\u1f39\u{1f7ca}\u8b23\u01d3\uf68d\ud4ba\u0e56\u0fce\u080b\u7047\ucc07',
+  size: {width: 658, height: 20, depthOrArrayLayers: 424},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+buffer3.destroy();
+} catch {}
+let commandEncoder11 = device0.createCommandEncoder({});
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 828});
+let textureView12 = texture6.createView({label: '\u0779\ud8a0\u{1fb04}', baseMipLevel: 1});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({
+  label: '\uc435\ue280\u{1f9e2}\u{1fc72}',
+  colorFormats: ['rgba8sint', 'rg16float'],
+  depthReadOnly: true,
+});
+let renderBundle8 = renderBundleEncoder3.finish();
+let sampler3 = device0.createSampler({
+  label: '\u01e6\u7f32\u674c\u24f4\uf0ea',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 99.49,
+  lodMaxClamp: 99.86,
+});
+try {
+texture0.destroy();
+} catch {}
+let video0 = await videoWithData();
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  label: '\u7726\u0632\u55a5\ua55e\u8d61\u{1f866}\u{1ff94}\u8c6f\ub3e7',
+  entries: [
+    {
+      binding: 3212,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+let pipelineLayout4 = device0.createPipelineLayout({label: '\u0858\u{1fe4a}\u0358', bindGroupLayouts: [bindGroupLayout5, bindGroupLayout4]});
+let buffer4 = device0.createBuffer({
+  label: '\ue6f2\u5055\u2fd7\uc344\u8ea5\u{1f803}\u019b\u054e',
+  size: 252010,
+  usage: GPUBufferUsage.COPY_DST,
+});
+let texture7 = device0.createTexture({
+  label: '\ue9ce\u{1fed8}\u0d30\u2c78\u{1fdad}\u5ee7\ua804\u4bda\u{1fa97}\u0fa3\u{1fc18}',
+  size: {width: 120},
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16uint', 'rg16uint'],
+});
+let sampler4 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 85.52,
+  lodMaxClamp: 92.09,
+  compare: 'less-equal',
+});
+try {
+computePassEncoder6.setBindGroup(4, bindGroup3);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(340, 542);
+try {
+window.someLabel = device0.label;
+} catch {}
+let commandEncoder12 = device0.createCommandEncoder({label: '\u{1f84f}\u57d9\u1d00\u{1fea2}'});
+let textureView13 = texture7.createView({label: '\u{1f981}\u262e\u7ddb\uc66f\u{1fa06}\u0a51'});
+try {
+computePassEncoder3.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder4.setIndexBuffer(buffer1, 'uint32', 433272, 10447);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(8, buffer0, 0);
+} catch {}
+try {
+commandEncoder9.copyBufferToBuffer(buffer2, 10224, buffer4, 140944, 368);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let video1 = await videoWithData();
+let textureView14 = texture6.createView({label: '\u09d3\u39ba\uaec6\u6f20\u{1fd1c}\u02b8\u9c5e\u08a1\u0516', baseMipLevel: 1});
+let renderBundle9 = renderBundleEncoder2.finish({});
+try {
+commandEncoder9.copyBufferToBuffer(buffer2, 2420, buffer4, 200228, 11820);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 70, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer0), /* required buffer size: 817 */
+{offset: 556}, {width: 261, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext0 = offscreenCanvas2.getContext('webgpu');
+let img2 = await imageWithData(195, 181, '#7cbd4878', '#eb387518');
+let textureView15 = texture6.createView({label: '\uf6a5\u96eb', baseMipLevel: 1});
+let externalTexture0 = device0.importExternalTexture({
+  label: '\u04c2\u0af1\ua2ca\u030e\ub645\u0795\u8356\ud62b\u{1fcf9}',
+  source: video1,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder1.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(6, buffer0, 0, 4243);
+} catch {}
+let canvas1 = document.createElement('canvas');
+let bindGroupLayout6 = pipeline4.getBindGroupLayout(1);
+let buffer5 = device0.createBuffer({
+  label: '\u985e\u0827\u{1febc}\uf24d\u{1f892}\u0c19\u{1f729}\u6f11\u1f4b',
+  size: 68880,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let commandEncoder13 = device0.createCommandEncoder({label: '\u0935\u0c9b\u0bf2\u87fc'});
+let texture8 = device0.createTexture({
+  label: '\u0949\u0142\u200f',
+  size: {width: 658},
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16float', 'rg16float'],
+});
+let sampler5 = device0.createSampler({
+  label: '\u0069\u3539\u{1f90a}\ud7bd',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 89.82,
+  lodMaxClamp: 94.41,
+});
+try {
+renderBundleEncoder5.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(0, bindGroup3, new Uint32Array(8349), 2502, 0);
+} catch {}
+try {
+commandEncoder12.copyBufferToBuffer(buffer5, 49680, buffer4, 250800, 1080);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder13.copyBufferToTexture({
+  /* bytesInLastRow: 738 widthInBlocks: 369 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 10342 */
+  offset: 9604,
+  buffer: buffer2,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 369, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+computePassEncoder3.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 35228, new BigUint64Array(48095), 12361, 3704);
+} catch {}
+let pipeline10 = device0.createComputePipeline({
+  label: '\u{1f603}\u{1f813}',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext1 = canvas1.getContext('webgpu');
+let img3 = await imageWithData(194, 216, '#c45655d3', '#112e2a34');
+let pipelineLayout5 = device0.createPipelineLayout({
+  label: '\u{1f799}\u{1fa9e}\u5197',
+  bindGroupLayouts: [bindGroupLayout4, bindGroupLayout3, bindGroupLayout2, bindGroupLayout6],
+});
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 3026});
+let textureView16 = texture8.createView({
+  label: '\u02c3\u778e\u339d\u02eb\u3ad0\u484f\u04d7\u{1fb6d}\u{1f81d}\u7bad\u{1f805}',
+  dimension: '1d',
+});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({
+  label: '\u2ee2\u04df',
+  colorFormats: ['rg32sint', 'rgba32uint', 'rgba16float', 'rg16uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+try {
+renderBundleEncoder6.setBindGroup(2, bindGroup0, new Uint32Array(2752), 2013, 0);
+} catch {}
+let querySet10 = device0.createQuerySet({label: '\u{1fe02}\u{1f8c0}\u5430\u0397\u03e2\u{1ff30}', type: 'occlusion', count: 1364});
+let textureView17 = texture5.createView({dimension: '2d', baseMipLevel: 4, baseArrayLayer: 839});
+let computePassEncoder8 = commandEncoder13.beginComputePass({label: '\u{1f9d7}\u{1f6d5}\u2ebb\u{1f97c}'});
+let renderBundle10 = renderBundleEncoder0.finish({label: '\ucd5c\u2566\u962d\u0e40\u8c7b\u3a77'});
+try {
+computePassEncoder8.setBindGroup(6, bindGroup1, new Uint32Array(5427), 4519, 0);
+} catch {}
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(6, bindGroup0, new Uint32Array(4401), 317, 0);
+} catch {}
+try {
+commandEncoder12.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 36},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 17, height: 2, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder8.clearBuffer(buffer4, 61020, 29580);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0, commandBuffer2]);
+} catch {}
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 1022,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 2432,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 1184,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let bindGroupLayout8 = pipeline3.getBindGroupLayout(2);
+let commandEncoder14 = device0.createCommandEncoder();
+let texture9 = device0.createTexture({
+  label: '\u0eef\u389b\u{1f77e}\u15ff\ud6f3\u0a1c\u93a4\u2912\u0f37',
+  size: [1317, 40, 24],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView18 = texture3.createView({label: '\u0d61\u04b4\u{1fa8c}\u5045\u960f\u4c96\ubec3\u{1f6c3}\ub146'});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\u23c3\u{1fb79}\u{1faf6}',
+  colorFormats: ['rg32sint', 'rgba32uint', 'rgba16float', 'rg16uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+commandEncoder8.copyBufferToBuffer(buffer2, 8336, buffer4, 76684, 1796);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder9.clearBuffer(buffer4, 64068, 80204);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let pipeline11 = await device0.createComputePipelineAsync({
+  label: '\u74d0\u6b4f\u9684',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule1, entryPoint: 'compute0'},
+});
+let canvas2 = document.createElement('canvas');
+let buffer6 = device0.createBuffer({
+  label: '\u{1f723}\u{1f76d}\u{1fae5}\u0f9b\ue526\u04c3\ubdd1\u8eb0\ufa38\u0851',
+  size: 117652,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let querySet11 = device0.createQuerySet({label: '\u7f43\ub0c2\u3e6b\u0887\u11c2\u07d5', type: 'occlusion', count: 3201});
+let externalTexture1 = device0.importExternalTexture({label: '\ube4c\u0cfa\u06ea', source: video1, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup3, new Uint32Array(8693), 7658, 0);
+} catch {}
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 17, y: 11, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 264, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(new ArrayBuffer(32)), /* required buffer size: 152 */
+{offset: 152}, {width: 480, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline12 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  label: '\uc0fd\uc74e\u{1fab0}\ue561\u06da\u435b\u0577\u{1f84c}\ue9d9\uf7de',
+  colorFormats: ['rgba8unorm-srgb', 'r8unorm', 'r16sint', 'r8sint', 'rgba32float'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let renderBundle11 = renderBundleEncoder3.finish();
+try {
+device0.queue.writeBuffer(buffer4, 20324, new DataView(new ArrayBuffer(10800)), 6915, 748);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 24},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer0), /* required buffer size: 2_867_795 */
+{offset: 83, bytesPerRow: 84, rowsPerImage: 169}, {width: 9, height: 2, depthOrArrayLayers: 203});
+} catch {}
+let pipeline13 = await device0.createComputePipelineAsync({
+  label: '\u068b\u{1fc79}\uec7a\u{1fff3}\uda20\u52b9',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+offscreenCanvas2.height = 1667;
+let offscreenCanvas3 = new OffscreenCanvas(119, 667);
+let imageData2 = new ImageData(20, 228);
+let buffer7 = device0.createBuffer({
+  label: '\uea9d\u0603\u1dac\u{1f81c}\u4859\u4a84\u{1f9d7}\u{1fb16}\u{1f9f0}',
+  size: 499788,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let commandEncoder15 = device0.createCommandEncoder();
+let querySet12 = device0.createQuerySet({
+  label: '\u0cd9\u450c\u{1fbf6}\u{1f946}\u0277\u98b9\u7260\u0caf\uf4c7\u0381\u08c4',
+  type: 'occlusion',
+  count: 927,
+});
+let commandBuffer3 = commandEncoder8.finish();
+let textureView19 = texture2.createView({
+  label: '\u{1f88b}\uc350\u{1f810}\u77fd\uca19\u{1f8af}\u6c4c\u0137\u1749\u{1fc03}',
+  format: 'rgba8unorm',
+  mipLevelCount: 1,
+});
+let externalTexture2 = device0.importExternalTexture({
+  label: '\uddb0\u{1f872}\u{1fe5d}\u0b16\u0903\ud872\ue783\uceab\ud9f6',
+  source: videoFrame0,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup1, new Uint32Array(5020), 1737, 0);
+} catch {}
+try {
+commandEncoder11.copyTextureToTexture({
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 72, y: 4, z: 1},
+  aspect: 'all',
+},
+{width: 204, height: 14, depthOrArrayLayers: 2});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 173, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(183), /* required buffer size: 183 */
+{offset: 183}, {width: 100, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(965, 825);
+try {
+window.someLabel = device0.label;
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  label: '\u{1f999}\u0387',
+  code: `@group(0) @binding(6934)
+var<storage, read_write> function0: array<u32>;
+@group(2) @binding(3007)
+var<storage, read_write> global1: array<u32>;
+@group(1) @binding(281)
+var<storage, read_write> function1: array<u32>;
+@group(1) @binding(4360)
+var<storage, read_write> local2: array<u32>;
+@group(0) @binding(2330)
+var<storage, read_write> type2: array<u32>;
+
+@compute @workgroup_size(6, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @builtin(sample_mask) f1: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(front_facing) a2: bool, @builtin(sample_mask) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(13) a0: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let computePassEncoder9 = commandEncoder9.beginComputePass({label: '\u{1f785}\u5573'});
+let sampler6 = device0.createSampler({
+  label: '\u57f3\u9bfe\u0c03\u01e3\u8e64\u02a6\u0e81\u{1fb75}\ue9cb\u0a22\ue13d',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 34.73,
+  lodMaxClamp: 66.30,
+  compare: 'equal',
+});
+let externalTexture3 = device0.importExternalTexture({label: '\udb61\uab37\u0991\u00d0', source: video0});
+try {
+commandEncoder15.clearBuffer(buffer4, 115108, 32656);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(5, 591);
+let textureView20 = texture5.createView({
+  label: '\u06ed\ud70f\ue7f0\u{1fe28}\u{1ff35}\u06c4\u0dde\u8867\u7468',
+  dimension: '2d',
+  baseMipLevel: 5,
+  baseArrayLayer: 856,
+});
+let sampler7 = device0.createSampler({
+  label: '\u0708\u5408\u25cc\uae3a',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 24.63,
+});
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(1, buffer0);
+} catch {}
+try {
+commandEncoder13.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let imageData3 = new ImageData(148, 88);
+try {
+offscreenCanvas5.getContext('webgl');
+} catch {}
+let buffer8 = device0.createBuffer({
+  label: '\ued62\u16f6\u{1f682}\u0e51\u{1f7ba}\u06b9\u0488\u{1fd18}',
+  size: 110097,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let querySet13 = device0.createQuerySet({label: '\u{1f8bb}\u{1f64a}', type: 'occlusion', count: 3040});
+try {
+computePassEncoder7.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(5, buffer0, 0);
+} catch {}
+try {
+commandEncoder14.copyBufferToBuffer(buffer2, 1600, buffer6, 34276, 2972);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer7);
+dissociateBuffer(device0, buffer7);
+} catch {}
+canvas1.width = 2481;
+let imageData4 = new ImageData(96, 68);
+let commandEncoder16 = device0.createCommandEncoder({label: '\u713c\u4e70\u0a60\u9d5b\u0ca6\ueab2\u{1fabc}\ueb36\u0660\u06a5\u077f'});
+let textureView21 = texture5.createView({
+  label: '\u{1fafe}\uc470\u0f11\ub8cd\u0db9\u0db6\u{1fc20}\u12ac\u{1f611}\u{1fa34}',
+  format: 'rg16float',
+  baseMipLevel: 4,
+  baseArrayLayer: 1240,
+  arrayLayerCount: 206,
+});
+let externalTexture4 = device0.importExternalTexture({label: '\u0612\u09d8\uc40f\u0a8d\u0d2b\ua390', source: video0});
+try {
+computePassEncoder5.setBindGroup(6, bindGroup3, new Uint32Array(9211), 7284, 0);
+} catch {}
+try {
+computePassEncoder3.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+commandEncoder11.copyBufferToBuffer(buffer2, 7644, buffer7, 85992, 1496);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder15.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 40, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 816 widthInBlocks: 408 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 38058 */
+  offset: 38058,
+  buffer: buffer8,
+}, {width: 408, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder13.clearBuffer(buffer4, 240132, 10672);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let bindGroupLayout9 = device0.createBindGroupLayout({entries: []});
+let bindGroup4 = device0.createBindGroup({label: '\ub53b\uc5c9\u3d5d\u0b77', layout: bindGroupLayout0, entries: []});
+let buffer9 = device0.createBuffer({
+  label: '\u08e7\uf3d2\u06eb\u0b0e\u70b6\u00c5\u0940\u57c2\u0ecc',
+  size: 246228,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let querySet14 = device0.createQuerySet({
+  label: '\u6613\u6772\u4dc5\u42be\u0633\uedf5\u{1fc81}\u010a\u{1faf8}\u65ed',
+  type: 'occlusion',
+  count: 2797,
+});
+let textureView22 = texture7.createView({label: '\ua84f\uf1a4\u{1f9e3}\u9f15\u0db1\u093f'});
+try {
+renderBundleEncoder7.setVertexBuffer(7, buffer0, 0, 2833);
+} catch {}
+document.body.prepend(canvas1);
+let textureView23 = texture5.createView({
+  label: '\u934c\u7193\u79f5\u5a16',
+  dimension: '2d',
+  baseMipLevel: 6,
+  mipLevelCount: 1,
+  baseArrayLayer: 565,
+});
+try {
+computePassEncoder9.setPipeline(pipeline11);
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 65 widthInBlocks: 65 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 831 */
+  offset: 831,
+  buffer: buffer2,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 65, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder16.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 55, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 734 widthInBlocks: 367 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 10422 */
+  offset: 10422,
+  buffer: buffer8,
+}, {width: 367, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer8);
+} catch {}
+let video2 = await videoWithData();
+let videoFrame1 = new VideoFrame(video0, {timestamp: 0});
+let bindGroup5 = device0.createBindGroup({layout: bindGroupLayout9, entries: []});
+let renderBundle12 = renderBundleEncoder4.finish({});
+let externalTexture5 = device0.importExternalTexture({label: '\u0f9c\ub1b0\u92a1\uef1b\u{1fe68}\u34a2\u{1f8f9}\u{1fd2b}\u9543\u046f', source: video1});
+try {
+commandEncoder13.copyBufferToBuffer(buffer2, 3316, buffer6, 27712, 9380);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder14.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 7},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 22, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 39},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer0), /* required buffer size: 14_168_781 */
+{offset: 958, bytesPerRow: 297, rowsPerImage: 300}, {width: 8, height: 4, depthOrArrayLayers: 160});
+} catch {}
+let promise2 = device0.createComputePipelineAsync({
+  label: '\u0d10\u1d25\ufcc4\u09a6\ub3cc\ua0d9\u{1f7a3}\u{1fe14}\u01bf',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer10 = device0.createBuffer({
+  label: '\u476d\u0db3\u97b0\u{1fb7b}\u254a\u3463',
+  size: 254667,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder17 = device0.createCommandEncoder({});
+let commandBuffer4 = commandEncoder14.finish({});
+let textureView24 = texture4.createView({dimension: '2d', baseMipLevel: 1, baseArrayLayer: 203});
+let computePassEncoder10 = commandEncoder11.beginComputePass({label: '\u0c92\u{1f7e8}\u{1fefb}\uddc2\u{1f832}\u7382\u6357'});
+try {
+renderBundleEncoder7.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(6409, undefined, 0, 2539626132);
+} catch {}
+let querySet15 = device0.createQuerySet({label: '\u74ee\u75ea', type: 'occlusion', count: 2192});
+let commandBuffer5 = commandEncoder16.finish({label: '\u67dc\uc3fd\u{1fd7c}\u{1f90f}\u{1fe2d}\ueaee\ue8a2'});
+let texture10 = device0.createTexture({size: [329], dimension: '1d', format: 'rgba8sint', usage: GPUTextureUsage.COPY_SRC, viewFormats: []});
+let renderBundle13 = renderBundleEncoder3.finish({label: '\u0223\u9fa4\u{1fda9}\uda25\u02d8\ub471\u0c8a\u14a1'});
+let sampler8 = device0.createSampler({
+  label: '\u123b\u{1fda0}\u2a77\u0921\u5a4a\u08bf\u099d\u0963\u00e0\u5b8c',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 28.91,
+  lodMaxClamp: 38.76,
+  maxAnisotropy: 20,
+});
+try {
+buffer8.unmap();
+} catch {}
+let pipeline14 = device0.createRenderPipeline({
+  label: '\u4b9a\ub9f9\u0c8b\u0607\uadca\u0758\u0bd3\u0e84\ue1c9\ud8e2',
+  layout: pipelineLayout1,
+  multisample: {count: 4, mask: 0xd956f94d},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALPHA}, {format: 'r8unorm', writeMask: 0}, {format: 'r16sint'}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba32float', writeMask: GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 744,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 32, shaderLocation: 4},
+          {format: 'uint32x4', offset: 324, shaderLocation: 25},
+        ],
+      },
+      {arrayStride: 356, attributes: [{format: 'uint32', offset: 152, shaderLocation: 22}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'back'},
+});
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  label: '\u0c46\u1704\u4d47\u3ca3\uc85e\u0211\u{1fd9b}\u0ce0\u8dde',
+  entries: [
+    {
+      binding: 3304,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 4100,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder18 = device0.createCommandEncoder({label: '\u4053\uf443\u91e8\u{1fe5a}'});
+let querySet16 = device0.createQuerySet({label: '\u0665\u0e1f\u{1fb6e}\u19f7\u9169\u642b', type: 'occlusion', count: 3511});
+let textureView25 = texture2.createView({label: '\ud34a\u06a7\u02b2\u6c9f\u0a93\ud5ab\uc35d', baseArrayLayer: 0});
+let sampler9 = device0.createSampler({
+  label: '\u05d0\u450e\u{1fa1d}\u950a\u867d\u{1fa4c}\u{1fe81}\u{1f883}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 66.49,
+  lodMaxClamp: 92.66,
+  compare: 'not-equal',
+  maxAnisotropy: 14,
+});
+try {
+buffer9.unmap();
+} catch {}
+try {
+commandEncoder13.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 874 widthInBlocks: 437 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 5370 */
+  offset: 5370,
+  buffer: buffer10,
+}, {width: 437, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise3 = device0.createComputePipelineAsync({layout: pipelineLayout1, compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}}});
+let texture11 = device0.createTexture({
+  label: '\u500d\uca50\u02e6\uac74\ud6ec\u{1f7b8}\u041c',
+  size: [240],
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+});
+let textureView26 = texture9.createView({label: '\ud4a2\u7aa4\u09d3\u{1f725}', baseMipLevel: 1, mipLevelCount: 3});
+try {
+commandEncoder18.clearBuffer(buffer8, 14536, 49116);
+dissociateBuffer(device0, buffer8);
+} catch {}
+let pipeline15 = await promise3;
+let pipeline16 = device0.createRenderPipeline({
+  label: '\u74e7\u08f3\u80ed\u0524\ue25e\u{1ffa8}\u{1fe30}\u{1fc94}\u{1f674}\u7be2',
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2064,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 886, shaderLocation: 19},
+          {format: 'uint16x4', offset: 352, shaderLocation: 6},
+          {format: 'sint8x2', offset: 84, shaderLocation: 3},
+          {format: 'sint8x4', offset: 240, shaderLocation: 2},
+          {format: 'sint32x3', offset: 20, shaderLocation: 23},
+          {format: 'unorm16x4', offset: 756, shaderLocation: 10},
+          {format: 'float32x2', offset: 72, shaderLocation: 8},
+          {format: 'float32', offset: 376, shaderLocation: 15},
+          {format: 'float32', offset: 528, shaderLocation: 14},
+          {format: 'unorm16x2', offset: 284, shaderLocation: 12},
+          {format: 'uint32x3', offset: 488, shaderLocation: 21},
+          {format: 'snorm8x2', offset: 16, shaderLocation: 25},
+          {format: 'float32x2', offset: 168, shaderLocation: 0},
+          {format: 'float16x2', offset: 180, shaderLocation: 22},
+          {format: 'float16x2', offset: 64, shaderLocation: 16},
+          {format: 'sint16x2', offset: 372, shaderLocation: 20},
+          {format: 'sint32x2', offset: 80, shaderLocation: 26},
+          {format: 'unorm10-10-10-2', offset: 2060, shaderLocation: 5},
+          {format: 'float32x2', offset: 680, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 696, shaderLocation: 1},
+          {format: 'uint32x2', offset: 312, shaderLocation: 24},
+          {format: 'sint16x4', offset: 16, shaderLocation: 4},
+          {format: 'uint16x4', offset: 1724, shaderLocation: 27},
+          {format: 'sint32x2', offset: 420, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 40,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 0, shaderLocation: 7},
+          {format: 'uint32x4', offset: 4, shaderLocation: 17},
+          {format: 'snorm16x2', offset: 0, shaderLocation: 18},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'front'},
+});
+let gpuCanvasContext2 = offscreenCanvas4.getContext('webgpu');
+let bindGroup6 = device0.createBindGroup({label: '\ua3fa\u7f6f\u317a\u0b54', layout: bindGroupLayout9, entries: []});
+let querySet17 = device0.createQuerySet({label: '\ud6c5\u05e3\u0567\uad85\u0599\u08a6', type: 'occlusion', count: 3479});
+let texture12 = device0.createTexture({
+  label: '\u{1fd12}\ub707\u199e',
+  size: {width: 2634},
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let externalTexture6 = device0.importExternalTexture({
+  label: '\u019a\u78c5\u2d0b\ucf02\u4e80\ua968\ubf2b\u{1fb03}\u{1f624}',
+  source: video0,
+  colorSpace: 'srgb',
+});
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder17.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+renderBundleEncoder7.pushDebugGroup('\u{1f72c}');
+} catch {}
+let pipeline17 = device0.createRenderPipeline({
+  layout: 'auto',
+  multisample: {mask: 0xffffffff},
+  fragment: {module: shaderModule2, entryPoint: 'fragment0', constants: {}, targets: [{format: 'rg16uint'}]},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'less-equal', depthFailOp: 'zero', passOp: 'invert'},
+    stencilBack: {compare: 'greater', failOp: 'invert', depthFailOp: 'replace', passOp: 'invert'},
+    stencilReadMask: 3559241846,
+    depthBias: -362793553,
+    depthBiasClamp: 278.2621623718628,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [{arrayStride: 988, attributes: [{format: 'snorm8x2', offset: 60, shaderLocation: 13}]}],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'back'},
+});
+try {
+sampler3.label = '\uee68\u0f08\uede4\ucf09\u26ab\ucc7b\u0c4b\u40a6\u8f5c';
+} catch {}
+let commandEncoder19 = device0.createCommandEncoder({});
+let textureView27 = texture6.createView({label: '\u430e\u6940\udf5a\u7898\ua75a\u3a57\uccc4', mipLevelCount: 1});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\u01e9\u2f89\uf560\u05b9\u6250\u4b0f',
+  colorFormats: ['rgba8unorm-srgb', 'r8unorm', 'r16sint', 'r8sint', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+commandEncoder18.copyBufferToBuffer(buffer9, 80276, buffer6, 14132, 101052);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder17.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 29, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 4,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 147 */
+{offset: 147, rowsPerImage: 101}, {width: 52, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline18 = await promise2;
+let offscreenCanvas6 = new OffscreenCanvas(983, 993);
+let querySet18 = device0.createQuerySet({label: '\u2068\ud165\u3409\uc361\ua184', type: 'occlusion', count: 3515});
+let textureView28 = texture3.createView({label: '\ucc71\uc310\uf552\uba1c\uf813\ua38f\u744e\u{1f831}'});
+let sampler10 = device0.createSampler({
+  label: '\u5572\udd08\u{1f829}\udc66\u5cf1\u4745\u0b91\u4908\u0c3d\u062c',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 91.49,
+  lodMaxClamp: 96.50,
+  maxAnisotropy: 3,
+});
+try {
+commandEncoder18.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 71, y: 3, z: 1},
+  aspect: 'all',
+},
+{width: 256, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer4, 191508, 37640);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder15.pushDebugGroup('\u33c5');
+} catch {}
+let pipeline19 = await device0.createRenderPipelineAsync({
+  label: '\u5958\u0b96\u{1ffea}\u{1fd57}\u798a\u4b15\u43e0\u0ce9\uc6ca\u{1fe57}\u8cc6',
+  layout: pipelineLayout3,
+  multisample: {count: 4, mask: 0x99060793},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'equal', failOp: 'zero', depthFailOp: 'decrement-wrap', passOp: 'replace'},
+    stencilBack: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'decrement-clamp'},
+    stencilReadMask: 2281662757,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1096,
+        attributes: [
+          {format: 'unorm16x2', offset: 12, shaderLocation: 12},
+          {format: 'sint32x3', offset: 8, shaderLocation: 2},
+          {format: 'unorm10-10-10-2', offset: 292, shaderLocation: 19},
+          {format: 'unorm8x4', offset: 560, shaderLocation: 14},
+          {format: 'snorm8x4', offset: 32, shaderLocation: 0},
+          {format: 'snorm8x2', offset: 168, shaderLocation: 8},
+          {format: 'snorm8x2', offset: 268, shaderLocation: 18},
+          {format: 'sint16x2', offset: 140, shaderLocation: 11},
+          {format: 'uint16x4', offset: 72, shaderLocation: 6},
+          {format: 'sint32', offset: 16, shaderLocation: 20},
+          {format: 'float16x4', offset: 32, shaderLocation: 1},
+          {format: 'float32x3', offset: 224, shaderLocation: 5},
+          {format: 'snorm16x2', offset: 152, shaderLocation: 7},
+          {format: 'float32x2', offset: 68, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 3084,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint8x4', offset: 200, shaderLocation: 21},
+          {format: 'unorm8x4', offset: 372, shaderLocation: 22},
+          {format: 'snorm8x4', offset: 100, shaderLocation: 25},
+          {format: 'sint32x2', offset: 412, shaderLocation: 26},
+          {format: 'float32', offset: 2800, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 180,
+        attributes: [{format: 'sint32x4', offset: 0, shaderLocation: 3}, {format: 'sint8x2', offset: 58, shaderLocation: 4}],
+      },
+      {
+        arrayStride: 3552,
+        attributes: [
+          {format: 'float32x2', offset: 452, shaderLocation: 16},
+          {format: 'snorm16x4', offset: 128, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 1476,
+        attributes: [
+          {format: 'uint32x4', offset: 240, shaderLocation: 27},
+          {format: 'sint8x2', offset: 1120, shaderLocation: 23},
+          {format: 'uint16x4', offset: 580, shaderLocation: 17},
+        ],
+      },
+      {arrayStride: 660, attributes: []},
+      {arrayStride: 268, attributes: []},
+      {arrayStride: 1504, attributes: []},
+      {
+        arrayStride: 868,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x4', offset: 136, shaderLocation: 24}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'front'},
+});
+try {
+offscreenCanvas3.getContext('webgl2');
+} catch {}
+let bindGroupLayout11 = pipeline10.getBindGroupLayout(1);
+let texture13 = device0.createTexture({
+  label: '\u611d\u0e89\ub39e\uf360\u1552\u8e1c\u748f\ueb21\u031c\u035a',
+  size: {width: 120, height: 8, depthOrArrayLayers: 9},
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32float', 'rgba32float'],
+});
+let textureView29 = texture2.createView({label: '\u{1f611}\u{1fbf4}\u{1fe63}\uf178\u27d1\ub899\u2717\ub486\ud3b1\u54cf', dimension: '2d'});
+let renderPassEncoder0 = commandEncoder18.beginRenderPass({
+  colorAttachments: [{view: textureView24, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet10,
+  maxDrawCount: 1065682805,
+});
+let sampler11 = device0.createSampler({
+  label: '\u2e2c\ub3ce\u003e\u6cab\u9097\ud7b9\u5a4a\u{1ff59}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 39.34,
+  lodMaxClamp: 51.62,
+  maxAnisotropy: 14,
+});
+try {
+renderPassEncoder0.setStencilReference(3460);
+} catch {}
+try {
+commandEncoder19.clearBuffer(buffer4, 107268, 12172);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise4 = device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+let textureView30 = texture11.createView({label: '\uf2bf\u{1f7eb}\u2702\udf8f\ud906\u037e\u004e\u{1fea0}\u{1fe2f}\u0d7c', arrayLayerCount: 1});
+let computePassEncoder11 = commandEncoder19.beginComputePass({label: '\ue26e\u4f07\u09b4\u{1fbf5}\u0e62\u0363\u01ac'});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({label: '\uc07f\u03b4\ua50d', colorFormats: ['rg16uint'], stencilReadOnly: true});
+try {
+renderPassEncoder0.setBlendConstant({ r: -270.5, g: -595.4, b: -257.5, a: 233.2, });
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint16');
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline16);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(2, buffer0, 0, 20159);
+} catch {}
+try {
+commandEncoder12.copyBufferToBuffer(buffer9, 157260, buffer6, 96852, 11380);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder15.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 11},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 32, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder7.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 7980, new BigUint64Array(57295), 14827, 484);
+} catch {}
+let bindGroupLayout12 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 2558,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 1399,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 6609,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let bindGroup7 = device0.createBindGroup({
+  label: '\u04a6\u0020\ua7f7\u31c9\u26ca\udd2b\u0691\u{1f988}\u83db',
+  layout: bindGroupLayout2,
+  entries: [{binding: 3007, resource: sampler9}],
+});
+let computePassEncoder12 = commandEncoder13.beginComputePass();
+let renderPassEncoder1 = commandEncoder12.beginRenderPass({
+  colorAttachments: [{
+  view: textureView24,
+  clearValue: { r: -26.32, g: 33.89, b: -573.4, a: -148.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 684257902,
+});
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup6, []);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 414.9, g: -203.4, b: -821.1, a: 300.6, });
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer0, 5000, 8349);
+} catch {}
+try {
+commandEncoder15.clearBuffer(buffer10, 55216, 152172);
+dissociateBuffer(device0, buffer10);
+} catch {}
+let pipeline20 = await device0.createRenderPipelineAsync({
+  label: '\u{1f6c2}\u{1f882}\u{1f96e}',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0xabba5783},
+  fragment: {
+  module: shaderModule0,
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 5340,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 52, shaderLocation: 25},
+          {format: 'unorm16x4', offset: 328, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 60,
+        attributes: [
+          {format: 'uint32x3', offset: 8, shaderLocation: 24},
+          {format: 'snorm8x2', offset: 0, shaderLocation: 19},
+          {format: 'uint8x2', offset: 14, shaderLocation: 17},
+          {format: 'sint32x3', offset: 0, shaderLocation: 20},
+          {format: 'float16x4', offset: 4, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 1108,
+        attributes: [
+          {format: 'float32', offset: 88, shaderLocation: 13},
+          {format: 'sint32x4', offset: 408, shaderLocation: 11},
+          {format: 'uint16x4', offset: 300, shaderLocation: 21},
+          {format: 'unorm16x2', offset: 168, shaderLocation: 1},
+          {format: 'sint8x4', offset: 8, shaderLocation: 3},
+          {format: 'float32x3', offset: 312, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 668,
+        attributes: [
+          {format: 'sint8x4', offset: 24, shaderLocation: 2},
+          {format: 'float16x4', offset: 32, shaderLocation: 14},
+          {format: 'uint32', offset: 404, shaderLocation: 27},
+          {format: 'uint16x2', offset: 0, shaderLocation: 6},
+          {format: 'sint32x2', offset: 40, shaderLocation: 26},
+          {format: 'float16x2', offset: 124, shaderLocation: 8},
+          {format: 'sint32x2', offset: 60, shaderLocation: 4},
+          {format: 'unorm16x2', offset: 40, shaderLocation: 7},
+          {format: 'sint32x3', offset: 240, shaderLocation: 23},
+          {format: 'snorm16x2', offset: 16, shaderLocation: 22},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [{format: 'float16x4', offset: 1748, shaderLocation: 12}],
+      },
+      {
+        arrayStride: 2184,
+        attributes: [
+          {format: 'snorm8x4', offset: 100, shaderLocation: 16},
+          {format: 'float32x3', offset: 180, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 1352, attributes: []},
+      {arrayStride: 1188, attributes: [{format: 'float32x2', offset: 140, shaderLocation: 15}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'back', unclippedDepth: false},
+});
+try {
+window.someLabel = textureView28.label;
+} catch {}
+let buffer11 = device0.createBuffer({
+  label: '\u03fe\u{1fff9}\u8fb9\u976b',
+  size: 2588,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder20 = device0.createCommandEncoder({label: '\u{1fc5e}\u{1fe1f}\u0597\u896f\u00e0\u0fec\uaf6a\u0f57\u8be9'});
+let textureView31 = texture10.createView({format: 'rgba8sint'});
+try {
+computePassEncoder9.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(759);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -326.5, g: 667.7, b: -311.6, a: -862.8, });
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(3, buffer0, 6764, 14065);
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(buffer5, 43144, buffer4, 220216, 8712);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder20.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let video3 = await videoWithData();
+let shaderModule3 = device0.createShaderModule({
+  label: '\u811f\u2f1e\u21e0\ue0de\u{1fc02}\u9f75',
+  code: `@group(0) @binding(2330)
+var<storage, read_write> function2: array<u32>;
+@group(0) @binding(6934)
+var<storage, read_write> field0: array<u32>;
+
+@compute @workgroup_size(8, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S2 {
+  @location(1) f0: vec4<f32>,
+  @location(35) f1: vec2<f16>,
+  @location(20) f2: vec4<f32>,
+  @location(25) f3: vec2<f16>,
+  @location(11) f4: i32,
+  @location(12) f5: vec2<f16>,
+  @location(15) f6: vec2<i32>,
+  @location(30) f7: vec4<f16>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @location(3) f1: vec2<i32>,
+  @location(1) f2: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(17) a0: vec2<f32>, a1: S2) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f28: vec4<f32>,
+  @location(25) f29: vec2<f16>,
+  @location(12) f30: vec2<f16>,
+  @location(35) f31: vec2<f16>,
+  @location(34) f32: f32,
+  @location(11) f33: i32,
+  @location(17) f34: vec2<f32>,
+  @location(1) f35: vec4<f32>,
+  @location(30) f36: vec4<f16>,
+  @location(15) f37: vec2<i32>,
+  @location(20) f38: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec2<i32>, @location(5) a1: vec3<f16>, @location(3) a2: vec2<f16>, @location(4) a3: vec3<i32>, @builtin(instance_index) a4: u32, @location(19) a5: i32, @location(24) a6: vec3<i32>, @builtin(vertex_index) a7: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+});
+let bindGroupLayout13 = device0.createBindGroupLayout({label: '\u{1fdf7}\u{1fbf9}', entries: []});
+let textureView32 = texture8.createView({label: '\u7530\u402e\u{1fba9}\u{1fe76}\u0168', mipLevelCount: 1, arrayLayerCount: 1});
+let renderBundle14 = renderBundleEncoder1.finish({label: '\u844b\u06c4\u73bd\u{1f939}\u57df\u15ba\ub45d'});
+try {
+renderPassEncoder0.executeBundles([renderBundle7, renderBundle8, renderBundle13, renderBundle11, renderBundle8, renderBundle13, renderBundle11, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer0, 0, 6622);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(2, buffer11, 0);
+} catch {}
+let arrayBuffer1 = buffer7.getMappedRange(240744, 138580);
+try {
+commandEncoder13.clearBuffer(buffer8, 12412, 92564);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline21 = await promise4;
+let pipeline22 = device0.createRenderPipeline({
+  label: '\u1482\u{1fe1f}\u8e96\u02b8\u{1fa12}\ue30b\uc506\u{1fc32}\u6cac\u{1fa1d}\u{1fa40}',
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8sint', writeMask: 0}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'dst'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'not-equal', failOp: 'invert', depthFailOp: 'zero', passOp: 'zero'},
+    stencilBack: {failOp: 'decrement-wrap', passOp: 'zero'},
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 1068, attributes: [{format: 'sint32x4', offset: 268, shaderLocation: 15}]},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 1496, shaderLocation: 24},
+          {format: 'snorm8x2', offset: 2540, shaderLocation: 3},
+          {format: 'snorm8x4', offset: 740, shaderLocation: 5},
+          {format: 'sint32x4', offset: 2948, shaderLocation: 19},
+        ],
+      },
+      {
+        arrayStride: 932,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x3', offset: 16, shaderLocation: 4}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', unclippedDepth: false},
+});
+let shaderModule4 = device0.createShaderModule({
+  label: '\u{1ff4e}\u3f3f\u{1fc55}\u0ff3\u0942\u{1ffc2}',
+  code: `@group(2) @binding(4360)
+var<storage, read_write> function3: array<u32>;
+@group(2) @binding(281)
+var<storage, read_write> field1: array<u32>;
+@group(0) @binding(4360)
+var<storage, read_write> global2: array<u32>;
+
+@compute @workgroup_size(7, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(28) a0: vec3<f32>, @location(32) a1: f16, @location(37) a2: vec4<f16>, @location(23) a3: f16, @location(16) a4: vec4<i32>, @location(38) a5: vec3<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S3 {
+  @location(14) f0: vec2<f32>,
+  @location(10) f1: f32,
+  @location(8) f2: vec3<f16>,
+  @location(3) f3: vec3<f32>,
+  @location(18) f4: vec3<f32>
+}
+struct VertexOutput0 {
+  @location(23) f39: f16,
+  @builtin(position) f40: vec4<f32>,
+  @location(8) f41: f32,
+  @location(16) f42: vec4<i32>,
+  @location(6) f43: vec4<i32>,
+  @location(28) f44: vec3<f32>,
+  @location(32) f45: f16,
+  @location(38) f46: vec3<u32>,
+  @location(9) f47: vec2<i32>,
+  @location(2) f48: vec4<f32>,
+  @location(37) f49: vec4<f16>,
+  @location(30) f50: vec2<f16>,
+  @location(4) f51: vec4<u32>,
+  @location(29) f52: i32,
+  @location(13) f53: f32
+}
+
+@vertex
+fn vertex0(@location(23) a0: u32, @location(17) a1: f16, @location(4) a2: vec4<u32>, @location(22) a3: i32, @location(24) a4: vec4<i32>, @location(19) a5: vec4<f16>, @location(12) a6: vec2<u32>, @location(26) a7: vec4<f32>, @location(0) a8: f16, @location(6) a9: vec4<u32>, @location(21) a10: f16, @location(15) a11: f32, @location(25) a12: vec4<i32>, @builtin(vertex_index) a13: u32, a14: S3, @builtin(instance_index) a15: u32, @location(7) a16: vec4<f32>, @location(16) a17: vec2<f32>, @location(5) a18: vec3<i32>, @location(9) a19: vec2<i32>, @location(20) a20: vec4<u32>, @location(13) a21: vec4<f16>, @location(1) a22: vec2<i32>, @location(2) a23: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout14 = pipeline22.getBindGroupLayout(1);
+let commandEncoder21 = device0.createCommandEncoder({});
+try {
+renderPassEncoder1.setPipeline(pipeline16);
+} catch {}
+try {
+commandEncoder20.clearBuffer(buffer6, 103608);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 2676, new BigUint64Array(29364), 25899, 872);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 9}
+*/
+{
+  source: video3,
+  origin: { x: 3, y: 2 },
+  flipY: false,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline23 = await device0.createRenderPipelineAsync({
+  label: '\u{1f8da}\u{1fcfe}\uc55c\u{1fa71}\u{1f807}\u0b7e\ucd6d\u0f3c\u259b',
+  layout: pipelineLayout3,
+  multisample: {mask: 0x99f67ca8},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 908, stepMode: 'instance', attributes: []},
+      {arrayStride: 484, stepMode: 'vertex', attributes: []},
+      {arrayStride: 400, stepMode: 'instance', attributes: []},
+      {arrayStride: 2564, attributes: []},
+      {arrayStride: 1004, attributes: [{format: 'float32x3', offset: 256, shaderLocation: 13}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw'},
+});
+let querySet19 = device0.createQuerySet({type: 'occlusion', count: 3508});
+let textureView33 = texture11.createView({label: '\u0352\u7635\u6615\u0edd\u317d\u4fbe\ub032', format: 'rgba16float'});
+let computePassEncoder13 = commandEncoder13.beginComputePass({});
+try {
+computePassEncoder2.setBindGroup(2, bindGroup4, new Uint32Array(5223), 1246, 0);
+} catch {}
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+commandEncoder17.copyBufferToTexture({
+  /* bytesInLastRow: 368 widthInBlocks: 92 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2920 */
+  offset: 2920,
+  buffer: buffer9,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 49, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 92, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder21.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 340 widthInBlocks: 85 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 696 */
+  offset: 696,
+  rowsPerImage: 19,
+  buffer: buffer8,
+}, {width: 85, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder15.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 28, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline24 = await device0.createComputePipelineAsync({layout: pipelineLayout1, compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}}});
+let textureView34 = texture4.createView({
+  label: '\ubf78\u{1fb70}\u6efc\ub6c5\udd60\u0573\u065c',
+  format: 'rg16uint',
+  baseArrayLayer: 77,
+  arrayLayerCount: 64,
+});
+try {
+renderPassEncoder1.beginOcclusionQuery(432);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer11, 0);
+} catch {}
+try {
+commandEncoder20.copyBufferToTexture({
+  /* bytesInLastRow: 174 widthInBlocks: 174 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2619 */
+  offset: 2619,
+  rowsPerImage: 174,
+  buffer: buffer2,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 174, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder0.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 44, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 204, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let video4 = await videoWithData();
+let commandEncoder22 = device0.createCommandEncoder({label: '\u0711\u9b87\u{1f9d8}\u7107\uc881\u0cba'});
+let querySet20 = device0.createQuerySet({type: 'occlusion', count: 900});
+let textureView35 = texture8.createView({label: '\u0061\u{1f701}\u014b\u{1fbe5}\u8758\u{1fb0c}\ucbc2\u03f1\u15a8\u77bd', dimension: '1d'});
+let computePassEncoder14 = commandEncoder21.beginComputePass({});
+let renderPassEncoder2 = commandEncoder17.beginRenderPass({
+  label: '\u{1fe96}\u8208\u6942\u{1fb6d}\ub3b3\u{1fba1}\u0afa\u668d\u{1f956}\ucfe5\u0c2e',
+  colorAttachments: [{
+  view: textureView24,
+  clearValue: { r: 247.5, g: -571.6, b: 154.3, a: 643.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet8,
+  maxDrawCount: 1143125200,
+});
+let externalTexture7 = device0.importExternalTexture({
+  label: '\u0b79\u078d\u2f5f\u0da9\uac89\u0e61\u9123\ud54d\ued64',
+  source: video4,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder1.executeBundles([renderBundle8, renderBundle13, renderBundle7, renderBundle11, renderBundle13, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 385.8, g: 486.8, b: 206.6, a: -601.7, });
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(14, 0, 13, 2);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer1, 'uint32', 506876, 80200);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline16);
+} catch {}
+try {
+device0.queue.submit([commandBuffer5, commandBuffer3]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+let commandEncoder23 = device0.createCommandEncoder();
+let querySet21 = device0.createQuerySet({label: '\u{1fa30}\udfbd\u0373\u270e\u09a1\u8af2\u3b14', type: 'occlusion', count: 3070});
+let texture14 = device0.createTexture({
+  label: '\u3d9a\ub4ae\u8234\u06fe\udf31',
+  size: [240, 16, 18],
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16float'],
+});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({
+  label: '\uac8e\u01f6\u8159\u{1fd72}',
+  colorFormats: ['rgba8sint', 'rg16float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle15 = renderBundleEncoder10.finish({});
+try {
+renderPassEncoder0.executeBundles([renderBundle7, renderBundle13, renderBundle11, renderBundle13, renderBundle7, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder0.setViewport(18.62, 0.9905, 1.072, 0.4715, 0.5520, 0.8112);
+} catch {}
+try {
+renderBundleEncoder7.setIndexBuffer(buffer1, 'uint16', 363494);
+} catch {}
+try {
+commandEncoder20.copyBufferToTexture({
+  /* bytesInLastRow: 19176 widthInBlocks: 2397 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 7024 */
+  offset: 7024,
+  buffer: buffer9,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 65, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2397, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder15.copyTextureToBuffer({
+  texture: texture9,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 408 widthInBlocks: 51 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 27904 */
+  offset: 27904,
+  bytesPerRow: 512,
+  rowsPerImage: 113,
+  buffer: buffer4,
+}, {width: 51, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer4);
+} catch {}
+let img4 = await imageWithData(153, 34, '#cb979901', '#cce49ab6');
+try {
+offscreenCanvas6.getContext('webgl2');
+} catch {}
+let commandEncoder24 = device0.createCommandEncoder({label: '\u386d\u3c2c\u99f0\ubfad\u0a19\uc110'});
+let texture15 = device0.createTexture({
+  label: '\ue67f\u9ebc\u0990\u05a2\uea84\u0509\u{1ff52}\u83d2\u6243',
+  size: {width: 658, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView36 = texture13.createView({label: '\u6038\uaf80\u02ef\udc8a\u2fc8', aspect: 'all', format: 'rgba32float', mipLevelCount: 1});
+let externalTexture8 = device0.importExternalTexture({label: '\ue08f\u{1f932}\u0758\u0c1e\u{1fdda}\u0391\ub157', source: videoFrame1, colorSpace: 'srgb'});
+try {
+commandEncoder15.copyBufferToBuffer(buffer2, 11516, buffer10, 94468, 184);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder0.clearBuffer(buffer4, 13308, 227688);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let img5 = await imageWithData(232, 98, '#299f4183', '#2fe09c21');
+let commandEncoder25 = device0.createCommandEncoder({label: '\u0dc7\u779a\u8e81\u07df\u174c\ubce0\uab78\u042d\u0bb7\u32a9'});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(743);
+} catch {}
+try {
+renderPassEncoder1.setViewport(17.52, 0.2037, 3.868, 1.721, 0.6219, 0.7822);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer1, 'uint16', 584356);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer1, 'uint32', 166500, 312794);
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(buffer9, 197720, buffer7, 219808, 16132);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 289 */
+{offset: 289}, {width: 461, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline25 = device0.createRenderPipeline({
+  label: '\u0ed5\u0104\u064b\uc75d\u523a\u{1ff92}\u{1fe21}\u2941',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0x914a95af},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 5752, stepMode: 'instance', attributes: []},
+      {arrayStride: 1080, attributes: []},
+      {
+        arrayStride: 460,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 228, shaderLocation: 4},
+          {format: 'sint32x3', offset: 4, shaderLocation: 15},
+          {format: 'sint32x4', offset: 48, shaderLocation: 19},
+          {format: 'snorm16x4', offset: 16, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 1036,
+        attributes: [
+          {format: 'sint16x4', offset: 288, shaderLocation: 24},
+          {format: 'float16x2', offset: 64, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'front'},
+});
+let gpuCanvasContext3 = canvas2.getContext('webgpu');
+gc();
+let imageData5 = new ImageData(136, 136);
+let commandEncoder26 = device0.createCommandEncoder({label: '\u{1fc3d}\u50d9\u188b\u028a\u7346'});
+let texture16 = device0.createTexture({
+  size: [60, 4, 4],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg16uint', 'rg16uint'],
+});
+let renderPassEncoder3 = commandEncoder25.beginRenderPass({
+  label: '\u97da\u7e31\u08a7\ue81b\u052f\u{1f9fe}\ufaf1\u{1fc03}\u01c0\u7fd2\u7dfd',
+  colorAttachments: [{
+  view: textureView24,
+  clearValue: { r: -201.7, g: -177.7, b: 492.7, a: -700.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet9,
+  maxDrawCount: 362965219,
+});
+let renderBundle16 = renderBundleEncoder5.finish({label: '\u{1fb07}\uaaa6\ud4b9\u{1fbae}\u0f4d\ud9fd\ufa57\u{1fa15}\u{1fbc8}\u0304\ud4ad'});
+let promise5 = buffer10.mapAsync(GPUMapMode.READ, 128144, 63416);
+try {
+commandEncoder20.clearBuffer(buffer8, 27524, 49976);
+dissociateBuffer(device0, buffer8);
+} catch {}
+let pipeline26 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0x4588c57c},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'constant'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'src', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'r16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba32float', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2324,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 320, shaderLocation: 4},
+          {format: 'uint8x4', offset: 332, shaderLocation: 22},
+          {format: 'uint16x4', offset: 188, shaderLocation: 25},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back'},
+});
+try {
+window.someLabel = externalTexture4.label;
+} catch {}
+let texture17 = gpuCanvasContext1.getCurrentTexture();
+let renderBundle17 = renderBundleEncoder1.finish();
+let externalTexture9 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'display-p3'});
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(390);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(16, 2, 2, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(8, buffer0, 0, 19944);
+} catch {}
+try {
+commandEncoder0.copyBufferToTexture({
+  /* bytesInLastRow: 304 widthInBlocks: 76 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 13760 */
+  offset: 13760,
+  buffer: buffer9,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 103, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 76, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 4892, new BigUint64Array(60210), 42143, 3940);
+} catch {}
+let pipeline27 = device0.createComputePipeline({
+  label: '\u{1f7a7}\uc577\u0b11\u58de\u{1ff2d}\uefec',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let commandBuffer6 = commandEncoder0.finish({label: '\u{1f861}\ubf66\u0584\u06f7\u{1f9a4}\u{1fa99}\u06e2\u067d\u0b44'});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'r8unorm', 'r16sint', 'r8sint', 'rgba32float'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup7, new Uint32Array(9840), 7915, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup6, new Uint32Array(6654), 448, 0);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(120);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle8, renderBundle11, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 580.9, g: 575.5, b: -835.4, a: 640.6, });
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(11, 0, 14, 0);
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(buffer11, 1408, buffer10, 38896, 1024);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder20.clearBuffer(buffer4, 104956, 76764);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let pipeline28 = await device0.createComputePipelineAsync({
+  label: '\u12aa\u0c01\u14f3\u{1fd34}\u0159\u9545\u0625\u{1fa88}\u0a2a\uebb8\ubca0',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+let imageBitmap1 = await createImageBitmap(img3);
+try {
+window.someLabel = textureView2.label;
+} catch {}
+let shaderModule5 = device0.createShaderModule({
+  label: '\u08c2\u0970\u{1fe07}',
+  code: `@group(1) @binding(6934)
+var<storage, read_write> local3: array<u32>;
+@group(1) @binding(2330)
+var<storage, read_write> parameter1: array<u32>;
+@group(0) @binding(3212)
+var<storage, read_write> function4: array<u32>;
+
+@compute @workgroup_size(3, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(2) f1: i32,
+  @location(1) f2: vec3<f32>,
+  @location(3) f3: i32,
+  @location(7) f4: vec2<f32>,
+  @location(4) f5: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(23) a0: vec4<i32>, @location(9) a1: vec2<i32>, @location(39) a2: vec2<u32>, @location(4) a3: vec4<i32>, @location(25) a4: vec3<u32>, @location(10) a5: f32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S4 {
+  @location(8) f0: vec4<i32>,
+  @builtin(vertex_index) f1: u32,
+  @location(4) f2: vec4<f16>,
+  @location(9) f3: vec3<i32>,
+  @location(2) f4: vec2<f16>,
+  @location(16) f5: vec4<f16>,
+  @location(25) f6: vec3<f16>,
+  @location(0) f7: vec3<f16>,
+  @location(18) f8: u32,
+  @location(15) f9: vec4<i32>,
+  @location(20) f10: vec4<u32>,
+  @location(21) f11: u32,
+  @location(17) f12: f16,
+  @location(10) f13: vec3<i32>
+}
+struct VertexOutput0 {
+  @location(10) f54: f32,
+  @location(12) f55: vec4<f16>,
+  @location(7) f56: vec2<f32>,
+  @location(35) f57: vec3<i32>,
+  @location(23) f58: vec4<i32>,
+  @location(22) f59: vec4<i32>,
+  @location(20) f60: vec3<i32>,
+  @location(18) f61: vec2<i32>,
+  @location(8) f62: vec2<f16>,
+  @location(19) f63: vec4<f32>,
+  @location(27) f64: vec3<f32>,
+  @location(28) f65: vec4<u32>,
+  @location(14) f66: i32,
+  @location(9) f67: vec2<i32>,
+  @location(11) f68: vec2<f16>,
+  @location(15) f69: vec3<i32>,
+  @location(26) f70: vec2<i32>,
+  @location(21) f71: vec2<f16>,
+  @location(38) f72: vec4<f16>,
+  @location(16) f73: vec3<u32>,
+  @location(13) f74: vec3<i32>,
+  @location(34) f75: vec3<f16>,
+  @location(17) f76: vec2<f32>,
+  @location(1) f77: vec2<f16>,
+  @location(30) f78: vec4<u32>,
+  @location(36) f79: vec4<i32>,
+  @location(32) f80: vec2<f32>,
+  @location(39) f81: vec2<u32>,
+  @location(37) f82: vec4<f16>,
+  @builtin(position) f83: vec4<f32>,
+  @location(31) f84: vec2<i32>,
+  @location(3) f85: vec4<f32>,
+  @location(2) f86: vec3<f32>,
+  @location(0) f87: vec3<u32>,
+  @location(33) f88: f32,
+  @location(4) f89: vec4<i32>,
+  @location(24) f90: vec3<f32>,
+  @location(29) f91: vec4<f16>,
+  @location(6) f92: vec2<u32>,
+  @location(25) f93: vec3<u32>,
+  @location(5) f94: u32
+}
+
+@vertex
+fn vertex0(a0: S4, @location(13) a1: vec3<f16>, @location(7) a2: vec2<f16>, @location(14) a3: f32, @location(26) a4: vec3<f16>, @location(1) a5: vec2<u32>, @location(22) a6: vec2<u32>, @location(5) a7: f16, @location(12) a8: vec4<u32>, @location(23) a9: u32, @location(11) a10: vec4<f32>, @location(3) a11: vec2<u32>, @location(24) a12: vec4<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let querySet22 = device0.createQuerySet({label: '\u9721\u{1fdc5}\u02b6\u91b3\u3f0c', type: 'occlusion', count: 1919});
+let textureView37 = texture13.createView({label: '\u2de1\u557e\u0385\u051b\u06e0\u{1f67e}\u0aa1\u03c7\u{1f71d}', arrayLayerCount: 1});
+try {
+computePassEncoder11.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle15, renderBundle13, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(17, 0, 13, 0);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(1, bindGroup5);
+} catch {}
+let promise6 = device0.popErrorScope();
+try {
+commandEncoder4.copyBufferToBuffer(buffer2, 10836, buffer8, 44036, 1576);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer8);
+} catch {}
+let imageData6 = new ImageData(228, 96);
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  label: '\ubc1e\u9293',
+  colorFormats: ['rgba8unorm-srgb', 'r8unorm', 'r16sint', 'r8sint', 'rgba32float'],
+});
+let externalTexture10 = device0.importExternalTexture({label: '\ub251\u{1f9ee}\uea9b\u{1fd70}\u{1f9f5}\u0846', source: videoFrame0, colorSpace: 'display-p3'});
+try {
+renderPassEncoder3.setIndexBuffer(buffer1, 'uint32');
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(4, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder13.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder15.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 132712, new Int16Array(33322), 27317, 632);
+} catch {}
+let bindGroupLayout15 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 4214,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 3385, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 4883, visibility: 0, sampler: { type: 'filtering' }},
+  ],
+});
+let commandEncoder27 = device0.createCommandEncoder();
+let textureView38 = texture4.createView({
+  label: '\u8f33\u1afd\u0e7c\u2367\u{1fcca}\u34a2',
+  dimension: '2d',
+  baseArrayLayer: 207,
+  arrayLayerCount: 1,
+});
+let renderBundle18 = renderBundleEncoder8.finish({});
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle7]);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(24, 1, 1, 1);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(3900, undefined, 0, 899579537);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 148, new DataView(new ArrayBuffer(24096)), 14393, 2348);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 9}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 1, y: 2 },
+  flipY: true,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 4, y: 5, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+externalTexture6.label = '\u{1fde6}\ua88c';
+} catch {}
+let commandBuffer7 = commandEncoder4.finish();
+let texture18 = device0.createTexture({
+  label: '\u2a43\u{1fa3e}\u067d\u39b2\ueb50\u08fe\u0485\u0b48',
+  size: [1317, 40, 946],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder3.setBlendConstant({ r: 572.3, g: -328.9, b: -702.7, a: -112.9, });
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup3, []);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 26060, new BigUint64Array(11029), 9679, 56);
+} catch {}
+try {
+  await promise6;
+} catch {}
+let img6 = await imageWithData(19, 221, '#c4c2e1a6', '#ca184ddc');
+let sampler12 = device0.createSampler({
+  label: '\u{1ff98}\u{1f67f}',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 14.12,
+  lodMaxClamp: 37.94,
+});
+try {
+computePassEncoder1.setBindGroup(6, bindGroup2, new Uint32Array(1370), 1354, 0);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(102);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(1437);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer1, 'uint16');
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(4, buffer11, 328);
+} catch {}
+try {
+renderBundleEncoder13.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder20.copyBufferToTexture({
+  /* bytesInLastRow: 336 widthInBlocks: 168 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4612 */
+  offset: 4612,
+  bytesPerRow: 512,
+  buffer: buffer2,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 168, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 9}
+*/
+{
+  source: offscreenCanvas5,
+  origin: { x: 0, y: 41 },
+  flipY: true,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 22, y: 3, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise5;
+} catch {}
+let bindGroup8 = device0.createBindGroup({
+  label: '\u0aeb\ub6cb\u{1f919}\u{1fb3a}\u{1f669}',
+  layout: bindGroupLayout2,
+  entries: [{binding: 3007, resource: sampler9}],
+});
+let commandBuffer8 = commandEncoder20.finish({});
+let textureView39 = texture9.createView({label: '\u{1f658}\u6041\ua30a\ud230', baseMipLevel: 4});
+let renderBundle19 = renderBundleEncoder2.finish({label: '\u9f99\u05c5\u0cf7\u{1f995}\ua985\u{1fdba}\u52ad\u4b23\u07e8'});
+try {
+computePassEncoder13.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(4, bindGroup8);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(8, buffer0, 20612, 307);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(1, bindGroup0, new Uint32Array(3706), 2741, 0);
+} catch {}
+try {
+commandEncoder24.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 240 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 30312 */
+  offset: 30312,
+  rowsPerImage: 257,
+  buffer: buffer8,
+}, {width: 30, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder22.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 1,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 58244, new DataView(new ArrayBuffer(27795)), 20667, 328);
+} catch {}
+let videoFrame2 = new VideoFrame(img2, {timestamp: 0});
+let pipelineLayout6 = device0.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout10, bindGroupLayout11, bindGroupLayout10, bindGroupLayout13, bindGroupLayout3],
+});
+let commandEncoder28 = device0.createCommandEncoder();
+let textureView40 = texture13.createView({label: '\u0b20\ue7a3\uf839\u45f1\u272e\u0842\ucfb1\u243b\u1a58'});
+let externalTexture11 = device0.importExternalTexture({label: '\u515a\u0173\ueaff\uc5c0\u0951\u9f13\uf91d', source: videoFrame1});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -30.81, g: 718.7, b: -217.2, a: -494.5, });
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(6, buffer0, 10720, 6514);
+} catch {}
+let video5 = await videoWithData();
+let bindGroup9 = device0.createBindGroup({
+  label: '\u{1fd8c}\ue28d\u45a4\ub2d9\u07e2\udc28\ub2f9\u02d0\u421c',
+  layout: bindGroupLayout0,
+  entries: [],
+});
+let commandEncoder29 = device0.createCommandEncoder();
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({
+  label: '\u0a86\u6d0f\u5db5\uef90\udf85',
+  colorFormats: ['rgba16uint', undefined, 'rgb10a2uint', 'r32float', 'rgba16uint', 'r8uint', 'r16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler13 = device0.createSampler({
+  label: '\u0cd2\u52f9\u1dd4\u{1f617}\u{1fcf5}',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 93.79,
+});
+try {
+renderPassEncoder1.setStencilReference(885);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(0, buffer0, 2444, 5110);
+} catch {}
+try {
+commandEncoder24.copyBufferToBuffer(buffer5, 4484, buffer6, 81912, 2228);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let imageData7 = new ImageData(136, 108);
+let textureView41 = texture17.createView({dimension: '2d-array', format: 'rgba8unorm-srgb'});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({
+  label: '\u468e\u0fbf\u9356\u0134\u0f17\u5b32',
+  colorFormats: ['rgba16uint', undefined, 'rgb10a2uint', 'r32float', 'rgba16uint', 'r8uint', 'r16sint'],
+  stencilReadOnly: true,
+});
+let sampler14 = device0.createSampler({
+  label: '\u161b\u425e\uf976\u{1f9d7}\u64bb\u{1fb22}\u07c8\u07dc\uf3ff\u07a4\u{1fdae}',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 75.21,
+  lodMaxClamp: 82.42,
+});
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 79.67, g: 948.9, b: -791.8, a: 307.2, });
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer0, 0, 17989);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(322, 70, 149_699_166);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(2, buffer0, 0, 5776);
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let pipeline29 = device0.createRenderPipeline({
+  label: '\u1a91\u93a3\u32b3\uf296\ua89c\u0fb2\u0ec6\u0625\udc93\u7117',
+  layout: pipelineLayout1,
+  multisample: {mask: 0xd65801a4},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'add', srcFactor: 'constant', dstFactor: 'constant'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'one'},
+  },
+}, {format: 'r8unorm', writeMask: 0}, {format: 'r16sint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8sint'}, {format: 'rgba32float'}],
+},
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 44,
+        attributes: [
+          {format: 'float32x4', offset: 4, shaderLocation: 14},
+          {format: 'uint32x3', offset: 0, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 10, shaderLocation: 4},
+          {format: 'float32', offset: 0, shaderLocation: 26},
+          {format: 'unorm10-10-10-2', offset: 0, shaderLocation: 11},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 2},
+          {format: 'float32', offset: 0, shaderLocation: 13},
+          {format: 'uint32', offset: 0, shaderLocation: 3},
+          {format: 'sint16x4', offset: 8, shaderLocation: 15},
+          {format: 'unorm16x2', offset: 12, shaderLocation: 16},
+          {format: 'uint16x4', offset: 0, shaderLocation: 12},
+          {format: 'uint32x3', offset: 4, shaderLocation: 21},
+          {format: 'sint16x4', offset: 0, shaderLocation: 10},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 0},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 7},
+          {format: 'sint16x4', offset: 0, shaderLocation: 8},
+          {format: 'float32x2', offset: 8, shaderLocation: 25},
+          {format: 'uint32', offset: 0, shaderLocation: 20},
+        ],
+      },
+      {
+        arrayStride: 152,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 24, shaderLocation: 5},
+          {format: 'uint32x4', offset: 16, shaderLocation: 24},
+          {format: 'float32x4', offset: 24, shaderLocation: 17},
+          {format: 'uint8x4', offset: 36, shaderLocation: 22},
+        ],
+      },
+      {arrayStride: 660, stepMode: 'vertex', attributes: []},
+      {arrayStride: 4780, attributes: []},
+      {
+        arrayStride: 4756,
+        attributes: [
+          {format: 'sint8x2', offset: 1070, shaderLocation: 9},
+          {format: 'uint32', offset: 588, shaderLocation: 18},
+        ],
+      },
+      {arrayStride: 3716, attributes: []},
+      {arrayStride: 408, attributes: []},
+      {arrayStride: 1252, attributes: [{format: 'uint16x2', offset: 112, shaderLocation: 23}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'ccw', cullMode: 'none'},
+});
+let bindGroup10 = device0.createBindGroup({label: '\u6414\u{1f866}\u{1f870}', layout: bindGroupLayout9, entries: []});
+let commandEncoder30 = device0.createCommandEncoder({label: '\uae00\u05b4\u0eb6\uc51e\u{1fd3f}\u{1fe02}\u6754\uf7c7\ucf5f\u088c'});
+let querySet23 = device0.createQuerySet({label: '\u87c2\u7f5b\u{1f620}\u0f29\u2027\u0d39\u09a0\u397b\u{1ffa6}', type: 'occlusion', count: 2870});
+let renderBundle20 = renderBundleEncoder12.finish({label: '\uf861\u98fa\u{1fe4a}\u5820\u0ad9\u0365'});
+let externalTexture12 = device0.importExternalTexture({source: video1});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(1263);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -46.93, g: 632.7, b: 392.4, a: -798.2, });
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(24, 1, 3, 1);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer1, 'uint32');
+} catch {}
+try {
+renderBundleEncoder13.draw(271, 20, 1_177_522_023, 441_509_470);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer3, 146348);
+} catch {}
+try {
+commandEncoder27.copyBufferToTexture({
+  /* bytesInLastRow: 402 widthInBlocks: 402 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1489 */
+  offset: 1489,
+  buffer: buffer2,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 402, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let querySet24 = device0.createQuerySet({label: '\uef64\ue14d\u21fd\u5a4e\u9899\u{1f874}\uc543', type: 'occlusion', count: 478});
+let renderPassEncoder4 = commandEncoder30.beginRenderPass({
+  label: '\ubf1f\ucbf3',
+  colorAttachments: [{
+  view: textureView24,
+  clearValue: { r: -814.4, g: 966.8, b: 984.6, a: -524.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet16,
+});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({label: '\uf768\u0b6b\u000c\u1c32', colorFormats: ['rg16uint'], depthReadOnly: true});
+let renderBundle21 = renderBundleEncoder0.finish({label: '\ucfaa\u{1fb2b}\u0c0c'});
+let sampler15 = device0.createSampler({
+  label: '\u{1fa30}\ue983\u0387\u0867',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  lodMinClamp: 46.04,
+  lodMaxClamp: 51.50,
+  compare: 'less-equal',
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setViewport(24.15, 1.011, 2.364, 0.5396, 0.9573, 0.9877);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer1, 'uint32', 453184);
+} catch {}
+try {
+commandEncoder27.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1176 widthInBlocks: 147 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 19136 */
+  offset: 19136,
+  buffer: buffer8,
+}, {width: 147, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer8);
+} catch {}
+let pipeline30 = device0.createRenderPipeline({
+  label: '\ub142\u909d\u0feb\u8f3c\u0009\u{1f6c9}\u{1f797}\u{1fa30}',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-wrap', passOp: 'invert'},
+    stencilBack: {compare: 'greater-equal', failOp: 'keep', depthFailOp: 'invert', passOp: 'zero'},
+    stencilReadMask: 344035045,
+    depthBiasSlopeScale: 14.530535306033656,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 768,
+        stepMode: 'vertex',
+        attributes: [{format: 'float32x2', offset: 12, shaderLocation: 13}],
+      },
+    ],
+  },
+});
+let commandEncoder31 = device0.createCommandEncoder({label: '\u07fa\uc2be\u{1fef5}\u{1fff0}\uda82\u41c4\ua337\u5902\u87b4'});
+let renderPassEncoder5 = commandEncoder29.beginRenderPass({
+  label: '\u06e1\u05ab',
+  colorAttachments: [{
+  view: textureView24,
+  clearValue: { r: -793.7, g: 712.5, b: 278.2, a: -53.49, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 414570578,
+});
+try {
+computePassEncoder13.setBindGroup(4, bindGroup10, new Uint32Array(3852), 2484, 0);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(2237);
+} catch {}
+try {
+renderPassEncoder5.setViewport(16.59, 0.6871, 11.47, 0.1809, 0.9927, 0.9998);
+} catch {}
+try {
+renderBundleEncoder13.draw(290);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(6, buffer11);
+} catch {}
+try {
+commandEncoder31.clearBuffer(buffer10, 207068, 1092);
+dissociateBuffer(device0, buffer10);
+} catch {}
+let commandBuffer9 = commandEncoder31.finish();
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder13.draw(198);
+} catch {}
+try {
+commandEncoder27.copyBufferToBuffer(buffer11, 64, buffer4, 217692, 1844);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder27.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 66, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 300 widthInBlocks: 300 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 23478 */
+  offset: 23178,
+  buffer: buffer4,
+}, {width: 300, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder28.insertDebugMarker('\u0235');
+} catch {}
+let querySet25 = device0.createQuerySet({
+  label: '\uc3fa\uad88\uf909\u{1fd00}\u0f67\u27f7\u0210\u7d9b\u5dc4\u30bf',
+  type: 'occlusion',
+  count: 3594,
+});
+try {
+renderPassEncoder0.setBindGroup(4, bindGroup0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup10, new Uint32Array(3374), 3163, 0);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(5, buffer11, 0, 1304);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(2, bindGroup9, new Uint32Array(7399), 1279, 0);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer7, 189080, new Int16Array(46154), 23850, 4000);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 197 */
+{offset: 27, bytesPerRow: 98, rowsPerImage: 297}, {width: 18, height: 2, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 9}
+*/
+{
+  source: video3,
+  origin: { x: 1, y: 0 },
+  flipY: true,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline31 = await device0.createComputePipelineAsync({layout: pipelineLayout5, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+let bindGroupLayout16 = device0.createBindGroupLayout({label: '\u7163\ub05f', entries: []});
+let textureView42 = texture11.createView({aspect: 'all', baseArrayLayer: 0, arrayLayerCount: 1});
+let externalTexture13 = device0.importExternalTexture({
+  label: '\ucf00\udeb9\ub28d\ue1f0\uc0b3\ud2d1\u{1f790}\u{1f7e4}\u98ff\u0c27',
+  source: videoFrame0,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder9.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle13, renderBundle13, renderBundle7, renderBundle11, renderBundle7, renderBundle15]);
+} catch {}
+try {
+renderBundleEncoder13.draw(453, 221);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(486, 61, 1_181_403_923, 330_579_755, 1_134_503_692);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer3, 8564);
+} catch {}
+try {
+renderPassEncoder3.pushDebugGroup('\u7c3b');
+} catch {}
+try {
+renderPassEncoder3.popDebugGroup();
+} catch {}
+let textureView43 = texture15.createView({label: '\u08c6\u{1f6c1}\ue01a\u8324\u5172', baseMipLevel: 2});
+try {
+renderBundleEncoder13.draw(55);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(7, buffer11);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+  await buffer7.mapAsync(GPUMapMode.READ);
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture({
+  /* bytesInLastRow: 6400 widthInBlocks: 800 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 26936 */
+  offset: 26936,
+  bytesPerRow: 6656,
+  buffer: buffer9,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 80, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 800, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder27.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 932 widthInBlocks: 233 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3368 */
+  offset: 3368,
+  buffer: buffer4,
+}, {width: 233, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer4);
+} catch {}
+let pipeline32 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout0,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'r8unorm', writeMask: 0}, {format: 'r16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 1024, attributes: [{format: 'uint8x4', offset: 220, shaderLocation: 22}]},
+      {
+        arrayStride: 588,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 60, shaderLocation: 16},
+          {format: 'snorm16x2', offset: 56, shaderLocation: 5},
+          {format: 'uint32x2', offset: 128, shaderLocation: 24},
+          {format: 'unorm16x2', offset: 44, shaderLocation: 26},
+          {format: 'uint8x4', offset: 0, shaderLocation: 23},
+          {format: 'snorm8x4', offset: 56, shaderLocation: 2},
+          {format: 'uint8x4', offset: 48, shaderLocation: 20},
+        ],
+      },
+      {
+        arrayStride: 2068,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 568, shaderLocation: 14},
+          {format: 'sint32', offset: 720, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 168,
+        attributes: [
+          {format: 'uint32x2', offset: 0, shaderLocation: 18},
+          {format: 'snorm16x4', offset: 8, shaderLocation: 7},
+          {format: 'float32x3', offset: 36, shaderLocation: 13},
+          {format: 'sint16x4', offset: 0, shaderLocation: 10},
+          {format: 'uint8x4', offset: 28, shaderLocation: 21},
+          {format: 'uint32x2', offset: 8, shaderLocation: 3},
+          {format: 'snorm8x2', offset: 30, shaderLocation: 17},
+          {format: 'snorm16x4', offset: 8, shaderLocation: 25},
+        ],
+      },
+      {
+        arrayStride: 7360,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 1372, shaderLocation: 12},
+          {format: 'sint16x2', offset: 3232, shaderLocation: 8},
+          {format: 'unorm16x2', offset: 340, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 1456,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 56, shaderLocation: 15},
+          {format: 'unorm16x4', offset: 36, shaderLocation: 0},
+          {format: 'float32x4', offset: 248, shaderLocation: 11},
+          {format: 'uint32x2', offset: 164, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back'},
+});
+document.body.prepend(canvas0);
+let offscreenCanvas7 = new OffscreenCanvas(10, 851);
+try {
+offscreenCanvas7.getContext('webgpu');
+} catch {}
+let computePassEncoder15 = commandEncoder22.beginComputePass({label: '\uc362\u0a2f\u{1fb54}\u92bb\u0d15\uc850\u60d7\uc69c\u01b4\u05e3\u8298'});
+let renderBundle22 = renderBundleEncoder1.finish({label: '\u88b6\u0fa1\u3848\u08e2\u6755'});
+try {
+renderPassEncoder4.setBlendConstant({ r: 942.2, g: -766.8, b: -834.6, a: 562.7, });
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(1237);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer1, 'uint32');
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(194, 275, 276_385_917, 733_545_053, 1_133_934_746);
+} catch {}
+try {
+renderBundleEncoder13.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8104 */
+  offset: 3984,
+  bytesPerRow: 256,
+  rowsPerImage: 8,
+  buffer: buffer9,
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 1, depthOrArrayLayers: 3});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder15.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 3,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 58, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer8, 78920, 5204);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder15.insertDebugMarker('\u07ea');
+} catch {}
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(6, bindGroup4);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline16);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder27.copyBufferToTexture({
+  /* bytesInLastRow: 120 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 36456 */
+  offset: 36456,
+  bytesPerRow: 256,
+  buffer: buffer9,
+}, {
+  texture: texture15,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 30, height: 4, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder15.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1040 widthInBlocks: 520 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 27322 */
+  offset: 26282,
+  buffer: buffer4,
+}, {width: 520, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer8, 67168, 41248);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 35752, new BigUint64Array(62489), 27470, 148);
+} catch {}
+gc();
+let querySet26 = device0.createQuerySet({label: '\u0edf\u1166\u0a3c\u8f0a', type: 'occlusion', count: 453});
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture({
+  /* bytesInLastRow: 1396 widthInBlocks: 349 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 680 */
+  offset: 680,
+  buffer: buffer2,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 349, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(new ArrayBuffer(32)), /* required buffer size: 496 */
+{offset: 496, bytesPerRow: 418}, {width: 56, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let texture19 = device0.createTexture({
+  size: {width: 60, height: 4, depthOrArrayLayers: 4},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView44 = texture11.createView({label: '\u0407\ud638\u0be6\ub8ea\u3e7f\uf883\u{1f986}\u{1fa12}\uac22\u1114\u{1fd5c}'});
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(13, 0, 5, 2);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer11, 0, 745);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer3, 119224);
+} catch {}
+try {
+commandEncoder23.copyBufferToBuffer(buffer2, 5012, buffer7, 434120, 9232);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 8996, new DataView(new ArrayBuffer(6030)), 56, 2164);
+} catch {}
+let commandEncoder32 = device0.createCommandEncoder({label: '\u7d30\u458b\u{1fed4}\u0c9e\u6886'});
+try {
+renderPassEncoder0.setStencilReference(256);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(829, undefined, 0, 2061355798);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(537);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer3, 210056);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer1, 'uint16', 317026);
+} catch {}
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(8)), /* required buffer size: 664 */
+{offset: 664, bytesPerRow: 344}, {width: 13, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+try {
+externalTexture12.label = '\u5c50\uf904\u094b\u0605\u503b\u5984\u8ab7\uf8c3\u{1feae}';
+} catch {}
+let commandEncoder33 = device0.createCommandEncoder({label: '\u{1fd9e}\ubf94\uf3fd\u0cac\u7252\u{1f67c}\u{1f693}'});
+let querySet27 = device0.createQuerySet({label: '\u1375\u002f\u0337\u52f4', type: 'occlusion', count: 2648});
+let computePassEncoder16 = commandEncoder32.beginComputePass({});
+let sampler16 = device0.createSampler({
+  label: '\u42cf\u{1f718}\uee50\ud233\u589b\u853f',
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 43.34,
+  compare: 'never',
+});
+try {
+renderPassEncoder3.setIndexBuffer(buffer1, 'uint32', 157512, 113042);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(8, buffer11, 0, 845);
+} catch {}
+let commandBuffer10 = commandEncoder27.finish({label: '\u74b9\ua629\uedcf\u0d6d\u2f6c'});
+let textureView45 = texture1.createView({label: '\u1263\u8ca1', arrayLayerCount: 1});
+let computePassEncoder17 = commandEncoder15.beginComputePass({label: '\u7d6d\u1b96\u0fd8\udc2b\ubb21\u3076\u0691'});
+try {
+computePassEncoder17.setBindGroup(4, bindGroup5, new Uint32Array(7246), 2515, 0);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(1503);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder13.draw(179, 17, 821_332_440, 667_182_367);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer1, 'uint16', 320924, 287009);
+} catch {}
+let arrayBuffer2 = buffer5.getMappedRange(45056);
+try {
+commandEncoder28.copyBufferToBuffer(buffer9, 198160, buffer10, 68412, 14736);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder23.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 682 widthInBlocks: 341 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 40104 */
+  offset: 40104,
+  bytesPerRow: 768,
+  buffer: buffer10,
+}, {width: 341, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 9}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 3, y: 2 },
+  flipY: false,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 23, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise8 = device0.createRenderPipelineAsync({
+  label: '\uda9f\uca61',
+  layout: pipelineLayout1,
+  multisample: {mask: 0x2387e294},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'equal', failOp: 'decrement-clamp', depthFailOp: 'increment-wrap', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'not-equal', failOp: 'zero', depthFailOp: 'decrement-wrap', passOp: 'increment-wrap'},
+    stencilReadMask: 227897600,
+    depthBiasSlopeScale: 0.0,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 1056, stepMode: 'instance', attributes: []},
+      {arrayStride: 696, attributes: [{format: 'unorm8x4', offset: 40, shaderLocation: 13}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'ccw'},
+});
+let videoFrame3 = new VideoFrame(offscreenCanvas2, {timestamp: 0});
+let pipelineLayout7 = device0.createPipelineLayout({label: '\u{1f7d4}\u{1fe04}\u562d', bindGroupLayouts: []});
+let querySet28 = device0.createQuerySet({label: '\u9677\u9079', type: 'occlusion', count: 2854});
+let textureView46 = texture17.createView({
+  label: '\u{1f964}\u6094\u0af0\u8d90\u{1ff28}\ua888\u96c9\u4f9d\u2e9a\u0f8f\uee95',
+  format: 'rgba8unorm',
+});
+let renderPassEncoder6 = commandEncoder2.beginRenderPass({
+  colorAttachments: [{
+  view: textureView24,
+  clearValue: { r: -790.6, g: 373.3, b: -511.1, a: 687.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet15,
+  maxDrawCount: 4523047,
+});
+try {
+computePassEncoder13.setBindGroup(6, bindGroup6, new Uint32Array(3892), 725, 0);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(1340);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(3547);
+} catch {}
+try {
+renderPassEncoder0.setViewport(14.50, 0.6015, 10.35, 0.7092, 0.02349, 0.1730);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(5, buffer11);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer1, 'uint32', 404276);
+} catch {}
+let arrayBuffer3 = buffer7.getMappedRange(11088, 369872);
+try {
+computePassEncoder16.insertDebugMarker('\uc206');
+} catch {}
+let promise9 = device0.createRenderPipelineAsync({
+  label: '\ufd9f\u{1fca0}\u{1fcd7}\u0282\u{1fae7}\uf4fc\u{1fa50}',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 1024, stepMode: 'instance', attributes: []},
+      {arrayStride: 120, stepMode: 'instance', attributes: []},
+      {arrayStride: 1080, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 124,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x4', offset: 0, shaderLocation: 13}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front'},
+});
+gc();
+let bindGroup11 = device0.createBindGroup({
+  label: '\u03f7\ub879\u04d0\u47c6\ufe3b\u{1f9dd}\u7c9b\u09e8\u2d19\u30bb\u0d02',
+  layout: bindGroupLayout16,
+  entries: [],
+});
+let commandEncoder34 = device0.createCommandEncoder();
+let textureView47 = texture3.createView({label: '\u5ca7\u005c', baseArrayLayer: 0, arrayLayerCount: 1});
+try {
+computePassEncoder9.setBindGroup(6, bindGroup1, new Uint32Array(5814), 2878, 0);
+} catch {}
+try {
+computePassEncoder13.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle8]);
+} catch {}
+try {
+renderPassEncoder1.setViewport(3.565, 1.951, 26.14, 0.01965, 0.5507, 0.6549);
+} catch {}
+try {
+renderPassEncoder2.draw(76, 131);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer2, 709_832_208);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(3422, undefined);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder13.draw(51, 101, 77_237_770, 940_863_487);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(677, 45, 187_324_468, 32_487_305, 92_647_312);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer3, 43348);
+} catch {}
+try {
+commandEncoder28.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture19,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder33.insertDebugMarker('\u0583');
+} catch {}
+let pipeline33 = device0.createComputePipeline({
+  label: '\ua3aa\u0726',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let pipeline34 = device0.createRenderPipeline({
+  label: '\u{1f8c8}\u{1fcaf}\u8fed',
+  layout: pipelineLayout4,
+  multisample: {count: 1, mask: 0xdcb5c837},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 292,
+        attributes: [
+          {format: 'uint16x4', offset: 200, shaderLocation: 27},
+          {format: 'sint32x3', offset: 140, shaderLocation: 3},
+          {format: 'uint32x3', offset: 24, shaderLocation: 17},
+          {format: 'float32x2', offset: 40, shaderLocation: 10},
+          {format: 'sint32', offset: 16, shaderLocation: 11},
+          {format: 'unorm16x4', offset: 20, shaderLocation: 12},
+          {format: 'float32x4', offset: 16, shaderLocation: 19},
+          {format: 'float32x2', offset: 12, shaderLocation: 0},
+          {format: 'unorm16x2', offset: 32, shaderLocation: 7},
+          {format: 'sint16x2', offset: 32, shaderLocation: 20},
+        ],
+      },
+      {
+        arrayStride: 356,
+        attributes: [
+          {format: 'float32x4', offset: 16, shaderLocation: 15},
+          {format: 'uint8x2', offset: 2, shaderLocation: 21},
+          {format: 'snorm8x2', offset: 2, shaderLocation: 22},
+          {format: 'snorm8x2', offset: 6, shaderLocation: 25},
+          {format: 'unorm16x4', offset: 56, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint8x2', offset: 114, shaderLocation: 23},
+          {format: 'snorm8x4', offset: 256, shaderLocation: 14},
+          {format: 'float32x2', offset: 528, shaderLocation: 1},
+          {format: 'sint16x4', offset: 1312, shaderLocation: 26},
+        ],
+      },
+      {arrayStride: 120, attributes: []},
+      {
+        arrayStride: 1392,
+        attributes: [
+          {format: 'float32x2', offset: 4, shaderLocation: 16},
+          {format: 'uint32x4', offset: 104, shaderLocation: 6},
+          {format: 'snorm8x4', offset: 376, shaderLocation: 13},
+          {format: 'sint32x4', offset: 256, shaderLocation: 2},
+          {format: 'unorm8x4', offset: 56, shaderLocation: 18},
+          {format: 'uint32x3', offset: 228, shaderLocation: 24},
+        ],
+      },
+      {arrayStride: 1936, attributes: []},
+      {arrayStride: 1288, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 260,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x2', offset: 8, shaderLocation: 8}],
+      },
+      {arrayStride: 644, attributes: [{format: 'sint16x4', offset: 156, shaderLocation: 4}]},
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', cullMode: 'back'},
+});
+let shaderModule6 = device0.createShaderModule({
+  label: '\uce53\u0989\uc7b8\uf434\u041a\u0d20',
+  code: `@group(2) @binding(3007)
+var<storage, read_write> field2: array<u32>;
+@group(1) @binding(4360)
+var<storage, read_write> field3: array<u32>;
+@group(0) @binding(6934)
+var<storage, read_write> field4: array<u32>;
+@group(1) @binding(281)
+var<storage, read_write> field5: array<u32>;
+@group(0) @binding(2330)
+var<storage, read_write> global3: array<u32>;
+
+@compute @workgroup_size(2, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S5 {
+  @location(26) f0: f32,
+  @location(27) f1: vec3<f16>,
+  @location(1) f2: vec2<f32>,
+  @location(10) f3: vec2<f16>,
+  @location(4) f4: vec3<f32>,
+  @location(21) f5: vec3<i32>,
+  @location(17) f6: vec2<u32>,
+  @builtin(position) f7: vec4<f32>,
+  @location(29) f8: f16,
+  @location(3) f9: u32,
+  @location(32) f10: vec4<i32>,
+  @location(16) f11: vec4<f16>,
+  @location(34) f12: vec2<u32>,
+  @location(7) f13: vec2<u32>,
+  @builtin(sample_mask) f14: u32,
+  @builtin(front_facing) f15: bool,
+  @builtin(sample_index) f16: u32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec3<i32>,
+  @location(1) f1: vec4<u32>,
+  @location(3) f2: vec4<u32>,
+  @location(2) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(2) a0: f16, @location(31) a1: f32, @location(14) a2: vec3<u32>, @location(20) a3: vec2<f32>, @location(35) a4: vec4<f32>, @location(19) a5: vec3<f16>, a6: S5) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(16) f95: vec4<f16>,
+  @location(14) f96: vec3<u32>,
+  @location(27) f97: vec3<f16>,
+  @location(4) f98: vec3<f32>,
+  @location(29) f99: f16,
+  @location(7) f100: vec2<u32>,
+  @location(17) f101: vec2<u32>,
+  @location(35) f102: vec4<f32>,
+  @location(26) f103: f32,
+  @location(20) f104: vec2<f32>,
+  @location(32) f105: vec4<i32>,
+  @location(1) f106: vec2<f32>,
+  @location(3) f107: u32,
+  @location(10) f108: vec2<f16>,
+  @builtin(position) f109: vec4<f32>,
+  @location(34) f110: vec2<u32>,
+  @location(19) f111: vec3<f16>,
+  @location(2) f112: f16,
+  @location(21) f113: vec3<i32>,
+  @location(31) f114: f32
+}
+
+@vertex
+fn vertex0(@location(16) a0: vec4<u32>, @location(22) a1: vec4<i32>, @location(27) a2: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder35 = device0.createCommandEncoder({});
+let querySet29 = device0.createQuerySet({type: 'occlusion', count: 856});
+let texture20 = device0.createTexture({
+  label: '\u0b1c\u52f5\u3e8e\u{1fc12}\u8707',
+  size: [120, 8, 9],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rg32sint'],
+});
+let renderBundle23 = renderBundleEncoder16.finish({label: '\u0066\ub967'});
+let sampler17 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 56.21,
+});
+let externalTexture14 = device0.importExternalTexture({label: '\u{1f93f}\u5947\u034b', source: video5});
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(472);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer3, 82440);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer3, 58260);
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture({
+  /* bytesInLastRow: 190 widthInBlocks: 95 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4840 */
+  offset: 4840,
+  rowsPerImage: 18,
+  buffer: buffer2,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 155, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 95, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 9},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer0), /* required buffer size: 11_880_451 */
+{offset: 91, bytesPerRow: 320, rowsPerImage: 275}, {width: 10, height: 2, depthOrArrayLayers: 136});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 9}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 180, y: 81 },
+  flipY: true,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 36, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let video6 = await videoWithData();
+let textureView48 = texture11.createView({label: '\u{1f71a}\ue2f6\u47df\u98fb\u{1fe0b}\u0842\u29c4\u{1fd06}\u{1fcca}', format: 'rgba16float'});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba16uint', undefined, 'rgb10a2uint', 'r32float', 'rgba16uint', 'r8uint', 'r16sint'],
+  depthReadOnly: true,
+});
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: 717.6, g: 877.8, b: 397.3, a: 428.7, });
+} catch {}
+try {
+renderPassEncoder2.draw(158, 641, 120_456_225);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(7, buffer11, 0);
+} catch {}
+try {
+renderBundleEncoder13.draw(44, 141, 1_486_725_926, 886_820_503);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer3, 46944);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer3, 2652);
+} catch {}
+try {
+commandEncoder24.copyBufferToTexture({
+  /* bytesInLastRow: 10528 widthInBlocks: 1316 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 10648 */
+  offset: 120,
+  buffer: buffer2,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 213, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1316, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 9}
+*/
+{
+  source: imageData5,
+  origin: { x: 3, y: 10 },
+  flipY: false,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let adapter2 = await navigator.gpu.requestAdapter({});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint'], depthReadOnly: true, stencilReadOnly: true});
+let sampler18 = device0.createSampler({
+  label: '\u06b4\u{1f9f1}\u995c\u1e87\u0da1',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 83.23,
+  compare: 'never',
+  maxAnisotropy: 18,
+});
+try {
+renderPassEncoder2.drawIndexed(446);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer6, 224_387_130);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer1, 'uint16');
+} catch {}
+try {
+computePassEncoder10.insertDebugMarker('\u250e');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 3,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(new ArrayBuffer(72)), /* required buffer size: 2_122 */
+{offset: 586, bytesPerRow: 596, rowsPerImage: 97}, {width: 43, height: 3, depthOrArrayLayers: 1});
+} catch {}
+let buffer12 = device0.createBuffer({
+  label: '\u609d\ue6f2\u0a9f\u1be7\u{1fb46}\ue19e',
+  size: 103836,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder36 = device0.createCommandEncoder({});
+let externalTexture15 = device0.importExternalTexture({source: video2, colorSpace: 'display-p3'});
+try {
+computePassEncoder9.setPipeline(pipeline13);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(63, 204, 11_145_898, 219_996_991, 1_233_004_930);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(7, buffer0, 4480, 13341);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(2, buffer0, 11448, 676);
+} catch {}
+try {
+commandEncoder34.copyBufferToTexture({
+  /* bytesInLastRow: 52 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 193948 */
+  offset: 12648,
+  bytesPerRow: 256,
+  rowsPerImage: 236,
+  buffer: buffer9,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 13, height: 1, depthOrArrayLayers: 4});
+dissociateBuffer(device0, buffer9);
+} catch {}
+let shaderModule7 = device0.createShaderModule({
+  label: '\u0934\u{1fb5e}\u{1f90b}',
+  code: `
+
+@compute @workgroup_size(4, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec4<u32>,
+  @location(2) f1: vec4<u32>,
+  @location(3) f2: vec3<f32>,
+  @location(0) f3: vec4<u32>,
+  @location(6) f4: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S6 {
+  @location(25) f0: u32,
+  @location(11) f1: vec2<u32>,
+  @location(2) f2: vec3<f16>,
+  @location(26) f3: i32,
+  @location(12) f4: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(21) a0: vec4<u32>, @location(6) a1: vec2<i32>, @location(10) a2: vec3<u32>, @location(16) a3: vec3<f32>, @location(17) a4: vec2<u32>, @location(18) a5: vec2<i32>, @location(20) a6: vec3<f16>, @location(5) a7: u32, @location(7) a8: vec3<f32>, @location(24) a9: vec3<f16>, @location(14) a10: f16, @builtin(vertex_index) a11: u32, a12: S6, @location(1) a13: vec3<u32>, @location(9) a14: vec4<f32>, @location(8) a15: vec4<f16>, @location(27) a16: vec2<f32>, @builtin(instance_index) a17: u32, @location(19) a18: vec4<i32>, @location(23) a19: vec2<f32>, @location(22) a20: vec2<f16>, @location(15) a21: u32, @location(13) a22: vec2<f32>, @location(4) a23: vec2<i32>, @location(0) a24: vec4<f32>, @location(3) a25: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView49 = texture0.createView({label: '\u{1fd85}\u50b9\u04fd\u685d\u3c20\u059e\u{1f918}\u0667', baseArrayLayer: 0});
+let externalTexture16 = device0.importExternalTexture({
+  label: '\u042a\u0d52\u010f\u0527\uf271\uc537\ua0ad\uf6ec\u0b8a',
+  source: video1,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(2159);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(144, 232, 1_778_622_778, 139_827_141, 725_593_803);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer3, 2472);
+} catch {}
+let promise10 = buffer10.mapAsync(GPUMapMode.READ, 0, 182608);
+try {
+commandEncoder36.copyBufferToTexture({
+  /* bytesInLastRow: 204 widthInBlocks: 51 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 233136 */
+  offset: 10212,
+  bytesPerRow: 256,
+  rowsPerImage: 290,
+  buffer: buffer9,
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 51, height: 1, depthOrArrayLayers: 4});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder36.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer6, 83240);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 15076, new Int16Array(9313), 7070, 216);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 9}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 24, y: 30 },
+  flipY: true,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 3, y: 5, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap2 = await createImageBitmap(canvas2);
+let commandEncoder37 = device0.createCommandEncoder({});
+let externalTexture17 = device0.importExternalTexture({label: '\u{1fe1d}\u0346\u{1fffb}\uf615\u057b\u06dc', source: videoFrame1, colorSpace: 'srgb'});
+try {
+renderPassEncoder1.setBindGroup(4, bindGroup1, new Uint32Array(7578), 6502, 0);
+} catch {}
+try {
+renderPassEncoder4.setViewport(6.036, 0.5374, 13.72, 0.2618, 0.1908, 0.6504);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer4, 174_137_203);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer0, 157_541_408);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer3, 51352);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(4, buffer11, 0, 2400);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let promise11 = buffer8.mapAsync(GPUMapMode.READ, 0, 89904);
+try {
+commandEncoder28.clearBuffer(buffer7, 5428);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 80912, new Float32Array(8448), 2936, 788);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(new ArrayBuffer(80)), /* required buffer size: 769 */
+{offset: 769}, {width: 2169, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let img7 = await imageWithData(228, 23, '#f8d403c5', '#b0986df4');
+let shaderModule8 = device0.createShaderModule({
+  label: '\u{1fad2}\u8d1e\uf279\u58c6\u004a\u2dc7\u{1f68a}\uc063\u45a9',
+  code: `@group(0) @binding(2330)
+var<storage, read_write> type3: array<u32>;
+@group(0) @binding(6934)
+var<storage, read_write> local4: array<u32>;
+
+@compute @workgroup_size(1, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S8 {
+  @location(1) f0: vec3<u32>,
+  @location(15) f1: vec3<u32>,
+  @location(31) f2: vec3<f32>,
+  @location(13) f3: vec2<f16>,
+  @builtin(position) f4: vec4<f32>,
+  @builtin(front_facing) f5: bool,
+  @location(3) f6: vec4<u32>,
+  @location(39) f7: vec3<f16>,
+  @location(17) f8: i32
+}
+struct FragmentOutput0 {
+  @location(4) f0: vec4<f32>,
+  @location(3) f1: vec3<i32>,
+  @location(2) f2: vec3<i32>,
+  @location(1) f3: vec3<f32>,
+  @location(0) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(a0: S8, @location(33) a1: u32, @builtin(sample_index) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S7 {
+  @location(19) f0: vec2<f16>,
+  @location(22) f1: f16,
+  @location(2) f2: vec2<f16>,
+  @location(5) f3: vec2<u32>,
+  @location(8) f4: vec4<f32>,
+  @location(21) f5: f32
+}
+struct VertexOutput0 {
+  @location(17) f115: i32,
+  @location(36) f116: i32,
+  @builtin(position) f117: vec4<f32>,
+  @location(30) f118: f32,
+  @location(18) f119: u32,
+  @location(16) f120: vec3<u32>,
+  @location(39) f121: vec3<f16>,
+  @location(7) f122: vec3<i32>,
+  @location(21) f123: vec3<i32>,
+  @location(27) f124: i32,
+  @location(14) f125: vec4<u32>,
+  @location(20) f126: vec2<i32>,
+  @location(4) f127: vec2<f32>,
+  @location(13) f128: vec2<f16>,
+  @location(28) f129: vec3<f32>,
+  @location(15) f130: vec3<u32>,
+  @location(23) f131: vec3<f32>,
+  @location(0) f132: vec4<u32>,
+  @location(10) f133: vec2<u32>,
+  @location(25) f134: vec3<f32>,
+  @location(37) f135: vec4<u32>,
+  @location(31) f136: vec3<f32>,
+  @location(35) f137: vec4<f32>,
+  @location(8) f138: f32,
+  @location(19) f139: u32,
+  @location(12) f140: vec2<f32>,
+  @location(5) f141: vec2<f16>,
+  @location(9) f142: vec3<f32>,
+  @location(33) f143: u32,
+  @location(32) f144: vec4<i32>,
+  @location(34) f145: vec2<u32>,
+  @location(1) f146: vec3<u32>,
+  @location(24) f147: u32,
+  @location(26) f148: vec2<f32>,
+  @location(3) f149: vec4<u32>,
+  @location(11) f150: vec2<f32>,
+  @location(29) f151: f16,
+  @location(22) f152: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(6) a0: u32, @location(1) a1: f16, @location(17) a2: vec2<u32>, @location(4) a3: vec3<u32>, @location(18) a4: u32, @location(9) a5: vec3<i32>, a6: S7, @builtin(vertex_index) a7: u32, @location(14) a8: vec2<f16>, @location(13) a9: vec3<f32>, @builtin(instance_index) a10: u32, @location(15) a11: vec3<f16>, @location(16) a12: vec3<f32>, @location(3) a13: vec3<u32>, @location(23) a14: f32, @location(20) a15: vec4<f32>, @location(0) a16: vec2<u32>, @location(10) a17: vec4<u32>, @location(27) a18: vec4<f16>, @location(12) a19: vec2<f16>, @location(25) a20: vec2<i32>, @location(26) a21: vec4<f32>, @location(11) a22: vec3<f16>, @location(7) a23: vec4<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let buffer13 = device0.createBuffer({
+  label: '\u08d3\u08ba\u84e3\uf99d\u0851\u65e3\u{1f841}\u995c\u0834\udf07\u20ac',
+  size: 156961,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let querySet30 = device0.createQuerySet({label: '\u37fd\u2a0f\u83ca\u0b84\uf3a6\u1381', type: 'occlusion', count: 4070});
+let textureView50 = texture4.createView({label: '\ud736\u{1ff08}\u7d32\uee9c', mipLevelCount: 1, baseArrayLayer: 258});
+let renderPassEncoder7 = commandEncoder24.beginRenderPass({
+  label: '\u{1ffaf}\u{1fdea}\u35cf\u04a8',
+  colorAttachments: [{
+  view: textureView24,
+  clearValue: { r: 563.3, g: 565.7, b: -682.7, a: -97.76, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 839607471,
+});
+try {
+computePassEncoder2.setPipeline(pipeline31);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(2991);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer1, 'uint16', 610888, 24555);
+} catch {}
+try {
+commandEncoder37.copyBufferToBuffer(buffer11, 440, buffer8, 30648, 2064);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder33.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2204 widthInBlocks: 551 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 100000 */
+  offset: 100000,
+  buffer: buffer4,
+}, {width: 551, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder23.copyTextureToTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 48, y: 4, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 1064, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 987, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+window.someLabel = querySet12.label;
+} catch {}
+let textureView51 = texture4.createView({
+  label: '\uace7\u0c03\u99da\u4314\u0e3d\u0dd3\u0c77\u{1fcfb}\u1496',
+  dimension: '2d',
+  format: 'rg16uint',
+  baseMipLevel: 1,
+  baseArrayLayer: 154,
+  arrayLayerCount: 1,
+});
+let renderPassEncoder8 = commandEncoder34.beginRenderPass({
+  label: '\u{1fd9d}\u097f\u4b55\ua2fd\u{1f6ad}',
+  colorAttachments: [{view: textureView51, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet17,
+  maxDrawCount: 329308473,
+});
+try {
+computePassEncoder11.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(612);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(29, 1, 0, 1);
+} catch {}
+try {
+renderPassEncoder2.draw(16);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer10, 2_241_492_921);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer0);
+} catch {}
+try {
+renderBundleEncoder13.setPipeline(pipeline7);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline35 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}}});
+let commandEncoder38 = device0.createCommandEncoder({label: '\u0258\u0429'});
+let textureView52 = texture8.createView({label: '\u056e\u{1f967}\uea88\u{1faf2}\u{1fba9}\u0d08', baseMipLevel: 0});
+let computePassEncoder18 = commandEncoder38.beginComputePass({label: '\u0a7e\u0602\udc44\uabee\u072b\ua7e1\u{1f925}'});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb', 'r8unorm', 'r16sint', 'r8sint', 'rgba32float']});
+let externalTexture18 = device0.importExternalTexture({label: '\u2988\u0a18\uc201\u01dc', source: videoFrame3, colorSpace: 'srgb'});
+try {
+renderPassEncoder2.setViewport(9.778, 1.604, 1.644, 0.3082, 0.8285, 0.9770);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 39, 9_809_170);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(155, 17, 636_166_513, -2_085_564_143, 991_360_467);
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 9}
+*/
+{
+  source: video0,
+  origin: { x: 4, y: 0 },
+  flipY: false,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline36 = device0.createRenderPipeline({
+  label: '\u84c6\u0401',
+  layout: pipelineLayout2,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-src-alpha', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'dst'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {
+  format: 'r16sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'rgba32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 796,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 12, shaderLocation: 23},
+          {format: 'sint8x2', offset: 46, shaderLocation: 9},
+          {format: 'float16x2', offset: 4, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 344,
+        attributes: [
+          {format: 'unorm8x2', offset: 70, shaderLocation: 26},
+          {format: 'sint32', offset: 24, shaderLocation: 7},
+          {format: 'float32x4', offset: 4, shaderLocation: 13},
+          {format: 'uint8x2', offset: 56, shaderLocation: 18},
+          {format: 'unorm16x2', offset: 56, shaderLocation: 12},
+          {format: 'float16x4', offset: 32, shaderLocation: 19},
+          {format: 'float32x2', offset: 80, shaderLocation: 1},
+          {format: 'float32x3', offset: 20, shaderLocation: 16},
+          {format: 'uint32x4', offset: 28, shaderLocation: 5},
+          {format: 'uint32x3', offset: 28, shaderLocation: 17},
+          {format: 'uint32x2', offset: 28, shaderLocation: 10},
+          {format: 'float32', offset: 116, shaderLocation: 20},
+          {format: 'uint16x4', offset: 4, shaderLocation: 0},
+          {format: 'float32x4', offset: 124, shaderLocation: 14},
+          {format: 'uint16x4', offset: 40, shaderLocation: 6},
+          {format: 'float32x2', offset: 32, shaderLocation: 27},
+          {format: 'unorm16x4', offset: 36, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 52, shaderLocation: 22},
+          {format: 'uint16x2', offset: 44, shaderLocation: 4},
+          {format: 'snorm16x2', offset: 32, shaderLocation: 21},
+          {format: 'sint32x2', offset: 16, shaderLocation: 25},
+        ],
+      },
+      {arrayStride: 1096, attributes: []},
+      {
+        arrayStride: 2736,
+        attributes: [
+          {format: 'snorm8x2', offset: 744, shaderLocation: 11},
+          {format: 'uint32x4', offset: 188, shaderLocation: 3},
+          {format: 'snorm8x2', offset: 2722, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {},
+});
+let bindGroupLayout17 = device0.createBindGroupLayout({
+  label: '\u0d3e\u{1f9e1}\u3afc\u94a9\u0fb9\u07e4\u4030\u{1ff91}\uc150',
+  entries: [
+    {
+      binding: 1053,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 2612,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 5374,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let commandEncoder39 = device0.createCommandEncoder();
+let querySet31 = device0.createQuerySet({type: 'occlusion', count: 287});
+let externalTexture19 = device0.importExternalTexture({source: video0, colorSpace: 'display-p3'});
+try {
+renderPassEncoder3.setStencilReference(1248);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(141, 216, 634_743_411, 641_239_003, 582_822_228);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(16, 128, 341_267_989, -1_466_137_453, 2_517_463_275);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer3, 12216);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer3, 69204);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 98, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(24)), /* required buffer size: 531 */
+{offset: 531, rowsPerImage: 116}, {width: 146, height: 0, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas2.width = 1662;
+let bindGroup12 = device0.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 3007, resource: sampler9}]});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint'], stencilReadOnly: true});
+try {
+renderPassEncoder0.setBlendConstant({ r: 616.2, g: 849.0, b: -542.3, a: -570.6, });
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(252);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer5, 733_970_604);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer7, 2_384_855_351);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer1, 'uint16', 433374, 166874);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline16);
+} catch {}
+try {
+renderBundleEncoder13.draw(77, 73, 64_260_096, 90_153_120);
+} catch {}
+let arrayBuffer4 = buffer6.getMappedRange(0, 62772);
+try {
+commandEncoder28.copyBufferToBuffer(buffer5, 24160, buffer7, 96056, 9808);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 1_021 */
+{offset: 913, bytesPerRow: 281, rowsPerImage: 194}, {width: 27, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline37 = await device0.createRenderPipelineAsync({
+  label: '\uf700\u1733\ub186\uc74f\u0fb2\u317c\u2154\u0953\u595a\u8e7c',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'equal', failOp: 'zero', depthFailOp: 'increment-clamp', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'less', failOp: 'zero', depthFailOp: 'zero', passOp: 'invert'},
+    stencilReadMask: 3065500593,
+    stencilWriteMask: 2280563714,
+    depthBias: 920735746,
+    depthBiasSlopeScale: -38.58652553787883,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 628,
+        attributes: [
+          {format: 'float16x2', offset: 28, shaderLocation: 17},
+          {format: 'float32x2', offset: 76, shaderLocation: 7},
+          {format: 'sint8x4', offset: 144, shaderLocation: 1},
+          {format: 'float32x4', offset: 468, shaderLocation: 19},
+          {format: 'unorm10-10-10-2', offset: 12, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 68, shaderLocation: 10},
+          {format: 'uint32x2', offset: 68, shaderLocation: 4},
+          {format: 'snorm16x2', offset: 4, shaderLocation: 16},
+          {format: 'float32', offset: 288, shaderLocation: 3},
+          {format: 'snorm8x2', offset: 236, shaderLocation: 0},
+          {format: 'snorm16x4', offset: 4, shaderLocation: 21},
+          {format: 'float32x4', offset: 4, shaderLocation: 26},
+          {format: 'snorm16x2', offset: 104, shaderLocation: 15},
+          {format: 'snorm16x4', offset: 412, shaderLocation: 8},
+          {format: 'uint8x2', offset: 128, shaderLocation: 12},
+          {format: 'uint16x2', offset: 20, shaderLocation: 23},
+        ],
+      },
+      {
+        arrayStride: 2208,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 352, shaderLocation: 18},
+          {format: 'float32x2', offset: 904, shaderLocation: 2},
+          {format: 'sint8x2', offset: 176, shaderLocation: 5},
+          {format: 'sint32x2', offset: 84, shaderLocation: 22},
+          {format: 'sint8x4', offset: 480, shaderLocation: 9},
+          {format: 'sint8x2', offset: 420, shaderLocation: 24},
+          {format: 'uint8x2', offset: 16, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 656,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32', offset: 216, shaderLocation: 25}],
+      },
+      {arrayStride: 1852, attributes: []},
+      {arrayStride: 260, attributes: [{format: 'snorm16x4', offset: 0, shaderLocation: 13}]},
+      {arrayStride: 484, stepMode: 'instance', attributes: []},
+      {arrayStride: 2264, attributes: [{format: 'uint8x2', offset: 334, shaderLocation: 20}]},
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw'},
+});
+gc();
+let videoFrame4 = new VideoFrame(video4, {timestamp: 0});
+let commandEncoder40 = device0.createCommandEncoder({label: '\uff90\u7ddd'});
+let renderPassEncoder9 = commandEncoder33.beginRenderPass({
+  label: '\uea19\u{1fa98}\uf06a\u0464\u84a3\u066f\u{1fd6e}\uf1cf\ub39e\u{1fd03}',
+  colorAttachments: [{
+  view: textureView51,
+  clearValue: { r: -359.7, g: 8.077, b: 605.4, a: 571.3, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet17,
+  maxDrawCount: 454242672,
+});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({colorFormats: ['rg16uint'], stencilReadOnly: true});
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer8, 1_254_399_159);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(2, bindGroup7, new Uint32Array(7424), 3888, 0);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer3, 12080);
+} catch {}
+try {
+commandEncoder37.resolveQuerySet(querySet22, 831, 875, buffer13, 90112);
+} catch {}
+let buffer14 = device0.createBuffer({size: 9308, usage: GPUBufferUsage.INDIRECT, mappedAtCreation: true});
+let querySet32 = device0.createQuerySet({label: '\udbd5\u5a9a\u22bf', type: 'occlusion', count: 228});
+let renderBundle24 = renderBundleEncoder7.finish({});
+let externalTexture20 = device0.importExternalTexture({source: videoFrame2, colorSpace: 'srgb'});
+try {
+renderPassEncoder8.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setViewport(5.821, 0.9415, 6.204, 1.030, 0.3626, 0.4821);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer12, 365_215_255);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer1, 540_533_772);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer1, 'uint32', 110760);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(4, buffer11);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(4, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder13.draw(91, 99, 404_240_741, 705_431_562);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(161, 39);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer14, 2244);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(2, buffer0, 16604, 3144);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 9}
+*/
+{
+  source: offscreenCanvas3,
+  origin: { x: 19, y: 17 },
+  flipY: false,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let imageData8 = new ImageData(124, 140);
+let commandEncoder41 = device0.createCommandEncoder();
+try {
+computePassEncoder5.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+computePassEncoder16.setBindGroup(5, bindGroup11, new Uint32Array(3532), 2393, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup3, new Uint32Array(4382), 4140, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(2, buffer0, 0, 70);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(283, 84, 186_120_539, 19_606_863, 1_044_312_708);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(3, buffer11, 0, 1853);
+} catch {}
+try {
+commandEncoder21.copyBufferToBuffer(buffer2, 4328, buffer8, 2516, 3196);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer8);
+} catch {}
+let textureView53 = texture1.createView({
+  label: '\u{1f782}\u7909\u{1fee8}\uac01\u{1f76b}\u03d1\u3d5f\u{1fcc7}\u0de3\u9a89\u40f5',
+  baseMipLevel: 0,
+  arrayLayerCount: 1,
+});
+try {
+computePassEncoder9.setPipeline(pipeline35);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup4, new Uint32Array(3453), 3013, 0);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(841);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(404);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer1, 'uint32', 70740, 14907);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(212, 298, 668_757_354, 1_596_161_540, 1_423_186_208);
+} catch {}
+try {
+commandEncoder23.copyBufferToBuffer(buffer11, 1664, buffer6, 91184, 160);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder21.copyBufferToTexture({
+  /* bytesInLastRow: 332 widthInBlocks: 332 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 34125 */
+  offset: 34125,
+  buffer: buffer9,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 332, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 56, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer4), /* required buffer size: 897 */
+{offset: 897, bytesPerRow: 532}, {width: 126, height: 19, depthOrArrayLayers: 0});
+} catch {}
+let pipeline38 = device0.createComputePipeline({layout: pipelineLayout5, compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}}});
+let promise12 = device0.createRenderPipelineAsync({
+  label: '\ue4c4\u0ed7\u1abe\ud87d\u075a\ub99f\u0e78',
+  layout: pipelineLayout7,
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 232,
+        attributes: [
+          {format: 'snorm16x4', offset: 12, shaderLocation: 0},
+          {format: 'unorm8x2', offset: 40, shaderLocation: 8},
+          {format: 'uint32x3', offset: 44, shaderLocation: 6},
+          {format: 'float16x4', offset: 16, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 110, shaderLocation: 7},
+          {format: 'snorm16x2', offset: 100, shaderLocation: 3},
+        ],
+      },
+      {arrayStride: 180, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 548,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x3', offset: 196, shaderLocation: 24},
+          {format: 'unorm10-10-10-2', offset: 40, shaderLocation: 18},
+          {format: 'unorm16x4', offset: 16, shaderLocation: 2},
+          {format: 'float32', offset: 84, shaderLocation: 21},
+          {format: 'float32x4', offset: 128, shaderLocation: 13},
+          {format: 'float16x4', offset: 44, shaderLocation: 10},
+          {format: 'sint16x2', offset: 12, shaderLocation: 22},
+          {format: 'uint32x3', offset: 28, shaderLocation: 20},
+          {format: 'sint8x2', offset: 38, shaderLocation: 25},
+          {format: 'float32', offset: 164, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 384,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 16, shaderLocation: 9},
+          {format: 'sint32x2', offset: 76, shaderLocation: 5},
+          {format: 'uint8x4', offset: 12, shaderLocation: 12},
+          {format: 'uint32x3', offset: 4, shaderLocation: 23},
+          {format: 'float32', offset: 96, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 172,
+        attributes: [
+          {format: 'uint8x4', offset: 0, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 20, shaderLocation: 14},
+          {format: 'sint8x4', offset: 16, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 1096,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x4', offset: 356, shaderLocation: 26}],
+      },
+      {arrayStride: 32, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 1176,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x2', offset: 28, shaderLocation: 19}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'back'},
+});
+gc();
+let textureView54 = texture3.createView({label: '\u2533\ucb54\u0c85\u{1f722}\u5a53'});
+let renderBundle25 = renderBundleEncoder8.finish();
+try {
+renderPassEncoder9.setBindGroup(5, bindGroup1);
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(17, 0, 3, 2);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(4, 32, 295_248_459, 273_228_597, 1_191_767_057);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer1, 451_316_004);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer4, 540_365_583);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer1, 'uint16');
+} catch {}
+try {
+renderBundleEncoder13.draw(135, 747, 164_441_960, 525_975_074);
+} catch {}
+let arrayBuffer5 = buffer11.getMappedRange(1896, 152);
+try {
+commandEncoder39.copyTextureToBuffer({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 10656 widthInBlocks: 1332 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 28504 */
+  offset: 17848,
+  buffer: buffer4,
+}, {width: 1332, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder23.clearBuffer(buffer8, 16900, 11060);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 77592, new BigUint64Array(34033), 25553, 524);
+} catch {}
+let promise13 = device0.createRenderPipelineAsync({
+  label: '\u68e7\u5d2d\u{1fc8e}\u3811',
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16uint', writeMask: GPUColorWrite.ALL}, undefined, {format: 'rgb10a2uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {
+  format: 'r32float',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba16uint', writeMask: 0}, {format: 'r8uint', writeMask: 0}, {format: 'r16sint'}],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 1540,
+        attributes: [
+          {format: 'uint16x4', offset: 616, shaderLocation: 5},
+          {format: 'sint32x4', offset: 0, shaderLocation: 26},
+          {format: 'uint32x3', offset: 616, shaderLocation: 21},
+          {format: 'float16x2', offset: 140, shaderLocation: 22},
+          {format: 'sint16x4', offset: 204, shaderLocation: 3},
+          {format: 'sint32x4', offset: 372, shaderLocation: 12},
+          {format: 'sint8x2', offset: 38, shaderLocation: 6},
+          {format: 'sint16x2', offset: 260, shaderLocation: 19},
+          {format: 'uint32x3', offset: 404, shaderLocation: 25},
+          {format: 'float32x4', offset: 284, shaderLocation: 16},
+          {format: 'unorm16x4', offset: 80, shaderLocation: 7},
+          {format: 'float16x2', offset: 80, shaderLocation: 0},
+          {format: 'float32', offset: 100, shaderLocation: 23},
+          {format: 'float32x2', offset: 248, shaderLocation: 2},
+          {format: 'float32', offset: 32, shaderLocation: 13},
+          {format: 'sint32', offset: 152, shaderLocation: 18},
+          {format: 'uint32x2', offset: 52, shaderLocation: 1},
+          {format: 'uint8x4', offset: 160, shaderLocation: 17},
+          {format: 'snorm8x4', offset: 356, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'uint8x2', offset: 1198, shaderLocation: 10},
+          {format: 'uint16x2', offset: 348, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 2212,
+        attributes: [
+          {format: 'uint16x4', offset: 60, shaderLocation: 15},
+          {format: 'sint8x4', offset: 40, shaderLocation: 4},
+          {format: 'float32x2', offset: 112, shaderLocation: 8},
+          {format: 'float32x2', offset: 16, shaderLocation: 27},
+          {format: 'float16x2', offset: 64, shaderLocation: 24},
+        ],
+      },
+      {arrayStride: 4460, attributes: [{format: 'snorm16x4', offset: 168, shaderLocation: 9}]},
+      {arrayStride: 716, attributes: []},
+      {arrayStride: 372, stepMode: 'instance', attributes: []},
+      {arrayStride: 4520, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 328,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 28, shaderLocation: 20}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', cullMode: 'back'},
+});
+canvas1.height = 1075;
+let img8 = await imageWithData(164, 179, '#f1253705', '#a6b5aec7');
+let buffer15 = device0.createBuffer({
+  label: '\u8ea6\u3394\u08bb\u{1feda}\u62a2\u530c\u009c',
+  size: 30051,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: false,
+});
+let textureView55 = texture10.createView({});
+let externalTexture21 = device0.importExternalTexture({label: '\u{1fa72}\u{1ff12}\u0568\u29d5\u{1fb1d}\u55ff', source: video0});
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(14, 2, 16, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer0, 375_664_397);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer1, 'uint32', 260536, 27810);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(3, buffer0, 0);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer1, 'uint16', 260734, 10221);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(3, buffer0, 0, 21182);
+} catch {}
+try {
+renderBundleEncoder11.insertDebugMarker('\u70e6');
+} catch {}
+let canvas3 = document.createElement('canvas');
+let texture21 = gpuCanvasContext3.getCurrentTexture();
+let textureView56 = texture6.createView({label: '\uef0a\u04a2\u8224\u0a81\u94b6', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup7, new Uint32Array(4943), 627, 0);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(423);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle7, renderBundle8, renderBundle13, renderBundle15, renderBundle23, renderBundle13, renderBundle15, renderBundle23, renderBundle15, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer7, 16_822_961);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer1, 'uint32', 316972, 330373);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(1, bindGroup10, new Uint32Array(8307), 3013, 0);
+} catch {}
+try {
+commandEncoder36.resolveQuerySet(querySet3, 17, 1379, buffer13, 127232);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer15, 1732, new BigUint64Array(47362), 42760, 96);
+} catch {}
+try {
+  await promise10;
+} catch {}
+let textureView57 = texture9.createView({
+  label: '\u6b80\uacf7\u42d5\ufe2f\u5abe\u0939\ue98f\u64dd',
+  aspect: 'all',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({
+  label: '\u2646\u{1fd7a}\u2136\u00ce\ufe0d\u2e37\u{1f958}',
+  colorFormats: ['rg32sint', 'rgba32uint', 'rgba16float', 'rg16uint'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+let externalTexture22 = device0.importExternalTexture({source: video2, colorSpace: 'srgb'});
+try {
+computePassEncoder18.setBindGroup(6, bindGroup3, new Uint32Array(6714), 98, 0);
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(7, 1, 16, 1);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(29, 35);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer1, 'uint16', 298178);
+} catch {}
+try {
+renderBundleEncoder13.draw(28, 70);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer3, 20248);
+} catch {}
+try {
+commandEncoder37.copyBufferToBuffer(buffer5, 6104, buffer4, 14948, 28428);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder36.copyBufferToTexture({
+  /* bytesInLastRow: 362 widthInBlocks: 362 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 8910 */
+  offset: 8910,
+  buffer: buffer12,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 362, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer7);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img1,
+  origin: { x: 10, y: 19 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline39 = device0.createRenderPipeline({
+  layout: pipelineLayout3,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'add', srcFactor: 'dst-alpha', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'constant', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: 0,
+}, {format: 'r16sint', writeMask: GPUColorWrite.ALPHA}, {format: 'r8sint', writeMask: GPUColorWrite.RED}, {format: 'rgba32float', writeMask: GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 1284,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 116, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 60, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 552,
+        attributes: [
+          {format: 'sint8x4', offset: 228, shaderLocation: 9},
+          {format: 'uint32', offset: 236, shaderLocation: 21},
+          {format: 'uint8x2', offset: 134, shaderLocation: 22},
+          {format: 'float32x4', offset: 28, shaderLocation: 14},
+          {format: 'float32x4', offset: 256, shaderLocation: 26},
+          {format: 'sint32', offset: 104, shaderLocation: 8},
+          {format: 'uint8x4', offset: 172, shaderLocation: 1},
+          {format: 'unorm16x2', offset: 12, shaderLocation: 5},
+          {format: 'snorm16x2', offset: 32, shaderLocation: 11},
+          {format: 'unorm10-10-10-2', offset: 20, shaderLocation: 25},
+        ],
+      },
+      {
+        arrayStride: 648,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 4, shaderLocation: 17},
+          {format: 'unorm16x4', offset: 4, shaderLocation: 0},
+          {format: 'uint16x4', offset: 8, shaderLocation: 3},
+          {format: 'unorm16x2', offset: 456, shaderLocation: 2},
+          {format: 'sint32x3', offset: 24, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 1276,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 24, shaderLocation: 18},
+          {format: 'sint32x3', offset: 156, shaderLocation: 15},
+          {format: 'uint16x2', offset: 104, shaderLocation: 23},
+          {format: 'float16x2', offset: 944, shaderLocation: 4},
+          {format: 'float32x2', offset: 216, shaderLocation: 7},
+          {format: 'uint32x2', offset: 52, shaderLocation: 20},
+          {format: 'uint32', offset: 280, shaderLocation: 24},
+        ],
+      },
+      {arrayStride: 620, attributes: [{format: 'float32x3', offset: 100, shaderLocation: 13}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw'},
+});
+let imageBitmap3 = await createImageBitmap(imageBitmap1);
+let shaderModule9 = device0.createShaderModule({
+  label: '\u{1fe4e}\uc5da\uc5dc\u0467\u{1f90a}\u0377',
+  code: `@group(2) @binding(3007)
+var<storage, read_write> global4: array<u32>;
+@group(0) @binding(2330)
+var<storage, read_write> parameter2: array<u32>;
+@group(0) @binding(6934)
+var<storage, read_write> local5: array<u32>;
+@group(1) @binding(4360)
+var<storage, read_write> type4: array<u32>;
+@group(1) @binding(281)
+var<storage, read_write> global5: array<u32>;
+
+@compute @workgroup_size(2, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S10 {
+  @location(39) f0: vec4<f32>,
+  @location(0) f1: vec3<f32>,
+  @location(14) f2: vec2<i32>,
+  @location(21) f3: u32,
+  @location(11) f4: vec4<f32>,
+  @builtin(position) f5: vec4<f32>,
+  @builtin(front_facing) f6: bool,
+  @location(4) f7: u32,
+  @builtin(sample_mask) f8: u32,
+  @location(5) f9: vec3<u32>,
+  @location(16) f10: vec3<f16>,
+  @location(38) f11: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(3) f0: vec3<u32>,
+  @location(2) f1: vec4<f32>,
+  @location(0) f2: vec4<i32>,
+  @location(1) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(17) a0: f16, @location(13) a1: f32, @location(30) a2: f16, @builtin(sample_index) a3: u32, a4: S10, @location(32) a5: vec2<i32>, @location(37) a6: vec3<f16>, @location(3) a7: vec4<i32>, @location(12) a8: vec3<u32>, @location(8) a9: vec3<f16>, @location(31) a10: u32, @location(28) a11: f32, @location(22) a12: vec4<u32>, @location(20) a13: vec2<f32>, @location(10) a14: vec2<f16>, @location(15) a15: vec3<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S9 {
+  @builtin(vertex_index) f0: u32,
+  @location(22) f1: i32,
+  @location(2) f2: vec3<f16>,
+  @builtin(instance_index) f3: u32,
+  @location(18) f4: vec4<u32>,
+  @location(3) f5: vec4<f32>,
+  @location(17) f6: f16,
+  @location(8) f7: vec2<u32>,
+  @location(5) f8: vec4<i32>,
+  @location(15) f9: vec2<i32>,
+  @location(20) f10: vec2<f32>,
+  @location(26) f11: vec3<i32>,
+  @location(0) f12: vec4<u32>,
+  @location(19) f13: vec3<i32>,
+  @location(25) f14: vec2<f32>,
+  @location(12) f15: vec2<f32>,
+  @location(21) f16: vec3<f32>,
+  @location(27) f17: f32,
+  @location(9) f18: f16,
+  @location(13) f19: u32
+}
+struct VertexOutput0 {
+  @location(28) f153: f32,
+  @location(15) f154: vec3<f32>,
+  @location(11) f155: vec4<f32>,
+  @location(37) f156: vec3<f16>,
+  @builtin(position) f157: vec4<f32>,
+  @location(31) f158: u32,
+  @location(0) f159: vec3<f32>,
+  @location(39) f160: vec4<f32>,
+  @location(10) f161: vec2<f16>,
+  @location(14) f162: vec2<i32>,
+  @location(4) f163: u32,
+  @location(38) f164: vec4<f32>,
+  @location(12) f165: vec3<u32>,
+  @location(32) f166: vec2<i32>,
+  @location(8) f167: vec3<f16>,
+  @location(3) f168: vec4<i32>,
+  @location(22) f169: vec4<u32>,
+  @location(17) f170: f16,
+  @location(16) f171: vec3<f16>,
+  @location(21) f172: u32,
+  @location(20) f173: vec2<f32>,
+  @location(30) f174: f16,
+  @location(13) f175: f32,
+  @location(5) f176: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec2<u32>, @location(10) a1: vec3<i32>, @location(6) a2: vec3<f32>, @location(16) a3: vec3<i32>, @location(4) a4: vec2<f16>, @location(1) a5: f32, @location(23) a6: vec3<f32>, @location(14) a7: u32, a8: S9, @location(24) a9: vec4<f16>, @location(7) a10: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let computePassEncoder19 = commandEncoder41.beginComputePass({label: '\u090d\u009b\u3997\u8626\u{1ff3b}\u0177\u054a\u0de8\ufc2f'});
+try {
+computePassEncoder9.setPipeline(pipeline18);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(5, bindGroup12, new Uint32Array(6916), 2313, 0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle7, renderBundle13, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder0.setViewport(28.59, 0.4513, 1.369, 0.8119, 0.2795, 0.4174);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder13.draw(118, 429, 852_415_066, 57_327_910);
+} catch {}
+try {
+commandEncoder37.resolveQuerySet(querySet13, 1534, 269, buffer13, 83456);
+} catch {}
+try {
+renderPassEncoder3.insertDebugMarker('\u9534');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 931 */
+{offset: 931}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline40 = await device0.createComputePipelineAsync({
+  label: '\u1714\ucd4a\u4851\ue65c\uda02\u0e91',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let video7 = await videoWithData();
+let textureView58 = texture14.createView({label: '\ue6f6\u0f58\u{1fb63}\uc666\u014e\u{1f7de}\u{1f881}', baseMipLevel: 5});
+let sampler19 = device0.createSampler({
+  label: '\u5afc\u0c76\u0f02\u{1f760}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 21.42,
+  compare: 'equal',
+  maxAnisotropy: 1,
+});
+let externalTexture23 = device0.importExternalTexture({label: '\u2cd5\u000b\u03d4\u165a', source: videoFrame0, colorSpace: 'srgb'});
+try {
+renderPassEncoder2.draw(198);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(46, 613, 2_348_176_859, 708_311_335, 1_865_013_898);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer1, 'uint16');
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer13, 140304, 7855);
+} catch {}
+try {
+renderBundleEncoder21.setBindGroup(6, bindGroup5, new Uint32Array(500), 445, 0);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer3, 174708);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer3, 165016);
+} catch {}
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+let commandEncoder42 = device0.createCommandEncoder({label: '\u4aba\u0cbb\u4048\u41c8\u{1f7f8}\uabb7'});
+let querySet33 = device0.createQuerySet({label: '\u{1fb23}\u0ad7', type: 'occlusion', count: 3764});
+let texture22 = device0.createTexture({
+  label: '\u0e41\u029b\u9890\u8475',
+  size: {width: 480, height: 32, depthOrArrayLayers: 77},
+  format: 'r32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32float', 'r32float'],
+});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({
+  label: '\u{1fd67}\u{1fc8c}\u{1fa43}\u1aab\u018c\u839e\u{1fa71}\ua5d4\u0b2c\u029a',
+  colorFormats: ['rg16uint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder17.setPipeline(pipeline35);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 952.2, g: 994.3, b: -433.2, a: 853.7, });
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(3591);
+} catch {}
+try {
+renderPassEncoder2.draw(161, 65, 29_679_308);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer1, 386_344_630);
+} catch {}
+try {
+renderBundleEncoder13.draw(360);
+} catch {}
+try {
+commandEncoder28.copyBufferToBuffer(buffer12, 103612, buffer6, 15752, 204);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder19.copyBufferToTexture({
+  /* bytesInLastRow: 152 widthInBlocks: 38 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 142156 */
+  offset: 40780,
+  bytesPerRow: 256,
+  rowsPerImage: 198,
+  buffer: buffer9,
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 38, height: 0, depthOrArrayLayers: 3});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder19.clearBuffer(buffer10, 98704, 5192);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img4,
+  origin: { x: 66, y: 5 },
+  flipY: false,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline41 = await promise8;
+try {
+renderPassEncoder4.beginOcclusionQuery(3428);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant({ r: 130.1, g: 977.1, b: 505.4, a: 688.8, });
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(2430);
+} catch {}
+try {
+renderPassEncoder2.draw(202, 248, 74_992_527, 171_878_018);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer7, 1_293_741_693);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer1, 'uint32', 234548, 188535);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer11, 0, 1225);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(307);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer14, 632);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline7);
+} catch {}
+try {
+commandEncoder19.copyTextureToBuffer({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 28832 */
+  offset: 28832,
+  bytesPerRow: 0,
+  buffer: buffer4,
+}, {width: 0, height: 4, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder21.clearBuffer(buffer10, 95860, 133240);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder35.resolveQuerySet(querySet10, 898, 218, buffer13, 77568);
+} catch {}
+try {
+computePassEncoder16.insertDebugMarker('\u5221');
+} catch {}
+let buffer16 = device0.createBuffer({
+  label: '\uecc2\u1ea6',
+  size: 138676,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let querySet34 = device0.createQuerySet({type: 'occlusion', count: 1918});
+let texture23 = device0.createTexture({
+  label: '\u0c5b\u5034\u48d7\uc91b',
+  size: [480, 32, 36],
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let renderBundle26 = renderBundleEncoder1.finish({});
+let externalTexture24 = device0.importExternalTexture({
+  label: '\u0684\u0d25\u0acb\u5229\u5e53\u{1f7df}\u140a\u0e39\u51c1\u14c7\u{1f6bd}',
+  source: videoFrame2,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup3, []);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(6, bindGroup11);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(1, 0, 29, 0);
+} catch {}
+try {
+renderPassEncoder3.setViewport(29.87, 1.729, 0.06934, 0.08767, 0.4805, 0.7200);
+} catch {}
+try {
+commandEncoder21.resolveQuerySet(querySet1, 133, 1138, buffer13, 76800);
+} catch {}
+let commandEncoder43 = device0.createCommandEncoder({});
+let sampler20 = device0.createSampler({
+  label: '\u92fb\uaa4a\uf768',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 29.99,
+  lodMaxClamp: 97.45,
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder18.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(67);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer16, 'uint32', 57764, 62257);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer11, 1020);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(75, 585, 19_697_715, -1_810_170_057, 812_702_336);
+} catch {}
+try {
+renderBundleEncoder17.insertDebugMarker('\u3a4e');
+} catch {}
+let shaderModule10 = device0.createShaderModule({
+  label: '\u01e8\ueeb0\u0c32\u0720\ubf92\u0ea3\uea5f\u{1f875}',
+  code: `@group(0) @binding(2330)
+var<storage, read_write> field6: array<u32>;
+@group(0) @binding(6934)
+var<storage, read_write> field7: array<u32>;
+@group(2) @binding(3007)
+var<storage, read_write> field8: array<u32>;
+@group(1) @binding(281)
+var<storage, read_write> field9: array<u32>;
+@group(1) @binding(4360)
+var<storage, read_write> type5: array<u32>;
+
+@compute @workgroup_size(6, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec3<f32>,
+  @location(2) f1: vec4<u32>,
+  @builtin(sample_mask) f2: u32,
+  @location(6) f3: i32,
+  @location(5) f4: u32,
+  @location(4) f5: vec4<u32>,
+  @location(0) f6: vec4<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(21) a0: vec4<f32>, @location(26) a1: f32, @location(9) a2: vec2<i32>, @location(27) a3: vec3<i32>, @builtin(instance_index) a4: u32, @location(14) a5: vec2<i32>, @location(12) a6: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle11, renderBundle8, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(26, 2, 4, 0);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(93, 34, 831_028_261, 445_615_698, 253_864_459);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer14, 1280);
+} catch {}
+try {
+commandEncoder36.copyTextureToBuffer({
+  texture: texture16,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 83268 */
+  offset: 14888,
+  bytesPerRow: 256,
+  rowsPerImage: 267,
+  buffer: buffer4,
+}, {width: 7, height: 1, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder35.resolveQuerySet(querySet15, 1127, 8, buffer13, 70656);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 1,
+  origin: {x: 4, y: 3, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 425 */
+{offset: 73, bytesPerRow: 118}, {width: 29, height: 3, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture24 = device0.createTexture({
+  label: '\uf576\u9ec5\u6db6\ud41b\u0d29\uab69\u{1fb6b}\u0f6a\u691b\udf54\u{1fe9f}',
+  size: [329, 10, 1939],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView59 = texture11.createView({label: '\u0367\u0675\u1c54\ufb0f\u0542\u2f99\ua0f0\u22a4', mipLevelCount: 1});
+let externalTexture25 = device0.importExternalTexture({source: video5, colorSpace: 'srgb'});
+try {
+computePassEncoder15.setBindGroup(4, bindGroup11);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle7, renderBundle23, renderBundle8, renderBundle11, renderBundle11, renderBundle15, renderBundle11, renderBundle15, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer2, 2_141_777_395);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer12, 936_892_136);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer16, 'uint16', 110954, 14425);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer3, 104564);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer3, 99028);
+} catch {}
+try {
+commandEncoder35.resolveQuerySet(querySet11, 3186, 8, buffer13, 107008);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 79, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer0), /* required buffer size: 34 */
+{offset: 34, bytesPerRow: 1415}, {width: 342, height: 19, depthOrArrayLayers: 0});
+} catch {}
+let pipeline42 = device0.createRenderPipeline({
+  label: '\u6461\u9b13\u{1f70a}\ub41a\u7ccd\uc468\u7986\u5700\u980c',
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba16uint', writeMask: GPUColorWrite.ALL}, undefined, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'r32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r8uint', writeMask: 0}, {format: 'r16sint'}],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1152,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint32', offset: 100, shaderLocation: 21}],
+      },
+      {
+        arrayStride: 168,
+        attributes: [
+          {format: 'float32x2', offset: 8, shaderLocation: 22},
+          {format: 'sint16x4', offset: 60, shaderLocation: 18},
+          {format: 'uint16x2', offset: 72, shaderLocation: 25},
+          {format: 'unorm10-10-10-2', offset: 0, shaderLocation: 0},
+          {format: 'uint8x2', offset: 8, shaderLocation: 11},
+          {format: 'uint8x4', offset: 0, shaderLocation: 10},
+          {format: 'uint32x4', offset: 8, shaderLocation: 5},
+          {format: 'float32x4', offset: 0, shaderLocation: 7},
+          {format: 'sint16x4', offset: 0, shaderLocation: 26},
+          {format: 'snorm8x4', offset: 0, shaderLocation: 24},
+          {format: 'sint8x4', offset: 104, shaderLocation: 3},
+          {format: 'float32x3', offset: 8, shaderLocation: 9},
+          {format: 'sint16x4', offset: 4, shaderLocation: 12},
+          {format: 'uint32x2', offset: 24, shaderLocation: 17},
+          {format: 'uint8x2', offset: 8, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 8, shaderLocation: 14},
+          {format: 'float32x2', offset: 36, shaderLocation: 2},
+          {format: 'sint8x4', offset: 36, shaderLocation: 4},
+          {format: 'sint32x2', offset: 20, shaderLocation: 19},
+          {format: 'uint8x2', offset: 54, shaderLocation: 15},
+          {format: 'unorm16x4', offset: 40, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 52, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 724, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 2248,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 182, shaderLocation: 6},
+          {format: 'snorm16x4', offset: 268, shaderLocation: 20},
+          {format: 'snorm16x2', offset: 172, shaderLocation: 16},
+          {format: 'float32', offset: 244, shaderLocation: 23},
+        ],
+      },
+      {
+        arrayStride: 1176,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm10-10-10-2', offset: 260, shaderLocation: 27}],
+      },
+    ],
+  },
+  primitive: {},
+});
+try {
+canvas3.getContext('webgl2');
+} catch {}
+let shaderModule11 = device0.createShaderModule({
+  code: `@group(1) @binding(281)
+var<storage, read_write> type6: array<u32>;
+@group(0) @binding(6934)
+var<storage, read_write> field10: array<u32>;
+@group(0) @binding(2330)
+var<storage, read_write> parameter3: array<u32>;
+@group(1) @binding(4360)
+var<storage, read_write> local6: array<u32>;
+
+@compute @workgroup_size(6, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(0) f1: vec4<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S11 {
+  @location(0) f0: vec3<u32>,
+  @location(24) f1: f16,
+  @builtin(instance_index) f2: u32,
+  @location(9) f3: i32,
+  @location(16) f4: vec2<f32>
+}
+
+@vertex
+fn vertex0(a0: S11, @location(12) a1: vec3<f16>, @location(21) a2: vec3<f32>, @location(11) a3: vec3<i32>, @location(22) a4: vec3<f32>, @builtin(vertex_index) a5: u32, @location(5) a6: f32, @location(18) a7: u32, @location(4) a8: vec2<f32>, @location(10) a9: f16, @location(26) a10: vec4<f16>, @location(8) a11: i32, @location(2) a12: vec4<u32>, @location(17) a13: vec3<i32>, @location(20) a14: vec4<f32>, @location(27) a15: vec3<i32>, @location(23) a16: vec3<u32>, @location(25) a17: vec3<u32>, @location(1) a18: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer17 = device0.createBuffer({label: '\u07ab\u{1fba7}\u7455\u{1fdc2}\ua2c3\u9ed2\uee52', size: 61411, usage: GPUBufferUsage.UNIFORM});
+let commandEncoder44 = device0.createCommandEncoder({label: '\u0e63\uefd6\u00b6\u0a98\u{1f87a}'});
+let querySet35 = device0.createQuerySet({label: '\ucf72\u0dd1\u0d30\u0bf2\u0107\u{1f9c6}\u1588\u0887\u{1ffee}', type: 'occlusion', count: 62});
+let textureView60 = texture13.createView({});
+try {
+renderPassEncoder4.beginOcclusionQuery(3252);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant({ r: 790.7, g: -424.0, b: 398.0, a: -484.7, });
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(360);
+} catch {}
+try {
+renderPassEncoder6.setViewport(29.94, 1.247, 0.01869, 0.00327, 0.7326, 0.7713);
+} catch {}
+try {
+renderPassEncoder2.draw(141, 156, 840_622_731, 63_835_627);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline34);
+} catch {}
+try {
+renderBundleEncoder13.draw(169, 204);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer3, 29192);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer16, 'uint32', 8080, 45899);
+} catch {}
+try {
+commandEncoder23.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 29184 */
+  offset: 29184,
+  buffer: buffer9,
+}, {
+  texture: texture20,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 14460, new Int16Array(48296), 3248, 3052);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder45 = device0.createCommandEncoder({label: '\u016a\ub91a\ua3d6'});
+let textureView61 = texture10.createView({label: '\uddb8\ub7c0\ua86e\u5299', dimension: '1d'});
+let sampler21 = device0.createSampler({
+  label: '\ucf97\u2f46\u571b\u{1f6bb}\u07ed\ucb15\u186c',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 13.38,
+  lodMaxClamp: 97.22,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder2.setPipeline(pipeline40);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(18, 2, 1, 0);
+} catch {}
+try {
+renderPassEncoder9.setViewport(20.61, 1.832, 6.054, 0.03348, 0.8732, 0.9620);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(114, 33);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer15, 704_317_376);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer11);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer3, 69324);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 12676, new Int16Array(13528), 1308, 3072);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas7,
+  origin: { x: 1, y: 82 },
+  flipY: false,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData9 = new ImageData(96, 136);
+let shaderModule12 = device0.createShaderModule({
+  code: `@group(2) @binding(281)
+var<storage, read_write> global6: array<u32>;
+
+@compute @workgroup_size(7, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec3<f32>,
+  @location(0) f1: vec4<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(9) a0: vec3<f16>, @location(14) a1: f32, @location(24) a2: vec2<i32>, @location(21) a3: vec4<f32>, @location(6) a4: vec4<f16>, @location(3) a5: vec4<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let bindGroupLayout18 = device0.createBindGroupLayout({
+  label: '\u1658\u00a9\u4589\uc14f\u0b13\ue11e\u055d\u006d\u33cd',
+  entries: [
+    {
+      binding: 3692,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 6875,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let computePassEncoder20 = commandEncoder44.beginComputePass({});
+try {
+computePassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(646);
+} catch {}
+try {
+renderPassEncoder2.draw(1, 770, 58_997_374, 35_772_375);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer9, 1_285_538_266);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer7, 124_760_468);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer1, 'uint32', 604012);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline34);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(1, buffer0, 11936, 986);
+} catch {}
+try {
+renderBundleEncoder13.draw(598, 135, 412_569_894, 586_119_025);
+} catch {}
+try {
+commandEncoder35.copyBufferToTexture({
+  /* bytesInLastRow: 232 widthInBlocks: 58 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 35608 */
+  offset: 9520,
+  bytesPerRow: 256,
+  rowsPerImage: 100,
+  buffer: buffer12,
+}, {
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 58, height: 2, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 43248, new DataView(new ArrayBuffer(26173)), 1382, 3612);
+} catch {}
+let bindGroupLayout19 = pipeline25.getBindGroupLayout(1);
+let commandBuffer11 = commandEncoder37.finish();
+let texture25 = device0.createTexture({
+  size: [120, 8, 9],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rg32sint', 'rg32sint', 'rg32sint'],
+});
+let textureView62 = texture14.createView({baseMipLevel: 4});
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.setViewport(28.34, 1.996, 0.7619, 0.00355, 0.07748, 0.2133);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(65, 11, 1_789_675_267, 275_375_957);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer15, 2_065_398_547);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer14, 36);
+} catch {}
+try {
+commandEncoder43.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderPassEncoder8.insertDebugMarker('\u05af');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(336), /* required buffer size: 336 */
+{offset: 336}, {width: 8, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline43 = device0.createRenderPipeline({
+  label: '\u{1fafc}\u1ee8\uaee0',
+  layout: pipelineLayout2,
+  multisample: {count: 4, mask: 0x5000f1b0},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALPHA}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'greater', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'zero'},
+    stencilBack: {depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilReadMask: 1189598134,
+    stencilWriteMask: 1222621758,
+    depthBiasClamp: 821.6102610334434,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 1248,
+        attributes: [
+          {format: 'float16x4', offset: 32, shaderLocation: 8},
+          {format: 'sint8x2', offset: 56, shaderLocation: 22},
+          {format: 'float16x2', offset: 212, shaderLocation: 19},
+          {format: 'unorm10-10-10-2', offset: 156, shaderLocation: 17},
+          {format: 'float32x3', offset: 184, shaderLocation: 18},
+          {format: 'unorm8x2', offset: 544, shaderLocation: 26},
+          {format: 'uint8x2', offset: 162, shaderLocation: 4},
+          {format: 'float32x3', offset: 108, shaderLocation: 13},
+          {format: 'uint16x4', offset: 128, shaderLocation: 12},
+          {format: 'unorm16x2', offset: 264, shaderLocation: 15},
+          {format: 'sint16x4', offset: 340, shaderLocation: 24},
+          {format: 'float32x4', offset: 732, shaderLocation: 0},
+          {format: 'sint16x4', offset: 360, shaderLocation: 1},
+          {format: 'snorm8x4', offset: 96, shaderLocation: 14},
+          {format: 'float32x3', offset: 488, shaderLocation: 10},
+          {format: 'sint32x2', offset: 108, shaderLocation: 9},
+          {format: 'uint32x3', offset: 64, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 120,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm16x4', offset: 40, shaderLocation: 7},
+          {format: 'float32x3', offset: 32, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 956,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 116, shaderLocation: 3},
+          {format: 'float16x2', offset: 8, shaderLocation: 21},
+          {format: 'uint32x4', offset: 48, shaderLocation: 23},
+          {format: 'sint32x2', offset: 100, shaderLocation: 5},
+          {format: 'sint32x4', offset: 104, shaderLocation: 25},
+        ],
+      },
+      {
+        arrayStride: 2032,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x2', offset: 452, shaderLocation: 16}],
+      },
+      {arrayStride: 1344, attributes: []},
+      {arrayStride: 752, attributes: [{format: 'uint8x2', offset: 34, shaderLocation: 20}]},
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'cw', cullMode: 'back'},
+});
+let videoFrame5 = new VideoFrame(video3, {timestamp: 0});
+let commandEncoder46 = device0.createCommandEncoder({});
+let texture26 = device0.createTexture({
+  label: '\u3a57\u0a15\ue9fd\ubd7f\u{1fd8b}\u{1fe2b}\u{1fdde}\ucd20',
+  size: [329, 10, 1],
+  sampleCount: 1,
+  format: 'rgb9e5ufloat',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgb9e5ufloat', 'rgb9e5ufloat'],
+});
+let textureView63 = texture20.createView({label: '\ufb31\u{1fc57}\u06e3\u0b48\u0c7e\u22f0', baseMipLevel: 1, mipLevelCount: 1});
+let externalTexture26 = device0.importExternalTexture({source: videoFrame2, colorSpace: 'display-p3'});
+try {
+renderPassEncoder1.beginOcclusionQuery(462);
+} catch {}
+try {
+renderPassEncoder2.draw(103, 90, 570_490_909, 576_704_467);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline16);
+} catch {}
+try {
+commandEncoder43.copyBufferToTexture({
+  /* bytesInLastRow: 258 widthInBlocks: 258 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 17588 */
+  offset: 17588,
+  buffer: buffer9,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 46, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 258, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer9);
+} catch {}
+let shaderModule13 = device0.createShaderModule({
+  label: '\u26e7\ue094\u4488\uec7a\u3e58\u6163\u0f2a\u09e0',
+  code: `@group(2) @binding(281)
+var<storage, read_write> type7: array<u32>;
+
+@compute @workgroup_size(1, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @builtin(sample_mask) f1: u32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S12 {
+  @location(10) f0: vec4<i32>,
+  @location(17) f1: vec2<f16>,
+  @location(18) f2: i32,
+  @location(22) f3: vec2<f16>,
+  @builtin(instance_index) f4: u32,
+  @builtin(vertex_index) f5: u32,
+  @location(4) f6: vec3<f16>,
+  @location(24) f7: u32,
+  @location(16) f8: vec2<u32>,
+  @location(13) f9: vec3<f32>,
+  @location(8) f10: f32,
+  @location(14) f11: vec4<u32>,
+  @location(9) f12: vec2<i32>,
+  @location(5) f13: vec2<f32>,
+  @location(0) f14: vec4<f16>,
+  @location(6) f15: vec3<f32>,
+  @location(2) f16: vec3<f16>,
+  @location(7) f17: f16,
+  @location(21) f18: f16,
+  @location(19) f19: vec4<f16>,
+  @location(12) f20: vec3<i32>,
+  @location(26) f21: f16
+}
+struct VertexOutput0 {
+  @location(30) f177: vec4<f32>,
+  @location(14) f178: i32,
+  @builtin(position) f179: vec4<f32>,
+  @location(11) f180: vec4<i32>,
+  @location(15) f181: vec2<f16>,
+  @location(23) f182: vec3<u32>,
+  @location(31) f183: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(23) a0: i32, @location(25) a1: vec3<f16>, @location(3) a2: vec2<i32>, a3: S12, @location(27) a4: vec4<f32>, @location(15) a5: f32, @location(20) a6: f16, @location(11) a7: vec4<f32>, @location(1) a8: f16) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+});
+let texture27 = device0.createTexture({
+  label: '\u1233\u3901',
+  size: {width: 658, height: 20, depthOrArrayLayers: 654},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({label: '\ued05\u0fe3\ub5c9\u244f\u04a3\u3e19\uacd8', colorFormats: ['rg16uint']});
+let renderBundle27 = renderBundleEncoder23.finish();
+let sampler22 = device0.createSampler({
+  label: '\u0170\uf247\u02d7\u5a51\u33a7\ua36c\u{1fa4a}\uf9db\ued0b',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 98.63,
+  lodMaxClamp: 99.48,
+});
+let externalTexture27 = device0.importExternalTexture({label: '\u92ca\u0d3e\uee08\u{1fdcd}\u3303\uf5ca\uc894', source: videoFrame0});
+try {
+computePassEncoder2.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 146.9, g: -16.47, b: -54.22, a: 256.6, });
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(348, 169, 267_592_913, 418_076_714, 19_587_616);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer1, 'uint16');
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(4, buffer0, 0);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(0, buffer16);
+} catch {}
+try {
+commandEncoder35.clearBuffer(buffer7);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer15, 2748, new DataView(new ArrayBuffer(58737)), 26767, 2452);
+} catch {}
+let pipeline44 = device0.createComputePipeline({
+  label: '\u04aa\ue0df\u8aab\ucb97\uc6a3\ubedc\u{1f99d}',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule6, entryPoint: 'compute0'},
+});
+let pipeline45 = device0.createRenderPipeline({
+  label: '\uc7de\u213d\u2c4c\uc059\ud4d6\u5ea1\ubb09',
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.GREEN}, {format: 'rg16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule12,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {arrayStride: 2312, stepMode: 'instance', attributes: []},
+      {arrayStride: 852, stepMode: 'instance', attributes: []},
+      {arrayStride: 220, stepMode: 'instance', attributes: []},
+      {arrayStride: 704, attributes: [{format: 'sint32x4', offset: 208, shaderLocation: 24}]},
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm16x2', offset: 376, shaderLocation: 9},
+          {format: 'float32x2', offset: 328, shaderLocation: 6},
+          {format: 'snorm8x2', offset: 4492, shaderLocation: 14},
+        ],
+      },
+      {arrayStride: 2880, attributes: [{format: 'float32x4', offset: 912, shaderLocation: 3}]},
+      {
+        arrayStride: 1704,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x2', offset: 144, shaderLocation: 21}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back'},
+});
+gc();
+let imageBitmap4 = await createImageBitmap(imageData0);
+let textureView64 = texture4.createView({label: '\u0bfa\u{1f79d}\ucc03\u004c', dimension: '2d', baseMipLevel: 1, baseArrayLayer: 20});
+let computePassEncoder21 = commandEncoder46.beginComputePass({label: '\u{1fe75}\u1955\u089e\u03fa\ued8d\u{1f8bf}\u{1f794}'});
+let renderBundle28 = renderBundleEncoder0.finish();
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer3, 1_193_234_937);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer3, 66776);
+} catch {}
+try {
+commandEncoder19.copyBufferToBuffer(buffer9, 10104, buffer8, 47192, 15808);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder39.copyTextureToBuffer({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1168 */
+  offset: 1168,
+  rowsPerImage: 181,
+  buffer: buffer15,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer5), /* required buffer size: 804 */
+{offset: 804, bytesPerRow: 477}, {width: 381, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise14 = device0.queue.onSubmittedWorkDone();
+let bindGroupLayout20 = pipeline29.getBindGroupLayout(2);
+let commandEncoder47 = device0.createCommandEncoder({label: '\u478f\u01bb\uf74c'});
+try {
+renderPassEncoder9.beginOcclusionQuery(1619);
+} catch {}
+try {
+renderPassEncoder3.setViewport(22.83, 0.9057, 2.474, 0.2814, 0.4348, 0.4590);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(479);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer16, 'uint32', 35720, 43632);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer11, 1436, 408);
+} catch {}
+try {
+renderBundleEncoder13.draw(164);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline42);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(8, buffer11);
+} catch {}
+try {
+commandEncoder23.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline46 = await device0.createComputePipelineAsync({
+  label: '\u09fd\ue2e7\uf056\u0f84',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let pipeline47 = device0.createRenderPipeline({
+  label: '\u00cd\u5fd8\uf003\u0c45\u0640\u071e',
+  layout: pipelineLayout6,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 736,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm16x2', offset: 116, shaderLocation: 3},
+          {format: 'sint8x4', offset: 396, shaderLocation: 9},
+          {format: 'sint8x2', offset: 150, shaderLocation: 24},
+          {format: 'float32x3', offset: 80, shaderLocation: 19},
+          {format: 'snorm16x2', offset: 80, shaderLocation: 26},
+          {format: 'unorm10-10-10-2', offset: 68, shaderLocation: 0},
+          {format: 'uint8x4', offset: 140, shaderLocation: 12},
+          {format: 'unorm8x2', offset: 250, shaderLocation: 13},
+          {format: 'float32x4', offset: 4, shaderLocation: 15},
+          {format: 'uint32', offset: 0, shaderLocation: 23},
+          {format: 'sint16x4', offset: 104, shaderLocation: 25},
+          {format: 'snorm8x4', offset: 4, shaderLocation: 14},
+          {format: 'uint32', offset: 56, shaderLocation: 6},
+          {format: 'uint32x4', offset: 52, shaderLocation: 20},
+          {format: 'unorm10-10-10-2', offset: 332, shaderLocation: 2},
+          {format: 'sint32x2', offset: 60, shaderLocation: 5},
+          {format: 'float16x4', offset: 512, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 1060,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 12, shaderLocation: 16},
+          {format: 'float16x4', offset: 156, shaderLocation: 21},
+          {format: 'sint16x2', offset: 460, shaderLocation: 1},
+          {format: 'unorm10-10-10-2', offset: 120, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 44,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x2', offset: 16, shaderLocation: 4}],
+      },
+      {
+        arrayStride: 828,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 8, shaderLocation: 22},
+          {format: 'float32x3', offset: 8, shaderLocation: 10},
+          {format: 'snorm16x2', offset: 224, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 1228,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm10-10-10-2', offset: 172, shaderLocation: 18}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'ccw'},
+});
+let texture28 = device0.createTexture({
+  label: '\u{1f6dc}\u404f\u3c65',
+  size: {width: 2634},
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({
+  label: '\u5856\u{1fe51}\uaf30\u{1feed}\u256e\u95b4\u3658',
+  colorFormats: ['rgba16uint', undefined, 'rgb10a2uint', 'r32float', 'rgba16uint', 'r8uint', 'r16sint'],
+  depthReadOnly: true,
+});
+let renderBundle29 = renderBundleEncoder14.finish();
+let externalTexture28 = device0.importExternalTexture({label: '\u70f0\u0174\u6391\u00d2\u{1fc9a}\u{1fa55}\u4605', source: video4});
+try {
+renderPassEncoder0.setScissorRect(14, 0, 8, 1);
+} catch {}
+try {
+renderPassEncoder2.draw(49, 201, 701_232_813, 841_350_270);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer0, 19404, 508);
+} catch {}
+try {
+renderBundleEncoder13.draw(241);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline29);
+} catch {}
+try {
+commandEncoder23.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 508, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 3,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 106, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder19.clearBuffer(buffer8, 79668, 2664);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.submit([commandBuffer8, commandBuffer9]);
+} catch {}
+let pipelineLayout8 = device0.createPipelineLayout({
+  label: '\ub486\u{1f6ab}\u0f4d',
+  bindGroupLayouts: [bindGroupLayout15, bindGroupLayout2, bindGroupLayout3],
+});
+let buffer18 = device0.createBuffer({
+  label: '\u2058\u79a2\u41f0\u{1feb8}\u05c5\u{1f65b}\u7be7',
+  size: 407985,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({
+  label: '\u7075\u{1fa93}',
+  colorFormats: ['rg32sint', 'rgba32uint', 'rgba16float', 'rg16uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler23 = device0.createSampler({
+  label: '\u5140\u556b\u0e65\udd86\u{1fb2b}\u{1f65e}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 50.17,
+  lodMaxClamp: 58.01,
+  maxAnisotropy: 14,
+});
+let externalTexture29 = device0.importExternalTexture({
+  label: '\u{1f926}\u0db3\u0ea4\u0760\u0f0c\u3337\u23e5\ue2dc\u{1fbd6}\u9360',
+  source: video6,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder8.setScissorRect(12, 2, 18, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(123, 136, 1_169_185_738, 766_384_310);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(238, 33, 499_190_409, 165_816_085, 442_845_146);
+} catch {}
+try {
+renderBundleEncoder13.draw(133);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(123, 194);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer3, 97972);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer14, 1164);
+} catch {}
+try {
+commandEncoder47.clearBuffer(buffer8, 98300, 9988);
+dissociateBuffer(device0, buffer8);
+} catch {}
+let bindGroupLayout21 = device0.createBindGroupLayout({label: '\u3744\u2de7\ub5a2\u12f5\u80c3\u4662\u{1f64a}', entries: []});
+let commandEncoder48 = device0.createCommandEncoder({});
+let textureView65 = texture8.createView({label: '\u6d03\u6665\ua642\ubb72\u05d6\u{1f90a}\u48e3\u{1f8bc}\u07f8\u{1fc35}'});
+let computePassEncoder22 = commandEncoder43.beginComputePass({});
+try {
+computePassEncoder18.end();
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline35);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer11, 1_186_831_929);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer13, 54_768_827);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer11, 0, 521);
+} catch {}
+try {
+renderBundleEncoder26.setBindGroup(2, bindGroup1, new Uint32Array(3950), 2933, 0);
+} catch {}
+try {
+renderBundleEncoder13.draw(74);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(1);
+} catch {}
+try {
+renderBundleEncoder21.setPipeline(pipeline47);
+} catch {}
+try {
+texture20.destroy();
+} catch {}
+try {
+commandEncoder40.copyTextureToBuffer({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 172 widthInBlocks: 43 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 132356 */
+  offset: 58200,
+  bytesPerRow: 256,
+  rowsPerImage: 289,
+  buffer: buffer18,
+}, {width: 43, height: 1, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 36408, new Int16Array(49720), 37961, 3008);
+} catch {}
+let videoFrame6 = new VideoFrame(canvas1, {timestamp: 0});
+let buffer19 = device0.createBuffer({
+  label: '\ucd6f\u{1ffb5}\u{1fa8f}\uebc8\u{1f686}\uea43',
+  size: 50271,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+try {
+renderPassEncoder4.setBindGroup(4, bindGroup6, new Uint32Array(1459), 187, 0);
+} catch {}
+try {
+renderPassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder2.draw(2, 463, 876_239_815, 1_397_532_776);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer16, 'uint16', 21828, 70453);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline34);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer14, 128);
+} catch {}
+let arrayBuffer6 = buffer5.getMappedRange(0, 16940);
+try {
+renderPassEncoder2.beginOcclusionQuery(296);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle13, renderBundle11, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: 85.85, g: 696.5, b: -772.1, a: 603.5, });
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(13, 1, 11, 1);
+} catch {}
+try {
+renderPassEncoder2.draw(11, 159, 158_648_243, 1_791_587_755);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(0, buffer13, 0, 93835);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(49, 153);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 22128, new Int16Array(3141), 2411, 28);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 9}
+*/
+{
+  source: offscreenCanvas3,
+  origin: { x: 5, y: 2 },
+  flipY: false,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 28, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline48 = await device0.createComputePipelineAsync({
+  label: '\ud70f\u6bec\u0923\u09ec\u{1f9a5}\u0a0f\u056a\u{1f8a0}\u7599\u2b1a\u{1fbad}',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let pipeline49 = device0.createRenderPipeline({
+  label: '\u{1fa5a}\uc05c\u03a3\u5edd\u61d5\u0236',
+  layout: 'auto',
+  multisample: {mask: 0xe63ecef5},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 3336, attributes: []},
+      {arrayStride: 1076, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 496,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 136, shaderLocation: 4},
+          {format: 'sint32x4', offset: 32, shaderLocation: 5},
+          {format: 'float16x4', offset: 120, shaderLocation: 10},
+          {format: 'uint8x4', offset: 16, shaderLocation: 20},
+          {format: 'float16x4', offset: 0, shaderLocation: 3},
+          {format: 'sint32x4', offset: 236, shaderLocation: 9},
+          {format: 'uint32x3', offset: 0, shaderLocation: 6},
+          {format: 'float32x2', offset: 112, shaderLocation: 19},
+          {format: 'float32', offset: 160, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 204,
+        attributes: [
+          {format: 'float32', offset: 140, shaderLocation: 14},
+          {format: 'sint32x2', offset: 64, shaderLocation: 1},
+          {format: 'snorm16x2', offset: 44, shaderLocation: 26},
+          {format: 'sint16x4', offset: 0, shaderLocation: 24},
+        ],
+      },
+      {
+        arrayStride: 1920,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 490, shaderLocation: 13},
+          {format: 'uint8x4', offset: 40, shaderLocation: 23},
+          {format: 'uint32x2', offset: 204, shaderLocation: 12},
+          {format: 'unorm8x2', offset: 22, shaderLocation: 7},
+          {format: 'sint8x2', offset: 788, shaderLocation: 22},
+          {format: 'float32x3', offset: 796, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 452,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 4, shaderLocation: 16},
+          {format: 'unorm8x2', offset: 74, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 264, attributes: []},
+      {
+        arrayStride: 408,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 12, shaderLocation: 2},
+          {format: 'unorm8x2', offset: 10, shaderLocation: 21},
+          {format: 'sint16x2', offset: 60, shaderLocation: 25},
+        ],
+      },
+      {
+        arrayStride: 752,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 26, shaderLocation: 17},
+          {format: 'float32x3', offset: 216, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+});
+gc();
+let video8 = await videoWithData();
+let texture29 = device0.createTexture({
+  size: {width: 2634},
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16uint', 'rgba16uint'],
+});
+let textureView66 = texture16.createView({label: '\u0dee\u08c1\u068a\u009f\u0694\u2d8d\u9874', mipLevelCount: 1});
+let computePassEncoder23 = commandEncoder42.beginComputePass({label: '\uc5af\ucb85'});
+let sampler24 = device0.createSampler({
+  label: '\ud98f\uaa26\u{1fd52}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 96.80,
+});
+let externalTexture30 = device0.importExternalTexture({source: videoFrame4});
+try {
+renderPassEncoder9.beginOcclusionQuery(1543);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle8, renderBundle13, renderBundle13, renderBundle13, renderBundle23, renderBundle27, renderBundle27, renderBundle7, renderBundle23, renderBundle27]);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(1, 0, 1, 1);
+} catch {}
+try {
+renderPassEncoder4.setViewport(27.55, 1.566, 1.622, 0.2125, 0.4094, 0.7230);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer3, 214220);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(7, buffer13, 14224, 31083);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise15 = adapter1.requestAdapterInfo();
+let bindGroup13 = device0.createBindGroup({
+  label: '\ub040\u026b\u2752\u0377\ua9bb\u8aef\u0058\u7341\uc307\u089f\u0620',
+  layout: bindGroupLayout6,
+  entries: [],
+});
+let querySet36 = device0.createQuerySet({type: 'occlusion', count: 1430});
+let renderPassEncoder10 = commandEncoder26.beginRenderPass({
+  colorAttachments: [{
+  view: textureView24,
+  clearValue: { r: -255.0, g: -403.8, b: -589.5, a: 28.73, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet9,
+  maxDrawCount: 352339216,
+});
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(1054);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(11, 1, 6, 0);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline49);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(85, 68, 1_206_303_099, 286_693_125, 183_849_115);
+} catch {}
+try {
+commandEncoder48.copyBufferToTexture({
+  /* bytesInLastRow: 7940 widthInBlocks: 1985 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 13396 */
+  offset: 13396,
+  buffer: buffer2,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 61, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1985, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder39.resolveQuerySet(querySet29, 541, 145, buffer13, 67840);
+} catch {}
+let commandBuffer12 = commandEncoder23.finish({label: '\u79ec\u{1fda3}\u53d6'});
+let textureView67 = texture4.createView({
+  label: '\ud3db\u1e84\u{1feec}\u0365\u6626\u{1fb0d}\u{1fe29}\u{1fc8f}\u3e6d\u{1f9b9}',
+  dimension: '2d',
+  aspect: 'all',
+  baseArrayLayer: 127,
+  arrayLayerCount: 1,
+});
+let sampler25 = device0.createSampler({
+  label: '\u90f3\u0ee2\uf293\u00b4',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 51.47,
+  lodMaxClamp: 70.20,
+  maxAnisotropy: 7,
+});
+try {
+renderPassEncoder2.draw(100, 42);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(0, buffer16, 0, 124991);
+} catch {}
+try {
+renderBundleEncoder13.draw(180);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(378, 348, 108_259_147, 287_956_906, 732_525_298);
+} catch {}
+try {
+commandEncoder47.copyBufferToTexture({
+  /* bytesInLastRow: 120 widthInBlocks: 120 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 75482 */
+  offset: 75482,
+  buffer: buffer9,
+}, {
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 93, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 120, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData7,
+  origin: { x: 3, y: 4 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline50 = await device0.createComputePipelineAsync({layout: pipelineLayout5, compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}}});
+let commandEncoder49 = device0.createCommandEncoder({});
+let renderBundle30 = renderBundleEncoder3.finish();
+let sampler26 = device0.createSampler({
+  label: '\ue682\u0bb5\u400c\ubd41\u05ae\u{1f693}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 46.87,
+  lodMaxClamp: 89.53,
+});
+try {
+computePassEncoder21.setBindGroup(4, bindGroup2);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(0, buffer0, 10104, 7172);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(5, bindGroup9, new Uint32Array(2652), 609, 0);
+} catch {}
+try {
+commandEncoder40.copyBufferToBuffer(buffer9, 52196, buffer15, 4852, 24752);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder48.resolveQuerySet(querySet33, 584, 2365, buffer19, 22528);
+} catch {}
+let pipeline51 = device0.createComputePipeline({
+  label: '\u050d\u{1ffa4}\u14b7',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule12, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise14;
+} catch {}
+let bindGroupLayout22 = device0.createBindGroupLayout({
+  label: '\u30d7\u{1f6a6}\u57cc\u21e5\u0465\u088d\u0895\u0d7f\ud6b2',
+  entries: [
+    {
+      binding: 3579,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let textureView68 = texture23.createView({
+  label: '\u{1f857}\udca2\u{1fcb2}\u0603\ueed1\u{1fe07}\u8157\u92d7\u2086\u0950\u40aa',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+});
+try {
+computePassEncoder20.setPipeline(pipeline35);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setViewport(3.401, 1.780, 12.98, 0.1987, 0.2976, 0.3888);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(4, 167, 789_787_671);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline49);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(0, buffer11, 0, 842);
+} catch {}
+try {
+commandEncoder49.copyBufferToBuffer(buffer12, 98156, buffer7, 430168, 4364);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+commandEncoder13.copyTextureToBuffer({
+  texture: texture14,
+  mipLevel: 4,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 17252 */
+  offset: 17252,
+  buffer: buffer4,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder38.resolveQuerySet(querySet35, 16, 27, buffer19, 15616);
+} catch {}
+let pipeline52 = await promise9;
+let shaderModule14 = device0.createShaderModule({
+  label: '\u5006\u0de1',
+  code: `@group(0) @binding(6934)
+var<storage, read_write> field11: array<u32>;
+@group(1) @binding(281)
+var<storage, read_write> parameter4: array<u32>;
+@group(1) @binding(4360)
+var<storage, read_write> global7: array<u32>;
+@group(0) @binding(2330)
+var<storage, read_write> field12: array<u32>;
+@group(2) @binding(3007)
+var<storage, read_write> n0: array<u32>;
+
+@compute @workgroup_size(2, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0() -> @location(200) vec3<u32> {
+return vec3<u32>();
+}
+
+struct S13 {
+  @location(11) f0: u32,
+  @location(1) f1: vec4<u32>,
+  @location(6) f2: vec3<f16>,
+  @location(12) f3: vec4<f16>,
+  @location(13) f4: vec3<u32>,
+  @location(24) f5: vec3<i32>
+}
+struct VertexOutput0 {
+  @location(31) f184: vec3<i32>,
+  @location(0) f185: vec3<u32>,
+  @location(23) f186: f32,
+  @location(15) f187: vec3<f32>,
+  @location(25) f188: vec2<f32>,
+  @location(39) f189: i32,
+  @location(18) f190: vec2<i32>,
+  @builtin(position) f191: vec4<f32>,
+  @location(34) f192: vec4<f32>,
+  @location(9) f193: vec3<u32>,
+  @location(37) f194: vec2<i32>,
+  @location(11) f195: f16,
+  @location(14) f196: vec4<u32>,
+  @location(12) f197: vec4<i32>,
+  @location(20) f198: vec2<f32>
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec3<f32>, @builtin(instance_index) a1: u32, @location(26) a2: vec2<u32>, @location(9) a3: u32, @location(27) a4: vec3<f32>, @builtin(vertex_index) a5: u32, @location(22) a6: i32, @location(21) a7: vec3<f32>, @location(19) a8: vec2<u32>, @location(5) a9: vec2<f32>, @location(7) a10: vec3<f32>, @location(16) a11: vec4<f32>, @location(3) a12: vec2<i32>, @location(4) a13: f16, @location(25) a14: vec2<f32>, a15: S13, @location(20) a16: vec3<u32>, @location(14) a17: vec4<f16>, @location(17) a18: u32, @location(8) a19: f16, @location(15) a20: vec3<u32>, @location(10) a21: vec3<f16>, @location(0) a22: i32, @location(23) a23: vec3<u32>, @location(18) a24: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView69 = texture26.createView({label: '\u8ae1\uafd0\u54c0\u3481\u0731\udb74\u438d', dimension: '2d-array'});
+try {
+renderPassEncoder4.setStencilReference(764);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer11, 361_280_978);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline47);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(1, buffer11, 0, 1827);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+commandEncoder28.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 77, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 231, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder39.clearBuffer(buffer10, 73376, 179396);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 233},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 3_755_415 */
+{offset: 908, bytesPerRow: 231, rowsPerImage: 125}, {width: 16, height: 4, depthOrArrayLayers: 131});
+} catch {}
+let pipeline53 = await device0.createRenderPipelineAsync({
+  label: '\u8c84\u17f5\u6b03\u4f94\ub8d2\u{1f67a}\u0fb9\u7c9d',
+  layout: pipelineLayout6,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r8unorm', writeMask: 0}, {format: 'r16sint', writeMask: 0}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rgba32float'}],
+},
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 484,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 8, shaderLocation: 18},
+          {format: 'float32', offset: 56, shaderLocation: 2},
+          {format: 'float32', offset: 128, shaderLocation: 7},
+          {format: 'unorm16x4', offset: 64, shaderLocation: 16},
+          {format: 'sint8x2', offset: 98, shaderLocation: 10},
+          {format: 'sint32x3', offset: 72, shaderLocation: 9},
+          {format: 'uint32x3', offset: 164, shaderLocation: 20},
+          {format: 'float32x3', offset: 16, shaderLocation: 13},
+          {format: 'sint32x4', offset: 232, shaderLocation: 15},
+          {format: 'float16x2', offset: 312, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 1412,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 300, shaderLocation: 11},
+          {format: 'float16x2', offset: 20, shaderLocation: 25},
+        ],
+      },
+      {
+        arrayStride: 1088,
+        attributes: [
+          {format: 'snorm8x4', offset: 216, shaderLocation: 26},
+          {format: 'uint32x3', offset: 120, shaderLocation: 24},
+          {format: 'sint16x4', offset: 264, shaderLocation: 8},
+          {format: 'unorm16x2', offset: 36, shaderLocation: 4},
+          {format: 'uint32x3', offset: 332, shaderLocation: 1},
+          {format: 'uint8x4', offset: 260, shaderLocation: 12},
+          {format: 'uint16x4', offset: 736, shaderLocation: 23},
+          {format: 'snorm16x2', offset: 40, shaderLocation: 17},
+          {format: 'float32x2', offset: 4, shaderLocation: 0},
+          {format: 'uint32x3', offset: 100, shaderLocation: 22},
+          {format: 'unorm16x4', offset: 68, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x2', offset: 476, shaderLocation: 21}],
+      },
+      {
+        arrayStride: 1656,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x2', offset: 300, shaderLocation: 3}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'back'},
+});
+let offscreenCanvas8 = new OffscreenCanvas(996, 998);
+let commandBuffer13 = commandEncoder48.finish();
+let renderPassEncoder11 = commandEncoder39.beginRenderPass({
+  colorAttachments: [{
+  view: textureView24,
+  clearValue: { r: -75.03, g: 242.8, b: -251.2, a: -426.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 866072171,
+});
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(9, 1, 9, 1);
+} catch {}
+try {
+renderPassEncoder2.draw(99, 186, 465_356_179);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(68, 47, 151_135_310, 587_172_249, 25_615_162);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer18, 15_060_159);
+} catch {}
+try {
+renderBundleEncoder13.draw(115);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer3, 41688);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+let bindGroupLayout23 = device0.createBindGroupLayout({label: '\u09ed\u{1f91d}\u{1f7f2}\u5a8b\u0a8a\u82bb\u073f\uaa3d', entries: []});
+let externalTexture31 = device0.importExternalTexture({label: '\u07ec\u0961\u0643\u6699\u7cda\u5e31\u0d71\u9143', source: video8, colorSpace: 'srgb'});
+try {
+renderPassEncoder11.setStencilReference(1864);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline52);
+} catch {}
+try {
+renderBundleEncoder13.draw(6, 31, 1_119_597_102, 129_830_166);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(60, 44, 238_145_381, 226_404_009, 1_166_514_314);
+} catch {}
+try {
+commandEncoder45.copyTextureToTexture({
+  texture: texture9,
+  mipLevel: 4,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 46, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 43, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 9}
+*/
+{
+  source: img5,
+  origin: { x: 26, y: 19 },
+  flipY: true,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 76, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 39, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({
+  label: '\u05d3\uc0ce\u1fd1\u1025\u31a8\u67e9\u0bd8\u9cd7\u{1f6bc}',
+  colorFormats: ['rg16uint'],
+  stencilReadOnly: true,
+});
+let externalTexture32 = device0.importExternalTexture({
+  label: '\u00cb\u{1fa4b}\u4f5f\u1583\u{1f8f9}\u1318\u0d82\u{1fb9f}\ubb31\u7bd9\u{1fb7b}',
+  source: videoFrame6,
+});
+try {
+computePassEncoder16.setBindGroup(6, bindGroup13);
+} catch {}
+try {
+renderPassEncoder11.setViewport(4.988, 1.219, 2.354, 0.04526, 0.3134, 0.3702);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer9, 1_695_186_395);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer7, 314_277_785);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup2, []);
+} catch {}
+try {
+commandEncoder47.copyBufferToBuffer(buffer12, 32748, buffer8, 64844, 21168);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder21.copyBufferToTexture({
+  /* bytesInLastRow: 856 widthInBlocks: 214 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 95148 */
+  offset: 88148,
+  bytesPerRow: 1024,
+  buffer: buffer12,
+}, {
+  texture: texture15,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 214, height: 7, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 605_049 */
+{offset: 221, bytesPerRow: 470, rowsPerImage: 257}, {width: 51, height: 2, depthOrArrayLayers: 6});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 9}
+*/
+{
+  source: imageData4,
+  origin: { x: 13, y: 3 },
+  flipY: false,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame7 = new VideoFrame(img1, {timestamp: 0});
+let shaderModule15 = device0.createShaderModule({
+  label: '\ucbf3\u003e\uc652\ucb94\u2ea0\uddac\u75a2',
+  code: `@group(2) @binding(4360)
+var<storage, read_write> field13: array<u32>;
+@group(0) @binding(3385)
+var<storage, read_write> parameter5: array<u32>;
+@group(0) @binding(4214)
+var<storage, read_write> n1: array<u32>;
+@group(1) @binding(3007)
+var<storage, read_write> type8: array<u32>;
+
+@compute @workgroup_size(8, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(4) f1: vec4<u32>,
+  @builtin(sample_mask) f2: u32,
+  @location(6) f3: vec4<i32>,
+  @location(2) f4: vec4<u32>,
+  @location(3) f5: vec2<f32>,
+  @location(5) f6: u32
+}
+
+@fragment
+fn fragment0(@location(8) a0: f16, @location(33) a1: vec3<u32>, @location(31) a2: vec4<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S14 {
+  @location(16) f0: i32,
+  @location(10) f1: vec2<f32>,
+  @location(12) f2: vec3<i32>,
+  @location(6) f3: vec2<i32>,
+  @location(3) f4: vec4<i32>,
+  @location(1) f5: vec2<i32>,
+  @location(25) f6: vec2<u32>,
+  @location(7) f7: vec4<i32>,
+  @location(13) f8: vec2<i32>,
+  @builtin(vertex_index) f9: u32,
+  @location(18) f10: i32,
+  @location(2) f11: vec2<f16>,
+  @location(8) f12: vec3<i32>,
+  @location(21) f13: u32,
+  @location(24) f14: u32,
+  @location(14) f15: vec4<i32>,
+  @location(17) f16: vec3<u32>
+}
+struct VertexOutput0 {
+  @location(31) f199: vec4<f16>,
+  @location(13) f200: f32,
+  @location(2) f201: vec4<u32>,
+  @location(21) f202: vec4<u32>,
+  @location(19) f203: u32,
+  @location(0) f204: i32,
+  @location(4) f205: vec2<f16>,
+  @location(26) f206: vec3<u32>,
+  @location(16) f207: vec3<u32>,
+  @location(8) f208: f16,
+  @location(30) f209: f16,
+  @location(33) f210: vec3<u32>,
+  @builtin(position) f211: vec4<f32>,
+  @location(36) f212: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec4<i32>, @location(15) a1: f32, @location(19) a2: vec4<i32>, a3: S14, @location(27) a4: vec2<u32>, @location(20) a5: f32, @location(23) a6: vec3<u32>, @location(4) a7: vec2<f32>, @builtin(instance_index) a8: u32, @location(5) a9: vec2<u32>, @location(26) a10: vec2<f16>, @location(22) a11: vec4<u32>, @location(11) a12: vec2<f16>, @location(0) a13: vec2<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet37 = device0.createQuerySet({label: '\u{1f609}\u007c\ubc6a\ucaee', type: 'occlusion', count: 730});
+let textureView70 = texture11.createView({label: '\u0cb4\uef03\udda5\u5249\u{1f6cf}\u0b2a\u0ebe\u0c65'});
+try {
+computePassEncoder4.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(4, bindGroup2, []);
+} catch {}
+try {
+renderPassEncoder2.draw(17);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline47);
+} catch {}
+try {
+renderBundleEncoder13.draw(0, 15);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline42);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(8, buffer13);
+} catch {}
+try {
+commandEncoder38.copyTextureToBuffer({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 13592 */
+  offset: 13592,
+  buffer: buffer18,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder28.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder50 = device0.createCommandEncoder();
+let texture30 = device0.createTexture({
+  size: [480, 32, 598],
+  mipLevelCount: 4,
+  format: 'r32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['r32float', 'r32float', 'r32float'],
+});
+let externalTexture33 = device0.importExternalTexture({label: '\uc511\u01d1\u89ba\ufa49\u65dd\u5cbe\u0cb7', source: video1, colorSpace: 'srgb'});
+try {
+computePassEncoder15.setBindGroup(5, bindGroup5);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(440);
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(3, 2, 17, 0);
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(3498);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(160);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer9, 13_871_559);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline49);
+} catch {}
+try {
+renderBundleEncoder13.draw(631);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline34);
+} catch {}
+try {
+buffer19.unmap();
+} catch {}
+let pipeline54 = await promise12;
+document.body.prepend(canvas3);
+let commandEncoder51 = device0.createCommandEncoder({label: '\u0907\ua989\u0c7c\ud2c8\u9e2c\ua96a\u0e5a\ucff5'});
+let querySet38 = device0.createQuerySet({label: '\u09a5\u059e\u{1fea9}\uf0fd\u0583\u2786\u3dcf', type: 'occlusion', count: 815});
+let textureView71 = texture21.createView({dimension: '2d-array'});
+let renderBundle31 = renderBundleEncoder16.finish({});
+let externalTexture34 = device0.importExternalTexture({
+  label: '\u02e7\u44d3\udd82\u0f98\u{1f78a}\u12ce\u04cc\u0778\u{1f755}',
+  source: videoFrame4,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder11.executeBundles([renderBundle15, renderBundle15, renderBundle8, renderBundle23, renderBundle31, renderBundle11, renderBundle27, renderBundle8, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer13, 144624, 4181);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(138, 133);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer19, 1048);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer3, 22388);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(3, buffer16, 101108, 16811);
+} catch {}
+try {
+commandEncoder35.clearBuffer(buffer18, 406624, 760);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 10784, new Float32Array(4478), 1407, 2732);
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+let pipeline55 = await device0.createRenderPipelineAsync({
+  label: '\u0f7b\u9e77\u61ef\u59e1\u93e0\u{1f85b}\udaf1\u{1f679}\u10c0',
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8sint', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule12,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4052,
+        attributes: [
+          {format: 'float16x4', offset: 1680, shaderLocation: 14},
+          {format: 'float16x4', offset: 684, shaderLocation: 6},
+          {format: 'float32x4', offset: 644, shaderLocation: 21},
+        ],
+      },
+      {arrayStride: 0, attributes: [{format: 'float16x2', offset: 60, shaderLocation: 9}]},
+      {
+        arrayStride: 1108,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 208, shaderLocation: 24},
+          {format: 'snorm16x2', offset: 116, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'back'},
+});
+try {
+  await promise15;
+} catch {}
+let bindGroupLayout24 = device0.createBindGroupLayout({
+  label: '\u6539\u0475\u3bd9\u1668\u85be\u05d2\u7be8',
+  entries: [
+    {
+      binding: 5253,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({
+  label: '\u8417\u{1f711}\u2ced\u3396\u86b9\u0526\u04aa\ufaf5\ubcb0\ucaa5\u{1f934}',
+  colorFormats: ['bgra8unorm', 'rgba8unorm-srgb', 'rg8uint', 'rgba16float', 'bgra8unorm'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder20.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(6, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(17, 127, 130_369_923);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(3, buffer0, 10236, 2819);
+} catch {}
+try {
+renderBundleEncoder13.draw(11, 131, 1_097_923_562, 142_104_439);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer19, 25784);
+} catch {}
+try {
+commandEncoder47.copyBufferToTexture({
+  /* bytesInLastRow: 12768 widthInBlocks: 1596 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 10360 */
+  offset: 10360,
+  buffer: buffer12,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 497, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1596, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let querySet39 = device0.createQuerySet({label: '\ua399\u0b26', type: 'occlusion', count: 3422});
+let texture31 = device0.createTexture({
+  size: [1317, 40, 1],
+  mipLevelCount: 5,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16uint', 'rgba16uint', 'rgba16uint'],
+});
+let sampler27 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 72.66,
+  lodMaxClamp: 85.49,
+});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(10, 2, 16, 0);
+} catch {}
+try {
+commandEncoder49.resolveQuerySet(querySet16, 2435, 137, buffer13, 31744);
+} catch {}
+let textureView72 = texture27.createView({label: '\u2683\u{1fe35}\ud540', format: 'rgba8snorm', baseMipLevel: 1, baseArrayLayer: 0});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({
+  label: '\u067f\u0a60\u056c\u79c1\uaf25\u0b09\u07b3\udcdd\uf3f2\u5a2e',
+  colorFormats: ['bgra8unorm', 'rgba8unorm-srgb', 'rg8uint', 'rgba16float', 'bgra8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder11.setViewport(25.89, 0.9399, 1.018, 0.2868, 0.2785, 0.3702);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(463, 235);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+commandEncoder13.clearBuffer(buffer10, 218080, 10648);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+  await promise11;
+} catch {}
+document.body.prepend(video7);
+try {
+offscreenCanvas8.getContext('webgl');
+} catch {}
+let shaderModule16 = device0.createShaderModule({
+  label: '\u{1f969}\u09d7\u0e6f\u0b14\u0678\u{1fdf5}\u2003\u2484\u5c65\u031d',
+  code: `@group(2) @binding(4360)
+var<storage, read_write> type9: array<u32>;
+@group(2) @binding(281)
+var<storage, read_write> local7: array<u32>;
+@group(0) @binding(4883)
+var<storage, read_write> local8: array<u32>;
+@group(0) @binding(4214)
+var<storage, read_write> function5: array<u32>;
+@group(1) @binding(3007)
+var<storage, read_write> type10: array<u32>;
+
+@compute @workgroup_size(2, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(7) f0: vec3<u32>,
+  @location(3) f1: vec3<i32>,
+  @location(1) f2: vec2<f32>,
+  @location(4) f3: vec4<f32>,
+  @location(0) f4: vec4<f32>,
+  @location(2) f5: vec4<i32>,
+  @location(6) f6: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(8) a0: vec3<f16>, @location(3) a1: f16, @location(4) a2: vec4<u32>, @builtin(vertex_index) a3: u32, @location(20) a4: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder52 = device0.createCommandEncoder({label: '\uef8e\u{1f845}\u{1fef0}\u0cd3\u046d\u{1fce6}'});
+let textureView73 = texture28.createView({label: '\u46ff\u{1f8a4}\u12d3\u1871\uc18c', dimension: '1d'});
+let computePassEncoder24 = commandEncoder36.beginComputePass({label: '\u2fe2\u0ca0\uba07\ueb44\udc3e\ub1da\u80dd'});
+let renderPassEncoder12 = commandEncoder28.beginRenderPass({
+  label: '\ud153\u364b\u0a80\u21fa\u0686\u2f45\u0623\u0728\u0c3f\u02e8',
+  colorAttachments: [{
+  view: textureView51,
+  clearValue: { r: -877.7, g: -962.0, b: 544.5, a: -120.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet7,
+  maxDrawCount: 711164088,
+});
+let renderBundle32 = renderBundleEncoder1.finish({label: '\u{1fc37}\u09aa\u{1fb1c}\u0c3f\u{1fb78}\u04ed\u{1f65e}\u{1f8b2}\uf48b'});
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer6, 237_947_184);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(0, buffer16, 113512, 17739);
+} catch {}
+try {
+querySet26.destroy();
+} catch {}
+try {
+commandEncoder45.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 74, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture19,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder13.resolveQuerySet(querySet10, 914, 440, buffer19, 12800);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder53 = device0.createCommandEncoder({label: '\u03fb\uef34\ub779\u9ead\u1df1\ua7c1'});
+let sampler28 = device0.createSampler({
+  label: '\u0b57\u{1fd78}\u{1f9f3}\u00e1\u0b0e',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 1.089,
+  lodMaxClamp: 44.82,
+});
+try {
+renderPassEncoder0.executeBundles([renderBundle27, renderBundle11, renderBundle13, renderBundle7, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: 875.1, g: 856.5, b: 179.8, a: -485.3, });
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(52);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(0, buffer13, 11324, 23429);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer3, 69180);
+} catch {}
+try {
+commandEncoder21.resolveQuerySet(querySet28, 421, 792, buffer19, 9728);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.submit([commandBuffer6]);
+} catch {}
+let pipeline56 = await promise13;
+try {
+  await promise16;
+} catch {}
+let imageBitmap5 = await createImageBitmap(imageBitmap4);
+let shaderModule17 = device0.createShaderModule({
+  label: '\uac6b\u0a92\u44db\u01a2\u0a31\ue915\u7aeb\ubbc6\u{1f67b}\u3ece',
+  code: `@group(2) @binding(3304)
+var<storage, read_write> type11: array<u32>;
+@group(2) @binding(4100)
+var<storage, read_write> field14: array<u32>;
+@group(4) @binding(4360)
+var<storage, read_write> parameter6: array<u32>;
+@group(1) @binding(2330)
+var<storage, read_write> type12: array<u32>;
+@group(4) @binding(281)
+var<storage, read_write> type13: array<u32>;
+
+@compute @workgroup_size(5, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec2<f32>,
+  @location(2) f1: vec4<u32>,
+  @builtin(sample_mask) f2: u32,
+  @location(5) f3: u32,
+  @location(6) f4: vec2<i32>,
+  @location(4) f5: vec4<u32>,
+  @location(0) f6: vec4<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S15 {
+  @location(2) f0: vec2<f16>,
+  @location(0) f1: vec2<i32>,
+  @location(23) f2: i32,
+  @location(1) f3: vec4<f32>,
+  @location(19) f4: f16,
+  @location(7) f5: vec3<f16>,
+  @location(24) f6: u32,
+  @builtin(instance_index) f7: u32,
+  @location(8) f8: vec4<u32>,
+  @location(25) f9: f32,
+  @location(18) f10: vec4<i32>,
+  @location(6) f11: vec2<f32>,
+  @location(4) f12: vec4<f16>
+}
+struct VertexOutput0 {
+  @builtin(position) f213: vec4<f32>,
+  @location(3) f214: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec4<i32>, @location(21) a1: i32, @location(13) a2: vec4<u32>, @location(26) a3: vec2<f16>, @location(9) a4: vec4<f32>, a5: S15, @location(11) a6: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+computePassEncoder21.setBindGroup(3, bindGroup5, new Uint32Array(6125), 997, 0);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 601.7, g: -674.9, b: -216.3, a: 290.4, });
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer14, 295_262_117);
+} catch {}
+try {
+commandEncoder38.resolveQuerySet(querySet13, 1544, 1296, buffer19, 23552);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 72436, new Float32Array(13359), 11617, 320);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 8, depthOrArrayLayers: 9}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 56, y: 3 },
+  flipY: true,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+video1.height = 137;
+let video9 = await videoWithData();
+let commandEncoder54 = device0.createCommandEncoder({label: '\u5182\u27f5'});
+let computePassEncoder25 = commandEncoder52.beginComputePass({label: '\u{1fe05}\u{1fc3c}'});
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(5, bindGroup6, new Uint32Array(9769), 7188, 0);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(1996);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer5, 319_313_786);
+} catch {}
+try {
+renderBundleEncoder13.draw(752);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(248, 6, 839_108_730, 43_105_122, 2_192_591_609);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(321, undefined, 479998181, 441063303);
+} catch {}
+let arrayBuffer7 = buffer10.getMappedRange(112136, 14756);
+try {
+commandEncoder51.copyBufferToBuffer(buffer2, 12176, buffer4, 233620, 812);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder49.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1600 widthInBlocks: 400 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10048 */
+  offset: 10048,
+  buffer: buffer15,
+}, {width: 400, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer15);
+} catch {}
+let texture32 = gpuCanvasContext0.getCurrentTexture();
+let textureView74 = texture5.createView({label: '\ucab2\u9f13\u03f6', dimension: '2d', baseMipLevel: 6, baseArrayLayer: 1403});
+try {
+renderPassEncoder6.beginOcclusionQuery(1440);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(256, 14, 975_143_617, 85_894_722);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer9, 240_423_984);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(7, buffer13, 119796, 11533);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(24, 57, 407_672_139, 234_727_809, 150_283_039);
+} catch {}
+try {
+commandEncoder54.clearBuffer(buffer18, 45376, 207840);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder53.resolveQuerySet(querySet38, 731, 66, buffer19, 35840);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 77560, new Float32Array(4999), 3514, 208);
+} catch {}
+let canvas4 = document.createElement('canvas');
+let offscreenCanvas9 = new OffscreenCanvas(963, 441);
+let video10 = await videoWithData();
+let videoFrame8 = new VideoFrame(offscreenCanvas2, {timestamp: 0});
+let bindGroup14 = device0.createBindGroup({
+  label: '\u323a\u{1fa14}\u090d\u{1f6de}\u08b6\u{1fca6}\u{1fdab}',
+  layout: bindGroupLayout19,
+  entries: [],
+});
+let commandEncoder55 = device0.createCommandEncoder();
+let texture33 = device0.createTexture({
+  size: {width: 240, height: 16, depthOrArrayLayers: 18},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView75 = texture10.createView({label: '\u{1f6dc}\ub032\u03ec\ub1ef\u{1fd4d}\u523c\u01d2\u00cd\u{1fb88}', dimension: '1d'});
+let computePassEncoder26 = commandEncoder47.beginComputePass({label: '\u4a6d\u0731\u0b8c\u5b56\u0441\u8a1d\u{1fd74}\u82b6'});
+try {
+renderPassEncoder1.setBindGroup(4, bindGroup1, new Uint32Array(6367), 1622, 0);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -363.4, g: -936.6, b: 627.9, a: -198.7, });
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer11, 295_316_420);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer16, 123916, 11578);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(8, buffer19, 1276);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder19.copyBufferToTexture({
+  /* bytesInLastRow: 88 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 18264 */
+  offset: 15616,
+  bytesPerRow: 256,
+  rowsPerImage: 99,
+  buffer: buffer12,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 99, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 22, height: 11, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 83_875 */
+{offset: 651, bytesPerRow: 301, rowsPerImage: 275}, {width: 37, height: 2, depthOrArrayLayers: 2});
+} catch {}
+let promise17 = device0.queue.onSubmittedWorkDone();
+let pipeline57 = await device0.createComputePipelineAsync({
+  label: '\u{1fe42}\u69e0\u{1fd49}',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule1, entryPoint: 'compute0'},
+});
+let canvas5 = document.createElement('canvas');
+try {
+canvas4.getContext('2d');
+} catch {}
+let bindGroup15 = device0.createBindGroup({
+  label: '\u0997\ub921\u8b77\u{1f665}',
+  layout: bindGroupLayout22,
+  entries: [{binding: 3579, resource: sampler23}],
+});
+let texture34 = device0.createTexture({
+  label: '\u{1f82b}\u112e\uf6e2',
+  size: [480, 32, 1],
+  sampleCount: 4,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView76 = texture6.createView({format: 'rg16float', baseMipLevel: 1});
+try {
+computePassEncoder25.setBindGroup(6, bindGroup7, new Uint32Array(7821), 5169, 0);
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: 93.18, g: -528.9, b: -83.16, a: -471.2, });
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(18, 1, 2, 1);
+} catch {}
+try {
+renderPassEncoder10.setViewport(26.15, 0.5389, 1.222, 1.184, 0.5381, 0.7646);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer16, 'uint16', 120256, 9325);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder13.draw(163);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(60, 72, 2_041_757_247, 202_472_227, 924_223_600);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer3, 152836);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline7);
+} catch {}
+let arrayBuffer8 = buffer8.getMappedRange(80672, 2848);
+try {
+commandEncoder53.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 16160 */
+  offset: 16156,
+  buffer: buffer18,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer15, 1720, new Float32Array(56655), 10225, 876);
+} catch {}
+let pipeline58 = device0.createRenderPipeline({
+  label: '\u{1fabe}\u2aa2\u4ddf\u0c20\uc587\u{1f696}\u084e\u0a53\u0df2\u82e0\u{1f6b4}',
+  layout: pipelineLayout0,
+  multisample: {},
+  fragment: {
+  module: shaderModule17,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, undefined, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'r32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r8uint', writeMask: 0}, {format: 'r16sint'}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'less', failOp: 'zero', depthFailOp: 'decrement-wrap', passOp: 'zero'},
+    stencilBack: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'increment-clamp'},
+    stencilReadMask: 3402719406,
+    stencilWriteMask: 1398818574,
+    depthBias: 646535700,
+    depthBiasClamp: 885.8865657703388,
+  },
+  vertex: {
+    module: shaderModule17,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 2112, shaderLocation: 6},
+          {format: 'uint8x2', offset: 118, shaderLocation: 13},
+          {format: 'sint16x2', offset: 3644, shaderLocation: 18},
+          {format: 'snorm8x4', offset: 436, shaderLocation: 2},
+          {format: 'unorm16x4', offset: 5596, shaderLocation: 25},
+          {format: 'unorm10-10-10-2', offset: 1508, shaderLocation: 11},
+          {format: 'sint16x2', offset: 448, shaderLocation: 0},
+          {format: 'unorm8x2', offset: 1394, shaderLocation: 26},
+          {format: 'uint8x2', offset: 422, shaderLocation: 8},
+          {format: 'unorm16x4', offset: 3732, shaderLocation: 4},
+          {format: 'sint32', offset: 968, shaderLocation: 21},
+          {format: 'snorm16x4', offset: 880, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 696,
+        attributes: [
+          {format: 'unorm8x2', offset: 138, shaderLocation: 1},
+          {format: 'sint16x4', offset: 60, shaderLocation: 23},
+          {format: 'sint8x2', offset: 12, shaderLocation: 14},
+          {format: 'snorm8x2', offset: 400, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 1200,
+        attributes: [
+          {format: 'float32x3', offset: 200, shaderLocation: 19},
+          {format: 'uint16x4', offset: 88, shaderLocation: 24},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'none'},
+});
+let promise18 = adapter0.requestAdapterInfo();
+let commandEncoder56 = device0.createCommandEncoder({label: '\u0f16\u513d\u{1fb4e}\u0d38\u{1fb3b}\ud7f3\u0656\u2419\u0335\u{1ff25}\u{1fb32}'});
+let textureView77 = texture4.createView({
+  label: '\u053f\u00bf\u9462\u{1f8ba}\u{1fc20}\ubac5\u8e22\u26dd\u0cdc\u{1fe98}',
+  baseMipLevel: 0,
+  baseArrayLayer: 22,
+  arrayLayerCount: 31,
+});
+let computePassEncoder27 = commandEncoder35.beginComputePass({label: '\ucae5\ua992\u{1f9c1}\uefb3\u0e81\u7cf7\uacbf'});
+let renderBundle33 = renderBundleEncoder16.finish({label: '\ua02a\u2091\uc7b2\u619b\u928e\ua749\u5717'});
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer14, 44);
+} catch {}
+try {
+renderBundleEncoder25.setIndexBuffer(buffer19, 'uint32', 21764, 16292);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline47);
+} catch {}
+let promise19 = device0.popErrorScope();
+try {
+commandEncoder38.clearBuffer(buffer4, 126528, 47156);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let textureView78 = texture34.createView({label: '\u1a8f\u0106\u0887\u09cd\u{1f7c5}'});
+let sampler29 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 68.73,
+  lodMaxClamp: 91.94,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder9.setBindGroup(4, bindGroup15);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: 789.3, g: 981.1, b: -25.95, a: -217.0, });
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(6, 1, 8, 1);
+} catch {}
+try {
+renderPassEncoder2.draw(129, 321, 2_458_770_405, 1_645_226_311);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(211);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline34);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(4, bindGroup9, new Uint32Array(193), 4, 0);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(449, 54, 1_954_812_904);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer19, 19952);
+} catch {}
+let promise20 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext4 = offscreenCanvas9.getContext('webgpu');
+let imageData10 = new ImageData(136, 60);
+let bindGroupLayout25 = device0.createBindGroupLayout({label: '\u089d\u{1fea8}\ue86d\u43da\ud70e\u055d\u0cde\u08f4\u0b6b', entries: []});
+let commandBuffer14 = commandEncoder13.finish();
+let computePassEncoder28 = commandEncoder40.beginComputePass({label: '\uc678\u3968\u0f8a'});
+try {
+renderPassEncoder12.beginOcclusionQuery(421);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -114.6, g: 578.9, b: 27.83, a: -23.99, });
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(28, 0, 2, 1);
+} catch {}
+try {
+renderPassEncoder2.draw(50, 1);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer9, 1_081_161_146);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline34);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(3, bindGroup10, []);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer14, 2756);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer19, 8996);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder21.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 52, y: 0, z: 46},
+  aspect: 'all',
+},
+{
+  texture: texture19,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 11, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise21 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext5 = canvas5.getContext('webgpu');
+let commandBuffer15 = commandEncoder50.finish({label: '\ub580\ua694\u7240\ub192\u{1f743}\udc20\uc2c1\u{1fa15}\u932e\uefee'});
+let sampler30 = device0.createSampler({
+  label: '\uf576\u3307\u0476\u4807\ufb3f\u0ec4\u395c\u4409\u6f42\u7748\u53ff',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 58.83,
+  lodMaxClamp: 99.49,
+  maxAnisotropy: 3,
+});
+let externalTexture35 = device0.importExternalTexture({source: videoFrame6, colorSpace: 'display-p3'});
+try {
+renderPassEncoder9.beginOcclusionQuery(3374);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(4, 1, 15, 1);
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(7);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(341, 41, 1_116_548_848);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer6, 1_108_824_595);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer18, 355_449_930);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(68);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer19, 9716);
+} catch {}
+try {
+commandEncoder49.copyBufferToBuffer(buffer5, 60424, buffer18, 245016, 6568);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer15, 1996, new Float32Array(62695), 6324, 2244);
+} catch {}
+document.body.prepend(canvas1);
+let offscreenCanvas10 = new OffscreenCanvas(230, 966);
+let bindGroup16 = device0.createBindGroup({layout: bindGroupLayout16, entries: []});
+let commandEncoder57 = device0.createCommandEncoder({label: '\u204d\ucef2\u2fb9\ud7d4\ueb02\u04f7\u7a95'});
+let sampler31 = device0.createSampler({
+  label: '\u{1fbe1}\ua435\u{1ffcd}\u{1fb63}\u0f6a\u02e2\u83fb\u85af\u5276\u411e',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 63.38,
+  lodMaxClamp: 73.33,
+  compare: 'not-equal',
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder10.setScissorRect(2, 0, 19, 2);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer1, 358_973_719);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer18, 201_155_748);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer16, 'uint16', 23512, 57394);
+} catch {}
+try {
+renderBundleEncoder13.draw(368, 635, 2_687_229_792, 208_180_300);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(277, 84);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer14, 1484);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer19, 16364);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline34);
+} catch {}
+try {
+commandEncoder45.copyBufferToBuffer(buffer12, 100288, buffer6, 58892, 2164);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder57.copyBufferToTexture({
+  /* bytesInLastRow: 528 widthInBlocks: 66 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 160384 */
+  offset: 16496,
+  bytesPerRow: 1024,
+  rowsPerImage: 69,
+  buffer: buffer9,
+}, {
+  texture: texture9,
+  mipLevel: 3,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 66, height: 3, depthOrArrayLayers: 3});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder55.resolveQuerySet(querySet36, 217, 1130, buffer13, 81664);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer15, 9336, new Int16Array(6723), 2216, 480);
+} catch {}
+try {
+  await promise19;
+} catch {}
+let querySet40 = device0.createQuerySet({label: '\u{1ff1d}\u9dfd\u5e6e', type: 'occlusion', count: 1333});
+let textureView79 = texture10.createView({
+  label: '\u51dd\u0cc5\ub047\u{1fde9}\u{1fd24}\u5ff6\u3d88\ua19a\u{1fd67}\ue9e9\u969e',
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+let renderBundle34 = renderBundleEncoder15.finish({label: '\u5b22\ua6ec\u04f6\u{1faf7}\u{1f92d}\u23c3\u{1f983}\u04d3\ua23a\u{1f686}\u0563'});
+try {
+renderPassEncoder2.drawIndirect(buffer6, 1_396_660_013);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(320, 27, 778_471_491);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer19, 2612);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer14, 1396);
+} catch {}
+try {
+commandEncoder54.copyBufferToBuffer(buffer5, 58200, buffer6, 39316, 8528);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder55.clearBuffer(buffer6);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder21.resolveQuerySet(querySet35, 32, 10, buffer13, 4096);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 19652, new DataView(new ArrayBuffer(10359)), 7611, 20);
+} catch {}
+let promise22 = device0.createComputePipelineAsync({
+  label: '\u4ca2\u{1f67a}\u0e94\u418a\u0a31\uf178\u92df\ub23e',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+let pipeline59 = device0.createRenderPipeline({
+  label: '\u0850\u4128\u07d6\u08fe\uab94\u9a8c',
+  layout: pipelineLayout0,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'dst-alpha', dstFactor: 'src'},
+  },
+  writeMask: 0,
+}, {format: 'r16sint', writeMask: GPUColorWrite.ALL}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba32float'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'not-equal', failOp: 'invert', depthFailOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'greater', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilReadMask: 3011934949,
+    stencilWriteMask: 423491908,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1688,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 276, shaderLocation: 12},
+          {format: 'uint16x4', offset: 204, shaderLocation: 20},
+          {format: 'uint8x2', offset: 482, shaderLocation: 24},
+          {format: 'snorm8x2', offset: 46, shaderLocation: 4},
+          {format: 'uint8x2', offset: 190, shaderLocation: 1},
+          {format: 'sint8x2', offset: 246, shaderLocation: 9},
+          {format: 'uint32', offset: 176, shaderLocation: 22},
+          {format: 'uint32x2', offset: 372, shaderLocation: 21},
+          {format: 'float32x4', offset: 156, shaderLocation: 25},
+          {format: 'float16x2', offset: 24, shaderLocation: 16},
+          {format: 'unorm16x4', offset: 372, shaderLocation: 0},
+          {format: 'sint32', offset: 12, shaderLocation: 10},
+          {format: 'unorm16x2', offset: 212, shaderLocation: 5},
+          {format: 'sint32x2', offset: 216, shaderLocation: 8},
+          {format: 'float16x2', offset: 292, shaderLocation: 17},
+          {format: 'uint32x2', offset: 224, shaderLocation: 23},
+          {format: 'uint32x2', offset: 256, shaderLocation: 3},
+          {format: 'unorm10-10-10-2', offset: 108, shaderLocation: 2},
+          {format: 'sint8x4', offset: 288, shaderLocation: 15},
+          {format: 'snorm8x4', offset: 128, shaderLocation: 14},
+        ],
+      },
+      {arrayStride: 2672, attributes: []},
+      {arrayStride: 1160, attributes: []},
+      {
+        arrayStride: 2524,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 48, shaderLocation: 18},
+          {format: 'unorm8x2', offset: 28, shaderLocation: 26},
+          {format: 'float16x2', offset: 296, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 844, attributes: [{format: 'float16x4', offset: 44, shaderLocation: 7}]},
+      {arrayStride: 788, stepMode: 'instance', attributes: []},
+      {arrayStride: 36, attributes: [{format: 'snorm16x4', offset: 4, shaderLocation: 11}]},
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front'},
+});
+let gpuCanvasContext6 = offscreenCanvas10.getContext('webgpu');
+gc();
+let video11 = await videoWithData();
+let imageData11 = new ImageData(104, 64);
+let buffer20 = device0.createBuffer({size: 135133, usage: GPUBufferUsage.UNIFORM});
+let commandBuffer16 = commandEncoder45.finish();
+let textureView80 = texture29.createView({label: '\u077f\u9f6d\u{1fe3e}\u4101\u988d\u{1fa38}\u03a3', aspect: 'all'});
+let sampler32 = device0.createSampler({
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 27.82,
+  lodMaxClamp: 29.84,
+  compare: 'greater-equal',
+});
+try {
+renderPassEncoder10.beginOcclusionQuery(329);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: 872.9, g: -903.3, b: 96.81, a: 306.6, });
+} catch {}
+try {
+renderPassEncoder8.setStencilReference(2687);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer4, 267_114_698);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer15, 1_336_139_675);
+} catch {}
+try {
+renderBundleEncoder13.draw(59);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(133, 4);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer14, 1828);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer1, 'uint32');
+} catch {}
+try {
+commandEncoder38.copyBufferToBuffer(buffer11, 1596, buffer4, 57764, 484);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder57.resolveQuerySet(querySet32, 10, 201, buffer19, 4608);
+} catch {}
+try {
+device0.queue.submit([commandBuffer7, commandBuffer15, commandBuffer10]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule18 = device0.createShaderModule({
+  label: '\u0288\u{1fed1}\u00b8\u{1ffc2}',
+  code: `@group(4) @binding(4360)
+var<storage, read_write> n2: array<u32>;
+@group(0) @binding(4100)
+var<storage, read_write> local9: array<u32>;
+@group(1) @binding(6934)
+var<storage, read_write> type14: array<u32>;
+@group(0) @binding(3304)
+var<storage, read_write> global8: array<u32>;
+@group(2) @binding(4100)
+var<storage, read_write> local10: array<u32>;
+@group(4) @binding(281)
+var<storage, read_write> function6: array<u32>;
+@group(2) @binding(3304)
+var<storage, read_write> function7: array<u32>;
+
+@compute @workgroup_size(2, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(3) f1: vec4<f32>,
+  @location(2) f2: vec4<u32>,
+  @location(1) f3: vec4<f32>,
+  @location(4) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S16 {
+  @location(11) f0: vec4<f32>,
+  @location(14) f1: vec2<f16>,
+  @location(10) f2: vec2<f32>,
+  @location(7) f3: vec4<i32>,
+  @builtin(vertex_index) f4: u32,
+  @location(13) f5: vec2<f16>,
+  @location(9) f6: u32,
+  @location(1) f7: u32,
+  @location(15) f8: vec3<f16>,
+  @location(25) f9: vec4<u32>,
+  @location(18) f10: vec3<u32>,
+  @location(22) f11: vec4<f16>,
+  @location(3) f12: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec3<u32>, a1: S16, @location(8) a2: u32, @location(24) a3: vec3<i32>, @location(0) a4: vec4<f32>, @builtin(instance_index) a5: u32, @location(17) a6: vec4<i32>, @location(27) a7: vec4<i32>, @location(5) a8: vec4<i32>, @location(20) a9: vec2<u32>, @location(12) a10: i32, @location(21) a11: vec3<f32>, @location(19) a12: vec2<i32>, @location(16) a13: vec4<f16>, @location(23) a14: vec4<i32>, @location(26) a15: vec2<f32>, @location(6) a16: vec2<i32>, @location(4) a17: vec3<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet41 = device0.createQuerySet({label: '\u{1ffab}\u814b\u72af\u8f94\u52cc', type: 'occlusion', count: 3547});
+let texture35 = device0.createTexture({
+  size: [658, 20, 680],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8sint', 'rgba8sint', 'rgba8sint'],
+});
+let textureView81 = texture6.createView({label: '\u0c16\u0245\u0e22\u{1f961}\u031f\u1bb2\ub3a8\ufb59', aspect: 'all', baseMipLevel: 1});
+let computePassEncoder29 = commandEncoder55.beginComputePass({label: '\u4bee\u1ccf\u0e7f\ue21f\u69d0\u8d5a\u1faa\u4056\u{1fd52}\u0e92'});
+let externalTexture36 = device0.importExternalTexture({source: video4, colorSpace: 'display-p3'});
+try {
+computePassEncoder27.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(4, bindGroup15, new Uint32Array(3746), 696, 0);
+} catch {}
+try {
+renderPassEncoder8.beginOcclusionQuery(2528);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer11, 622_617_723);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer20, 1_471_820_546);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(3, bindGroup10, new Uint32Array(7703), 2659, 0);
+} catch {}
+try {
+renderBundleEncoder13.draw(13, 106, 1_407_935_269, 931_585_912);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(203, 65, 161_993_480);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer3, 5940);
+} catch {}
+try {
+commandEncoder51.copyBufferToBuffer(buffer2, 6164, buffer18, 238268, 1524);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder21.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 41, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline60 = await device0.createRenderPipelineAsync({
+  label: '\ud22c\u314f\u03e9\uac7f\u9b87\u5efb',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba16uint', writeMask: 0}, undefined, {format: 'rgb10a2uint', writeMask: 0}, {format: 'r32float'}, {format: 'rgba16uint'}, {format: 'r8uint', writeMask: 0}, {format: 'r16sint', writeMask: GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 512,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x3', offset: 56, shaderLocation: 12},
+          {format: 'sint32', offset: 244, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 2104,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 912, shaderLocation: 26},
+          {format: 'sint16x4', offset: 340, shaderLocation: 14},
+          {format: 'snorm16x2', offset: 184, shaderLocation: 21},
+          {format: 'sint32x3', offset: 92, shaderLocation: 27},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front'},
+});
+let video12 = await videoWithData();
+let pipelineLayout9 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout4]});
+let computePassEncoder30 = commandEncoder38.beginComputePass({label: '\u0899\u384a\u8dde\u0d43\ua81f\u6757'});
+try {
+renderPassEncoder0.beginOcclusionQuery(879);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle15, renderBundle27, renderBundle8, renderBundle8, renderBundle15, renderBundle31, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline34);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(6, bindGroup8, new Uint32Array(8297), 5094, 0);
+} catch {}
+try {
+renderBundleEncoder13.draw(180, 185, 701_913_806, 79_803_116);
+} catch {}
+try {
+commandEncoder54.copyTextureToBuffer({
+  texture: texture33,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 116 widthInBlocks: 29 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10712 */
+  offset: 10596,
+  buffer: buffer15,
+}, {width: 29, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder57.clearBuffer(buffer15, 20520, 9364);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+computePassEncoder19.pushDebugGroup('\u17e8');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 112884, new BigUint64Array(17175), 14384, 1140);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img4,
+  origin: { x: 33, y: 5 },
+  flipY: false,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline61 = await device0.createRenderPipelineAsync({
+  label: '\u{1f7e0}\u{1fbff}\u5ab5\u00d2\u5dd5\u43cf\ub1f4',
+  layout: pipelineLayout2,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba16uint'}, undefined, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r8uint', writeMask: 0}, {format: 'r16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'greater-equal', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'greater', failOp: 'decrement-clamp', passOp: 'increment-clamp'},
+    stencilReadMask: 1139519140,
+    stencilWriteMask: 3347354739,
+    depthBiasSlopeScale: 0.0,
+    depthBiasClamp: 235.73315031267452,
+  },
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4636,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 276, shaderLocation: 26},
+          {format: 'sint32x4', offset: 3024, shaderLocation: 9},
+          {format: 'sint16x2', offset: 400, shaderLocation: 27},
+        ],
+      },
+      {arrayStride: 772, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 420,
+        attributes: [
+          {format: 'sint16x2', offset: 8, shaderLocation: 12},
+          {format: 'sint16x4', offset: 40, shaderLocation: 14},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 240, attributes: []},
+      {
+        arrayStride: 248,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x2', offset: 52, shaderLocation: 21}],
+      },
+    ],
+  },
+});
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle13, renderBundle13, renderBundle30, renderBundle31]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer0, 850_159_883);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer2, 1_267_064_700);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(6, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(39, 18, 218_856_604, 217_280_559, 1_252_824_254);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer19, 2428);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline56);
+} catch {}
+let arrayBuffer9 = buffer5.getMappedRange(32344, 2092);
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline62 = device0.createComputePipeline({
+  label: '\u6da0\u{1fde5}\u70ce\u3888\u0993\u67da\u0add\uba98',
+  layout: pipelineLayout9,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(canvas1);
+gc();
+let videoFrame9 = new VideoFrame(offscreenCanvas7, {timestamp: 0});
+let renderBundle35 = renderBundleEncoder8.finish({});
+try {
+computePassEncoder9.setPipeline(pipeline38);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(13, 2, 4, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(29, 381, 882_012_183, 402_421_466);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline16);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(19, 74, 411_525_028, 370_562_758, 73_381_186);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer14, 2528);
+} catch {}
+try {
+commandEncoder49.copyBufferToTexture({
+  /* bytesInLastRow: 272 widthInBlocks: 34 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 4456 */
+  offset: 4184,
+  rowsPerImage: 138,
+  buffer: buffer12,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 857, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 34, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer12);
+} catch {}
+let img9 = await imageWithData(212, 126, '#b7f7dd3b', '#93b10aef');
+let commandEncoder58 = device0.createCommandEncoder({label: '\ucbea\u{1f6d3}\ude42\u0c87'});
+let computePassEncoder31 = commandEncoder21.beginComputePass();
+try {
+renderPassEncoder2.setBindGroup(4, bindGroup5);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(6, bindGroup3, new Uint32Array(5824), 2901, 0);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(0, 0, 13, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer0, 803_428_821);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer5, 189_119_030);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer16, 'uint16', 74000, 52309);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline34);
+} catch {}
+try {
+renderBundleEncoder13.draw(60, 127);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(1, buffer16, 0, 88682);
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(buffer12, 37124, buffer18, 200412, 59000);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer18);
+} catch {}
+let imageData12 = new ImageData(80, 220);
+try {
+computePassEncoder22.setPipeline(pipeline40);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -858.1, g: -790.4, b: 963.0, a: -602.3, });
+} catch {}
+try {
+renderPassEncoder2.draw(64, 110);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer16, 'uint32', 43556, 28074);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer16, 0, 36188);
+} catch {}
+try {
+renderBundleEncoder13.draw(9, 839);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer14, 1888);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(0, buffer16, 120668, 4707);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+try {
+commandEncoder49.clearBuffer(buffer7);
+dissociateBuffer(device0, buffer7);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 54900, new DataView(new ArrayBuffer(44586)), 18769, 2432);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(8)), /* required buffer size: 982 */
+{offset: 86, rowsPerImage: 93}, {width: 56, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer21 = device0.createBuffer({
+  label: '\u54a4\u{1fb0f}\u0e68\u962b',
+  size: 9088,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder59 = device0.createCommandEncoder({label: '\u7c8d\uee44\u455d\udf0a\u3f4f'});
+let texture36 = device0.createTexture({
+  label: '\u081e\u0d1e\u88cb\u8744\u0eb9\u9646',
+  size: {width: 329, height: 10, depthOrArrayLayers: 240},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+});
+try {
+renderPassEncoder9.setBindGroup(5, bindGroup12);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle23, renderBundle7, renderBundle13, renderBundle27, renderBundle30, renderBundle13, renderBundle33]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer9, 1_368_555_144);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(409, 46);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline29);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder60 = device0.createCommandEncoder();
+let commandBuffer17 = commandEncoder57.finish({});
+let texture37 = device0.createTexture({
+  label: '\u{1fc3a}\ue708\u{1fe98}\ud682\u{1fdc0}\uf62e\u0614\u0c78\u75f9',
+  size: {width: 1317, height: 40, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['depth24plus-stencil8'],
+});
+let textureView82 = texture33.createView({label: '\u63d4\u{1ff95}\u1085', baseMipLevel: 4});
+try {
+renderPassEncoder2.setBlendConstant({ r: -271.5, g: 103.6, b: 84.38, a: -726.0, });
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer21, 335_267_089);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer0, 9_728_019);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(5, buffer16, 127960);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(385);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(2, buffer19, 0);
+} catch {}
+try {
+computePassEncoder19.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer8), /* required buffer size: 485 */
+{offset: 485, bytesPerRow: 108}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise23 = device0.createRenderPipelineAsync({
+  label: '\u0cde\uf343\u9e80\u050e\ua8b1\u{1f661}\u03ef\u80f5\u{1f738}\u0f5b\u2368',
+  layout: pipelineLayout8,
+  multisample: {count: 4, mask: 0xccf671ae},
+  fragment: {
+  module: shaderModule17,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16uint'}, undefined, {format: 'rgb10a2uint'}, {format: 'r32float', writeMask: GPUColorWrite.BLUE}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r8uint', writeMask: 0}, {format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule17,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 292,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32', offset: 84, shaderLocation: 1},
+          {format: 'uint8x4', offset: 4, shaderLocation: 8},
+          {format: 'float32', offset: 28, shaderLocation: 26},
+          {format: 'float16x4', offset: 40, shaderLocation: 2},
+          {format: 'snorm8x4', offset: 72, shaderLocation: 19},
+          {format: 'sint32', offset: 8, shaderLocation: 23},
+          {format: 'sint16x4', offset: 40, shaderLocation: 18},
+          {format: 'unorm10-10-10-2', offset: 56, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 2684,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 48, shaderLocation: 25},
+          {format: 'unorm8x4', offset: 2680, shaderLocation: 9},
+          {format: 'uint32x3', offset: 320, shaderLocation: 24},
+          {format: 'sint32x2', offset: 440, shaderLocation: 21},
+          {format: 'sint16x2', offset: 296, shaderLocation: 0},
+          {format: 'float32x2', offset: 36, shaderLocation: 4},
+          {format: 'float32x3', offset: 0, shaderLocation: 7},
+          {format: 'uint32', offset: 348, shaderLocation: 13},
+          {format: 'float16x4', offset: 484, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 240,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x4', offset: 36, shaderLocation: 14}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', cullMode: 'back'},
+});
+document.body.prepend(img0);
+let texture38 = device0.createTexture({
+  size: [658, 20, 1160],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder32 = commandEncoder60.beginComputePass({label: '\u0923\ufa41'});
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({label: '\u3824\u75c0\u2084\uc491\u0c9c\u0dbc', colorFormats: ['rg16uint'], stencilReadOnly: false});
+let renderBundle36 = renderBundleEncoder10.finish({});
+try {
+renderPassEncoder1.beginOcclusionQuery(18);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer15, 884_875_115);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(1, buffer0);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer3, 9852);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer14, 644);
+} catch {}
+try {
+renderBundleEncoder17.setVertexBuffer(4, buffer11, 748, 37);
+} catch {}
+try {
+commandEncoder59.copyBufferToBuffer(buffer11, 84, buffer18, 149716, 1300);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder59.resolveQuerySet(querySet23, 342, 120, buffer13, 25344);
+} catch {}
+let pipelineLayout10 = device0.createPipelineLayout({
+  label: '\u18e8\u0445\u0c3e\u933d\u125a\ua53d\ufc78\u34d5',
+  bindGroupLayouts: [bindGroupLayout15, bindGroupLayout3, bindGroupLayout2, bindGroupLayout21],
+});
+let commandEncoder61 = device0.createCommandEncoder({label: '\u317a\u{1fabf}\uf9f5\u{1f826}\uc3da\u3d68'});
+try {
+renderPassEncoder8.setStencilReference(2753);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer19, 475_355_979);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer19, 'uint16', 48534);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(47);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer19, 1168);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(6, buffer16, 24328, 68310);
+} catch {}
+let promise24 = buffer15.mapAsync(GPUMapMode.READ, 0, 26104);
+try {
+commandEncoder59.copyTextureToBuffer({
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 54, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 320 widthInBlocks: 40 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 30520 */
+  offset: 28152,
+  bytesPerRow: 512,
+  buffer: buffer4,
+}, {width: 40, height: 5, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder49.clearBuffer(buffer10, 176868, 61252);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder51.resolveQuerySet(querySet34, 1139, 608, buffer19, 18176);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'stencil-only',
+}, new Uint32Array(new ArrayBuffer(16)), /* required buffer size: 176 */
+{offset: 176, bytesPerRow: 1461}, {width: 1317, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline63 = await promise23;
+try {
+  await promise18;
+} catch {}
+let commandBuffer18 = commandEncoder19.finish();
+let textureView83 = texture31.createView({
+  label: '\ue24e\u{1fbf8}\u0097\u79a1\u65f0\u06ed\u58d2\u7a06\ud2c4\u{1fcd8}\u{1f865}',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let computePassEncoder33 = commandEncoder54.beginComputePass({});
+let renderBundle37 = renderBundleEncoder16.finish({label: '\u0f7a\u44e1'});
+let externalTexture37 = device0.importExternalTexture({
+  label: '\u{1f65d}\u0fca\ub8bd\u{1f8ea}\u1ce5\u1359\u0aab\u8f19\u81b3\u0b96\u7215',
+  source: video5,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder31.setBindGroup(2, bindGroup13, new Uint32Array(506), 13, 0);
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant({ r: 395.1, g: 636.5, b: -767.3, a: -739.0, });
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer1, 'uint32', 10912);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(224, 5, 6_430_691, 233_675_192, 641_481_721);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer3, 70456);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer14, 1000);
+} catch {}
+try {
+renderBundleEncoder19.setPipeline(pipeline7);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(5, buffer11, 532);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder51.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 20568 */
+  offset: 20568,
+  rowsPerImage: 264,
+  buffer: buffer9,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+device0.queue.submit([commandBuffer14, commandBuffer13]);
+} catch {}
+let pipeline64 = device0.createRenderPipeline({
+  label: '\u4183\u95fc\u04dc\u49c6\u7a26\u7912\u1533',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'greater', failOp: 'increment-clamp', depthFailOp: 'keep', passOp: 'zero'},
+    stencilBack: {compare: 'greater', failOp: 'zero', passOp: 'increment-wrap'},
+    stencilReadMask: 1282800429,
+    stencilWriteMask: 1201184953,
+    depthBiasSlopeScale: 721.1694894984054,
+    depthBiasClamp: 211.8554305887717,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 764,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 12, shaderLocation: 4},
+          {format: 'float32x4', offset: 8, shaderLocation: 16},
+          {format: 'sint32x2', offset: 20, shaderLocation: 11},
+          {format: 'unorm16x2', offset: 68, shaderLocation: 22},
+          {format: 'uint16x2', offset: 32, shaderLocation: 27},
+          {format: 'unorm16x2', offset: 136, shaderLocation: 13},
+          {format: 'unorm16x4', offset: 276, shaderLocation: 15},
+          {format: 'uint16x2', offset: 16, shaderLocation: 24},
+          {format: 'uint32', offset: 0, shaderLocation: 17},
+          {format: 'sint32', offset: 16, shaderLocation: 2},
+          {format: 'sint32x2', offset: 32, shaderLocation: 23},
+          {format: 'sint32', offset: 204, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 1468,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 24, shaderLocation: 7},
+          {format: 'snorm8x4', offset: 436, shaderLocation: 10},
+          {format: 'float32x2', offset: 84, shaderLocation: 0},
+          {format: 'uint8x2', offset: 296, shaderLocation: 21},
+          {format: 'snorm8x2', offset: 142, shaderLocation: 5},
+          {format: 'snorm16x4', offset: 148, shaderLocation: 18},
+          {format: 'sint16x4', offset: 372, shaderLocation: 26},
+          {format: 'sint32x4', offset: 232, shaderLocation: 20},
+          {format: 'float16x4', offset: 164, shaderLocation: 19},
+        ],
+      },
+      {arrayStride: 556, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 728,
+        attributes: [
+          {format: 'uint32x2', offset: 144, shaderLocation: 6},
+          {format: 'float32x3', offset: 124, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 4144,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x4', offset: 992, shaderLocation: 25}],
+      },
+      {arrayStride: 332, attributes: [{format: 'float16x4', offset: 156, shaderLocation: 12}]},
+      {arrayStride: 96, attributes: []},
+      {
+        arrayStride: 404,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 12, shaderLocation: 8},
+          {format: 'float32x4', offset: 104, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32'},
+});
+let pipelineLayout11 = device0.createPipelineLayout({
+  label: '\u0b47\u4c42\u08e6\u05dd\u4a9b\u0355\ucbd9\u76e6',
+  bindGroupLayouts: [bindGroupLayout5, bindGroupLayout24],
+});
+let commandEncoder62 = device0.createCommandEncoder({label: '\ude3f\u606d\u08ca\u0b19\u09b6\ua5ee\u{1fdf3}\u003e\u11f6\u0db1\u0462'});
+let querySet42 = device0.createQuerySet({label: '\u{1ff5d}\u0e65', type: 'occlusion', count: 1831});
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({
+  label: '\u{1f853}\u75dc\u9d46\u48c3\u0b22\u0434\u07d8\u5597\u9cc9\u3496',
+  colorFormats: ['rgba8unorm-srgb', 'r8unorm', 'r16sint', 'r8sint', 'rgba32float'],
+});
+try {
+renderPassEncoder2.setScissorRect(13, 0, 7, 1);
+} catch {}
+try {
+renderPassEncoder2.draw(25);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer1, 'uint16');
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder13.draw(27, 354);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer19, 'uint16', 13426, 16796);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(0, buffer13, 0, 6582);
+} catch {}
+let arrayBuffer10 = buffer5.getMappedRange(34440, 6388);
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 44, y: 0, z: 22},
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder59.resolveQuerySet(querySet30, 2090, 1705, buffer13, 60160);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 35452, new Float32Array(41089), 956, 5512);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 353 */
+{offset: 353}, {width: 14, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let querySet43 = device0.createQuerySet({
+  label: '\u02f9\u57c6\u0404\u042c\u0172\ud2b3\u{1f99c}\u0b1c\u6b28\u{1fc77}\u5ae6',
+  type: 'occlusion',
+  count: 1249,
+});
+try {
+renderPassEncoder1.executeBundles([renderBundle33, renderBundle27, renderBundle33, renderBundle30, renderBundle33]);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant({ r: 545.0, g: 946.5, b: 49.29, a: -770.5, });
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(3037);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer17, 465_607_759);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer19, 17676);
+} catch {}
+try {
+renderBundleEncoder21.setIndexBuffer(buffer19, 'uint32');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 37916, new Int16Array(41457), 4343, 3268);
+} catch {}
+let pipeline65 = await device0.createRenderPipelineAsync({
+  label: '\u{1fe6d}\u2e53\u0978\u0845',
+  layout: 'auto',
+  multisample: {mask: 0x42c39a13},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'less-equal', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'equal', failOp: 'decrement-clamp', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilReadMask: 219498683,
+    stencilWriteMask: 2998619578,
+    depthBias: -792263188,
+    depthBiasSlopeScale: 64.98100192516142,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1020,
+        attributes: [
+          {format: 'sint16x4', offset: 128, shaderLocation: 2},
+          {format: 'unorm10-10-10-2', offset: 236, shaderLocation: 7},
+          {format: 'uint16x4', offset: 308, shaderLocation: 6},
+          {format: 'sint32x4', offset: 100, shaderLocation: 4},
+          {format: 'sint16x4', offset: 48, shaderLocation: 3},
+          {format: 'snorm8x4', offset: 368, shaderLocation: 16},
+          {format: 'float16x4', offset: 380, shaderLocation: 18},
+          {format: 'unorm8x2', offset: 132, shaderLocation: 12},
+          {format: 'unorm8x2', offset: 172, shaderLocation: 8},
+          {format: 'sint32x4', offset: 32, shaderLocation: 20},
+          {format: 'uint32x3', offset: 244, shaderLocation: 27},
+          {format: 'float32x4', offset: 144, shaderLocation: 13},
+          {format: 'uint32x4', offset: 224, shaderLocation: 17},
+          {format: 'sint32', offset: 140, shaderLocation: 23},
+          {format: 'float32x3', offset: 36, shaderLocation: 19},
+          {format: 'unorm8x2', offset: 160, shaderLocation: 5},
+          {format: 'sint8x2', offset: 182, shaderLocation: 11},
+          {format: 'float32x2', offset: 424, shaderLocation: 0},
+          {format: 'float16x4', offset: 396, shaderLocation: 25},
+          {format: 'sint8x4', offset: 132, shaderLocation: 26},
+          {format: 'unorm8x2', offset: 216, shaderLocation: 22},
+          {format: 'float32', offset: 88, shaderLocation: 10},
+          {format: 'float32x4', offset: 144, shaderLocation: 15},
+          {format: 'uint16x4', offset: 72, shaderLocation: 24},
+          {format: 'snorm16x4', offset: 264, shaderLocation: 14},
+          {format: 'uint8x4', offset: 232, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x4', offset: 24, shaderLocation: 1}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front'},
+});
+try {
+computePassEncoder10.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(26, 1, 3, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(82, 113, 1_138_158_502, 785_888_838);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline52);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(6, bindGroup2, new Uint32Array(3049), 218, 0);
+} catch {}
+try {
+renderBundleEncoder13.draw(154, 558, 648_934_887, 649_949_367);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer19, 8912);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer1, 'uint32', 114524, 395469);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(2, buffer16, 0, 94078);
+} catch {}
+let arrayBuffer11 = buffer6.getMappedRange(62776, 16176);
+try {
+commandEncoder51.resolveQuerySet(querySet12, 694, 143, buffer13, 81152);
+} catch {}
+let pipeline66 = device0.createComputePipeline({
+  label: '\ua452\u75ff\u42c4\u{1f95d}\u58a4\uffe3\u{1fc9f}\u68ff\ubee9',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule18, entryPoint: 'compute0', constants: {}},
+});
+let renderBundle38 = renderBundleEncoder14.finish();
+try {
+computePassEncoder21.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle37, renderBundle27, renderBundle27, renderBundle37, renderBundle36]);
+} catch {}
+try {
+renderPassEncoder11.setBlendConstant({ r: 205.4, g: -261.2, b: -47.84, a: -144.8, });
+} catch {}
+try {
+renderPassEncoder2.draw(12, 197);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer20, 378_377_473);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer19, 2720);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(2, buffer16);
+} catch {}
+try {
+commandEncoder51.copyBufferToTexture({
+  /* bytesInLastRow: 8816 widthInBlocks: 2204 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3000 */
+  offset: 3000,
+  bytesPerRow: 8960,
+  buffer: buffer9,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 159, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2204, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder58.clearBuffer(buffer4, 124956, 89848);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let shaderModule19 = device0.createShaderModule({
+  code: `@group(2) @binding(281)
+var<storage, read_write> field15: array<u32>;
+@group(2) @binding(4360)
+var<storage, read_write> type15: array<u32>;
+
+@compute @workgroup_size(7, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(0) f1: vec4<i32>,
+  @builtin(sample_mask) f2: u32,
+  @location(7) f3: vec3<i32>,
+  @location(6) f4: vec2<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(2) a0: i32, @location(25) a1: vec3<f16>, @location(14) a2: vec3<f16>, @location(5) a3: vec3<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet44 = device0.createQuerySet({
+  label: '\u869b\u{1f744}\u0d4c\u02cb\u9ded\u0c02\u897b\u{1f9e0}\u{1f8f8}',
+  type: 'occlusion',
+  count: 80,
+});
+let textureView84 = texture38.createView({label: '\u{1fbd4}\u{1f6fd}\u8b6f\u4363\u9da3\u{1fb4c}\u931f\u018a\u0827', baseMipLevel: 3});
+let renderBundleEncoder32 = device0.createRenderBundleEncoder({label: '\u0061\u4110\u0258\u0410', colorFormats: ['rg16uint'], stencilReadOnly: true});
+try {
+renderPassEncoder2.executeBundles([renderBundle7, renderBundle13, renderBundle7, renderBundle27]);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(11, 38);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline16);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(152, 103, 224_651_147, -1_597_664_771);
+} catch {}
+try {
+commandEncoder51.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2052 widthInBlocks: 513 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4288 */
+  offset: 4288,
+  bytesPerRow: 2304,
+  rowsPerImage: 44,
+  buffer: buffer10,
+}, {width: 513, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba16float'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 4,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(40), /* required buffer size: 684 */
+{offset: 684}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder63 = device0.createCommandEncoder({label: '\u00e6\u0a88\u565f\u{1f8e8}\u0f67\u{1f6b2}\u0b14'});
+let renderBundleEncoder33 = device0.createRenderBundleEncoder({label: '\uae02\u4c7b\u6b34\u8f66', colorFormats: ['rgba8sint', 'rg16float'], stencilReadOnly: true});
+let sampler33 = device0.createSampler({
+  label: '\u0ff5\u0e26\u01ec\u0831\u3c90\u{1ff47}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 6.595,
+  lodMaxClamp: 93.72,
+  compare: 'less',
+  maxAnisotropy: 9,
+});
+let externalTexture38 = device0.importExternalTexture({
+  label: '\uedf3\u6f33\u01eb\u{1fb06}\u{1fc48}\u0da2\u3c66\u3738\u0e03\u2d20',
+  source: videoFrame3,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder12.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder10.setViewport(10.19, 1.722, 7.087, 0.1577, 0.3911, 0.4322);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(120);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer14, 400);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer19, 'uint16', 42326, 4986);
+} catch {}
+try {
+commandEncoder62.copyBufferToBuffer(buffer5, 28544, buffer15, 6888, 3788);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder53.copyTextureToBuffer({
+  texture: texture14,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 208 widthInBlocks: 52 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 45268 */
+  offset: 44292,
+  bytesPerRow: 256,
+  rowsPerImage: 163,
+  buffer: buffer4,
+}, {width: 52, height: 4, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder53.clearBuffer(buffer15, 22736, 6696);
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder63.resolveQuerySet(querySet26, 55, 342, buffer19, 1280);
+} catch {}
+let imageBitmap6 = await createImageBitmap(video4);
+let externalTexture39 = device0.importExternalTexture({label: '\u{1f6ec}\u{1f76e}\u71c6\ua125\u0fbf\u{1f6ec}\udb2e\u{1ff2f}\udc06', source: video7});
+try {
+computePassEncoder23.setBindGroup(4, bindGroup8, new Uint32Array(2494), 59, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(4, bindGroup2);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(3, 2, 1, 0);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline34);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(97, 89, 746_768_394, 96_786_358, 859_071_622);
+} catch {}
+try {
+renderBundleEncoder33.setPipeline(pipeline45);
+} catch {}
+try {
+texture38.destroy();
+} catch {}
+try {
+commandEncoder61.resolveQuerySet(querySet12, 406, 390, buffer19, 29440);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 46576, new DataView(new ArrayBuffer(25072)), 4411, 4912);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 88},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 308 */
+{offset: 308, bytesPerRow: 1021}, {width: 199, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let pipeline67 = await promise22;
+let adapter3 = await navigator.gpu.requestAdapter();
+try {
+adapter1.label = '\ub26f\u0ba0';
+} catch {}
+let bindGroupLayout26 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 6948,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 621,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let buffer22 = device0.createBuffer({size: 119450, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView85 = texture23.createView({baseMipLevel: 1, mipLevelCount: 4, baseArrayLayer: 0});
+try {
+computePassEncoder32.setPipeline(pipeline51);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(4, bindGroup13, new Uint32Array(5570), 3971, 0);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(30, 0, 0, 1);
+} catch {}
+try {
+renderPassEncoder12.setViewport(20.63, 1.292, 3.566, 0.4799, 0.2762, 0.6723);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline47);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(4, buffer0, 11692, 1898);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder13.draw(148, 14, 1_498_247_487, 450_167_908);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(129);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer19, 'uint32');
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(8, buffer16, 56360, 75966);
+} catch {}
+try {
+commandEncoder62.copyBufferToBuffer(buffer9, 27832, buffer22, 75408, 5292);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer22);
+} catch {}
+try {
+commandEncoder63.copyBufferToTexture({
+  /* bytesInLastRow: 172 widthInBlocks: 43 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 228368 */
+  offset: 4964,
+  bytesPerRow: 256,
+  rowsPerImage: 290,
+  buffer: buffer9,
+}, {
+  texture: texture33,
+  mipLevel: 2,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 43, height: 3, depthOrArrayLayers: 4});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder56.clearBuffer(buffer8, 14432, 61660);
+dissociateBuffer(device0, buffer8);
+} catch {}
+let pipeline68 = device0.createComputePipeline({
+  label: '\u{1fd55}\u02f3\uf079\u400e\u{1fb77}\u7d8c\u04eb',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule15, entryPoint: 'compute0', constants: {}},
+});
+let pipeline69 = device0.createRenderPipeline({
+  layout: pipelineLayout0,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-src-alpha'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-src'},
+  },
+  writeMask: 0,
+}, {format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'r8sint', writeMask: 0}, {format: 'rgba32float', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {failOp: 'increment-clamp', depthFailOp: 'zero'},
+    stencilBack: {compare: 'greater-equal', failOp: 'increment-wrap', depthFailOp: 'replace', passOp: 'decrement-wrap'},
+    stencilReadMask: 1300312236,
+    stencilWriteMask: 1372329920,
+    depthBias: -1883829868,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 400,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm16x4', offset: 96, shaderLocation: 5},
+          {format: 'uint16x2', offset: 4, shaderLocation: 21},
+          {format: 'unorm16x4', offset: 20, shaderLocation: 2},
+          {format: 'float32x2', offset: 44, shaderLocation: 16},
+          {format: 'uint32x2', offset: 32, shaderLocation: 3},
+          {format: 'snorm16x2', offset: 60, shaderLocation: 25},
+          {format: 'uint32', offset: 4, shaderLocation: 1},
+          {format: 'uint32x4', offset: 88, shaderLocation: 23},
+          {format: 'float32', offset: 32, shaderLocation: 26},
+          {format: 'float32x2', offset: 8, shaderLocation: 14},
+          {format: 'uint16x4', offset: 72, shaderLocation: 22},
+          {format: 'uint16x4', offset: 128, shaderLocation: 12},
+          {format: 'sint32x3', offset: 24, shaderLocation: 10},
+          {format: 'sint32x2', offset: 16, shaderLocation: 8},
+          {format: 'sint8x4', offset: 96, shaderLocation: 9},
+          {format: 'uint8x2', offset: 164, shaderLocation: 20},
+          {format: 'float32x3', offset: 8, shaderLocation: 4},
+          {format: 'float32x4', offset: 8, shaderLocation: 17},
+          {format: 'uint16x4', offset: 152, shaderLocation: 24},
+          {format: 'float32x3', offset: 16, shaderLocation: 0},
+          {format: 'float32x2', offset: 12, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 60, shaderLocation: 7},
+          {format: 'unorm8x4', offset: 36, shaderLocation: 11},
+          {format: 'uint8x4', offset: 72, shaderLocation: 18},
+        ],
+      },
+      {arrayStride: 876, stepMode: 'instance', attributes: []},
+      {arrayStride: 400, attributes: [{format: 'sint8x2', offset: 152, shaderLocation: 15}]},
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: false},
+});
+document.body.prepend(canvas1);
+let video13 = await videoWithData();
+let videoFrame10 = new VideoFrame(videoFrame6, {timestamp: 0});
+let texture39 = device0.createTexture({
+  size: [480, 32, 224],
+  mipLevelCount: 4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+});
+let textureView86 = texture16.createView({baseMipLevel: 1});
+let computePassEncoder34 = commandEncoder63.beginComputePass({label: '\u3c9c\u0d1e\u97d5'});
+try {
+renderPassEncoder8.setBindGroup(4, bindGroup4, new Uint32Array(3417), 166, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer19, 'uint16', 32820);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(4, bindGroup11, new Uint32Array(6758), 6486, 0);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline52);
+} catch {}
+try {
+device0.queue.submit([commandBuffer16, commandBuffer11]);
+} catch {}
+let pipeline70 = await device0.createRenderPipelineAsync({
+  label: '\ueaa9\u1072\u{1fcca}\u0f2e\ua13e\u{1fb5f}\u327e\u350b\u9bea\u0b66\u{1f741}',
+  layout: pipelineLayout6,
+  multisample: {count: 4, mask: 0xebb75b57},
+  fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8sint', writeMask: 0}, {format: 'rg16float'}],
+},
+  vertex: {
+    module: shaderModule12,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 688,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 12, shaderLocation: 21},
+          {format: 'float32x3', offset: 64, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 648,
+        attributes: [
+          {format: 'float32', offset: 12, shaderLocation: 9},
+          {format: 'sint32', offset: 4, shaderLocation: 24},
+          {format: 'float32', offset: 28, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 1920,
+        stepMode: 'vertex',
+        attributes: [{format: 'unorm8x2', offset: 58, shaderLocation: 3}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip'},
+});
+let textureView87 = texture27.createView({label: '\u02b3\ua9e4\u570c\u5eb2\uee8e', aspect: 'all', baseMipLevel: 2});
+let externalTexture40 = device0.importExternalTexture({label: '\ub256\u{1fec0}\u0a94\u2e64\uf067\u3da2\u6aa2\u2865\ua57f', source: videoFrame10});
+try {
+renderPassEncoder11.setScissorRect(25, 2, 4, 0);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(24, 73);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer10, 51_560_999);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer13, 317_150_304);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(508, 83);
+} catch {}
+try {
+renderBundleEncoder28.setIndexBuffer(buffer19, 'uint32');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 3,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer2), /* required buffer size: 89 */
+{offset: 89}, {width: 14, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline71 = device0.createRenderPipeline({
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule17,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16uint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, undefined, {format: 'rgb10a2uint', writeMask: 0}, {format: 'r32float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba16uint', writeMask: 0}, {format: 'r8uint', writeMask: 0}, {format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule17,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4088,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x2', offset: 704, shaderLocation: 0}],
+      },
+      {
+        arrayStride: 172,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 6, shaderLocation: 14},
+          {format: 'float32x4', offset: 48, shaderLocation: 7},
+          {format: 'snorm16x4', offset: 48, shaderLocation: 9},
+          {format: 'unorm8x2', offset: 4, shaderLocation: 25},
+          {format: 'sint8x2', offset: 4, shaderLocation: 23},
+          {format: 'sint32', offset: 44, shaderLocation: 21},
+          {format: 'unorm8x2', offset: 18, shaderLocation: 6},
+          {format: 'float32x2', offset: 8, shaderLocation: 1},
+          {format: 'uint8x2', offset: 10, shaderLocation: 8},
+          {format: 'snorm16x4', offset: 80, shaderLocation: 11},
+          {format: 'uint32x3', offset: 4, shaderLocation: 24},
+          {format: 'float32x3', offset: 8, shaderLocation: 19},
+          {format: 'uint16x4', offset: 8, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 300,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 14, shaderLocation: 18},
+          {format: 'unorm16x2', offset: 4, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 1492, attributes: [{format: 'snorm16x2', offset: 756, shaderLocation: 2}]},
+      {
+        arrayStride: 568,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x2', offset: 184, shaderLocation: 26}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw'},
+});
+document.body.prepend(canvas0);
+let commandBuffer19 = commandEncoder56.finish({label: '\u64c1\ua3c0\ub5c8\udfbb\u51da\ub26b\u43f4'});
+let textureView88 = texture27.createView({mipLevelCount: 2});
+try {
+renderPassEncoder9.beginOcclusionQuery(2337);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(189, 50, 809_136_733, 257_802_431, 26_668_473);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer12, 19_310_496);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer3, 126_023_158);
+} catch {}
+try {
+commandEncoder62.copyBufferToBuffer(buffer11, 1136, buffer22, 76068, 436);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer22);
+} catch {}
+try {
+commandEncoder58.resolveQuerySet(querySet34, 1851, 35, buffer13, 49920);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline72 = device0.createComputePipeline({
+  label: '\ubf99\u0495\ufa5f\u0e1b\u0fcb',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}},
+});
+try {
+adapter3.label = '\u02b9\u{1feaf}\u08dc\u079e\u540d\u3ce8';
+} catch {}
+let bindGroupLayout27 = device0.createBindGroupLayout({entries: []});
+let commandEncoder64 = device0.createCommandEncoder({label: '\u0e6d\ua3ba'});
+let texture40 = device0.createTexture({
+  label: '\uaec3\uaa40',
+  size: {width: 329, height: 10, depthOrArrayLayers: 399},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle39 = renderBundleEncoder16.finish({label: '\u0b07\u{1fd7d}'});
+try {
+computePassEncoder32.setBindGroup(2, bindGroup13, new Uint32Array(3532), 652, 0);
+} catch {}
+try {
+renderPassEncoder10.draw(85);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer9, 642_418_417);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer8, 384_455_754);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer13, 124112, 25851);
+} catch {}
+try {
+renderBundleEncoder13.setIndexBuffer(buffer1, 'uint32', 457712);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(4, buffer16, 0);
+} catch {}
+try {
+commandEncoder59.resolveQuerySet(querySet3, 575, 1168, buffer13, 3840);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 378 */
+{offset: 326}, {width: 13, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup3, new Uint32Array(6220), 2841, 0);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(584);
+} catch {}
+try {
+renderPassEncoder0.setViewport(11.59, 1.781, 7.766, 0.1717, 0.3186, 0.5633);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(187, 31, 1_086_476_361, 114_449_091);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer19, 'uint16');
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline49);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(8, buffer13, 0, 143625);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(4, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(269);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer3, 119548);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer19, 4824);
+} catch {}
+try {
+commandEncoder53.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 6,
+  origin: {x: 1, y: 0, z: 149},
+  aspect: 'all',
+},
+{
+  texture: texture19,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder27.insertDebugMarker('\u0cea');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline73 = device0.createComputePipeline({
+  label: '\uc887\uf2c3',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule15, entryPoint: 'compute0'},
+});
+let commandEncoder65 = device0.createCommandEncoder({label: '\u0b60\u498e\u{1fe34}\u5bcf\u4bcc\uaa9a'});
+let renderBundle40 = renderBundleEncoder16.finish({label: '\u{1f952}\ua2bc\u0736\u445d\u9f90\u{1fe9f}\u0e73\u161d'});
+try {
+renderPassEncoder12.setBindGroup(4, bindGroup14);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(75, 131, 59_058_521, 174_450_706, 1_882_428_917);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer16, 'uint16', 29810, 52125);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer19, 0, 22444);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer14, 172);
+} catch {}
+try {
+commandEncoder64.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 31, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 14192, new Int16Array(44733), 11095, 2200);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video5,
+  origin: { x: 2, y: 3 },
+  flipY: true,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline74 = await device0.createComputePipelineAsync({
+  label: '\u{1f812}\u0eec\u{1fcb9}\u0cae\u0026\u0f7d\u0a4f\uc41c\u1f30\u02f5\ud204',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder66 = device0.createCommandEncoder({label: '\u0618\u76f6\ufb4e\u13a5\u0216\u0156\ub4d0\u1df1\u6fe6'});
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({label: '\u02ad\ub127', colorFormats: ['rg16uint'], stencilReadOnly: true});
+let sampler34 = device0.createSampler({
+  label: '\u00c4\u39b4\u{1f96e}\u0b77\u13a4\u0de5\u81ac\u{1fe9c}\u0daf\u{1f79d}',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 55.24,
+  lodMaxClamp: 93.84,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder22.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup12, new Uint32Array(5922), 4206, 0);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 570.6, g: -765.1, b: 878.3, a: -551.2, });
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(54);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer9, 194_357_507);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer9, 220_239_781);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer1, 'uint32', 582800, 2420);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(4, buffer11, 0, 1536);
+} catch {}
+try {
+renderBundleEncoder13.draw(239);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(13, 308);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline47);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(8, buffer0, 0, 1608);
+} catch {}
+try {
+commandEncoder59.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 255 widthInBlocks: 255 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 4475 */
+  offset: 4475,
+  bytesPerRow: 256,
+  buffer: buffer10,
+}, {width: 255, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.submit([commandBuffer12, commandBuffer17, commandBuffer19, commandBuffer18]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 154, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 134 */
+{offset: 134, bytesPerRow: 727, rowsPerImage: 104}, {width: 118, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline75 = device0.createComputePipeline({
+  label: '\u53af\u01d2\u{1fd19}\u{1f791}\u0faf\u0e38\u{1fdba}\u098e',
+  layout: pipelineLayout11,
+  compute: {module: shaderModule15, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let videoFrame11 = new VideoFrame(img7, {timestamp: 0});
+let commandEncoder67 = device0.createCommandEncoder({label: '\u584c\u0905\u63fd'});
+let computePassEncoder35 = commandEncoder65.beginComputePass({label: '\u797b\u27e7'});
+let externalTexture41 = device0.importExternalTexture({label: '\u{1feda}\u05fd\u52cd', source: videoFrame0});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup15, []);
+} catch {}
+try {
+renderPassEncoder6.setViewport(10.28, 1.247, 18.65, 0.1869, 0.5523, 0.7703);
+} catch {}
+try {
+renderPassEncoder10.draw(185, 160, 688_714_050, 131_259_632);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer15, 746_355_576);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer16, 'uint16', 22610, 95023);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline23);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(7, buffer16, 60292, 56247);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(108, 389, 823_342_513, -1_688_533_493, 324_851_287);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer14, 1200);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer3, 38536);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer1, 'uint32', 164936);
+} catch {}
+try {
+commandEncoder61.copyTextureToBuffer({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 32152 */
+  offset: 32152,
+  buffer: buffer4,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer4);
+} catch {}
+let buffer23 = device0.createBuffer({
+  label: '\u8168\u03a1\u8876\u2669\u0910\u{1f638}\ufc39\u0963\u0c7b\u5937\ufd39',
+  size: 30959,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+});
+let commandEncoder68 = device0.createCommandEncoder({label: '\u9231\uf1a2\u0f46\ud15d\u0b95\ub620\ua4c9\ud954'});
+let commandBuffer20 = commandEncoder67.finish({label: '\u51fc\udb79\uc618\u08d8\u4786\ue175\u8bf7'});
+let textureView89 = texture10.createView({label: '\u{1fdc5}\u26fe\ueaa2\uee73\u5dcc'});
+try {
+renderPassEncoder10.setBindGroup(6, bindGroup3);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer11, 911_996_639);
+} catch {}
+try {
+texture38.destroy();
+} catch {}
+try {
+commandEncoder61.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 808 widthInBlocks: 101 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 26176 */
+  offset: 25368,
+  buffer: buffer18,
+}, {width: 101, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer18);
+} catch {}
+let pipeline76 = await device0.createRenderPipelineAsync({
+  label: '\u00f4\u526e\u04cd\u0744',
+  layout: pipelineLayout9,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALL}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'add', srcFactor: 'src-alpha', dstFactor: 'one-minus-src-alpha'},
+  },
+  writeMask: 0,
+}, {format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rgba32float', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'never', failOp: 'zero', depthFailOp: 'zero', passOp: 'replace'},
+    stencilBack: {compare: 'greater-equal', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'increment-clamp'},
+    stencilReadMask: 791468883,
+    stencilWriteMask: 2698594855,
+    depthBiasClamp: 127.7555658219203,
+  },
+  vertex: {
+    module: shaderModule16,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 204, attributes: []},
+      {
+        arrayStride: 988,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 18, shaderLocation: 20}],
+      },
+      {
+        arrayStride: 2160,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 280, shaderLocation: 8},
+          {format: 'uint32x2', offset: 212, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 1416, attributes: []},
+      {arrayStride: 460, stepMode: 'instance', attributes: []},
+      {arrayStride: 1780, stepMode: 'vertex', attributes: []},
+      {arrayStride: 648, attributes: []},
+      {arrayStride: 720, stepMode: 'instance', attributes: []},
+      {arrayStride: 908, attributes: [{format: 'snorm16x2', offset: 152, shaderLocation: 3}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front'},
+});
+let commandEncoder69 = device0.createCommandEncoder({label: '\u0f3d\u1a66\u07b2\u053b\u229c\u2c69\uf3e3'});
+let texture41 = device0.createTexture({
+  label: '\u0fb7\u700e\ue002\u3e18\u0623\u4fc5',
+  size: [120],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView90 = texture2.createView({label: '\u0277\u05b6\u02cf\u0ce7\u6a50\u0513\u2da1\u9b7d\u0e0c', format: 'rgba8unorm'});
+try {
+renderPassEncoder9.setScissorRect(22, 0, 8, 0);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer10, 279_054_860);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer12, 280_358_443);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer23, 'uint32', 17496);
+} catch {}
+try {
+renderBundleEncoder13.draw(355, 338, 38_621_868, 246_384_717);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer19, 452);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer3, 56576);
+} catch {}
+try {
+  await buffer9.mapAsync(GPUMapMode.WRITE, 129584);
+} catch {}
+try {
+commandEncoder69.copyBufferToBuffer(buffer9, 76456, buffer8, 71028, 7836);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer6), /* required buffer size: 676 */
+{offset: 676}, {width: 1156, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout12 = device0.createPipelineLayout({
+  label: '\u{1fe5e}\u{1fdeb}\u3f5b\uab72\u0931\u{1fedd}\u{1f6f4}\u30d4\u205b',
+  bindGroupLayouts: [bindGroupLayout12, bindGroupLayout13, bindGroupLayout21, bindGroupLayout4, bindGroupLayout24],
+});
+let commandEncoder70 = device0.createCommandEncoder({label: '\u{1fd0c}\u0804\ue319\u0bf6\u01e6\u{1fca4}\u{1fe9a}\u7ba6'});
+let querySet45 = device0.createQuerySet({
+  label: '\u{1f8fd}\u28bb\u06d9\u00a7\uf499\u7f6f\ua5a1\u3637\ud4a5\u6e0f\u1034',
+  type: 'occlusion',
+  count: 3614,
+});
+let texture42 = device0.createTexture({
+  label: '\u{1f7c6}\ua5e7\u9d85\u062e\ua81e\udf39\u0d1e\u{1fda7}\u6ef6',
+  size: {width: 1317, height: 40, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm-srgb'],
+});
+let sampler35 = device0.createSampler({
+  label: '\ucc92\u{1f7a2}\u31fd\u6050\u{1f753}\u{1fc1a}\u876f',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 46.41,
+  lodMaxClamp: 78.80,
+  compare: 'less-equal',
+});
+let externalTexture42 = device0.importExternalTexture({label: '\u{1fccf}\u4b1c\uf2cb', source: video7, colorSpace: 'display-p3'});
+try {
+computePassEncoder32.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant({ r: 968.5, g: -912.2, b: -821.4, a: -383.4, });
+} catch {}
+try {
+renderPassEncoder10.draw(195, 15, 1_940_111_199, 824_226_582);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(222, 52, 1_345_458_854, 318_831_221, 228_819_957);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer12, 32_882_563);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(4, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(346, 22, 260_034, 71_414_521);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer3, 215488);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+commandEncoder69.copyBufferToTexture({
+  /* bytesInLastRow: 944 widthInBlocks: 236 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2232 */
+  offset: 2232,
+  bytesPerRow: 1024,
+  buffer: buffer23,
+}, {
+  texture: texture15,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 236, height: 8, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer23);
+} catch {}
+try {
+commandEncoder58.copyTextureToTexture({
+  texture: texture42,
+  mipLevel: 3,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture42,
+  mipLevel: 1,
+  origin: {x: 92, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 115, height: 4, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder53.resolveQuerySet(querySet7, 913, 257, buffer13, 68608);
+} catch {}
+try {
+renderPassEncoder11.insertDebugMarker('\u{1fbaa}');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 5584, new DataView(new ArrayBuffer(9548)), 9033, 108);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas2,
+  origin: { x: 17, y: 539 },
+  flipY: false,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas6 = document.createElement('canvas');
+let bindGroup17 = device0.createBindGroup({
+  label: '\u08c3\u{1fa0d}\uca86\u{1f86c}\u{1f71b}\ue773\u0bed\u06fd',
+  layout: bindGroupLayout0,
+  entries: [],
+});
+let sampler36 = device0.createSampler({
+  label: '\u{1f80a}\u2d9f\u0b86\u05a3\u4e01\u56e6\ub02e\u0e1e\u{1faeb}\ua548',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 8.527,
+  lodMaxClamp: 42.23,
+  compare: 'equal',
+});
+let externalTexture43 = device0.importExternalTexture({
+  label: '\uacfe\u09e4\u1f49\u{1fc73}\u4380\ua45b\ud043\u{1fc05}\u2de3\u{1fd61}\ubd84',
+  source: video8,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder28.setPipeline(pipeline44);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 902.1, g: -839.1, b: 919.4, a: 709.9, });
+} catch {}
+try {
+renderPassEncoder6.setScissorRect(19, 1, 2, 1);
+} catch {}
+try {
+renderPassEncoder2.draw(206, 27, 728_125_977, 1_118_729_255);
+} catch {}
+try {
+commandEncoder53.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 828 */
+  offset: 828,
+  bytesPerRow: 512,
+  rowsPerImage: 37,
+  buffer: buffer2,
+}, {
+  texture: texture19,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 2, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder49.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 559, height: 1, depthOrArrayLayers: 1});
+} catch {}
+video13.height = 100;
+let img10 = await imageWithData(13, 96, '#38ce02ff', '#6b7d45e8');
+let commandEncoder71 = device0.createCommandEncoder({label: '\u04a7\ub6df\u{1f75d}'});
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(863);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer16, 'uint32', 5256, 10325);
+} catch {}
+try {
+commandEncoder61.copyBufferToBuffer(buffer23, 8708, buffer21, 480, 7168);
+dissociateBuffer(device0, buffer23);
+dissociateBuffer(device0, buffer21);
+} catch {}
+try {
+commandEncoder66.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 136, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 2,
+  origin: {x: 15, y: 0, z: 2},
+  aspect: 'all',
+}, arrayBuffer11, /* required buffer size: 2_137_565 */
+{offset: 959, bytesPerRow: 161, rowsPerImage: 99}, {width: 34, height: 5, depthOrArrayLayers: 135});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let bindGroup18 = device0.createBindGroup({label: '\u08d8\u046c', layout: bindGroupLayout16, entries: []});
+let commandEncoder72 = device0.createCommandEncoder({label: '\u90b1\u07e5\u9a27\u{1fd94}\uf3ce'});
+let querySet46 = device0.createQuerySet({
+  label: '\u5164\u4bd1\ucb9a\u017c\u4c37\u71e0\u0578\uda3b\u{1ff81}\u861f',
+  type: 'occlusion',
+  count: 3473,
+});
+let texture43 = device0.createTexture({
+  label: '\ua917\u9a93\u0992\ud9d1\u40d2\u0ce3\u0a66\u4c62\u{1fbbc}\u7ceb\u{1fab0}',
+  size: [480],
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8unorm'],
+});
+let sampler37 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 41.09,
+  lodMaxClamp: 51.16,
+  compare: 'always',
+});
+let externalTexture44 = device0.importExternalTexture({
+  label: '\u0f1e\u{1fab8}\u0a76\u5f75\u{1ff91}\u{1febd}\ufd88',
+  source: video8,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder2.drawIndirect(buffer14, 1_988_413_738);
+} catch {}
+try {
+commandEncoder69.resolveQuerySet(querySet41, 325, 574, buffer19, 41728);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer6), /* required buffer size: 25_448 */
+{offset: 679, bytesPerRow: 2087, rowsPerImage: 246}, {width: 453, height: 12, depthOrArrayLayers: 1});
+} catch {}
+let videoFrame12 = new VideoFrame(imageBitmap6, {timestamp: 0});
+let bindGroupLayout28 = device0.createBindGroupLayout({
+  label: '\u670e\u076c\u0139\ud2d5\u88ae\u{1f6b2}',
+  entries: [
+    {
+      binding: 4372,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder73 = device0.createCommandEncoder({label: '\ub3de\uab86\u{1fd31}\u516a\ud65d\u{1fce1}\u02c5\u{1f95d}'});
+let querySet47 = device0.createQuerySet({label: '\u{1fb28}\u9bc1\u417c\u{1f6c7}\u{1f6e9}\u72ac', type: 'occlusion', count: 1195});
+let commandBuffer21 = commandEncoder64.finish({label: '\u0759\u0aaa\ua2a0\u{1fc29}\u0664\u{1fb1a}\ucd8f\u{1f856}\u{1f79f}'});
+let renderBundle41 = renderBundleEncoder22.finish({label: '\u012c\ue2f4'});
+let sampler38 = device0.createSampler({
+  label: '\ub1d1\u8dc5\u{1ff1e}\u{1fb98}\u6cb1\ua309\u{1fa7a}\u8ee6\u0ad9\u6cdd\uc0e7',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 44.06,
+  lodMaxClamp: 97.64,
+});
+try {
+renderPassEncoder9.executeBundles([renderBundle33, renderBundle40]);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer5, 797_988_757);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(2, buffer13, 0, 33486);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 19132, new BigUint64Array(6673), 5767, 236);
+} catch {}
+document.body.prepend(canvas1);
+let textureView91 = texture37.createView({label: '\u50db\ub8b5', dimension: '2d-array', mipLevelCount: 1, arrayLayerCount: 1});
+let renderBundle42 = renderBundleEncoder18.finish({label: '\u097c\ue53e\u17c8\u8a19\u09f4'});
+try {
+renderPassEncoder10.drawIndexed(185, 74, 1_388_904_590, 287_726_045, 610_893_541);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer2, 7_683_298);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderBundleEncoder13.draw(305);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(9, 306, 1_459_528_954, 51_415_764, 2_037_134_281);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer23, 1648);
+} catch {}
+try {
+device0.queue.submit([commandBuffer20, commandBuffer21]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer22, 24372, new BigUint64Array(28722), 594, 1476);
+} catch {}
+let pipeline77 = await device0.createComputePipelineAsync({
+  label: '\u0714\u5976\u0d4d\uc7b3\u{1f781}\u0cb7',
+  layout: pipelineLayout12,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext7 = canvas6.getContext('webgpu');
+offscreenCanvas10.height = 1039;
+let video14 = await videoWithData();
+try {
+window.someLabel = textureView18.label;
+} catch {}
+let commandEncoder74 = device0.createCommandEncoder({label: '\u9057\u75d6\u62f6\u{1fd94}'});
+let texture44 = device0.createTexture({
+  label: '\u636d\ub116\u50af\u{1fc96}\u0a5c\u45d1\u4290\ud999',
+  size: [329, 10, 1],
+  mipLevelCount: 3,
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder36 = commandEncoder69.beginComputePass({label: '\u062c\u1108\u{1f687}'});
+let externalTexture45 = device0.importExternalTexture({label: '\u0cbc\ubdc8\ufaf7', source: videoFrame8, colorSpace: 'srgb'});
+try {
+renderPassEncoder4.beginOcclusionQuery(2220);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(3, 285);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer6, 281_571_573);
+} catch {}
+try {
+renderBundleEncoder13.draw(106, 445, 2_802_200_027, 831_151_554);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(338, 103, 306_283_769, 165_976_666);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer23, 1632);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(6, buffer11, 0);
+} catch {}
+let bindGroup19 = device0.createBindGroup({
+  label: '\u72b2\uc547\u0f7d\u6b0c\u{1f8f3}\uc4a4\u676e\u014f\u{1f93b}\u0542\u01df',
+  layout: bindGroupLayout27,
+  entries: [],
+});
+let texture45 = gpuCanvasContext2.getCurrentTexture();
+let textureView92 = texture31.createView({label: '\u2576\u{1f76d}', dimension: '2d-array', baseMipLevel: 4});
+try {
+renderPassEncoder2.beginOcclusionQuery(30);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle39, renderBundle13, renderBundle8, renderBundle37, renderBundle30, renderBundle31, renderBundle31, renderBundle23]);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer13, 3_580_705_431);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer1, 'uint32', 216624);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(4, buffer16, 0, 17136);
+} catch {}
+try {
+commandEncoder68.copyTextureToBuffer({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 92, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 24 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 14264 */
+  offset: 928,
+  bytesPerRow: 256,
+  rowsPerImage: 49,
+  buffer: buffer15,
+}, {width: 3, height: 4, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1317, height: 40, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData12,
+  origin: { x: 17, y: 12 },
+  flipY: true,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 543, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 31, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let shaderModule20 = device0.createShaderModule({
+  label: '\u{1fb4b}\u0e6e\u{1fbe4}\u{1f98e}\u4cb5\u0960\u3f51',
+  code: `@group(2) @binding(4360)
+var<storage, read_write> global9: array<u32>;
+@group(2) @binding(281)
+var<storage, read_write> local11: array<u32>;
+
+@compute @workgroup_size(2, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S18 {
+  @builtin(position) f0: vec4<f32>,
+  @builtin(sample_mask) f1: u32,
+  @builtin(sample_index) f2: u32
+}
+struct FragmentOutput0 {
+  @location(6) f0: vec2<f32>,
+  @location(3) f1: vec4<f32>,
+  @location(0) f2: vec4<f32>,
+  @location(1) f3: vec4<f32>,
+  @location(2) f4: vec2<u32>,
+  @location(4) f5: vec4<f32>,
+  @location(7) f6: vec4<u32>
+}
+
+@fragment
+fn fragment0(a0: S18) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S17 {
+  @location(24) f0: vec2<i32>,
+  @location(25) f1: f32,
+  @location(20) f2: vec3<u32>,
+  @location(11) f3: vec2<f16>,
+  @location(27) f4: vec2<u32>,
+  @location(26) f5: vec3<u32>,
+  @location(0) f6: vec2<f16>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(10) a1: vec4<f16>, @location(21) a2: vec3<i32>, @location(14) a3: vec2<u32>, @location(1) a4: vec4<f16>, a5: S17, @location(7) a6: vec3<f16>, @location(9) a7: vec3<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({label: '\u{1fd48}\u5346\ua746\u4dc0\u{1f8ad}\u7c65', colorFormats: ['rg16uint']});
+let sampler39 = device0.createSampler({
+  label: '\u5d7e\u8871\ua93f\u{1ffc0}\ucd4e\u04f9\u40b2',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 60.70,
+  lodMaxClamp: 83.66,
+});
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant({ r: -119.6, g: 591.4, b: -380.8, a: 508.5, });
+} catch {}
+try {
+renderPassEncoder6.setViewport(18.73, 0.05752, 5.064, 1.351, 0.2087, 0.7235);
+} catch {}
+try {
+renderPassEncoder10.draw(89);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(114, 118, 1_276_327_439, -2_130_447_093);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer19, 15172);
+} catch {}
+try {
+renderBundleEncoder33.setPipeline(pipeline45);
+} catch {}
+try {
+commandEncoder71.copyBufferToTexture({
+  /* bytesInLastRow: 12904 widthInBlocks: 1613 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 14064 */
+  offset: 1160,
+  buffer: buffer2,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 62, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1613, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let imageBitmap7 = await createImageBitmap(videoFrame1);
+let bindGroup20 = device0.createBindGroup({label: '\u4870\u116b', layout: bindGroupLayout16, entries: []});
+let commandEncoder75 = device0.createCommandEncoder({label: '\u7f16\uc115\u0662\u7720'});
+let texture46 = device0.createTexture({
+  label: '\u108e\uc512\u122d\u04a3\u2d76\u1bff\ucb29\ude94\u01d1',
+  size: [480],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint'],
+});
+let textureView93 = texture10.createView({baseArrayLayer: 0});
+let sampler40 = device0.createSampler({
+  label: '\u0c50\u399f\u{1fdb7}\udbcc\u1e37\u0149\ue01a\u0c8c\u8476',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 13.14,
+  lodMaxClamp: 31.57,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder9.setPipeline(pipeline57);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer1, 'uint32', 8068, 547265);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(4, buffer16, 0);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(1, bindGroup9, new Uint32Array(9453), 759, 0);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline23);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(1, buffer16, 94348, 16612);
+} catch {}
+try {
+commandEncoder70.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 15},
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 1, depthOrArrayLayers: 2});
+} catch {}
+let pipeline78 = device0.createComputePipeline({
+  label: '\u{1f77a}\u1256\u{1fa8c}\u416d',
+  layout: 'auto',
+  compute: {module: shaderModule16, entryPoint: 'compute0', constants: {}},
+});
+let pipeline79 = device0.createRenderPipeline({
+  label: '\u{1f6c3}\ub1c7\u0515\uaf41\u{1ffcf}\u{1fd51}\u4e65\u{1fa7d}',
+  layout: pipelineLayout8,
+  multisample: {},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8sint'}, {format: 'rg16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'equal', depthFailOp: 'decrement-wrap', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'not-equal', failOp: 'zero', depthFailOp: 'zero', passOp: 'replace'},
+    stencilReadMask: 3552476623,
+    stencilWriteMask: 2281052076,
+    depthBias: -1067397981,
+    depthBiasSlopeScale: 35.34252919636219,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1408,
+        attributes: [
+          {format: 'snorm16x4', offset: 252, shaderLocation: 3},
+          {format: 'sint16x4', offset: 188, shaderLocation: 15},
+          {format: 'float32x4', offset: 72, shaderLocation: 5},
+          {format: 'sint32x3', offset: 616, shaderLocation: 24},
+          {format: 'sint8x4', offset: 716, shaderLocation: 19},
+          {format: 'sint8x2', offset: 388, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'back'},
+});
+try {
+device0.destroy();
+} catch {}
+gc();
+let canvas7 = document.createElement('canvas');
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+document.body.prepend(video11);
+try {
+pipeline8.label = '\u{1fc69}\u{1ff7d}';
+} catch {}
+gc();
+let pipelineLayout13 = device0.createPipelineLayout({
+  label: '\u3b2a\u5c3b\u74c5\u{1f837}\u66ec\u8fc4\u0434\u0763\u0b30\u0b30\ucbcd',
+  bindGroupLayouts: [bindGroupLayout3],
+});
+let textureView94 = texture19.createView({
+  label: '\ua15e\u0d07\u03eb\u{1fe9a}\u0ec6\u6673\u{1f7f9}\u6054\ue53c\ue4bc',
+  aspect: 'all',
+  baseMipLevel: 3,
+});
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({
+  colorFormats: ['rg32sint', 'rgba32uint', 'rgba16float', 'rg16uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+try {
+computePassEncoder29.setPipeline(pipeline48);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(245);
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant({ r: -251.3, g: -209.8, b: 913.8, a: 175.2, });
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(19, 2, 10, 0);
+} catch {}
+try {
+renderPassEncoder10.draw(263);
+} catch {}
+try {
+renderPassEncoder12.drawIndexed(153);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer4, 69_439_891);
+} catch {}
+try {
+commandEncoder53.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 154, y: 2, z: 153},
+  aspect: 'all',
+},
+{
+  texture: texture27,
+  mipLevel: 2,
+  origin: {x: 14, y: 1, z: 2},
+  aspect: 'all',
+},
+{width: 126, height: 1, depthOrArrayLayers: 142});
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 84464, new BigUint64Array(41669), 32609, 5900);
+} catch {}
+let img11 = await imageWithData(50, 140, '#7e4f1693', '#ec47b9c0');
+let videoFrame13 = new VideoFrame(offscreenCanvas10, {timestamp: 0});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise21;
+} catch {}
+let video15 = await videoWithData();
+video9.height = 152;
+let canvas8 = document.createElement('canvas');
+try {
+canvas7.getContext('webgl2');
+} catch {}
+let gpuCanvasContext8 = canvas8.getContext('webgpu');
+let imageBitmap8 = await createImageBitmap(videoFrame2);
+canvas1.width = 175;
+gc();
+try {
+  await promise17;
+} catch {}
+let canvas9 = document.createElement('canvas');
+let gpuCanvasContext9 = canvas9.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+window.someLabel = pipeline20.label;
+} catch {}
+let imageData13 = new ImageData(140, 80);
+document.body.prepend(canvas0);
+let canvas10 = document.createElement('canvas');
+let gpuCanvasContext10 = canvas10.getContext('webgpu');
+let commandEncoder76 = device0.createCommandEncoder({label: '\u543d\u7b45\u2bf6\u3ce5\ud120\u0452\u{1ff89}\u{1f6c7}\u65ed'});
+try {
+computePassEncoder33.setBindGroup(5, bindGroup20, new Uint32Array(9425), 5857, 0);
+} catch {}
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(29, 143, 523_358_454);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(8, buffer11, 0, 1527);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(570, 349, 1_552_491_426);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(4, buffer19, 42084, 5131);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+let offscreenCanvas11 = new OffscreenCanvas(650, 724);
+let gpuCanvasContext11 = offscreenCanvas11.getContext('webgpu');
+gc();
+let video16 = await videoWithData();
+let videoFrame14 = new VideoFrame(img7, {timestamp: 0});
+let promise25 = adapter0.requestAdapterInfo();
+gc();
+let video17 = await videoWithData();
+try {
+  await promise7;
+} catch {}
+try {
+  await promise24;
+} catch {}
+offscreenCanvas3.height = 1536;
+let video18 = await videoWithData();
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+gc();
+try {
+window.someLabel = externalTexture36.label;
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let videoFrame15 = new VideoFrame(canvas5, {timestamp: 0});
+try {
+adapter3.label = '\u{1f9b7}\u0ea3\uc5ca';
+} catch {}
+let offscreenCanvas12 = new OffscreenCanvas(938, 83);
+canvas4.height = 417;
+let img12 = await imageWithData(184, 198, '#1840b2d5', '#0fdf3f2c');
+try {
+  await promise20;
+} catch {}
+let texture47 = device0.createTexture({
+  size: [658, 20, 1],
+  mipLevelCount: 7,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView95 = texture19.createView({baseMipLevel: 2, mipLevelCount: 1});
+try {
+computePassEncoder2.setBindGroup(4, bindGroup0, new Uint32Array(2422), 2139, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle13, renderBundle37]);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline47);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(118, 158);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(4, buffer0, 0, 21630);
+} catch {}
+try {
+commandEncoder61.copyBufferToTexture({
+  /* bytesInLastRow: 564 widthInBlocks: 141 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 20844 */
+  offset: 20280,
+  buffer: buffer23,
+}, {
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 44, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 141, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer23);
+} catch {}
+try {
+commandEncoder73.clearBuffer(buffer10, 62432, 51316);
+dissociateBuffer(device0, buffer10);
+} catch {}
+let video19 = await videoWithData();
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+try {
+adapter1.label = '\ubb54\u0936\u3cc8\ufdaa\u{1f92b}\udc52\u63d0\u2c8a\uf8a0';
+} catch {}
+try {
+offscreenCanvas12.getContext('webgl2');
+} catch {}
+document.body.prepend(video10);
+try {
+  await promise25;
+} catch {}
+video18.height = 19;
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let offscreenCanvas13 = new OffscreenCanvas(629, 321);
+let gpuCanvasContext12 = offscreenCanvas13.getContext('webgpu');
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+canvas5.height = 1773;
+let imageBitmap9 = await createImageBitmap(img2);
+canvas0.height = 401;
+let promise26 = adapter0.requestAdapterInfo();
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+try {
+  await promise26;
+} catch {}
+let offscreenCanvas14 = new OffscreenCanvas(405, 200);
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+gc();
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+gc();
+let img13 = await imageWithData(81, 298, '#c992d1c6', '#c3e08362');
+offscreenCanvas12.height = 3392;
+offscreenCanvas7.height = 1484;
+try {
+offscreenCanvas14.getContext('webgpu');
+} catch {}
+let promise27 = adapter3.requestDevice({
+  label: '\u{1ff98}\u0066\u02a8\ua9e0\u9c4a\u{1ff82}\u0e34\u{1f9e3}\u7a53\u043d\u7bd3',
+  requiredFeatures: [
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 8,
+    maxColorAttachmentBytesPerSample: 39,
+    maxVertexAttributes: 25,
+    maxVertexBufferArrayStride: 30241,
+    maxStorageTexturesPerShaderStage: 27,
+    maxStorageBuffersPerShaderStage: 35,
+    maxDynamicStorageBuffersPerPipelineLayout: 11358,
+    maxDynamicUniformBuffersPerPipelineLayout: 43851,
+    maxBindingsPerBindGroup: 1200,
+    maxTextureArrayLayers: 1167,
+    maxTextureDimension1D: 13360,
+    maxTextureDimension2D: 15326,
+    maxVertexBuffers: 9,
+    maxBindGroupsPlusVertexBuffers: 29,
+    minStorageBufferOffsetAlignment: 128,
+    minUniformBufferOffsetAlignment: 32,
+    maxUniformBufferBindingSize: 221293494,
+    maxStorageBufferBindingSize: 221730481,
+    maxUniformBuffersPerShaderStage: 17,
+    maxSampledTexturesPerShaderStage: 26,
+    maxInterStageShaderVariables: 48,
+    maxInterStageShaderComponents: 118,
+    maxSamplersPerShaderStage: 21,
+  },
+});
+let device1 = await promise1;
+let videoFrame16 = new VideoFrame(videoFrame9, {timestamp: 0});
+gc();
+let querySet48 = device1.createQuerySet({label: '\u2241\u0a94\u0d4a\u3113', type: 'occlusion', count: 1788});
+let texture48 = device1.createTexture({
+  label: '\u4b27\ua1da\u9b37\u{1f641}',
+  size: {width: 640, height: 48, depthOrArrayLayers: 951},
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let video20 = await videoWithData();
+let imageData14 = new ImageData(136, 8);
+let buffer24 = device1.createBuffer({
+  label: '\u62f3\u4d1f\u{1f9a7}\u03ae\u04dd\ubb82\uab66\u34ee\u0d0a\ub29b\u62ce',
+  size: 149477,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let commandEncoder77 = device1.createCommandEncoder({});
+let commandBuffer22 = commandEncoder77.finish({label: '\u0ae8\uc73b\u{1f6ca}\u03df\ue798\u0b22\u{1fda8}\u62b8\u3519\u0a4d'});
+let texture49 = device1.createTexture({
+  size: [1608, 1, 488],
+  mipLevelCount: 8,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32uint'],
+});
+let video21 = await videoWithData();
+let adapter4 = await navigator.gpu.requestAdapter({});
+let texture50 = device1.createTexture({
+  label: '\ud24b\uc3bf\u{1fc18}\u{1fe22}\u6ee4\u8ab5\ub685\u29b8\u17fe\ub202',
+  size: {width: 640, height: 48, depthOrArrayLayers: 1},
+  mipLevelCount: 9,
+  format: 'astc-8x8-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['astc-8x8-unorm-srgb'],
+});
+let renderBundleEncoder37 = device1.createRenderBundleEncoder({
+  colorFormats: ['r8unorm', 'rg8unorm', 'bgra8unorm-srgb', 'r32sint', 'rg32sint', 'bgra8unorm', 'rgba8unorm', 'r32float'],
+  sampleCount: 4,
+});
+let sampler41 = device1.createSampler({
+  label: '\u0c52\u0347\u{1fe4b}\u0dc6\uecd1\ud1ec\u{1ff1a}\u4085\u0a03\u{1f89e}',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 78.88,
+  lodMaxClamp: 98.59,
+  maxAnisotropy: 13,
+});
+let externalTexture46 = device1.importExternalTexture({label: '\udf68\u82a7\u191a', source: videoFrame2, colorSpace: 'display-p3'});
+try {
+  await device1.popErrorScope();
+} catch {}
+let video22 = await videoWithData();
+let bindGroupLayout29 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 999,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let textureView96 = texture49.createView({dimension: '2d', baseMipLevel: 2, mipLevelCount: 3, baseArrayLayer: 368});
+try {
+renderBundleEncoder37.setVertexBuffer(1000, undefined, 0, 2308654752);
+} catch {}
+let commandEncoder78 = device1.createCommandEncoder({label: '\u0274\uc13c\u2118\u{1f63e}\u0473\u0fd1\u{1f955}\u9b9c\u{1f9ca}\u3e9b'});
+let querySet49 = device1.createQuerySet({label: '\u{1f750}\u{1fbf8}', type: 'occlusion', count: 2346});
+let computePassEncoder37 = commandEncoder78.beginComputePass();
+let texture51 = device1.createTexture({
+  label: '\u1184\u0431\ufb32\u09ce\uefa5\u2395\u0d41\ub5f3',
+  size: {width: 1200, height: 1, depthOrArrayLayers: 490},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r8unorm', 'r8unorm', 'r8unorm'],
+});
+let textureView97 = texture51.createView({
+  label: '\u{1f975}\u074a\u0458\ue3d4\u0e83\ub1e9\u0bff\udb44\u{1f6e4}',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+});
+let sampler42 = device1.createSampler({
+  label: '\u{1fcec}\u87cb\u{1f9e0}\u045d\u{1f8b3}\uac44',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.51,
+  maxAnisotropy: 14,
+});
+let externalTexture47 = device1.importExternalTexture({source: videoFrame7, colorSpace: 'srgb'});
+try {
+device1.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 10},
+  aspect: 'all',
+}, new Uint32Array(new ArrayBuffer(72)), /* required buffer size: 38_565_262 */
+{offset: 22, bytesPerRow: 20734, rowsPerImage: 30}, {width: 1282, height: 0, depthOrArrayLayers: 63});
+} catch {}
+let promise28 = device1.queue.onSubmittedWorkDone();
+canvas3.width = 418;
+let texture52 = device1.createTexture({
+  label: '\u2e16\u1928\u{1f899}\u2955',
+  size: [96, 3, 156],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+});
+let textureView98 = texture51.createView({label: '\u7d2c\ua0ad\uef89\u97f0', baseMipLevel: 2, arrayLayerCount: 1});
+let renderBundle43 = renderBundleEncoder37.finish({label: '\u0613\u{1f6d4}'});
+let sampler43 = device1.createSampler({
+  label: '\u525d\ue715\u{1ff91}\ua2a5\u0eaf\u0161\u80f4\u4e0f\u0302\u8a36',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 92.47,
+  lodMaxClamp: 95.72,
+});
+let externalTexture48 = device1.importExternalTexture({label: '\u397b\ub11b\u017f\u{1ff36}\u292d\u07e2\u05d9\udff8', source: video12, colorSpace: 'srgb'});
+try {
+window.someLabel = texture50.label;
+} catch {}
+let commandEncoder79 = device1.createCommandEncoder({label: '\u4a59\u0365\u02f3'});
+let querySet50 = device1.createQuerySet({label: '\u{1f9dc}\u86ad', type: 'occlusion', count: 3955});
+let sampler44 = device1.createSampler({
+  label: '\u{1fe61}\ud920\u0b06\ucfbf\u{1fc8e}\u0a24\uaa07\u75ab\u0c1f\ued3a',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 2.266,
+  lodMaxClamp: 45.65,
+  maxAnisotropy: 9,
+});
+try {
+commandEncoder79.resolveQuerySet(querySet50, 1747, 1970, buffer24, 117248);
+} catch {}
+let textureView99 = texture49.createView({baseMipLevel: 5, mipLevelCount: 2, baseArrayLayer: 215, arrayLayerCount: 40});
+let renderBundle44 = renderBundleEncoder37.finish({label: '\ud129\u{1fbaa}\u0201'});
+let pipelineLayout14 = device1.createPipelineLayout({
+  label: '\u7ace\u{1f88b}\u068e\u07af\u0ce8\u567a\u{1fa71}',
+  bindGroupLayouts: [bindGroupLayout29, bindGroupLayout29, bindGroupLayout29, bindGroupLayout29, bindGroupLayout29, bindGroupLayout29, bindGroupLayout29],
+});
+let querySet51 = device1.createQuerySet({
+  label: '\u0a2d\uead8\u0e68\u0025\u{1fdfc}\u0e6f\u{1fea7}\u0568\ue84d\ufa50',
+  type: 'occlusion',
+  count: 2636,
+});
+let renderBundle45 = renderBundleEncoder37.finish({label: '\uffd5\u{1fb12}\u81e9\u06e7\u192a\u0209\u62eb\u{1ff15}\u0f73\u3ce9\u{1ffd2}'});
+let buffer25 = device1.createBuffer({
+  label: '\u1928\u05d1\ucd6b\u6f2e\ud663\u4254',
+  size: 38087,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let computePassEncoder38 = commandEncoder79.beginComputePass({label: '\ub48c\u0790\u3621\u086e\u{1fc66}\u{1f888}\u034b\u8c1f\u2e77\u0e76\u02bc'});
+let renderBundleEncoder38 = device1.createRenderBundleEncoder({
+  label: '\u2b27\u{1fd89}',
+  colorFormats: ['r8unorm', 'rg8unorm', 'bgra8unorm-srgb', 'r32sint', 'rg32sint', 'bgra8unorm', 'rgba8unorm', 'r32float'],
+  sampleCount: 4,
+  stencilReadOnly: false,
+});
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 6, height: 1, depthOrArrayLayers: 9}
+*/
+{
+  source: imageBitmap7,
+  origin: { x: 1, y: 3 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let adapter5 = await navigator.gpu.requestAdapter({});
+let shaderModule21 = device1.createShaderModule({
+  code: `@group(6) @binding(999)
+var<storage, read_write> function8: array<u32>;
+@group(1) @binding(999)
+var<storage, read_write> parameter7: array<u32>;
+
+@compute @workgroup_size(7, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(5) f1: vec4<f32>,
+  @location(2) f2: vec4<f32>,
+  @location(0) f3: vec2<f32>,
+  @location(3) f4: vec2<i32>,
+  @builtin(sample_mask) f5: u32,
+  @location(4) f6: vec2<i32>,
+  @location(6) f7: vec4<f32>,
+  @location(7) f8: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(front_facing) a1: bool, @builtin(sample_mask) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(15) a0: vec3<u32>, @location(22) a1: vec2<f32>, @location(23) a2: vec3<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let renderBundle46 = renderBundleEncoder38.finish({label: '\u89be\u536d\u00a1'});
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 24, height: 1, depthOrArrayLayers: 39}
+*/
+{
+  source: video17,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData15 = new ImageData(216, 96);
+let imageData16 = new ImageData(168, 28);
+let commandEncoder80 = device1.createCommandEncoder({label: '\u{1f77b}\uc09a\ud063\ub4c1\u07ce'});
+let computePassEncoder39 = commandEncoder80.beginComputePass({label: '\ub206\ub7b3\u0de8'});
+try {
+device1.queue.writeTexture({
+  texture: texture52,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 7},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer8), /* required buffer size: 1_150_041 */
+{offset: 857, bytesPerRow: 252, rowsPerImage: 80}, {width: 16, height: 1, depthOrArrayLayers: 58});
+} catch {}
+canvas10.width = 2563;
+let videoFrame17 = new VideoFrame(canvas10, {timestamp: 0});
+let commandEncoder81 = device1.createCommandEncoder();
+let textureView100 = texture52.createView({label: '\ua258\u8466\uc4a0\u04f2\u9a1d\u{1faa6}', baseMipLevel: 4});
+let computePassEncoder40 = commandEncoder81.beginComputePass();
+try {
+computePassEncoder39.insertDebugMarker('\u0c47');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 6, height: 1, depthOrArrayLayers: 9}
+*/
+{
+  source: imageData14,
+  origin: { x: 45, y: 1 },
+  flipY: false,
+}, {
+  texture: texture52,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let video23 = await videoWithData();
+let bindGroup21 = device0.createBindGroup({
+  label: '\ue3d0\u000b',
+  layout: bindGroupLayout18,
+  entries: [
+    {binding: 3692, resource: textureView17},
+    {binding: 6875, resource: {buffer: buffer17, offset: 45184, size: 7724}},
+  ],
+});
+let buffer26 = device0.createBuffer({
+  label: '\ue78c\u{1fe49}\u668b\u08c6\u9162\uc12a\u0ab0\ufce3\u{1f7b5}\u08ca',
+  size: 66752,
+  usage: GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: true,
+});
+let computePassEncoder41 = commandEncoder62.beginComputePass({label: '\u9307\uccac\u{1fa8e}\u01c4\u7442'});
+try {
+renderPassEncoder12.executeBundles([renderBundle27, renderBundle15, renderBundle33]);
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(6, 2, 23, 0);
+} catch {}
+try {
+renderPassEncoder1.setViewport(15.03, 0.5302, 8.214, 1.017, 0.3030, 0.7516);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer19, 'uint16', 40182, 6869);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(7, buffer13, 6688, 20398);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(141, 199, 1_238_517_241, 114_468_495, 5_722_782);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline23);
+} catch {}
+try {
+commandEncoder58.copyBufferToBuffer(buffer9, 76276, buffer10, 142452, 10972);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder66.copyTextureToBuffer({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 724 widthInBlocks: 181 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 42444 */
+  offset: 41720,
+  rowsPerImage: 80,
+  buffer: buffer10,
+}, {width: 181, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'stencil-only',
+}, new Uint32Array(arrayBuffer7), /* required buffer size: 506 */
+{offset: 506}, {width: 658, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline80 = device0.createRenderPipeline({
+  label: '\u03c6\uc6fc\u76f0\u{1fe38}\u0337\u050b\u090e\ufacb\u065b\u0af2',
+  layout: pipelineLayout13,
+  multisample: {count: 4, mask: 0x5cc9e21e},
+  fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rg16float', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule19,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1572,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'snorm16x4', offset: 384, shaderLocation: 25},
+          {format: 'float32x3', offset: 40, shaderLocation: 14},
+          {format: 'sint16x2', offset: 432, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 3212, stepMode: 'instance', attributes: []},
+      {arrayStride: 100, attributes: [{format: 'float32x2', offset: 12, shaderLocation: 5}]},
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front'},
+});
+let commandEncoder82 = device0.createCommandEncoder({label: '\u8a16\u9a0e\u{1fa92}\u{1fd4e}\uf172\u2b30\u{1f904}\u9c87'});
+let textureView101 = texture40.createView({label: '\u0f24\u{1fc73}\u48b9\u2bce\u43db\u074a\u04cf', baseMipLevel: 3, arrayLayerCount: 1});
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: 974.4, g: -26.63, b: 166.9, a: 281.7, });
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(13, 2, 5, 0);
+} catch {}
+try {
+renderBundleEncoder13.draw(23, 165, 98_505_951);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer14, 748);
+} catch {}
+try {
+buffer22.destroy();
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let imageBitmap10 = await createImageBitmap(canvas1);
+let commandEncoder83 = device1.createCommandEncoder({label: '\u0cd1\u02fa'});
+let texture53 = device1.createTexture({
+  label: '\u051a\u7415\u571b\u0408',
+  size: {width: 1200},
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm'],
+});
+let computePassEncoder42 = commandEncoder83.beginComputePass();
+let externalTexture49 = device1.importExternalTexture({
+  label: '\u55c8\u0483\u1a7a\u11fb\u0ff4\ud1ca\u6425\u045d\uc4c6\u0c91',
+  source: videoFrame5,
+  colorSpace: 'srgb',
+});
+let pipeline81 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout14,
+  fragment: {
+  module: shaderModule21,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r8unorm', writeMask: 0}, {format: 'rg8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r32sint', writeMask: 0}, {format: 'rg32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'bgra8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.RED,
+}, {format: 'r32float'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {
+      compare: 'less-equal',
+      failOp: 'increment-clamp',
+      depthFailOp: 'decrement-clamp',
+      passOp: 'increment-clamp',
+    },
+    stencilBack: {compare: 'equal', depthFailOp: 'invert'},
+    stencilReadMask: 4294967295,
+    stencilWriteMask: 3739769828,
+    depthBias: 2054887108,
+    depthBiasSlopeScale: -20.71432566532485,
+  },
+  vertex: {
+    module: shaderModule21,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 10188,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'snorm16x4', offset: 2012, shaderLocation: 22},
+          {format: 'uint16x2', offset: 372, shaderLocation: 15},
+          {format: 'uint32', offset: 104, shaderLocation: 23},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back'},
+});
+let canvas11 = document.createElement('canvas');
+try {
+canvas11.getContext('webgl');
+} catch {}
+let commandEncoder84 = device1.createCommandEncoder();
+let querySet52 = device1.createQuerySet({type: 'occlusion', count: 1339});
+let texture54 = device1.createTexture({
+  label: '\u02f6\u3015\u{1fa48}\u0eaf',
+  size: {width: 640, height: 48, depthOrArrayLayers: 194},
+  mipLevelCount: 3,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32float', 'r32float'],
+});
+let textureView102 = texture53.createView({label: '\u{1fdeb}\u100b\u04e8\u0c76\u{1ff66}\ua1ab\u595b'});
+let sampler45 = device1.createSampler({
+  label: '\ubbd7\u{1f62a}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 15.22,
+  lodMaxClamp: 97.57,
+  maxAnisotropy: 16,
+});
+let pipeline82 = await device1.createComputePipelineAsync({
+  label: '\u1bba\uf0fd\u0f9d\u8586\u6d0c\u{1f9e5}\ua56d\u{1fe1e}\u0dc4\u{1fd52}\ueaab',
+  layout: pipelineLayout14,
+  compute: {module: shaderModule21, entryPoint: 'compute0'},
+});
+let pipeline83 = device1.createRenderPipeline({
+  layout: pipelineLayout14,
+  multisample: {count: 4, mask: 0x609053e1},
+  fragment: {
+  module: shaderModule21,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rg8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALPHA}, {format: 'r32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rg32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'dst', dstFactor: 'zero'},
+    alpha: {operation: 'add', srcFactor: 'constant', dstFactor: 'constant'},
+  },
+  writeMask: 0,
+}, {format: 'r32float', writeMask: GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'always', failOp: 'replace', passOp: 'zero'},
+    stencilBack: {compare: 'less', depthFailOp: 'decrement-wrap', passOp: 'decrement-wrap'},
+    stencilReadMask: 337123126,
+    stencilWriteMask: 4119539545,
+    depthBias: 2105594165,
+    depthBiasClamp: 405.4896063242616,
+  },
+  vertex: {
+    module: shaderModule21,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 4076, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint8x4', offset: 124, shaderLocation: 15}],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 2052,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x4', offset: 332, shaderLocation: 22}],
+      },
+      {
+        arrayStride: 2344,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint8x4', offset: 368, shaderLocation: 23}],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'ccw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+let img14 = await imageWithData(39, 162, '#135444c7', '#c7979d9c');
+let imageBitmap11 = await createImageBitmap(offscreenCanvas7);
+let textureView103 = texture49.createView({
+  label: '\u2319\u{1fe22}\u{1ff4c}\u0fad\ud586\ue8fa\u105d\u{1fed4}',
+  dimension: '2d',
+  mipLevelCount: 1,
+  baseArrayLayer: 405,
+});
+try {
+gpuCanvasContext6.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline84 = await device1.createComputePipelineAsync({layout: pipelineLayout14, compute: {module: shaderModule21, entryPoint: 'compute0'}});
+let commandEncoder85 = device1.createCommandEncoder({});
+let textureView104 = texture50.createView({
+  label: '\ub4b6\uc52a\u196b\u95cd\u0c50\ue05f\ud8cf\u3370\u0221\u9d05\u6cbb',
+  format: 'astc-8x8-unorm-srgb',
+  baseMipLevel: 7,
+  mipLevelCount: 1,
+});
+let sampler46 = device1.createSampler({
+  label: '\u40fc\u5bb2\u{1fbe7}\u062c\u2f78\u0b13',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  lodMinClamp: 79.90,
+  lodMaxClamp: 80.78,
+});
+let externalTexture50 = device1.importExternalTexture({label: '\uf022\u021a\u{1fbd9}', source: video1, colorSpace: 'srgb'});
+try {
+computePassEncoder40.setPipeline(pipeline84);
+} catch {}
+try {
+commandEncoder84.resolveQuerySet(querySet51, 1830, 439, buffer24, 115712);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule22 = device1.createShaderModule({
+  code: `@group(5) @binding(999)
+var<storage, read_write> function9: array<u32>;
+@group(2) @binding(999)
+var<storage, read_write> parameter8: array<u32>;
+@group(1) @binding(999)
+var<storage, read_write> parameter9: array<u32>;
+@group(6) @binding(999)
+var<storage, read_write> function10: array<u32>;
+@group(3) @binding(999)
+var<storage, read_write> local12: array<u32>;
+@group(4) @binding(999)
+var<storage, read_write> function11: array<u32>;
+
+@compute @workgroup_size(1, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S20 {
+  @location(2) f0: vec2<i32>,
+  @location(71) f1: vec4<f16>,
+  @location(9) f2: vec4<f32>,
+  @location(115) f3: vec3<u32>,
+  @location(5) f4: vec3<f32>,
+  @location(89) f5: vec2<f32>,
+  @location(95) f6: vec4<f32>,
+  @location(64) f7: vec3<i32>,
+  @location(85) f8: vec3<u32>,
+  @location(66) f9: vec4<u32>,
+  @location(74) f10: u32,
+  @builtin(sample_index) f11: u32,
+  @location(73) f12: vec4<f16>,
+  @location(32) f13: vec4<f16>,
+  @location(27) f14: vec2<i32>,
+  @location(112) f15: i32,
+  @location(55) f16: vec3<u32>,
+  @location(54) f17: i32,
+  @location(7) f18: vec4<i32>,
+  @location(25) f19: u32,
+  @location(14) f20: f32,
+  @location(3) f21: i32,
+  @location(69) f22: vec2<i32>,
+  @location(28) f23: f32,
+  @location(83) f24: vec3<u32>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec3<f32>,
+  @location(2) f1: vec4<f32>,
+  @location(4) f2: vec2<i32>,
+  @location(6) f3: vec4<f32>,
+  @location(1) f4: vec2<f32>,
+  @location(7) f5: vec2<f32>,
+  @location(3) f6: vec3<i32>,
+  @location(5) f7: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @location(56) a1: f32, @location(16) a2: vec3<u32>, a3: S20, @location(99) a4: i32, @location(11) a5: f32, @location(12) a6: vec4<f16>, @builtin(position) a7: vec4<f32>, @builtin(front_facing) a8: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S19 {
+  @location(26) f0: vec4<f16>,
+  @location(13) f1: vec3<i32>,
+  @location(19) f2: vec3<i32>
+}
+struct VertexOutput0 {
+  @location(95) f215: vec4<f32>,
+  @location(64) f216: vec3<i32>,
+  @location(66) f217: vec4<u32>,
+  @location(89) f218: vec2<f32>,
+  @location(9) f219: vec4<f32>,
+  @location(73) f220: vec4<f16>,
+  @location(71) f221: vec4<f16>,
+  @location(7) f222: vec4<i32>,
+  @location(5) f223: vec3<f32>,
+  @location(25) f224: u32,
+  @location(115) f225: vec3<u32>,
+  @location(112) f226: i32,
+  @location(56) f227: f32,
+  @location(69) f228: vec2<i32>,
+  @location(3) f229: i32,
+  @location(32) f230: vec4<f16>,
+  @location(54) f231: i32,
+  @location(27) f232: vec2<i32>,
+  @location(2) f233: vec2<i32>,
+  @location(12) f234: vec4<f16>,
+  @location(99) f235: i32,
+  @location(83) f236: vec3<u32>,
+  @location(74) f237: u32,
+  @builtin(position) f238: vec4<f32>,
+  @location(11) f239: f32,
+  @location(55) f240: vec3<u32>,
+  @location(14) f241: f32,
+  @location(85) f242: vec3<u32>,
+  @location(28) f243: f32,
+  @location(16) f244: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec4<f32>, @location(22) a1: vec4<f32>, @location(3) a2: vec4<f16>, @location(1) a3: vec3<u32>, @builtin(instance_index) a4: u32, @location(12) a5: vec4<i32>, @location(5) a6: vec3<u32>, @location(20) a7: vec4<f16>, @location(18) a8: u32, @location(23) a9: vec2<u32>, @location(4) a10: vec4<i32>, @location(10) a11: vec2<f32>, a12: S19, @location(24) a13: vec2<i32>, @location(15) a14: vec2<f32>, @location(21) a15: i32, @builtin(vertex_index) a16: u32, @location(16) a17: vec3<i32>, @location(17) a18: u32, @location(6) a19: f16, @location(9) a20: vec3<f16>, @location(14) a21: vec3<u32>, @location(25) a22: vec4<i32>, @location(8) a23: f32, @location(2) a24: vec3<f32>, @location(0) a25: u32, @location(7) a26: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandBuffer23 = commandEncoder84.finish({});
+let textureView105 = texture48.createView({label: '\u{1ff7d}\u8c9a'});
+let renderBundleEncoder39 = device1.createRenderBundleEncoder({
+  label: '\u{1fb23}\u040d\u48fd\ue389\u{1f92c}\u0f1d\u{1fa21}',
+  colorFormats: ['r8unorm', 'rg8unorm', 'bgra8unorm-srgb', 'r32sint', 'rg32sint', 'bgra8unorm', 'rgba8unorm', 'r32float'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 320, height: 24, depthOrArrayLayers: 97}
+*/
+{
+  source: videoFrame15,
+  origin: { x: 21, y: 15 },
+  flipY: false,
+}, {
+  texture: texture54,
+  mipLevel: 1,
+  origin: {x: 89, y: 5, z: 23},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 41, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise28;
+} catch {}
+let textureView106 = texture52.createView({label: '\u1fd1\u7911\u0a5f\u{1ff59}\u06e4\u2348\u41b8\u{1ffc4}', baseMipLevel: 1, mipLevelCount: 1});
+let renderBundle47 = renderBundleEncoder38.finish({label: '\u7f5b\u0a77\u68ab\u5ced\u0f84\u9e80\u1360'});
+let sampler47 = device1.createSampler({
+  label: '\uab58\u9bdf\u5fa5',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 40.04,
+  lodMaxClamp: 55.23,
+  maxAnisotropy: 1,
+});
+let externalTexture51 = device1.importExternalTexture({source: videoFrame15, colorSpace: 'display-p3'});
+let canvas12 = document.createElement('canvas');
+let textureView107 = texture53.createView({arrayLayerCount: 1});
+document.body.prepend(canvas4);
+try {
+device1.destroy();
+} catch {}
+let imageBitmap12 = await createImageBitmap(imageBitmap10);
+try {
+canvas12.getContext('webgl2');
+} catch {}
+gc();
+let video24 = await videoWithData();
+let offscreenCanvas15 = new OffscreenCanvas(158, 1005);
+try {
+adapter1.label = '\u36e0\u0031\u0619\u0843\u4880\u{1ff46}\ub738\uc5b0';
+} catch {}
+try {
+  await adapter3.requestAdapterInfo();
+} catch {}
+let img15 = await imageWithData(203, 105, '#03d2d7b7', '#faaa2a8a');
+let video25 = await videoWithData();
+document.body.prepend(img2);
+offscreenCanvas2.width = 485;
+let shaderModule23 = device0.createShaderModule({
+  label: '\u06c5\u0e2e\u0485\uc8e2\u0426',
+  code: `@group(0) @binding(2330)
+var<storage, read_write> global10: array<u32>;
+
+@compute @workgroup_size(4, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S22 {
+  @location(30) f0: vec2<f16>,
+  @location(17) f1: i32,
+  @location(20) f2: vec2<i32>,
+  @location(36) f3: u32,
+  @location(0) f4: vec4<f32>,
+  @location(19) f5: vec2<f16>,
+  @builtin(sample_mask) f6: u32,
+  @location(2) f7: vec2<f32>,
+  @location(9) f8: u32,
+  @location(6) f9: u32,
+  @location(16) f10: f32
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<i32>,
+  @location(6) f1: i32,
+  @location(3) f2: vec2<i32>,
+  @location(4) f3: vec4<f32>,
+  @location(0) f4: vec4<f32>,
+  @location(2) f5: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(27) a0: vec2<f16>, @location(22) a1: vec3<f32>, @location(31) a2: i32, @location(26) a3: vec4<u32>, @location(3) a4: vec3<i32>, @location(29) a5: vec3<f16>, @builtin(sample_index) a6: u32, @location(35) a7: vec4<u32>, @builtin(front_facing) a8: bool, @location(23) a9: f32, @location(15) a10: vec3<u32>, @location(39) a11: vec3<u32>, @builtin(position) a12: vec4<f32>, @location(34) a13: f32, @location(8) a14: i32, @location(11) a15: vec4<i32>, a16: S22) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S21 {
+  @location(19) f0: vec2<f32>,
+  @location(0) f1: vec3<u32>,
+  @location(24) f2: vec3<i32>,
+  @location(1) f3: vec2<i32>,
+  @location(7) f4: vec3<u32>,
+  @location(3) f5: vec2<u32>,
+  @location(6) f6: vec4<i32>,
+  @location(20) f7: vec3<u32>,
+  @location(16) f8: vec2<f32>,
+  @location(2) f9: vec2<f32>
+}
+struct VertexOutput0 {
+  @location(21) f245: vec2<i32>,
+  @location(17) f246: i32,
+  @location(15) f247: vec3<u32>,
+  @location(10) f248: vec4<f16>,
+  @location(9) f249: u32,
+  @location(11) f250: vec4<i32>,
+  @location(26) f251: vec4<u32>,
+  @location(39) f252: vec3<u32>,
+  @location(37) f253: vec3<u32>,
+  @location(27) f254: vec2<f16>,
+  @location(22) f255: vec3<f32>,
+  @location(0) f256: vec4<f32>,
+  @location(16) f257: f32,
+  @location(31) f258: i32,
+  @location(29) f259: vec3<f16>,
+  @location(30) f260: vec2<f16>,
+  @location(20) f261: vec2<i32>,
+  @location(19) f262: vec2<f16>,
+  @location(3) f263: vec3<i32>,
+  @location(2) f264: vec2<f32>,
+  @location(35) f265: vec4<u32>,
+  @location(1) f266: vec3<u32>,
+  @location(34) f267: f32,
+  @location(8) f268: i32,
+  @location(23) f269: f32,
+  @location(7) f270: vec2<i32>,
+  @location(36) f271: u32,
+  @builtin(position) f272: vec4<f32>,
+  @location(6) f273: u32
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec4<f32>, @location(12) a1: vec4<u32>, @builtin(instance_index) a2: u32, @builtin(vertex_index) a3: u32, @location(25) a4: vec3<f16>, @location(8) a5: f16, @location(27) a6: vec3<i32>, @location(22) a7: vec4<u32>, a8: S21, @location(14) a9: vec4<i32>, @location(26) a10: vec4<i32>, @location(18) a11: f32, @location(17) a12: f16, @location(11) a13: vec4<u32>, @location(15) a14: vec2<f16>, @location(9) a15: vec2<u32>, @location(4) a16: vec2<i32>, @location(10) a17: vec2<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let commandEncoder86 = device0.createCommandEncoder({label: '\u0d12\ue4ed\u{1fd13}\u8736\u080b\uc359\u03a7\u077f\u06ad\ua2fe'});
+let querySet53 = device0.createQuerySet({label: '\u0dd6\u9cef', type: 'occlusion', count: 2543});
+let textureView108 = texture31.createView({label: '\u047b\u{1f766}\udfe4\ubd8f\u065e\u05da\u{1fa45}\u0474\uacdc', mipLevelCount: 3});
+let renderBundle48 = renderBundleEncoder1.finish({});
+try {
+renderPassEncoder12.setScissorRect(16, 0, 14, 2);
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(77);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer12, 175_606_943);
+} catch {}
+try {
+renderPassEncoder10.drawIndirect(buffer20, 549_660_507);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer19, 'uint16');
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(1, bindGroup7, new Uint32Array(8390), 7740, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 415, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 322 */
+{offset: 322, bytesPerRow: 4074}, {width: 1007, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 658, height: 20, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData15,
+  origin: { x: 0, y: 20 },
+  flipY: false,
+}, {
+  texture: texture42,
+  mipLevel: 1,
+  origin: {x: 194, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 67, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let pipeline85 = device0.createComputePipeline({
+  label: '\u0069\u{1fecb}\u{1f62f}',
+  layout: pipelineLayout11,
+  compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let canvas13 = document.createElement('canvas');
+let imageData17 = new ImageData(100, 132);
+let gpuCanvasContext13 = offscreenCanvas15.getContext('webgpu');
+let pipelineLayout15 = device1.createPipelineLayout({
+  label: '\u7d47\u05b3\u{1ff54}\ubd9c\u{1fe7e}\u{1fc9e}\u06a5\ub6e2',
+  bindGroupLayouts: [bindGroupLayout29, bindGroupLayout29, bindGroupLayout29, bindGroupLayout29, bindGroupLayout29, bindGroupLayout29],
+});
+let renderBundleEncoder40 = device1.createRenderBundleEncoder({
+  label: '\uee6f\u019d\u{1ff4f}\u{1f6dd}\u02e9',
+  colorFormats: ['r8unorm', 'rg8unorm', 'bgra8unorm-srgb', 'r32sint', 'rg32sint', 'bgra8unorm', 'rgba8unorm', 'r32float'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle49 = renderBundleEncoder37.finish();
+let sampler48 = device1.createSampler({
+  label: '\u{1fe62}\u8242',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 95.00,
+  lodMaxClamp: 96.61,
+  compare: 'greater-equal',
+});
+try {
+buffer25.unmap();
+} catch {}
+let canvas14 = document.createElement('canvas');
+try {
+canvas13.getContext('bitmaprenderer');
+} catch {}
+canvas12.width = 18;
+let gpuCanvasContext14 = canvas14.getContext('webgpu');
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+try {
+sampler48.label = '\u352d\uf955\u0728\ua88d\uf3f6';
+} catch {}
+let adapter6 = await navigator.gpu.requestAdapter({});
+offscreenCanvas13.height = 2200;
+let imageData18 = new ImageData(212, 236);
+let video26 = await videoWithData();
+document.body.prepend(video9);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let img16 = await imageWithData(44, 228, '#42108940', '#7199140c');
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+let promise29 = adapter2.requestAdapterInfo();
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let offscreenCanvas16 = new OffscreenCanvas(960, 707);
+let commandEncoder87 = device0.createCommandEncoder({label: '\uc074\ub80b\u05d5\u0d1e\u0420\u{1f8d6}'});
+let texture55 = device0.createTexture({
+  size: [480],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView109 = texture11.createView({label: '\u41c8\u0f94\u0c9f\u{1fc79}\u08b5\u1fdb\u8dd3', baseMipLevel: 0});
+let sampler49 = device0.createSampler({
+  label: '\u7671\u{1fcde}\u4391\u00ee\u261c\ua5cb',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 86.86,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder29.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline27);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer8, 326_529_235);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer3, 173212);
+} catch {}
+try {
+commandEncoder66.resolveQuerySet(querySet32, 66, 104, buffer19, 3072);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 1916, new Float32Array(18424), 2993, 160);
+} catch {}
+let promise30 = device0.createRenderPipelineAsync({
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, undefined, {format: 'rgb10a2uint'}, {format: 'r32float', writeMask: 0}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r8uint', writeMask: 0}, {format: 'r16sint'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'less-equal', failOp: 'invert', depthFailOp: 'increment-wrap', passOp: 'invert'},
+    stencilBack: {compare: 'greater', failOp: 'replace', depthFailOp: 'increment-clamp', passOp: 'increment-wrap'},
+    stencilReadMask: 2813226191,
+    stencilWriteMask: 19946515,
+    depthBiasSlopeScale: 281.5830016901024,
+  },
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 460, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 3044,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x3', offset: 448, shaderLocation: 12},
+          {format: 'sint32x4', offset: 152, shaderLocation: 9},
+          {format: 'snorm8x4', offset: 248, shaderLocation: 26},
+        ],
+      },
+      {
+        arrayStride: 112,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 0, shaderLocation: 14},
+          {format: 'sint16x4', offset: 32, shaderLocation: 27},
+          {format: 'snorm16x2', offset: 28, shaderLocation: 21},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front'},
+});
+canvas3.height = 290;
+let img17 = await imageWithData(280, 47, '#1f15e718', '#bfff09ee');
+try {
+  await promise29;
+} catch {}
+let offscreenCanvas17 = new OffscreenCanvas(612, 325);
+let img18 = await imageWithData(124, 16, '#a365b637', '#be6ad17e');
+let gpuCanvasContext15 = offscreenCanvas17.getContext('webgpu');
+let promise31 = adapter4.requestAdapterInfo();
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+try {
+  await promise31;
+} catch {}
+let texture56 = device0.createTexture({
+  label: '\u7d87\u7f42\u7db4\u{1f865}\u4de3\uf945\u21c1\u{1fcb5}',
+  size: {width: 658},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder43 = commandEncoder68.beginComputePass({});
+let renderBundleEncoder41 = device0.createRenderBundleEncoder({
+  label: '\u{1f98a}\u08f2\u{1ff5f}\u38f3\u0e98\ub92d',
+  colorFormats: ['bgra8unorm', 'rgba8unorm-srgb', 'rg8uint', 'rgba16float', 'bgra8unorm'],
+});
+try {
+computePassEncoder28.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(4);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer13, 609_864_420);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline49);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(3, buffer0, 0);
+} catch {}
+try {
+commandEncoder59.resolveQuerySet(querySet7, 248, 656, buffer19, 16128);
+} catch {}
+let pipeline86 = device0.createRenderPipeline({
+  label: '\u02ad\u0d92\u241f\u{1f9fd}\u0f43\u0a6d\u02c1\u223f\u70a7\u348c\u{1fb3a}',
+  layout: pipelineLayout13,
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 72,
+        attributes: [
+          {format: 'unorm16x4', offset: 0, shaderLocation: 12},
+          {format: 'uint8x2', offset: 16, shaderLocation: 15},
+          {format: 'uint8x2', offset: 2, shaderLocation: 1},
+          {format: 'sint8x2', offset: 2, shaderLocation: 3},
+          {format: 'snorm16x2', offset: 0, shaderLocation: 14},
+          {format: 'unorm10-10-10-2', offset: 28, shaderLocation: 6},
+          {format: 'unorm16x2', offset: 16, shaderLocation: 7},
+          {format: 'float16x2', offset: 0, shaderLocation: 25},
+          {format: 'uint8x4', offset: 12, shaderLocation: 17},
+          {format: 'float32x2', offset: 4, shaderLocation: 2},
+          {format: 'uint16x4', offset: 8, shaderLocation: 11},
+          {format: 'sint32x2', offset: 20, shaderLocation: 24},
+          {format: 'snorm16x4', offset: 4, shaderLocation: 5},
+          {format: 'float32x2', offset: 20, shaderLocation: 27},
+          {format: 'uint16x2', offset: 0, shaderLocation: 13},
+          {format: 'uint16x4', offset: 4, shaderLocation: 9},
+          {format: 'float32x4', offset: 12, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 48,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 16, shaderLocation: 19},
+          {format: 'uint8x2', offset: 8, shaderLocation: 23},
+        ],
+      },
+      {
+        arrayStride: 532,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 8, shaderLocation: 4},
+          {format: 'uint32x2', offset: 20, shaderLocation: 26},
+          {format: 'sint8x2', offset: 110, shaderLocation: 0},
+          {format: 'float16x2', offset: 8, shaderLocation: 16},
+          {format: 'unorm8x4', offset: 8, shaderLocation: 18},
+          {format: 'uint16x2', offset: 52, shaderLocation: 20},
+        ],
+      },
+      {arrayStride: 1992, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 3524,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float16x4', offset: 164, shaderLocation: 8},
+          {format: 'unorm8x2', offset: 634, shaderLocation: 21},
+        ],
+      },
+      {arrayStride: 7360, stepMode: 'instance', attributes: []},
+      {arrayStride: 1312, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 444,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x2', offset: 44, shaderLocation: 22}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'back'},
+});
+let gpuCanvasContext16 = offscreenCanvas16.getContext('webgpu');
+gc();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let img19 = await imageWithData(290, 271, '#09fa3b70', '#a1853ab5');
+video10.height = 174;
+document.body.prepend(canvas7);
+let imageData19 = new ImageData(148, 104);
+let videoFrame18 = new VideoFrame(video2, {timestamp: 0});
+video8.height = 81;
+let offscreenCanvas18 = new OffscreenCanvas(929, 881);
+let gpuCanvasContext17 = offscreenCanvas18.getContext('webgpu');
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+let commandEncoder88 = device0.createCommandEncoder({label: '\u04c1\uea9b\u{1f620}\u{1fbb0}'});
+let querySet54 = device0.createQuerySet({label: '\u7b80\u06dc\uf972\ub46f', type: 'occlusion', count: 836});
+let texture57 = device0.createTexture({
+  label: '\u{1fe93}\ucbbf\u78ee\u4393\u0d6e\u9011\uf69d\u{1ffed}\u96d7\uc1b3',
+  size: [240],
+  dimension: '1d',
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg8uint', 'rg8uint'],
+});
+let sampler50 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 97.00,
+  lodMaxClamp: 98.99,
+  maxAnisotropy: 19,
+});
+let externalTexture52 = device0.importExternalTexture({
+  label: '\ueee0\u8893\u{1f6f8}\u04d8\u3b75\u4369\u8f64\u{1ff0f}\u1289\uf98d\u083e',
+  source: video9,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle7, renderBundle33, renderBundle11, renderBundle37, renderBundle37, renderBundle33, renderBundle42, renderBundle39, renderBundle40]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 173.3, g: 617.0, b: 5.078, a: -106.2, });
+} catch {}
+try {
+renderPassEncoder10.draw(71, 51, 1_312_857_381, 73_208_018);
+} catch {}
+try {
+renderBundleEncoder29.setBindGroup(3, bindGroup7, new Uint32Array(8467), 6964, 0);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexedIndirect(buffer23, 3084);
+} catch {}
+try {
+commandEncoder86.copyBufferToTexture({
+  /* bytesInLastRow: 140 widthInBlocks: 35 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 25824 */
+  offset: 25824,
+  bytesPerRow: 256,
+  buffer: buffer23,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 60, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 35, height: 18, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer23);
+} catch {}
+try {
+commandEncoder70.resolveQuerySet(querySet8, 784, 39, buffer26, 58624);
+} catch {}
+let imageBitmap13 = await createImageBitmap(imageBitmap11);
+offscreenCanvas4.height = 608;
+document.body.prepend(video3);
+let videoFrame19 = new VideoFrame(offscreenCanvas13, {timestamp: 0});
+let video27 = await videoWithData();
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let canvas15 = document.createElement('canvas');
+let canvas16 = document.createElement('canvas');
+let canvas17 = document.createElement('canvas');
+let gpuCanvasContext18 = canvas15.getContext('webgpu');
+offscreenCanvas6.width = 425;
+let img20 = await imageWithData(126, 232, '#a4486e9f', '#1e6fe77b');
+try {
+canvas16.getContext('webgl2');
+} catch {}
+let gpuCanvasContext19 = canvas17.getContext('webgpu');
+let offscreenCanvas19 = new OffscreenCanvas(220, 207);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let video28 = await videoWithData();
+try {
+gpuCanvasContext12.unconfigure();
+} catch {}
+let videoFrame20 = new VideoFrame(offscreenCanvas14, {timestamp: 0});
+let img21 = await imageWithData(18, 154, '#1d912414', '#0aaf230a');
+try {
+offscreenCanvas19.getContext('webgpu');
+} catch {}
+let canvas18 = document.createElement('canvas');
+try {
+externalTexture21.label = '\u1c51\u0193\u042f\ue696\u0452';
+} catch {}
+let offscreenCanvas20 = new OffscreenCanvas(56, 888);
+let offscreenCanvas21 = new OffscreenCanvas(717, 250);
+try {
+window.someLabel = externalTexture20.label;
+} catch {}
+let offscreenCanvas22 = new OffscreenCanvas(764, 695);
+let videoFrame21 = new VideoFrame(videoFrame20, {timestamp: 0});
+let img22 = await imageWithData(81, 161, '#50da7402', '#4a22bb10');
+let gpuCanvasContext20 = offscreenCanvas20.getContext('webgpu');
+let gpuCanvasContext21 = canvas18.getContext('webgpu');
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+let imageBitmap14 = await createImageBitmap(offscreenCanvas12);
+try {
+offscreenCanvas21.getContext('webgpu');
+} catch {}
+let imageData20 = new ImageData(4, 24);
+try {
+offscreenCanvas22.getContext('webgl');
+} catch {}
+document.body.prepend(canvas17);
+try {
+  await adapter5.requestAdapterInfo();
+} catch {}
+gc();
+document.body.prepend(video23);
+let imageData21 = new ImageData(80, 120);
+let videoFrame22 = new VideoFrame(video22, {timestamp: 0});
+let imageData22 = new ImageData(12, 156);
+document.body.prepend(img9);
+let img23 = await imageWithData(46, 60, '#cb62bcaf', '#71e5d9c4');
+let querySet55 = device0.createQuerySet({label: '\u06eb\ucccd\u8b6a', type: 'occlusion', count: 2409});
+let renderBundle50 = renderBundleEncoder23.finish({});
+let externalTexture53 = device0.importExternalTexture({source: video11, colorSpace: 'display-p3'});
+try {
+computePassEncoder36.setPipeline(pipeline77);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(1, buffer19, 46308, 3219);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(129, 23, 37_117_807, -1_869_493_863, 1_559_027_228);
+} catch {}
+let promise32 = buffer12.mapAsync(GPUMapMode.WRITE, 78720);
+try {
+commandEncoder59.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 25864 */
+  offset: 25856,
+  buffer: buffer23,
+}, {
+  texture: texture19,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer23);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer15, 4812, new DataView(new ArrayBuffer(33460)), 16421, 932);
+} catch {}
+let imageBitmap15 = await createImageBitmap(offscreenCanvas5);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let promise33 = adapter5.requestAdapterInfo();
+try {
+adapter3.label = '\u{1fc73}\u04e3';
+} catch {}
+gc();
+let img24 = await imageWithData(160, 147, '#53179bf1', '#c4c6bc35');
+let video29 = await videoWithData();
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+try {
+  await promise33;
+} catch {}
+let videoFrame23 = new VideoFrame(video12, {timestamp: 0});
+let imageBitmap16 = await createImageBitmap(video17);
+gc();
+video20.height = 26;
+let img25 = await imageWithData(96, 243, '#11bde8c2', '#fcc8d2c6');
+try {
+  await promise32;
+} catch {}
+let imageBitmap17 = await createImageBitmap(imageData17);
+document.body.prepend(video29);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let bindGroupLayout30 = device1.createBindGroupLayout({
+  label: '\u{1fb04}\u1a63\u{1fd4d}\u0420\u2c55\u56cd\u2370\u03cf\u96bf',
+  entries: [{binding: 4495, visibility: 0, sampler: { type: 'filtering' }}],
+});
+let commandEncoder89 = device1.createCommandEncoder({label: '\uc702\u6dd9\u{1ff14}\u3752\u0d22\u{1ffcc}\u{1fd8a}\ue5c9\u03b5\uec61'});
+let texture58 = device1.createTexture({
+  label: '\u0587\u{1fd2f}\u{1ff45}\uc407\u6538\u{1f940}',
+  size: [2560, 192, 1],
+  mipLevelCount: 3,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8unorm', 'rg8unorm'],
+});
+let textureView110 = texture53.createView({label: '\ud3a8\u4dc8\u0a17\u592b\u7dd9\u01fc', format: 'bgra8unorm-srgb'});
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+canvas14.height = 194;
+let offscreenCanvas23 = new OffscreenCanvas(120, 269);
+let video30 = await videoWithData();
+let canvas19 = document.createElement('canvas');
+let commandEncoder90 = device1.createCommandEncoder({label: '\u0f5b\u{1fab5}\u769b\uf721\u08e7'});
+let querySet56 = device1.createQuerySet({label: '\u{1fc92}\u4657\u3059\uf94f\u{1fc2a}', type: 'occlusion', count: 2586});
+let computePassEncoder44 = commandEncoder89.beginComputePass({label: '\u036b\u0300\uc0b9\ueebd\u0c9f\u6893\ua9f8\u{1f959}\u0d68\u0e2f\uece1'});
+let renderBundleEncoder42 = device1.createRenderBundleEncoder({
+  label: '\u{1fb1e}\u99f6\ua63c\u05e9\ufe4a\u{1fa9d}\ua380\u5b97\u6228\u9d4b',
+  colorFormats: ['r8unorm', 'rg8unorm', 'bgra8unorm-srgb', 'r32sint', 'rg32sint', 'bgra8unorm', 'rgba8unorm', 'r32float'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler51 = device1.createSampler({
+  label: '\ua66d\uc4a3\u726f',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 87.40,
+  lodMaxClamp: 88.70,
+});
+try {
+commandEncoder85.copyTextureToTexture({
+  texture: texture49,
+  mipLevel: 3,
+  origin: {x: 6, y: 0, z: 12},
+  aspect: 'all',
+},
+{
+  texture: texture49,
+  mipLevel: 6,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 19, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 6, height: 1, depthOrArrayLayers: 9}
+*/
+{
+  source: video18,
+  origin: { x: 0, y: 5 },
+  flipY: true,
+}, {
+  texture: texture52,
+  mipLevel: 4,
+  origin: {x: 2, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap18 = await createImageBitmap(imageData11);
+gc();
+try {
+externalTexture30.label = '\u8f31\u{1f737}\u702c\uf17c\u0287\u4f9c\u0ccc\u02ce\u98ca\u9d7e';
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+gc();
+let videoFrame24 = new VideoFrame(imageBitmap2, {timestamp: 0});
+let video31 = await videoWithData();
+let imageBitmap19 = await createImageBitmap(imageBitmap1);
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let img26 = await imageWithData(284, 78, '#cee8f5e6', '#fc04a21f');
+let imageData23 = new ImageData(84, 140);
+try {
+adapter0.label = '\u07b5\u07b7\u{1fe3e}\u0574\ud74e\u{1fe79}\u0571\u0dc3\uf5b9\u{1ff5d}\u6966';
+} catch {}
+try {
+canvas19.getContext('webgpu');
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let videoFrame25 = new VideoFrame(offscreenCanvas8, {timestamp: 0});
+let promise34 = adapter3.requestAdapterInfo();
+let commandEncoder91 = device1.createCommandEncoder({});
+let textureView111 = texture53.createView({label: '\ua77d\u8351\u88bf\u0292\u0617\u0cba\u{1f8d7}\u8916'});
+try {
+renderBundleEncoder39.setVertexBuffer(9144, undefined, 2845020397, 1107171879);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 160, height: 12, depthOrArrayLayers: 48}
+*/
+{
+  source: img14,
+  origin: { x: 1, y: 12 },
+  flipY: false,
+}, {
+  texture: texture54,
+  mipLevel: 2,
+  origin: {x: 9, y: 2, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 34, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline87 = await device1.createComputePipelineAsync({
+  label: '\u{1f984}\u{1f645}\ub5d7\ucecf\ud1dd\u{1ff8c}\u{1f97c}\u{1fdc9}',
+  layout: 'auto',
+  compute: {module: shaderModule22, entryPoint: 'compute0', constants: {}},
+});
+let bindGroupLayout31 = device0.createBindGroupLayout({
+  label: '\uad19\u7ac6\u{1f779}\u0b76\u0ce9',
+  entries: [
+    {
+      binding: 557,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {binding: 2460, visibility: 0, externalTexture: {}},
+    {
+      binding: 4497,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+  ],
+});
+let bindGroup22 = device0.createBindGroup({layout: bindGroupLayout0, entries: []});
+let buffer27 = device0.createBuffer({
+  label: '\u216c\ub05e\u{1fff2}\u8869\ueffe\u0a11\u{1f6e6}',
+  size: 132465,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let renderBundleEncoder43 = device0.createRenderBundleEncoder({
+  label: '\u{1fc2e}\u4d5e\u07d1\u{1fc8c}\u6ac3\u{1fb48}\u{1fccb}\u2fc5\u0bb3\u0f3c',
+  colorFormats: ['bgra8unorm', 'r8sint', 'rgb10a2uint', 'r16sint', 'bgra8unorm-srgb'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler52 = device0.createSampler({
+  label: '\u0a75\u9a7a\u{1fae7}\u6434\u9539\uca71\u0708\u093b',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 54.49,
+  lodMaxClamp: 58.35,
+  compare: 'never',
+  maxAnisotropy: 16,
+});
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(21, 0, 5, 1);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer13, 363_695_294);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer23, 1116);
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(8, buffer16);
+} catch {}
+try {
+commandEncoder73.clearBuffer(buffer8, 108284, 152);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 2,
+  origin: {x: 9, y: 0, z: 22},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer10), /* required buffer size: 3_183_113 */
+{offset: 355, bytesPerRow: 485, rowsPerImage: 243}, {width: 47, height: 2, depthOrArrayLayers: 28});
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let videoFrame26 = new VideoFrame(img17, {timestamp: 0});
+let img27 = await imageWithData(51, 138, '#346954ed', '#eed8944c');
+try {
+offscreenCanvas23.getContext('webgl2');
+} catch {}
+gc();
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let renderBundleEncoder44 = device0.createRenderBundleEncoder({label: '\u0db3\u7c1c\u2c64\u07d4\u5abc', colorFormats: ['rg16uint'], depthReadOnly: true});
+let renderBundle51 = renderBundleEncoder43.finish({label: '\uc6a6\u1f72\u0dcc\u9034\u0ee7\u8e3b\u4407\u1d91'});
+let sampler53 = device0.createSampler({
+  label: '\ueb09\uc0ae\uf545\u3f59\u13d2\u53b0\ua7ac\u{1f708}\u{1f932}\u13c1',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 88.10,
+  lodMaxClamp: 88.86,
+});
+try {
+renderPassEncoder9.beginOcclusionQuery(1784);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle15, renderBundle50, renderBundle8, renderBundle30, renderBundle33, renderBundle30]);
+} catch {}
+try {
+renderPassEncoder11.setStencilReference(859);
+} catch {}
+try {
+renderPassEncoder8.setViewport(11.67, 0.6843, 9.136, 1.162, 0.2520, 0.3536);
+} catch {}
+try {
+renderPassEncoder10.drawIndexed(151, 453, 2_084_706_353, 447_064_236, 1_137_404_604);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(6, bindGroup19);
+} catch {}
+try {
+renderBundleEncoder13.draw(81, 57, 234_728_211, 1_236_105_435);
+} catch {}
+try {
+renderBundleEncoder13.drawIndirect(buffer19, 4308);
+} catch {}
+try {
+commandEncoder49.copyTextureToTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 0, y: 7, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 0, y: 5, z: 0},
+  aspect: 'all',
+},
+{width: 480, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder73.resolveQuerySet(querySet55, 2314, 84, buffer26, 5120);
+} catch {}
+try {
+gpuCanvasContext19.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer10, /* required buffer size: 365_377 */
+{offset: 865, bytesPerRow: 722, rowsPerImage: 83}, {width: 39, height: 7, depthOrArrayLayers: 7});
+} catch {}
+document.body.prepend(video8);
+let imageData24 = new ImageData(236, 4);
+let canvas20 = document.createElement('canvas');
+let offscreenCanvas24 = new OffscreenCanvas(847, 744);
+let imageData25 = new ImageData(96, 204);
+try {
+canvas20.getContext('2d');
+} catch {}
+let device2 = await adapter4.requestDevice({
+  defaultQueue: {label: '\u5413\u0c73\u{1fd7c}\u6142\u7e30\u5a90\u3338\u{1faf7}\u0e00\uad38'},
+  requiredLimits: {
+    maxBindGroups: 6,
+    maxColorAttachmentBytesPerSample: 53,
+    maxVertexAttributes: 18,
+    maxVertexBufferArrayStride: 41723,
+    maxStorageTexturesPerShaderStage: 33,
+    maxStorageBuffersPerShaderStage: 8,
+    maxDynamicStorageBuffersPerPipelineLayout: 13193,
+    maxDynamicUniformBuffersPerPipelineLayout: 31360,
+    maxBindingsPerBindGroup: 6340,
+    maxTextureArrayLayers: 1407,
+    maxTextureDimension1D: 16151,
+    maxTextureDimension2D: 14806,
+    maxVertexBuffers: 9,
+    maxBindGroupsPlusVertexBuffers: 29,
+    minStorageBufferOffsetAlignment: 128,
+    minUniformBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 202967607,
+    maxStorageBufferBindingSize: 265245301,
+    maxUniformBuffersPerShaderStage: 34,
+    maxSampledTexturesPerShaderStage: 24,
+    maxInterStageShaderComponents: 116,
+    maxSamplersPerShaderStage: 18,
+  },
+});
+let commandEncoder92 = device2.createCommandEncoder({label: '\u2621\u2156\u04b4\u6913\u440f\u0edb\ud5e8\u019b\u091e'});
+let texture59 = device2.createTexture({size: [1476, 1, 1], mipLevelCount: 10, format: 'r8uint', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let computePassEncoder45 = commandEncoder92.beginComputePass({label: '\u{1f812}\uc0f6\u5e15\uad2c\ue63a\ueda9\u22b5\u{1fc2a}'});
+let renderBundleEncoder45 = device2.createRenderBundleEncoder({
+  label: '\u5b77\ue037',
+  colorFormats: ['rgba16float', 'rgba32float', 'rgba8unorm', 'rg32sint', 'rg8unorm'],
+  depthReadOnly: true,
+});
+try {
+gpuCanvasContext18.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+  await promise34;
+} catch {}
+let video32 = await videoWithData();
+let buffer28 = device2.createBuffer({size: 120300, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE, mappedAtCreation: true});
+let texture60 = device2.createTexture({
+  label: '\u0ddc\u623a\uea0f\u{1f87c}\u{1f910}\ub987\u{1fcff}\u095d\uc46a\u0f10\uf52a',
+  size: [1256],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32sint', 'rg32sint'],
+});
+let textureView112 = texture60.createView({
+  label: '\u9aaa\u{1ffb7}\u3065\u{1fb5e}\u{1fc2a}\uac03\uac86\u05c0\u9899\u{1f759}\u{1fef0}',
+  arrayLayerCount: 1,
+});
+try {
+renderBundleEncoder45.setVertexBuffer(9496, undefined, 1592812487);
+} catch {}
+try {
+offscreenCanvas24.getContext('webgl');
+} catch {}
+let textureView113 = texture60.createView({format: 'rg32sint', baseMipLevel: 0});
+try {
+computePassEncoder45.end();
+} catch {}
+let videoFrame27 = new VideoFrame(videoFrame21, {timestamp: 0});
+let commandEncoder93 = device2.createCommandEncoder({label: '\u470e\ue998\u{1fa46}'});
+let texture61 = device2.createTexture({
+  size: [2512],
+  dimension: '1d',
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32uint'],
+});
+let textureView114 = texture61.createView({label: '\u8c22\u0062\ucba4\ube5f\ub26a\u0190\u5c40\u0bb1\u22a7'});
+let sampler54 = device2.createSampler({
+  label: '\u04c3\ud491\u6331',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 74.88,
+  lodMaxClamp: 83.54,
+});
+gc();
+let textureView115 = texture59.createView({label: '\u17c5\u0175\u77b8', baseMipLevel: 1});
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let bindGroupLayout32 = device2.createBindGroupLayout({
+  label: '\u0ccf\uf2d5\u0c4f\udef6',
+  entries: [
+    {
+      binding: 6124,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 2213,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 2086,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+let pipelineLayout16 = device2.createPipelineLayout({
+  label: '\ub291\u070f\u{1fffa}\u0966\u2970\u0663',
+  bindGroupLayouts: [bindGroupLayout32, bindGroupLayout32],
+});
+let commandEncoder94 = device2.createCommandEncoder({label: '\uc094\uae5c'});
+let texture62 = device2.createTexture({
+  label: '\u3197\u87ae\uf5f0\u5811\u{1fd1c}\u6fc0\u6090',
+  size: {width: 1260, height: 1, depthOrArrayLayers: 1820},
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg32sint'],
+});
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let img28 = await imageWithData(126, 7, '#81903bb1', '#7162cabe');
+let querySet57 = device2.createQuerySet({label: '\u0970\u{1f7b9}\u{1f940}\u0c30\u5327\u081a\udd37', type: 'occlusion', count: 390});
+let texture63 = device2.createTexture({
+  label: '\uf4d7\u4f56\uda43',
+  size: [369, 1, 230],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder46 = device2.createRenderBundleEncoder({
+  label: '\u2b5b\u{1f83c}\u0351\u3c38\u027f\u0590\u{1f81d}\u66ce\u{1f8f0}\u9a21\u075f',
+  colorFormats: ['rgba16float', 'rgba32float', 'rgba8unorm', 'rg32sint', 'rg8unorm'],
+  depthReadOnly: true,
+});
+try {
+commandEncoder92.copyTextureToTexture({
+  texture: texture62,
+  mipLevel: 5,
+  origin: {x: 9, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture62,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 1, depthOrArrayLayers: 8});
+} catch {}
+let canvas21 = document.createElement('canvas');
+let videoFrame28 = new VideoFrame(videoFrame7, {timestamp: 0});
+try {
+canvas21.getContext('bitmaprenderer');
+} catch {}
+let texture64 = device2.createTexture({
+  label: '\u9a99\u{1f9a3}\u0b43\u03b0\ufaa7\u5f82\u786e',
+  size: [1256, 1, 12],
+  mipLevelCount: 11,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float'],
+});
+let textureView116 = texture61.createView({label: '\ub60c\u0ca4\u{1fb1c}\u0260\u{1fa3e}\u4784'});
+let arrayBuffer12 = buffer28.getMappedRange(0, 78464);
+let buffer29 = device2.createBuffer({
+  label: '\u3c67\ufe23\u04c9\u078f\u0e55\ucef5\u30df\u{1fe2d}\u5e2d',
+  size: 571568,
+  usage: GPUBufferUsage.INDIRECT,
+});
+let commandBuffer24 = commandEncoder94.finish({});
+let textureView117 = texture62.createView({label: '\u53e4\u12d2\u15c7\u575e\u7215', aspect: 'all', baseMipLevel: 6, mipLevelCount: 1});
+try {
+renderBundleEncoder46.setVertexBuffer(7635, undefined);
+} catch {}
+let videoFrame29 = new VideoFrame(img15, {timestamp: 0});
+document.body.prepend(video24);
+let imageData26 = new ImageData(224, 52);
+let imageData27 = new ImageData(212, 104);
+let querySet58 = device1.createQuerySet({
+  label: '\u0fc1\ua7e6\u0554\u7b5c\u3826\u0aec\uf77f\u{1fb45}\u{1fb9a}\u577c',
+  type: 'occlusion',
+  count: 2850,
+});
+let commandBuffer25 = commandEncoder85.finish({});
+let texture65 = device1.createTexture({
+  label: '\uca4d\u022c\u4301',
+  size: [768],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32float', 'r32float'],
+});
+let textureView118 = texture48.createView({aspect: 'all', baseMipLevel: 1, mipLevelCount: 2});
+let computePassEncoder46 = commandEncoder91.beginComputePass({label: '\u0bd4\u{1f76a}\ue22e'});
+try {
+renderBundleEncoder39.setVertexBuffer(7654, undefined, 1978036090);
+} catch {}
+try {
+commandEncoder90.resolveQuerySet(querySet48, 763, 855, buffer24, 70912);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 640, height: 48, depthOrArrayLayers: 194}
+*/
+{
+  source: imageBitmap10,
+  origin: { x: 47, y: 184 },
+  flipY: false,
+}, {
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 282, y: 10, z: 13},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let canvas22 = document.createElement('canvas');
+try {
+adapter3.label = '\u162c\u2cfd\u{1fb48}\u0b87\u{1f728}\u{1ff66}\u3d19\u0a2e';
+} catch {}
+let commandEncoder95 = device2.createCommandEncoder();
+let texture66 = device2.createTexture({
+  label: '\uae85\u{1fa9e}\u040d',
+  size: {width: 2952},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba32float'],
+});
+let renderBundle52 = renderBundleEncoder46.finish({label: '\uba78\u{1fe6d}\u0329\u{1fc1c}\u2be5\u{1f675}\uf157\u6a78'});
+gc();
+let gpuCanvasContext22 = canvas22.getContext('webgpu');
+let commandEncoder96 = device2.createCommandEncoder({label: '\u08a8\u0a5f\uca7d\u06fe\u0ffe\u{1fe09}'});
+let querySet59 = device2.createQuerySet({
+  label: '\u{1feff}\uaee4\u0f3c\u0c61\ued46\uc745\u9b6d\u6c1e\u9f51\u{1fcd0}',
+  type: 'occlusion',
+  count: 3091,
+});
+try {
+device2.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 3,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer5), /* required buffer size: 104 */
+{offset: 104, bytesPerRow: 490}, {width: 33, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let canvas23 = document.createElement('canvas');
+let commandEncoder97 = device2.createCommandEncoder({label: '\u{1f6e0}\ubbb5\u7684\ucef9\u0e4f\u{1fba1}\uf035\u09ff\u0359'});
+let textureView119 = texture61.createView({baseMipLevel: 0});
+let externalTexture54 = device2.importExternalTexture({label: '\u{1fb7e}\u0008', source: videoFrame28, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder45.setVertexBuffer(2523, undefined, 0);
+} catch {}
+offscreenCanvas19.width = 50;
+let bindGroupLayout33 = device2.createBindGroupLayout({
+  label: '\uadd0\u026a\uf6ae\u{1fec7}\u2f70\u7eac\u0723\u{1fd18}\u2282',
+  entries: [
+    {
+      binding: 1762,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {binding: 4492, visibility: 0, buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false }},
+    {binding: 1457, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }},
+  ],
+});
+let commandEncoder98 = device2.createCommandEncoder({label: '\u2ff0\u079b\u001b\ubebe\u4772\uadcd\uef19'});
+let commandBuffer26 = commandEncoder96.finish({label: '\u93cb\u{1f900}\u4938\u{1f64f}'});
+let renderBundleEncoder47 = device2.createRenderBundleEncoder({
+  colorFormats: ['rgba16float', 'rgba32float', 'rgba8unorm', 'rg32sint', 'rg8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+try {
+renderBundleEncoder47.setVertexBuffer(5677, undefined, 3286790868, 539588418);
+} catch {}
+let offscreenCanvas25 = new OffscreenCanvas(920, 797);
+let canvas24 = document.createElement('canvas');
+canvas5.height = 219;
+let offscreenCanvas26 = new OffscreenCanvas(984, 701);
+gc();
+offscreenCanvas20.width = 1555;
+let computePassEncoder47 = commandEncoder98.beginComputePass({label: '\u59b9\u{1fde1}\u0a5b'});
+let renderBundle53 = renderBundleEncoder46.finish({});
+let img29 = await imageWithData(260, 253, '#38128a73', '#400240b5');
+try {
+commandEncoder90.copyTextureToTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 216, y: 0, z: 45},
+  aspect: 'all',
+},
+{
+  texture: texture49,
+  mipLevel: 7,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise35 = device1.createComputePipelineAsync({
+  label: '\u{1fbc4}\uc2a0\uf0bf\ue803\u{1fbbd}\u58c9\u{1fe68}\u8ae7\u99b5\u4dba',
+  layout: pipelineLayout15,
+  compute: {module: shaderModule21, entryPoint: 'compute0', constants: {}},
+});
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let pipelineLayout17 = device2.createPipelineLayout({
+  label: '\u0ed9\u9bd1\u06ff\uaeef',
+  bindGroupLayouts: [bindGroupLayout32, bindGroupLayout32, bindGroupLayout33, bindGroupLayout33],
+});
+let textureView120 = texture63.createView({label: '\u07cf\u0627\u214a\u0ae0\u51ce\u45ef\u{1fda4}\u{1fbcd}\u0f72\u0f3f\u165b'});
+let sampler55 = device2.createSampler({
+  label: '\u90a4\u00ac',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 55.15,
+  maxAnisotropy: 18,
+});
+try {
+canvas23.getContext('2d');
+} catch {}
+let commandEncoder99 = device2.createCommandEncoder({label: '\ufa6a\u{1fb2a}'});
+let textureView121 = texture62.createView({label: '\u0564\u286b\uc369\u4048\u{1fdd8}\u5967\u{1f7d7}\u6411', dimension: '3d', baseMipLevel: 8});
+let renderBundleEncoder48 = device2.createRenderBundleEncoder({
+  colorFormats: ['rgba16float', 'rgba32float', 'rgba8unorm', 'rg32sint', 'rg8unorm'],
+  depthReadOnly: true,
+});
+let sampler56 = device2.createSampler({
+  label: '\ufa59\u{1f63d}\u{1fda2}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 28.51,
+  lodMaxClamp: 96.61,
+});
+let externalTexture55 = device2.importExternalTexture({source: video11, colorSpace: 'display-p3'});
+try {
+computePassEncoder47.end();
+} catch {}
+try {
+commandEncoder92.copyTextureToTexture({
+  texture: texture64,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 10},
+  aspect: 'all',
+},
+{width: 113, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let querySet60 = device2.createQuerySet({label: '\u56ac\u0239\u357c\u60a4\u{1fbfe}', type: 'occlusion', count: 1312});
+try {
+renderBundleEncoder45.setVertexBuffer(5531, undefined);
+} catch {}
+let shaderModule24 = device2.createShaderModule({
+  label: '\u{1fa1a}\u0928\u0625\u{1f6bc}\ubc7f\u0078\u0ddb\u0556\u{1fba9}\u{1fb27}',
+  code: `@group(2) @binding(4492)
+var<storage, read_write> global11: array<u32>;
+@group(1) @binding(2213)
+var<storage, read_write> local13: array<u32>;
+@group(3) @binding(4492)
+var<storage, read_write> field16: array<u32>;
+@group(0) @binding(2086)
+var<storage, read_write> global12: array<u32>;
+@group(3) @binding(1762)
+var<storage, read_write> field17: array<u32>;
+@group(3) @binding(1457)
+var<storage, read_write> parameter10: array<u32>;
+@group(1) @binding(6124)
+var<storage, read_write> local14: array<u32>;
+@group(0) @binding(2213)
+var<storage, read_write> n3: array<u32>;
+@group(2) @binding(1762)
+var<storage, read_write> function12: array<u32>;
+
+@compute @workgroup_size(6, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec3<i32>,
+  @location(1) f1: vec4<f32>,
+  @location(2) f2: vec4<f32>,
+  @location(4) f3: vec4<f32>,
+  @location(0) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(14) a0: vec4<f32>, @location(3) a1: vec3<f32>, @builtin(sample_mask) a2: u32, @location(10) a3: vec2<u32>, @location(7) a4: vec3<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(10) f274: vec2<u32>,
+  @location(2) f275: vec3<f16>,
+  @location(15) f276: vec2<f32>,
+  @location(3) f277: vec3<f32>,
+  @location(13) f278: vec3<f32>,
+  @location(5) f279: u32,
+  @location(8) f280: f32,
+  @location(9) f281: f32,
+  @location(14) f282: vec4<f32>,
+  @location(1) f283: vec2<u32>,
+  @location(0) f284: f32,
+  @builtin(position) f285: vec4<f32>,
+  @location(7) f286: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec4<f16>, @location(15) a1: vec2<f32>, @location(13) a2: vec3<i32>, @location(17) a3: f32, @builtin(instance_index) a4: u32, @location(10) a5: vec4<f16>, @location(4) a6: vec2<i32>, @builtin(vertex_index) a7: u32, @location(16) a8: vec2<f16>, @location(6) a9: vec2<f16>, @location(9) a10: vec3<i32>, @location(12) a11: vec4<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let querySet61 = device2.createQuerySet({type: 'occlusion', count: 783});
+let texture67 = device2.createTexture({
+  size: {width: 314, height: 1, depthOrArrayLayers: 1419},
+  mipLevelCount: 11,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg16uint', 'rg16uint'],
+});
+let textureView122 = texture61.createView({label: '\u0b31\u62c2\u08fe\u07f9\u04f2', dimension: '1d', format: 'rg32uint'});
+let pipeline88 = device2.createComputePipeline({
+  label: '\u0b3b\u047b',
+  layout: pipelineLayout17,
+  compute: {module: shaderModule24, entryPoint: 'compute0', constants: {}},
+});
+gc();
+let videoFrame30 = new VideoFrame(videoFrame29, {timestamp: 0});
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let imageBitmap20 = await createImageBitmap(imageBitmap10);
+document.body.prepend(img3);
+let img30 = await imageWithData(36, 158, '#2c75b7db', '#f9b11781');
+let imageBitmap21 = await createImageBitmap(canvas24);
+let commandEncoder100 = device2.createCommandEncoder({});
+let textureView123 = texture64.createView({label: '\uc6ff\u56e2\u1394\ufa54\u{1fde0}\u{1fd0f}\ue436\uce83\u0d62', mipLevelCount: 9});
+let externalTexture56 = device2.importExternalTexture({
+  label: '\uaa27\ua767\u{1fcfe}\u26b4\u86d7\u0f19\u9f43\u337c\ub29b\u202e',
+  source: videoFrame13,
+  colorSpace: 'srgb',
+});
+try {
+gpuCanvasContext7.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm', 'bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+});
+} catch {}
+let gpuCanvasContext23 = canvas24.getContext('webgpu');
+let gpuCanvasContext24 = offscreenCanvas26.getContext('webgpu');
+let canvas25 = document.createElement('canvas');
+let commandEncoder101 = device2.createCommandEncoder({label: '\u98a6\u095a\u1ed0'});
+let videoFrame31 = new VideoFrame(img11, {timestamp: 0});
+let textureView124 = texture53.createView({format: 'bgra8unorm-srgb'});
+let computePassEncoder48 = commandEncoder90.beginComputePass({});
+try {
+device1.queue.submit([]);
+} catch {}
+let pipeline89 = device1.createRenderPipeline({
+  label: '\u888c\u3df5\u4499\u8538\u50ca\u048b\u4b85\uc7de\u73ad',
+  layout: pipelineLayout15,
+  fragment: {
+  module: shaderModule22,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'dst'},
+  },
+}, {format: 'bgra8unorm-srgb'}, {format: 'r32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg32sint', writeMask: GPUColorWrite.BLUE}, {
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA,
+}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one', dstFactor: 'dst-alpha'},
+  },
+  writeMask: GPUColorWrite.GREEN,
+}, {format: 'r32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule22,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3632,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x3', offset: 72, shaderLocation: 21},
+          {format: 'sint8x2', offset: 0, shaderLocation: 25},
+          {format: 'unorm16x4', offset: 260, shaderLocation: 22},
+          {format: 'unorm8x4', offset: 1104, shaderLocation: 26},
+          {format: 'unorm8x4', offset: 648, shaderLocation: 20},
+          {format: 'uint32x4', offset: 128, shaderLocation: 1},
+          {format: 'float32x4', offset: 112, shaderLocation: 6},
+          {format: 'float32', offset: 260, shaderLocation: 9},
+          {format: 'uint32', offset: 652, shaderLocation: 23},
+          {format: 'uint32x3', offset: 1360, shaderLocation: 18},
+          {format: 'uint16x2', offset: 884, shaderLocation: 14},
+          {format: 'uint32x4', offset: 164, shaderLocation: 0},
+          {format: 'uint32x3', offset: 412, shaderLocation: 7},
+          {format: 'float16x4', offset: 224, shaderLocation: 2},
+          {format: 'float32x2', offset: 156, shaderLocation: 8},
+          {format: 'sint32', offset: 176, shaderLocation: 12},
+          {format: 'sint8x4', offset: 176, shaderLocation: 19},
+          {format: 'uint8x4', offset: 192, shaderLocation: 17},
+          {format: 'float32', offset: 1132, shaderLocation: 3},
+          {format: 'float32x3', offset: 116, shaderLocation: 11},
+          {format: 'sint32x2', offset: 1064, shaderLocation: 4},
+          {format: 'sint32x4', offset: 40, shaderLocation: 13},
+          {format: 'uint8x2', offset: 108, shaderLocation: 5},
+        ],
+      },
+      {arrayStride: 8540, attributes: []},
+      {
+        arrayStride: 2180,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x3', offset: 392, shaderLocation: 16},
+          {format: 'unorm8x2', offset: 760, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 5616,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x2', offset: 48, shaderLocation: 10}],
+      },
+      {arrayStride: 6536, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 5512,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x4', offset: 876, shaderLocation: 24}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', cullMode: 'none', unclippedDepth: true},
+});
+offscreenCanvas8.height = 631;
+gc();
+let imageData28 = new ImageData(92, 152);
+try {
+adapter1.label = '\ufb3b\u6fa9\u{1f79f}';
+} catch {}
+let gpuCanvasContext25 = canvas25.getContext('webgpu');
+let gpuCanvasContext26 = offscreenCanvas25.getContext('webgpu');
+let videoFrame32 = new VideoFrame(canvas14, {timestamp: 0});
+try {
+renderBundleEncoder45.setVertexBuffer(140, undefined);
+} catch {}
+let pipeline90 = device2.createRenderPipeline({
+  label: '\u371f\u{1f728}\u{1fb04}\u626c\u{1f667}\u{1fb11}\u{1f7f1}\u8990\u69f4\u3179\u{1fe41}',
+  layout: 'auto',
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule24,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba32float', writeMask: 0}, {format: 'rgba8unorm', writeMask: GPUColorWrite.GREEN}, {format: 'rg32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'increment-wrap', depthFailOp: 'zero', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'replace', passOp: 'increment-wrap'},
+    stencilReadMask: 4294967295,
+    stencilWriteMask: 937345745,
+    depthBias: 1333883401,
+    depthBiasSlopeScale: 571.5810536785013,
+    depthBiasClamp: 361.01102279527805,
+  },
+  vertex: {
+    module: shaderModule24,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 2500, attributes: []},
+      {
+        arrayStride: 1740,
+        attributes: [
+          {format: 'sint8x2', offset: 2, shaderLocation: 12},
+          {format: 'unorm16x4', offset: 340, shaderLocation: 15},
+          {format: 'sint32x2', offset: 32, shaderLocation: 13},
+          {format: 'sint16x4', offset: 1060, shaderLocation: 4},
+          {format: 'sint32x4', offset: 388, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 9452,
+        attributes: [
+          {format: 'float16x4', offset: 1880, shaderLocation: 17},
+          {format: 'float16x4', offset: 1920, shaderLocation: 6},
+          {format: 'unorm16x4', offset: 1120, shaderLocation: 5},
+          {format: 'unorm8x2', offset: 3730, shaderLocation: 16},
+          {format: 'unorm8x4', offset: 44, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'back'},
+});
+let offscreenCanvas27 = new OffscreenCanvas(949, 945);
+let bindGroupLayout34 = device2.createBindGroupLayout({
+  label: '\u8565\u06c6\u35ca',
+  entries: [
+    {binding: 3012, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {binding: 3325, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 44,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+  ],
+});
+let bindGroupLayout35 = pipeline90.getBindGroupLayout(0);
+let texture68 = device2.createTexture({
+  label: '\u2d04\u{1fca9}\u6d51\u06dd\u0aea\u{1f9af}\u18b8\u{1ff79}\uf418\u194c\u4780',
+  size: [315],
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32sint'],
+});
+let textureView125 = texture61.createView({label: '\uc0f3\u0baf\u02e7\u3f6a\u{1ff2e}\u{1f968}\u6f90\ub1bd\u{1fd06}\u0797\u{1fbda}'});
+let computePassEncoder49 = commandEncoder100.beginComputePass({label: '\u{1fe64}\u03a0\ufe6c\u4a63\u0cde\ue974\u0008'});
+try {
+computePassEncoder49.setPipeline(pipeline88);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture67,
+  mipLevel: 4,
+  origin: {x: 3, y: 0, z: 2},
+  aspect: 'all',
+}, arrayBuffer10, /* required buffer size: 630_234 */
+{offset: 586, bytesPerRow: 184, rowsPerImage: 59}, {width: 14, height: 0, depthOrArrayLayers: 59});
+} catch {}
+let pipeline91 = device2.createComputePipeline({layout: pipelineLayout17, compute: {module: shaderModule24, entryPoint: 'compute0', constants: {}}});
+let buffer30 = device2.createBuffer({size: 73494, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let querySet62 = device2.createQuerySet({label: '\uea68\u0f38\u1730\u38fe\u02ef\u0e75\u0229', type: 'occlusion', count: 3677});
+let texture69 = device2.createTexture({
+  label: '\uca18\u9efa\u1e86\u089f\u0931\u932b\u{1faaa}\u00c0\ub8ad\u53ec\u0d40',
+  size: {width: 157},
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm'],
+});
+let renderBundle54 = renderBundleEncoder46.finish();
+try {
+device2.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 253 */
+{offset: 253, rowsPerImage: 178}, {width: 28, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView126 = texture63.createView({baseMipLevel: 2});
+let externalTexture57 = device2.importExternalTexture({
+  label: '\u2644\u0804\u0747\ue8dc\u{1fddd}\u9945\u064d\u{1f8fa}',
+  source: video24,
+  colorSpace: 'display-p3',
+});
+try {
+texture59.destroy();
+} catch {}
+try {
+commandEncoder97.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2088 */
+  offset: 2088,
+  bytesPerRow: 0,
+  rowsPerImage: 176,
+  buffer: buffer30,
+}, {
+  texture: texture62,
+  mipLevel: 8,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 5});
+dissociateBuffer(device2, buffer30);
+} catch {}
+let pipeline92 = device2.createRenderPipeline({
+  label: '\u0c1a\u99c4\udf12\u8e35\u{1fd8b}\u7d62\u{1f8ff}\u97bc\u{1fc30}\u0140',
+  layout: pipelineLayout16,
+  fragment: {
+  module: shaderModule24,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba16float', writeMask: 0}, {format: 'rgba32float', writeMask: 0}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA,
+}, {format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg8unorm'}],
+},
+  vertex: {
+    module: shaderModule24,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 5056,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x2', offset: 126, shaderLocation: 13}],
+      },
+      {
+        arrayStride: 5704,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x2', offset: 666, shaderLocation: 12}],
+      },
+      {
+        arrayStride: 1696,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 324, shaderLocation: 15},
+          {format: 'snorm16x2', offset: 92, shaderLocation: 6},
+          {format: 'sint8x4', offset: 28, shaderLocation: 9},
+          {format: 'float32', offset: 188, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 3576,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x3', offset: 588, shaderLocation: 16}],
+      },
+      {arrayStride: 5528, attributes: [{format: 'unorm8x4', offset: 132, shaderLocation: 10}]},
+      {arrayStride: 120, attributes: []},
+      {
+        arrayStride: 7988,
+        attributes: [
+          {format: 'unorm8x4', offset: 284, shaderLocation: 17},
+          {format: 'sint32x2', offset: 136, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', cullMode: 'back'},
+});
+let gpuCanvasContext27 = offscreenCanvas27.getContext('webgpu');
+let canvas26 = document.createElement('canvas');
+let offscreenCanvas28 = new OffscreenCanvas(41, 998);
+let imageBitmap22 = await createImageBitmap(canvas5);
+let imageData29 = new ImageData(164, 52);
+let imageData30 = new ImageData(200, 168);
+gc();
+let commandEncoder102 = device2.createCommandEncoder({label: '\u075d\u0ce6\ud106'});
+let sampler57 = device2.createSampler({
+  label: '\u3ea8\u{1fd08}\u4159\uf387',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 34.94,
+  lodMaxClamp: 58.09,
+});
+try {
+renderBundleEncoder48.setPipeline(pipeline92);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(8, buffer30, 0, 21704);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, arrayBuffer11, /* required buffer size: 2_168_774 */
+{offset: 350, bytesPerRow: 904, rowsPerImage: 109}, {width: 79, height: 1, depthOrArrayLayers: 23});
+} catch {}
+let imageBitmap23 = await createImageBitmap(video14);
+let offscreenCanvas29 = new OffscreenCanvas(261, 817);
+let video33 = await videoWithData();
+let imageBitmap24 = await createImageBitmap(video32);
+offscreenCanvas20.height = 153;
+let gpuCanvasContext28 = offscreenCanvas28.getContext('webgpu');
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+let gpuCanvasContext29 = canvas26.getContext('webgpu');
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+let computePassEncoder50 = commandEncoder92.beginComputePass({label: '\u0f0e\u2872\u1e3a\u{1f837}\ucf06\u6e0b\uf943\u{1fd4b}'});
+let renderBundleEncoder49 = device2.createRenderBundleEncoder({
+  label: '\u919b\u00e6',
+  colorFormats: ['rgba16float', 'rgba32float', 'rgba8unorm', 'rg32sint', 'rg8unorm'],
+  depthReadOnly: true,
+});
+let sampler58 = device2.createSampler({
+  label: '\u{1f6cf}\ue56f\u2846\u{1fb08}\uec14\u4dee',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 39.11,
+  lodMaxClamp: 79.40,
+});
+try {
+computePassEncoder50.setPipeline(pipeline88);
+} catch {}
+try {
+renderBundleEncoder49.setPipeline(pipeline92);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(8, buffer30, 55580);
+} catch {}
+try {
+buffer30.unmap();
+} catch {}
+try {
+gpuCanvasContext21.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline93 = device2.createRenderPipeline({
+  label: '\uaa17\u0fd9\u1d89\u97a5',
+  layout: pipelineLayout17,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule24,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba32float', writeMask: 0}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rg32sint', writeMask: GPUColorWrite.BLUE}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'src-alpha-saturated'},
+    alpha: {operation: 'add', srcFactor: 'src-alpha-saturated', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: GPUColorWrite.GREEN,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {
+      compare: 'greater-equal',
+      failOp: 'increment-wrap',
+      depthFailOp: 'increment-clamp',
+      passOp: 'decrement-clamp',
+    },
+    stencilBack: {compare: 'less', failOp: 'increment-wrap', depthFailOp: 'zero', passOp: 'zero'},
+    stencilReadMask: 1604716563,
+    stencilWriteMask: 4114055150,
+    depthBias: 1817790221,
+    depthBiasSlopeScale: 164.17705894567706,
+    depthBiasClamp: 771.4286987846475,
+  },
+  vertex: {
+    module: shaderModule24,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3580,
+        attributes: [
+          {format: 'float32x2', offset: 2068, shaderLocation: 6},
+          {format: 'snorm8x2', offset: 2008, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 2020,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float16x2', offset: 140, shaderLocation: 15},
+          {format: 'float32x3', offset: 80, shaderLocation: 5},
+          {format: 'sint32x2', offset: 20, shaderLocation: 13},
+          {format: 'sint32x2', offset: 336, shaderLocation: 4},
+          {format: 'unorm8x2', offset: 282, shaderLocation: 17},
+        ],
+      },
+      {arrayStride: 1360, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 12304,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 7976, shaderLocation: 10},
+          {format: 'sint8x4', offset: 3188, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 2772, attributes: [{format: 'sint32x2', offset: 356, shaderLocation: 9}]},
+    ],
+  },
+});
+try {
+offscreenCanvas29.getContext('webgpu');
+} catch {}
+let bindGroupLayout36 = device2.createBindGroupLayout({label: '\u{1f967}\u{1f76a}\u6f06\u09ab', entries: []});
+let commandEncoder103 = device2.createCommandEncoder();
+let sampler59 = device2.createSampler({
+  label: '\uf3b1\u3204\u65db\u00dd\ua26b\u0862\ud103\u857f',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 3.909,
+  lodMaxClamp: 61.56,
+  maxAnisotropy: 9,
+});
+let commandEncoder104 = device2.createCommandEncoder({label: '\u080e\u09cd\u{1fa01}\u0e82\u3519\u08e1\ufed3\u{1fb92}\u04f7'});
+let textureView127 = texture60.createView({label: '\u{1ff08}\u0b6f\u04df\u1d29\ub6fe\u7d58\u2eb1\u{1f8b6}\u0fd3\ue4e1', dimension: '1d'});
+try {
+renderBundleEncoder48.setPipeline(pipeline92);
+} catch {}
+let arrayBuffer13 = buffer28.getMappedRange(105056, 1988);
+try {
+buffer29.unmap();
+} catch {}
+let video34 = await videoWithData();
+let img31 = await imageWithData(206, 50, '#29f02f49', '#4177891b');
+let renderBundle55 = renderBundleEncoder48.finish({label: '\u6ada\u2dde\u89a1\u02f1\u62f8\u0cfb\ud962\uc78e\u082e'});
+try {
+computePassEncoder50.setPipeline(pipeline91);
+} catch {}
+try {
+renderBundleEncoder45.setPipeline(pipeline92);
+} catch {}
+try {
+buffer28.destroy();
+} catch {}
+try {
+commandEncoder104.copyTextureToTexture({
+  texture: texture64,
+  mipLevel: 4,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture63,
+  mipLevel: 1,
+  origin: {x: 12, y: 0, z: 88},
+  aspect: 'all',
+},
+{width: 5, height: 1, depthOrArrayLayers: 1});
+} catch {}
+gc();
+let textureView128 = texture62.createView({
+  label: '\u423f\u0d2b\u{1fd85}\u40e9\u9834\u90bc\ued02\u00cc\uc09c\u0509\ue24f',
+  aspect: 'all',
+  baseMipLevel: 7,
+  mipLevelCount: 2,
+});
+let renderBundleEncoder50 = device2.createRenderBundleEncoder({
+  label: '\u4200\u07d7\ued27\u5e92\u{1f6c4}\ud4c0\u3666\u03db',
+  colorFormats: ['rgba16float', 'rgba32float', 'rgba8unorm', 'rg32sint', 'rg8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle56 = renderBundleEncoder50.finish({label: '\u05df\u2fc2'});
+let externalTexture58 = device2.importExternalTexture({label: '\u0ceb\u09b4\u{1fcf0}', source: videoFrame19, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder49.setPipeline(pipeline92);
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let device3 = await promise27;
+try {
+if (!arrayBuffer13.detached) { new Uint8Array(arrayBuffer13).fill(0x55) };
+} catch {}
+let canvas27 = document.createElement('canvas');
+let commandEncoder105 = device3.createCommandEncoder({label: '\ub9e1\u493a\u{1fa2a}\u{1f76f}\ud89a\u{1fa71}\u0cd8'});
+let texture70 = device3.createTexture({
+  size: [104, 1, 393],
+  mipLevelCount: 2,
+  format: 'depth32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['depth32float', 'depth32float', 'depth32float'],
+});
+let textureView129 = texture70.createView({
+  label: '\u8e3c\u0998\uf258\u0650\udbff\u0651',
+  dimension: '2d',
+  baseMipLevel: 1,
+  baseArrayLayer: 234,
+  arrayLayerCount: 1,
+});
+let sampler60 = device3.createSampler({
+  label: '\uac57\u{1f789}\u0c33\u007a\u{1f882}\u{1f626}\u{1fa78}\uf8e6\u4e38',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 27.20,
+  lodMaxClamp: 52.30,
+  compare: 'not-equal',
+  maxAnisotropy: 7,
+});
+try {
+gpuCanvasContext4.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+canvas27.getContext('webgl2');
+} catch {}
+try {
+textureView129.label = '\u05d7\u1ad9\u{1f831}\u{1f8db}\u{1fe8d}';
+} catch {}
+let sampler61 = device3.createSampler({
+  label: '\u09b2\ue5e5\u57c6\udcf3\ubfa8\u0b84\u{1f686}',
+  addressModeU: 'clamp-to-edge',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 94.85,
+  lodMaxClamp: 95.19,
+  compare: 'less-equal',
+});
+let texture71 = device3.createTexture({
+  label: '\u{1fc63}\u{1f715}\u5f4e\u5971\u0f4b\u{1fd8f}\u0002',
+  size: [416, 1, 998],
+  mipLevelCount: 2,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['depth16unorm', 'depth16unorm'],
+});
+let promise36 = device3.queue.onSubmittedWorkDone();
+let device4 = await adapter5.requestDevice({
+  label: '\u0c4e\u{1ff65}\uca7b\uaf88\u08d7\uc6c2\u0a95\u0b5e',
+  requiredFeatures: [
+    'depth-clip-control',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+  ],
+  requiredLimits: {
+    maxBindGroups: 5,
+    maxColorAttachmentBytesPerSample: 49,
+    maxVertexAttributes: 19,
+    maxVertexBufferArrayStride: 54031,
+    maxStorageTexturesPerShaderStage: 16,
+    maxStorageBuffersPerShaderStage: 38,
+    maxDynamicStorageBuffersPerPipelineLayout: 1600,
+    maxDynamicUniformBuffersPerPipelineLayout: 12038,
+    maxBindingsPerBindGroup: 1340,
+    maxTextureArrayLayers: 2001,
+    maxTextureDimension1D: 10839,
+    maxTextureDimension2D: 11538,
+    maxVertexBuffers: 10,
+    minUniformBufferOffsetAlignment: 64,
+    maxUniformBufferBindingSize: 5577233,
+    maxStorageBufferBindingSize: 161107906,
+    maxUniformBuffersPerShaderStage: 22,
+    maxSampledTexturesPerShaderStage: 16,
+    maxInterStageShaderVariables: 47,
+    maxInterStageShaderComponents: 110,
+    maxSamplersPerShaderStage: 21,
+  },
+});
+let img32 = await imageWithData(260, 42, '#86026c77', '#ef6d8626');
+try {
+adapter0.label = '\uff13\u012a\u097e\u02f4\u020a\u040f\u{1fdb8}\u52aa\ueefa\ufd6e';
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let querySet63 = device4.createQuerySet({label: '\ufb1e\u{1fff7}\u94ed\uec37\u6417\u01b3', type: 'occlusion', count: 3591});
+let promise37 = device4.queue.onSubmittedWorkDone();
+document.body.prepend(video23);
+let imageBitmap25 = await createImageBitmap(videoFrame16);
+let bindGroupLayout37 = device4.createBindGroupLayout({
+  entries: [
+    {binding: 875, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 1173,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d' },
+    },
+  ],
+});
+let texture72 = device4.createTexture({
+  label: '\u{1fd71}\u{1f600}\u021b',
+  size: [2304, 960, 479],
+  mipLevelCount: 3,
+  format: 'etc2-rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['etc2-rgba8unorm', 'etc2-rgba8unorm', 'etc2-rgba8unorm'],
+});
+let textureView130 = texture72.createView({
+  label: '\u8c2f\u{1fea0}\u0ef1\u0b46\u08a8\ud0b4\u09c6\u01fd\u4de0\u{1fb47}',
+  dimension: '2d-array',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 111,
+  arrayLayerCount: 310,
+});
+offscreenCanvas1.width = 1990;
+let img33 = await imageWithData(227, 152, '#215e0650', '#21c53947');
+let pipelineLayout18 = device4.createPipelineLayout({
+  label: '\u2f9c\u{1f940}\u35c2\ue60d\u007e\u635b',
+  bindGroupLayouts: [bindGroupLayout37, bindGroupLayout37, bindGroupLayout37, bindGroupLayout37],
+});
+let renderBundleEncoder51 = device4.createRenderBundleEncoder({
+  label: '\ubaaf\u{1ff34}\u{1fbe4}\u{1ffad}\u0fd7\u6a89\u3796\u0b17\u2120\u{1f983}',
+  colorFormats: ['rgba8uint'],
+});
+let externalTexture59 = device4.importExternalTexture({label: '\u5ed9\u0678\u{1fa81}\u{1fa39}\uf5d7\ub91e\uf8a7\u74d1', source: video7, colorSpace: 'srgb'});
+let renderBundle57 = renderBundleEncoder51.finish({});
+let sampler62 = device4.createSampler({
+  label: '\u0a00\u{1fde6}\uf830',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 30.52,
+  lodMaxClamp: 94.10,
+});
+let videoFrame33 = new VideoFrame(canvas23, {timestamp: 0});
+let commandEncoder106 = device3.createCommandEncoder({label: '\u{1fe93}\u011d'});
+let textureView131 = texture71.createView({dimension: '2d', baseMipLevel: 1, baseArrayLayer: 932});
+let externalTexture60 = device3.importExternalTexture({label: '\ubbf6\u7d87\u01c6\u07d7\u{1fbe9}\uf005\u039a\u7b0e\ucca2\u3d54', source: videoFrame28});
+try {
+gpuCanvasContext1.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let video35 = await videoWithData();
+offscreenCanvas8.height = 1149;
+let canvas28 = document.createElement('canvas');
+canvas15.width = 2192;
+let bindGroupLayout38 = device3.createBindGroupLayout({
+  label: '\u{1fa12}\u4a11\u{1f9b7}\u9c87\u{1f7c0}\u0026\u2190\u4eb5\u{1f604}\u6e16',
+  entries: [
+    {binding: 110, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 586,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16sint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 990,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let commandEncoder107 = device3.createCommandEncoder({label: '\u2561\u9847\u{1fb43}\u2ad9\ude24\u0554\u4e0f\u748a\ufff8\u{1ffd7}\udd2a'});
+let sampler63 = device3.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 48.44,
+  lodMaxClamp: 75.63,
+  compare: 'equal',
+});
+let externalTexture61 = device3.importExternalTexture({label: '\u8d4f\u031d\u5729\ucd52\uc93b\ufa6c\u8694\u7ae6', source: video25, colorSpace: 'display-p3'});
+offscreenCanvas3.width = 1414;
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+document.body.prepend(img3);
+let commandEncoder108 = device4.createCommandEncoder();
+let textureView132 = texture72.createView({dimension: '2d', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 72});
+try {
+texture72.destroy();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let canvas29 = document.createElement('canvas');
+let bindGroupLayout39 = device4.createBindGroupLayout({
+  label: '\u{1f8f6}\u08ba\u0d8d\u{1f99f}\u01cc',
+  entries: [
+    {
+      binding: 512,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 509,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32uint', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let commandEncoder109 = device4.createCommandEncoder({label: '\uec59\uc635'});
+let textureView133 = texture72.createView({dimension: '2d', baseMipLevel: 1, baseArrayLayer: 151});
+let externalTexture62 = device4.importExternalTexture({
+  label: '\u{1fd9d}\u05fb\u8c43\u{1fe32}\u1bc1\u809b\u0bbc\u0baa\u9128\u9d3f',
+  source: videoFrame1,
+  colorSpace: 'display-p3',
+});
+let shaderModule25 = device2.createShaderModule({
+  label: '\u{1fb2f}\u17b1\ue127\u0b20\u096b\ua47f\ud2c9\u8409',
+  code: `@group(1) @binding(2213)
+var<storage, read_write> function13: array<u32>;
+@group(1) @binding(6124)
+var<storage, read_write> field18: array<u32>;
+@group(0) @binding(6124)
+var<storage, read_write> global13: array<u32>;
+@group(1) @binding(2086)
+var<storage, read_write> n4: array<u32>;
+@group(0) @binding(2086)
+var<storage, read_write> local15: array<u32>;
+
+@compute @workgroup_size(8, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec3<f32>,
+  @location(3) f1: vec3<i32>,
+  @location(2) f2: vec4<f32>,
+  @location(1) f3: vec4<f32>,
+  @location(0) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(9) a0: f16, @location(7) a1: vec2<f32>, @location(15) a2: i32, @location(3) a3: vec4<i32>, @location(5) a4: vec3<u32>, @location(6) a5: vec2<u32>, @location(11) a6: vec2<i32>, @location(14) a7: vec4<f16>, @builtin(sample_index) a8: u32, @builtin(front_facing) a9: bool, @builtin(position) a10: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(15) f287: i32,
+  @location(7) f288: vec2<f32>,
+  @location(14) f289: vec4<f16>,
+  @location(11) f290: vec2<i32>,
+  @location(3) f291: vec4<i32>,
+  @location(6) f292: vec2<u32>,
+  @builtin(position) f293: vec4<f32>,
+  @location(5) f294: vec3<u32>,
+  @location(9) f295: f16
+}
+
+@vertex
+fn vertex0(@location(4) a0: u32, @location(0) a1: vec2<f16>, @location(11) a2: vec2<i32>, @location(8) a3: vec3<u32>, @location(17) a4: vec3<i32>, @location(16) a5: vec4<f16>, @location(6) a6: vec2<u32>, @location(2) a7: vec4<f16>, @location(12) a8: vec3<f32>, @location(7) a9: vec2<f16>, @location(9) a10: vec3<u32>, @location(10) a11: vec3<i32>, @location(1) a12: vec4<f16>, @location(3) a13: f16, @location(14) a14: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let bindGroupLayout40 = device2.createBindGroupLayout({
+  label: '\u963a\u7261\uea17\ubff5\u0373\u0b0f\u075f\udc35\u{1f85c}\u733d\u10dc',
+  entries: [
+    {
+      binding: 6156,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 1519,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '2d' },
+    },
+  ],
+});
+let textureView134 = texture69.createView({label: '\uedd6\u05e0\u1492\u0aeb\u831c\u2744', format: 'bgra8unorm'});
+let sampler64 = device2.createSampler({
+  label: '\u0a71\u7655',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 1.284,
+  lodMaxClamp: 2.814,
+});
+try {
+renderBundleEncoder45.setPipeline(pipeline92);
+} catch {}
+try {
+device2.queue.submit([commandBuffer24]);
+} catch {}
+let pipeline94 = await device2.createRenderPipelineAsync({
+  label: '\u4608\u{1f627}\u{1f677}\u{1f782}\ub3c5\u03b1\u94f8\u06db\u{1f7ba}',
+  layout: pipelineLayout16,
+  fragment: {
+  module: shaderModule24,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'src-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'src-alpha'},
+  },
+}, {format: 'rgba32float', writeMask: 0}, {format: 'rgba8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg32sint'}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'less', failOp: 'decrement-clamp', depthFailOp: 'keep', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'greater-equal', depthFailOp: 'increment-wrap', passOp: 'decrement-wrap'},
+    stencilReadMask: 1387725280,
+    stencilWriteMask: 2411413216,
+  },
+  vertex: {
+    module: shaderModule24,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3424,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 144, shaderLocation: 16},
+          {format: 'sint16x4', offset: 1912, shaderLocation: 9},
+          {format: 'sint8x4', offset: 408, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 4888,
+        attributes: [
+          {format: 'snorm8x2', offset: 1160, shaderLocation: 10},
+          {format: 'float16x2', offset: 2888, shaderLocation: 17},
+          {format: 'unorm16x2', offset: 2404, shaderLocation: 15},
+          {format: 'sint32x4', offset: 352, shaderLocation: 12},
+          {format: 'sint32', offset: 64, shaderLocation: 4},
+          {format: 'unorm16x4', offset: 756, shaderLocation: 5},
+          {format: 'float32x2', offset: 1172, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+});
+let buffer31 = device4.createBuffer({
+  label: '\ub655\u6d45\u2e7a\u{1ff45}\ubcdf\u59aa\u{1fa9b}\u{1f8bd}',
+  size: 273828,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder110 = device4.createCommandEncoder({label: '\u{1fc13}\uf64a\u0e97\u0866'});
+let videoFrame34 = new VideoFrame(canvas11, {timestamp: 0});
+let buffer32 = device4.createBuffer({
+  label: '\u14b2\u{1fbe5}\uf11c',
+  size: 425748,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder111 = device4.createCommandEncoder();
+let querySet64 = device4.createQuerySet({type: 'occlusion', count: 3469});
+let texture73 = device4.createTexture({
+  size: [576, 240, 479],
+  mipLevelCount: 7,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule26 = device2.createShaderModule({
+  label: '\u0753\u13f5',
+  code: `@group(1) @binding(6124)
+var<storage, read_write> type16: array<u32>;
+@group(0) @binding(6124)
+var<storage, read_write> function14: array<u32>;
+@group(0) @binding(2086)
+var<storage, read_write> type17: array<u32>;
+@group(1) @binding(2213)
+var<storage, read_write> function15: array<u32>;
+@group(1) @binding(2086)
+var<storage, read_write> function16: array<u32>;
+@group(0) @binding(2213)
+var<storage, read_write> type18: array<u32>;
+
+@compute @workgroup_size(4, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(3) f1: vec4<i32>,
+  @builtin(sample_mask) f2: u32,
+  @location(4) f3: vec4<f32>,
+  @location(1) f4: vec4<f32>,
+  @location(0) f5: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(1) a0: vec3<u32>, @location(7) a1: vec2<u32>, @location(4) a2: f32, @location(14) a3: vec3<u32>, @location(0) a4: vec4<i32>, @location(3) a5: i32, @location(5) a6: i32, @location(12) a7: vec3<u32>, @builtin(sample_index) a8: u32, @builtin(sample_mask) a9: u32, @builtin(position) a10: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f296: vec4<f32>,
+  @location(4) f297: f32,
+  @location(3) f298: i32,
+  @location(7) f299: vec2<u32>,
+  @location(12) f300: vec3<u32>,
+  @location(1) f301: vec3<u32>,
+  @location(5) f302: i32,
+  @location(0) f303: vec4<i32>,
+  @location(14) f304: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: u32, @location(5) a1: vec2<f16>, @location(10) a2: vec2<u32>, @location(15) a3: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+});
+let bindGroup23 = device2.createBindGroup({label: '\u0892\u711a\u{1fc16}\uecd9', layout: bindGroupLayout36, entries: []});
+let commandEncoder112 = device2.createCommandEncoder({});
+let textureView135 = texture61.createView({label: '\u8bd4\uafb3\uf27b\u08d1\u919c\u3da5', arrayLayerCount: 1});
+try {
+computePassEncoder49.end();
+} catch {}
+try {
+computePassEncoder50.insertDebugMarker('\ub00f');
+} catch {}
+let imageBitmap26 = await createImageBitmap(offscreenCanvas24);
+let computePassEncoder51 = commandEncoder98.beginComputePass({label: '\u{1fb37}\u8aa2\u0fcd\u0c1f\uabab\ue28c\u0721\u0c02\u5582\u{1fc8b}'});
+try {
+computePassEncoder50.setPipeline(pipeline91);
+} catch {}
+try {
+renderBundleEncoder45.setVertexBuffer(6, buffer30);
+} catch {}
+try {
+gpuCanvasContext18.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline95 = await device2.createComputePipelineAsync({
+  label: '\u{1f6cb}\ud64c\u{1ff6d}\u{1fd99}\u{1fd30}\u00bc\u4b24\u0bee\u0bfe',
+  layout: pipelineLayout17,
+  compute: {module: shaderModule25, entryPoint: 'compute0', constants: {}},
+});
+let computePassEncoder52 = commandEncoder103.beginComputePass({label: '\u1530\u{1fb4d}\u{1ff95}\u4bef\u{1f8ee}\u57e6\u20d0\uff85'});
+let pipeline96 = await device2.createComputePipelineAsync({
+  label: '\u00b0\u{1f6cf}\u7d1d\u{1fc10}\ubbcb\u0de6\u0733\u{1fce5}',
+  layout: pipelineLayout16,
+  compute: {module: shaderModule26, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext19.unconfigure();
+} catch {}
+let querySet65 = device2.createQuerySet({label: '\u089c\u0cb2', type: 'occlusion', count: 1779});
+let textureView136 = texture67.createView({label: '\u8a0e\u2f15', baseMipLevel: 3, mipLevelCount: 7});
+let sampler65 = device2.createSampler({
+  label: '\u0b04\u194a\ud19f\u3428\u3563\u8b75\u07c3\u1277\u677b\u0116',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 62.57,
+  lodMaxClamp: 84.77,
+  compare: 'less-equal',
+  maxAnisotropy: 11,
+});
+let externalTexture63 = device2.importExternalTexture({
+  label: '\uae75\uef7f\uc9c0\u02da\u86bf\u636c\u0af8\u{1fa94}\ubb8d\u2c59\u0a6e',
+  source: video28,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder45.setVertexBuffer(7, buffer30, 0, 12793);
+} catch {}
+try {
+buffer29.destroy();
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer0), /* required buffer size: 6_111_232 */
+{offset: 880, bytesPerRow: 470, rowsPerImage: 260}, {width: 44, height: 1, depthOrArrayLayers: 51});
+} catch {}
+let gpuCanvasContext30 = canvas28.getContext('webgpu');
+let canvas30 = document.createElement('canvas');
+let commandEncoder113 = device2.createCommandEncoder({label: '\u6c31\u01da\u5de6'});
+let renderBundleEncoder52 = device2.createRenderBundleEncoder({
+  label: '\ubfca\u{1fb71}\ub17c\u4fc9\u0015',
+  colorFormats: ['rgba16float', 'rgba32float', 'rgba8unorm', 'rg32sint', 'rg8unorm'],
+});
+let renderBundle58 = renderBundleEncoder50.finish({});
+try {
+computePassEncoder51.setBindGroup(4, bindGroup23, new Uint32Array(415), 252, 0);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(0, buffer30, 59756, 10473);
+} catch {}
+try {
+commandEncoder104.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 4912 */
+  offset: 4912,
+  bytesPerRow: 0,
+  rowsPerImage: 289,
+  buffer: buffer30,
+}, {
+  texture: texture62,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 5});
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+  await promise37;
+} catch {}
+let pipelineLayout19 = device3.createPipelineLayout({
+  label: '\u31b8\ue139\u4b8b\u0e16\u8913\u{1fbe2}',
+  bindGroupLayouts: [bindGroupLayout38, bindGroupLayout38, bindGroupLayout38],
+});
+try {
+commandEncoder106.insertDebugMarker('\u1cf5');
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder114 = device3.createCommandEncoder({});
+let textureView137 = texture70.createView({
+  label: '\u0a97\u07cd\u366b',
+  dimension: '2d',
+  aspect: 'depth-only',
+  baseMipLevel: 1,
+  baseArrayLayer: 368,
+});
+try {
+gpuCanvasContext0.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder115 = device4.createCommandEncoder({label: '\u{1fbfa}\ua235\u924d'});
+let textureView138 = texture72.createView({label: '\uca85\uea72\u4516\ua825', dimension: '2d', mipLevelCount: 2, baseArrayLayer: 374});
+try {
+commandEncoder109.clearBuffer(buffer31);
+dissociateBuffer(device4, buffer31);
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let canvas31 = document.createElement('canvas');
+let commandEncoder116 = device4.createCommandEncoder({label: '\u9c65\u001e\u07a7\u0370\u0bb6\u{1fcf9}\u8b52'});
+let querySet66 = device4.createQuerySet({
+  label: '\u{1ffa9}\u0b39\u00b8\ufc91\u1820\u1f00\u{1fc64}\u068e\u31d9\u056f',
+  type: 'occlusion',
+  count: 2795,
+});
+let textureView139 = texture72.createView({
+  label: '\u{1f867}\u8907\u{1fde3}\u0522\u{1fa10}\u5d2d\u598b\u8ebc\u6449\u6c53\u01d2',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 230,
+});
+try {
+commandEncoder109.clearBuffer(buffer32);
+dissociateBuffer(device4, buffer32);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer32, 34332, new Int16Array(60415), 12181);
+} catch {}
+offscreenCanvas0.width = 2842;
+let offscreenCanvas30 = new OffscreenCanvas(436, 271);
+let querySet67 = device2.createQuerySet({label: '\uedb4\u{1f901}\u0ec1\uf60c\u0c7b', type: 'occlusion', count: 3441});
+let textureView140 = texture64.createView({baseMipLevel: 9, mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder51.setBindGroup(0, bindGroup23, new Uint32Array(7346), 5977, 0);
+} catch {}
+try {
+computePassEncoder52.setPipeline(pipeline88);
+} catch {}
+try {
+renderBundleEncoder49.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder45.setPipeline(pipeline92);
+} catch {}
+let commandEncoder117 = device3.createCommandEncoder({label: '\ucc57\u{1fe44}\u9ae5'});
+try {
+  await adapter6.requestAdapterInfo();
+} catch {}
+let imageBitmap27 = await createImageBitmap(video26);
+let textureView141 = texture70.createView({
+  label: '\u0032\u4d36\u28a4\ued0d\ued05\u153a',
+  aspect: 'depth-only',
+  baseMipLevel: 1,
+  baseArrayLayer: 13,
+  arrayLayerCount: 72,
+});
+try {
+gpuCanvasContext30.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let texture74 = device4.createTexture({
+  label: '\u{1f7e8}\u0572\u1fad\uf6af\u{1f7ac}\u5557\ud52e\u0b66\u00d0\u8f46',
+  size: {width: 1152, height: 480, depthOrArrayLayers: 479},
+  mipLevelCount: 11,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView142 = texture73.createView({
+  label: '\u{1fcff}\u4428\u0659\u44f1\u{1f971}\u0df3\udcc2',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 338,
+  arrayLayerCount: 136,
+});
+let renderBundleEncoder53 = device4.createRenderBundleEncoder({
+  label: '\u0317\ufd44\u{1f734}\uab30\u{1fb14}\ua941\u0bc8\u7b35\u476e\uc79b\u0963',
+  colorFormats: ['rgba8uint'],
+});
+try {
+commandEncoder115.copyTextureToBuffer({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 208, y: 76, z: 82},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 5408 widthInBlocks: 338 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 7568 */
+  offset: 7568,
+  bytesPerRow: 5632,
+  buffer: buffer32,
+}, {width: 1352, height: 40, depthOrArrayLayers: 0});
+dissociateBuffer(device4, buffer32);
+} catch {}
+try {
+gpuCanvasContext21.configure({
+  device: device4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device4.queue.writeBuffer(buffer31, 7412, new Int16Array(43665), 29106, 6892);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 5,
+  origin: {x: 2, y: 0, z: 81},
+  aspect: 'all',
+}, arrayBuffer8, /* required buffer size: 2_422_263 */
+{offset: 64, bytesPerRow: 319, rowsPerImage: 292}, {width: 8, height: 2, depthOrArrayLayers: 27});
+} catch {}
+let gpuCanvasContext31 = canvas29.getContext('webgpu');
+try {
+  await promise36;
+} catch {}
+let img34 = await imageWithData(109, 38, '#2cd416f0', '#262c3667');
+let sampler66 = device2.createSampler({
+  label: '\u478e\u{1fdd1}\u4a3b\uc98a\ub943\u{1faa1}\u70e9\ud72a',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 6.993,
+  lodMaxClamp: 82.76,
+});
+try {
+computePassEncoder51.setBindGroup(5, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder45.setPipeline(pipeline92);
+} catch {}
+try {
+commandEncoder95.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1936 */
+  offset: 1936,
+  rowsPerImage: 181,
+  buffer: buffer28,
+}, {
+  texture: texture67,
+  mipLevel: 10,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer28);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer5), /* required buffer size: 1_463 */
+{offset: 271}, {width: 149, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let querySet68 = device2.createQuerySet({label: '\u{1fd0a}\ucae1\u5e5c\u255a\u0ecc\u00f1\u0395\u19ea\u03c2', type: 'occlusion', count: 285});
+let renderBundleEncoder54 = device2.createRenderBundleEncoder({
+  label: '\uba1a\u3944\ua6a9\u4e62\u07f3',
+  colorFormats: ['rgba16float', 'rgba32float', 'rgba8unorm', 'rg32sint', 'rg8unorm'],
+  stencilReadOnly: false,
+});
+try {
+renderBundleEncoder49.setPipeline(pipeline92);
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+let gpuCanvasContext32 = canvas31.getContext('webgpu');
+let shaderModule27 = device2.createShaderModule({
+  label: '\u0c81\u0f87\u0b3d\u7e00\u{1f79b}',
+  code: `@group(0) @binding(2086)
+var<storage, read_write> local16: array<u32>;
+@group(2) @binding(1457)
+var<storage, read_write> n5: array<u32>;
+@group(3) @binding(4492)
+var<storage, read_write> function17: array<u32>;
+@group(2) @binding(1762)
+var<storage, read_write> global14: array<u32>;
+@group(1) @binding(2086)
+var<storage, read_write> parameter11: array<u32>;
+@group(3) @binding(1762)
+var<storage, read_write> local17: array<u32>;
+@group(2) @binding(4492)
+var<storage, read_write> local18: array<u32>;
+@group(1) @binding(6124)
+var<storage, read_write> local19: array<u32>;
+@group(0) @binding(6124)
+var<storage, read_write> field19: array<u32>;
+@group(1) @binding(2213)
+var<storage, read_write> local20: array<u32>;
+
+@compute @workgroup_size(7, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(3) f1: vec4<i32>,
+  @location(2) f2: vec4<f32>,
+  @location(4) f3: vec2<f32>,
+  @location(0) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(8) a0: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout41 = device2.createBindGroupLayout({label: '\u{1fbf2}\u09f4\u1bb8\ubbb5\u005e\u{1f84f}\u0b51\u{1f94a}\u{1f856}', entries: []});
+let commandEncoder118 = device2.createCommandEncoder();
+try {
+computePassEncoder52.setBindGroup(1, bindGroup23);
+} catch {}
+try {
+computePassEncoder50.setPipeline(pipeline96);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 9,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer7), /* required buffer size: 588 */
+{offset: 572}, {width: 2, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline97 = await device2.createComputePipelineAsync({
+  label: '\u{1f7a6}\u{1fc66}\u4d16\u9f68',
+  layout: pipelineLayout17,
+  compute: {module: shaderModule25, entryPoint: 'compute0', constants: {}},
+});
+let pipeline98 = await device2.createRenderPipelineAsync({
+  label: '\uc45b\u{1fa13}\u0be0\u0809\u35f1\u7fdb\u00af',
+  layout: pipelineLayout16,
+  fragment: {
+  module: shaderModule26,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+}, {format: 'rgba32float', writeMask: 0}, {format: 'rgba8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {failOp: 'decrement-wrap', passOp: 'invert'},
+    stencilBack: {compare: 'greater', failOp: 'decrement-wrap', depthFailOp: 'invert', passOp: 'replace'},
+    stencilReadMask: 3896344055,
+    stencilWriteMask: 1551093660,
+    depthBiasSlopeScale: 24.142588649015593,
+  },
+  vertex: {
+    module: shaderModule26,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2868,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 1608, shaderLocation: 15},
+          {format: 'float32', offset: 744, shaderLocation: 5},
+          {format: 'uint16x4', offset: 928, shaderLocation: 10},
+          {format: 'uint32x4', offset: 1172, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'back', unclippedDepth: false},
+});
+let imageBitmap28 = await createImageBitmap(videoFrame24);
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let commandEncoder119 = device2.createCommandEncoder();
+let textureView143 = texture67.createView({label: '\u52b5\u5d35\u0a8b\u{1fc51}\u0683', dimension: '3d', baseMipLevel: 2, mipLevelCount: 3});
+let externalTexture64 = device2.importExternalTexture({label: '\u{1f6ee}\uc69d', source: video0});
+try {
+renderBundleEncoder52.setVertexBuffer(6, buffer30, 0, 15018);
+} catch {}
+let texture75 = device2.createTexture({
+  size: [157, 1, 778],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView144 = texture64.createView({
+  label: '\ue3e8\u{1f6fa}\ucec5\u08cd\u1ac9\uf253\u7d70\u{1ff8f}\ua91d',
+  baseMipLevel: 2,
+  mipLevelCount: 2,
+});
+try {
+computePassEncoder52.setPipeline(pipeline95);
+} catch {}
+try {
+renderBundleEncoder52.setVertexBuffer(0, buffer30, 0, 46647);
+} catch {}
+try {
+device2.queue.submit([commandBuffer26]);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 22},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer0), /* required buffer size: 20_315_699 */
+{offset: 899, bytesPerRow: 950, rowsPerImage: 99}, {width: 199, height: 0, depthOrArrayLayers: 217});
+} catch {}
+let pipeline99 = await device2.createComputePipelineAsync({layout: pipelineLayout16, compute: {module: shaderModule24, entryPoint: 'compute0', constants: {}}});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let shaderModule28 = device0.createShaderModule({
+  label: '\ufaed\u6db0\u{1ffb0}\u0d22',
+  code: `@group(0) @binding(2330)
+var<storage, read_write> field20: array<u32>;
+@group(0) @binding(6934)
+var<storage, read_write> n6: array<u32>;
+
+@compute @workgroup_size(5, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec4<i32>,
+  @location(5) f2: vec2<f32>,
+  @location(1) f3: vec4<u32>,
+  @location(2) f4: vec4<f32>,
+  @location(3) f5: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool, @builtin(sample_mask) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S23 {
+  @location(24) f0: u32,
+  @location(27) f1: vec4<u32>,
+  @location(10) f2: vec4<f32>,
+  @location(23) f3: vec4<f16>,
+  @location(20) f4: i32,
+  @location(22) f5: vec2<u32>,
+  @location(21) f6: vec4<u32>,
+  @location(7) f7: f16,
+  @location(25) f8: i32,
+  @location(11) f9: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(4) a0: i32, @location(5) a1: vec3<i32>, @location(16) a2: vec3<u32>, @location(26) a3: vec2<f32>, @location(1) a4: u32, @location(3) a5: vec3<f16>, @location(12) a6: f16, @location(15) a7: vec4<f16>, @location(0) a8: f16, @location(19) a9: vec4<i32>, @builtin(vertex_index) a10: u32, @location(13) a11: u32, @builtin(instance_index) a12: u32, @location(14) a13: vec2<u32>, @location(8) a14: vec4<i32>, @location(6) a15: f16, @location(2) a16: i32, @location(9) a17: vec3<u32>, @location(17) a18: vec2<u32>, a19: S23, @location(18) a20: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let bindGroup24 = device0.createBindGroup({layout: bindGroupLayout6, entries: []});
+let querySet69 = device0.createQuerySet({label: '\u9c1f\uaa44\u03c9\u06fd\u0d5b\u2163', type: 'occlusion', count: 2851});
+let commandBuffer27 = commandEncoder88.finish({label: '\u0bc9\u0a5f\u12a8\ufa2d'});
+let computePassEncoder53 = commandEncoder70.beginComputePass({});
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(5, 0, 2, 1);
+} catch {}
+try {
+renderPassEncoder12.draw(43, 152, 245_271_347, 406_839_574);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer10, 454_402_776);
+} catch {}
+let promise38 = device0.createRenderPipelineAsync({
+  label: '\u95e2\udb26\u01d8\u{1f9c1}\u8d75\u0063\ucc8a\u005a\u44b8\u62e3\u4f0e',
+  layout: pipelineLayout9,
+  multisample: {mask: 0xf7846b27},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg16uint', writeMask: GPUColorWrite.ALL}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'less', failOp: 'replace', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'not-equal', failOp: 'zero', depthFailOp: 'zero', passOp: 'keep'},
+    stencilReadMask: 1540272732,
+    stencilWriteMask: 2957671495,
+    depthBiasSlopeScale: 561.7213975361383,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 308,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x4', offset: 16, shaderLocation: 13}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'front'},
+});
+try {
+adapter2.label = '\u{1fc76}\ufc3f\u25b8\u9ed8\u{1fbb5}\u82fb\u042a\u839c\u1d2e';
+} catch {}
+try {
+offscreenCanvas30.getContext('bitmaprenderer');
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let shaderModule29 = device4.createShaderModule({
+  label: '\u70fb\u0561\uad21\ub472\uc9fd\ud1de\u5df7\u00cc\u6e65\u1e9c\u7377',
+  code: `@group(1) @binding(875)
+var<storage, read_write> field21: array<u32>;
+@group(3) @binding(1173)
+var<storage, read_write> n7: array<u32>;
+@group(2) @binding(875)
+var<storage, read_write> field22: array<u32>;
+@group(0) @binding(875)
+var<storage, read_write> global15: array<u32>;
+@group(3) @binding(875)
+var<storage, read_write> function18: array<u32>;
+@group(2) @binding(1173)
+var<storage, read_write> n8: array<u32>;
+@group(1) @binding(1173)
+var<storage, read_write> n9: array<u32>;
+@group(0) @binding(1173)
+var<storage, read_write> type19: array<u32>;
+
+@compute @workgroup_size(7, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S25 {
+  @location(24) f0: vec4<f16>,
+  @builtin(front_facing) f1: bool,
+  @location(32) f2: vec2<u32>,
+  @location(45) f3: f32,
+  @location(11) f4: vec2<f16>,
+  @location(3) f5: vec4<u32>,
+  @location(39) f6: u32,
+  @location(23) f7: vec2<f32>,
+  @location(28) f8: vec4<f32>,
+  @location(20) f9: vec2<i32>,
+  @location(21) f10: vec4<i32>,
+  @location(9) f11: u32,
+  @location(40) f12: vec3<f32>,
+  @builtin(position) f13: vec4<f32>,
+  @builtin(sample_mask) f14: u32,
+  @location(8) f15: vec2<u32>,
+  @location(26) f16: vec2<f16>,
+  @location(38) f17: vec4<u32>,
+  @location(29) f18: i32,
+  @location(10) f19: f32,
+  @location(25) f20: vec4<f32>,
+  @location(17) f21: vec2<f32>,
+  @location(7) f22: vec3<f16>,
+  @location(44) f23: u32,
+  @location(1) f24: vec3<u32>,
+  @location(18) f25: vec2<i32>,
+  @location(34) f26: vec3<u32>,
+  @location(42) f27: vec2<u32>,
+  @location(15) f28: vec2<i32>,
+  @location(37) f29: vec3<i32>,
+  @builtin(sample_index) f30: u32
+}
+struct FragmentOutput0 {
+  @location(3) f0: f32,
+  @location(0) f1: vec4<u32>
+}
+
+@fragment
+fn fragment0(a0: S25) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S24 {
+  @location(5) f0: f32,
+  @location(11) f1: vec4<f32>
+}
+struct VertexOutput0 {
+  @location(42) f305: vec2<u32>,
+  @location(15) f306: vec2<i32>,
+  @location(34) f307: vec3<u32>,
+  @location(45) f308: f32,
+  @location(1) f309: vec3<u32>,
+  @location(29) f310: i32,
+  @location(18) f311: vec2<i32>,
+  @location(38) f312: vec4<u32>,
+  @location(10) f313: f32,
+  @location(21) f314: vec4<i32>,
+  @location(39) f315: u32,
+  @location(23) f316: vec2<f32>,
+  @location(3) f317: vec4<u32>,
+  @location(28) f318: vec4<f32>,
+  @location(40) f319: vec3<f32>,
+  @builtin(position) f320: vec4<f32>,
+  @location(8) f321: vec2<u32>,
+  @location(32) f322: vec2<u32>,
+  @location(20) f323: vec2<i32>,
+  @location(17) f324: vec2<f32>,
+  @location(37) f325: vec3<i32>,
+  @location(44) f326: u32,
+  @location(24) f327: vec4<f16>,
+  @location(7) f328: vec3<f16>,
+  @location(26) f329: vec2<f16>,
+  @location(9) f330: u32,
+  @location(11) f331: vec2<f16>,
+  @location(25) f332: vec4<f32>
+}
+
+@vertex
+fn vertex0(a0: S24, @location(14) a1: vec4<f32>, @location(10) a2: vec2<f16>, @location(7) a3: vec2<f16>, @location(2) a4: vec2<f32>, @location(9) a5: vec4<f16>, @location(12) a6: i32, @builtin(instance_index) a7: u32, @location(15) a8: vec4<f16>, @location(17) a9: vec4<f16>, @location(13) a10: vec3<i32>, @builtin(vertex_index) a11: u32, @location(6) a12: f16, @location(8) a13: vec2<u32>, @location(16) a14: u32, @location(4) a15: vec3<f32>, @location(18) a16: vec4<f32>, @location(0) a17: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let computePassEncoder54 = commandEncoder116.beginComputePass({label: '\ub6ac\u614f\u0bc9\u04a3\u{1fa1a}\u86fb\u0865\u{1fc43}\u0095\u{1f877}'});
+let sampler67 = device4.createSampler({
+  label: '\u9f2c\u0260\u8c8b\ub32b\u{1f836}\u0508\u{1f8b9}\u80a4\u6cd5',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 12.18,
+  maxAnisotropy: 19,
+});
+try {
+commandEncoder110.clearBuffer(buffer31, 165792);
+dissociateBuffer(device4, buffer31);
+} catch {}
+let canvas32 = document.createElement('canvas');
+let video36 = await videoWithData();
+let buffer33 = device2.createBuffer({label: '\u{1fe0b}\uddcd', size: 228139, usage: GPUBufferUsage.MAP_WRITE});
+let commandEncoder120 = device2.createCommandEncoder();
+let renderBundleEncoder55 = device2.createRenderBundleEncoder({
+  label: '\u{1feb3}\u027c\u0ae2\ub26b\u02af',
+  colorFormats: ['rgba16float', 'rgba32float', 'rgba8unorm', 'rg32sint', 'rg8unorm'],
+  stencilReadOnly: true,
+});
+let sampler68 = device2.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 62.82,
+  lodMaxClamp: 63.84,
+});
+try {
+renderBundleEncoder49.setPipeline(pipeline92);
+} catch {}
+try {
+renderBundleEncoder52.setVertexBuffer(5, buffer30, 50264, 6553);
+} catch {}
+let shaderModule30 = device2.createShaderModule({
+  label: '\u0343\u50ab\u0fbe\u6b7d\udc34',
+  code: `@group(2) @binding(1457)
+var<storage, read_write> local21: array<u32>;
+@group(0) @binding(6124)
+var<storage, read_write> function19: array<u32>;
+@group(0) @binding(2213)
+var<storage, read_write> function20: array<u32>;
+@group(2) @binding(1762)
+var<storage, read_write> type20: array<u32>;
+@group(3) @binding(1457)
+var<storage, read_write> parameter12: array<u32>;
+@group(0) @binding(2086)
+var<storage, read_write> local22: array<u32>;
+@group(1) @binding(2213)
+var<storage, read_write> field23: array<u32>;
+@group(3) @binding(4492)
+var<storage, read_write> type21: array<u32>;
+@group(3) @binding(1762)
+var<storage, read_write> local23: array<u32>;
+
+@compute @workgroup_size(2, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(4) f1: vec3<f32>,
+  @location(2) f2: vec4<f32>,
+  @location(3) f3: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(10) a0: i32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(10) f333: i32,
+  @location(13) f334: i32,
+  @builtin(position) f335: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec2<f32>, @location(3) a1: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let commandEncoder121 = device2.createCommandEncoder({label: '\u01bb\uda1d\u06aa\u0887\ub37b\u{1fa30}\ud8dd\u9f4e\ud930'});
+let querySet70 = device2.createQuerySet({type: 'occlusion', count: 3218});
+let texture76 = device2.createTexture({
+  label: '\u{1faa5}\u0aff\u44e9\u{1ff84}',
+  size: {width: 1256, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float'],
+});
+let computePassEncoder55 = commandEncoder100.beginComputePass({label: '\u23f9\u{1fbf9}\u1d1d\u{1fd3a}'});
+let renderBundle59 = renderBundleEncoder45.finish({label: '\ufd2b\u8aaa\u9a93\ue3c8\u0579\u9449'});
+let pipeline100 = device2.createComputePipeline({
+  label: '\u0aa9\u05ce\u54ea',
+  layout: pipelineLayout16,
+  compute: {module: shaderModule27, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext33 = canvas32.getContext('webgpu');
+try {
+adapter5.label = '\u0822\u{1ff6f}\u{1fbcc}';
+} catch {}
+let commandEncoder122 = device2.createCommandEncoder({label: '\u04f4\u0ebe\u0931\u4692\u{1f605}\u{1f883}\u027a\ue14b\u4d97\u1982'});
+let querySet71 = device2.createQuerySet({type: 'occlusion', count: 1875});
+let texture77 = device2.createTexture({
+  label: '\u2244\u6417\u9b39\uae4a\u0eae',
+  size: [1476],
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView145 = texture68.createView({label: '\ud1a9\u1b77\u4547\u4064\u0696\u09ac\u6df2'});
+let sampler69 = device2.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 94.43,
+  lodMaxClamp: 96.94,
+  compare: 'less-equal',
+});
+let externalTexture65 = device2.importExternalTexture({
+  label: '\u1d36\u{1f7d3}\u{1f96f}\u{1ff88}\u0ec2\u{1fda4}\u{1fa7a}',
+  source: video21,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder54.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+gpuCanvasContext31.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline101 = await device2.createComputePipelineAsync({
+  label: '\ucf45\uf1d3\u4525\ue57d\u05a3\u0bdd\u040f\u0401\u061d',
+  layout: pipelineLayout16,
+  compute: {module: shaderModule26, entryPoint: 'compute0'},
+});
+let promise39 = device2.createRenderPipelineAsync({
+  label: '\u023c\u23bd\u{1f79f}\u{1fba1}\u{1fa34}\ub08b\uffc5',
+  layout: pipelineLayout16,
+  multisample: {mask: 0x7b89e5ed},
+  fragment: {
+  module: shaderModule25,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float'}, {format: 'rgba32float', writeMask: 0}, {format: 'rgba8unorm'}, {format: 'rg32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg8unorm'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'less', failOp: 'invert', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilBack: {compare: 'less-equal', failOp: 'increment-wrap', depthFailOp: 'replace', passOp: 'zero'},
+    stencilReadMask: 1200969007,
+    stencilWriteMask: 2401724232,
+    depthBiasSlopeScale: 102.23039440711153,
+  },
+  vertex: {
+    module: shaderModule25,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 10108,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint8x2', offset: 1732, shaderLocation: 17},
+          {format: 'sint32x3', offset: 996, shaderLocation: 10},
+          {format: 'snorm8x2', offset: 2514, shaderLocation: 0},
+          {format: 'uint32x4', offset: 2268, shaderLocation: 8},
+          {format: 'float16x4', offset: 244, shaderLocation: 2},
+          {format: 'unorm10-10-10-2', offset: 1124, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 2850, shaderLocation: 16},
+          {format: 'float32x4', offset: 3900, shaderLocation: 7},
+          {format: 'float32x3', offset: 204, shaderLocation: 14},
+          {format: 'unorm16x2', offset: 1948, shaderLocation: 12},
+          {format: 'sint32x3', offset: 2112, shaderLocation: 11},
+          {format: 'uint32x4', offset: 1108, shaderLocation: 4},
+          {format: 'float32x3', offset: 7596, shaderLocation: 3},
+          {format: 'uint16x4', offset: 952, shaderLocation: 9},
+          {format: 'uint32x2', offset: 1008, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back'},
+});
+try {
+adapter1.label = '\ub9a7\u291c\u0180\u097b\u1a3b\ua3b3\u0f77';
+} catch {}
+try {
+window.someLabel = externalTexture46.label;
+} catch {}
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+gc();
+let offscreenCanvas31 = new OffscreenCanvas(1016, 318);
+try {
+adapter2.label = '\u9f25\u0025';
+} catch {}
+let shaderModule31 = device2.createShaderModule({
+  code: `@group(0) @binding(6124)
+var<storage, read_write> local24: array<u32>;
+@group(0) @binding(2213)
+var<storage, read_write> n10: array<u32>;
+@group(0) @binding(2086)
+var<storage, read_write> type22: array<u32>;
+@group(1) @binding(2086)
+var<storage, read_write> function21: array<u32>;
+@group(1) @binding(6124)
+var<storage, read_write> parameter13: array<u32>;
+
+@compute @workgroup_size(3, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S26 {
+  @builtin(sample_mask) f0: u32,
+  @builtin(front_facing) f1: bool,
+  @builtin(position) f2: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(7) f0: vec3<i32>,
+  @location(4) f1: vec4<f32>,
+  @location(0) f2: vec4<f32>,
+  @location(3) f3: vec2<i32>,
+  @location(2) f4: vec4<f32>,
+  @location(1) f5: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(7) a0: vec3<u32>, @builtin(sample_index) a1: u32, a2: S26) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f336: vec4<f32>,
+  @location(7) f337: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec4<i32>, @location(1) a1: i32, @location(3) a2: vec4<i32>, @location(15) a3: vec3<i32>, @location(14) a4: i32, @location(13) a5: vec2<u32>, @location(0) a6: i32, @location(17) a7: vec3<i32>, @location(16) a8: f16, @location(5) a9: vec2<f32>, @builtin(vertex_index) a10: u32, @builtin(instance_index) a11: u32, @location(10) a12: vec2<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+});
+let buffer34 = device2.createBuffer({
+  label: '\u002a\ua1ea\u0c7e\u0740\u3422\u{1f7da}\u75d1\u1875\u8177',
+  size: 191210,
+  usage: GPUBufferUsage.STORAGE,
+});
+let commandEncoder123 = device2.createCommandEncoder({label: '\u{1f959}\u{1f9ed}\u0b55\u2184\u{1ffdc}\ue678\ufcf5\uef35'});
+let textureView146 = texture76.createView({label: '\u{1fa5d}\uabc1\u3f96\u37cb', baseMipLevel: 2});
+let renderBundle60 = renderBundleEncoder52.finish({label: '\u0f25\u{1f883}\u13f0\u{1fd05}\u{1f8af}\u{1fb53}'});
+let sampler70 = device2.createSampler({
+  label: '\u07ff\u05cf\ub0e1\u0b0f\uef0e',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 77.61,
+  lodMaxClamp: 87.83,
+});
+try {
+device2.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 3,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 78 */
+{offset: 78}, {width: 63, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+let texture78 = device2.createTexture({size: [628], dimension: '1d', format: 'rg32sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView147 = texture67.createView({label: '\ub603\uc3b8\u337e', baseMipLevel: 7, mipLevelCount: 3});
+try {
+renderBundleEncoder49.setBindGroup(5, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder49.setVertexBuffer(8, buffer30, 0, 2087);
+} catch {}
+let pipeline102 = await device2.createComputePipelineAsync({
+  label: '\u0a3d\u9154\u77c9\u383a\u0437\ud3d0\uda9b\u{1fb6a}\u0a9e',
+  layout: pipelineLayout17,
+  compute: {module: shaderModule31, entryPoint: 'compute0', constants: {}},
+});
+offscreenCanvas18.width = 758;
+let commandEncoder124 = device3.createCommandEncoder();
+let commandBuffer28 = commandEncoder114.finish({label: '\ua68e\u0f92\ue331'});
+let renderBundleEncoder56 = device3.createRenderBundleEncoder({
+  label: '\u0285\u2508\u2cca\u0d25\u36c1',
+  colorFormats: ['rg8unorm', 'r16uint', 'rgba8unorm-srgb', 'rg16sint', 'bgra8unorm-srgb', 'rg11b10ufloat', 'r16float'],
+  depthStencilFormat: 'depth16unorm',
+});
+let offscreenCanvas32 = new OffscreenCanvas(715, 855);
+let gpuCanvasContext34 = canvas30.getContext('webgpu');
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let imageData31 = new ImageData(16, 220);
+try {
+offscreenCanvas32.getContext('webgl2');
+} catch {}
+let commandEncoder125 = device4.createCommandEncoder({label: '\uf378\u1621\u012e\u8973\uaa79\u4a40\u9914\u0747\u7ad3\u{1fd2a}\ua1ed'});
+let renderBundle61 = renderBundleEncoder51.finish();
+let sampler71 = device4.createSampler({
+  label: '\u0e97\u25a6\u{1f613}\u{1fd64}\ueca2\u0ac1\u40b9',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 8.409,
+  lodMaxClamp: 20.54,
+  maxAnisotropy: 11,
+});
+try {
+commandEncoder110.clearBuffer(buffer31, 216320, 27460);
+dissociateBuffer(device4, buffer31);
+} catch {}
+let commandBuffer29 = commandEncoder109.finish({label: '\u{1f7db}\ubf11\u22f1\u0424\u3504\u0e81\u0437\u5ecd'});
+let computePassEncoder56 = commandEncoder110.beginComputePass();
+let sampler72 = device4.createSampler({
+  label: '\u0102\u0966\u{1fffc}\u0e19',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 3.889,
+  lodMaxClamp: 75.41,
+  maxAnisotropy: 7,
+});
+let externalTexture66 = device4.importExternalTexture({
+  label: '\u097f\u193b\u907f\u9f03\u{1fa75}\u4077\ued4a\u4aba\ua1c2\ud6f8',
+  source: videoFrame33,
+  colorSpace: 'display-p3',
+});
+try {
+device4.queue.writeBuffer(buffer32, 129848, new BigUint64Array(57781), 56273);
+} catch {}
+let promise40 = device4.createComputePipelineAsync({
+  label: '\u6d91\u0a17\u4ffe\u9854\u692d\u9064\u2a25\u027f\ud3ff\u{1fe52}',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule29, entryPoint: 'compute0'},
+});
+let textureView148 = texture72.createView({
+  label: '\u{1fb33}\u52b7\ufb08\u{1f6d5}\u0332\u{1f6da}',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+  baseArrayLayer: 186,
+  arrayLayerCount: 146,
+});
+let sampler73 = device4.createSampler({
+  label: '\uf12f\u081b\u{1f9f0}',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 78.27,
+  lodMaxClamp: 81.20,
+});
+try {
+commandEncoder125.copyTextureToBuffer({
+  texture: texture72,
+  mipLevel: 1,
+  origin: {x: 92, y: 148, z: 61},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2064 widthInBlocks: 129 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 12288 */
+  offset: 12288,
+  bytesPerRow: 2304,
+  rowsPerImage: 241,
+  buffer: buffer31,
+}, {width: 516, height: 20, depthOrArrayLayers: 0});
+dissociateBuffer(device4, buffer31);
+} catch {}
+try {
+commandEncoder108.insertDebugMarker('\uce37');
+} catch {}
+try {
+device4.queue.writeBuffer(buffer31, 9108, new BigUint64Array(61639), 28608, 632);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let imageBitmap29 = await createImageBitmap(imageData31);
+canvas20.height = 323;
+let commandEncoder126 = device4.createCommandEncoder({label: '\u0282\u0733\u4bfb\u0c00\u{1f9e3}\u{1f9c5}\u3b05\ua9a7'});
+let querySet72 = device4.createQuerySet({type: 'occlusion', count: 774});
+let sampler74 = device4.createSampler({
+  label: '\u{1f726}\u{1fe2a}\u0216\u6cd3\u{1fd05}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 58.01,
+  lodMaxClamp: 98.39,
+  maxAnisotropy: 4,
+});
+try {
+device4.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 9,
+  origin: {x: 0, y: 0, z: 20},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 7_139_365 */
+{offset: 997, bytesPerRow: 243, rowsPerImage: 68}, {width: 1, height: 0, depthOrArrayLayers: 433});
+} catch {}
+let video37 = await videoWithData();
+try {
+offscreenCanvas31.getContext('webgpu');
+} catch {}
+let commandEncoder127 = device4.createCommandEncoder({label: '\uaece\u{1f6e8}\u{1fb43}\ubd94\u0d13\u{1fa15}\u348f\u04a5\u068e'});
+let texture79 = device4.createTexture({
+  size: {width: 288, height: 120, depthOrArrayLayers: 50},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint', 'rgba8uint'],
+});
+let renderBundleEncoder57 = device4.createRenderBundleEncoder({colorFormats: ['rgba8uint'], depthReadOnly: true});
+let renderBundle62 = renderBundleEncoder57.finish({label: '\u{1f6d6}\u79e7\u{1f8d8}\u7e7a\u0d67\u08b3\u{1ff65}\uccf8\u{1f889}'});
+try {
+renderBundleEncoder53.setVertexBuffer(4139, undefined, 905646385, 3115021698);
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline103 = device4.createComputePipeline({
+  label: '\u94f5\u8c4e\u6306\u0b24\u4c8a\u34b7',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule29, entryPoint: 'compute0', constants: {}},
+});
+let buffer35 = device4.createBuffer({size: 322380, usage: GPUBufferUsage.COPY_DST});
+let commandEncoder128 = device4.createCommandEncoder();
+let textureView149 = texture79.createView({label: '\ue2af\u{1ff59}\u{1f868}\u0500\u0d1b\uff7a', baseMipLevel: 3});
+let renderBundleEncoder58 = device4.createRenderBundleEncoder({colorFormats: ['rgba8uint']});
+try {
+commandEncoder128.copyTextureToBuffer({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 76, y: 184, z: 60},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 5024 widthInBlocks: 314 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 48 */
+  offset: 48,
+  bytesPerRow: 5376,
+  rowsPerImage: 231,
+  buffer: buffer32,
+}, {width: 1256, height: 72, depthOrArrayLayers: 0});
+dissociateBuffer(device4, buffer32);
+} catch {}
+let pipeline104 = await promise40;
+let video38 = await videoWithData();
+let textureView150 = texture74.createView({
+  label: '\u0539\u{1f818}\u0972\ue8df\u903f\u0551\uae52\ub3bf\u8647\u0beb\u2aed',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 9,
+  baseArrayLayer: 59,
+  arrayLayerCount: 162,
+});
+try {
+commandEncoder108.copyTextureToTexture({
+  texture: texture73,
+  mipLevel: 1,
+  origin: {x: 1, y: 42, z: 12},
+  aspect: 'all',
+},
+{
+  texture: texture73,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let imageBitmap30 = await createImageBitmap(imageData2);
+let bindGroupLayout42 = device3.createBindGroupLayout({
+  entries: [
+    {
+      binding: 1093,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 993,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {binding: 1136, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let commandEncoder129 = device3.createCommandEncoder();
+let querySet73 = device3.createQuerySet({label: '\u0fe5\ufbda\uf7f6\u0215\ufdc7\ud63d\ua006', type: 'occlusion', count: 2061});
+let texture80 = device3.createTexture({
+  label: '\ue138\u8708\uc37e\u6795\u05cd\u{1f71b}\u16a6\ufb1f',
+  size: [424, 1, 88],
+  mipLevelCount: 2,
+  format: 'r16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView151 = texture80.createView({
+  label: '\u{1f7bd}\u7546\u0c9e\u4cc7\u81ef\u0576',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 1,
+  baseArrayLayer: 30,
+});
+let renderBundleEncoder59 = device3.createRenderBundleEncoder({
+  label: '\ue228\u{1f8c3}\uba40\u9ba3\u013d',
+  colorFormats: ['rg8unorm', 'r16uint', 'rgba8unorm-srgb', 'rg16sint', 'bgra8unorm-srgb', 'rg11b10ufloat', 'r16float'],
+  depthStencilFormat: 'depth16unorm',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder59.setVertexBuffer(9944, undefined, 0);
+} catch {}
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+let video39 = await videoWithData();
+try {
+adapter6.label = '\u{1fecd}\u{1fd83}\uedf8\u0ce2\u{1fb6f}';
+} catch {}
+gc();
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+gc();
+let offscreenCanvas33 = new OffscreenCanvas(861, 540);
+let promise41 = adapter3.requestAdapterInfo();
+try {
+renderBundleEncoder49.label = '\u{1fa9b}\u07f8\u1339\u4900';
+} catch {}
+let textureView152 = texture67.createView({mipLevelCount: 4});
+let computePassEncoder57 = commandEncoder93.beginComputePass({label: '\u{1fda1}\ufd60\u{1fb43}\uc515\u2600\u916f\u{1fee1}'});
+try {
+renderBundleEncoder47.setBindGroup(3, bindGroup23);
+} catch {}
+try {
+gpuCanvasContext18.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline105 = device2.createRenderPipeline({
+  label: '\u6a64\u49f0\ucc72',
+  layout: 'auto',
+  multisample: {count: 1, mask: 0xbc4cc758},
+  fragment: {
+  module: shaderModule25,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'one-minus-src'},
+  },
+  writeMask: 0,
+}, {format: 'rgba32float', writeMask: 0}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL,
+}, {format: 'rg32sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'constant'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'dst', dstFactor: 'src-alpha-saturated'},
+  },
+}],
+},
+  vertex: {
+    module: shaderModule25,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3500,
+        attributes: [
+          {format: 'uint32x3', offset: 1932, shaderLocation: 4},
+          {format: 'sint8x4', offset: 112, shaderLocation: 10},
+          {format: 'unorm8x2', offset: 394, shaderLocation: 14},
+          {format: 'uint16x4', offset: 328, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 108, shaderLocation: 16},
+          {format: 'snorm16x2', offset: 1236, shaderLocation: 1},
+          {format: 'float32', offset: 752, shaderLocation: 7},
+          {format: 'unorm8x4', offset: 228, shaderLocation: 0},
+          {format: 'sint32x2', offset: 1588, shaderLocation: 17},
+          {format: 'snorm16x4', offset: 116, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 916, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 4840, shaderLocation: 6},
+          {format: 'uint32x2', offset: 4448, shaderLocation: 8},
+          {format: 'sint32x3', offset: 5680, shaderLocation: 11},
+          {format: 'float16x4', offset: 7816, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 4328,
+        stepMode: 'vertex',
+        attributes: [{format: 'float32x2', offset: 688, shaderLocation: 3}],
+      },
+    ],
+  },
+});
+canvas17.width = 364;
+let video40 = await videoWithData();
+let bindGroupLayout43 = device2.createBindGroupLayout({
+  label: '\uf9d5\u6228\u26ae\uc0b1\ueaaa\uf2c4\u{1f99b}\u0419',
+  entries: [
+    {
+      binding: 2530,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 5539,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder130 = device2.createCommandEncoder({label: '\ud63c\uf675'});
+let textureView153 = texture75.createView({format: 'rg32sint', baseMipLevel: 3, mipLevelCount: 2});
+let computePassEncoder58 = commandEncoder123.beginComputePass({});
+let renderBundle63 = renderBundleEncoder46.finish({label: '\u3b73\u1b46\ue3e7\uc916\u087f\u{1fa2d}\u{1fe05}\u942c\ua9b3\u0989\uf832'});
+try {
+computePassEncoder51.end();
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(3, bindGroup23, []);
+} catch {}
+try {
+renderBundleEncoder47.setBindGroup(4, bindGroup23, new Uint32Array(9035), 126, 0);
+} catch {}
+try {
+renderBundleEncoder54.setPipeline(pipeline105);
+} catch {}
+let commandEncoder131 = device4.createCommandEncoder({label: '\u3bc6\u54dd\u0ea1\u050a\u8225\ube40'});
+let renderBundle64 = renderBundleEncoder57.finish({label: '\u1e93\u0c61\u4241'});
+try {
+commandEncoder131.clearBuffer(buffer35, 260572);
+dissociateBuffer(device4, buffer35);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 95},
+  aspect: 'all',
+}, new ArrayBuffer(2_282_714), /* required buffer size: 2_282_714 */
+{offset: 136, bytesPerRow: 310, rowsPerImage: 80}, {width: 12, height: 4, depthOrArrayLayers: 93});
+} catch {}
+try {
+  await promise41;
+} catch {}
+let video41 = await videoWithData();
+let commandEncoder132 = device2.createCommandEncoder();
+let textureView154 = texture76.createView({label: '\ud2ca\u3fd5\ue040\u062f\u04f4\u1b37\uc287\u0e4c\u83f3\u{1fe73}\u91a2', baseMipLevel: 1});
+let renderBundle65 = renderBundleEncoder45.finish();
+let externalTexture67 = device2.importExternalTexture({source: video21, colorSpace: 'display-p3'});
+try {
+computePassEncoder58.setPipeline(pipeline95);
+} catch {}
+try {
+querySet67.destroy();
+} catch {}
+let videoFrame35 = new VideoFrame(videoFrame31, {timestamp: 0});
+try {
+gpuCanvasContext19.unconfigure();
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let canvas33 = document.createElement('canvas');
+let commandEncoder133 = device4.createCommandEncoder();
+let querySet74 = device4.createQuerySet({label: '\udd2d\u55a3\u067d\u2f70', type: 'occlusion', count: 3262});
+let textureView155 = texture72.createView({
+  label: '\u0d69\u0b14\u8ee3\uc838\u06ae\u4370\u07c0\ub01a',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 389,
+});
+let externalTexture68 = device4.importExternalTexture({label: '\u010b\u3eab\u5cfe\u{1fc74}\u{1f9ac}\u4d6b', source: videoFrame18, colorSpace: 'display-p3'});
+try {
+commandEncoder111.copyTextureToBuffer({
+  texture: texture72,
+  mipLevel: 1,
+  origin: {x: 16, y: 72, z: 85},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3888 widthInBlocks: 243 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 106480 */
+  offset: 4288,
+  bytesPerRow: 4096,
+  buffer: buffer32,
+}, {width: 972, height: 100, depthOrArrayLayers: 1});
+dissociateBuffer(device4, buffer32);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer31, 120552, new BigUint64Array(15060), 11682);
+} catch {}
+let shaderModule32 = device3.createShaderModule({
+  label: '\u0f92\u6922\uf5c1\u707b\ufe44',
+  code: `@group(2) @binding(586)
+var<storage, read_write> n11: array<u32>;
+@group(1) @binding(586)
+var<storage, read_write> global16: array<u32>;
+@group(0) @binding(586)
+var<storage, read_write> field24: array<u32>;
+@group(0) @binding(110)
+var<storage, read_write> global17: array<u32>;
+@group(0) @binding(990)
+var<storage, read_write> field25: array<u32>;
+@group(1) @binding(990)
+var<storage, read_write> local25: array<u32>;
+@group(2) @binding(110)
+var<storage, read_write> n12: array<u32>;
+@group(1) @binding(110)
+var<storage, read_write> global18: array<u32>;
+
+@compute @workgroup_size(2, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S28 {
+  @location(34) f0: vec4<i32>,
+  @location(45) f1: vec3<i32>,
+  @location(19) f2: vec2<f32>,
+  @location(3) f3: vec3<i32>,
+  @location(33) f4: vec3<u32>,
+  @location(32) f5: vec2<u32>,
+  @location(35) f6: vec4<i32>,
+  @location(10) f7: vec4<i32>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec2<u32>,
+  @builtin(frag_depth) f1: f32,
+  @location(2) f2: vec4<f32>,
+  @location(4) f3: vec4<f32>,
+  @location(3) f4: vec3<i32>,
+  @location(0) f5: vec4<f32>,
+  @location(5) f6: vec4<f32>,
+  @location(6) f7: f32
+}
+
+@fragment
+fn fragment0(@location(6) a0: vec3<i32>, @location(20) a1: vec3<i32>, @location(38) a2: vec2<i32>, @builtin(sample_index) a3: u32, @location(18) a4: u32, @location(43) a5: f16, @location(40) a6: vec2<i32>, @location(13) a7: vec3<f16>, @location(11) a8: i32, @location(15) a9: vec3<f32>, a10: S28, @builtin(front_facing) a11: bool, @location(24) a12: vec2<i32>, @builtin(sample_mask) a13: u32, @location(17) a14: vec4<u32>, @location(14) a15: vec4<u32>, @location(39) a16: f16, @location(8) a17: vec4<f16>, @location(46) a18: vec2<f16>, @builtin(position) a19: vec4<f32>, @location(41) a20: vec2<i32>, @location(44) a21: vec2<u32>, @location(47) a22: vec2<i32>, @location(30) a23: i32, @location(2) a24: vec3<f16>, @location(23) a25: vec2<f32>, @location(29) a26: vec2<i32>, @location(27) a27: vec3<f32>, @location(31) a28: vec3<f32>, @location(0) a29: u32, @location(22) a30: f32, @location(16) a31: vec4<f32>, @location(28) a32: u32, @location(25) a33: vec2<i32>, @location(9) a34: vec2<i32>, @location(4) a35: f32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S27 {
+  @location(12) f0: vec3<f32>,
+  @location(16) f1: vec4<u32>,
+  @location(7) f2: vec2<f16>,
+  @location(17) f3: vec4<i32>,
+  @location(23) f4: vec3<f16>,
+  @location(22) f5: vec2<u32>,
+  @location(2) f6: vec3<u32>,
+  @location(24) f7: vec3<u32>,
+  @builtin(vertex_index) f8: u32,
+  @builtin(instance_index) f9: u32,
+  @location(18) f10: vec3<u32>
+}
+struct VertexOutput0 {
+  @location(42) f338: vec2<f32>,
+  @location(22) f339: f32,
+  @location(21) f340: vec3<f16>,
+  @location(41) f341: vec2<i32>,
+  @location(24) f342: vec2<i32>,
+  @location(11) f343: i32,
+  @location(47) f344: vec2<i32>,
+  @location(30) f345: i32,
+  @location(26) f346: vec4<f32>,
+  @location(44) f347: vec2<u32>,
+  @location(2) f348: vec3<f16>,
+  @location(18) f349: u32,
+  @location(36) f350: vec2<f32>,
+  @location(33) f351: vec3<u32>,
+  @location(23) f352: vec2<f32>,
+  @location(39) f353: f16,
+  @location(7) f354: f16,
+  @location(14) f355: vec4<u32>,
+  @location(35) f356: vec4<i32>,
+  @location(1) f357: u32,
+  @location(4) f358: f32,
+  @location(16) f359: vec4<f32>,
+  @location(45) f360: vec3<i32>,
+  @location(9) f361: vec2<i32>,
+  @location(12) f362: vec4<i32>,
+  @location(43) f363: f16,
+  @location(40) f364: vec2<i32>,
+  @location(28) f365: u32,
+  @location(0) f366: u32,
+  @location(13) f367: vec3<f16>,
+  @location(38) f368: vec2<i32>,
+  @location(32) f369: vec2<u32>,
+  @location(25) f370: vec2<i32>,
+  @location(5) f371: f32,
+  @location(8) f372: vec4<f16>,
+  @location(27) f373: vec3<f32>,
+  @location(31) f374: vec3<f32>,
+  @location(46) f375: vec2<f16>,
+  @builtin(position) f376: vec4<f32>,
+  @location(34) f377: vec4<i32>,
+  @location(37) f378: vec4<f32>,
+  @location(10) f379: vec4<i32>,
+  @location(15) f380: vec3<f32>,
+  @location(29) f381: vec2<i32>,
+  @location(17) f382: vec4<u32>,
+  @location(19) f383: vec2<f32>,
+  @location(6) f384: vec3<i32>,
+  @location(3) f385: vec3<i32>,
+  @location(20) f386: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(0) a0: i32, a1: S27, @location(14) a2: vec2<f16>, @location(6) a3: vec4<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet75 = device3.createQuerySet({label: '\u0d9b\u{1f7e3}', type: 'occlusion', count: 3385});
+let renderBundleEncoder60 = device3.createRenderBundleEncoder({
+  label: '\u545f\u0d59\u4299\u5854\u6c57\ud20f\ufa93\u{1f9e8}\u592e\u2e39',
+  colorFormats: ['r8unorm', 'rg11b10ufloat', 'rg8sint', 'r8sint', 'rg32sint', 'rgba16uint', 'rg16float'],
+  sampleCount: 1,
+  stencilReadOnly: true,
+});
+let sampler75 = device3.createSampler({
+  label: '\u{1ff54}\ud0a1\u{1fc6d}\ubee8\u{1fe0c}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 21.16,
+  lodMaxClamp: 60.48,
+  maxAnisotropy: 18,
+});
+try {
+renderBundleEncoder56.setVertexBuffer(1112, undefined, 0, 2468218632);
+} catch {}
+let canvas34 = document.createElement('canvas');
+try {
+canvas34.getContext('bitmaprenderer');
+} catch {}
+let gpuCanvasContext35 = offscreenCanvas33.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let texture81 = device4.createTexture({
+  label: '\u0551\u9b31\uc44d\u863f\u{1fe36}\u9cef\u0ac9',
+  size: [1152, 480, 299],
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint', 'rgba8uint'],
+});
+try {
+computePassEncoder56.setPipeline(pipeline103);
+} catch {}
+try {
+renderBundleEncoder58.setVertexBuffer(7389, undefined, 0, 1597604121);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 68, y: 80, z: 20},
+  aspect: 'all',
+}, new ArrayBuffer(94_116), /* required buffer size: 94_116 */
+{offset: 996, bytesPerRow: 2220}, {width: 525, height: 42, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let video42 = await videoWithData();
+let pipelineLayout20 = device2.createPipelineLayout({
+  label: '\u22fd\u0340\u1e00\u006b\u{1fbd2}\u6fb6',
+  bindGroupLayouts: [bindGroupLayout34, bindGroupLayout40, bindGroupLayout35, bindGroupLayout35, bindGroupLayout36],
+});
+let textureView156 = texture77.createView({label: '\u0650\ufafe\u3caa\uc6e3\u4033\u3b3d\u{1f741}\u0c05\u8f59\u0a99\u{1fbd3}'});
+try {
+computePassEncoder57.setBindGroup(3, bindGroup23, new Uint32Array(6860), 5603, 0);
+} catch {}
+try {
+renderBundleEncoder49.setVertexBuffer(1, buffer30, 1440);
+} catch {}
+let pipeline106 = await device2.createComputePipelineAsync({layout: pipelineLayout20, compute: {module: shaderModule30, entryPoint: 'compute0', constants: {}}});
+let gpuCanvasContext36 = canvas33.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let canvas35 = document.createElement('canvas');
+let renderBundle66 = renderBundleEncoder59.finish({label: '\u0d65\udf5b\u{1fd4c}\u0835'});
+let externalTexture69 = device3.importExternalTexture({source: videoFrame19});
+try {
+renderBundleEncoder56.setVertexBuffer(9095, undefined);
+} catch {}
+let shaderModule33 = device4.createShaderModule({
+  label: '\u0797\u429b\u4fd0\u{1febe}\uccfa',
+  code: `@group(0) @binding(1173)
+var<storage, read_write> parameter14: array<u32>;
+@group(1) @binding(1173)
+var<storage, read_write> n13: array<u32>;
+@group(3) @binding(875)
+var<storage, read_write> local26: array<u32>;
+@group(3) @binding(1173)
+var<storage, read_write> parameter15: array<u32>;
+@group(2) @binding(1173)
+var<storage, read_write> global19: array<u32>;
+@group(0) @binding(875)
+var<storage, read_write> n14: array<u32>;
+
+@compute @workgroup_size(3, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(1) f1: vec3<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S29 {
+  @location(1) f0: vec2<f32>,
+  @location(3) f1: vec2<f16>,
+  @builtin(vertex_index) f2: u32,
+  @location(5) f3: vec2<i32>,
+  @location(10) f4: vec2<u32>,
+  @location(15) f5: vec4<i32>,
+  @location(8) f6: f16,
+  @location(7) f7: u32,
+  @location(6) f8: vec3<i32>,
+  @location(0) f9: vec3<f16>,
+  @location(16) f10: vec4<f32>,
+  @location(14) f11: vec4<u32>,
+  @location(2) f12: vec2<f16>,
+  @location(9) f13: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(17) a0: vec3<u32>, @location(18) a1: vec3<f16>, @builtin(instance_index) a2: u32, @location(12) a3: vec3<u32>, @location(4) a4: vec3<u32>, a5: S29, @location(13) a6: vec4<f32>, @location(11) a7: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let textureView157 = texture73.createView({
+  label: '\u0db6\u7b8e\u{1fcab}\u12fa',
+  dimension: '2d-array',
+  aspect: 'all',
+  baseMipLevel: 2,
+  mipLevelCount: 3,
+  baseArrayLayer: 171,
+  arrayLayerCount: 232,
+});
+let computePassEncoder59 = commandEncoder111.beginComputePass({label: '\u1d2c\u{1f971}\u278e'});
+let renderBundleEncoder61 = device4.createRenderBundleEncoder({label: '\uf24c\u529b\u{1f7aa}', colorFormats: ['rgba8uint'], stencilReadOnly: true});
+let externalTexture70 = device4.importExternalTexture({source: videoFrame21, colorSpace: 'srgb'});
+try {
+device4.queue.writeBuffer(buffer35, 75456, new BigUint64Array(64371), 20904, 928);
+} catch {}
+let canvas36 = document.createElement('canvas');
+let videoFrame36 = new VideoFrame(canvas25, {timestamp: 0});
+let commandEncoder134 = device3.createCommandEncoder({label: '\ufeec\uaffa\uf051\u446d\u0229\u54b6\u3ed7'});
+let querySet76 = device3.createQuerySet({label: '\u5d6f\u0f19\uc925\u0317\ufee1\u0966\u0d77', type: 'occlusion', count: 2990});
+let renderBundleEncoder62 = device3.createRenderBundleEncoder({
+  label: '\uce9e\u{1f8d6}\u499a\ua034\u022d\u0543\u4799\u0e4f\ue667\u{1fb64}\u{1fc27}',
+  colorFormats: ['rg8unorm', 'r16uint', 'rgba8unorm-srgb', 'rg16sint', 'bgra8unorm-srgb', 'rg11b10ufloat', 'r16float'],
+  depthStencilFormat: 'depth16unorm',
+  stencilReadOnly: true,
+});
+let sampler76 = device3.createSampler({
+  label: '\u0f5f\u5994\u02fe',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 52.56,
+  lodMaxClamp: 94.73,
+  maxAnisotropy: 11,
+});
+offscreenCanvas9.width = 177;
+let canvas37 = document.createElement('canvas');
+let bindGroupLayout44 = device4.createBindGroupLayout({
+  label: '\ucd13\u0786\u0226\u{1fb1f}',
+  entries: [
+    {
+      binding: 1159,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 371,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 665,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8unorm', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let commandEncoder135 = device4.createCommandEncoder({});
+let commandBuffer30 = commandEncoder115.finish();
+try {
+device4.queue.writeBuffer(buffer35, 63244, new Float32Array(56798));
+} catch {}
+let textureView158 = texture70.createView({
+  label: '\u01cd\u{1feb1}\u3111',
+  dimension: '2d',
+  aspect: 'depth-only',
+  baseMipLevel: 1,
+  baseArrayLayer: 269,
+});
+try {
+commandEncoder106.insertDebugMarker('\u022b');
+} catch {}
+let video43 = await videoWithData();
+let imageBitmap31 = await createImageBitmap(imageData2);
+let bindGroupLayout45 = device2.createBindGroupLayout({
+  label: '\u9faf\u{1f97c}\u3427\u235d\u072e\u{1f777}',
+  entries: [
+    {
+      binding: 3194,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 5743, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let bindGroup25 = device2.createBindGroup({
+  layout: bindGroupLayout45,
+  entries: [{binding: 5743, resource: externalTexture65}, {binding: 3194, resource: externalTexture65}],
+});
+let pipelineLayout21 = device2.createPipelineLayout({
+  label: '\u4d53\u0796\u{1f701}\u0d1e\u{1fc5d}\u3295\u2c2c\ud541\uba5a',
+  bindGroupLayouts: [bindGroupLayout35, bindGroupLayout35, bindGroupLayout36, bindGroupLayout41, bindGroupLayout33, bindGroupLayout34],
+});
+let buffer36 = device2.createBuffer({label: '\u4ea9\ud526', size: 74651, usage: GPUBufferUsage.INDIRECT});
+let renderBundleEncoder63 = device2.createRenderBundleEncoder({
+  label: '\uf365\u27fa\u0d6a\u4cf2',
+  colorFormats: ['rgba16float', 'rgba32float', 'rgba8unorm', 'rg32sint', 'rg8unorm'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder58.setPipeline(pipeline102);
+} catch {}
+try {
+renderBundleEncoder55.setBindGroup(4, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(1, bindGroup23, new Uint32Array(2836), 1294, 0);
+} catch {}
+let promise42 = buffer33.mapAsync(GPUMapMode.WRITE, 84296, 100236);
+let gpuCanvasContext37 = canvas36.getContext('webgpu');
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+  await promise42;
+} catch {}
+let imageBitmap32 = await createImageBitmap(video28);
+let imageData32 = new ImageData(244, 80);
+let commandEncoder136 = device3.createCommandEncoder({label: '\ue7e2\ub05d\u7d44\ubbcb\u{1f684}'});
+let textureView159 = texture70.createView({label: '\ueb31\u{1fcaa}\u0f55\u{1ff9e}', dimension: '2d', mipLevelCount: 1, baseArrayLayer: 312});
+try {
+gpuCanvasContext32.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise43 = device3.queue.onSubmittedWorkDone();
+try {
+canvas37.getContext('bitmaprenderer');
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let offscreenCanvas34 = new OffscreenCanvas(484, 411);
+let imageBitmap33 = await createImageBitmap(imageData13);
+let commandBuffer31 = commandEncoder136.finish({label: '\u{1f75c}\u09a0\u000b\u270f\u995c\u4f5c\u0464\ud305'});
+let renderBundle67 = renderBundleEncoder56.finish({label: '\u0830\ud9f6\u0b59\uab9f\u{1f725}\u056c\ubf47\u0911\u0be6'});
+try {
+gpuCanvasContext6.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline107 = device3.createRenderPipeline({
+  layout: pipelineLayout19,
+  fragment: {
+  module: shaderModule32,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {
+  format: 'r16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.RED,
+}, {format: 'rg16sint'}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'add', srcFactor: 'src-alpha', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'constant'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {
+  format: 'rg11b10ufloat',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'one-minus-dst'},
+  },
+  writeMask: 0,
+}, {
+  format: 'r16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {failOp: 'invert', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilBack: {compare: 'less-equal', failOp: 'decrement-clamp', depthFailOp: 'replace', passOp: 'invert'},
+    stencilReadMask: 2657631490,
+    depthBiasSlopeScale: 375.3280563941986,
+    depthBiasClamp: 69.18767069006881,
+  },
+  vertex: {
+    module: shaderModule32,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 5268,
+        attributes: [
+          {format: 'uint32', offset: 4, shaderLocation: 2},
+          {format: 'unorm16x4', offset: 856, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 1236,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 288, shaderLocation: 16},
+          {format: 'uint32', offset: 144, shaderLocation: 6},
+          {format: 'float32x2', offset: 12, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 10, shaderLocation: 23},
+          {format: 'float32x4', offset: 68, shaderLocation: 12},
+          {format: 'sint16x4', offset: 320, shaderLocation: 17},
+          {format: 'uint32', offset: 72, shaderLocation: 24},
+        ],
+      },
+      {
+        arrayStride: 1224,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 0, shaderLocation: 18},
+          {format: 'uint32', offset: 76, shaderLocation: 22},
+          {format: 'sint32x2', offset: 240, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let offscreenCanvas35 = new OffscreenCanvas(531, 261);
+let canvas38 = document.createElement('canvas');
+let commandEncoder137 = device3.createCommandEncoder({label: '\u{1fca8}\u52b4\u{1fc1a}\u21c8\u0552\u5315\u49a1\u{1f97a}\ub481\uac07\uecc3'});
+let textureView160 = texture71.createView({
+  label: '\u00b0\u04e3\u395e\ucabd\ub843\u0b85\u04a4\u001f\u{1f838}',
+  dimension: '2d',
+  aspect: 'depth-only',
+  baseArrayLayer: 324,
+});
+let video44 = await videoWithData();
+let textureView161 = texture72.createView({
+  label: '\u01fc\ud46e\u7306\u560a\u0bcb\u{1fab1}',
+  mipLevelCount: 1,
+  baseArrayLayer: 287,
+  arrayLayerCount: 109,
+});
+let computePassEncoder60 = commandEncoder135.beginComputePass({});
+let pipeline108 = await device4.createComputePipelineAsync({layout: pipelineLayout18, compute: {module: shaderModule29, entryPoint: 'compute0', constants: {}}});
+let pipeline109 = await device4.createRenderPipelineAsync({
+  label: '\u1284\u0a46\u008f\u{1fa21}\u8c57\ue543\ud04c\ub58c\u0b22',
+  layout: pipelineLayout18,
+  multisample: {count: 1},
+  fragment: {module: shaderModule33, entryPoint: 'fragment0', targets: [{format: 'rgba8uint', writeMask: 0}]},
+  vertex: {
+    module: shaderModule33,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 15024,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 1960, shaderLocation: 13},
+          {format: 'uint8x4', offset: 716, shaderLocation: 12},
+          {format: 'uint32x3', offset: 312, shaderLocation: 7},
+          {format: 'snorm16x2', offset: 7236, shaderLocation: 2},
+          {format: 'snorm8x2', offset: 804, shaderLocation: 16},
+          {format: 'uint8x2', offset: 1866, shaderLocation: 17},
+          {format: 'sint16x4', offset: 2628, shaderLocation: 5},
+          {format: 'uint32x3', offset: 2848, shaderLocation: 10},
+          {format: 'unorm8x2', offset: 844, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 13520, attributes: [{format: 'unorm16x2', offset: 1560, shaderLocation: 18}]},
+      {
+        arrayStride: 13928,
+        attributes: [
+          {format: 'uint16x4', offset: 52, shaderLocation: 14},
+          {format: 'sint32x3', offset: 2020, shaderLocation: 9},
+          {format: 'snorm8x4', offset: 1536, shaderLocation: 0},
+          {format: 'unorm8x2', offset: 122, shaderLocation: 1},
+          {format: 'sint32x2', offset: 1016, shaderLocation: 15},
+          {format: 'uint32', offset: 652, shaderLocation: 4},
+          {format: 'snorm16x2', offset: 1268, shaderLocation: 11},
+          {format: 'float16x2', offset: 84, shaderLocation: 3},
+          {format: 'sint32x3', offset: 308, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'front', unclippedDepth: true},
+});
+let textureView162 = texture76.createView({label: '\u0162\ud234\u78ba\u0dc5', baseMipLevel: 2});
+let renderBundleEncoder64 = device2.createRenderBundleEncoder({
+  label: '\u{1ff2d}\u0f52\u03bd\u1dbb\u3c41\u4989\u00b7\u2854\u5442\uadaf\u0858',
+  colorFormats: ['rgba16float', 'rgba32float', 'rgba8unorm', 'rg32sint', 'rg8unorm'],
+});
+try {
+computePassEncoder52.setBindGroup(5, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(0, buffer30, 46336, 8384);
+} catch {}
+try {
+offscreenCanvas35.getContext('bitmaprenderer');
+} catch {}
+try {
+  await promise43;
+} catch {}
+try {
+offscreenCanvas34.getContext('webgl');
+} catch {}
+let commandEncoder138 = device4.createCommandEncoder({label: '\u0456\u288e\u9b4f\u0f0c'});
+gc();
+try {
+canvas35.getContext('webgl');
+} catch {}
+let commandEncoder139 = device2.createCommandEncoder();
+let sampler77 = device2.createSampler({
+  label: '\u0652\ua586\u0815\u8497\u0c21\u777e\u091c\u6cf2\uf155\u{1fb1a}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 20.75,
+  lodMaxClamp: 68.66,
+});
+try {
+renderBundleEncoder47.setBindGroup(3, bindGroup25);
+} catch {}
+let arrayBuffer14 = buffer33.getMappedRange(120832, 58712);
+try {
+commandEncoder119.copyTextureToTexture({
+  texture: texture62,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 10},
+  aspect: 'all',
+},
+{
+  texture: texture62,
+  mipLevel: 5,
+  origin: {x: 4, y: 0, z: 19},
+  aspect: 'all',
+},
+{width: 17, height: 1, depthOrArrayLayers: 9});
+} catch {}
+document.body.prepend(img20);
+gc();
+let pipelineLayout22 = device4.createPipelineLayout({
+  label: '\ud6fe\u04d0\u2df9\u6a0b\u0ee7\u0c4a\u910e\u1a81\ue081\u0f1c\ub800',
+  bindGroupLayouts: [bindGroupLayout44, bindGroupLayout44, bindGroupLayout44],
+});
+let texture82 = device4.createTexture({
+  label: '\u8012\u2bd1\u049d\ubc39\ud598\ud3f8\u063d\u0bc3\u3f17\u{1ff1f}\u0e4a',
+  size: {width: 1152, height: 480, depthOrArrayLayers: 479},
+  mipLevelCount: 10,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder61 = commandEncoder108.beginComputePass({});
+try {
+renderBundleEncoder61.setVertexBuffer(6241, undefined, 0);
+} catch {}
+try {
+commandEncoder125.copyTextureToBuffer({
+  texture: texture72,
+  mipLevel: 2,
+  origin: {x: 0, y: 20, z: 387},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2192 widthInBlocks: 137 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 26800 */
+  offset: 20000,
+  bytesPerRow: 2304,
+  buffer: buffer35,
+}, {width: 548, height: 12, depthOrArrayLayers: 1});
+dissociateBuffer(device4, buffer35);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 47, y: 34, z: 28},
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 479_955 */
+{offset: 476, bytesPerRow: 595, rowsPerImage: 471}, {width: 126, height: 335, depthOrArrayLayers: 2});
+} catch {}
+let pipeline110 = device4.createComputePipeline({
+  label: '\u861b\u{1fb94}\ue27e',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule33, entryPoint: 'compute0'},
+});
+let bindGroupLayout46 = device4.createBindGroupLayout({
+  label: '\u{1f90e}\u03bf',
+  entries: [
+    {
+      binding: 62,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {
+      binding: 659,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 3853487, hasDynamicOffset: false },
+    },
+    {
+      binding: 210,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let buffer37 = device4.createBuffer({label: '\u0267\u01fa\u{1f975}\ub7b2\u4e08\u0b17\ue596', size: 173315, usage: GPUBufferUsage.INDEX});
+let querySet77 = device4.createQuerySet({label: '\u0f0d\u59e6\u{1faf8}\u{1fd00}\u068b', type: 'occlusion', count: 1843});
+let textureView163 = texture81.createView({label: '\u{1fbb8}\u0167\u{1fb97}\u{1fb5c}\u062a\u230f\u37f1\u{1ff2a}\u60b5', mipLevelCount: 1});
+try {
+renderBundleEncoder58.setVertexBuffer(8970, undefined, 3490389253, 396307946);
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroup26 = device1.createBindGroup({
+  label: '\u8975\u{1fc47}\u{1fa7e}\u36d5\u0c8d\u6fc0\u00ad\u09ff',
+  layout: bindGroupLayout30,
+  entries: [{binding: 4495, resource: sampler46}],
+});
+let pipelineLayout23 = device1.createPipelineLayout({
+  label: '\u7784\u{1f61c}\uc873\u{1fcde}',
+  bindGroupLayouts: [bindGroupLayout29, bindGroupLayout30, bindGroupLayout29, bindGroupLayout29, bindGroupLayout30, bindGroupLayout30, bindGroupLayout30, bindGroupLayout29],
+});
+let commandEncoder140 = device1.createCommandEncoder({label: '\udebc\u28a4\u{1f76b}\u284c\uf66b\uc750\u0f7d\u0c99\u02f9'});
+let texture83 = device1.createTexture({
+  label: '\u{1f6af}\u6688\u0f04',
+  size: [9600],
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder62 = commandEncoder140.beginComputePass({label: '\u78b2\u{1f761}\u97b2\ud2c0\u{1f793}\u1feb\u057a'});
+let renderBundle68 = renderBundleEncoder37.finish({label: '\u028b\ubfc4\u499e\u081c\u871d\ua539\u9b00\u{1fd4f}'});
+let computePassEncoder63 = commandEncoder101.beginComputePass({label: '\uc29f\u314c\uefc5\u{1f7b4}\u3e2c\u{1fec0}\ub1ec\u461f\u0b16'});
+let renderBundleEncoder65 = device2.createRenderBundleEncoder({
+  label: '\ud037\u{1f639}\u{1fb14}\ucc9b\u4ce0\u3a3c\u2ab4\uc3f8\u022b',
+  colorFormats: ['rgba16float', 'rgba32float', 'rgba8unorm', 'rg32sint', 'rg8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder63.setBindGroup(2, bindGroup25);
+} catch {}
+let offscreenCanvas36 = new OffscreenCanvas(966, 588);
+try {
+adapter4.label = '\u07f7\u6926\u0e32';
+} catch {}
+try {
+canvas38.getContext('webgpu');
+} catch {}
+let querySet78 = device3.createQuerySet({type: 'occlusion', count: 3291});
+let textureView164 = texture70.createView({
+  label: '\u380e\u7206\u25f2\udde7\ua488',
+  dimension: '2d',
+  aspect: 'depth-only',
+  baseMipLevel: 1,
+  baseArrayLayer: 295,
+});
+let renderBundle69 = renderBundleEncoder56.finish({label: '\u204f\u33cc\u5c6b\uec07\uf870\u6f97\u5eeb\ud36d\u2652'});
+try {
+device3.queue.submit([commandBuffer28]);
+} catch {}
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+gc();
+let videoFrame37 = new VideoFrame(videoFrame29, {timestamp: 0});
+let shaderModule34 = device3.createShaderModule({
+  label: '\ufdac\u77f8\u7c79\ub4ab\u0705\ufd70\u6e8b\u{1f785}\u0681\u2a66',
+  code: `@group(1) @binding(110)
+var<storage, read_write> global20: array<u32>;
+@group(1) @binding(990)
+var<storage, read_write> local27: array<u32>;
+@group(0) @binding(990)
+var<storage, read_write> parameter16: array<u32>;
+@group(0) @binding(110)
+var<storage, read_write> function22: array<u32>;
+@group(0) @binding(586)
+var<storage, read_write> local28: array<u32>;
+@group(2) @binding(990)
+var<storage, read_write> function23: array<u32>;
+@group(1) @binding(586)
+var<storage, read_write> function24: array<u32>;
+
+@compute @workgroup_size(2, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(5) f0: vec4<u32>,
+  @location(2) f1: vec3<i32>,
+  @location(1) f2: vec4<f32>,
+  @location(6) f3: vec2<f32>,
+  @location(3) f4: i32,
+  @location(4) f5: vec2<i32>,
+  @location(0) f6: f32
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(front_facing) a1: bool, @builtin(sample_mask) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(17) a1: vec4<f32>, @location(1) a2: f16, @location(3) a3: vec4<f32>, @location(6) a4: f32, @location(16) a5: i32, @location(2) a6: vec3<f32>, @location(4) a7: vec2<u32>, @location(21) a8: f32, @location(9) a9: vec2<f16>, @location(19) a10: i32, @builtin(vertex_index) a11: u32, @location(11) a12: vec3<f16>, @location(23) a13: vec4<f16>, @location(12) a14: vec4<i32>, @location(7) a15: i32, @location(24) a16: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let pipeline111 = await device3.createRenderPipelineAsync({
+  label: '\u0a89\uac5c\u09e5',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule34,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'rg11b10ufloat', writeMask: GPUColorWrite.ALL}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rg32sint', writeMask: GPUColorWrite.GREEN}, {format: 'rgba16uint', writeMask: 0}, {
+  format: 'rg16float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule34,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1256,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 64, shaderLocation: 11},
+          {format: 'sint16x4', offset: 64, shaderLocation: 19},
+          {format: 'float16x4', offset: 24, shaderLocation: 23},
+          {format: 'float16x4', offset: 140, shaderLocation: 3},
+          {format: 'sint8x2', offset: 68, shaderLocation: 12},
+          {format: 'uint32x4', offset: 24, shaderLocation: 24},
+          {format: 'sint32x3', offset: 64, shaderLocation: 7},
+          {format: 'float16x4', offset: 92, shaderLocation: 21},
+          {format: 'float32x2', offset: 420, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 2316,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 260, shaderLocation: 16},
+          {format: 'float16x2', offset: 312, shaderLocation: 6},
+          {format: 'uint8x4', offset: 192, shaderLocation: 4},
+          {format: 'unorm16x4', offset: 936, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 1136, shaderLocation: 17},
+        ],
+      },
+      {arrayStride: 3052, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 13580,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm10-10-10-2', offset: 1180, shaderLocation: 2}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let offscreenCanvas37 = new OffscreenCanvas(465, 827);
+let video45 = await videoWithData();
+let querySet79 = device2.createQuerySet({label: '\u{1ff84}\u9398\u21df\u849d\ufaaa\u2de3\u07ec', type: 'occlusion', count: 1887});
+let commandBuffer32 = commandEncoder119.finish({label: '\uaf2a\u74a8\u0ad9\u0b05\u{1fb34}\u{1f657}\uc920\u{1fc72}\u{1fa98}\u06c2\u{1fcc7}'});
+let texture84 = device2.createTexture({
+  size: [315],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8unorm', 'rg8unorm', 'rg8unorm'],
+});
+let textureView165 = texture59.createView({label: '\u1e47\u6ca0\u09f1', baseMipLevel: 6, mipLevelCount: 3});
+let sampler78 = device2.createSampler({
+  label: '\u0337\u06a1',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 84.41,
+});
+try {
+buffer33.destroy();
+} catch {}
+try {
+commandEncoder99.copyTextureToTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 100, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture62,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 18, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext37.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let canvas39 = document.createElement('canvas');
+let imageData33 = new ImageData(72, 48);
+try {
+adapter4.label = '\u{1f92a}\u4aef\u82e0\u0e3f\u023b\u{1fbf1}';
+} catch {}
+let commandEncoder141 = device2.createCommandEncoder({label: '\u2545\u23dd\u9cda\u{1f771}\u0657'});
+let texture85 = device2.createTexture({
+  label: '\u{1f8f0}\u0513\uc7aa',
+  size: {width: 738},
+  dimension: '1d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rg32sint'],
+});
+let textureView166 = texture77.createView({aspect: 'all'});
+try {
+renderBundleEncoder54.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder65.setBindGroup(3, bindGroup25, new Uint32Array(335), 218, 0);
+} catch {}
+try {
+buffer33.unmap();
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture62,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 61_762 */
+{offset: 987, bytesPerRow: 221, rowsPerImage: 55}, {width: 1, height: 0, depthOrArrayLayers: 6});
+} catch {}
+offscreenCanvas21.width = 588;
+let bindGroup27 = device2.createBindGroup({label: '\ue0f8\u{1f952}\u61f2\u{1fe7e}\u{1fc58}\uaacf\u02ce', layout: bindGroupLayout41, entries: []});
+let commandEncoder142 = device2.createCommandEncoder({label: '\u8776\u0b1f\u0d9c\u04fa\u3d3f'});
+let textureView167 = texture67.createView({dimension: '3d', aspect: 'all', mipLevelCount: 2});
+let renderBundleEncoder66 = device2.createRenderBundleEncoder({
+  label: '\u{1fcb1}\u973c\u{1fe58}\u{1fcc4}\ue663',
+  colorFormats: ['rgba16float', 'rgba32float', 'rgba8unorm', 'rg32sint', 'rg8unorm'],
+  depthReadOnly: true,
+});
+let externalTexture71 = device2.importExternalTexture({label: '\uacbf\u{1f776}\u0d71\ud768\u{1fdba}\u5a30\u0ae9\u0429', source: video26});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder65.setBindGroup(4, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder47.setPipeline(pipeline105);
+} catch {}
+let pipeline112 = await device2.createComputePipelineAsync({layout: pipelineLayout21, compute: {module: shaderModule27, entryPoint: 'compute0', constants: {}}});
+document.body.prepend(video27);
+try {
+window.someLabel = textureView164.label;
+} catch {}
+let commandEncoder143 = device3.createCommandEncoder({label: '\ufce1\u79b8\u0e25\u5f8d'});
+let renderBundle70 = renderBundleEncoder62.finish({label: '\u{1fc52}\uaa3c\u{1fcce}\uc517'});
+try {
+adapter5.label = '\ubb13\ufdb4\u3495\u{1fb6b}';
+} catch {}
+let commandEncoder144 = device3.createCommandEncoder({});
+let promise44 = device3.popErrorScope();
+try {
+querySet75.destroy();
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+let offscreenCanvas38 = new OffscreenCanvas(425, 423);
+let img35 = await imageWithData(293, 207, '#1b7116c5', '#ad906e14');
+try {
+externalTexture66.label = '\u5a67\u{1f9e9}';
+} catch {}
+let textureView168 = texture73.createView({
+  label: '\uad68\u1ec4\u{1fbb6}\u{1f8fb}\u{1fae4}\u05e6',
+  dimension: '2d',
+  mipLevelCount: 1,
+  baseArrayLayer: 403,
+  arrayLayerCount: 1,
+});
+let computePassEncoder64 = commandEncoder126.beginComputePass({label: '\u97d7\u{1fe11}\u0d43\u438b\u{1f8bb}\ubf8c\ucd9f\u{1fe1d}\u{1fe7a}\u07e8'});
+let renderBundleEncoder67 = device4.createRenderBundleEncoder({
+  label: '\u{1fd88}\u3da5\u05a9\ub82a\u{1ff90}\u2ca3\ueec1\u5b63\ue193\udeba',
+  colorFormats: ['rgba8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder59.setPipeline(pipeline108);
+} catch {}
+try {
+commandEncoder133.copyTextureToBuffer({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 88, y: 588, z: 235},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 7104 widthInBlocks: 444 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 28576 */
+  offset: 28576,
+  bytesPerRow: 7168,
+  buffer: buffer32,
+}, {width: 1776, height: 16, depthOrArrayLayers: 0});
+dissociateBuffer(device4, buffer32);
+} catch {}
+try {
+commandEncoder138.copyTextureToTexture({
+  texture: texture73,
+  mipLevel: 6,
+  origin: {x: 1, y: 0, z: 107},
+  aspect: 'all',
+},
+{
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 176, y: 29, z: 34},
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 150});
+} catch {}
+try {
+commandEncoder133.clearBuffer(buffer32);
+dissociateBuffer(device4, buffer32);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 65, y: 62, z: 40},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 316_564 */
+{offset: 507, bytesPerRow: 3951}, {width: 982, height: 80, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+let buffer38 = device4.createBuffer({
+  label: '\ub6d0\u88c1\u0912\u0b18\u37b6\u0722',
+  size: 526731,
+  usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder145 = device4.createCommandEncoder({label: '\ueb2c\u13d9'});
+let computePassEncoder65 = commandEncoder128.beginComputePass({label: '\u0a42\u{1fa2d}\u0627\u{1fbcf}\u6b3b\u{1f8d0}\uf2c4\uda46'});
+let renderBundle71 = renderBundleEncoder67.finish({label: '\u839a\u0ad6\u{1fd77}\ud13c'});
+try {
+renderBundleEncoder61.setPipeline(pipeline109);
+} catch {}
+let pipeline113 = await device4.createRenderPipelineAsync({
+  layout: pipelineLayout22,
+  multisample: {mask: 0x64a5ab6e},
+  fragment: {module: shaderModule29, entryPoint: 'fragment0', targets: [{format: 'rgba8uint', writeMask: 0}]},
+  vertex: {
+    module: shaderModule29,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'float16x2', offset: 6828, shaderLocation: 2},
+          {format: 'float32x2', offset: 4576, shaderLocation: 5},
+          {format: 'unorm8x2', offset: 3102, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 1062, shaderLocation: 11},
+          {format: 'uint32x4', offset: 328, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'float32x4', offset: 2324, shaderLocation: 6},
+          {format: 'float16x4', offset: 13104, shaderLocation: 10},
+          {format: 'sint32x3', offset: 25368, shaderLocation: 12},
+          {format: 'snorm8x4', offset: 14252, shaderLocation: 17},
+          {format: 'uint32', offset: 8476, shaderLocation: 16},
+          {format: 'uint8x4', offset: 8596, shaderLocation: 0},
+          {format: 'sint8x2', offset: 26724, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 5330, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 4224, shaderLocation: 9},
+          {format: 'float32', offset: 20408, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 4032,
+        attributes: [
+          {format: 'float16x4', offset: 64, shaderLocation: 7},
+          {format: 'snorm8x2', offset: 734, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+let gpuCanvasContext38 = offscreenCanvas36.getContext('webgpu');
+let imageData34 = new ImageData(200, 112);
+try {
+canvas39.getContext('webgpu');
+} catch {}
+let pipelineLayout24 = device3.createPipelineLayout({bindGroupLayouts: [bindGroupLayout38, bindGroupLayout42]});
+let commandEncoder146 = device3.createCommandEncoder({});
+let querySet80 = device3.createQuerySet({label: '\u0070\u958e\u74de\u{1f84a}\u{1ff94}\u07e5\uc5fe', type: 'occlusion', count: 1275});
+let textureView169 = texture70.createView({label: '\ue112\u407b', dimension: '2d', aspect: 'depth-only', baseMipLevel: 1, baseArrayLayer: 366});
+let textureView170 = texture62.createView({baseMipLevel: 6, mipLevelCount: 2, baseArrayLayer: 0});
+let renderBundleEncoder68 = device2.createRenderBundleEncoder({
+  label: '\uc55d\u0048\u{1fab8}\u0588\u{1f8d1}\u3d59\ueff6',
+  colorFormats: ['rgba16float', 'rgba32float', 'rgba8unorm', 'rg32sint', 'rg8unorm'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder47.setBindGroup(2, bindGroup25, new Uint32Array(873), 66, 0);
+} catch {}
+try {
+renderBundleEncoder54.setVertexBuffer(4, buffer30, 12420, 24060);
+} catch {}
+try {
+commandEncoder118.copyBufferToTexture({
+  /* bytesInLastRow: 1216 widthInBlocks: 152 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 26488 */
+  offset: 25272,
+  buffer: buffer30,
+}, {
+  texture: texture76,
+  mipLevel: 1,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 152, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+commandEncoder130.copyTextureToTexture({
+  texture: texture63,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 83, y: 0, z: 30},
+  aspect: 'all',
+},
+{width: 38, height: 1, depthOrArrayLayers: 26});
+} catch {}
+let gpuCanvasContext39 = offscreenCanvas37.getContext('webgpu');
+let commandEncoder147 = device2.createCommandEncoder({label: '\u0c6a\uf619\u086d\u97cd\u2559\u3d14\u0432\u3882\ue175'});
+let commandBuffer33 = commandEncoder141.finish({label: '\u478d\u{1f8ec}'});
+let textureView171 = texture59.createView({
+  label: '\u0061\uac0f\u2b7e\u{1f9e0}',
+  dimension: '2d-array',
+  baseMipLevel: 6,
+  mipLevelCount: 2,
+  arrayLayerCount: 1,
+});
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+let offscreenCanvas39 = new OffscreenCanvas(599, 558);
+try {
+offscreenCanvas38.getContext('bitmaprenderer');
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let shaderModule35 = device3.createShaderModule({
+  code: `@group(1) @binding(1136)
+var<storage, read_write> global21: array<u32>;
+@group(0) @binding(990)
+var<storage, read_write> n15: array<u32>;
+@group(1) @binding(993)
+var<storage, read_write> parameter17: array<u32>;
+@group(1) @binding(1093)
+var<storage, read_write> type23: array<u32>;
+@group(0) @binding(586)
+var<storage, read_write> type24: array<u32>;
+
+@compute @workgroup_size(2, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S31 {
+  @location(37) f0: vec2<f16>,
+  @location(22) f1: vec4<i32>,
+  @location(16) f2: vec2<i32>,
+  @location(7) f3: u32,
+  @location(34) f4: vec2<u32>,
+  @location(45) f5: i32,
+  @location(46) f6: vec2<f32>,
+  @location(20) f7: vec4<u32>,
+  @location(30) f8: vec3<f16>,
+  @location(2) f9: vec3<i32>,
+  @builtin(sample_index) f10: u32,
+  @location(28) f11: vec3<i32>,
+  @builtin(sample_mask) f12: u32,
+  @location(32) f13: vec2<u32>,
+  @location(19) f14: vec4<f16>,
+  @builtin(front_facing) f15: bool,
+  @location(42) f16: vec3<f16>,
+  @location(33) f17: vec4<f32>,
+  @location(35) f18: vec2<f16>,
+  @location(25) f19: vec3<u32>,
+  @location(5) f20: u32,
+  @location(40) f21: vec2<f16>,
+  @location(41) f22: vec4<f32>,
+  @location(15) f23: vec4<i32>,
+  @location(6) f24: vec3<f32>
+}
+struct FragmentOutput0 {
+  @location(4) f0: vec3<i32>,
+  @location(6) f1: vec3<f32>,
+  @location(5) f2: vec4<u32>,
+  @location(2) f3: vec4<i32>,
+  @location(1) f4: vec3<f32>,
+  @location(3) f5: vec2<i32>,
+  @location(0) f6: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(3) a0: vec2<f16>, @location(27) a1: vec2<f32>, @location(11) a2: vec2<f16>, @location(1) a3: vec2<i32>, @location(44) a4: vec2<f32>, @location(31) a5: vec3<f16>, a6: S31, @location(10) a7: vec3<f32>, @location(18) a8: vec2<i32>, @location(47) a9: i32, @location(13) a10: vec2<f32>, @location(9) a11: f16, @location(17) a12: vec3<u32>, @location(39) a13: vec2<f32>, @location(23) a14: vec2<f16>, @location(24) a15: i32, @builtin(position) a16: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S30 {
+  @builtin(vertex_index) f0: u32,
+  @location(0) f1: vec3<f32>,
+  @location(24) f2: vec3<i32>,
+  @location(13) f3: vec2<f16>,
+  @location(10) f4: vec3<i32>,
+  @location(4) f5: f16,
+  @location(11) f6: vec3<u32>,
+  @location(6) f7: f32,
+  @location(12) f8: u32,
+  @location(21) f9: vec3<u32>,
+  @location(2) f10: f16,
+  @location(23) f11: vec4<f16>,
+  @builtin(instance_index) f12: u32,
+  @location(7) f13: vec2<f32>,
+  @location(19) f14: vec4<f16>,
+  @location(18) f15: vec2<u32>,
+  @location(5) f16: u32,
+  @location(9) f17: vec4<i32>,
+  @location(14) f18: vec3<i32>,
+  @location(17) f19: vec4<i32>,
+  @location(1) f20: vec4<f32>,
+  @location(8) f21: f16,
+  @location(22) f22: vec3<f16>
+}
+struct VertexOutput0 {
+  @location(44) f387: vec2<f32>,
+  @location(24) f388: i32,
+  @location(1) f389: vec2<i32>,
+  @location(5) f390: u32,
+  @location(30) f391: vec3<f16>,
+  @location(34) f392: vec2<u32>,
+  @location(6) f393: vec3<f32>,
+  @location(28) f394: vec3<i32>,
+  @location(11) f395: vec2<f16>,
+  @location(2) f396: vec3<i32>,
+  @location(20) f397: vec4<u32>,
+  @location(32) f398: vec2<u32>,
+  @location(41) f399: vec4<f32>,
+  @location(35) f400: vec2<f16>,
+  @location(23) f401: vec2<f16>,
+  @location(16) f402: vec2<i32>,
+  @builtin(position) f403: vec4<f32>,
+  @location(25) f404: vec3<u32>,
+  @location(22) f405: vec4<i32>,
+  @location(9) f406: f16,
+  @location(10) f407: vec3<f32>,
+  @location(40) f408: vec2<f16>,
+  @location(3) f409: vec2<f16>,
+  @location(18) f410: vec2<i32>,
+  @location(39) f411: vec2<f32>,
+  @location(33) f412: vec4<f32>,
+  @location(42) f413: vec3<f16>,
+  @location(46) f414: vec2<f32>,
+  @location(27) f415: vec2<f32>,
+  @location(37) f416: vec2<f16>,
+  @location(13) f417: vec2<f32>,
+  @location(47) f418: i32,
+  @location(19) f419: vec4<f16>,
+  @location(31) f420: vec3<f16>,
+  @location(17) f421: vec3<u32>,
+  @location(15) f422: vec4<i32>,
+  @location(45) f423: i32,
+  @location(7) f424: u32
+}
+
+@vertex
+fn vertex0(@location(20) a0: vec3<u32>, @location(16) a1: f32, @location(3) a2: vec3<f16>, @location(15) a3: vec3<f16>, a4: S30) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let commandEncoder148 = device3.createCommandEncoder({label: '\u{1f85f}\ue289\uca90\ud070'});
+let texture86 = device3.createTexture({
+  label: '\u6797\ueb86\u{1fbd4}\u0b7f\udb09\u07cf\u87b5\u08d9\u090e\u0dc8\u4077',
+  size: [832],
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let renderBundleEncoder69 = device3.createRenderBundleEncoder({
+  label: '\u0b9b\u74e9\u9d42\u0a95\u{1f9b8}\u76c6\u0329\u{1f7a8}\u{1f677}\u85db\u1c2a',
+  colorFormats: ['rg8unorm', 'r16uint', 'rgba8unorm-srgb', 'rg16sint', 'bgra8unorm-srgb', 'rg11b10ufloat', 'r16float'],
+  depthStencilFormat: 'depth16unorm',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture72 = device3.importExternalTexture({label: '\u3566\u{1fd57}\u8595\u{1f930}\ua0d3\u6679', source: videoFrame35, colorSpace: 'srgb'});
+try {
+gpuCanvasContext13.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let video46 = await videoWithData();
+let canvas40 = document.createElement('canvas');
+let promise45 = adapter2.requestAdapterInfo();
+let commandEncoder149 = device3.createCommandEncoder({label: '\u{1f913}\ua419\u{1f626}\u76c9\ua343\u{1ff4a}\u08ec\u0932\u0129'});
+let renderBundleEncoder70 = device3.createRenderBundleEncoder({
+  label: '\u0bb0\uf63b\u0365',
+  colorFormats: ['r8unorm', 'rg11b10ufloat', 'rg8sint', 'r8sint', 'rg32sint', 'rgba16uint', 'rg16float'],
+});
+gc();
+let textureView172 = texture86.createView({label: '\u{1fb51}\u{1f9a0}\u01bb'});
+let commandEncoder150 = device4.createCommandEncoder({});
+let sampler79 = device4.createSampler({
+  label: '\ub388\u01bc\u0cac\u35ae\u67f7',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 94.71,
+  lodMaxClamp: 96.54,
+  compare: 'greater',
+  maxAnisotropy: 14,
+});
+let pipeline114 = await device4.createRenderPipelineAsync({
+  label: '\u28d4\u83a2\ucca1\u{1ff4a}\ua6c6\u{1ff45}\u{1fb0d}\u{1fa19}\u1158\u{1f9bf}\u4d98',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule33,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule33,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3848,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 650, shaderLocation: 2},
+          {format: 'sint32x4', offset: 540, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 2112,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 1372, shaderLocation: 9},
+          {format: 'unorm10-10-10-2', offset: 940, shaderLocation: 0},
+          {format: 'uint32x2', offset: 244, shaderLocation: 12},
+          {format: 'unorm8x2', offset: 354, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 30, shaderLocation: 16},
+          {format: 'float16x4', offset: 2104, shaderLocation: 1},
+          {format: 'uint16x4', offset: 68, shaderLocation: 10},
+          {format: 'sint8x4', offset: 236, shaderLocation: 15},
+          {format: 'sint32x4', offset: 112, shaderLocation: 5},
+          {format: 'uint32', offset: 380, shaderLocation: 4},
+          {format: 'float32x3', offset: 8, shaderLocation: 18},
+          {format: 'uint32x3', offset: 20, shaderLocation: 17},
+          {format: 'uint16x4', offset: 252, shaderLocation: 7},
+          {format: 'float32', offset: 124, shaderLocation: 3},
+          {format: 'uint16x4', offset: 76, shaderLocation: 14},
+          {format: 'float16x4', offset: 44, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 3960, attributes: [{format: 'float16x4', offset: 56, shaderLocation: 11}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+document.body.prepend(canvas19);
+let commandEncoder151 = device2.createCommandEncoder({label: '\u{1fc78}\u{1f748}\u0eb1'});
+let textureView173 = texture67.createView({
+  label: '\u98f5\u{1fc84}\ue67d\u92e2\u02d7\u{1ffbf}\u0747\u0e5d\u4de2',
+  aspect: 'all',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+});
+let externalTexture73 = device2.importExternalTexture({label: '\u85d7\uf3be\u2a81', source: videoFrame33, colorSpace: 'srgb'});
+try {
+computePassEncoder55.setBindGroup(5, bindGroup23, new Uint32Array(6882), 150, 0);
+} catch {}
+try {
+renderBundleEncoder65.setVertexBuffer(7, buffer30);
+} catch {}
+let promise46 = device2.queue.onSubmittedWorkDone();
+try {
+adapter4.label = '\u4c08\ue4ba';
+} catch {}
+let querySet81 = device2.createQuerySet({label: '\ua1a8\u3a9d\ud058', type: 'occlusion', count: 495});
+try {
+renderBundleEncoder55.setBindGroup(4, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder63.setPipeline(pipeline105);
+} catch {}
+let promise47 = device2.popErrorScope();
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+commandEncoder147.copyTextureToTexture({
+  texture: texture63,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 32},
+  aspect: 'all',
+},
+{
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 252, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 138, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder63.insertDebugMarker('\ud633');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture76,
+  mipLevel: 2,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(24)), /* required buffer size: 590 */
+{offset: 590, bytesPerRow: 2384, rowsPerImage: 50}, {width: 284, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext40 = offscreenCanvas39.getContext('webgpu');
+let textureView174 = texture74.createView({dimension: '2d', baseMipLevel: 2, mipLevelCount: 2, baseArrayLayer: 439});
+try {
+buffer31.unmap();
+} catch {}
+try {
+device4.queue.writeBuffer(buffer32, 113712, new DataView(new ArrayBuffer(24744)));
+} catch {}
+let gpuCanvasContext41 = canvas40.getContext('webgpu');
+try {
+  await promise45;
+} catch {}
+try {
+adapter0.label = '\u5118\ucbb9';
+} catch {}
+let shaderModule36 = device2.createShaderModule({
+  label: '\u02ae\u74ed\u072e\u08f0\ue007\u1eee',
+  code: `@group(4) @binding(1457)
+var<storage, read_write> field26: array<u32>;
+@group(5) @binding(3325)
+var<storage, read_write> type25: array<u32>;
+@group(5) @binding(3012)
+var<storage, read_write> field27: array<u32>;
+@group(4) @binding(4492)
+var<storage, read_write> parameter18: array<u32>;
+@group(0) @binding(2086)
+var<storage, read_write> global22: array<u32>;
+@group(0) @binding(6124)
+var<storage, read_write> n16: array<u32>;
+@group(1) @binding(2213)
+var<storage, read_write> local29: array<u32>;
+@group(4) @binding(1762)
+var<storage, read_write> field28: array<u32>;
+@group(5) @binding(44)
+var<storage, read_write> type26: array<u32>;
+@group(1) @binding(6124)
+var<storage, read_write> type27: array<u32>;
+
+@compute @workgroup_size(6, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S33 {
+  @location(1) f0: vec4<i32>
+}
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(4) f1: vec3<f32>,
+  @location(1) f2: vec4<f32>,
+  @location(2) f3: vec4<f32>,
+  @location(0) f4: vec4<f32>,
+  @location(3) f5: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(0) a0: u32, @location(3) a1: vec2<f16>, a2: S33, @location(7) a3: f16, @location(4) a4: vec4<f16>, @builtin(front_facing) a5: bool, @builtin(sample_index) a6: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S32 {
+  @builtin(instance_index) f0: u32,
+  @builtin(vertex_index) f1: u32,
+  @location(11) f2: vec4<i32>,
+  @location(9) f3: vec2<f16>,
+  @location(4) f4: i32,
+  @location(8) f5: vec4<f16>,
+  @location(2) f6: vec3<f16>,
+  @location(13) f7: f32,
+  @location(0) f8: u32
+}
+struct VertexOutput0 {
+  @location(4) f425: vec4<f16>,
+  @location(7) f426: f16,
+  @location(3) f427: vec2<f16>,
+  @location(1) f428: vec4<i32>,
+  @builtin(position) f429: vec4<f32>,
+  @location(0) f430: u32
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec3<f16>, @location(5) a1: vec3<u32>, a2: S32, @location(17) a3: vec3<u32>, @location(15) a4: vec3<f16>, @location(7) a5: vec4<f32>, @location(14) a6: vec3<u32>, @location(1) a7: vec2<f32>, @location(10) a8: f32, @location(16) a9: vec2<f32>, @location(12) a10: vec2<f16>, @location(3) a11: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet82 = device2.createQuerySet({label: '\u{1fb61}\uf9c2\u2ffc\u{1ff4f}\u04a1\u{1f6db}\u360b\uc3b9', type: 'occlusion', count: 2577});
+let textureView175 = texture68.createView({dimension: '1d'});
+let sampler80 = device2.createSampler({
+  label: '\u0ff1\ube79\u{1fed9}\u07da',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 6.650,
+  maxAnisotropy: 9,
+});
+try {
+device2.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder122.copyBufferToTexture({
+  /* bytesInLastRow: 8664 widthInBlocks: 1083 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 19208 */
+  offset: 19208,
+  rowsPerImage: 282,
+  buffer: buffer28,
+}, {
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1083, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer28);
+} catch {}
+let pipeline115 = device2.createRenderPipeline({
+  label: '\uc0e8\u7095\u4c7c\u7b94\u7855\u0537\u3f87\ue706',
+  layout: 'auto',
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule30,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba16float', writeMask: GPUColorWrite.ALL}, {format: 'rgba32float', writeMask: 0}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}, {format: 'rg32sint'}, {format: 'rg8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule30,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 6816, attributes: [{format: 'float16x4', offset: 660, shaderLocation: 3}]},
+      {arrayStride: 2688, stepMode: 'instance', attributes: []},
+      {arrayStride: 4004, stepMode: 'vertex', attributes: []},
+      {arrayStride: 2264, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 9748,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 152, shaderLocation: 8}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'none'},
+});
+let imageData35 = new ImageData(236, 180);
+try {
+  await promise47;
+} catch {}
+try {
+gpuCanvasContext40.unconfigure();
+} catch {}
+try {
+  await promise44;
+} catch {}
+let imageBitmap34 = await createImageBitmap(canvas17);
+let commandEncoder152 = device1.createCommandEncoder({label: '\ub4db\u4914\u207e\u7a33\u09c3\u8dd0\u0d9b\ud62b\u{1f6e7}\u0e03'});
+let texture87 = device1.createTexture({
+  label: '\u0e98\u2de2\u785d\u{1fd30}\u{1f6f8}\u0822\u0067\u05a3\ue270',
+  size: {width: 1608, height: 1, depthOrArrayLayers: 13},
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg32sint', 'rg32sint', 'rg32sint'],
+});
+let textureView176 = texture58.createView({
+  label: '\u05d6\u0ded\u0839\ueeb6\u9cd0\u02fa\u7ee9\u889a',
+  dimension: '2d-array',
+  format: 'rg8unorm',
+  baseMipLevel: 0,
+  mipLevelCount: 2,
+});
+let renderBundle72 = renderBundleEncoder39.finish({label: '\u8523\udbac\u0f16\u1018\u6adc'});
+let externalTexture74 = device1.importExternalTexture({label: '\u0959\u{1f708}', source: video29, colorSpace: 'srgb'});
+try {
+computePassEncoder44.setPipeline(pipeline87);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(8, bindGroup26);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(0, bindGroup26, new Uint32Array(4608), 1536, 0);
+} catch {}
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+let promise48 = buffer25.mapAsync(GPUMapMode.WRITE, 0, 15268);
+document.body.prepend(video17);
+let buffer39 = device2.createBuffer({size: 16450, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder153 = device2.createCommandEncoder({label: '\u8909\u0284\u05cc\udfa4\u0121\uc390\u0ce5\u8869'});
+let textureView177 = texture84.createView({label: '\u5dd8\uac76\udcec\ue247\u0072\u{1faf4}'});
+let renderBundleEncoder71 = device2.createRenderBundleEncoder({colorFormats: ['rgba16float', 'rgba32float', 'rgba8unorm', 'rg32sint', 'rg8unorm']});
+try {
+computePassEncoder50.setBindGroup(4, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder47.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder47.setPipeline(pipeline92);
+} catch {}
+let promise49 = device2.popErrorScope();
+try {
+commandEncoder121.copyBufferToTexture({
+  /* bytesInLastRow: 2496 widthInBlocks: 312 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 22504 */
+  offset: 22504,
+  bytesPerRow: 2560,
+  buffer: buffer30,
+}, {
+  texture: texture76,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 312, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer30);
+} catch {}
+let img36 = await imageWithData(280, 272, '#792f3113', '#bf54c459');
+let querySet83 = device4.createQuerySet({label: '\u{1fe3f}\u4db7\ufeba\u{1f9bc}', type: 'occlusion', count: 3717});
+let externalTexture75 = device4.importExternalTexture({label: '\u{1fade}\u1dbf\u06ea\u01e4\u2f8f\u{1fc69}\ue5e5\u0a56', source: video31, colorSpace: 'srgb'});
+try {
+renderBundleEncoder53.setPipeline(pipeline113);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer32, 13776, new Int16Array(55994));
+} catch {}
+let pipeline116 = device4.createRenderPipeline({
+  layout: 'auto',
+  multisample: {count: 4, mask: 0x392b3799},
+  fragment: {
+  module: shaderModule33,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'never', failOp: 'invert', depthFailOp: 'increment-wrap', passOp: 'zero'},
+    stencilBack: {compare: 'equal', failOp: 'decrement-wrap', passOp: 'decrement-wrap'},
+    stencilReadMask: 2278466602,
+    stencilWriteMask: 3340840006,
+    depthBias: -316559309,
+    depthBiasClamp: -10.226306177696756,
+  },
+  vertex: {
+    module: shaderModule33,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3432,
+        attributes: [
+          {format: 'snorm8x2', offset: 370, shaderLocation: 1},
+          {format: 'uint8x2', offset: 802, shaderLocation: 10},
+          {format: 'uint8x4', offset: 364, shaderLocation: 17},
+          {format: 'snorm16x2', offset: 228, shaderLocation: 16},
+          {format: 'sint32x3', offset: 1364, shaderLocation: 5},
+          {format: 'float32x3', offset: 984, shaderLocation: 8},
+          {format: 'uint32x3', offset: 624, shaderLocation: 12},
+          {format: 'unorm16x4', offset: 472, shaderLocation: 2},
+          {format: 'snorm8x4', offset: 352, shaderLocation: 0},
+          {format: 'unorm10-10-10-2', offset: 40, shaderLocation: 18},
+          {format: 'uint8x4', offset: 2156, shaderLocation: 4},
+          {format: 'snorm16x2', offset: 172, shaderLocation: 3},
+          {format: 'snorm16x2', offset: 156, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 21352,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 1940, shaderLocation: 7},
+          {format: 'sint32x4', offset: 1888, shaderLocation: 9},
+          {format: 'unorm8x2', offset: 1378, shaderLocation: 11},
+          {format: 'sint16x4', offset: 1456, shaderLocation: 6},
+          {format: 'uint32', offset: 2696, shaderLocation: 14},
+        ],
+      },
+      {arrayStride: 9892, attributes: []},
+      {
+        arrayStride: 5016,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x4', offset: 576, shaderLocation: 15}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: true},
+});
+let imageBitmap35 = await createImageBitmap(imageBitmap0);
+try {
+  await promise48;
+} catch {}
+let imageBitmap36 = await createImageBitmap(videoFrame26);
+let imageData36 = new ImageData(176, 200);
+let commandEncoder154 = device2.createCommandEncoder({label: '\u00d6\u0d7f\u962d\u{1fb3e}\u9aa8\u{1fe06}'});
+let textureView178 = texture66.createView({baseMipLevel: 0});
+try {
+computePassEncoder52.setBindGroup(3, bindGroup27, new Uint32Array(1940), 834, 0);
+} catch {}
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+let imageBitmap37 = await createImageBitmap(imageData16);
+let videoFrame38 = new VideoFrame(offscreenCanvas12, {timestamp: 0});
+let commandBuffer34 = commandEncoder131.finish({});
+let texture88 = device4.createTexture({
+  size: {width: 576, height: 240, depthOrArrayLayers: 479},
+  mipLevelCount: 8,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderBundle73 = renderBundleEncoder51.finish({label: '\u0d5c\uad68\u9e45\uff75\u6db0\u3320'});
+try {
+commandEncoder127.clearBuffer(buffer32);
+dissociateBuffer(device4, buffer32);
+} catch {}
+let promise50 = device4.queue.onSubmittedWorkDone();
+let shaderModule37 = device2.createShaderModule({
+  label: '\u04d7\u5e95\u{1fda1}\u{1fa01}\u0805\u6ad5\uf821',
+  code: `@group(3) @binding(1457)
+var<storage, read_write> global23: array<u32>;
+@group(1) @binding(6124)
+var<storage, read_write> n17: array<u32>;
+@group(2) @binding(1457)
+var<storage, read_write> field29: array<u32>;
+@group(2) @binding(1762)
+var<storage, read_write> field30: array<u32>;
+@group(2) @binding(4492)
+var<storage, read_write> field31: array<u32>;
+@group(0) @binding(6124)
+var<storage, read_write> local30: array<u32>;
+@group(3) @binding(4492)
+var<storage, read_write> global24: array<u32>;
+@group(1) @binding(2213)
+var<storage, read_write> parameter19: array<u32>;
+@group(1) @binding(2086)
+var<storage, read_write> local31: array<u32>;
+@group(0) @binding(2086)
+var<storage, read_write> parameter20: array<u32>;
+
+@compute @workgroup_size(5, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(2) f1: vec4<f32>,
+  @location(3) f2: vec4<i32>,
+  @location(4) f3: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(8) a0: vec2<f16>, @location(0) a1: vec3<f16>, @builtin(front_facing) a2: bool, @location(9) a3: vec3<f16>, @location(1) a4: vec2<f32>, @builtin(sample_mask) a5: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S34 {
+  @location(17) f0: vec3<f32>,
+  @location(9) f1: vec3<f32>,
+  @location(3) f2: vec4<f16>,
+  @location(15) f3: vec4<u32>,
+  @location(11) f4: vec4<f16>,
+  @location(10) f5: vec4<u32>,
+  @location(13) f6: u32,
+  @location(16) f7: vec2<f32>,
+  @builtin(instance_index) f8: u32,
+  @location(0) f9: vec3<f32>,
+  @location(5) f10: vec3<f32>
+}
+struct VertexOutput0 {
+  @location(9) f431: vec3<f16>,
+  @location(0) f432: vec3<f16>,
+  @location(8) f433: vec2<f16>,
+  @location(1) f434: vec2<f32>,
+  @builtin(position) f435: vec4<f32>
+}
+
+@vertex
+fn vertex0(a0: S34, @location(12) a1: vec3<i32>, @location(4) a2: vec3<u32>, @location(1) a3: vec3<i32>, @location(8) a4: vec4<f32>, @location(6) a5: vec3<f16>, @location(2) a6: f32, @location(14) a7: vec4<f32>, @location(7) a8: vec2<u32>, @builtin(vertex_index) a9: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+computePassEncoder55.setBindGroup(2, bindGroup27, new Uint32Array(7176), 6351, 0);
+} catch {}
+try {
+  await promise50;
+} catch {}
+let video47 = await videoWithData();
+let pipeline117 = await device3.createComputePipelineAsync({
+  label: '\u0b24\u{1f9fb}\u9641\u8557\u5d27',
+  layout: pipelineLayout24,
+  compute: {module: shaderModule34, entryPoint: 'compute0', constants: {}},
+});
+let videoFrame39 = new VideoFrame(imageBitmap28, {timestamp: 0});
+let computePassEncoder66 = commandEncoder143.beginComputePass({label: '\u{1f87b}\u9ca7\u0cbc\u{1ff80}\u601c\ue1a4\ue8eb\u{1f67a}\u8513'});
+try {
+computePassEncoder66.setPipeline(pipeline117);
+} catch {}
+let commandEncoder155 = device2.createCommandEncoder({label: '\uae3f\u0bf8'});
+let renderBundleEncoder72 = device2.createRenderBundleEncoder({
+  label: '\u02b0\u01d3\u0666\u{1febf}\u0548\u81d4\u6c95\u6274',
+  colorFormats: ['rgba16float', 'rgba32float', 'rgba8unorm', 'rg32sint', 'rg8unorm'],
+  depthReadOnly: true,
+});
+let renderBundle74 = renderBundleEncoder64.finish({label: '\u{1f6d5}\u{1fe7a}\u4a3f\u01e0\u9bad\ubc23\u725a'});
+let externalTexture76 = device2.importExternalTexture({label: '\u845f\ue21a', source: video43, colorSpace: 'display-p3'});
+try {
+computePassEncoder57.setPipeline(pipeline100);
+} catch {}
+try {
+commandEncoder139.copyTextureToTexture({
+  texture: texture62,
+  mipLevel: 3,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 51},
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 220});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture62,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer14), /* required buffer size: 167_098 */
+{offset: 778, bytesPerRow: 126, rowsPerImage: 220}, {width: 0, height: 1, depthOrArrayLayers: 7});
+} catch {}
+canvas39.width = 316;
+let canvas41 = document.createElement('canvas');
+let shaderModule38 = device2.createShaderModule({
+  label: '\u0ef2\u05d6\uf11d\u9daf',
+  code: `@group(0) @binding(6124)
+var<storage, read_write> local32: array<u32>;
+@group(1) @binding(6124)
+var<storage, read_write> field32: array<u32>;
+@group(0) @binding(2213)
+var<storage, read_write> function25: array<u32>;
+@group(1) @binding(2086)
+var<storage, read_write> function26: array<u32>;
+@group(0) @binding(2086)
+var<storage, read_write> n18: array<u32>;
+@group(1) @binding(2213)
+var<storage, read_write> function27: array<u32>;
+
+@compute @workgroup_size(4, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec3<i32>,
+  @location(0) f1: vec4<f32>,
+  @location(2) f2: vec4<f32>,
+  @location(1) f3: vec4<f32>,
+  @location(4) f4: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @location(8) a1: vec4<f16>, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f436: vec4<f32>,
+  @location(8) f437: vec4<f16>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(0) a1: vec3<i32>, @builtin(vertex_index) a2: u32, @location(12) a3: vec2<f32>, @location(17) a4: vec4<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let renderBundleEncoder73 = device2.createRenderBundleEncoder({
+  colorFormats: ['rgba16float', 'rgba32float', 'rgba8unorm', 'rg32sint', 'rg8unorm'],
+  depthReadOnly: true,
+});
+let renderBundle75 = renderBundleEncoder63.finish({label: '\ucafe\u610c\u082c\u0462\u{1fc2b}\ufe4e\u{1fb1f}\u0ee8\u91c7\u2c6b'});
+let sampler81 = device2.createSampler({
+  label: '\u1b3d\u{1fbff}\u0513\u0119\ufb40\u0c58\u0a3a\ue9de\u006f\ucf26',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 66.69,
+  lodMaxClamp: 75.53,
+});
+try {
+computePassEncoder52.setPipeline(pipeline102);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(video35);
+let texture89 = device4.createTexture({
+  label: '\u{1fe7a}\u6519\u0d11\ue564\u0b2d\u023d\u8aff\u9575\u{1ff45}\u0a26',
+  size: [1152, 480, 479],
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView179 = texture72.createView({label: '\u{1fb24}\u{1f6ae}\u8bac', baseMipLevel: 2, baseArrayLayer: 41, arrayLayerCount: 262});
+let computePassEncoder67 = commandEncoder125.beginComputePass({label: '\u276c\u06d7\u0eb1\u6c66\u08aa\u0a66'});
+try {
+computePassEncoder61.setPipeline(pipeline110);
+} catch {}
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 2,
+  origin: {x: 2, y: 3, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer7), /* required buffer size: 2_342_879 */
+{offset: 281, bytesPerRow: 106, rowsPerImage: 184}, {width: 26, height: 20, depthOrArrayLayers: 121});
+} catch {}
+let promise51 = device4.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule29,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule29,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 20312,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 2220, shaderLocation: 4},
+          {format: 'sint32x3', offset: 7232, shaderLocation: 12},
+          {format: 'float32', offset: 4204, shaderLocation: 17},
+          {format: 'float32x4', offset: 3896, shaderLocation: 6},
+          {format: 'snorm16x4', offset: 9096, shaderLocation: 14},
+          {format: 'float32x4', offset: 388, shaderLocation: 18},
+          {format: 'float16x2', offset: 7236, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 2376,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 944, shaderLocation: 13},
+          {format: 'unorm8x2', offset: 532, shaderLocation: 7},
+          {format: 'unorm8x4', offset: 740, shaderLocation: 11},
+          {format: 'uint32', offset: 272, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 80, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 620,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 248, shaderLocation: 2},
+          {format: 'uint32x3', offset: 40, shaderLocation: 0},
+          {format: 'float32', offset: 76, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 6940,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x4', offset: 564, shaderLocation: 16}],
+      },
+      {arrayStride: 25004, attributes: []},
+      {arrayStride: 14640, attributes: [{format: 'float16x4', offset: 104, shaderLocation: 9}]},
+    ],
+  },
+  primitive: {cullMode: 'front', unclippedDepth: true},
+});
+let offscreenCanvas40 = new OffscreenCanvas(307, 67);
+let img37 = await imageWithData(268, 277, '#e057cca6', '#82b8aa06');
+let commandEncoder156 = device3.createCommandEncoder();
+let commandBuffer35 = commandEncoder148.finish({label: '\u80a6\u965b\u{1f88a}\uf55a\u838b\u0105\ud585\uaee8'});
+let texture90 = device3.createTexture({
+  label: '\u0ba4\u0d25\u35bc\u1a34\u{1fd41}\u8a51',
+  size: [848],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder66.end();
+} catch {}
+try {
+renderBundleEncoder60.setPipeline(pipeline111);
+} catch {}
+let gpuCanvasContext42 = canvas41.getContext('webgpu');
+gc();
+let bindGroupLayout47 = device4.createBindGroupLayout({
+  entries: [
+    {
+      binding: 872,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+    },
+  ],
+});
+let commandEncoder157 = device4.createCommandEncoder({});
+let renderBundleEncoder74 = device4.createRenderBundleEncoder({
+  label: '\u{1fb07}\ub64e\u5c13\u2b29\u4160\u0f8b\u{1f650}\u2bdf\u4a33\u64c5',
+  colorFormats: ['rgba8uint'],
+});
+try {
+computePassEncoder59.setPipeline(pipeline110);
+} catch {}
+try {
+commandEncoder150.copyTextureToTexture({
+  texture: texture82,
+  mipLevel: 5,
+  origin: {x: 0, y: 1, z: 8},
+  aspect: 'all',
+},
+{
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 448, y: 38, z: 32},
+  aspect: 'all',
+},
+{width: 28, height: 1, depthOrArrayLayers: 106});
+} catch {}
+try {
+device4.queue.writeBuffer(buffer31, 27896, new Float32Array(53855), 30201);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 2,
+  origin: {x: 7, y: 3, z: 35},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer7), /* required buffer size: 2_012_034 */
+{offset: 250, bytesPerRow: 153, rowsPerImage: 257}, {width: 35, height: 42, depthOrArrayLayers: 52});
+} catch {}
+let texture91 = gpuCanvasContext30.getCurrentTexture();
+let renderBundle76 = renderBundleEncoder49.finish({});
+try {
+commandEncoder154.copyTextureToTexture({
+  texture: texture63,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 7},
+  aspect: 'all',
+},
+{
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 26, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 73},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer6), /* required buffer size: 4 */
+{offset: 4, bytesPerRow: 1237, rowsPerImage: 48}, {width: 150, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame40 = new VideoFrame(imageBitmap28, {timestamp: 0});
+let textureView180 = texture71.createView({
+  label: '\u01da\u880f\u{1fd6a}\u{1fe7b}\u095b',
+  dimension: '2d',
+  aspect: 'depth-only',
+  baseMipLevel: 1,
+  baseArrayLayer: 665,
+});
+let externalTexture77 = device3.importExternalTexture({
+  label: '\u{1fa81}\uff8e\u35de\u03a9\ue04b\u{1fd07}\u{1fa93}\u0f26\u0cc8\u5978\u6b8f',
+  source: video40,
+  colorSpace: 'display-p3',
+});
+try {
+  await device3.popErrorScope();
+} catch {}
+try {
+gpuCanvasContext20.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'srgb',
+});
+} catch {}
+let pipeline118 = device3.createComputePipeline({
+  label: '\ua2f3\ucce9\ud40b\u{1feee}\uacc8\ud3e4\u854f\u555c\ua9d2\u0079',
+  layout: pipelineLayout24,
+  compute: {module: shaderModule32, entryPoint: 'compute0', constants: {}},
+});
+let offscreenCanvas41 = new OffscreenCanvas(833, 909);
+let commandEncoder158 = device4.createCommandEncoder({label: '\u335e\u81a9\u2b3e\u0550'});
+let querySet84 = device4.createQuerySet({label: '\u{1fe24}\ub269\u0692\uf1ad\u69a4\u00e3\u4d14\u25f1\u0f0b', type: 'occlusion', count: 1177});
+let externalTexture78 = device4.importExternalTexture({
+  label: '\ud9c2\ud775\u467c\u80c8\u018b\u{1f950}\u{1fb83}\u2de2\u003d\u28bc\u0ba8',
+  source: video46,
+  colorSpace: 'display-p3',
+});
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+try {
+buffer37.unmap();
+} catch {}
+let pipeline119 = device4.createRenderPipeline({
+  label: '\u56c3\u5439\u0452\u0b40\u{1f851}\u2b54\ud076\ud477',
+  layout: 'auto',
+  fragment: {
+  module: shaderModule29,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'never', failOp: 'increment-clamp', depthFailOp: 'increment-clamp', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'decrement-wrap', passOp: 'zero'},
+    stencilWriteMask: 4248821652,
+    depthBiasSlopeScale: 547.721462295432,
+    depthBiasClamp: 308.3928873874277,
+  },
+  vertex: {
+    module: shaderModule29,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 13284,
+        attributes: [
+          {format: 'snorm16x2', offset: 204, shaderLocation: 17},
+          {format: 'float16x4', offset: 252, shaderLocation: 6},
+          {format: 'uint16x2', offset: 7228, shaderLocation: 16},
+          {format: 'unorm10-10-10-2', offset: 7164, shaderLocation: 2},
+          {format: 'sint32x4', offset: 48, shaderLocation: 12},
+          {format: 'unorm10-10-10-2', offset: 3932, shaderLocation: 14},
+          {format: 'float32', offset: 6144, shaderLocation: 18},
+          {format: 'uint32', offset: 2452, shaderLocation: 8},
+          {format: 'float16x2', offset: 1908, shaderLocation: 4},
+          {format: 'snorm16x4', offset: 2960, shaderLocation: 10},
+          {format: 'float32x4', offset: 284, shaderLocation: 7},
+          {format: 'float32', offset: 3536, shaderLocation: 5},
+          {format: 'uint32x4', offset: 2440, shaderLocation: 0},
+          {format: 'sint16x2', offset: 884, shaderLocation: 13},
+          {format: 'float32', offset: 1828, shaderLocation: 9},
+          {format: 'float32', offset: 2456, shaderLocation: 15},
+        ],
+      },
+      {arrayStride: 11276, stepMode: 'instance', attributes: []},
+      {arrayStride: 5928, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 16356, stepMode: 'instance', attributes: []},
+      {arrayStride: 27344, attributes: []},
+      {
+        arrayStride: 1028,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 64, shaderLocation: 11}],
+      },
+    ],
+  },
+});
+let textureView181 = texture72.createView({baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 238, arrayLayerCount: 158});
+let renderBundle77 = renderBundleEncoder61.finish({label: '\u{1fb2e}\u31b5\u4993\u09c7\u{1fa0f}\u0fda\u1b81\u076d'});
+try {
+renderBundleEncoder53.setPipeline(pipeline114);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(5, buffer38, 0);
+} catch {}
+try {
+commandEncoder138.copyTextureToTexture({
+  texture: texture82,
+  mipLevel: 3,
+  origin: {x: 76, y: 4, z: 70},
+  aspect: 'all',
+},
+{
+  texture: texture74,
+  mipLevel: 5,
+  origin: {x: 5, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 13, height: 8, depthOrArrayLayers: 0});
+} catch {}
+try {
+device4.queue.writeBuffer(buffer31, 186308, new DataView(new ArrayBuffer(10239)), 4918, 732);
+} catch {}
+try {
+  await promise46;
+} catch {}
+let querySet85 = device2.createQuerySet({label: '\u0dac\u{1fc97}\u6a87', type: 'occlusion', count: 643});
+let textureView182 = texture61.createView({label: '\u043b\ue440\u{1f869}', aspect: 'all'});
+let renderBundle78 = renderBundleEncoder63.finish({label: '\u{1f8ba}\u8158\u07b0\u08f0\u5c0f\u6424\u6ceb\u{1fedb}'});
+try {
+renderBundleEncoder73.setPipeline(pipeline92);
+} catch {}
+let pipeline120 = device2.createComputePipeline({
+  label: '\u141f\ucc0f\u0f6d\u{1fd39}\u6c64\u419e',
+  layout: pipelineLayout16,
+  compute: {module: shaderModule25, entryPoint: 'compute0', constants: {}},
+});
+let pipeline121 = device2.createRenderPipeline({
+  layout: pipelineLayout16,
+  multisample: {mask: 0xcca128a2},
+  fragment: {
+  module: shaderModule36,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: 0}, {format: 'rgba32float', writeMask: 0}, {format: 'rgba8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rg32sint', writeMask: 0}, {format: 'rg8unorm', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'never', failOp: 'increment-clamp', depthFailOp: 'decrement-wrap', passOp: 'zero'},
+    stencilBack: {compare: 'not-equal', failOp: 'decrement-wrap', depthFailOp: 'decrement-wrap', passOp: 'replace'},
+    depthBiasClamp: 965.4027631159788,
+  },
+  vertex: {
+    module: shaderModule36,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 13124,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x2', offset: 3508, shaderLocation: 10}],
+      },
+      {
+        arrayStride: 4672,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32x4', offset: 3336, shaderLocation: 1},
+          {format: 'snorm8x4', offset: 920, shaderLocation: 8},
+          {format: 'uint32x3', offset: 432, shaderLocation: 14},
+          {format: 'float16x4', offset: 212, shaderLocation: 16},
+          {format: 'float32x4', offset: 504, shaderLocation: 9},
+          {format: 'snorm8x4', offset: 964, shaderLocation: 12},
+          {format: 'unorm16x2', offset: 328, shaderLocation: 2},
+          {format: 'unorm16x4', offset: 168, shaderLocation: 13},
+          {format: 'uint32x3', offset: 280, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 1280,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 80, shaderLocation: 7},
+          {format: 'sint32x4', offset: 20, shaderLocation: 4},
+          {format: 'snorm16x4', offset: 12, shaderLocation: 6},
+          {format: 'uint8x4', offset: 108, shaderLocation: 5},
+          {format: 'sint16x2', offset: 352, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 260, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 2952,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 980, shaderLocation: 0},
+          {format: 'uint16x4', offset: 332, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw'},
+});
+let gpuCanvasContext43 = offscreenCanvas40.getContext('webgpu');
+try {
+  await promise49;
+} catch {}
+offscreenCanvas8.width = 718;
+let imageBitmap38 = await createImageBitmap(offscreenCanvas29);
+try {
+offscreenCanvas41.getContext('webgl');
+} catch {}
+let shaderModule39 = device2.createShaderModule({
+  code: `@group(2) @binding(1457)
+var<storage, read_write> global25: array<u32>;
+@group(2) @binding(4492)
+var<storage, read_write> local33: array<u32>;
+@group(3) @binding(1762)
+var<storage, read_write> n19: array<u32>;
+@group(0) @binding(2213)
+var<storage, read_write> local34: array<u32>;
+@group(1) @binding(2086)
+var<storage, read_write> local35: array<u32>;
+@group(3) @binding(1457)
+var<storage, read_write> function28: array<u32>;
+@group(1) @binding(2213)
+var<storage, read_write> parameter21: array<u32>;
+@group(0) @binding(6124)
+var<storage, read_write> type28: array<u32>;
+@group(3) @binding(4492)
+var<storage, read_write> global26: array<u32>;
+@group(0) @binding(2086)
+var<storage, read_write> n20: array<u32>;
+@group(2) @binding(1762)
+var<storage, read_write> global27: array<u32>;
+
+@compute @workgroup_size(2, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S35 {
+  @builtin(sample_mask) f0: u32,
+  @builtin(position) f1: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(4) f0: vec3<f32>,
+  @location(3) f1: vec3<i32>,
+  @location(2) f2: vec4<f32>,
+  @location(0) f3: vec4<f32>,
+  @location(1) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_index) a1: u32, a2: S35) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(3) a0: vec2<f16>, @location(11) a1: vec3<u32>, @location(1) a2: vec4<f16>, @location(0) a3: f16, @location(2) a4: vec3<i32>, @location(9) a5: vec4<i32>, @location(4) a6: vec3<f32>, @location(8) a7: vec2<f32>, @location(13) a8: vec2<i32>, @location(5) a9: i32, @location(12) a10: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup28 = device2.createBindGroup({
+  label: '\u{1f818}\u5dd2\u0c09\ueb7e\u{1ffbc}\uc14c\u{1f8e5}\u0c8d\ueccf\u{1ff17}',
+  layout: bindGroupLayout36,
+  entries: [],
+});
+let commandEncoder159 = device2.createCommandEncoder({label: '\u0290\u0bbb\u4bbd'});
+let querySet86 = device2.createQuerySet({label: '\u75d6\u4268\ua67e\u6f3d\u{1fe3d}\u2b36\uf5d3\udcd1', type: 'occlusion', count: 619});
+let sampler82 = device2.createSampler({
+  label: '\ue7dd\uced4\u{1f70b}\u9999\u2ac0\uf70d\u0033\u77cb\u91d2\uec9e\u0362',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 48.19,
+  lodMaxClamp: 68.58,
+  compare: 'less-equal',
+});
+try {
+renderBundleEncoder66.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let commandEncoder160 = device3.createCommandEncoder({});
+let sampler83 = device3.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 74.28,
+  lodMaxClamp: 99.29,
+});
+let externalTexture79 = device3.importExternalTexture({source: video7, colorSpace: 'display-p3'});
+let promise52 = device3.queue.onSubmittedWorkDone();
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+try {
+  await promise52;
+} catch {}
+let video48 = await videoWithData();
+let bindGroupLayout48 = device3.createBindGroupLayout({
+  label: '\u0d83\u{1f869}\u931d\u4acc',
+  entries: [{binding: 1001, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}}],
+});
+let bindGroupLayout49 = pipeline111.getBindGroupLayout(2);
+let computePassEncoder68 = commandEncoder149.beginComputePass({});
+let renderBundleEncoder75 = device3.createRenderBundleEncoder({
+  label: '\u07e7\u{1fe21}\u452e\u3e79\u59ba',
+  colorFormats: ['r8unorm', 'rg11b10ufloat', 'rg8sint', 'r8sint', 'rg32sint', 'rgba16uint', 'rg16float'],
+  depthReadOnly: true,
+});
+let renderBundle79 = renderBundleEncoder56.finish({label: '\uc31a\u02a9\u1af7\u{1f7d8}\u00d8\u19d9\u5f83\u6585\u565e\u{1f83b}'});
+let sampler84 = device3.createSampler({
+  label: '\uec4c\uea2f\u72f4\u938b\u09c7\u{1f645}\uc831\ua3e9\u0db8',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 41.05,
+  lodMaxClamp: 67.54,
+  maxAnisotropy: 3,
+});
+let externalTexture80 = device3.importExternalTexture({
+  label: '\u0dad\u113f\u2c22\u4a3d\u{1fce3}\u{1fdb4}\u6779\uff6d',
+  source: video43,
+  colorSpace: 'display-p3',
+});
+let pipeline122 = await device3.createRenderPipelineAsync({
+  label: '\u6639\uaece\u02f7\u3c62\u09cf',
+  layout: 'auto',
+  multisample: {mask: 0xae9c1c00},
+  fragment: {
+  module: shaderModule34,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rg11b10ufloat'}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg32sint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba16uint'}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'constant'},
+    alpha: {operation: 'subtract', srcFactor: 'one', dstFactor: 'constant'},
+  },
+  writeMask: GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'equal', failOp: 'increment-wrap', depthFailOp: 'decrement-wrap', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'greater-equal', depthFailOp: 'increment-clamp', passOp: 'invert'},
+    stencilReadMask: 1469562041,
+    stencilWriteMask: 450038041,
+    depthBias: -90154407,
+    depthBiasSlopeScale: 78.4469426985838,
+    depthBiasClamp: 243.38614188879978,
+  },
+  vertex: {
+    module: shaderModule34,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 29904,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'snorm16x4', offset: 216, shaderLocation: 6},
+          {format: 'sint32x2', offset: 8032, shaderLocation: 7},
+          {format: 'sint16x2', offset: 4812, shaderLocation: 12},
+          {format: 'float32x3', offset: 5904, shaderLocation: 21},
+          {format: 'uint16x2', offset: 11996, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 5160, shaderLocation: 23},
+          {format: 'float32x4', offset: 19188, shaderLocation: 3},
+          {format: 'sint32x3', offset: 4644, shaderLocation: 16},
+          {format: 'unorm8x4', offset: 1140, shaderLocation: 17},
+          {format: 'float32x4', offset: 3104, shaderLocation: 11},
+          {format: 'float32x3', offset: 2508, shaderLocation: 1},
+          {format: 'uint8x2', offset: 7708, shaderLocation: 24},
+        ],
+      },
+      {
+        arrayStride: 8712,
+        attributes: [
+          {format: 'snorm16x2', offset: 2584, shaderLocation: 2},
+          {format: 'snorm8x2', offset: 322, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 13988,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x4', offset: 704, shaderLocation: 19}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let querySet87 = device0.createQuerySet({label: '\u{1fb49}\u2f37\u00ef\u7d23\u{1f7fb}\u034e\u4289', type: 'occlusion', count: 3366});
+let commandBuffer36 = commandEncoder72.finish({label: '\u0ae8\u{1f6f7}\u708e\uf36a\u4ee6\u3de2\ucbcb\u7ff0\ue8a7\u0308'});
+let texture92 = device0.createTexture({
+  label: '\u0fd2\ud503\u0a94\u62b8\u5274\ucea0\ubdcd\ua123\u4143',
+  size: {width: 120},
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8sint', 'rgba8sint', 'rgba8sint'],
+});
+let computePassEncoder69 = commandEncoder87.beginComputePass({label: '\u8ecc\u40c2\u0d28'});
+try {
+renderPassEncoder2.beginOcclusionQuery(268);
+} catch {}
+try {
+renderPassEncoder10.setViewport(27.63, 0.8216, 2.255, 0.3474, 0.1523, 0.4010);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(117, 119, 1_277_882_489, 646_411_937, 445_186_713);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline86);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(0, buffer11);
+} catch {}
+let promise53 = buffer15.mapAsync(GPUMapMode.READ, 8112, 8804);
+canvas21.width = 3061;
+let offscreenCanvas42 = new OffscreenCanvas(952, 346);
+let computePassEncoder70 = commandEncoder124.beginComputePass({label: '\u{1fe40}\u{1fcd8}\u{1fc1a}\uc693\ue66b\u001e'});
+let renderBundle80 = renderBundleEncoder59.finish({label: '\u04a8\u2804\u02ff\u428b\u6d21\ueb6f\u5323\u7a6a'});
+let sampler85 = device3.createSampler({
+  label: '\u{1fa6f}\u2390\u78c3\u1bfa\u388a\u0970\u1d59\u5bd7\u{1fab4}\u6294',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 96.34,
+  lodMaxClamp: 98.23,
+});
+let externalTexture81 = device3.importExternalTexture({
+  label: '\u5ea3\u0513\uf0a5\u{1faa2}\uf46a\u744b\u255f\u{1fd4b}',
+  source: videoFrame31,
+  colorSpace: 'display-p3',
+});
+let pipeline123 = device3.createRenderPipeline({
+  label: '\u0dc1\u438d\ub19a\u4532',
+  layout: pipelineLayout19,
+  fragment: {
+  module: shaderModule34,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rg11b10ufloat',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg32sint', writeMask: 0}, {format: 'rgba16uint'}, {format: 'rg16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule34,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2640,
+        attributes: [
+          {format: 'snorm8x4', offset: 1100, shaderLocation: 3},
+          {format: 'snorm8x4', offset: 68, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 396, shaderLocation: 23},
+        ],
+      },
+      {
+        arrayStride: 2820,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 492, shaderLocation: 17},
+          {format: 'float32x2', offset: 196, shaderLocation: 11},
+          {format: 'sint16x4', offset: 304, shaderLocation: 19},
+          {format: 'float32x4', offset: 980, shaderLocation: 9},
+          {format: 'sint16x2', offset: 1304, shaderLocation: 16},
+          {format: 'unorm16x2', offset: 1720, shaderLocation: 2},
+          {format: 'uint8x4', offset: 268, shaderLocation: 24},
+          {format: 'snorm8x2', offset: 560, shaderLocation: 1},
+          {format: 'sint8x2', offset: 478, shaderLocation: 7},
+          {format: 'sint16x4', offset: 300, shaderLocation: 12},
+          {format: 'snorm8x4', offset: 132, shaderLocation: 21},
+          {format: 'uint16x4', offset: 324, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front'},
+});
+try {
+offscreenCanvas42.getContext('webgpu');
+} catch {}
+let commandEncoder161 = device3.createCommandEncoder();
+try {
+renderBundleEncoder60.setPipeline(pipeline123);
+} catch {}
+let pipeline124 = await device3.createComputePipelineAsync({layout: pipelineLayout24, compute: {module: shaderModule32, entryPoint: 'compute0', constants: {}}});
+let video49 = await videoWithData();
+let querySet88 = device4.createQuerySet({label: '\u1b52\ubc46\u03cf\u0ace\u4e38\u05e4\u08ba\u{1faf7}\u{1f6a2}', type: 'occlusion', count: 3774});
+let renderBundle81 = renderBundleEncoder57.finish();
+try {
+renderBundleEncoder58.setIndexBuffer(buffer37, 'uint16');
+} catch {}
+try {
+texture79.destroy();
+} catch {}
+try {
+commandEncoder133.clearBuffer(buffer31);
+dissociateBuffer(device4, buffer31);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer32, 136580, new Float32Array(45123));
+} catch {}
+let pipeline125 = await device4.createRenderPipelineAsync({
+  label: '\ua360\u3163\u{1f682}\u0a15',
+  layout: pipelineLayout18,
+  fragment: {
+  module: shaderModule33,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule33,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 13412,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 2648, shaderLocation: 13},
+          {format: 'unorm16x4', offset: 640, shaderLocation: 16},
+          {format: 'unorm8x2', offset: 166, shaderLocation: 11},
+          {format: 'sint8x2', offset: 2324, shaderLocation: 9},
+          {format: 'uint8x2', offset: 1312, shaderLocation: 17},
+          {format: 'sint8x2', offset: 3632, shaderLocation: 15},
+          {format: 'sint32x4', offset: 420, shaderLocation: 5},
+          {format: 'unorm8x2', offset: 7968, shaderLocation: 8},
+          {format: 'unorm16x2', offset: 1008, shaderLocation: 0},
+          {format: 'snorm8x4', offset: 0, shaderLocation: 18},
+          {format: 'sint8x2', offset: 1666, shaderLocation: 6},
+          {format: 'uint32x4', offset: 2916, shaderLocation: 12},
+          {format: 'float32x4', offset: 388, shaderLocation: 2},
+          {format: 'snorm8x4', offset: 864, shaderLocation: 3},
+          {format: 'snorm8x4', offset: 48, shaderLocation: 1},
+          {format: 'uint32x2', offset: 20, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 600,
+        attributes: [
+          {format: 'uint8x2', offset: 24, shaderLocation: 7},
+          {format: 'uint32x3', offset: 24, shaderLocation: 10},
+          {format: 'uint32x4', offset: 140, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'back', unclippedDepth: true},
+});
+let bindGroupLayout50 = device2.createBindGroupLayout({
+  label: '\u{1f90e}\ub799',
+  entries: [
+    {
+      binding: 5089,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 4279,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 600,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let commandEncoder162 = device2.createCommandEncoder();
+let texture93 = device2.createTexture({
+  label: '\u0342\u2717\u02f0\u{1fd3b}',
+  size: [1256, 1, 1825],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView183 = texture64.createView({label: '\uc2f8\u{1fa1e}', baseMipLevel: 6, mipLevelCount: 3});
+let computePassEncoder71 = commandEncoder139.beginComputePass({label: '\u0d82\u4e93\u{1f61f}\u03b4\u391d\u979b\u{1fbf9}\u0717\u64ce\ub993'});
+let sampler86 = device2.createSampler({
+  label: '\uf404\u810b\u90a0\ued0a\u6c24\u2f79\ub431\u9880\u6a97',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 69.67,
+  lodMaxClamp: 94.83,
+  compare: 'equal',
+  maxAnisotropy: 8,
+});
+try {
+computePassEncoder57.setBindGroup(1, bindGroup23);
+} catch {}
+let promise54 = device2.createRenderPipelineAsync({
+  label: '\u02dd\u13b7\u81c2\u0e1e\u23a6\u04e7\u29d9\ua622\ude49\ucf86\u{1fee1}',
+  layout: pipelineLayout20,
+  multisample: {count: 4, mask: 0x7f168867},
+  fragment: {
+  module: shaderModule38,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba32float', writeMask: 0}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'src-alpha-saturated', dstFactor: 'dst'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'rg32sint', writeMask: 0}, {format: 'rg8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilBack: {compare: 'greater-equal', failOp: 'decrement-clamp', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilReadMask: 441962454,
+    stencilWriteMask: 253532432,
+    depthBiasSlopeScale: 0.0,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule38,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 3664, attributes: []},
+      {
+        arrayStride: 5148,
+        attributes: [
+          {format: 'sint8x4', offset: 64, shaderLocation: 17},
+          {format: 'float32x2', offset: 244, shaderLocation: 12},
+          {format: 'sint16x2', offset: 108, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', cullMode: 'back'},
+});
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let img38 = await imageWithData(138, 99, '#008f8a26', '#ec4ff57e');
+let video50 = await videoWithData();
+let textureView184 = texture74.createView({
+  label: '\uc71a\ud39c\ud181\u{1f836}\ucb79\u3a2c',
+  dimension: '2d',
+  baseMipLevel: 5,
+  baseArrayLayer: 432,
+});
+let sampler87 = device4.createSampler({
+  label: '\u0eee\u{1f96d}\u01dd\u{1f9dc}\u794f\u{1fb1a}\u0c69\ue3b6',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  lodMinClamp: 44.59,
+  lodMaxClamp: 86.05,
+  compare: 'greater-equal',
+});
+let promise55 = buffer31.mapAsync(GPUMapMode.READ, 0, 225304);
+let pipeline126 = await device4.createComputePipelineAsync({layout: pipelineLayout22, compute: {module: shaderModule29, entryPoint: 'compute0', constants: {}}});
+let buffer40 = device2.createBuffer({
+  label: '\u01fa\u{1fa99}\u058b\u{1f9b7}\u0198\u02bb\ua8bb\uf50d\uaa7c',
+  size: 16470,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX,
+});
+let commandEncoder163 = device2.createCommandEncoder();
+let querySet89 = device2.createQuerySet({label: '\u1e83\u{1f61c}', type: 'occlusion', count: 2918});
+let sampler88 = device2.createSampler({
+  label: '\u4c81\u734c',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 89.49,
+  maxAnisotropy: 18,
+});
+try {
+renderBundleEncoder72.setPipeline(pipeline105);
+} catch {}
+try {
+device2.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder147.copyTextureToTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 45, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture62,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder142.clearBuffer(buffer40, 1236, 5424);
+dissociateBuffer(device2, buffer40);
+} catch {}
+let canvas42 = document.createElement('canvas');
+let commandEncoder164 = device4.createCommandEncoder({});
+let textureView185 = texture72.createView({
+  label: '\u00f3\uc743\u1deb\u09b5\u{1fd0d}\u{1faf2}',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 52,
+  arrayLayerCount: 212,
+});
+try {
+commandEncoder133.copyTextureToBuffer({
+  texture: texture82,
+  mipLevel: 1,
+  origin: {x: 99, y: 43, z: 52},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 280 widthInBlocks: 70 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 12192 */
+  offset: 12192,
+  bytesPerRow: 512,
+  rowsPerImage: 273,
+  buffer: buffer32,
+}, {width: 70, height: 112, depthOrArrayLayers: 0});
+dissociateBuffer(device4, buffer32);
+} catch {}
+try {
+commandEncoder145.clearBuffer(buffer32, 113856, 76);
+dissociateBuffer(device4, buffer32);
+} catch {}
+try {
+gpuCanvasContext23.configure({
+  device: device4,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device4.queue.writeBuffer(buffer35, 31476, new DataView(new ArrayBuffer(49132)));
+} catch {}
+let pipeline127 = device4.createComputePipeline({
+  label: '\u{1fcaa}\udc63\u0d02\u048c\ua8be\u{1ffe7}\u017f\u9859\u{1fa9d}\u{1fe16}\u070a',
+  layout: pipelineLayout22,
+  compute: {module: shaderModule33, entryPoint: 'compute0', constants: {}},
+});
+let pipeline128 = device4.createRenderPipeline({
+  label: '\u5a33\u32a4\u09b8\ua137\u0545\u7a95\u{1f917}\u{1f7b5}\ua799\u1584\u0256',
+  layout: pipelineLayout18,
+  fragment: {
+  module: shaderModule29,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'never', depthFailOp: 'zero', passOp: 'zero'},
+    stencilBack: {failOp: 'invert', depthFailOp: 'replace', passOp: 'increment-clamp'},
+    stencilReadMask: 3201365369,
+    stencilWriteMask: 1727714196,
+    depthBiasSlopeScale: 967.1284802400935,
+    depthBiasClamp: 725.9456254661261,
+  },
+  vertex: {
+    module: shaderModule29,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'sint32x4', offset: 30892, shaderLocation: 13},
+          {format: 'uint32x2', offset: 1148, shaderLocation: 8},
+          {format: 'unorm8x4', offset: 280, shaderLocation: 14},
+          {format: 'unorm16x2', offset: 15924, shaderLocation: 15},
+          {format: 'float16x2', offset: 1456, shaderLocation: 18},
+          {format: 'unorm10-10-10-2', offset: 13080, shaderLocation: 11},
+          {format: 'uint32', offset: 9504, shaderLocation: 16},
+          {format: 'sint8x4', offset: 11408, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 13052, shaderLocation: 9},
+          {format: 'unorm16x2', offset: 1844, shaderLocation: 5},
+          {format: 'unorm8x4', offset: 22068, shaderLocation: 6},
+          {format: 'float16x2', offset: 164, shaderLocation: 17},
+          {format: 'snorm8x2', offset: 31634, shaderLocation: 7},
+          {format: 'uint32', offset: 12528, shaderLocation: 0},
+          {format: 'snorm16x4', offset: 1376, shaderLocation: 2},
+          {format: 'float16x2', offset: 1456, shaderLocation: 10},
+          {format: 'float16x4', offset: 1208, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: false},
+});
+let gpuCanvasContext44 = canvas42.getContext('webgpu');
+let querySet90 = device2.createQuerySet({label: '\u034e\u0a7e\u6148\u040b\u8245\ud742', type: 'occlusion', count: 2306});
+let commandBuffer37 = commandEncoder113.finish({label: '\uabd7\u07d8\ucbbc\u6325\u8d64\u0fa2\u490f\u0f05\u{1f9fa}\u0871'});
+let sampler89 = device2.createSampler({
+  label: '\u8dc7\u{1fda2}\u8630\ub601\uca1c\u076c\u8426\u0f59',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 72.55,
+});
+try {
+renderBundleEncoder71.setPipeline(pipeline105);
+} catch {}
+let bindGroupLayout51 = device3.createBindGroupLayout({
+  label: '\u350f\u989f\u0b0b\u0c5e\u{1f9e7}\u{1fd8c}\u4123\u{1f762}\u919b',
+  entries: [
+    {
+      binding: 6,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d' },
+    },
+  ],
+});
+let commandEncoder165 = device3.createCommandEncoder({label: '\ua16d\u{1f74f}\u{1fdfd}\u0589\u1442\uec7a\ub29e\u4572\u9b6f\ue1ac'});
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+canvas24.height = 350;
+try {
+window.someLabel = externalTexture22.label;
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+document.body.prepend(video47);
+video7.width = 125;
+let querySet91 = device3.createQuerySet({type: 'occlusion', count: 1665});
+let pipeline129 = device3.createComputePipeline({
+  label: '\u5885\u0257\u45cb\u804e\ue003',
+  layout: 'auto',
+  compute: {module: shaderModule34, entryPoint: 'compute0'},
+});
+document.body.prepend(canvas5);
+let img39 = await imageWithData(211, 223, '#7f007c73', '#a3ab8746');
+let imageData37 = new ImageData(196, 232);
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let videoFrame41 = new VideoFrame(imageBitmap34, {timestamp: 0});
+let querySet92 = device4.createQuerySet({label: '\u900b\u{1fafd}\u{1fe65}\u070d\ube82\u{1f995}\uc8f8', type: 'occlusion', count: 1447});
+let textureView186 = texture89.createView({dimension: '2d', mipLevelCount: 3, baseArrayLayer: 305});
+let renderBundleEncoder76 = device4.createRenderBundleEncoder({colorFormats: ['rgba8uint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle82 = renderBundleEncoder58.finish({label: '\ue4d7\u454b\ude90\u6011\u{1f7c8}\u2fbe\u{1f9a8}\uf003\ub1d4'});
+try {
+commandEncoder150.clearBuffer(buffer32, 121288);
+dissociateBuffer(device4, buffer32);
+} catch {}
+try {
+gpuCanvasContext42.configure({
+  device: device4,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 4,
+  origin: {x: 0, y: 2, z: 2},
+  aspect: 'all',
+}, arrayBuffer10, /* required buffer size: 1_354_020 */
+{offset: 272, bytesPerRow: 113, rowsPerImage: 126}, {width: 2, height: 11, depthOrArrayLayers: 96});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let offscreenCanvas43 = new OffscreenCanvas(478, 880);
+let commandEncoder166 = device2.createCommandEncoder({label: '\ufaba\u3d77\u0c47\u0a4e\u{1fb4b}\u0901\u{1f62d}\ua666\uec41\uc04a\u8127'});
+let querySet93 = device2.createQuerySet({label: '\u0712\u0546', type: 'occlusion', count: 1155});
+let textureView187 = texture76.createView({label: '\u0ff9\u0430\u146c\u0881', baseMipLevel: 1, baseArrayLayer: 0});
+let renderBundle83 = renderBundleEncoder71.finish({label: '\uc0ee\u0b48\u6077'});
+try {
+commandEncoder159.copyTextureToBuffer({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 75, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 888 widthInBlocks: 111 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 13800 */
+  offset: 13800,
+  rowsPerImage: 155,
+  buffer: buffer40,
+}, {width: 111, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer40);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer40, 220, new Float32Array(31945), 16394, 204);
+} catch {}
+let pipeline130 = await device2.createComputePipelineAsync({
+  label: '\u07c2\u2eae\u2af6\u05a0\udd1a\u5130\u01b1',
+  layout: pipelineLayout16,
+  compute: {module: shaderModule25, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(canvas0);
+let bindGroupLayout52 = device3.createBindGroupLayout({
+  entries: [
+    {
+      binding: 469,
+      visibility: 0,
+      buffer: { type: 'storage', minBindingSize: 25630797, hasDynamicOffset: false },
+    },
+    {
+      binding: 344,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 245,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let texture94 = device3.createTexture({
+  size: [832, 1, 458],
+  mipLevelCount: 10,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView188 = texture86.createView({label: '\u1741\u3dec\u{1f832}\u{1fead}\u0691\uc01e\u0aaa\u595f\u{1f921}\ue73e'});
+offscreenCanvas36.height = 1530;
+let imageData38 = new ImageData(152, 140);
+try {
+  await promise55;
+} catch {}
+let offscreenCanvas44 = new OffscreenCanvas(906, 238);
+let textureView189 = texture80.createView({label: '\u01e8\ud6b0', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 85});
+let renderBundleEncoder77 = device3.createRenderBundleEncoder({
+  label: '\u{1fbf2}\uc727\u9094\u7cfc\u0c63\u03d3',
+  colorFormats: ['r8unorm', 'rg11b10ufloat', 'rg8sint', 'r8sint', 'rg32sint', 'rgba16uint', 'rg16float'],
+  stencilReadOnly: false,
+});
+let imageBitmap39 = await createImageBitmap(imageBitmap0);
+let renderBundle84 = renderBundleEncoder69.finish({label: '\u05de\u5456\u{1f856}\u1d1f\u4297\u429c\u0ca2'});
+let externalTexture82 = device3.importExternalTexture({
+  label: '\u{1ff65}\u75fc\u{1ffce}\ud6ef\ued58\u7b77\u2003\ud78a\u07d4',
+  source: videoFrame0,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder60.setPipeline(pipeline111);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder167 = device2.createCommandEncoder({});
+let texture95 = device2.createTexture({
+  label: '\uf8c5\u937d\udc38\u9a37\u56f8\u017b\uf325\u13f6\u0a7f\u036d',
+  size: [1256],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView190 = texture76.createView({label: '\u0a57\u{1fc08}', baseMipLevel: 2, baseArrayLayer: 0});
+let computePassEncoder72 = commandEncoder132.beginComputePass({});
+let renderBundle85 = renderBundleEncoder72.finish({label: '\ud414\u0852\u03c9\u{1fd6d}\ue60c'});
+try {
+renderBundleEncoder68.setBindGroup(3, bindGroup28, []);
+} catch {}
+try {
+commandEncoder151.copyTextureToTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 15},
+  aspect: 'all',
+},
+{
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 236, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 357, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 106, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer0), /* required buffer size: 221 */
+{offset: 221, rowsPerImage: 162}, {width: 164, height: 0, depthOrArrayLayers: 1});
+} catch {}
+video15.width = 159;
+let commandEncoder168 = device2.createCommandEncoder({label: '\u0241\ucf7a\u5a91'});
+let commandBuffer38 = commandEncoder154.finish({label: '\u069d\u5134\u3663\u0789\u22a5\uaf5d\u9397'});
+try {
+computePassEncoder57.setPipeline(pipeline95);
+} catch {}
+try {
+renderBundleEncoder47.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder66.setVertexBuffer(8, buffer30, 55948, 5011);
+} catch {}
+try {
+commandEncoder121.pushDebugGroup('\u{1ff7d}');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 2},
+  aspect: 'all',
+}, new ArrayBuffer(24), /* required buffer size: 4_090_480 */
+{offset: 394, bytesPerRow: 8853, rowsPerImage: 231}, {width: 1072, height: 0, depthOrArrayLayers: 3});
+} catch {}
+let promise56 = device2.queue.onSubmittedWorkDone();
+video47.width = 266;
+let imageData39 = new ImageData(148, 4);
+let bindGroupLayout53 = device2.createBindGroupLayout({
+  label: '\uebf3\u95c9\uae75\u5260\u3fc4\u1738\u4ff4\u0c66\u{1fdfc}',
+  entries: [
+    {
+      binding: 3292,
+      visibility: 0,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 68,
+      visibility: 0,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '2d-array' },
+    },
+  ],
+});
+let buffer41 = device2.createBuffer({label: '\u{1fe74}\u{1fd78}\u6805\u{1fc62}', size: 1793, usage: GPUBufferUsage.COPY_DST});
+let querySet94 = device2.createQuerySet({label: '\u479e\u0b3d\u{1fbd0}\uff22\u067a\u{1fe5f}\u5f77\u08f6\ueb3b', type: 'occlusion', count: 3486});
+let texture96 = device2.createTexture({
+  label: '\u{1fff2}\u4f33\u0cad\u{1fcce}\uda76\u05f0\u0122\u01c8\u0dc0\u0e9d',
+  size: [628],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm'],
+});
+let textureView191 = texture61.createView({label: '\u04e1\u0377', mipLevelCount: 1});
+try {
+commandEncoder104.copyBufferToTexture({
+  /* bytesInLastRow: 5816 widthInBlocks: 727 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 7896 */
+  offset: 2080,
+  bytesPerRow: 5888,
+  buffer: buffer39,
+}, {
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 727, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer39);
+} catch {}
+try {
+commandEncoder121.popDebugGroup();
+} catch {}
+try {
+  await promise56;
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+try {
+  await promise53;
+} catch {}
+let offscreenCanvas45 = new OffscreenCanvas(395, 304);
+let commandEncoder169 = device3.createCommandEncoder();
+let querySet95 = device3.createQuerySet({label: '\u57dd\ue54e', type: 'occlusion', count: 1610});
+let texture97 = device3.createTexture({
+  label: '\u0e6a\ue42c\u5e18\u1796',
+  size: {width: 424, height: 1, depthOrArrayLayers: 949},
+  mipLevelCount: 4,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView192 = texture94.createView({
+  label: '\ueea0\u0762\u0d84\u6866\ufd2e\u8a32\u{1f89b}\u020d',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 385,
+  arrayLayerCount: 9,
+});
+try {
+device3.queue.writeTexture({
+  texture: texture97,
+  mipLevel: 3,
+  origin: {x: 11, y: 0, z: 136},
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 9_682_006 */
+{offset: 433, bytesPerRow: 121, rowsPerImage: 179}, {width: 29, height: 0, depthOrArrayLayers: 448});
+} catch {}
+gc();
+let canvas43 = document.createElement('canvas');
+let sampler90 = device2.createSampler({
+  label: '\u{1ffc6}\u4c0f\u06bc\u826b\u9866',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  lodMinClamp: 28.32,
+});
+try {
+computePassEncoder58.setPipeline(pipeline97);
+} catch {}
+try {
+renderBundleEncoder65.setBindGroup(0, bindGroup27);
+} catch {}
+try {
+renderBundleEncoder73.setVertexBuffer(6, buffer40, 9100, 1817);
+} catch {}
+try {
+commandEncoder102.copyTextureToTexture({
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 41, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 31, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 376, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.submit([commandBuffer32]);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let commandEncoder170 = device0.createCommandEncoder({label: '\ud88d\ufadd\u03a1\uff45\u{1fe49}\u{1fd6e}\u0f65\u07c4'});
+let texture98 = device0.createTexture({
+  label: '\u0717\u06b7',
+  size: {width: 658, height: 20, depthOrArrayLayers: 854},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg16uint', 'rg16uint'],
+});
+let textureView193 = texture42.createView({
+  label: '\u195b\u{1f856}\u0627\u{1fcb3}\ub944\u18c1\u007f\u0571\ufebd\ue474\u9bee',
+  format: 'bgra8unorm-srgb',
+  baseMipLevel: 1,
+  mipLevelCount: 3,
+});
+try {
+renderPassEncoder11.end();
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(6, 1, 15, 1);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline86);
+} catch {}
+try {
+renderBundleEncoder13.draw(364, 438, 1_399_148_422, 117_935_287);
+} catch {}
+try {
+renderBundleEncoder13.drawIndexed(9, 11, 1_515_287_439, 195_897_038, 501_626_913);
+} catch {}
+try {
+commandEncoder170.copyBufferToBuffer(buffer5, 54224, buffer18, 117004, 3740);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder61.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderBundleEncoder9.insertDebugMarker('\u{1fcd7}');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 658, height: 20, depthOrArrayLayers: 1}
+*/
+{
+  source: img39,
+  origin: { x: 110, y: 34 },
+  flipY: true,
+}, {
+  texture: texture42,
+  mipLevel: 1,
+  origin: {x: 5, y: 3, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 48, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let pipeline131 = await promise30;
+let commandEncoder171 = device4.createCommandEncoder({label: '\u9a5c\u016c\u2bdb\u{1fed6}\u59df\u0b57\ucd85\u{1f974}\u1316'});
+let renderBundle86 = renderBundleEncoder74.finish({label: '\u07f1\u{1f770}\u06d8\ub6b2\u3dff\u70e8\u{1f916}\ue802'});
+let externalTexture83 = device4.importExternalTexture({label: '\u35a4\u0f5d\uba95', source: videoFrame18, colorSpace: 'srgb'});
+try {
+computePassEncoder59.end();
+} catch {}
+try {
+renderBundleEncoder53.setPipeline(pipeline109);
+} catch {}
+try {
+buffer37.destroy();
+} catch {}
+try {
+commandEncoder150.copyTextureToBuffer({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 72, y: 364, z: 20},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2384 widthInBlocks: 149 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 100096 */
+  offset: 13232,
+  bytesPerRow: 2560,
+  buffer: buffer35,
+}, {width: 596, height: 136, depthOrArrayLayers: 1});
+dissociateBuffer(device4, buffer35);
+} catch {}
+let pipeline132 = await device4.createRenderPipelineAsync({
+  label: '\u{1ff58}\uad1e\u9ea8\u0917\udc59',
+  layout: pipelineLayout22,
+  fragment: {
+  module: shaderModule33,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule33,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 12500,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 2104, shaderLocation: 13},
+          {format: 'uint8x4', offset: 816, shaderLocation: 17},
+          {format: 'float16x4', offset: 3492, shaderLocation: 16},
+          {format: 'unorm16x4', offset: 2524, shaderLocation: 1},
+          {format: 'sint32', offset: 4024, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 3148, shaderLocation: 2},
+          {format: 'float32x3', offset: 736, shaderLocation: 11},
+          {format: 'float32x3', offset: 956, shaderLocation: 18},
+          {format: 'sint32x2', offset: 88, shaderLocation: 6},
+          {format: 'float32x2', offset: 2264, shaderLocation: 0},
+          {format: 'uint16x4', offset: 144, shaderLocation: 7},
+          {format: 'sint32x3', offset: 668, shaderLocation: 15},
+          {format: 'uint32', offset: 1596, shaderLocation: 4},
+          {format: 'sint32x2', offset: 884, shaderLocation: 9},
+          {format: 'uint8x4', offset: 1992, shaderLocation: 12},
+          {format: 'unorm8x2', offset: 2408, shaderLocation: 8},
+          {format: 'uint32', offset: 3204, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 2880, shaderLocation: 3},
+          {format: 'uint32x4', offset: 2220, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw'},
+});
+let adapter7 = await navigator.gpu.requestAdapter();
+video10.width = 176;
+let imageData40 = new ImageData(172, 172);
+let commandEncoder172 = device4.createCommandEncoder({label: '\u0345\u7e34\u271b\u{1f99c}\u{1fff1}\ub260'});
+let renderBundle87 = renderBundleEncoder74.finish({label: '\ub298\u{1f8ab}\ude50\u{1f723}\u{1f867}\u096e\u1f8c\u0b7c\u0ccf\ud986'});
+try {
+computePassEncoder54.setPipeline(pipeline104);
+} catch {}
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+try {
+device4.queue.submit([commandBuffer29]);
+} catch {}
+let pipeline133 = await device4.createComputePipelineAsync({
+  label: '\u{1f6bf}\u{1f91e}\ud259\u6886\u85e4\u{1f652}\u0655\u505f\u38a7',
+  layout: pipelineLayout22,
+  compute: {module: shaderModule29, entryPoint: 'compute0'},
+});
+let commandEncoder173 = device3.createCommandEncoder({});
+let externalTexture84 = device3.importExternalTexture({label: '\u3bae\uc8c8\u62bd\ubeab\u02eb', source: videoFrame20, colorSpace: 'display-p3'});
+try {
+computePassEncoder70.end();
+} catch {}
+let pipeline134 = await device3.createComputePipelineAsync({layout: pipelineLayout24, compute: {module: shaderModule32, entryPoint: 'compute0', constants: {}}});
+let pipeline135 = await device3.createRenderPipelineAsync({
+  layout: pipelineLayout24,
+  multisample: {mask: 0xaf55040c},
+  fragment: {
+  module: shaderModule35,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8unorm', writeMask: GPUColorWrite.RED}, {
+  format: 'rg11b10ufloat',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'dst'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA}, {format: 'rg32sint', writeMask: 0}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALL}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'src'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'less-equal', failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilBack: {compare: 'never', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'replace'},
+    stencilReadMask: 1808143283,
+    stencilWriteMask: 1277953473,
+    depthBiasSlopeScale: 829.4975887625604,
+    depthBiasClamp: 621.7867281062324,
+  },
+  vertex: {
+    module: shaderModule35,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1100,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 64, shaderLocation: 7},
+          {format: 'sint8x2', offset: 54, shaderLocation: 9},
+          {format: 'uint32x4', offset: 120, shaderLocation: 5},
+          {format: 'float16x2', offset: 0, shaderLocation: 0},
+          {format: 'snorm16x4', offset: 352, shaderLocation: 15},
+          {format: 'unorm8x2', offset: 448, shaderLocation: 19},
+          {format: 'sint32x3', offset: 120, shaderLocation: 17},
+          {format: 'snorm16x4', offset: 352, shaderLocation: 6},
+          {format: 'float16x2', offset: 24, shaderLocation: 3},
+          {format: 'uint32', offset: 416, shaderLocation: 11},
+          {format: 'uint32x4', offset: 64, shaderLocation: 18},
+          {format: 'uint32', offset: 32, shaderLocation: 12},
+          {format: 'snorm16x2', offset: 424, shaderLocation: 22},
+        ],
+      },
+      {
+        arrayStride: 2452,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 84, shaderLocation: 24},
+          {format: 'snorm16x4', offset: 24, shaderLocation: 8},
+          {format: 'unorm16x2', offset: 936, shaderLocation: 1},
+          {format: 'float32x2', offset: 120, shaderLocation: 4},
+          {format: 'snorm8x2', offset: 696, shaderLocation: 2},
+          {format: 'unorm16x4', offset: 1348, shaderLocation: 16},
+          {format: 'snorm8x2', offset: 242, shaderLocation: 23},
+          {format: 'uint16x2', offset: 44, shaderLocation: 21},
+          {format: 'uint32', offset: 292, shaderLocation: 20},
+          {format: 'sint16x2', offset: 228, shaderLocation: 14},
+          {format: 'sint8x4', offset: 136, shaderLocation: 10},
+          {format: 'unorm16x4', offset: 1732, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', cullMode: 'front', unclippedDepth: true},
+});
+let gpuCanvasContext45 = offscreenCanvas44.getContext('webgpu');
+let imageData41 = new ImageData(152, 244);
+let videoFrame42 = new VideoFrame(video16, {timestamp: 0});
+let promise57 = adapter3.requestAdapterInfo();
+let texture99 = device2.createTexture({
+  size: {width: 738, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 8,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView194 = texture77.createView({label: '\u{1f744}\u{1f8e1}\u9d12\u2ad1'});
+let renderBundleEncoder78 = device2.createRenderBundleEncoder({colorFormats: ['rgba16float', 'rgba32float', 'rgba8unorm', 'rg32sint', 'rg8unorm']});
+let renderBundle88 = renderBundleEncoder63.finish({label: '\u03a6\uf30a\ubace\uef51\u0b4f\u5c39'});
+try {
+renderBundleEncoder47.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder78.setVertexBuffer(6, buffer30, 0, 14017);
+} catch {}
+try {
+commandEncoder104.copyBufferToTexture({
+  /* bytesInLastRow: 1300 widthInBlocks: 325 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3868 */
+  offset: 3868,
+  buffer: buffer28,
+}, {
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 325, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer28);
+} catch {}
+try {
+commandEncoder162.copyTextureToTexture({
+  texture: texture62,
+  mipLevel: 5,
+  origin: {x: 1, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture62,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 15});
+} catch {}
+try {
+device2.queue.submit([commandBuffer37]);
+} catch {}
+let pipeline136 = device2.createRenderPipeline({
+  label: '\u72e7\u0755',
+  layout: pipelineLayout21,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule24,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba32float', writeMask: 0}, {format: 'rgba8unorm', writeMask: 0}, {format: 'rg32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'src', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}],
+},
+  vertex: {
+    module: shaderModule24,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3308,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x2', offset: 532, shaderLocation: 6}],
+      },
+      {arrayStride: 892, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 27576, shaderLocation: 10},
+          {format: 'sint8x4', offset: 3332, shaderLocation: 9},
+          {format: 'sint8x2', offset: 8002, shaderLocation: 13},
+          {format: 'sint16x2', offset: 1584, shaderLocation: 4},
+          {format: 'float32x2', offset: 2336, shaderLocation: 15},
+          {format: 'float32x3', offset: 3448, shaderLocation: 5},
+          {format: 'snorm16x2', offset: 2524, shaderLocation: 16},
+          {format: 'snorm16x2', offset: 3404, shaderLocation: 17},
+          {format: 'sint32x3', offset: 3888, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'cw', cullMode: 'front'},
+});
+try {
+offscreenCanvas43.getContext('webgl2');
+} catch {}
+let shaderModule40 = device4.createShaderModule({
+  code: `@group(2) @binding(1159)
+var<storage, read_write> function29: array<u32>;
+@group(1) @binding(665)
+var<storage, read_write> global28: array<u32>;
+@group(0) @binding(371)
+var<storage, read_write> field33: array<u32>;
+@group(0) @binding(665)
+var<storage, read_write> field34: array<u32>;
+@group(2) @binding(665)
+var<storage, read_write> local36: array<u32>;
+
+@compute @workgroup_size(2, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_mask) a1: u32, @builtin(position) a2: vec4<f32>, @builtin(sample_index) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S36 {
+  @location(2) f0: u32,
+  @location(3) f1: f16,
+  @location(15) f2: vec4<i32>,
+  @location(10) f3: vec4<f32>,
+  @location(11) f4: vec3<u32>,
+  @location(7) f5: vec4<u32>,
+  @location(8) f6: vec2<f16>,
+  @location(17) f7: vec3<f16>,
+  @location(13) f8: f16,
+  @builtin(instance_index) f9: u32,
+  @location(1) f10: vec2<i32>,
+  @location(12) f11: vec4<u32>,
+  @location(18) f12: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(4) a0: vec3<f32>, @location(5) a1: vec3<f32>, @location(9) a2: vec3<i32>, a3: S36, @location(14) a4: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+try {
+computePassEncoder64.setPipeline(pipeline126);
+} catch {}
+try {
+renderBundleEncoder53.setIndexBuffer(buffer37, 'uint32');
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(5, buffer38, 0, 161055);
+} catch {}
+try {
+buffer31.destroy();
+} catch {}
+try {
+commandEncoder158.clearBuffer(buffer35);
+dissociateBuffer(device4, buffer35);
+} catch {}
+let videoFrame43 = new VideoFrame(imageBitmap35, {timestamp: 0});
+offscreenCanvas40.width = 5;
+let canvas44 = document.createElement('canvas');
+let texture100 = device3.createTexture({
+  label: '\u0aec\u01f4\u1eac\u0c3a\u0bf1',
+  size: {width: 832, height: 1, depthOrArrayLayers: 228},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView195 = texture97.createView({
+  label: '\u4821\u{1fbbd}\u{1fcba}',
+  dimension: '2d-array',
+  baseMipLevel: 0,
+  mipLevelCount: 3,
+  baseArrayLayer: 657,
+  arrayLayerCount: 96,
+});
+try {
+renderBundleEncoder75.setVertexBuffer(7610, undefined, 1785691080, 1827767722);
+} catch {}
+try {
+device3.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder106.copyTextureToTexture({
+  texture: texture100,
+  mipLevel: 4,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture100,
+  mipLevel: 1,
+  origin: {x: 23, y: 0, z: 6},
+  aspect: 'all',
+},
+{width: 36, height: 1, depthOrArrayLayers: 8});
+} catch {}
+try {
+gpuCanvasContext18.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 212, height: 1, depthOrArrayLayers: 949}
+*/
+{
+  source: video40,
+  origin: { x: 2, y: 0 },
+  flipY: false,
+}, {
+  texture: texture97,
+  mipLevel: 1,
+  origin: {x: 27, y: 0, z: 468},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData42 = new ImageData(208, 224);
+let commandEncoder174 = device4.createCommandEncoder({label: '\u05aa\u0029\u{1fa3f}\u0f39\u{1fddf}\u0c20\u8fc2'});
+let querySet96 = device4.createQuerySet({label: '\u056f\u6f1f', type: 'occlusion', count: 3426});
+let computePassEncoder73 = commandEncoder157.beginComputePass({label: '\ue880\u7da6'});
+let renderBundle89 = renderBundleEncoder74.finish({label: '\ue793\ubfa3\uf35c\u0b2d\u{1f97a}\u8142\ufc85\u05e3\u07ff\uc33d\u999c'});
+let externalTexture85 = device4.importExternalTexture({
+  label: '\u2ddc\u0c72\u{1f60f}\u0eb3\u004c\u5df2\u0379\u{1f693}\u4634\u001e\u{1f8b8}',
+  source: video15,
+});
+try {
+computePassEncoder60.setPipeline(pipeline103);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer35, 17912, new BigUint64Array(36389));
+} catch {}
+let gpuCanvasContext46 = canvas44.getContext('webgpu');
+try {
+gpuCanvasContext26.unconfigure();
+} catch {}
+try {
+  await promise57;
+} catch {}
+let img40 = await imageWithData(116, 177, '#5f2022cc', '#2efdf79f');
+let querySet97 = device4.createQuerySet({type: 'occlusion', count: 487});
+let textureView196 = texture72.createView({
+  label: '\u44e2\u{1f9ef}\uad3f\u7f2b\u{1ffed}\u1acd\u{1fcd8}',
+  aspect: 'all',
+  baseArrayLayer: 186,
+  arrayLayerCount: 141,
+});
+let imageBitmap40 = await createImageBitmap(canvas32);
+try {
+canvas43.getContext('webgl2');
+} catch {}
+let shaderModule41 = device3.createShaderModule({
+  label: '\u0519\uae03\uc63d\u0daf\u0041\ub4d2\u0710',
+  code: `@group(0) @binding(586)
+var<storage, read_write> type29: array<u32>;
+@group(0) @binding(990)
+var<storage, read_write> n21: array<u32>;
+@group(1) @binding(993)
+var<storage, read_write> n22: array<u32>;
+@group(1) @binding(1136)
+var<storage, read_write> local37: array<u32>;
+@group(0) @binding(110)
+var<storage, read_write> global29: array<u32>;
+
+@compute @workgroup_size(2, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(5) f0: vec4<u32>,
+  @location(3) f1: vec2<i32>,
+  @location(2) f2: vec2<i32>,
+  @location(1) f3: vec4<f32>,
+  @location(0) f4: vec3<f32>,
+  @location(4) f5: vec4<i32>,
+  @location(6) f6: vec2<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S37 {
+  @builtin(vertex_index) f0: u32,
+  @location(20) f1: f32,
+  @location(15) f2: vec3<f32>,
+  @location(2) f3: vec2<i32>,
+  @location(23) f4: vec2<f32>,
+  @location(18) f5: vec2<f32>,
+  @location(4) f6: vec4<u32>,
+  @location(7) f7: vec4<u32>,
+  @location(21) f8: vec4<i32>,
+  @location(17) f9: vec3<i32>,
+  @location(13) f10: vec2<f32>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec3<u32>, @location(11) a1: vec2<i32>, @location(6) a2: vec2<f16>, @location(3) a3: vec3<f16>, @location(0) a4: i32, @location(5) a5: vec3<i32>, @location(16) a6: vec4<u32>, a7: S37) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet98 = device3.createQuerySet({label: '\u044e\u9cd2', type: 'occlusion', count: 320});
+let commandBuffer39 = commandEncoder105.finish();
+let textureView197 = texture71.createView({label: '\u0566\u61fc\u077b\u6c3f\uff69', dimension: '2d', baseMipLevel: 1, baseArrayLayer: 293});
+let renderBundle90 = renderBundleEncoder77.finish({label: '\u05f0\u502c\uc181\u{1fbef}\u9e88\u{1f6b0}\u5c76\ucf35'});
+let externalTexture86 = device3.importExternalTexture({label: '\u433e\u895c', source: videoFrame42});
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+let shaderModule42 = device4.createShaderModule({
+  label: '\u07f0\u05ab\uf0b2',
+  code: `@group(2) @binding(1173)
+var<storage, read_write> parameter22: array<u32>;
+@group(3) @binding(1173)
+var<storage, read_write> type30: array<u32>;
+@group(0) @binding(1173)
+var<storage, read_write> parameter23: array<u32>;
+@group(3) @binding(875)
+var<storage, read_write> local38: array<u32>;
+@group(1) @binding(875)
+var<storage, read_write> type31: array<u32>;
+@group(0) @binding(875)
+var<storage, read_write> type32: array<u32>;
+
+@compute @workgroup_size(6, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S38 {
+  @location(10) f0: vec3<i32>,
+  @location(34) f1: vec2<u32>,
+  @location(28) f2: vec4<f16>,
+  @location(25) f3: vec3<f16>,
+  @location(17) f4: i32,
+  @location(21) f5: vec2<f16>,
+  @location(18) f6: vec3<u32>,
+  @location(38) f7: vec3<i32>,
+  @location(3) f8: vec2<i32>,
+  @location(46) f9: f32,
+  @location(41) f10: vec4<i32>,
+  @location(33) f11: vec3<u32>,
+  @location(5) f12: vec4<i32>,
+  @location(22) f13: vec4<u32>,
+  @builtin(sample_mask) f14: u32,
+  @location(14) f15: vec4<f16>,
+  @builtin(front_facing) f16: bool,
+  @location(9) f17: vec3<f32>,
+  @location(8) f18: vec2<i32>,
+  @location(24) f19: vec3<u32>,
+  @builtin(position) f20: vec4<f32>,
+  @location(6) f21: f16
+}
+
+@fragment
+fn fragment0(@location(0) a0: vec2<i32>, a1: S38, @location(13) a2: vec4<i32>, @location(7) a3: vec4<i32>, @location(39) a4: vec3<u32>, @location(12) a5: vec4<u32>, @location(2) a6: vec2<f32>, @location(31) a7: vec3<f16>, @location(32) a8: i32, @location(15) a9: vec3<f32>, @location(29) a10: vec4<f32>, @location(44) a11: vec4<i32>, @location(40) a12: vec4<u32>, @location(11) a13: vec2<i32>, @location(37) a14: vec3<f16>, @location(23) a15: vec4<u32>, @location(27) a16: vec2<f32>, @location(1) a17: vec2<f32>, @location(30) a18: vec2<f32>, @location(45) a19: i32, @location(20) a20: f16, @builtin(sample_index) a21: u32, @location(26) a22: i32) -> @location(200) vec4<u32> {
+return vec4<u32>();
+}
+
+struct VertexOutput0 {
+  @location(5) f438: vec4<i32>,
+  @location(7) f439: vec4<i32>,
+  @location(38) f440: vec3<i32>,
+  @location(39) f441: vec3<u32>,
+  @location(11) f442: vec2<i32>,
+  @location(37) f443: vec3<f16>,
+  @location(9) f444: vec3<f32>,
+  @location(8) f445: vec2<i32>,
+  @location(40) f446: vec4<u32>,
+  @location(45) f447: i32,
+  @location(46) f448: f32,
+  @location(10) f449: vec3<i32>,
+  @location(3) f450: vec2<i32>,
+  @location(13) f451: vec4<i32>,
+  @location(25) f452: vec3<f16>,
+  @location(29) f453: vec4<f32>,
+  @location(20) f454: f16,
+  @location(17) f455: i32,
+  @location(30) f456: vec2<f32>,
+  @location(32) f457: i32,
+  @location(26) f458: i32,
+  @location(28) f459: vec4<f16>,
+  @location(21) f460: vec2<f16>,
+  @location(18) f461: vec3<u32>,
+  @location(41) f462: vec4<i32>,
+  @location(1) f463: vec2<f32>,
+  @location(15) f464: vec3<f32>,
+  @location(31) f465: vec3<f16>,
+  @location(12) f466: vec4<u32>,
+  @location(27) f467: vec2<f32>,
+  @location(34) f468: vec2<u32>,
+  @location(33) f469: vec3<u32>,
+  @location(24) f470: vec3<u32>,
+  @location(2) f471: vec2<f32>,
+  @location(6) f472: f16,
+  @location(44) f473: vec4<i32>,
+  @location(22) f474: vec4<u32>,
+  @location(14) f475: vec4<f16>,
+  @location(23) f476: vec4<u32>,
+  @builtin(position) f477: vec4<f32>,
+  @location(0) f478: vec2<i32>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let commandBuffer40 = commandEncoder172.finish({label: '\u54be\uf009'});
+try {
+computePassEncoder56.setPipeline(pipeline103);
+} catch {}
+try {
+renderBundleEncoder76.setPipeline(pipeline114);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(6, buffer38, 0, 61136);
+} catch {}
+try {
+commandEncoder158.copyTextureToBuffer({
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 23, y: 40, z: 85},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3308 widthInBlocks: 827 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 304728 */
+  offset: 364,
+  bytesPerRow: 3584,
+  rowsPerImage: 47,
+  buffer: buffer35,
+}, {width: 827, height: 38, depthOrArrayLayers: 2});
+dissociateBuffer(device4, buffer35);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer32, 115988, new BigUint64Array(12456));
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder175 = device3.createCommandEncoder({label: '\u0843\u6dae\u3bc2\u0972\u{1fd4f}\u06dd\u{1fdf5}\u39ce\u3aae'});
+let textureView198 = texture71.createView({
+  label: '\ue1bb\u0f13\u01d7\u00d4\u083f\u0a03\ucb5d\u{1ffb8}\u096a\ub8f5\u0c9f',
+  dimension: '2d',
+  aspect: 'all',
+  format: 'depth16unorm',
+  baseMipLevel: 0,
+  mipLevelCount: 2,
+  baseArrayLayer: 518,
+});
+let computePassEncoder74 = commandEncoder161.beginComputePass({label: '\ufa2b\u0546\u0857\u07a0\u09ba\u0ae1'});
+try {
+renderBundleEncoder60.insertDebugMarker('\u018e');
+} catch {}
+let pipeline137 = await device3.createComputePipelineAsync({
+  label: '\u0279\u{1fad0}\u09da\u7c0f\u7a03\u364c\u056b',
+  layout: pipelineLayout24,
+  compute: {module: shaderModule35, entryPoint: 'compute0', constants: {}},
+});
+let video51 = await videoWithData();
+let texture101 = device3.createTexture({
+  label: '\u{1ff7c}\u7d8b\u0061\u0b7e\u08f9\u0340\uf3e1\ufe7c\u05f7\u6ef9',
+  size: {width: 1696, height: 1, depthOrArrayLayers: 240},
+  mipLevelCount: 9,
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let externalTexture87 = device3.importExternalTexture({label: '\u0f81\u27ad\u{1fc5b}\u0e83\u{1f63e}\u49fd\u4949', source: video22, colorSpace: 'display-p3'});
+try {
+computePassEncoder68.setPipeline(pipeline117);
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(4699, undefined, 0);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 208, height: 1, depthOrArrayLayers: 57}
+*/
+{
+  source: videoFrame30,
+  origin: { x: 18, y: 49 },
+  flipY: true,
+}, {
+  texture: texture100,
+  mipLevel: 2,
+  origin: {x: 40, y: 0, z: 12},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 31, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext47 = offscreenCanvas45.getContext('webgpu');
+let videoFrame44 = new VideoFrame(canvas2, {timestamp: 0});
+try {
+gpuCanvasContext36.unconfigure();
+} catch {}
+document.body.prepend(img35);
+offscreenCanvas39.width = 2616;
+let video52 = await videoWithData();
+let externalTexture88 = device3.importExternalTexture({label: '\u7ca4\u726c\u{1fd67}', source: videoFrame18});
+try {
+computePassEncoder68.end();
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 53, height: 1, depthOrArrayLayers: 949}
+*/
+{
+  source: canvas40,
+  origin: { x: 27, y: 41 },
+  flipY: false,
+}, {
+  texture: texture97,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 386},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise58 = device3.createComputePipelineAsync({
+  label: '\u05d8\u0565',
+  layout: 'auto',
+  compute: {module: shaderModule34, entryPoint: 'compute0', constants: {}},
+});
+try {
+adapter1.label = '\u{1fe5f}\u{1fa81}\u{1fdb9}\u0053\u693e\ubc71\u9004';
+} catch {}
+let bindGroupLayout54 = device3.createBindGroupLayout({
+  entries: [
+    {
+      binding: 848,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 1081,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let querySet99 = device3.createQuerySet({type: 'occlusion', count: 3889});
+let renderBundle91 = renderBundleEncoder60.finish();
+try {
+renderBundleEncoder70.setPipeline(pipeline111);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture97,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, arrayBuffer9, /* required buffer size: 21_702_819 */
+{offset: 445, bytesPerRow: 291, rowsPerImage: 98}, {width: 88, height: 1, depthOrArrayLayers: 762});
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 106, height: 1, depthOrArrayLayers: 949}
+*/
+{
+  source: videoFrame41,
+  origin: { x: 78, y: 5 },
+  flipY: false,
+}, {
+  texture: texture97,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 244},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 27, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline138 = device3.createComputePipeline({
+  label: '\u0b3d\u0a2d\u2bd1\u76ee\u{1f6b6}\u{1fd22}\u1ab0\u7467\u601a\u9176\u{1fe1f}',
+  layout: 'auto',
+  compute: {module: shaderModule41, entryPoint: 'compute0', constants: {}},
+});
+try {
+window.someLabel = renderBundle8.label;
+} catch {}
+let bindGroupLayout55 = device3.createBindGroupLayout({
+  label: '\u0dc0\u0bfc\u3d8d\uc115\u{1f631}\u0793\u0764',
+  entries: [
+    {
+      binding: 724,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 1139, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let buffer42 = device3.createBuffer({label: '\u08c7\u4a76\udc06\u1ba2\u833a', size: 109040, usage: GPUBufferUsage.STORAGE});
+let commandBuffer41 = commandEncoder124.finish({});
+let texture102 = device3.createTexture({
+  size: {width: 3392, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 7,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['depth16unorm', 'depth16unorm'],
+});
+try {
+computePassEncoder74.setPipeline(pipeline129);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture101,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 8},
+  aspect: 'all',
+}, new ArrayBuffer(12_411_023), /* required buffer size: 12_411_023 */
+{offset: 547, bytesPerRow: 1029, rowsPerImage: 60}, {width: 92, height: 1, depthOrArrayLayers: 202});
+} catch {}
+let pipeline139 = await promise58;
+let imageData43 = new ImageData(104, 248);
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let textureView199 = texture97.createView({label: '\u0162\u00cf', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 190, arrayLayerCount: 751});
+try {
+computePassEncoder74.setPipeline(pipeline117);
+} catch {}
+try {
+renderBundleEncoder75.setPipeline(pipeline123);
+} catch {}
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+let promise59 = device3.createComputePipelineAsync({layout: pipelineLayout24, compute: {module: shaderModule41, entryPoint: 'compute0', constants: {}}});
+let renderBundle92 = renderBundleEncoder58.finish({});
+let externalTexture89 = device4.importExternalTexture({label: '\u0e02\u{1fe98}\u{1f81f}\u{1f615}\u78dd\u8955', source: video9, colorSpace: 'srgb'});
+try {
+computePassEncoder64.setPipeline(pipeline127);
+} catch {}
+try {
+renderBundleEncoder76.setVertexBuffer(6, buffer38, 250108, 6620);
+} catch {}
+try {
+commandEncoder111.copyTextureToBuffer({
+  texture: texture72,
+  mipLevel: 2,
+  origin: {x: 8, y: 4, z: 127},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 656 widthInBlocks: 41 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 356608 */
+  offset: 2672,
+  bytesPerRow: 768,
+  rowsPerImage: 210,
+  buffer: buffer32,
+}, {width: 164, height: 164, depthOrArrayLayers: 3});
+dissociateBuffer(device4, buffer32);
+} catch {}
+try {
+commandEncoder171.copyTextureToTexture({
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 14, y: 90, z: 15},
+  aspect: 'all',
+},
+{
+  texture: texture74,
+  mipLevel: 3,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 78, height: 11, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder138.clearBuffer(buffer35, 22364);
+dissociateBuffer(device4, buffer35);
+} catch {}
+try {
+gpuCanvasContext29.configure({
+  device: device4,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device4.queue.submit([commandBuffer40]);
+} catch {}
+let pipeline140 = device4.createComputePipeline({
+  label: '\u{1ff94}\uf1ce\u{1fbce}\u092f\u0ae0\uc1f1\u{1fc22}\u3c12\u4115\uc927',
+  layout: pipelineLayout22,
+  compute: {module: shaderModule40, entryPoint: 'compute0', constants: {}},
+});
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55) };
+} catch {}
+let shaderModule43 = device3.createShaderModule({
+  label: '\ue44f\ub5c6\u{1fe8b}\u95b8\ufc49\u97c3\u0946\u7150\u774a\u{1f9b1}\u94f1',
+  code: `@group(0) @binding(110)
+var<storage, read_write> local39: array<u32>;
+@group(1) @binding(1093)
+var<storage, read_write> field35: array<u32>;
+
+@compute @workgroup_size(3, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec3<f32>,
+  @location(0) f1: vec2<f32>,
+  @location(5) f2: vec4<u32>,
+  @location(4) f3: vec2<i32>,
+  @location(2) f4: vec4<i32>,
+  @location(6) f5: vec3<f32>,
+  @location(3) f6: i32
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(sample_mask) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S39 {
+  @location(15) f0: f32,
+  @location(24) f1: vec2<i32>,
+  @builtin(instance_index) f2: u32,
+  @location(21) f3: vec3<f32>,
+  @location(19) f4: f16,
+  @location(20) f5: vec4<f16>,
+  @location(18) f6: vec4<i32>,
+  @location(2) f7: vec4<i32>,
+  @location(4) f8: vec3<f32>,
+  @location(8) f9: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec2<u32>, @location(1) a1: vec3<f16>, @location(13) a2: i32, @location(17) a3: vec2<f16>, @location(5) a4: vec4<u32>, @location(0) a5: vec4<f16>, @location(12) a6: u32, @location(23) a7: vec3<i32>, @location(6) a8: vec4<f16>, @location(7) a9: vec3<u32>, @location(11) a10: vec3<f32>, @builtin(vertex_index) a11: u32, @location(10) a12: vec4<f32>, @location(16) a13: f16, @location(22) a14: vec2<f32>, a15: S39, @location(14) a16: vec2<i32>, @location(9) a17: vec4<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let bindGroupLayout56 = device3.createBindGroupLayout({label: '\u4873\u92f6', entries: []});
+let commandEncoder176 = device3.createCommandEncoder();
+let texture103 = device3.createTexture({
+  label: '\u04b1\u{1f83f}',
+  size: {width: 208, height: 1, depthOrArrayLayers: 121},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView200 = texture97.createView({label: '\u01a0\u{1fc60}', mipLevelCount: 3, baseArrayLayer: 154, arrayLayerCount: 79});
+let computePassEncoder75 = commandEncoder165.beginComputePass({label: '\u{1fce9}\u7184\uf6a1\u0f98\u2b81\uf5a0\u{1fee2}\u{1faea}\u87d7'});
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 424, height: 1, depthOrArrayLayers: 949}
+*/
+{
+  source: video19,
+  origin: { x: 4, y: 5 },
+  flipY: true,
+}, {
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 112, y: 0, z: 169},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap41 = await createImageBitmap(offscreenCanvas31);
+let videoFrame45 = new VideoFrame(imageBitmap38, {timestamp: 0});
+let commandEncoder177 = device2.createCommandEncoder();
+let querySet100 = device2.createQuerySet({label: '\u{1fbeb}\u06b3\u8119', type: 'occlusion', count: 105});
+let commandBuffer42 = commandEncoder98.finish({label: '\u07e6\ub4f0\ub4a0\ud668\u{1f6fb}\u{1fcbf}\u{1f8f3}\u{1f9b3}\u5f8a'});
+let renderBundle93 = renderBundleEncoder78.finish({label: '\u00d8\u87ca\u95f4\u01ce\u{1f753}\ub909'});
+try {
+computePassEncoder71.setBindGroup(2, bindGroup27, new Uint32Array(5650), 3853, 0);
+} catch {}
+try {
+computePassEncoder57.setPipeline(pipeline102);
+} catch {}
+try {
+renderBundleEncoder73.setVertexBuffer(2, buffer30);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 1,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(arrayBuffer12), /* required buffer size: 957_164 */
+{offset: 802, bytesPerRow: 250, rowsPerImage: 85}, {width: 14, height: 1, depthOrArrayLayers: 46});
+} catch {}
+let pipeline141 = await device2.createComputePipelineAsync({
+  label: '\ue2ba\u0067\u0658\u{1fe10}',
+  layout: pipelineLayout17,
+  compute: {module: shaderModule37, entryPoint: 'compute0', constants: {}},
+});
+let pipeline142 = device2.createRenderPipeline({
+  label: '\u33fc\ud8a0\u3810\u{1f653}\u09a2',
+  layout: pipelineLayout16,
+  multisample: {mask: 0x2a4efc05},
+  fragment: {
+  module: shaderModule36,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'rgba32float', writeMask: 0}, {
+  format: 'rgba8unorm',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rg32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rg8unorm'}],
+},
+  vertex: {
+    module: shaderModule36,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint32x3', offset: 11648, shaderLocation: 5},
+          {format: 'uint32x2', offset: 2936, shaderLocation: 14},
+          {format: 'snorm8x4', offset: 4224, shaderLocation: 2},
+          {format: 'unorm8x2', offset: 1682, shaderLocation: 13},
+          {format: 'float32x2', offset: 15948, shaderLocation: 15},
+          {format: 'sint8x4', offset: 300, shaderLocation: 4},
+          {format: 'float32', offset: 5880, shaderLocation: 16},
+          {format: 'unorm16x4', offset: 14920, shaderLocation: 9},
+          {format: 'sint32x4', offset: 1820, shaderLocation: 11},
+          {format: 'float32x2', offset: 19944, shaderLocation: 7},
+          {format: 'unorm16x4', offset: 984, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 956,
+        attributes: [
+          {format: 'uint32x2', offset: 160, shaderLocation: 0},
+          {format: 'uint16x4', offset: 56, shaderLocation: 17},
+          {format: 'float32x4', offset: 324, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm16x4', offset: 6112, shaderLocation: 12},
+          {format: 'uint32', offset: 10460, shaderLocation: 3},
+        ],
+      },
+      {arrayStride: 13160, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 8548,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm16x4', offset: 400, shaderLocation: 10},
+          {format: 'float16x4', offset: 580, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw', unclippedDepth: false},
+});
+video1.height = 20;
+let commandEncoder178 = device2.createCommandEncoder({label: '\u016e\u7484\u0114\u{1ff72}\u3472\u0012\u7c14\u000d\u{1ff03}'});
+let texture104 = device2.createTexture({
+  label: '\ua861\udf3c',
+  size: [1256, 1, 1384],
+  mipLevelCount: 8,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView201 = texture63.createView({label: '\u{1fd63}\u98dc\u938b\u{1fde8}\u{1f79e}\u62d0\u58cf\u56a8\u8e34', mipLevelCount: 1});
+let computePassEncoder76 = commandEncoder177.beginComputePass({label: '\ub87c\u1c9d\uc827\u{1f797}\ub213\u{1f841}'});
+try {
+renderBundleEncoder65.setBindGroup(5, bindGroup27);
+} catch {}
+try {
+renderBundleEncoder73.setBindGroup(1, bindGroup27, new Uint32Array(1742), 795, 0);
+} catch {}
+try {
+renderBundleEncoder54.setVertexBuffer(6, buffer40, 0, 12852);
+} catch {}
+let video53 = await videoWithData();
+let imageData44 = new ImageData(128, 188);
+document.body.prepend(img1);
+let img41 = await imageWithData(196, 76, '#4a12d7f8', '#c2097198');
+let commandEncoder179 = device3.createCommandEncoder({label: '\u072f\ua8f8\u62dd\u6343\u{1fb0a}\u5a41\u0e88\ua3d9\u{1ffee}\u{1fac0}\uc5fa'});
+let commandBuffer43 = commandEncoder173.finish({label: '\u{1fbc7}\u3e50\u6088\u{1f93c}\u0c76\u{1fff9}\u08fa\u5812\ue585'});
+let sampler91 = device3.createSampler({
+  label: '\u{1f845}\uec3f',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 26.74,
+  lodMaxClamp: 46.38,
+});
+try {
+renderBundleEncoder70.setPipeline(pipeline111);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+canvas2.height = 1254;
+video51.width = 141;
+try {
+gpuCanvasContext37.unconfigure();
+} catch {}
+let video54 = await videoWithData();
+let canvas45 = document.createElement('canvas');
+let buffer43 = device4.createBuffer({label: '\uf7a1\u{1f635}', size: 84021, usage: GPUBufferUsage.MAP_READ});
+let textureView202 = texture89.createView({
+  label: '\u08a2\u{1f81b}\uf7e6\u0090\uba50\u0f82\u66ee\uf8e3\u0054\u0474\udab9',
+  dimension: '2d',
+  mipLevelCount: 2,
+  baseArrayLayer: 424,
+  arrayLayerCount: 1,
+});
+try {
+  await buffer32.mapAsync(GPUMapMode.READ, 62176, 74068);
+} catch {}
+canvas5.width = 85;
+let img42 = await imageWithData(39, 9, '#bd308817', '#49056824');
+try {
+adapter1.label = '\u28dc\u5318\u671b\u6cc0\uac49';
+} catch {}
+let bindGroupLayout57 = device2.createBindGroupLayout({
+  label: '\u963b\ub6e0\u0589\u{1fb68}\u29a7\u9782',
+  entries: [
+    {
+      binding: 2488,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 1406, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }},
+  ],
+});
+let pipelineLayout25 = device2.createPipelineLayout({
+  label: '\u2bad\uec8a\u6305\u{1fec7}\u839a',
+  bindGroupLayouts: [bindGroupLayout50, bindGroupLayout34, bindGroupLayout40, bindGroupLayout36, bindGroupLayout53],
+});
+let texture105 = device2.createTexture({
+  label: '\u0b8b\u0f3e\u0837\u{1fc89}\u{1fb32}',
+  size: [1260, 1, 1],
+  mipLevelCount: 8,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg8unorm'],
+});
+let textureView203 = texture95.createView({label: '\uc35f\uec44\uedd0\u{1f793}\u0e8b\u665f', baseMipLevel: 0, arrayLayerCount: 1});
+let renderBundleEncoder79 = device2.createRenderBundleEncoder({
+  label: '\u{1ff78}\u5cd6\u{1fe6a}',
+  colorFormats: ['rgba16float', 'rgba32float', 'rgba8unorm', 'rg32sint', 'rg8unorm'],
+  stencilReadOnly: false,
+});
+try {
+gpuCanvasContext4.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture104,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 15},
+  aspect: 'all',
+}, arrayBuffer9, /* required buffer size: 79_062_285 */
+{offset: 893, bytesPerRow: 248, rowsPerImage: 265}, {width: 29, height: 1, depthOrArrayLayers: 1204});
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let commandEncoder180 = device3.createCommandEncoder({label: '\u028f\uf941\u70c8\uddd6\u086b\u9bd8\u32c0\ube86\uaa65'});
+let commandBuffer44 = commandEncoder134.finish({label: '\u8d9e\uc34e\u5f25\u0945'});
+let texture106 = device3.createTexture({
+  label: '\u84b4\ud545',
+  size: [416, 1, 128],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16float'],
+});
+let renderBundle94 = renderBundleEncoder56.finish({label: '\ud392\u{1fa42}\u00c2\ud0fc'});
+try {
+renderBundleEncoder75.setVertexBuffer(1848, undefined, 0, 1234473918);
+} catch {}
+let renderBundle95 = renderBundleEncoder49.finish();
+try {
+renderBundleEncoder68.setPipeline(pipeline142);
+} catch {}
+try {
+renderBundleEncoder65.setVertexBuffer(2, buffer30, 0, 69261);
+} catch {}
+try {
+commandEncoder166.copyTextureToTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture75,
+  mipLevel: 2,
+  origin: {x: 5, y: 0, z: 114},
+  aspect: 'all',
+},
+{width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let img43 = await imageWithData(290, 2, '#adebf825', '#96d645a3');
+let textureView204 = texture79.createView({aspect: 'all', baseMipLevel: 3});
+let externalTexture90 = device4.importExternalTexture({source: video24, colorSpace: 'display-p3'});
+try {
+commandEncoder150.copyTextureToTexture({
+  texture: texture82,
+  mipLevel: 7,
+  origin: {x: 2, y: 0, z: 122},
+  aspect: 'all',
+},
+{
+  texture: texture74,
+  mipLevel: 3,
+  origin: {x: 3, y: 5, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 3, depthOrArrayLayers: 1});
+} catch {}
+let bindGroupLayout58 = device2.createBindGroupLayout({
+  label: '\u05f3\u{1ff6b}\u36db\uc00a\u1314\ue2b0\ucacf\u6bcc',
+  entries: [
+    {binding: 1232, visibility: 0, sampler: { type: 'filtering' }},
+    {
+      binding: 620,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let commandEncoder181 = device2.createCommandEncoder({label: '\u0eb9\u{1fcb9}\u8abb\u0fe5'});
+let textureView205 = texture62.createView({label: '\u0603\u0542\u8b92\u0575\ud43f\u0dcd', baseMipLevel: 3, mipLevelCount: 3});
+try {
+computePassEncoder72.setBindGroup(4, bindGroup28, new Uint32Array(1522), 1335, 0);
+} catch {}
+try {
+commandEncoder159.copyBufferToBuffer(buffer40, 2352, buffer41, 928, 112);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder95.copyTextureToBuffer({
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3068 widthInBlocks: 767 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2380 */
+  offset: 2380,
+  buffer: buffer40,
+}, {width: 767, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer40);
+} catch {}
+let pipeline143 = device2.createComputePipeline({layout: pipelineLayout16, compute: {module: shaderModule27, entryPoint: 'compute0', constants: {}}});
+let pipeline144 = await device2.createRenderPipelineAsync({
+  label: '\u{1f6bf}\uc25a',
+  layout: pipelineLayout25,
+  multisample: {count: 4, mask: 0xed0b6235},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'less-equal', failOp: 'invert', depthFailOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'equal', failOp: 'invert', depthFailOp: 'increment-wrap', passOp: 'invert'},
+    stencilWriteMask: 3830875877,
+    depthBiasSlopeScale: 965.1053861715641,
+  },
+  vertex: {
+    module: shaderModule36,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 7984,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint32x3', offset: 292, shaderLocation: 5},
+          {format: 'unorm16x2', offset: 148, shaderLocation: 9},
+          {format: 'unorm16x4', offset: 196, shaderLocation: 12},
+          {format: 'unorm16x4', offset: 312, shaderLocation: 15},
+          {format: 'sint32x3', offset: 1164, shaderLocation: 4},
+          {format: 'snorm16x4', offset: 528, shaderLocation: 2},
+          {format: 'uint32x3', offset: 280, shaderLocation: 3},
+          {format: 'uint32x4', offset: 132, shaderLocation: 0},
+          {format: 'unorm8x2', offset: 846, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 616,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 84, shaderLocation: 14},
+          {format: 'float16x2', offset: 12, shaderLocation: 10},
+          {format: 'unorm10-10-10-2', offset: 120, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 264, shaderLocation: 13},
+          {format: 'sint8x4', offset: 240, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 68, shaderLocation: 6},
+          {format: 'unorm10-10-10-2', offset: 44, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 7388,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x3', offset: 2512, shaderLocation: 7}],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x3', offset: 10644, shaderLocation: 17}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', cullMode: 'back'},
+});
+document.body.prepend(canvas7);
+let commandBuffer45 = commandEncoder164.finish();
+let textureView206 = texture81.createView({});
+let renderBundle96 = renderBundleEncoder67.finish({label: '\u0cf3\u{1fb8f}\ud057\u5723\u4d5e\u0bf2\ud65f'});
+let sampler92 = device4.createSampler({
+  label: '\ud525\u0cac\u0d9f\u009b\udaef\udc5e',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 48.92,
+  lodMaxClamp: 92.40,
+  compare: 'never',
+});
+try {
+renderBundleEncoder53.setPipeline(pipeline125);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer35, 15744, new BigUint64Array(13678));
+} catch {}
+let querySet101 = device3.createQuerySet({label: '\u{1fa00}\u867a\ubd90\u0310\u{1f6b0}\uadb1', type: 'occlusion', count: 1352});
+let textureView207 = texture100.createView({label: '\ue031\u5838', aspect: 'all', baseMipLevel: 4, mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder77 = commandEncoder180.beginComputePass({label: '\ua86a\ub9ce\uecdf\u{1fbac}'});
+try {
+device3.queue.submit([commandBuffer31]);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture100,
+  mipLevel: 1,
+  origin: {x: 49, y: 0, z: 1},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer6), /* required buffer size: 315_638 */
+{offset: 38, bytesPerRow: 60, rowsPerImage: 263}, {width: 15, height: 0, depthOrArrayLayers: 21});
+} catch {}
+let pipeline145 = device3.createComputePipeline({
+  label: '\u0453\u0d14',
+  layout: pipelineLayout19,
+  compute: {module: shaderModule43, entryPoint: 'compute0', constants: {}},
+});
+try {
+adapter5.label = '\u02d9\ufaa7';
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+try {
+computePassEncoder50.label = '\u0166\u6c67';
+} catch {}
+let bindGroup29 = device2.createBindGroup({label: '\ud024\ud8be\u{1f73d}\u{1fca9}', layout: bindGroupLayout36, entries: []});
+let renderBundle97 = renderBundleEncoder47.finish({label: '\u0346\u{1fa83}'});
+try {
+computePassEncoder52.setBindGroup(5, bindGroup29);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1260, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData33,
+  origin: { x: 7, y: 8 },
+  flipY: false,
+}, {
+  texture: texture105,
+  mipLevel: 0,
+  origin: {x: 229, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder182 = device2.createCommandEncoder();
+let textureView208 = texture104.createView({
+  label: '\u0349\u{1f991}\u6dc8\u2bc5\u43be\u0ece\u0f93\u758f',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 300,
+  arrayLayerCount: 148,
+});
+let renderBundle98 = renderBundleEncoder50.finish({label: '\u2d2a\u{1feaf}\u2469\ua37c\u{1f604}\u3b14\u063b\u19b8'});
+try {
+computePassEncoder50.setBindGroup(2, bindGroup28, new Uint32Array(2003), 1167, 0);
+} catch {}
+try {
+renderBundleEncoder55.setVertexBuffer(1, buffer30);
+} catch {}
+try {
+commandEncoder159.copyTextureToBuffer({
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1376 widthInBlocks: 172 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 7392 */
+  offset: 7392,
+  rowsPerImage: 105,
+  buffer: buffer40,
+}, {width: 172, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer40);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer12), /* required buffer size: 12_656_371 */
+{offset: 91, bytesPerRow: 1159, rowsPerImage: 168}, {width: 142, height: 0, depthOrArrayLayers: 66});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 9, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 83, y: 45 },
+  flipY: true,
+}, {
+  texture: texture105,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline146 = await device2.createComputePipelineAsync({
+  label: '\u03b2\ud59f\ub38d\u09e0\u9960\ua509\u01e0\u{1fe0c}\uf0d5\u0b27',
+  layout: pipelineLayout17,
+  compute: {module: shaderModule39, entryPoint: 'compute0', constants: {}},
+});
+let canvas46 = document.createElement('canvas');
+let offscreenCanvas46 = new OffscreenCanvas(979, 108);
+let bindGroupLayout59 = device3.createBindGroupLayout({
+  label: '\u0f05\u2c1b\u7c78\u{1fced}\u{1f6e2}\u9989\u5824\u8420\u0e3c',
+  entries: [
+    {
+      binding: 1148,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 68, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+    {binding: 623, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder183 = device3.createCommandEncoder({label: '\u{1f9e1}\u1927\u0e1f\u08da\u6015\u0c21\ub52e'});
+let texture107 = device3.createTexture({
+  size: [3392, 1, 1],
+  mipLevelCount: 4,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16uint', 'rgba16uint'],
+});
+let sampler93 = device3.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 84.09,
+  lodMaxClamp: 95.86,
+  maxAnisotropy: 6,
+});
+try {
+gpuCanvasContext10.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise60 = navigator.gpu.requestAdapter({});
+let offscreenCanvas47 = new OffscreenCanvas(48, 681);
+document.body.prepend(video50);
+try {
+canvas46.getContext('bitmaprenderer');
+} catch {}
+let sampler94 = device4.createSampler({
+  label: '\u0e75\uae68\u04f6\u{1f7ca}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 90.07,
+  lodMaxClamp: 93.82,
+  maxAnisotropy: 15,
+});
+try {
+renderBundleEncoder53.setPipeline(pipeline114);
+} catch {}
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+let commandBuffer46 = commandEncoder175.finish({label: '\u5838\uce6d\uf4b3'});
+let computePassEncoder78 = commandEncoder137.beginComputePass({});
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 52, height: 1, depthOrArrayLayers: 14}
+*/
+{
+  source: img0,
+  origin: { x: 66, y: 113 },
+  flipY: false,
+}, {
+  texture: texture100,
+  mipLevel: 4,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline147 = await device3.createComputePipelineAsync({
+  label: '\u6aaf\u0865\u1489',
+  layout: pipelineLayout24,
+  compute: {module: shaderModule35, entryPoint: 'compute0', constants: {}},
+});
+let imageData45 = new ImageData(128, 116);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+video25.height = 248;
+let commandEncoder184 = device3.createCommandEncoder({label: '\u{1ff3a}\u{1f7d6}\u0a92\u0f5f\u93f7\u2bbb\ub3d8\u69ac'});
+try {
+renderBundleEncoder75.setVertexBuffer(792, undefined);
+} catch {}
+let querySet102 = device4.createQuerySet({label: '\u1712\ud365', type: 'occlusion', count: 1831});
+let textureView209 = texture73.createView({baseMipLevel: 3, mipLevelCount: 1, baseArrayLayer: 38, arrayLayerCount: 222});
+let externalTexture91 = device4.importExternalTexture({source: video44, colorSpace: 'srgb'});
+try {
+renderBundleEncoder76.setPipeline(pipeline114);
+} catch {}
+let pipeline148 = await device4.createRenderPipelineAsync({
+  label: '\u08b2\uf784\ub4a8\u{1faef}\u14b7\ueeac\u0959\uda3f\u3efb',
+  layout: pipelineLayout18,
+  fragment: {
+  module: shaderModule29,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule29,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 37484,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x4', offset: 5492, shaderLocation: 5}],
+      },
+      {
+        arrayStride: 1200,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 24, shaderLocation: 16},
+          {format: 'float16x4', offset: 164, shaderLocation: 14},
+          {format: 'float32x4', offset: 100, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 5420,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 0, shaderLocation: 4},
+          {format: 'unorm16x2', offset: 36, shaderLocation: 6},
+          {format: 'uint8x4', offset: 844, shaderLocation: 0},
+          {format: 'float16x2', offset: 332, shaderLocation: 2},
+          {format: 'snorm16x4', offset: 392, shaderLocation: 10},
+          {format: 'snorm8x2', offset: 2534, shaderLocation: 17},
+          {format: 'uint32x3', offset: 4296, shaderLocation: 8},
+          {format: 'float32x2', offset: 36, shaderLocation: 9},
+          {format: 'sint8x2', offset: 472, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 2476, shaderLocation: 15},
+          {format: 'unorm8x2', offset: 612, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 376,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x4', offset: 164, shaderLocation: 12}],
+      },
+      {arrayStride: 5612, attributes: [{format: 'snorm8x4', offset: 148, shaderLocation: 7}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+canvas32.width = 865;
+let video55 = await videoWithData();
+let pipelineLayout26 = device4.createPipelineLayout({label: '\ub2a0\u1f54\u000b\uc91b\u4844', bindGroupLayouts: []});
+let texture108 = device4.createTexture({
+  label: '\ud430\u{1f8b4}\u5944\u0566\u{1f99a}\u8602\u33dc\uce89\u21d8\u0783\u0ddd',
+  size: [576],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32sint', 'r32sint'],
+});
+let textureView210 = texture73.createView({label: '\u{1fbd1}\ud5c6\u5152\ue4ad', mipLevelCount: 1, baseArrayLayer: 307, arrayLayerCount: 27});
+let computePassEncoder79 = commandEncoder150.beginComputePass({label: '\u6406\u9060'});
+let renderBundleEncoder80 = device4.createRenderBundleEncoder({
+  label: '\ucf58\u0334\u49a0\u{1ff42}\u{1ffb4}\ue67b\u0496\ufed9\ue854',
+  colorFormats: ['rgba8uint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder79.setPipeline(pipeline108);
+} catch {}
+try {
+renderBundleEncoder53.setIndexBuffer(buffer37, 'uint16', 81482, 78896);
+} catch {}
+try {
+renderBundleEncoder80.setVertexBuffer(7, buffer38);
+} catch {}
+try {
+commandEncoder127.copyTextureToTexture({
+  texture: texture73,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 38},
+  aspect: 'all',
+},
+{
+  texture: texture79,
+  mipLevel: 1,
+  origin: {x: 7, y: 13, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 19});
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 3,
+  origin: {x: 14, y: 28, z: 116},
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 1_706_587 */
+{offset: 941, bytesPerRow: 407, rowsPerImage: 190}, {width: 79, height: 11, depthOrArrayLayers: 23});
+} catch {}
+let commandEncoder185 = device2.createCommandEncoder({label: '\u0016\u2668\u09c7\u{1fe5d}\u{1f801}\udd9c'});
+let renderBundle99 = renderBundleEncoder52.finish({label: '\u6be9\u{1f76b}\u{1fadf}\u0d7b\ud3ed\u085e\u00ab\u024e'});
+try {
+computePassEncoder58.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder65.setBindGroup(3, bindGroup23, new Uint32Array(2121), 99, 0);
+} catch {}
+try {
+renderBundleEncoder54.setPipeline(pipeline142);
+} catch {}
+try {
+commandEncoder167.copyBufferToBuffer(buffer39, 9820, buffer41, 1564, 8);
+dissociateBuffer(device2, buffer39);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder122.copyBufferToTexture({
+  /* bytesInLastRow: 8056 widthInBlocks: 1007 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 14488 */
+  offset: 14488,
+  buffer: buffer30,
+}, {
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1007, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer30);
+} catch {}
+let pipeline149 = await device2.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule37, entryPoint: 'compute0', constants: {}}});
+try {
+offscreenCanvas47.getContext('webgl');
+} catch {}
+let texture109 = device2.createTexture({
+  label: '\u0d95\u{1f888}\u3362\u002a',
+  size: [630, 1, 755],
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg8unorm', 'rg8unorm', 'rg8unorm'],
+});
+let textureView211 = texture96.createView({label: '\u7f7c\u0a88\u{1fb07}\ufa12\u{1f664}\u506d\u6885\u12ec'});
+let sampler95 = device2.createSampler({
+  label: '\u{1f9e9}\u0f41\u4e58\u0ea5\u{1fa21}\u354d\u0811\u041e\u0850',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 81.95,
+  lodMaxClamp: 96.62,
+  maxAnisotropy: 9,
+});
+let externalTexture92 = device2.importExternalTexture({label: '\u4703\u9689\u{1fbf9}', source: videoFrame1, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder68.setBindGroup(0, bindGroup29, []);
+} catch {}
+try {
+renderBundleEncoder73.setVertexBuffer(8, buffer40, 0, 7369);
+} catch {}
+try {
+device2.queue.submit([commandBuffer33, commandBuffer38]);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 20},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer4), /* required buffer size: 26_106_927 */
+{offset: 62, bytesPerRow: 1023, rowsPerImage: 169}, {width: 116, height: 1, depthOrArrayLayers: 152});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 78, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas25,
+  origin: { x: 30, y: 68 },
+  flipY: true,
+}, {
+  texture: texture105,
+  mipLevel: 4,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let video56 = await videoWithData();
+let commandEncoder186 = device2.createCommandEncoder();
+let querySet103 = device2.createQuerySet({label: '\ub857\u7f23', type: 'occlusion', count: 2713});
+let commandBuffer47 = commandEncoder155.finish({label: '\u8945\u30b8\u{1fead}\u06cf\u4662\ue53b\u{1f82d}'});
+let textureView212 = texture105.createView({label: '\u01de\u6e01\u5434\u0447\u031b', baseMipLevel: 7});
+let renderBundle100 = renderBundleEncoder46.finish({label: '\u0a07\ucaaf\u{1f76f}\u{1fa0b}\u2c9c'});
+try {
+computePassEncoder58.end();
+} catch {}
+try {
+computePassEncoder50.setPipeline(pipeline100);
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+renderBundleEncoder55.setPipeline(pipeline105);
+} catch {}
+try {
+commandEncoder122.copyTextureToBuffer({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 208 widthInBlocks: 26 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 13144 */
+  offset: 13144,
+  buffer: buffer40,
+}, {width: 26, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer40);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm'],
+});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer41, 564, new Int16Array(14958), 5562, 36);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 630, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas31,
+  origin: { x: 32, y: 16 },
+  flipY: false,
+}, {
+  texture: texture105,
+  mipLevel: 1,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline150 = await promise54;
+let adapter8 = await promise60;
+try {
+offscreenCanvas46.getContext('2d');
+} catch {}
+let renderBundleEncoder81 = device4.createRenderBundleEncoder({
+  colorFormats: [undefined, 'r32sint', 'rg16float', 'rgba16sint', 'rgba8unorm', 'rgb10a2uint', 'rg32sint'],
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder67.end();
+} catch {}
+try {
+computePassEncoder61.setPipeline(pipeline133);
+} catch {}
+try {
+renderBundleEncoder76.setPipeline(pipeline113);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer35, 64836, new BigUint64Array(48273), 28485);
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext28.unconfigure();
+} catch {}
+gc();
+let imageBitmap42 = await createImageBitmap(videoFrame28);
+let shaderModule44 = device4.createShaderModule({
+  label: '\u84c8\u{1f9f8}\u0d46\u29d7\u2332\u0958\u47b3\u066a\ua46c',
+  code: `@group(0) @binding(665)
+var<storage, read_write> parameter24: array<u32>;
+@group(1) @binding(665)
+var<storage, read_write> n23: array<u32>;
+@group(2) @binding(665)
+var<storage, read_write> parameter25: array<u32>;
+@group(1) @binding(1159)
+var<storage, read_write> local40: array<u32>;
+@group(0) @binding(371)
+var<storage, read_write> global30: array<u32>;
+@group(2) @binding(1159)
+var<storage, read_write> function30: array<u32>;
+@group(1) @binding(371)
+var<storage, read_write> global31: array<u32>;
+@group(0) @binding(1159)
+var<storage, read_write> function31: array<u32>;
+
+@compute @workgroup_size(7, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(6) f0: vec4<i32>,
+  @location(4) f1: vec4<f32>,
+  @location(2) f2: vec2<f32>,
+  @location(3) f3: vec4<i32>,
+  @location(1) f4: vec2<i32>,
+  @location(5) f5: vec4<u32>,
+  @builtin(sample_mask) f6: u32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_index) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S40 {
+  @location(7) f0: u32,
+  @location(9) f1: vec3<u32>,
+  @location(16) f2: vec4<f16>,
+  @location(17) f3: vec3<f32>,
+  @location(5) f4: vec4<i32>,
+  @location(11) f5: vec4<u32>,
+  @location(15) f6: vec4<f32>,
+  @location(13) f7: f32,
+  @location(1) f8: vec3<u32>,
+  @location(4) f9: vec3<f16>,
+  @location(2) f10: f32,
+  @location(10) f11: vec3<u32>,
+  @location(6) f12: vec3<i32>,
+  @location(18) f13: vec2<f16>,
+  @location(3) f14: vec3<u32>,
+  @location(14) f15: vec2<u32>,
+  @location(8) f16: f16
+}
+
+@vertex
+fn vertex0(@location(0) a0: vec4<f32>, a1: S40, @location(12) a2: vec2<i32>, @builtin(vertex_index) a3: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+});
+let commandEncoder187 = device4.createCommandEncoder({label: '\ua23d\u{1fd83}\u07b1\uab44'});
+let querySet104 = device4.createQuerySet({label: '\u2586\ub220\u0ce4\u0625\u{1fd92}', type: 'occlusion', count: 1732});
+let texture110 = device4.createTexture({
+  label: '\u{1fb16}\u0ebf\ucfb2\uc636\u{1fb93}\u21b4\u80f0\u{1fb2d}\u366a\u2877\u{1fdf5}',
+  size: {width: 576, height: 240, depthOrArrayLayers: 1327},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rg32sint', 'rg32sint'],
+});
+let textureView213 = texture88.createView({
+  label: '\u043a\u{1fd87}\ua3bd',
+  baseMipLevel: 5,
+  mipLevelCount: 2,
+  baseArrayLayer: 121,
+  arrayLayerCount: 237,
+});
+let renderBundle101 = renderBundleEncoder81.finish({label: '\u76d2\u2ce8\u69fd\u{1fc2c}\uf7d5\u05c7\u{1ff4b}\u{1f8b8}\u{1fb96}\ue7e4'});
+try {
+computePassEncoder64.setPipeline(pipeline127);
+} catch {}
+let arrayBuffer15 = buffer32.getMappedRange(118896, 6396);
+try {
+commandEncoder174.clearBuffer(buffer32);
+dissociateBuffer(device4, buffer32);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer35, 25056, new BigUint64Array(14204));
+} catch {}
+try {
+canvas45.getContext('webgl2');
+} catch {}
+let offscreenCanvas48 = new OffscreenCanvas(957, 576);
+let videoFrame46 = new VideoFrame(canvas46, {timestamp: 0});
+let commandBuffer48 = commandEncoder158.finish();
+let texture111 = device4.createTexture({
+  label: '\u0270\ue6df',
+  size: {width: 288, height: 120, depthOrArrayLayers: 479},
+  mipLevelCount: 8,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rg32sint', 'rg32sint'],
+});
+let externalTexture93 = device4.importExternalTexture({
+  label: '\u052a\u7f4b\u090b\u0e36\ud537\u6afe\ue17a\u0040\ucbb9',
+  source: videoFrame2,
+  colorSpace: 'srgb',
+});
+try {
+commandEncoder125.copyTextureToBuffer({
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 10, y: 74, z: 22},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4396 widthInBlocks: 1099 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8968 */
+  offset: 8968,
+  bytesPerRow: 4608,
+  rowsPerImage: 127,
+  buffer: buffer35,
+}, {width: 1099, height: 34, depthOrArrayLayers: 0});
+dissociateBuffer(device4, buffer35);
+} catch {}
+let imageData46 = new ImageData(44, 140);
+let buffer44 = device4.createBuffer({label: '\u{1f9a1}\u0414\uf7d0\u{1fdaa}\u0563\ue7bd', size: 115953, usage: GPUBufferUsage.COPY_DST});
+let querySet105 = device4.createQuerySet({label: '\uc264\u5d4d\u{1fd08}\u8dba\u0c4e\ued28\u4abc\u924d', type: 'occlusion', count: 977});
+let computePassEncoder80 = commandEncoder171.beginComputePass({});
+let renderBundle102 = renderBundleEncoder80.finish({label: '\u2da4\u9a2a\u017d'});
+try {
+commandEncoder174.copyTextureToTexture({
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 10, y: 9, z: 250},
+  aspect: 'all',
+},
+{
+  texture: texture110,
+  mipLevel: 1,
+  origin: {x: 31, y: 11, z: 169},
+  aspect: 'all',
+},
+{width: 62, height: 50, depthOrArrayLayers: 8});
+} catch {}
+try {
+device4.queue.writeBuffer(buffer35, 53096, new Int16Array(63060));
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 52, y: 1, z: 25},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer9), /* required buffer size: 13_165_499 */
+{offset: 717, bytesPerRow: 1798, rowsPerImage: 215}, {width: 203, height: 12, depthOrArrayLayers: 35});
+} catch {}
+let pipeline151 = device4.createComputePipeline({layout: 'auto', compute: {module: shaderModule33, entryPoint: 'compute0', constants: {}}});
+let commandEncoder188 = device3.createCommandEncoder({label: '\u3975\u3936\u8e08\u{1f7f1}\u60ec\u2e28\u0aff\u{1fb31}\u{1fe36}\u281d'});
+let renderBundle103 = renderBundleEncoder56.finish({label: '\u88dd\u{1ff0d}\u{1f687}\u2a24\u675d'});
+try {
+renderBundleEncoder70.setPipeline(pipeline111);
+} catch {}
+gc();
+let imageBitmap43 = await createImageBitmap(img33);
+try {
+offscreenCanvas48.getContext('webgpu');
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+try {
+textureView168.label = '\uec8c\u0850\u6dee\uf387\u02ac\u0cbb\u0810';
+} catch {}
+let commandEncoder189 = device4.createCommandEncoder({});
+let texture112 = device4.createTexture({
+  label: '\u0cd6\u619e\u{1fd0a}\ufb7b\u{1f809}\u0de3\u02a4\u{1f77c}\u{1fedd}',
+  size: {width: 1152, height: 480, depthOrArrayLayers: 1431},
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16float', 'rg16float', 'rg16float'],
+});
+let textureView214 = texture108.createView({label: '\u0535\u2a35\u0b48\u09fc\ud586\u53c6\u8c26\u{1ffc1}'});
+try {
+renderBundleEncoder76.setPipeline(pipeline148);
+} catch {}
+try {
+renderBundleEncoder76.setVertexBuffer(8016, undefined, 2016549027, 1782484057);
+} catch {}
+try {
+querySet66.destroy();
+} catch {}
+try {
+  await buffer43.mapAsync(GPUMapMode.READ, 0, 20024);
+} catch {}
+try {
+commandEncoder174.insertDebugMarker('\u{1fb89}');
+} catch {}
+try {
+device4.queue.submit([commandBuffer34, commandBuffer48, commandBuffer45, commandBuffer30]);
+} catch {}
+let video57 = await videoWithData();
+let textureView215 = texture110.createView({});
+let promise61 = device4.popErrorScope();
+try {
+device4.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 100, y: 12, z: 28},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer10), /* required buffer size: 521_647 */
+{offset: 296, bytesPerRow: 1351, rowsPerImage: 284}, {width: 304, height: 102, depthOrArrayLayers: 2});
+} catch {}
+document.body.prepend(video44);
+let videoFrame47 = new VideoFrame(video40, {timestamp: 0});
+let renderBundleEncoder82 = device2.createRenderBundleEncoder({
+  label: '\uc5d4\u08ef\uf540\u01e6\u0022\u{1fe65}\u0f95\uc4a3',
+  colorFormats: ['rgba8unorm-srgb'],
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+let renderBundle104 = renderBundleEncoder82.finish();
+let sampler96 = device2.createSampler({
+  label: '\u01a2\u0d1c\u813a\u0d97\ua3c4\ua828',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 89.81,
+  lodMaxClamp: 90.29,
+});
+try {
+renderBundleEncoder66.setPipeline(pipeline142);
+} catch {}
+try {
+commandEncoder178.copyBufferToBuffer(buffer28, 5924, buffer40, 5828, 1088);
+dissociateBuffer(device2, buffer28);
+dissociateBuffer(device2, buffer40);
+} catch {}
+try {
+gpuCanvasContext42.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+let texture113 = device4.createTexture({
+  label: '\u{1f986}\u1c9f\u0ae0\u0e89\u{1fd31}\u0cde\uf090\u07f7\u{1fccf}\u{1fd16}\u07c3',
+  size: {width: 1152, height: 480, depthOrArrayLayers: 24},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView216 = texture110.createView({label: '\u7b70\u013a\u{1fb01}\u2ee5\u{1f6fb}\u{1ffde}\u{1fdc4}\u91b0\u8154', baseMipLevel: 1});
+try {
+renderBundleEncoder76.setPipeline(pipeline132);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(7, buffer38, 155740, 276779);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer35, 33348, new BigUint64Array(35982));
+} catch {}
+video30.height = 202;
+let canvas47 = document.createElement('canvas');
+try {
+canvas47.getContext('webgl2');
+} catch {}
+try {
+externalTexture65.label = '\u6442\u6408';
+} catch {}
+let bindGroup30 = device2.createBindGroup({
+  label: '\u{1f838}\u08c0\u083c',
+  layout: bindGroupLayout43,
+  entries: [
+    {binding: 5539, resource: textureView190},
+    {binding: 2530, resource: {buffer: buffer34, offset: 71040, size: 29440}},
+  ],
+});
+let textureView217 = texture99.createView({
+  label: '\u5ffe\u0355\u7cc0\ufe4c\u05b8\uc2e4\ud0cf\u5944\ue50a',
+  aspect: 'all',
+  baseMipLevel: 4,
+  mipLevelCount: 3,
+});
+let computePassEncoder81 = commandEncoder186.beginComputePass({label: '\u160d\ub845\u{1f6e2}\u0531'});
+let externalTexture94 = device2.importExternalTexture({
+  label: '\udc5c\u0121\u0c8b\u{1ffcd}\uc3d9\u268d\u{1f6a8}\u{1fc32}\uc2f3\u3eb9',
+  source: video20,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder65.setPipeline(pipeline105);
+} catch {}
+try {
+commandEncoder159.copyBufferToBuffer(buffer30, 19456, buffer40, 15976, 92);
+dissociateBuffer(device2, buffer30);
+dissociateBuffer(device2, buffer40);
+} catch {}
+try {
+gpuCanvasContext28.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm', 'bgra8unorm'],
+});
+} catch {}
+let promise62 = device2.createComputePipelineAsync({
+  label: '\u{1f69c}\uec65\u{1f6ed}',
+  layout: 'auto',
+  compute: {module: shaderModule30, entryPoint: 'compute0', constants: {}},
+});
+let renderBundle105 = renderBundleEncoder48.finish({label: '\u{1fed8}\uf3d0\u9e22\ub3c9\u016d'});
+try {
+computePassEncoder52.setPipeline(pipeline106);
+} catch {}
+let pipeline152 = device2.createRenderPipeline({
+  label: '\u5cc6\ucab0\u3728\u61ae\u05e7\u60ee\ub43b\u89b4\u30cb\u304b',
+  layout: pipelineLayout20,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule27,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba32float', writeMask: 0}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'one-minus-src'},
+  },
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rg32sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater', failOp: 'decrement-wrap', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'greater', failOp: 'increment-wrap', depthFailOp: 'increment-clamp', passOp: 'invert'},
+    stencilReadMask: 1495125886,
+    stencilWriteMask: 376663513,
+    depthBias: -837801856,
+    depthBiasSlopeScale: 335.1684701343857,
+    depthBiasClamp: 228.85792685163915,
+  },
+  vertex: {
+    module: shaderModule27,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 8740,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x4', offset: 532, shaderLocation: 8}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', cullMode: 'front'},
+});
+let textureView218 = texture113.createView({
+  label: '\u99e4\u0591\u{1fbc8}\u{1fd62}\u{1fb72}\u09cf\u0769\u9847\u4aa9\ub125',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+});
+try {
+commandEncoder145.clearBuffer(buffer44, 50948, 24312);
+dissociateBuffer(device4, buffer44);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture111,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 35},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer9), /* required buffer size: 17_304_618 */
+{offset: 55, bytesPerRow: 277, rowsPerImage: 174}, {width: 12, height: 6, depthOrArrayLayers: 360});
+} catch {}
+try {
+  await device4.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder190 = device4.createCommandEncoder({label: '\ue64d\ufcb6\u8ae6\u8842'});
+let querySet106 = device4.createQuerySet({label: '\u{1f663}\u125f\ufaed\ue285\u573a\u10f5', type: 'occlusion', count: 1800});
+let commandBuffer49 = commandEncoder111.finish({label: '\u5d59\u{1f747}\u3aad\ue8f4'});
+let textureView219 = texture112.createView({
+  label: '\u4264\ua244\uba72\u03ac\u{1fa1f}\u06bc\u0c1f\ubdbd\u2edb\ub215\u9b47',
+  baseMipLevel: 3,
+  mipLevelCount: 5,
+});
+let computePassEncoder82 = commandEncoder133.beginComputePass({label: '\u6eeb\u0abb\u{1fa25}\u06a8\u02e5\u{1f663}'});
+let renderBundle106 = renderBundleEncoder53.finish({label: '\uc032\ue1e5\u08ac\u7849\u0334\ueb14\u0c05\u0c16\u{1f765}'});
+let externalTexture95 = device4.importExternalTexture({
+  label: '\u66be\u05db\ua134\uf6ed\u{1f804}\u0438\u0fac\u0dbf\u{1f985}\u{1f8a2}\uad87',
+  source: videoFrame43,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder65.setPipeline(pipeline126);
+} catch {}
+try {
+renderBundleEncoder76.setVertexBuffer(8, buffer38, 0, 162127);
+} catch {}
+try {
+buffer43.unmap();
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 97},
+  aspect: 'all',
+}, new Float32Array(new ArrayBuffer(64)), /* required buffer size: 1_964_377 */
+{offset: 537, bytesPerRow: 192, rowsPerImage: 48}, {width: 16, height: 5, depthOrArrayLayers: 214});
+} catch {}
+let pipeline153 = await device4.createRenderPipelineAsync({
+  label: '\uf155\u{1f63e}\u050c\u7bcf\u{1fcc1}\u{1fe4c}\u{1fae5}',
+  layout: pipelineLayout22,
+  multisample: {mask: 0xdbf4cb4e},
+  fragment: {module: shaderModule42, entryPoint: 'fragment0', targets: [{format: 'rgba8uint', writeMask: 0}]},
+  vertex: {module: shaderModule42, entryPoint: 'vertex0', constants: {}, buffers: []},
+  primitive: {frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+let commandBuffer50 = commandEncoder189.finish();
+let texture114 = device4.createTexture({
+  label: '\u4c13\u{1f6d7}\ua762',
+  size: {width: 288, height: 120, depthOrArrayLayers: 186},
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+});
+let renderBundleEncoder83 = device4.createRenderBundleEncoder({colorFormats: ['rgba8uint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+gpuCanvasContext19.configure({
+  device: device4,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16float'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let pipeline154 = await device4.createComputePipelineAsync({
+  label: '\u{1f6c7}\u7a94\u890b\u0b66\u04d4',
+  layout: pipelineLayout22,
+  compute: {module: shaderModule44, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let commandBuffer51 = commandEncoder130.finish();
+let textureView220 = texture63.createView({label: '\u0b72\u6a48\u4e8a\u0ba1\ub505\uaa69', baseMipLevel: 2});
+let renderBundleEncoder84 = device2.createRenderBundleEncoder({
+  label: '\u0002\u04b7\u01e4\u1a6a',
+  colorFormats: ['rgba16float', 'rgba32float', 'rgba8unorm', 'rg32sint', 'rg8unorm'],
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder81.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+computePassEncoder81.setBindGroup(1, bindGroup25, new Uint32Array(7787), 3865, 0);
+} catch {}
+try {
+renderBundleEncoder68.setBindGroup(2, bindGroup23, new Uint32Array(8523), 4892, 0);
+} catch {}
+try {
+renderBundleEncoder73.setPipeline(pipeline142);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 19, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img29,
+  origin: { x: 20, y: 21 },
+  flipY: true,
+}, {
+  texture: texture105,
+  mipLevel: 6,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let video58 = await videoWithData();
+let commandEncoder191 = device3.createCommandEncoder({label: '\u{1fa94}\u02e2\u025e\u02b6\u0190\u0f12\u0721\u0b33\ue01d\ubb19\ub5c9'});
+let querySet107 = device3.createQuerySet({label: '\u426b\u9a70\u4a6f\uf2ce\ud68a\u0bf4\u0bf3\ua0df\u3bec\u06e0', type: 'occlusion', count: 3763});
+let texture115 = device3.createTexture({
+  size: [208, 1, 984],
+  dimension: '2d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8sint'],
+});
+let textureView221 = texture102.createView({label: '\u75b6\ub9a3\u9b85\u0fac\u0b48\u277c\ufe81', baseMipLevel: 4, mipLevelCount: 1});
+try {
+computePassEncoder75.insertDebugMarker('\u{1fad1}');
+} catch {}
+let shaderModule45 = device2.createShaderModule({
+  label: '\u0b42\u43cd\uff0b\u{1ff0e}\u{1f706}\u6630\u{1fea9}\u{1f846}\uc35a\u{1f8bb}',
+  code: `@group(0) @binding(4279)
+var<storage, read_write> local41: array<u32>;
+@group(4) @binding(68)
+var<storage, read_write> global32: array<u32>;
+@group(1) @binding(3012)
+var<storage, read_write> n24: array<u32>;
+@group(4) @binding(3292)
+var<storage, read_write> local42: array<u32>;
+@group(2) @binding(6156)
+var<storage, read_write> n25: array<u32>;
+@group(1) @binding(44)
+var<storage, read_write> local43: array<u32>;
+@group(0) @binding(600)
+var<storage, read_write> n26: array<u32>;
+@group(2) @binding(1519)
+var<storage, read_write> field36: array<u32>;
+
+@compute @workgroup_size(1, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S42 {
+  @location(13) f0: vec2<f16>,
+  @location(9) f1: vec4<f32>,
+  @location(1) f2: vec3<i32>,
+  @location(10) f3: i32,
+  @location(6) f4: vec4<i32>,
+  @location(0) f5: i32,
+  @location(12) f6: u32,
+  @builtin(sample_mask) f7: u32,
+  @builtin(sample_index) f8: u32,
+  @builtin(front_facing) f9: bool
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(2) a0: vec2<i32>, @location(15) a1: vec2<u32>, a2: S42, @builtin(position) a3: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S41 {
+  @builtin(instance_index) f0: u32
+}
+struct VertexOutput0 {
+  @location(12) f479: u32,
+  @location(10) f480: i32,
+  @builtin(position) f481: vec4<f32>,
+  @location(13) f482: vec2<f16>,
+  @location(1) f483: vec3<i32>,
+  @location(9) f484: vec4<f32>,
+  @location(0) f485: i32,
+  @location(2) f486: vec2<i32>,
+  @location(6) f487: vec4<i32>,
+  @location(15) f488: vec2<u32>
+}
+
+@vertex
+fn vertex0(a0: S41) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let commandBuffer52 = commandEncoder123.finish({label: '\u0a48\u3c2a\ufc8a\u5c2c\u653a\u0d07\u{1fdb0}\u{1ff94}\u0471'});
+let sampler97 = device2.createSampler({
+  label: '\ub13f\u0bcf\u0c91\u14c9\u46be\u12ce\u2282\uc76d',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 45.56,
+  lodMaxClamp: 69.37,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder72.setBindGroup(4, bindGroup30, new Uint32Array(3572), 952, 1);
+} catch {}
+try {
+renderBundleEncoder68.setBindGroup(5, bindGroup25);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture63,
+  mipLevel: 2,
+  origin: {x: 16, y: 0, z: 21},
+  aspect: 'all',
+}, arrayBuffer14, /* required buffer size: 92_116 */
+{offset: 916, bytesPerRow: 320, rowsPerImage: 15}, {width: 32, height: 0, depthOrArrayLayers: 20});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 630, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video13,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture105,
+  mipLevel: 1,
+  origin: {x: 84, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise61;
+} catch {}
+try {
+window.someLabel = externalTexture75.label;
+} catch {}
+let textureView222 = texture88.createView({
+  label: '\u07f8\u4613\ueda2\u0e45\u1a6b\u0fc8\u{1fcf7}\u{1fd65}\u97fb\ud18e',
+  baseMipLevel: 6,
+  mipLevelCount: 1,
+  baseArrayLayer: 316,
+  arrayLayerCount: 60,
+});
+try {
+computePassEncoder54.end();
+} catch {}
+try {
+device4.addEventListener('uncapturederror', e => { log('device4.uncapturederror'); log(e); e.label = device4.label; });
+} catch {}
+try {
+commandEncoder190.clearBuffer(buffer35);
+dissociateBuffer(device4, buffer35);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture112,
+  mipLevel: 2,
+  origin: {x: 0, y: 28, z: 223},
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(24)), /* required buffer size: 262_540 */
+{offset: 964, bytesPerRow: 709, rowsPerImage: 333}, {width: 166, height: 36, depthOrArrayLayers: 2});
+} catch {}
+let buffer45 = device4.createBuffer({label: '\u{1f6fb}\ub4d8\u0f97', size: 350332, usage: GPUBufferUsage.INDIRECT, mappedAtCreation: true});
+let commandEncoder192 = device4.createCommandEncoder({label: '\u97b6\u6dcb\uf510\udd0a\u45f3\ubbea\u04dc\u6d00'});
+let commandBuffer53 = commandEncoder187.finish();
+let textureView223 = texture89.createView({mipLevelCount: 3, baseArrayLayer: 297, arrayLayerCount: 92});
+let renderBundleEncoder85 = device4.createRenderBundleEncoder({
+  label: '\u{1ffac}\u{1fc77}\u4354\u025b',
+  colorFormats: ['r32sint', 'rg16float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture96 = device4.importExternalTexture({label: '\u5557\u5be6', source: video41, colorSpace: 'srgb'});
+try {
+computePassEncoder56.setPipeline(pipeline151);
+} catch {}
+try {
+renderBundleEncoder83.setVertexBuffer(0, buffer38, 0);
+} catch {}
+try {
+commandEncoder116.copyTextureToTexture({
+  texture: texture112,
+  mipLevel: 4,
+  origin: {x: 2, y: 5, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture112,
+  mipLevel: 1,
+  origin: {x: 4, y: 71, z: 41},
+  aspect: 'all',
+},
+{width: 50, height: 16, depthOrArrayLayers: 52});
+} catch {}
+try {
+commandEncoder174.clearBuffer(buffer31);
+dissociateBuffer(device4, buffer31);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer44, 45264, new DataView(new ArrayBuffer(44082)), 14502, 4264);
+} catch {}
+let pipelineLayout27 = device4.createPipelineLayout({
+  label: '\u8fde\uf85c\u03f5\u{1ff4a}\u034b\u0fb0\u00d7\ua4ee\u03db\ucd72',
+  bindGroupLayouts: [bindGroupLayout37, bindGroupLayout39, bindGroupLayout39, bindGroupLayout46],
+});
+let textureView224 = texture89.createView({
+  label: '\u113b\u06fe\u2685',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 363,
+  arrayLayerCount: 1,
+});
+let renderPassEncoder13 = commandEncoder138.beginRenderPass({
+  label: '\u{1fd14}\u73aa\u{1ffa7}\u0b42\u1369\u6c80\ua88a\ubb82\u0989\u{1fc1d}',
+  colorAttachments: [{
+  view: textureView224,
+  clearValue: { r: 804.5, g: -191.3, b: 223.7, a: -741.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet96,
+  maxDrawCount: 747219332,
+});
+try {
+computePassEncoder65.setPipeline(pipeline140);
+} catch {}
+try {
+commandEncoder125.clearBuffer(buffer31);
+dissociateBuffer(device4, buffer31);
+} catch {}
+try {
+adapter3.label = '\u{1f807}\u0705\u0786';
+} catch {}
+let commandEncoder193 = device4.createCommandEncoder({label: '\u{1feaf}\u{1fffe}\u0e19\u1f88\u{1fd95}\udc75\uf31c\udb16\u06ee'});
+let textureView225 = texture89.createView({
+  label: '\u{1f712}\u66c4\uf932\ub57e\udc22\u{1fd40}\u8022',
+  dimension: '2d',
+  baseMipLevel: 2,
+  baseArrayLayer: 89,
+});
+let computePassEncoder83 = commandEncoder125.beginComputePass({label: '\ua0db\u8935\u{1f6a0}\u746a\u8eca\u0a5f\u{1faaa}'});
+let renderBundle107 = renderBundleEncoder81.finish({label: '\u2223\u08e8\u0453'});
+try {
+renderPassEncoder13.setScissorRect(292, 160, 190, 22);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(2, buffer38, 0);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture88,
+  mipLevel: 1,
+  origin: {x: 6, y: 2, z: 118},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 59_132 */
+{offset: 848, bytesPerRow: 732}, {width: 114, height: 80, depthOrArrayLayers: 1});
+} catch {}
+document.body.prepend(video12);
+offscreenCanvas29.height = 1620;
+let buffer46 = device3.createBuffer({
+  label: '\u3a78\u0327\u8f34\u{1fd37}\u8f9b\ua3db\u{1fe8a}\u02ce',
+  size: 123007,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let textureView226 = texture106.createView({label: '\u3c30\u096e\u4b29\u0032\ua329', format: 'rg16float', baseMipLevel: 1});
+let computePassEncoder84 = commandEncoder143.beginComputePass({label: '\u0e0d\u{1fe21}\u54d8\u0a55\u91e0'});
+try {
+renderBundleEncoder75.setPipeline(pipeline123);
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+let img44 = await imageWithData(221, 67, '#fbc02fbe', '#ee7fd741');
+let videoFrame48 = new VideoFrame(canvas3, {timestamp: 0});
+let querySet108 = device3.createQuerySet({label: '\uc15c\ufafb\u06d3\u4fcf\u07d1\u5ad9\ud78c\u4972\u6886\u2bc2', type: 'occlusion', count: 2880});
+let computePassEncoder85 = commandEncoder184.beginComputePass({label: '\u1c29\ucbd9\u0bd4\u0248\u0bf1'});
+let textureView227 = texture78.createView({});
+let computePassEncoder86 = commandEncoder97.beginComputePass();
+let sampler98 = device2.createSampler({
+  label: '\u{1fba5}\u0914\u{1f712}\u07bb\u07d6',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 18.31,
+});
+let externalTexture97 = device2.importExternalTexture({source: video21, colorSpace: 'srgb'});
+try {
+renderBundleEncoder68.setVertexBuffer(3, buffer30, 68);
+} catch {}
+try {
+commandEncoder153.clearBuffer(buffer40, 1452, 3500);
+dissociateBuffer(device2, buffer40);
+} catch {}
+try {
+device2.queue.submit([commandBuffer52, commandBuffer47]);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer41, 4, new Float32Array(64328), 45943, 52);
+} catch {}
+video30.width = 190;
+let imageBitmap44 = await createImageBitmap(canvas44);
+let commandEncoder194 = device4.createCommandEncoder({label: '\u63ff\ua2c8\ufa13\u88dd\u7e5e'});
+try {
+renderPassEncoder13.setBlendConstant({ r: -479.2, g: -910.5, b: 371.8, a: 19.14, });
+} catch {}
+try {
+renderBundleEncoder85.setIndexBuffer(buffer37, 'uint32');
+} catch {}
+try {
+renderBundleEncoder83.setPipeline(pipeline153);
+} catch {}
+try {
+renderBundleEncoder76.setVertexBuffer(0, buffer38, 507540, 13237);
+} catch {}
+try {
+commandEncoder116.copyTextureToTexture({
+  texture: texture88,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 27},
+  aspect: 'all',
+},
+{
+  texture: texture73,
+  mipLevel: 4,
+  origin: {x: 3, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline155 = await device4.createComputePipelineAsync({
+  label: '\u02ff\u{1f916}\u0769\u{1fba1}\u3cc6\ufac0\u78b2\u4cab\u0fb3\u{1f8c5}\u53c5',
+  layout: pipelineLayout27,
+  compute: {module: shaderModule40, entryPoint: 'compute0', constants: {}},
+});
+let img45 = await imageWithData(103, 28, '#7c2cd8e9', '#e669e4e0');
+let video59 = await videoWithData();
+let offscreenCanvas49 = new OffscreenCanvas(949, 303);
+let commandEncoder195 = device2.createCommandEncoder({label: '\uf860\u39c8\u0250\ufdcb\uc8cb'});
+let commandBuffer54 = commandEncoder95.finish();
+let texture116 = device2.createTexture({
+  label: '\u0f82\u8ae7\u{1fe20}\u09a4\u80c1\u{1f6a6}\u{1fd05}',
+  size: {width: 1256, height: 1, depthOrArrayLayers: 1768},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundleEncoder86 = device2.createRenderBundleEncoder({
+  label: '\u{1fd3b}\u9ca4\u0aa9\u0fae\u857d\u9f6c\u07d9',
+  colorFormats: ['rgba16float', 'rgba32float', 'rgba8unorm', 'rg32sint', 'rg8unorm'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+let renderBundle108 = renderBundleEncoder47.finish();
+let externalTexture98 = device2.importExternalTexture({label: '\ue3c4\u{1fcef}\u86eb\u0b7b\u{1fa75}\u9b20\u{1fd33}\u994c\u{1f762}', source: videoFrame27});
+try {
+renderBundleEncoder79.setBindGroup(4, bindGroup25, new Uint32Array(2383), 909, 0);
+} catch {}
+let pipeline156 = device2.createComputePipeline({
+  label: '\u8c52\u{1ff76}\u{1f91c}\u0c54\u0974\u{1f87e}\u0a9e\u{1ff76}\u{1faec}\u{1fd6d}\u0968',
+  layout: pipelineLayout17,
+  compute: {module: shaderModule37, entryPoint: 'compute0'},
+});
+let pipeline157 = device2.createRenderPipeline({
+  layout: pipelineLayout20,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule39,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}, {format: 'rgba32float', writeMask: 0}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'dst', dstFactor: 'one-minus-src-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'one-minus-dst'},
+  },
+}, {format: 'rg32sint', writeMask: GPUColorWrite.RED}, {format: 'rg8unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule39,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 9164, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 1756,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 136, shaderLocation: 4},
+          {format: 'uint32', offset: 156, shaderLocation: 11},
+          {format: 'float16x4', offset: 16, shaderLocation: 12},
+          {format: 'sint32x4', offset: 180, shaderLocation: 2},
+          {format: 'snorm8x4', offset: 300, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 10876,
+        attributes: [
+          {format: 'sint16x4', offset: 6276, shaderLocation: 13},
+          {format: 'float32x2', offset: 2244, shaderLocation: 8},
+          {format: 'unorm8x4', offset: 3016, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 3632, attributes: [{format: 'sint16x4', offset: 1212, shaderLocation: 9}]},
+      {
+        arrayStride: 19120,
+        attributes: [
+          {format: 'unorm8x2', offset: 2876, shaderLocation: 1},
+          {format: 'sint32x4', offset: 4852, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+});
+let video60 = await videoWithData();
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+try {
+offscreenCanvas49.getContext('webgpu');
+} catch {}
+let bindGroupLayout60 = device4.createBindGroupLayout({
+  label: '\ub54c\u802a\u05e4\u0707\uc21c\u00a0',
+  entries: [
+    {
+      binding: 919,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 152, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 1064, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+  ],
+});
+let commandEncoder196 = device4.createCommandEncoder({label: '\u05c4\uda30\uccd0\u53eb\u0548\u08a8\uf021'});
+let textureView228 = texture89.createView({dimension: '2d', format: 'rgba8uint', baseMipLevel: 1, baseArrayLayer: 350});
+let computePassEncoder87 = commandEncoder196.beginComputePass({label: '\u0c34\u5815\ubfe7\u0e66\u0cc0'});
+let renderBundle109 = renderBundleEncoder57.finish({label: '\u06aa\u0838\u67af\u006b\u5a1c\u{1fb6d}\u7a00\u43f7\u{1fd79}\uc55b\uc2bd'});
+try {
+renderPassEncoder13.setBlendConstant({ r: -381.1, g: -911.0, b: -184.1, a: 403.5, });
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(171, 163, 203, 1);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(8, buffer38, 445444, 23671);
+} catch {}
+try {
+renderBundleEncoder83.drawIndirect(buffer45, 20272);
+} catch {}
+try {
+commandEncoder145.copyTextureToTexture({
+  texture: texture82,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 239},
+  aspect: 'all',
+},
+{
+  texture: texture74,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 2, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder145.clearBuffer(buffer32);
+dissociateBuffer(device4, buffer32);
+} catch {}
+let pipeline158 = device4.createComputePipeline({
+  label: '\u8074\u0892\u{1f8bf}',
+  layout: 'auto',
+  compute: {module: shaderModule40, entryPoint: 'compute0'},
+});
+let canvas48 = document.createElement('canvas');
+let imageBitmap45 = await createImageBitmap(canvas1);
+let querySet109 = device4.createQuerySet({
+  label: '\u{1f7b7}\u{1ff7f}\u{1f7fa}\uc5a1\u10d3\uc087\u70e0\u{1fadb}\u9b24',
+  type: 'occlusion',
+  count: 171,
+});
+let textureView229 = texture88.createView({baseMipLevel: 7, baseArrayLayer: 398, arrayLayerCount: 80});
+let renderPassEncoder14 = commandEncoder193.beginRenderPass({
+  label: '\u4b64\u009b',
+  colorAttachments: [{
+  view: textureView225,
+  clearValue: { r: 355.1, g: 589.2, b: 896.3, a: -985.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet106,
+  maxDrawCount: 666485457,
+});
+let renderBundleEncoder87 = device4.createRenderBundleEncoder({label: '\u{1f739}\u01cf\u{1fa17}', colorFormats: ['rgba8uint'], depthReadOnly: true});
+let sampler99 = device4.createSampler({
+  label: '\u58b7\u64b2\ue855\u258c\u75e2\u{1f8d4}\u0e28\u0529\u0778\u0d02\u2dda',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 64.19,
+  lodMaxClamp: 79.81,
+});
+try {
+renderPassEncoder13.setPipeline(pipeline113);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(3339, undefined, 0, 2080935506);
+} catch {}
+try {
+renderBundleEncoder83.drawIndexed(97, 59);
+} catch {}
+try {
+renderBundleEncoder83.drawIndexedIndirect(buffer45, 73824);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 5,
+  origin: {x: 0, y: 2, z: 8},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer2), /* required buffer size: 2_334_645 */
+{offset: 60, bytesPerRow: 327, rowsPerImage: 16}, {width: 33, height: 4, depthOrArrayLayers: 447});
+} catch {}
+let video61 = await videoWithData();
+let shaderModule46 = device3.createShaderModule({
+  label: '\uc8eb\u856f\u55a5\u0304\ub405\u147f\u83b0\u0b3b',
+  code: `@group(2) @binding(110)
+var<storage, read_write> field37: array<u32>;
+@group(0) @binding(586)
+var<storage, read_write> global33: array<u32>;
+@group(0) @binding(990)
+var<storage, read_write> function32: array<u32>;
+@group(2) @binding(990)
+var<storage, read_write> type33: array<u32>;
+@group(1) @binding(586)
+var<storage, read_write> parameter26: array<u32>;
+@group(1) @binding(990)
+var<storage, read_write> type34: array<u32>;
+@group(0) @binding(110)
+var<storage, read_write> field38: array<u32>;
+
+@compute @workgroup_size(8, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S43 {
+  @location(31) f0: vec2<f16>,
+  @location(33) f1: vec4<u32>,
+  @location(26) f2: i32,
+  @location(41) f3: vec3<i32>,
+  @location(3) f4: u32,
+  @location(39) f5: u32,
+  @location(13) f6: vec2<f32>,
+  @location(27) f7: vec4<f32>,
+  @location(47) f8: vec4<f32>,
+  @location(9) f9: f32,
+  @location(0) f10: vec2<f16>,
+  @location(14) f11: vec4<u32>,
+  @location(18) f12: vec4<u32>,
+  @location(44) f13: vec3<f16>,
+  @location(5) f14: vec4<i32>,
+  @location(19) f15: vec3<f16>,
+  @location(34) f16: vec2<u32>,
+  @builtin(front_facing) f17: bool,
+  @builtin(sample_index) f18: u32,
+  @builtin(position) f19: vec4<f32>,
+  @builtin(sample_mask) f20: u32
+}
+struct FragmentOutput0 {
+  @location(6) f0: vec2<f32>,
+  @location(0) f1: vec3<f32>,
+  @location(1) f2: vec2<u32>,
+  @location(4) f3: vec4<f32>,
+  @location(3) f4: vec4<i32>,
+  @location(5) f5: vec3<f32>,
+  @location(2) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(42) a0: i32, @location(40) a1: vec2<f16>, @location(16) a2: vec3<i32>, @location(28) a3: vec4<f32>, @location(35) a4: f32, @location(37) a5: vec3<f32>, @location(11) a6: vec2<f16>, @location(46) a7: f32, @location(20) a8: vec3<f16>, @location(29) a9: vec4<u32>, @location(22) a10: vec2<f32>, @location(25) a11: f32, @location(45) a12: f32, @location(43) a13: f32, @location(4) a14: u32, a15: S43) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(40) f489: vec2<f16>,
+  @location(4) f490: u32,
+  @location(41) f491: vec3<i32>,
+  @location(31) f492: vec2<f16>,
+  @location(19) f493: vec3<f16>,
+  @builtin(position) f494: vec4<f32>,
+  @location(46) f495: f32,
+  @location(33) f496: vec4<u32>,
+  @location(25) f497: f32,
+  @location(29) f498: vec4<u32>,
+  @location(5) f499: vec4<i32>,
+  @location(22) f500: vec2<f32>,
+  @location(42) f501: i32,
+  @location(34) f502: vec2<u32>,
+  @location(28) f503: vec4<f32>,
+  @location(3) f504: u32,
+  @location(27) f505: vec4<f32>,
+  @location(47) f506: vec4<f32>,
+  @location(43) f507: f32,
+  @location(18) f508: vec4<u32>,
+  @location(35) f509: f32,
+  @location(14) f510: vec4<u32>,
+  @location(45) f511: f32,
+  @location(13) f512: vec2<f32>,
+  @location(39) f513: u32,
+  @location(26) f514: i32,
+  @location(9) f515: f32,
+  @location(37) f516: vec3<f32>,
+  @location(20) f517: vec3<f16>,
+  @location(16) f518: vec3<i32>,
+  @location(44) f519: vec3<f16>,
+  @location(11) f520: vec2<f16>,
+  @location(0) f521: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(23) a0: vec3<i32>, @location(16) a1: vec2<f32>, @location(5) a2: u32, @location(18) a3: vec4<f16>, @location(3) a4: vec4<u32>, @location(17) a5: vec3<f16>, @location(6) a6: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout61 = device3.createBindGroupLayout({
+  entries: [
+    {
+      binding: 597,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+  ],
+});
+let commandEncoder197 = device3.createCommandEncoder({});
+try {
+renderBundleEncoder75.setIndexBuffer(buffer46, 'uint32');
+} catch {}
+try {
+renderBundleEncoder70.setVertexBuffer(5828, undefined, 0, 3385226112);
+} catch {}
+let pipeline159 = await device3.createRenderPipelineAsync({
+  label: '\ub0f5\u{1fbad}\u0317\u{1fe34}\u{1fcf6}\u42d9\u4c57\u1700\u{1fe1a}\u{1fbce}\uf319',
+  layout: pipelineLayout19,
+  fragment: {
+  module: shaderModule35,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'constant', dstFactor: 'zero'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'one-minus-dst'},
+  },
+}, {format: 'rg11b10ufloat', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: 0}, {format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg32sint'}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'less', failOp: 'increment-wrap', depthFailOp: 'decrement-wrap'},
+    stencilBack: {compare: 'never', failOp: 'replace', depthFailOp: 'keep', passOp: 'increment-clamp'},
+    stencilReadMask: 2580125384,
+    stencilWriteMask: 531695772,
+    depthBias: -836199744,
+    depthBiasSlopeScale: 374.1031376780711,
+    depthBiasClamp: 671.2886701498002,
+  },
+  vertex: {
+    module: shaderModule35,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 6988, shaderLocation: 17},
+          {format: 'uint16x4', offset: 5200, shaderLocation: 20},
+          {format: 'sint16x2', offset: 8320, shaderLocation: 9},
+          {format: 'float32x2', offset: 2096, shaderLocation: 19},
+          {format: 'uint8x4', offset: 4876, shaderLocation: 12},
+          {format: 'uint16x4', offset: 4132, shaderLocation: 11},
+          {format: 'float16x4', offset: 1800, shaderLocation: 6},
+          {format: 'unorm16x4', offset: 584, shaderLocation: 7},
+          {format: 'sint32x3', offset: 444, shaderLocation: 10},
+          {format: 'snorm16x4', offset: 3060, shaderLocation: 23},
+          {format: 'snorm16x2', offset: 5464, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 3660,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 520, shaderLocation: 16},
+          {format: 'snorm8x2', offset: 370, shaderLocation: 2},
+          {format: 'snorm16x4', offset: 652, shaderLocation: 22},
+          {format: 'uint16x2', offset: 208, shaderLocation: 5},
+          {format: 'float32x3', offset: 48, shaderLocation: 1},
+          {format: 'unorm16x2', offset: 300, shaderLocation: 13},
+          {format: 'sint8x4', offset: 732, shaderLocation: 24},
+          {format: 'float16x2', offset: 292, shaderLocation: 15},
+          {format: 'uint32x2', offset: 224, shaderLocation: 21},
+          {format: 'unorm8x2', offset: 848, shaderLocation: 8},
+          {format: 'unorm16x4', offset: 296, shaderLocation: 4},
+          {format: 'snorm8x2', offset: 1704, shaderLocation: 3},
+          {format: 'uint16x2', offset: 1048, shaderLocation: 18},
+        ],
+      },
+      {arrayStride: 760, attributes: [{format: 'sint8x2', offset: 286, shaderLocation: 14}]},
+    ],
+  },
+});
+let gpuCanvasContext48 = canvas48.getContext('webgpu');
+try {
+externalTexture65.label = '\u{1f7be}\ud3d5\u0481\u{1fbac}\uf5ba\u02d4\uf70a\u{1f9ed}';
+} catch {}
+let bindGroupLayout62 = device2.createBindGroupLayout({
+  label: '\u0c61\u0ce9\u137c\u20cd\u023f\u0226\u78d7',
+  entries: [
+    {
+      binding: 3751,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '1d' },
+    },
+    {binding: 4478, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let bindGroup31 = device2.createBindGroup({
+  label: '\u89b9\u{1fcb7}\u{1fbe7}\u4c4b\uefac\u0a46\u0341',
+  layout: bindGroupLayout58,
+  entries: [{binding: 620, resource: sampler57}, {binding: 1232, resource: sampler89}],
+});
+let textureView230 = texture62.createView({label: '\u02b5\u0d73\u{1fa87}\u2cc8\u{1fd44}\u0720\u363c\ud9d5\uffcc\u906a', baseMipLevel: 7});
+let renderBundleEncoder88 = device2.createRenderBundleEncoder({
+  label: '\u2fb2\u{1fde9}\ua200\u{1ffd0}',
+  colorFormats: ['rgba16float', 'rgba32float', 'rgba8unorm', 'rg32sint', 'rg8unorm'],
+  depthReadOnly: true,
+});
+let renderBundle110 = renderBundleEncoder78.finish({label: '\ua056\u{1f6b2}\u0bac'});
+let sampler100 = device2.createSampler({
+  label: '\u{1f753}\ucbdd\u9e59\u0451\u7214',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 64.68,
+  lodMaxClamp: 65.47,
+});
+try {
+commandEncoder104.copyTextureToTexture({
+  texture: texture109,
+  mipLevel: 0,
+  origin: {x: 82, y: 0, z: 100},
+  aspect: 'all',
+},
+{
+  texture: texture109,
+  mipLevel: 0,
+  origin: {x: 31, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 188, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer9), /* required buffer size: 940 */
+{offset: 940}, {width: 112, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder198 = device2.createCommandEncoder({label: '\uceab\u621e\u60d9'});
+let textureView231 = texture68.createView({label: '\u08c9\u022c'});
+let renderBundle111 = renderBundleEncoder68.finish({label: '\u06e9\u0816\u{1fb8b}\u9986\u734f\u0f78'});
+try {
+computePassEncoder76.setPipeline(pipeline120);
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(0, bindGroup30, [10880]);
+} catch {}
+try {
+device2.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder99.copyBufferToBuffer(buffer30, 37508, buffer41, 1184, 272);
+dissociateBuffer(device2, buffer30);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder178.copyTextureToBuffer({
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 759, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1176 widthInBlocks: 147 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 15064 */
+  offset: 13888,
+  rowsPerImage: 204,
+  buffer: buffer40,
+}, {width: 147, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer40);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer40, 3188, new BigUint64Array(43894), 25849, 212);
+} catch {}
+let pipeline160 = await device2.createRenderPipelineAsync({
+  layout: pipelineLayout16,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule36,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}, {format: 'rgba32float', writeMask: 0}, {format: 'rgba8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg32sint'}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one', dstFactor: 'one-minus-src'},
+    alpha: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'one-minus-dst-alpha'},
+  },
+}],
+},
+  vertex: {
+    module: shaderModule36,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'float16x4', offset: 3564, shaderLocation: 1},
+          {format: 'uint16x4', offset: 3796, shaderLocation: 5},
+          {format: 'unorm16x4', offset: 4676, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 11260, shaderLocation: 6},
+          {format: 'float16x2', offset: 6600, shaderLocation: 2},
+          {format: 'snorm8x2', offset: 154, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 13952,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'snorm16x4', offset: 1476, shaderLocation: 9},
+          {format: 'sint32x3', offset: 48, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'uint16x2', offset: 2392, shaderLocation: 0},
+          {format: 'unorm8x4', offset: 5416, shaderLocation: 16},
+          {format: 'uint32', offset: 16488, shaderLocation: 3},
+          {format: 'snorm16x2', offset: 3260, shaderLocation: 12},
+          {format: 'uint8x4', offset: 8536, shaderLocation: 14},
+          {format: 'sint16x4', offset: 27512, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 1568,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 712, shaderLocation: 10}],
+      },
+      {
+        arrayStride: 5472,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x2', offset: 290, shaderLocation: 17}],
+      },
+      {
+        arrayStride: 3676,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 60, shaderLocation: 15},
+          {format: 'unorm8x4', offset: 1480, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw'},
+});
+canvas25.width = 1094;
+let imageData47 = new ImageData(192, 192);
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55) };
+} catch {}
+let shaderModule47 = device2.createShaderModule({
+  label: '\ua5d9\u{1fcb2}\u0ee5\u{1f755}\u{1fb9f}',
+  code: `@group(0) @binding(4279)
+var<storage, read_write> parameter27: array<u32>;
+@group(1) @binding(3325)
+var<storage, read_write> type35: array<u32>;
+@group(0) @binding(600)
+var<storage, read_write> function33: array<u32>;
+@group(1) @binding(44)
+var<storage, read_write> global34: array<u32>;
+@group(4) @binding(3292)
+var<storage, read_write> type36: array<u32>;
+@group(0) @binding(5089)
+var<storage, read_write> parameter28: array<u32>;
+@group(2) @binding(1519)
+var<storage, read_write> function34: array<u32>;
+@group(1) @binding(3012)
+var<storage, read_write> parameter29: array<u32>;
+
+@compute @workgroup_size(5, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(front_facing) a1: bool, @builtin(sample_mask) a2: u32) -> @location(200) vec4<f32> {
+return vec4<f32>();
+}
+
+struct S44 {
+  @location(3) f0: vec3<u32>,
+  @location(17) f1: vec2<f32>,
+  @location(8) f2: f32,
+  @location(6) f3: vec2<i32>,
+  @location(10) f4: vec4<f16>,
+  @builtin(vertex_index) f5: u32,
+  @location(9) f6: vec3<u32>,
+  @location(15) f7: vec4<i32>,
+  @location(4) f8: vec2<u32>,
+  @location(7) f9: vec2<u32>,
+  @location(0) f10: vec3<u32>,
+  @builtin(instance_index) f11: u32,
+  @location(2) f12: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec3<f32>, @location(16) a1: vec3<f16>, @location(13) a2: i32, a3: S44, @location(1) a4: vec2<f16>, @location(12) a5: vec2<f16>, @location(14) a6: vec4<i32>, @location(11) a7: i32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder199 = device2.createCommandEncoder({});
+try {
+renderBundleEncoder88.setBindGroup(3, bindGroup23, new Uint32Array(8237), 7775, 0);
+} catch {}
+try {
+renderBundleEncoder88.setPipeline(pipeline92);
+} catch {}
+try {
+commandEncoder195.copyTextureToTexture({
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 518, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 336, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer41, 108, new BigUint64Array(482), 44, 68);
+} catch {}
+let pipeline161 = device2.createRenderPipeline({
+  layout: pipelineLayout16,
+  fragment: {
+  module: shaderModule36,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba32float', writeMask: 0}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'src-alpha-saturated'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'src'},
+  },
+  writeMask: 0,
+}, {format: 'rg32sint'}, {
+  format: 'rg8unorm',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule36,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 512,
+        attributes: [
+          {format: 'float16x2', offset: 172, shaderLocation: 2},
+          {format: 'uint16x2', offset: 160, shaderLocation: 3},
+          {format: 'uint8x4', offset: 44, shaderLocation: 17},
+          {format: 'uint16x4', offset: 216, shaderLocation: 0},
+          {format: 'uint32', offset: 88, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 3580,
+        attributes: [
+          {format: 'float32x2', offset: 772, shaderLocation: 13},
+          {format: 'sint32x2', offset: 652, shaderLocation: 11},
+          {format: 'snorm8x2', offset: 574, shaderLocation: 8},
+          {format: 'snorm8x2', offset: 14, shaderLocation: 16},
+          {format: 'float32', offset: 184, shaderLocation: 10},
+          {format: 'sint32x4', offset: 336, shaderLocation: 4},
+          {format: 'float16x2', offset: 84, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 2292,
+        attributes: [
+          {format: 'float32x3', offset: 392, shaderLocation: 1},
+          {format: 'unorm10-10-10-2', offset: 628, shaderLocation: 9},
+          {format: 'uint16x4', offset: 40, shaderLocation: 14},
+          {format: 'float16x4', offset: 180, shaderLocation: 15},
+          {format: 'unorm16x4', offset: 648, shaderLocation: 7},
+          {format: 'unorm10-10-10-2', offset: 144, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', cullMode: 'front'},
+});
+let shaderModule48 = device2.createShaderModule({
+  label: '\u{1fd3c}\u5aa5',
+  code: `@group(5) @binding(44)
+var<storage, read_write> field39: array<u32>;
+@group(0) @binding(2213)
+var<storage, read_write> n27: array<u32>;
+@group(4) @binding(4492)
+var<storage, read_write> field40: array<u32>;
+@group(0) @binding(6124)
+var<storage, read_write> local44: array<u32>;
+@group(1) @binding(2086)
+var<storage, read_write> global35: array<u32>;
+@group(1) @binding(2213)
+var<storage, read_write> field41: array<u32>;
+@group(4) @binding(1457)
+var<storage, read_write> function35: array<u32>;
+@group(0) @binding(2086)
+var<storage, read_write> global36: array<u32>;
+@group(4) @binding(1762)
+var<storage, read_write> field42: array<u32>;
+@group(1) @binding(6124)
+var<storage, read_write> type37: array<u32>;
+@group(5) @binding(3325)
+var<storage, read_write> n28: array<u32>;
+@group(5) @binding(3012)
+var<storage, read_write> parameter30: array<u32>;
+
+@compute @workgroup_size(4, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @builtin(sample_mask) f1: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(front_facing) a1: bool, @location(15) a2: vec3<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f522: vec4<f32>,
+  @location(15) f523: vec3<f16>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let buffer47 = device2.createBuffer({
+  label: '\u05df\u7bda\ue162\ube6e\u7bf3\u{1f73b}\u{1fb39}',
+  size: 59417,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM,
+});
+let querySet110 = device2.createQuerySet({type: 'occlusion', count: 3073});
+let textureView232 = texture96.createView({label: '\u81b7\u5b44\u8770\u0087\u7aa9'});
+try {
+renderBundleEncoder66.setBindGroup(1, bindGroup29, new Uint32Array(2018), 304, 0);
+} catch {}
+try {
+renderBundleEncoder86.setVertexBuffer(5, buffer40, 0, 9360);
+} catch {}
+try {
+commandEncoder118.clearBuffer(buffer41, 900, 632);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder168.insertDebugMarker('\u8500');
+} catch {}
+let promise63 = device2.queue.onSubmittedWorkDone();
+let pipeline162 = await device2.createComputePipelineAsync({
+  label: '\u0b31\u5b2f\u0a48\u7618\u3f2f\u0490',
+  layout: pipelineLayout17,
+  compute: {module: shaderModule47, entryPoint: 'compute0', constants: {}},
+});
+let commandBuffer55 = commandEncoder174.finish();
+let externalTexture99 = device4.importExternalTexture({label: '\u03bb\u6015\u0569\u4c44\u3a24\u2e7a\u07f3', source: videoFrame45, colorSpace: 'srgb'});
+try {
+computePassEncoder56.dispatchWorkgroupsIndirect(buffer45, 14028);
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline155);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle86, renderBundle71, renderBundle82, renderBundle82, renderBundle57, renderBundle62]);
+} catch {}
+try {
+renderPassEncoder14.setViewport(168.8, 11.07, 93.49, 71.26, 0.7543, 0.9769);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(5, buffer38);
+} catch {}
+try {
+renderBundleEncoder83.drawIndexed(31, 298, 2_711_770_975, 89_037_255, 817_397_394);
+} catch {}
+try {
+renderBundleEncoder83.drawIndirect(buffer45, 19976);
+} catch {}
+try {
+renderBundleEncoder76.setPipeline(pipeline153);
+} catch {}
+let pipeline163 = device4.createComputePipeline({
+  label: '\u1fa2\uc727\u4c0a\u{1fab3}\u06d5\ucf5d\u0965',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule42, entryPoint: 'compute0', constants: {}},
+});
+let bindGroupLayout63 = device4.createBindGroupLayout({label: '\u48ff\u03db\u6f23\u78ef\u094a\u79d9\u1a4c\u0dfb', entries: []});
+let bindGroup32 = device4.createBindGroup({label: '\u6e1f\u048c\u{1fe3c}\u7f54\u{1fac5}\u947d', layout: bindGroupLayout63, entries: []});
+let textureView233 = texture81.createView({dimension: '3d'});
+let renderBundle112 = renderBundleEncoder51.finish();
+try {
+renderPassEncoder14.setStencilReference(636);
+} catch {}
+try {
+renderBundleEncoder76.setVertexBuffer(6, buffer38);
+} catch {}
+let imageBitmap46 = await createImageBitmap(canvas27);
+gc();
+let commandEncoder200 = device3.createCommandEncoder({label: '\u762b\u077d\u20b6\u05d2\u64e3\u50ad\u5af5\u{1fbe5}\u00b3\u{1f9e7}'});
+let computePassEncoder88 = commandEncoder106.beginComputePass();
+let renderBundleEncoder89 = device3.createRenderBundleEncoder({
+  label: '\u0d38\u4537\u7a65\u7f0a',
+  colorFormats: ['r8unorm', 'rg11b10ufloat', 'rg8sint', 'r8sint', 'rg32sint', 'rgba16uint', 'rg16float'],
+  depthReadOnly: true,
+});
+let externalTexture100 = device3.importExternalTexture({
+  label: '\u0c7b\ua357\uf234\u{1ffd2}\u066d\u{1ff7d}\u{1fa0f}\u0ad3\u{1f649}',
+  source: video4,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder70.setIndexBuffer(buffer46, 'uint16', 120982);
+} catch {}
+try {
+renderBundleEncoder70.setVertexBuffer(2476, undefined, 2143772981, 1215303229);
+} catch {}
+gc();
+let buffer48 = device4.createBuffer({
+  label: '\u0312\u42f7\u447a\u4a5b\u08d9\u{1fc1e}',
+  size: 94106,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let renderPassEncoder15 = commandEncoder145.beginRenderPass({
+  label: '\u5ae8\u5184\u5f72\u7a89\u0904\ud677\u8f7a\u0dc6\u0f5e\u{1f694}',
+  colorAttachments: [{view: textureView224, loadOp: 'load', storeOp: 'store'}],
+  maxDrawCount: 607360536,
+});
+let renderBundleEncoder90 = device4.createRenderBundleEncoder({
+  label: '\u163e\u{1fcc3}\u9388\u{1fca3}\u05b9',
+  colorFormats: [undefined, 'r32sint', 'rg16float', 'rgba16sint', 'rgba8unorm', 'rgb10a2uint', 'rg32sint'],
+  depthReadOnly: true,
+});
+let renderBundle113 = renderBundleEncoder74.finish({label: '\u003f\u0ecf\u297a\u{1fbf7}\u3b2c\u0219\u8a08\u09b8\u26bf\u0c9f\u6213'});
+let externalTexture101 = device4.importExternalTexture({label: '\u{1fb72}\ue7a4', source: video51, colorSpace: 'srgb'});
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup32);
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(215, 78, 130, 51);
+} catch {}
+try {
+renderPassEncoder13.setStencilReference(2202);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer37, 'uint32', 27120, 123858);
+} catch {}
+try {
+renderBundleEncoder83.draw(250);
+} catch {}
+try {
+renderBundleEncoder83.drawIndexedIndirect(buffer45, 81520);
+} catch {}
+try {
+renderBundleEncoder90.setVertexBuffer(7888, undefined, 0);
+} catch {}
+try {
+commandEncoder190.clearBuffer(buffer31);
+dissociateBuffer(device4, buffer31);
+} catch {}
+let promise64 = device4.queue.onSubmittedWorkDone();
+let pipeline164 = device4.createComputePipeline({
+  label: '\u05d4\ub76d\u7993',
+  layout: pipelineLayout22,
+  compute: {module: shaderModule29, entryPoint: 'compute0', constants: {}},
+});
+let pipeline165 = device4.createRenderPipeline({
+  label: '\u5410\u8a21\u023a\uc865\u086f\u78a4\u04a9\uecce\u68a1\uba71\u02c6',
+  layout: pipelineLayout18,
+  fragment: {
+  module: shaderModule29,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'not-equal', failOp: 'increment-wrap', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'not-equal', failOp: 'invert', depthFailOp: 'zero', passOp: 'invert'},
+    stencilReadMask: 1880603071,
+    stencilWriteMask: 3825468970,
+    depthBiasClamp: 755.2553621955927,
+  },
+  vertex: {
+    module: shaderModule29,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 292,
+        attributes: [
+          {format: 'float32', offset: 76, shaderLocation: 6},
+          {format: 'unorm16x2', offset: 0, shaderLocation: 14},
+          {format: 'sint8x4', offset: 64, shaderLocation: 12},
+          {format: 'float16x4', offset: 28, shaderLocation: 7},
+          {format: 'float32x3', offset: 56, shaderLocation: 4},
+          {format: 'unorm16x2', offset: 4, shaderLocation: 10},
+          {format: 'snorm8x4', offset: 0, shaderLocation: 18},
+          {format: 'float32x4', offset: 36, shaderLocation: 17},
+          {format: 'uint32', offset: 12, shaderLocation: 8},
+          {format: 'float32x2', offset: 64, shaderLocation: 2},
+          {format: 'uint8x2', offset: 76, shaderLocation: 0},
+          {format: 'snorm8x4', offset: 32, shaderLocation: 5},
+          {format: 'float32x2', offset: 8, shaderLocation: 15},
+        ],
+      },
+      {arrayStride: 26948, stepMode: 'instance', attributes: []},
+      {arrayStride: 6744, attributes: [{format: 'float16x4', offset: 1200, shaderLocation: 9}]},
+      {
+        arrayStride: 25552,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 8824, shaderLocation: 16},
+          {format: 'unorm8x4', offset: 196, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 1428, attributes: []},
+      {arrayStride: 0, attributes: [{format: 'sint32', offset: 4264, shaderLocation: 13}]},
+    ],
+  },
+});
+let commandEncoder201 = device2.createCommandEncoder({label: '\u0799\u1d77\u{1fb0e}\u0c41\ua7d3\ubad5\u{1fe82}\u0154\u{1fa6e}'});
+let commandBuffer56 = commandEncoder118.finish({label: '\u{1fe84}\ue303\u{1fb21}\ua420\u4247'});
+let textureView234 = texture60.createView({label: '\u32e2\u1763\u{1f701}'});
+let renderBundleEncoder91 = device2.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb'], sampleCount: 4, depthReadOnly: true, stencilReadOnly: true});
+let renderBundle114 = renderBundleEncoder73.finish({label: '\u122a\uebe8\u{1fb32}\u5045\u0342'});
+try {
+renderBundleEncoder86.setBindGroup(3, bindGroup29);
+} catch {}
+try {
+renderBundleEncoder84.setPipeline(pipeline105);
+} catch {}
+try {
+renderBundleEncoder55.setVertexBuffer(2, buffer30);
+} catch {}
+try {
+commandEncoder122.copyTextureToTexture({
+  texture: texture63,
+  mipLevel: 2,
+  origin: {x: 26, y: 0, z: 27},
+  aspect: 'all',
+},
+{
+  texture: texture104,
+  mipLevel: 5,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 1, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let video62 = await videoWithData();
+try {
+externalTexture57.label = '\u{1ff40}\u0662\u2287\u0b43\uacc0\u8c87\ua9ab';
+} catch {}
+let pipelineLayout28 = device2.createPipelineLayout({
+  label: '\u0724\u03ee\ue0c9\u0993\uc07d\u50f3\uc6ed\u4be0',
+  bindGroupLayouts: [bindGroupLayout62, bindGroupLayout58, bindGroupLayout36, bindGroupLayout33, bindGroupLayout32],
+});
+let textureView235 = texture96.createView({});
+try {
+commandEncoder120.copyTextureToTexture({
+  texture: texture116,
+  mipLevel: 1,
+  origin: {x: 91, y: 0, z: 89},
+  aspect: 'all',
+},
+{
+  texture: texture104,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext21.unconfigure();
+} catch {}
+let canvas49 = document.createElement('canvas');
+let img46 = await imageWithData(75, 57, '#1de264ec', '#65a50b41');
+let canvas50 = document.createElement('canvas');
+try {
+canvas50.getContext('webgpu');
+} catch {}
+try {
+externalTexture56.label = '\u0f8d\u8f1f\ue941\u6f57\u16af\u7b7b\u{1fa69}\u143c\u4ccf\u{1f9aa}\udc15';
+} catch {}
+let textureView236 = texture59.createView({label: '\u6aea\u7c95\u01e7', mipLevelCount: 6});
+let sampler101 = device2.createSampler({
+  label: '\u03a8\u{1fc91}\u0030\u0559\u7f3a\ua0ee\u0fb9\u012a\u9235\u43e3\u066d',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 72.11,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder71.setPipeline(pipeline156);
+} catch {}
+try {
+renderBundleEncoder91.setVertexBuffer(7661, undefined, 2117832685, 345845697);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 9, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas35,
+  origin: { x: 32, y: 5 },
+  flipY: false,
+}, {
+  texture: texture105,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder202 = device4.createCommandEncoder({label: '\u0a1e\u0c7d\uecbc\ue02e\uf6b5'});
+let texture117 = device4.createTexture({
+  size: {width: 576, height: 240, depthOrArrayLayers: 801},
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let texture118 = gpuCanvasContext31.getCurrentTexture();
+let computePassEncoder89 = commandEncoder202.beginComputePass({label: '\u{1f838}\u3edb\ue535\ubca0'});
+try {
+renderPassEncoder13.executeBundles([renderBundle86, renderBundle71, renderBundle96, renderBundle112, renderBundle61]);
+} catch {}
+try {
+renderPassEncoder14.setScissorRect(65, 25, 169, 52);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer37, 'uint32', 121000, 45946);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(3, buffer38, 445208);
+} catch {}
+try {
+renderBundleEncoder76.drawIndirect(buffer45, 123628);
+} catch {}
+try {
+commandEncoder194.copyTextureToTexture({
+  texture: texture81,
+  mipLevel: 0,
+  origin: {x: 102, y: 36, z: 64},
+  aspect: 'all',
+},
+{
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 13, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 217, height: 88, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder194.resolveQuerySet(querySet72, 151, 515, buffer48, 6656);
+} catch {}
+let pipeline166 = device4.createComputePipeline({
+  label: '\ue203\u0231\uee32\u67f5\u041c',
+  layout: pipelineLayout22,
+  compute: {module: shaderModule44, entryPoint: 'compute0', constants: {}},
+});
+canvas30.height = 1194;
+let pipelineLayout29 = device3.createPipelineLayout({
+  label: '\u{1f795}\u4e98\u00a3\u2fe1\u{1fb54}',
+  bindGroupLayouts: [bindGroupLayout42, bindGroupLayout54],
+});
+let commandEncoder203 = device3.createCommandEncoder({});
+let texture119 = device3.createTexture({
+  label: '\u13d8\u163f\uae74',
+  size: {width: 208},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let imageData48 = new ImageData(160, 56);
+let videoFrame49 = new VideoFrame(video29, {timestamp: 0});
+try {
+adapter8.label = '\u{1fdd7}\u0f77\ufda6';
+} catch {}
+let buffer49 = device3.createBuffer({label: '\u0138\u0db9\u{1ff90}\u0efc', size: 74086, usage: GPUBufferUsage.STORAGE});
+let textureView237 = texture107.createView({
+  label: '\u{1fbc1}\u{1f97f}\u8da7\u{1f630}\u4841\uc94e\u{1f657}\u0268\u0f9e\u5da2\u0a01',
+  dimension: '2d-array',
+  mipLevelCount: 4,
+});
+let sampler102 = device3.createSampler({
+  label: '\u03df\ubabb\ucafb\u{1fccd}\u3345\u05a9\u0fad\uc968',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 20.28,
+  lodMaxClamp: 52.66,
+});
+try {
+computePassEncoder85.setPipeline(pipeline117);
+} catch {}
+try {
+renderBundleEncoder89.setPipeline(pipeline123);
+} catch {}
+try {
+gpuCanvasContext21.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+document.body.prepend(img12);
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+try {
+canvas49.getContext('webgl2');
+} catch {}
+let bindGroupLayout64 = pipeline108.getBindGroupLayout(2);
+let renderBundle115 = renderBundleEncoder87.finish();
+try {
+computePassEncoder61.setPipeline(pipeline163);
+} catch {}
+try {
+renderBundleEncoder76.drawIndexedIndirect(buffer45, 95472);
+} catch {}
+try {
+renderBundleEncoder76.setPipeline(pipeline114);
+} catch {}
+try {
+renderBundleEncoder85.setVertexBuffer(8065, undefined);
+} catch {}
+try {
+device4.queue.writeBuffer(buffer44, 1084, new DataView(new ArrayBuffer(27395)), 25744, 536);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture112,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(67_341), /* required buffer size: 67_341 */
+{offset: 951, bytesPerRow: 222, rowsPerImage: 299}, {width: 3, height: 1, depthOrArrayLayers: 2});
+} catch {}
+let pipeline167 = await device4.createRenderPipelineAsync({
+  layout: pipelineLayout27,
+  fragment: {
+  module: shaderModule44,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [undefined, {format: 'r32sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+}, {format: 'rgba16sint', writeMask: GPUColorWrite.ALPHA}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgb10a2uint'}, {format: 'rg32sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule44,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 17676,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 584, shaderLocation: 17},
+          {format: 'uint32x3', offset: 3028, shaderLocation: 7},
+          {format: 'sint8x2', offset: 1792, shaderLocation: 5},
+          {format: 'snorm8x2', offset: 1072, shaderLocation: 8},
+          {format: 'snorm16x4', offset: 2692, shaderLocation: 4},
+          {format: 'uint8x4', offset: 4140, shaderLocation: 10},
+          {format: 'snorm8x4', offset: 7836, shaderLocation: 15},
+          {format: 'uint8x4', offset: 660, shaderLocation: 14},
+          {format: 'uint32x3', offset: 1960, shaderLocation: 3},
+          {format: 'float16x2', offset: 3936, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 2216,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 28, shaderLocation: 13},
+          {format: 'sint32x3', offset: 76, shaderLocation: 12},
+          {format: 'uint8x2', offset: 260, shaderLocation: 9},
+          {format: 'sint32', offset: 664, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 316, shaderLocation: 2},
+          {format: 'uint32x3', offset: 404, shaderLocation: 1},
+          {format: 'uint16x2', offset: 4, shaderLocation: 11},
+          {format: 'unorm16x4', offset: 336, shaderLocation: 18},
+          {format: 'float16x4', offset: 200, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'back', unclippedDepth: true},
+});
+offscreenCanvas40.height = 209;
+let device5 = await adapter7.requestDevice({
+  label: '\u0e2e\u04f9\u{1f7b6}\u030e',
+  defaultQueue: {label: '\ua446\u{1fcc5}\u034c\u{1f974}\u0240\ua885\u36d3\u{1fd32}\u0c54\u07ca\u98ee'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 7,
+    maxColorAttachmentBytesPerSample: 35,
+    maxVertexAttributes: 24,
+    maxVertexBufferArrayStride: 48704,
+    maxStorageTexturesPerShaderStage: 44,
+    maxStorageBuffersPerShaderStage: 19,
+    maxDynamicStorageBuffersPerPipelineLayout: 28115,
+    maxDynamicUniformBuffersPerPipelineLayout: 22495,
+    maxBindingsPerBindGroup: 7336,
+    maxTextureArrayLayers: 538,
+    maxTextureDimension1D: 16013,
+    maxTextureDimension2D: 15033,
+    maxVertexBuffers: 9,
+    maxBindGroupsPlusVertexBuffers: 29,
+    minStorageBufferOffsetAlignment: 32,
+    minUniformBufferOffsetAlignment: 64,
+    maxUniformBufferBindingSize: 50379670,
+    maxStorageBufferBindingSize: 192369522,
+    maxUniformBuffersPerShaderStage: 43,
+    maxInterStageShaderVariables: 31,
+    maxInterStageShaderComponents: 95,
+    maxSamplersPerShaderStage: 18,
+  },
+});
+let buffer50 = device4.createBuffer({
+  label: '\u{1f9f8}\u5d2b\u0b79\ua00d',
+  size: 282585,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM,
+});
+let textureView238 = texture81.createView({label: '\u{1fe4e}\u{1f6ff}\uf813\u703e\u{1fc57}\u2f5b\u0c3f', aspect: 'all'});
+let renderBundleEncoder92 = device4.createRenderBundleEncoder({label: '\u4d5e\u332e', colorFormats: ['r32sint', 'rg16float']});
+let sampler103 = device4.createSampler({
+  label: '\u98b9\u0e81\u{1f6d9}\u{1f856}\u06c5\u{1fc92}\u9eaf',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 42.50,
+  lodMaxClamp: 86.72,
+  maxAnisotropy: 2,
+});
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup32, new Uint32Array(2164), 1606, 0);
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(287, 48, 130, 147);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline125);
+} catch {}
+let offscreenCanvas50 = new OffscreenCanvas(848, 276);
+let commandEncoder204 = device4.createCommandEncoder({label: '\u0eff\u02e5\u1d8a\u{1fc74}\udc65\u9e4c\ucca0\uefc8\uc247\ucc1a'});
+try {
+computePassEncoder56.dispatchWorkgroupsIndirect(buffer45, 116792);
+} catch {}
+try {
+renderPassEncoder15.setBlendConstant({ r: -393.4, g: 137.4, b: -518.6, a: -274.6, });
+} catch {}
+try {
+renderPassEncoder13.setStencilReference(3948);
+} catch {}
+try {
+renderPassEncoder13.setViewport(376.8, 141.0, 24.90, 15.47, 0.5683, 0.8072);
+} catch {}
+try {
+renderBundleEncoder83.drawIndexed(174, 307, 3_627_004, -1_997_827_294, 369_204_736);
+} catch {}
+try {
+renderBundleEncoder83.drawIndexedIndirect(buffer45, 87848);
+} catch {}
+try {
+renderBundleEncoder92.setVertexBuffer(6, buffer38, 92072);
+} catch {}
+let commandEncoder205 = device5.createCommandEncoder();
+let querySet111 = device5.createQuerySet({label: '\uaa00\u0f6a\u{1fe90}\uee56\ub203\u0fdc\ufcda\u{1f730}', type: 'occlusion', count: 1165});
+let texture120 = device5.createTexture({
+  label: '\u181a\u7a1a\u{1fd87}\ud9f2\u{1feb3}\u{1f829}\ufe18\ue4b1\ud348\u5334\u56cc',
+  size: [1656, 10, 1],
+  mipLevelCount: 5,
+  format: 'astc-12x10-unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder93 = device5.createRenderBundleEncoder({
+  label: '\u0f7a\u{1f6b0}\u5357\u0ae0\u3502\ubddb\u6025\u200a\u2096\u43c3',
+  colorFormats: ['r32uint', 'rg16sint'],
+  sampleCount: 4,
+});
+let renderBundle116 = renderBundleEncoder93.finish({label: '\u3436\u01c7\u{1fe29}\u255d\u0a4e\u892d'});
+let gpuCanvasContext49 = offscreenCanvas50.getContext('webgpu');
+let offscreenCanvas51 = new OffscreenCanvas(453, 104);
+let video63 = await videoWithData();
+let imageBitmap47 = await createImageBitmap(imageBitmap44);
+let bindGroupLayout65 = device2.createBindGroupLayout({
+  label: '\u68ca\ue2aa\u00a3\u717e\u65e4\u04a6\uf660\u{1f676}\u{1f744}\u06d4',
+  entries: [
+    {
+      binding: 218,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', minBindingSize: 32312493, hasDynamicOffset: false },
+    },
+    {binding: 378, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 3704, visibility: 0, externalTexture: {}},
+  ],
+});
+let commandEncoder206 = device2.createCommandEncoder({label: '\u{1f60f}\uac7d'});
+let commandBuffer57 = commandEncoder122.finish({label: '\u418d\u0d75\u{1fc84}\u0d1b\uf1bc\u07e3\u0970\u0cf5\u0ef4\ucc51'});
+let texture121 = device2.createTexture({
+  size: [2952],
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+});
+try {
+renderBundleEncoder84.setBindGroup(3, bindGroup31);
+} catch {}
+try {
+commandEncoder112.copyBufferToBuffer(buffer40, 14524, buffer41, 1240, 236);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer41, 708, new DataView(new ArrayBuffer(45750)), 986, 36);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 4,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 43 */
+{offset: 43}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline168 = await device2.createRenderPipelineAsync({
+  label: '\u{1fe38}\u0312\u09a6\udeff\u65b9\u049c\u62b3\uc909\u00ca\u0208',
+  layout: pipelineLayout17,
+  multisample: {mask: 0x22b0918a},
+  fragment: {
+  module: shaderModule26,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba16float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgba32float', writeMask: 0}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'rg32sint'}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'constant'},
+  },
+  writeMask: GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule26,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 16636, stepMode: 'vertex', attributes: []},
+      {arrayStride: 25092, attributes: [{format: 'uint16x2', offset: 9852, shaderLocation: 10}]},
+      {
+        arrayStride: 5884,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 520, shaderLocation: 11},
+          {format: 'snorm16x2', offset: 388, shaderLocation: 15},
+          {format: 'unorm8x2', offset: 454, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'front'},
+});
+let computePassEncoder90 = commandEncoder188.beginComputePass({label: '\u0058\ue4ce\u0e55\u{1fc67}\u01f4\ud101'});
+let pipeline169 = await device3.createRenderPipelineAsync({
+  label: '\u45c5\u0943\uce24',
+  layout: pipelineLayout29,
+  fragment: {
+  module: shaderModule34,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rg11b10ufloat', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg8sint'}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rg32sint'}, {format: 'rgba16uint', writeMask: 0}, {format: 'rg16float', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule34,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4032,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 2552, shaderLocation: 3},
+          {format: 'float32x4', offset: 1744, shaderLocation: 2},
+          {format: 'sint32x3', offset: 332, shaderLocation: 7},
+          {format: 'sint8x4', offset: 96, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 680,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 24, shaderLocation: 19},
+          {format: 'uint32x4', offset: 76, shaderLocation: 4},
+          {format: 'float16x4', offset: 48, shaderLocation: 6},
+          {format: 'uint8x4', offset: 40, shaderLocation: 24},
+          {format: 'unorm8x2', offset: 40, shaderLocation: 1},
+          {format: 'float32', offset: 112, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 4212,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 1008, shaderLocation: 23},
+          {format: 'sint16x4', offset: 24, shaderLocation: 12},
+          {format: 'float32', offset: 92, shaderLocation: 17},
+          {format: 'float32x4', offset: 196, shaderLocation: 9},
+        ],
+      },
+      {arrayStride: 1832, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 4760, shaderLocation: 21}],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+offscreenCanvas51.width = 1096;
+try {
+renderBundleEncoder79.setBindGroup(3, bindGroup27, []);
+} catch {}
+try {
+renderBundleEncoder54.setVertexBuffer(6, buffer30, 0, 55354);
+} catch {}
+let pipeline170 = await device2.createRenderPipelineAsync({
+  label: '\u07fb\u0ced\uda92\ud0ea\uc358',
+  layout: pipelineLayout16,
+  multisample: {count: 4, mask: 0x183da42e},
+  fragment: {
+  module: shaderModule30,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgba32float', writeMask: 0}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'src'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}, {format: 'rg32sint', writeMask: 0}, {format: 'rg8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule30,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 616,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 40, shaderLocation: 8},
+          {format: 'unorm8x2', offset: 2, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'front'},
+});
+gc();
+let gpuCanvasContext50 = offscreenCanvas51.getContext('webgpu');
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+let videoFrame50 = new VideoFrame(video37, {timestamp: 0});
+let commandBuffer58 = commandEncoder117.finish();
+let textureView239 = texture80.createView({dimension: '2d', baseArrayLayer: 56});
+let computePassEncoder91 = commandEncoder144.beginComputePass({label: '\u0bca\ube7f\u0b99'});
+let promise65 = device3.popErrorScope();
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+commandEncoder176.copyTextureToTexture({
+  texture: texture100,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 25},
+  aspect: 'all',
+},
+{
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 30},
+  aspect: 'all',
+},
+{width: 400, height: 0, depthOrArrayLayers: 4});
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 53, height: 1, depthOrArrayLayers: 949}
+*/
+{
+  source: canvas48,
+  origin: { x: 44, y: 14 },
+  flipY: false,
+}, {
+  texture: texture97,
+  mipLevel: 3,
+  origin: {x: 10, y: 0, z: 147},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas51 = document.createElement('canvas');
+let gpuCanvasContext51 = canvas51.getContext('webgpu');
+try {
+window.someLabel = device5.queue.label;
+} catch {}
+let textureView240 = texture120.createView({
+  label: '\u12a8\u{1fa65}\u3148\u056e\u0360\u{1f6c7}\ubb50\u{1fb22}\u0c87\u0674\u0c73',
+  dimension: '2d-array',
+  format: 'astc-12x10-unorm-srgb',
+  baseMipLevel: 4,
+});
+let externalTexture102 = device5.importExternalTexture({label: '\uf9a2\u{1fde4}\u7575\u0cde\ua635\u{1fc1d}\u3fc6', source: videoFrame15, colorSpace: 'srgb'});
+try {
+gpuCanvasContext35.unconfigure();
+} catch {}
+let offscreenCanvas52 = new OffscreenCanvas(309, 698);
+let shaderModule49 = device3.createShaderModule({
+  label: '\u{1fa94}\u{1ff3e}\ue20c\u0e58\u088f\ufa62\u39bc\u{1f775}\u0b3d\u10c1',
+  code: `@group(1) @binding(1081)
+var<storage, read_write> n29: array<u32>;
+@group(0) @binding(1136)
+var<storage, read_write> local45: array<u32>;
+@group(0) @binding(1093)
+var<storage, read_write> field43: array<u32>;
+@group(0) @binding(993)
+var<storage, read_write> field44: array<u32>;
+@group(1) @binding(848)
+var<storage, read_write> parameter31: array<u32>;
+
+@compute @workgroup_size(4, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: f32,
+  @location(0) f1: vec2<i32>,
+  @location(5) f2: vec4<u32>,
+  @location(2) f3: vec4<f32>,
+  @location(4) f4: vec3<i32>,
+  @location(3) f5: vec4<u32>,
+  @builtin(sample_mask) f6: u32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S45 {
+  @location(23) f0: vec2<u32>,
+  @location(5) f1: vec2<u32>,
+  @location(19) f2: vec2<f16>,
+  @location(20) f3: f32,
+  @location(7) f4: vec4<u32>,
+  @builtin(vertex_index) f5: u32,
+  @location(2) f6: f16,
+  @location(12) f7: f16,
+  @location(15) f8: vec4<f16>,
+  @location(18) f9: vec4<f16>,
+  @location(24) f10: vec4<i32>,
+  @location(6) f11: vec2<i32>,
+  @location(8) f12: f32,
+  @location(9) f13: vec3<f16>,
+  @location(4) f14: vec2<u32>,
+  @location(22) f15: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(21) a0: f16, @location(3) a1: vec4<f32>, @location(1) a2: f16, @location(10) a3: vec4<f16>, @builtin(instance_index) a4: u32, @location(11) a5: vec4<u32>, @location(14) a6: vec2<f16>, @location(16) a7: vec2<f32>, a8: S45, @location(0) a9: vec4<i32>, @location(13) a10: vec4<i32>, @location(17) a11: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup33 = device3.createBindGroup({
+  layout: bindGroupLayout54,
+  entries: [
+    {binding: 1081, resource: sampler83},
+    {binding: 848, resource: {buffer: buffer49, offset: 21504, size: 1900}},
+  ],
+});
+let texture122 = device3.createTexture({
+  label: '\u{1f80b}\u06ff\u{1febb}\u0bb5\u5ebe\u06ee\ufc53\u{1fe2b}\u0b04\ud20a',
+  size: [424, 1, 1],
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32sint', 'rg32sint', 'rg32sint'],
+});
+try {
+commandEncoder156.copyTextureToTexture({
+  texture: texture115,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 69},
+  aspect: 'all',
+},
+{
+  texture: texture115,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 87, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device3.queue.submit([]);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 424, height: 1, depthOrArrayLayers: 949}
+*/
+{
+  source: imageBitmap23,
+  origin: { x: 3, y: 0 },
+  flipY: false,
+}, {
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 36, y: 0, z: 63},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView241 = texture113.createView({
+  label: '\uc518\u{1ff7b}\u5251\ue4bf\u53d6\u6eee\u587c\u2e9a\u{1ff6b}\u5dd4',
+  baseMipLevel: 2,
+  baseArrayLayer: 0,
+});
+let renderBundle117 = renderBundleEncoder57.finish({label: '\u9860\u{1fbd0}\u0d08\u8d12\ubc63'});
+try {
+computePassEncoder64.setBindGroup(0, bindGroup32);
+} catch {}
+try {
+renderPassEncoder13.setStencilReference(1902);
+} catch {}
+try {
+  await buffer43.mapAsync(GPUMapMode.READ, 79736, 2932);
+} catch {}
+let pipeline171 = device4.createComputePipeline({
+  label: '\u07c3\u480f\u{1fd3b}\uf9cc\ufc34\u{1fde9}\u7760\u0d6d',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule40, entryPoint: 'compute0', constants: {}},
+});
+let offscreenCanvas53 = new OffscreenCanvas(619, 353);
+let img47 = await imageWithData(78, 161, '#76281e3f', '#4f658533');
+let commandEncoder207 = device3.createCommandEncoder({label: '\u0fe8\u{1fc14}\u019e\u054a\u0645'});
+let querySet112 = device3.createQuerySet({
+  label: '\u0bc5\u0c7f\u5887\ue251\u60c1\u{1fb52}\u30d9\u06d4\u0e50\u0b5a',
+  type: 'occlusion',
+  count: 353,
+});
+let texture123 = device3.createTexture({
+  size: {width: 104, height: 1, depthOrArrayLayers: 31},
+  mipLevelCount: 3,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView242 = texture86.createView({label: '\u05bd\u799c\u9ac9\u6ff4\u080e\u0288\ub268\u9c4e', format: 'rg16float', baseArrayLayer: 0});
+try {
+computePassEncoder74.setBindGroup(4, bindGroup33);
+} catch {}
+try {
+renderBundleEncoder89.setVertexBuffer(5368, undefined);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 424, height: 1, depthOrArrayLayers: 949}
+*/
+{
+  source: img1,
+  origin: { x: 1, y: 19 },
+  flipY: false,
+}, {
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 103, y: 0, z: 99},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise66 = device3.createRenderPipelineAsync({
+  layout: pipelineLayout29,
+  multisample: {count: 4, mask: 0xdaf9967c},
+  fragment: {
+  module: shaderModule43,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'add', srcFactor: 'dst-alpha', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: 0,
+}, {format: 'rg11b10ufloat', writeMask: 0}, {format: 'rg8sint'}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg32sint', writeMask: 0}, {
+  format: 'rgba16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one', dstFactor: 'src'},
+    alpha: {operation: 'subtract', srcFactor: 'one', dstFactor: 'constant'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'not-equal', failOp: 'zero', depthFailOp: 'replace', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'greater', depthFailOp: 'increment-clamp', passOp: 'decrement-wrap'},
+    stencilReadMask: 1899881447,
+    depthBias: 1214248670,
+  },
+  vertex: {
+    module: shaderModule43,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 7280,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 152, shaderLocation: 20},
+          {format: 'float32', offset: 1252, shaderLocation: 10},
+          {format: 'sint32x4', offset: 184, shaderLocation: 23},
+        ],
+      },
+      {
+        arrayStride: 1852,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 242, shaderLocation: 11},
+          {format: 'float32x2', offset: 220, shaderLocation: 17},
+          {format: 'float32', offset: 328, shaderLocation: 16},
+          {format: 'snorm8x4', offset: 1552, shaderLocation: 9},
+          {format: 'uint32x4', offset: 816, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 160, shaderLocation: 21},
+          {format: 'float16x2', offset: 516, shaderLocation: 4},
+          {format: 'unorm16x4', offset: 184, shaderLocation: 19},
+          {format: 'float16x2', offset: 436, shaderLocation: 8},
+          {format: 'float32x2', offset: 516, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 7620,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 316, shaderLocation: 15},
+          {format: 'float16x4', offset: 764, shaderLocation: 6},
+          {format: 'sint32', offset: 320, shaderLocation: 14},
+          {format: 'sint16x4', offset: 380, shaderLocation: 13},
+          {format: 'sint8x4', offset: 1932, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 5532,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 44, shaderLocation: 12},
+          {format: 'sint32', offset: 268, shaderLocation: 18},
+          {format: 'uint8x2', offset: 1002, shaderLocation: 7},
+          {format: 'float32x4', offset: 1368, shaderLocation: 22},
+        ],
+      },
+      {
+        arrayStride: 1668,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x4', offset: 496, shaderLocation: 3}],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 13228,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 3480, shaderLocation: 1},
+          {format: 'sint16x2', offset: 1552, shaderLocation: 24},
+        ],
+      },
+    ],
+  },
+});
+let buffer51 = device2.createBuffer({size: 11076, usage: GPUBufferUsage.COPY_DST, mappedAtCreation: true});
+let computePassEncoder92 = commandEncoder99.beginComputePass();
+let renderBundle118 = renderBundleEncoder54.finish();
+try {
+renderBundleEncoder65.setPipeline(pipeline105);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture64,
+  mipLevel: 7,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(new ArrayBuffer(56)), /* required buffer size: 327 */
+{offset: 327}, {width: 4, height: 0, depthOrArrayLayers: 1});
+} catch {}
+gc();
+let img48 = await imageWithData(36, 291, '#ba3c4e32', '#d0288cc6');
+let commandBuffer59 = commandEncoder112.finish({label: '\u9e46\u{1fa15}\u55fe\u0831\u01cd\u1e1d\u67cb'});
+let renderBundle119 = renderBundleEncoder73.finish({label: '\u0e9c\u45d4\u37f7\u{1f7c6}\u{1f8f2}\ud022\u{1f7b1}\u0de3'});
+try {
+renderBundleEncoder65.setPipeline(pipeline105);
+} catch {}
+try {
+renderBundleEncoder79.setVertexBuffer(6, buffer40, 172);
+} catch {}
+try {
+commandEncoder162.copyBufferToTexture({
+  /* bytesInLastRow: 8888 widthInBlocks: 1111 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 5536 */
+  offset: 5536,
+  buffer: buffer30,
+}, {
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1111, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer30);
+} catch {}
+try {
+commandEncoder153.clearBuffer(buffer40, 6296, 8672);
+dissociateBuffer(device2, buffer40);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device2.queue.writeBuffer(buffer40, 4692, new Float32Array(18649), 7658, 228);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 19, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img17,
+  origin: { x: 44, y: 4 },
+  flipY: true,
+}, {
+  texture: texture105,
+  mipLevel: 6,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline172 = device2.createRenderPipeline({
+  label: '\u067b\u{1fe56}\uc715\u0cd4\u{1f748}\u90fa\u0689\u005c',
+  layout: 'auto',
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule30,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'src'},
+  },
+  writeMask: 0,
+}, {format: 'rgba32float', writeMask: 0}, {format: 'rgba8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rg32sint'}, {
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'src'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule30,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 3716,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 1318, shaderLocation: 8}],
+      },
+      {
+        arrayStride: 2216,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 448, shaderLocation: 3}],
+      },
+    ],
+  },
+});
+let offscreenCanvas54 = new OffscreenCanvas(67, 801);
+let bindGroup34 = device3.createBindGroup({layout: bindGroupLayout56, entries: []});
+let commandEncoder208 = device3.createCommandEncoder({label: '\u{1fe48}\ucf00\u6903\ude8b\ub995\u{1f6cb}\u7835'});
+let texture124 = device3.createTexture({
+  label: '\u8a35\u{1fa19}\ud3fc\u0374\uadc5\u071b',
+  size: [9868, 4, 1],
+  mipLevelCount: 9,
+  format: 'eac-rg11snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder84.setBindGroup(4, bindGroup33);
+} catch {}
+try {
+renderBundleEncoder70.setPipeline(pipeline123);
+} catch {}
+try {
+buffer46.unmap();
+} catch {}
+let video64 = await videoWithData();
+try {
+offscreenCanvas52.getContext('webgpu');
+} catch {}
+let canvas52 = document.createElement('canvas');
+try {
+offscreenCanvas53.getContext('webgl');
+} catch {}
+let videoFrame51 = new VideoFrame(img14, {timestamp: 0});
+let renderBundle120 = renderBundleEncoder63.finish();
+try {
+renderBundleEncoder86.setPipeline(pipeline92);
+} catch {}
+try {
+renderBundleEncoder55.setVertexBuffer(5, buffer30, 70480, 715);
+} catch {}
+try {
+commandEncoder151.copyBufferToBuffer(buffer40, 10284, buffer41, 344, 1428);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder142.clearBuffer(buffer51);
+dissociateBuffer(device2, buffer51);
+} catch {}
+try {
+offscreenCanvas54.getContext('bitmaprenderer');
+} catch {}
+let bindGroupLayout66 = device3.createBindGroupLayout({
+  entries: [
+    {
+      binding: 901,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let commandEncoder209 = device3.createCommandEncoder({});
+let computePassEncoder93 = commandEncoder183.beginComputePass({label: '\ud508\u{1fb56}\u6583\u{1faab}\u7618\u00ad\uba42\u{1f794}\u{1fff1}'});
+try {
+renderBundleEncoder75.setBindGroup(1, bindGroup34);
+} catch {}
+try {
+renderBundleEncoder75.setVertexBuffer(6763, undefined, 3291605687, 169003484);
+} catch {}
+try {
+canvas52.getContext('webgl2');
+} catch {}
+let bindGroup35 = device1.createBindGroup({layout: bindGroupLayout30, entries: [{binding: 4495, resource: sampler44}]});
+let textureView243 = texture65.createView({label: '\u88c1\u4899\u063a\ua79a\u0418', baseMipLevel: 0, baseArrayLayer: 0});
+let renderBundle121 = renderBundleEncoder39.finish({label: '\u0067\ua53f\u45f4\u1690\u2735\u0f6a\u55bb\u9e9d\u0100'});
+try {
+computePassEncoder42.setPipeline(pipeline82);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(9, bindGroup26);
+} catch {}
+let imageBitmap48 = await createImageBitmap(imageData31);
+try {
+  await promise64;
+} catch {}
+let shaderModule50 = device4.createShaderModule({
+  label: '\u037a\u9c19\u08c2\u09a6\u9604\u01d9\u09d8',
+  code: `@group(2) @binding(509)
+var<storage, read_write> function36: array<u32>;
+@group(2) @binding(512)
+var<storage, read_write> parameter32: array<u32>;
+@group(0) @binding(875)
+var<storage, read_write> global37: array<u32>;
+@group(1) @binding(509)
+var<storage, read_write> global38: array<u32>;
+@group(3) @binding(210)
+var<storage, read_write> function37: array<u32>;
+@group(3) @binding(659)
+var<storage, read_write> type38: array<u32>;
+@group(0) @binding(1173)
+var<storage, read_write> type39: array<u32>;
+@group(3) @binding(62)
+var<storage, read_write> n30: array<u32>;
+
+@compute @workgroup_size(8, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(6) f0: vec2<i32>,
+  @location(3) f1: vec4<i32>,
+  @location(4) f2: vec4<f32>,
+  @location(5) f3: vec4<u32>,
+  @location(2) f4: vec3<f32>,
+  @location(1) f5: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(position) a1: vec4<f32>, @builtin(sample_mask) a2: u32, @builtin(sample_index) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(1) a0: vec3<u32>, @location(4) a1: vec4<f32>, @location(16) a2: vec3<u32>, @location(9) a3: vec3<f32>, @builtin(instance_index) a4: u32, @location(2) a5: vec4<f16>, @location(14) a6: vec3<i32>, @location(3) a7: u32, @builtin(vertex_index) a8: u32, @location(0) a9: vec2<u32>, @location(11) a10: i32, @location(5) a11: u32, @location(10) a12: f32, @location(8) a13: vec2<f32>, @location(6) a14: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView244 = texture111.createView({
+  label: '\u5ec3\u{1fd33}\u1047\u4829\u26df\u{1fb5e}',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 418,
+  arrayLayerCount: 1,
+});
+try {
+computePassEncoder73.setPipeline(pipeline126);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: 547.6, g: 242.1, b: -942.8, a: -161.4, });
+} catch {}
+try {
+renderPassEncoder15.setStencilReference(2150);
+} catch {}
+try {
+renderBundleEncoder83.draw(14, 42);
+} catch {}
+try {
+renderBundleEncoder83.drawIndexed(265, 376, 974_064_674, 1_133_706_945, 1_578_054_865);
+} catch {}
+try {
+renderBundleEncoder83.drawIndexedIndirect(buffer45, 43272);
+} catch {}
+try {
+commandEncoder190.clearBuffer(buffer32);
+dissociateBuffer(device4, buffer32);
+} catch {}
+try {
+computePassEncoder64.insertDebugMarker('\u0e48');
+} catch {}
+let offscreenCanvas55 = new OffscreenCanvas(271, 984);
+try {
+offscreenCanvas55.getContext('bitmaprenderer');
+} catch {}
+let shaderModule51 = device3.createShaderModule({
+  label: '\u{1fc09}\u6717\u624d\u0d83\u5c75\u5a36\u07c2\ucfd7\u{1fff1}\u67d2',
+  code: `@group(1) @binding(586)
+var<storage, read_write> n31: array<u32>;
+@group(0) @binding(990)
+var<storage, read_write> type40: array<u32>;
+@group(0) @binding(110)
+var<storage, read_write> parameter33: array<u32>;
+@group(2) @binding(110)
+var<storage, read_write> parameter34: array<u32>;
+@group(0) @binding(586)
+var<storage, read_write> local46: array<u32>;
+@group(2) @binding(586)
+var<storage, read_write> local47: array<u32>;
+@group(2) @binding(990)
+var<storage, read_write> type41: array<u32>;
+@group(1) @binding(110)
+var<storage, read_write> global39: array<u32>;
+
+@compute @workgroup_size(8, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(1) f1: vec4<f32>,
+  @location(3) f2: vec4<u32>,
+  @location(5) f3: vec4<u32>,
+  @location(2) f4: vec4<f32>,
+  @location(4) f5: vec2<i32>,
+  @location(0) f6: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(sample_index) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(20) a0: vec3<u32>, @location(7) a1: u32, @location(11) a2: vec4<f32>, @location(5) a3: vec2<i32>, @location(21) a4: vec4<i32>, @location(6) a5: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout67 = pipeline129.getBindGroupLayout(2);
+let commandEncoder210 = device3.createCommandEncoder({label: '\ue2cd\ub920\u{1fd0b}\u020f\u{1ffd0}\u{1f895}\ub1ca\uac77\u{1fda9}'});
+let renderBundleEncoder94 = device3.createRenderBundleEncoder({
+  colorFormats: ['rg16sint', 'r8unorm', 'rgb10a2unorm', 'rg16uint', 'rg32sint', 'rgb10a2uint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture103 = device3.importExternalTexture({label: '\u07fb\u{1feb3}\u5853\ud5fb', source: videoFrame34});
+let pipeline173 = device3.createRenderPipeline({
+  label: '\u2ed8\u01d8\u1f7d\ue466\u3ab6\u09e6\u0f8d\uc4b5\u5d81\u09e8\u0b48',
+  layout: pipelineLayout29,
+  fragment: {
+  module: shaderModule32,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8unorm', writeMask: 0}, {format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'one', dstFactor: 'src-alpha'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'one-minus-src-alpha'},
+  },
+}, {
+  format: 'rg11b10ufloat',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'r16float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'less', failOp: 'zero', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'equal', failOp: 'replace', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilReadMask: 3537549096,
+    stencilWriteMask: 2359224129,
+    depthBiasClamp: 699.5711214248275,
+  },
+  vertex: {
+    module: shaderModule32,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1736,
+        attributes: [
+          {format: 'sint16x2', offset: 1108, shaderLocation: 17},
+          {format: 'sint32x4', offset: 120, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 7804, attributes: [{format: 'uint8x2', offset: 696, shaderLocation: 18}]},
+      {
+        arrayStride: 64,
+        attributes: [
+          {format: 'snorm8x2', offset: 6, shaderLocation: 23},
+          {format: 'snorm8x2', offset: 4, shaderLocation: 7},
+          {format: 'uint16x2', offset: 24, shaderLocation: 22},
+          {format: 'uint32x3', offset: 0, shaderLocation: 24},
+          {format: 'uint32x3', offset: 24, shaderLocation: 2},
+          {format: 'uint32x4', offset: 0, shaderLocation: 6},
+          {format: 'uint16x4', offset: 0, shaderLocation: 16},
+          {format: 'float32x4', offset: 4, shaderLocation: 14},
+          {format: 'float32x3', offset: 0, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+});
+gc();
+let canvas53 = document.createElement('canvas');
+let querySet113 = device5.createQuerySet({label: '\u2074\u0bad\u{1fdab}\ubbff\u9ab5\u{1f93b}\u755d', type: 'occlusion', count: 799});
+let texture125 = device5.createTexture({
+  size: [192, 1, 13],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg16sint', 'rg16sint', 'rg16sint'],
+});
+let textureView245 = texture120.createView({
+  label: '\u887e\uf78f\ucc83\uac29\u1343\uef57\u0825\u0975\u093a\u51ec\u1b5e',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+});
+let canvas54 = document.createElement('canvas');
+let bindGroupLayout68 = pipeline165.getBindGroupLayout(0);
+let commandBuffer60 = commandEncoder194.finish();
+try {
+renderPassEncoder14.executeBundles([renderBundle106, renderBundle61, renderBundle61]);
+} catch {}
+try {
+renderPassEncoder14.setScissorRect(211, 106, 60, 10);
+} catch {}
+try {
+renderPassEncoder15.setViewport(242.5, 144.7, 123.7, 19.06, 0.6408, 0.7769);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(1, buffer38, 0, 459342);
+} catch {}
+try {
+renderBundleEncoder83.draw(177, 38, 160_183_078);
+} catch {}
+try {
+commandEncoder116.copyBufferToBuffer(buffer50, 92400, buffer44, 37084, 33080);
+dissociateBuffer(device4, buffer50);
+dissociateBuffer(device4, buffer44);
+} catch {}
+try {
+commandEncoder116.copyTextureToBuffer({
+  texture: texture112,
+  mipLevel: 4,
+  origin: {x: 18, y: 2, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4100 */
+  offset: 4100,
+  bytesPerRow: 0,
+  rowsPerImage: 292,
+  buffer: buffer35,
+}, {width: 0, height: 10, depthOrArrayLayers: 85});
+dissociateBuffer(device4, buffer35);
+} catch {}
+let gpuCanvasContext52 = canvas53.getContext('webgpu');
+let promise67 = adapter6.requestAdapterInfo();
+let bindGroupLayout69 = device2.createBindGroupLayout({
+  entries: [
+    {
+      binding: 12,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+  ],
+});
+let commandEncoder211 = device2.createCommandEncoder({});
+let querySet114 = device2.createQuerySet({
+  label: '\u89d2\u0886\u45a7\u4567\u{1fb90}\ub665\u{1fef9}\ud97e\uc1a0\u{1f9a0}\u0e46',
+  type: 'occlusion',
+  count: 3141,
+});
+let textureView246 = texture96.createView({
+  label: '\u564e\u{1f6ee}\u3f0c\u036e\u06d6\u{1f672}\u6200\ufb67\u2296\u9943\u03b8',
+  arrayLayerCount: 1,
+});
+let computePassEncoder94 = commandEncoder199.beginComputePass({});
+try {
+device2.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder182.clearBuffer(buffer40, 15184, 608);
+dissociateBuffer(device2, buffer40);
+} catch {}
+let video65 = await videoWithData();
+let commandEncoder212 = device4.createCommandEncoder({label: '\ub921\u5923\ufb1a\u0f88\u4ca9\u020c\ucc6f\u4c02\u9b4e\u{1f744}'});
+let querySet115 = device4.createQuerySet({label: '\u075b\u082e', type: 'occlusion', count: 3167});
+let renderBundleEncoder95 = device4.createRenderBundleEncoder({
+  label: '\u{1f667}\u{1fc6b}\u{1ff31}\u9740\u06dd\u9edb\u0c81\u{1fa41}\ub467\u{1fb8f}\ue85b',
+  colorFormats: [undefined, 'r32sint', 'rg16float', 'rgba16sint', 'rgba8unorm', 'rgb10a2uint', 'rg32sint'],
+  stencilReadOnly: true,
+});
+let renderBundle122 = renderBundleEncoder95.finish({label: '\ue725\u00e8\u0e09'});
+try {
+renderPassEncoder13.setBindGroup(4, bindGroup32);
+} catch {}
+try {
+renderPassEncoder15.setStencilReference(2597);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer37, 'uint32', 94476, 8668);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline153);
+} catch {}
+try {
+renderBundleEncoder83.drawIndirect(buffer45, 99684);
+} catch {}
+try {
+commandEncoder212.clearBuffer(buffer32);
+dissociateBuffer(device4, buffer32);
+} catch {}
+try {
+device4.queue.writeTexture({
+  texture: texture112,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(16)), /* required buffer size: 570_864 */
+{offset: 654, bytesPerRow: 229, rowsPerImage: 249}, {width: 16, height: 0, depthOrArrayLayers: 11});
+} catch {}
+let bindGroupLayout70 = device4.createBindGroupLayout({
+  entries: [
+    {
+      binding: 948,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 788,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let renderPassEncoder16 = commandEncoder190.beginRenderPass({
+  label: '\u4e17\u6580\u9f5b\u07e0\u0ae3\ubca0\u0f52\u0399\u046c',
+  colorAttachments: [{
+  view: textureView225,
+  clearValue: { r: 367.1, g: 10.46, b: 629.5, a: 274.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet77,
+  maxDrawCount: 71522722,
+});
+try {
+renderPassEncoder15.setBindGroup(4, bindGroup32, new Uint32Array(868), 574, 0);
+} catch {}
+try {
+renderPassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(198);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle57, renderBundle62, renderBundle64, renderBundle77, renderBundle71, renderBundle62, renderBundle87, renderBundle86, renderBundle73]);
+} catch {}
+try {
+renderPassEncoder13.setViewport(151.2, 162.5, 369.5, 71.56, 0.6428, 0.7561);
+} catch {}
+try {
+renderPassEncoder15.drawIndirect(buffer37, 2_139_490_233);
+} catch {}
+try {
+renderBundleEncoder83.drawIndexed(524);
+} catch {}
+try {
+renderBundleEncoder83.setIndexBuffer(buffer37, 'uint16', 91572);
+} catch {}
+try {
+renderBundleEncoder83.setVertexBuffer(2, buffer38, 92192, 177714);
+} catch {}
+try {
+commandEncoder127.copyBufferToBuffer(buffer50, 253744, buffer35, 147924, 5600);
+dissociateBuffer(device4, buffer50);
+dissociateBuffer(device4, buffer35);
+} catch {}
+try {
+commandEncoder116.clearBuffer(buffer31);
+dissociateBuffer(device4, buffer31);
+} catch {}
+let pipeline174 = device4.createComputePipeline({
+  label: '\u02c3\u4c22\u{1fe3c}\u6fe8\u{1f984}',
+  layout: pipelineLayout26,
+  compute: {module: shaderModule50, entryPoint: 'compute0', constants: {}},
+});
+try {
+if (!arrayBuffer11.detached) { new Uint8Array(arrayBuffer11).fill(0x55) };
+} catch {}
+try {
+adapter1.label = '\u7f75\u67a3\u0210\ub50e\u9bdd\u2265\u0064';
+} catch {}
+let textureView247 = texture120.createView({dimension: '2d-array', baseMipLevel: 0, mipLevelCount: 2});
+let computePassEncoder95 = commandEncoder205.beginComputePass();
+let renderBundleEncoder96 = device5.createRenderBundleEncoder({
+  label: '\ufa7f\u{1facf}\u06b1\uf218\u1c45\u818c',
+  colorFormats: ['r32uint', 'rg16sint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+let shaderModule52 = device3.createShaderModule({
+  code: `@group(0) @binding(586)
+var<storage, read_write> global40: array<u32>;
+@group(1) @binding(1093)
+var<storage, read_write> field45: array<u32>;
+@group(0) @binding(990)
+var<storage, read_write> field46: array<u32>;
+@group(1) @binding(993)
+var<storage, read_write> parameter35: array<u32>;
+@group(1) @binding(1136)
+var<storage, read_write> function38: array<u32>;
+
+@compute @workgroup_size(2, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec3<i32>,
+  @location(0) f1: vec4<i32>,
+  @location(2) f2: vec4<f32>,
+  @location(5) f3: vec4<u32>,
+  @location(1) f4: vec3<f32>,
+  @location(3) f5: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(sample_index) a1: u32, @builtin(front_facing) a2: bool, @builtin(position) a3: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S46 {
+  @location(13) f0: vec2<i32>,
+  @location(8) f1: vec3<u32>,
+  @location(15) f2: vec2<u32>,
+  @location(6) f3: vec2<i32>,
+  @location(1) f4: i32,
+  @location(7) f5: u32,
+  @location(9) f6: vec2<f16>,
+  @location(3) f7: vec3<i32>,
+  @location(18) f8: vec4<f32>,
+  @location(14) f9: f16,
+  @location(5) f10: u32,
+  @location(19) f11: f16
+}
+
+@vertex
+fn vertex0(@location(22) a0: vec4<f32>, @location(12) a1: vec2<u32>, @location(4) a2: u32, @location(16) a3: vec3<f32>, a4: S46, @location(11) a5: vec4<u32>, @location(10) a6: vec4<u32>, @location(2) a7: vec2<u32>, @location(20) a8: vec3<f32>, @location(21) a9: f16, @builtin(instance_index) a10: u32, @builtin(vertex_index) a11: u32, @location(17) a12: i32, @location(24) a13: vec4<u32>, @location(0) a14: vec4<f32>, @location(23) a15: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout71 = device3.createBindGroupLayout({
+  label: '\u0016\u08e1\u{1f87d}\u918c\u{1fac0}',
+  entries: [
+    {
+      binding: 273,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let textureView248 = texture119.createView({label: '\ucdab\u0fc1\u{1f771}', baseArrayLayer: 0});
+let computePassEncoder96 = commandEncoder203.beginComputePass({});
+let sampler104 = device3.createSampler({
+  label: '\u0216\u412f\u9685\u03f5\u406f\ue6dc\u3b88\u7872',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  lodMinClamp: 87.44,
+  lodMaxClamp: 89.52,
+});
+let externalTexture104 = device3.importExternalTexture({label: '\u01ee\u0cd4\ude75\u{1f96f}', source: videoFrame27, colorSpace: 'srgb'});
+try {
+computePassEncoder84.setBindGroup(6, bindGroup34, new Uint32Array(1185), 72, 0);
+} catch {}
+try {
+renderBundleEncoder70.setPipeline(pipeline111);
+} catch {}
+try {
+renderBundleEncoder94.setVertexBuffer(8043, undefined, 4188334033, 77296776);
+} catch {}
+try {
+  await promise63;
+} catch {}
+let img49 = await imageWithData(18, 165, '#9fecf92d', '#8c315710');
+let commandEncoder213 = device4.createCommandEncoder({label: '\uc09c\u{1faae}\u4b6d\u5ed0\u01a5\u4c31'});
+let texture126 = device4.createTexture({
+  label: '\udc08\u{1f715}\u{1ffea}\u670e\u04ba\u58ae\uc447\u{1fe9b}\ufaa9\u0bf6\u19e7',
+  size: {width: 576, height: 240, depthOrArrayLayers: 479},
+  mipLevelCount: 6,
+  format: 'astc-6x6-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView249 = texture72.createView({
+  label: '\u6ff2\u{1f8d3}\u9a67\u0473\u78fe\u0ee3\u7bdf\u{1fa6f}\u2f41\uc406\u0371',
+  dimension: '2d',
+  baseArrayLayer: 367,
+});
+let renderBundleEncoder97 = device4.createRenderBundleEncoder({
+  label: '\u{1fea0}\u2d7f\ubdee\u{1fd6b}\ue8c2\u68d2',
+  colorFormats: ['r32sint', 'rg16float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle123 = renderBundleEncoder61.finish({label: '\u53a8\ue101\u2c08\u12e7\u0562\u0e38\u{1f844}\u002a\u{1f7e0}'});
+let sampler105 = device4.createSampler({
+  label: '\u1b4d\u064b\u07a9',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 45.70,
+  maxAnisotropy: 19,
+});
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle64, renderBundle106, renderBundle77, renderBundle87, renderBundle64]);
+} catch {}
+try {
+renderPassEncoder15.drawIndexed(77, 48, 438_898_316);
+} catch {}
+try {
+renderPassEncoder15.drawIndexedIndirect(buffer37, 185_446_108);
+} catch {}
+try {
+commandEncoder213.clearBuffer(buffer32, 1180, 149348);
+dissociateBuffer(device4, buffer32);
+} catch {}
+let imageData49 = new ImageData(84, 108);
+let commandEncoder214 = device2.createCommandEncoder({label: '\u89cf\u0176\u79b6\u1cc8'});
+let textureView250 = texture63.createView({label: '\u22e8\ua7a5\u8160\ue4a1\uf64c\u5cfc\u{1f82b}\uf0c9', aspect: 'all', baseMipLevel: 2});
+let renderBundle124 = renderBundleEncoder91.finish({label: '\u9607\u687e'});
+try {
+computePassEncoder63.setPipeline(pipeline143);
+} catch {}
+let offscreenCanvas56 = new OffscreenCanvas(332, 446);
+gc();
+let pipelineLayout30 = device3.createPipelineLayout({
+  label: '\u1c8c\uba3c\u03ab\u04f6\u60b1\u0715\u{1ff76}',
+  bindGroupLayouts: [bindGroupLayout52, bindGroupLayout49, bindGroupLayout42, bindGroupLayout66, bindGroupLayout49, bindGroupLayout49],
+});
+let commandEncoder215 = device3.createCommandEncoder({label: '\u013f\u5aac\u{1ffa3}\uc304\u04c4\u{1fe51}\u2007\uc65f\udc45'});
+let computePassEncoder97 = commandEncoder197.beginComputePass();
+try {
+computePassEncoder88.setBindGroup(3, bindGroup33, new Uint32Array(2708), 611, 0);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture122,
+  mipLevel: 0,
+  origin: {x: 42, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer2), /* required buffer size: 852 */
+{offset: 852}, {width: 97, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline175 = await promise66;
+let canvas55 = document.createElement('canvas');
+let shaderModule53 = device3.createShaderModule({
+  label: '\uecb5\u649a',
+  code: `@group(1) @binding(993)
+var<storage, read_write> global41: array<u32>;
+@group(0) @binding(586)
+var<storage, read_write> type42: array<u32>;
+@group(1) @binding(1093)
+var<storage, read_write> function39: array<u32>;
+@group(0) @binding(990)
+var<storage, read_write> field47: array<u32>;
+@group(0) @binding(110)
+var<storage, read_write> n32: array<u32>;
+
+@compute @workgroup_size(8, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S48 {
+  @location(7) f0: u32,
+  @builtin(position) f1: vec4<f32>,
+  @location(23) f2: vec4<u32>,
+  @location(45) f3: f32,
+  @location(25) f4: i32,
+  @builtin(sample_index) f5: u32,
+  @location(37) f6: vec3<f16>,
+  @location(16) f7: vec2<f16>,
+  @location(47) f8: vec4<f16>,
+  @location(3) f9: vec3<f16>,
+  @location(20) f10: f16,
+  @location(4) f11: vec4<i32>,
+  @location(18) f12: vec2<f32>,
+  @location(34) f13: vec3<f32>
+}
+struct FragmentOutput0 {
+  @location(5) f0: vec4<u32>,
+  @location(4) f1: vec2<i32>,
+  @location(2) f2: vec4<f32>,
+  @location(3) f3: vec4<u32>,
+  @location(1) f4: vec2<f32>,
+  @location(0) f5: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(0) a0: f32, @location(44) a1: vec2<f32>, @location(42) a2: vec4<f16>, @location(40) a3: vec3<f32>, @location(22) a4: i32, @location(15) a5: vec4<i32>, @builtin(sample_mask) a6: u32, a7: S48, @location(36) a8: vec2<f16>, @location(17) a9: vec4<i32>, @location(31) a10: vec4<u32>, @location(24) a11: vec3<f32>, @location(21) a12: f32, @location(28) a13: vec4<f16>, @location(41) a14: vec3<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S47 {
+  @location(22) f0: vec3<f16>,
+  @location(5) f1: u32,
+  @location(8) f2: vec2<i32>,
+  @location(15) f3: vec4<f16>
+}
+struct VertexOutput0 {
+  @location(47) f524: vec4<f16>,
+  @location(25) f525: i32,
+  @location(4) f526: vec4<i32>,
+  @location(24) f527: vec3<f32>,
+  @location(37) f528: vec3<f16>,
+  @location(41) f529: vec3<u32>,
+  @location(40) f530: vec3<f32>,
+  @location(23) f531: vec4<u32>,
+  @location(7) f532: u32,
+  @location(3) f533: vec3<f16>,
+  @location(45) f534: f32,
+  @location(18) f535: vec2<f32>,
+  @location(31) f536: vec4<u32>,
+  @location(15) f537: vec4<i32>,
+  @location(27) f538: vec2<f16>,
+  @location(21) f539: f32,
+  @location(17) f540: vec4<i32>,
+  @location(42) f541: vec4<f16>,
+  @location(44) f542: vec2<f32>,
+  @location(34) f543: vec3<f32>,
+  @location(22) f544: i32,
+  @builtin(position) f545: vec4<f32>,
+  @location(0) f546: f32,
+  @location(36) f547: vec2<f16>,
+  @location(20) f548: f16,
+  @location(16) f549: vec2<f16>,
+  @location(28) f550: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(19) a0: vec4<f32>, @location(21) a1: f16, @location(10) a2: vec4<f16>, @location(17) a3: vec3<f32>, @location(9) a4: u32, @location(4) a5: vec4<i32>, @location(12) a6: vec3<u32>, a7: S47, @location(7) a8: f32, @location(13) a9: vec4<f16>, @location(3) a10: vec3<f32>, @location(1) a11: vec2<f32>, @location(14) a12: vec3<i32>, @location(24) a13: vec4<f16>, @location(11) a14: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandBuffer61 = commandEncoder149.finish({label: '\ub921\u00fc\u{1fb3b}\u0ab6\u0cd8\u8640\ud203\u{1fce9}\u04aa\u586e'});
+try {
+device3.queue.writeTexture({
+  texture: texture122,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 193 */
+{offset: 193}, {width: 405, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline176 = device3.createRenderPipeline({
+  label: '\u38d9\u6cd0\u{1f9b8}\uda60\u0f80\u7bdc\u0529',
+  layout: pipelineLayout19,
+  fragment: {
+  module: shaderModule43,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'one-minus-constant'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rg11b10ufloat', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r8sint', writeMask: GPUColorWrite.ALPHA}, {format: 'rg32sint'}, {format: 'rgba16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rg16float'}],
+},
+  vertex: {
+    module: shaderModule43,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1436,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x2', offset: 254, shaderLocation: 12},
+          {format: 'sint16x4', offset: 248, shaderLocation: 18},
+          {format: 'unorm16x2', offset: 160, shaderLocation: 9},
+          {format: 'uint32', offset: 16, shaderLocation: 5},
+          {format: 'float32x3', offset: 72, shaderLocation: 11},
+          {format: 'float32x2', offset: 564, shaderLocation: 22},
+          {format: 'unorm8x4', offset: 372, shaderLocation: 15},
+          {format: 'sint32x4', offset: 60, shaderLocation: 24},
+          {format: 'float32', offset: 492, shaderLocation: 4},
+          {format: 'float16x2', offset: 0, shaderLocation: 6},
+          {format: 'uint16x2', offset: 188, shaderLocation: 7},
+          {format: 'snorm16x4', offset: 144, shaderLocation: 8},
+          {format: 'uint16x4', offset: 208, shaderLocation: 3},
+          {format: 'unorm10-10-10-2', offset: 304, shaderLocation: 0},
+          {format: 'sint32', offset: 1040, shaderLocation: 23},
+          {format: 'sint8x2', offset: 22, shaderLocation: 14},
+          {format: 'float32x2', offset: 236, shaderLocation: 1},
+          {format: 'float32', offset: 192, shaderLocation: 20},
+          {format: 'float32x3', offset: 84, shaderLocation: 16},
+          {format: 'snorm8x2', offset: 70, shaderLocation: 17},
+          {format: 'sint32', offset: 88, shaderLocation: 13},
+          {format: 'sint8x2', offset: 198, shaderLocation: 2},
+          {format: 'float16x2', offset: 452, shaderLocation: 19},
+          {format: 'float32', offset: 192, shaderLocation: 21},
+          {format: 'unorm10-10-10-2', offset: 368, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+});
+let querySet116 = device2.createQuerySet({label: '\u1f12\u{1fb13}\u0b84', type: 'occlusion', count: 1028});
+let renderBundleEncoder98 = device2.createRenderBundleEncoder({
+  label: '\u3e69\u{1fb60}\u6c34\u0201\u0ac5\u{1f813}\u{1f853}\u6079',
+  colorFormats: ['rgba8unorm-srgb'],
+  sampleCount: 4,
+});
+try {
+commandEncoder163.clearBuffer(buffer51);
+dissociateBuffer(device2, buffer51);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer41, 180, new BigUint64Array(29785), 22256, 16);
+} catch {}
+let pipeline177 = device2.createRenderPipeline({
+  label: '\u84c1\u2210\u5a21\u17e5\u0280\u{1f63e}\u0e03\u405d',
+  layout: pipelineLayout17,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule31,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgba32float', writeMask: 0}, {format: 'rgba8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rg32sint', writeMask: 0}, {format: 'rg8unorm'}],
+},
+  vertex: {
+    module: shaderModule31,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 5460,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 2740, shaderLocation: 0},
+          {format: 'sint16x2', offset: 188, shaderLocation: 14},
+          {format: 'sint16x4', offset: 152, shaderLocation: 3},
+          {format: 'uint32', offset: 1224, shaderLocation: 13},
+          {format: 'unorm16x2', offset: 716, shaderLocation: 10},
+          {format: 'sint16x4', offset: 172, shaderLocation: 17},
+          {format: 'float16x4', offset: 1676, shaderLocation: 16},
+          {format: 'snorm16x2', offset: 816, shaderLocation: 5},
+          {format: 'sint16x2', offset: 88, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 2488, attributes: [{format: 'sint8x4', offset: 152, shaderLocation: 9}]},
+      {
+        arrayStride: 13280,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x4', offset: 1556, shaderLocation: 15}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'ccw', cullMode: 'back'},
+});
+let pipelineLayout31 = device2.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout53, bindGroupLayout35, bindGroupLayout41, bindGroupLayout36, bindGroupLayout62],
+});
+let texture127 = device2.createTexture({
+  label: '\u{1ff22}\u05b8\u0438\u04fe\u3105\u{1fc70}\u4088',
+  size: [1256],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderBundle125 = renderBundleEncoder82.finish({label: '\u560b\u0583\u5fcd\u0f50\u0de6\u42fd\u1ab5\u0701'});
+let externalTexture105 = device2.importExternalTexture({label: '\u43bc\u3b65', source: videoFrame16, colorSpace: 'display-p3'});
+try {
+  await device2.popErrorScope();
+} catch {}
+try {
+device2.queue.writeBuffer(buffer40, 52, new Int16Array(44670), 22095, 2068);
+} catch {}
+document.body.prepend(video49);
+let img50 = await imageWithData(114, 210, '#577a2794', '#70e19c65');
+try {
+canvas54.getContext('2d');
+} catch {}
+try {
+window.someLabel = device4.queue.label;
+} catch {}
+let shaderModule54 = device4.createShaderModule({
+  label: '\u00dd\ue13b\ud0f0\u525c\uc7e2\u0eb6\u0b0e\ud7f9\u7168',
+  code: `@group(0) @binding(1173)
+var<storage, read_write> type43: array<u32>;
+@group(3) @binding(659)
+var<storage, read_write> type44: array<u32>;
+@group(1) @binding(509)
+var<storage, read_write> field48: array<u32>;
+@group(3) @binding(62)
+var<storage, read_write> function40: array<u32>;
+@group(2) @binding(512)
+var<storage, read_write> n33: array<u32>;
+@group(0) @binding(875)
+var<storage, read_write> parameter36: array<u32>;
+@group(3) @binding(210)
+var<storage, read_write> local48: array<u32>;
+@group(2) @binding(509)
+var<storage, read_write> type45: array<u32>;
+
+@compute @workgroup_size(7, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S50 {
+  @location(39) f0: vec3<f32>,
+  @builtin(sample_mask) f1: u32,
+  @builtin(front_facing) f2: bool
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(0) f1: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(10) a0: vec4<i32>, @location(2) a1: vec4<u32>, @location(6) a2: f32, @location(1) a3: u32, @builtin(position) a4: vec4<f32>, @location(9) a5: vec3<i32>, @location(22) a6: vec3<f16>, @location(24) a7: vec4<f32>, @location(43) a8: vec2<u32>, @location(27) a9: vec3<i32>, @location(13) a10: vec3<i32>, @location(0) a11: i32, @location(5) a12: vec3<i32>, @location(42) a13: vec3<f16>, a14: S50, @builtin(sample_index) a15: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S49 {
+  @location(8) f0: i32,
+  @location(12) f1: f32,
+  @location(13) f2: f32,
+  @location(9) f3: vec4<i32>,
+  @builtin(vertex_index) f4: u32,
+  @location(2) f5: vec4<i32>
+}
+struct VertexOutput0 {
+  @location(39) f551: vec3<f32>,
+  @location(22) f552: vec3<f16>,
+  @location(0) f553: i32,
+  @location(43) f554: vec2<u32>,
+  @location(27) f555: vec3<i32>,
+  @location(6) f556: f32,
+  @location(42) f557: vec3<f16>,
+  @location(9) f558: vec3<i32>,
+  @location(10) f559: vec4<i32>,
+  @builtin(position) f560: vec4<f32>,
+  @location(2) f561: vec4<u32>,
+  @location(1) f562: u32,
+  @location(13) f563: vec3<i32>,
+  @location(5) f564: vec3<i32>,
+  @location(24) f565: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(4) a0: vec4<u32>, @location(6) a1: vec4<u32>, @location(18) a2: f32, @location(10) a3: vec2<u32>, @location(17) a4: vec3<f16>, @location(11) a5: vec3<f16>, @location(0) a6: i32, @location(7) a7: vec3<i32>, a8: S49, @location(16) a9: vec4<f32>, @builtin(instance_index) a10: u32, @location(15) a11: vec2<f16>, @location(1) a12: vec4<f32>, @location(3) a13: f16, @location(5) a14: f32, @location(14) a15: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture128 = device4.createTexture({
+  size: [2304, 960, 479],
+  mipLevelCount: 4,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView251 = texture111.createView({
+  label: '\u8669\u0919\u0a97\u{1fc18}\u6658\u5034\uf317\u0acc\ua535\u48a9\uf03a',
+  dimension: '2d',
+  baseMipLevel: 5,
+  mipLevelCount: 1,
+  baseArrayLayer: 84,
+});
+let renderBundleEncoder99 = device4.createRenderBundleEncoder({label: '\u409f\u07b6\u{1fac6}', colorFormats: ['r32sint', 'rg16float'], stencilReadOnly: true});
+let sampler106 = device4.createSampler({
+  label: '\ua84d\uf590\u1b6e\u{1fdab}\u0968\u{1fe3a}\uc9d2\ueabe',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 54.96,
+  lodMaxClamp: 89.46,
+  compare: 'equal',
+});
+let externalTexture106 = device4.importExternalTexture({
+  label: '\u74b2\u0d54\u92d0\u5d59\u95e7\u04d5\u2292\u79f2\ue1b9\u{1f871}\u71ed',
+  source: videoFrame37,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder15.drawIndexed(115, 27, 758_069_403);
+} catch {}
+try {
+renderBundleEncoder83.drawIndexed(179, 257);
+} catch {}
+try {
+renderBundleEncoder76.setIndexBuffer(buffer37, 'uint32');
+} catch {}
+try {
+renderBundleEncoder85.setVertexBuffer(9, buffer38, 0, 63300);
+} catch {}
+try {
+commandEncoder204.copyTextureToTexture({
+  texture: texture128,
+  mipLevel: 0,
+  origin: {x: 233, y: 148, z: 49},
+  aspect: 'all',
+},
+{
+  texture: texture128,
+  mipLevel: 3,
+  origin: {x: 11, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 218, height: 106, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder96.setVertexBuffer(8804, undefined);
+} catch {}
+try {
+computePassEncoder95.insertDebugMarker('\u04b6');
+} catch {}
+try {
+renderBundleEncoder96.insertDebugMarker('\u698c');
+} catch {}
+gc();
+let canvas56 = document.createElement('canvas');
+let commandEncoder216 = device5.createCommandEncoder({label: '\ue175\u64de\u5796\u4700\u0bd2\u33a8\ud9b4\u95cd\u0170'});
+let renderBundleEncoder100 = device5.createRenderBundleEncoder({
+  label: '\u{1fcc4}\u755b\ub11e\u3d07\u12ae\uc92c\u6cf7\u{1fbe6}\uf9b9\u7031\u0601',
+  colorFormats: ['r32uint', 'rg16sint'],
+  sampleCount: 4,
+});
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame36.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame40.close();
+videoFrame41.close();
+videoFrame42.close();
+videoFrame43.close();
+videoFrame44.close();
+videoFrame45.close();
+videoFrame46.close();
+videoFrame47.close();
+videoFrame48.close();
+videoFrame49.close();
+videoFrame50.close();
+videoFrame51.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>


### PR DESCRIPTION
#### 1e28db88d215147fda0c7816571ef401334fa16c
<pre>
[WebGPU] Destroyed Device leads to validation errors in render pipeline
<a href="https://bugs.webkit.org/show_bug.cgi?id=275228">https://bugs.webkit.org/show_bug.cgi?id=275228</a>
&lt;radar://129354702&gt;

Reviewed by Dan Glastonbury.

We need to return early if the Device is destroyed, since setting a nil
PSO will fail the validation layer.

* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::clampIndexBufferToValidValues):
(WebGPU::RenderPassEncoder::clampIndirectIndexBufferToValidValues):
(WebGPU::RenderPassEncoder::clampIndirectBufferToValidValues):
(WebGPU::RenderPassEncoder::executeBundles):

Canonical link: <a href="https://commits.webkit.org/279815@main">https://commits.webkit.org/279815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d0b747dcd78a4cf9366d8576ebc5f6d9d5e2bb6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54604 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7177 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57885 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5338 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44226 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3594 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56699 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32168 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47296 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25352 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28964 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4626 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3478 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4842 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59475 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29838 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4980 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51649 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30987 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51033 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11969 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31966 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30775 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->