### PR TITLE
[WebGPU] renderCommandEncoderWithDescriptor can fail if depthStencil texture is nil

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-275229-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-275229-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it doesn't crash

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-275229.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-275229.html
@@ -1,0 +1,18709 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ */
+function pseudoSubmit(device) {
+  for (let i = 0; i < 63; i++) {
+    device.createCommandEncoder();
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let adapter0 = await navigator.gpu.requestAdapter({powerPreference: 'high-performance'});
+let promise0 = adapter0.requestDevice({
+  requiredFeatures: [
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 6,
+    maxColorAttachmentBytesPerSample: 45,
+    maxVertexAttributes: 28,
+    maxVertexBufferArrayStride: 2190,
+    maxStorageTexturesPerShaderStage: 15,
+    maxStorageBuffersPerShaderStage: 25,
+    maxDynamicStorageBuffersPerPipelineLayout: 45916,
+    maxDynamicUniformBuffersPerPipelineLayout: 1849,
+    maxBindingsPerBindGroup: 6680,
+    maxTextureArrayLayers: 1209,
+    maxTextureDimension1D: 15064,
+    maxTextureDimension2D: 14379,
+    maxVertexBuffers: 11,
+    minStorageBufferOffsetAlignment: 128,
+    minUniformBufferOffsetAlignment: 32,
+    maxUniformBufferBindingSize: 238245991,
+    maxStorageBufferBindingSize: 251110028,
+    maxUniformBuffersPerShaderStage: 22,
+    maxSampledTexturesPerShaderStage: 29,
+    maxInterStageShaderVariables: 35,
+    maxInterStageShaderComponents: 123,
+    maxSamplersPerShaderStage: 22,
+  },
+});
+let adapter1 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter1.requestDevice({
+  defaultQueue: {label: '\ub575\u{1fa45}\u{1fa5e}\uf3e8\u0783\u3213\ub851\u45b0\u3051'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+});
+let commandEncoder0 = device0.createCommandEncoder({label: '\u147e\u3a0e\u0c30\u7fd5\ueaf0\u2aef\ued23\u{1faf5}\u{1fcdc}'});
+let querySet0 = device0.createQuerySet({label: '\u742a\u02fb', type: 'occlusion', count: 3665});
+let sampler0 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 13.07,
+  lodMaxClamp: 25.35,
+  maxAnisotropy: 9,
+});
+let commandEncoder1 = device0.createCommandEncoder({});
+let video0 = await videoWithData();
+let imageData0 = new ImageData(84, 216);
+let texture0 = device0.createTexture({
+  label: '\u0865\ue097\u0930',
+  size: [320],
+  dimension: '1d',
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32sint', 'rgba32sint'],
+});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({colorFormats: [], depthStencilFormat: 'stencil8', sampleCount: 1, stencilReadOnly: false});
+let texture1 = device0.createTexture({
+  size: {width: 320, height: 5, depthOrArrayLayers: 1},
+  mipLevelCount: 14,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler1 = device0.createSampler({
+  label: '\u02a1\u7ce1\u{1fcb9}\uddc0\u{1ff55}\u{1f8a7}\u{1fa9d}\u1ea9\u35ad\u03e8',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 10.90,
+  lodMaxClamp: 20.02,
+  maxAnisotropy: 3,
+});
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let textureView0 = texture0.createView({label: '\u17e5\ubaa8\u{1fcef}\ua8b7\u0f6f\u7ab0\ub841\u{1fdae}\u3f92\u07c1', dimension: '1d'});
+try {
+commandEncoder1.insertDebugMarker('\ua0fe');
+} catch {}
+let computePassEncoder0 = commandEncoder1.beginComputePass({label: '\u0b46\u72f3\u942d'});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  label: '\ud7a3\u{1ff90}\u0646\u38b2\u{1ff92}\ua870\ub4d5\u0282\ufb8a\u671c\ucbed',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  depthReadOnly: true,
+});
+let promise1 = device0.popErrorScope();
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let querySet1 = device0.createQuerySet({
+  label: '\u{1fb52}\u0dbd\u{1f7b5}\u065e\u2a95\uffbd\ue933\u{1f608}\ue9cd\u60f2\u8ce5',
+  type: 'occlusion',
+  count: 1271,
+});
+let computePassEncoder1 = commandEncoder0.beginComputePass();
+let commandEncoder2 = device0.createCommandEncoder({label: '\u{1f8b1}\u0dd0\uc0ef\u{1f935}'});
+try {
+renderBundleEncoder0.pushDebugGroup('\u{1ff4c}');
+} catch {}
+try {
+renderBundleEncoder0.popDebugGroup();
+} catch {}
+let textureView1 = texture1.createView({
+  label: '\ue1f1\u{1fff4}\u{1f91a}',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  baseMipLevel: 11,
+  mipLevelCount: 1,
+});
+let canvas0 = document.createElement('canvas');
+try {
+canvas0.getContext('bitmaprenderer');
+} catch {}
+let bindGroupLayout0 = device0.createBindGroupLayout({label: '\uaa94\u96c0\uf1ba\u{1f8bb}\ud81e\u67d1\u174d', entries: []});
+let bindGroup0 = device0.createBindGroup({label: '\ue00b\u{1fd4f}', layout: bindGroupLayout0, entries: []});
+let commandEncoder3 = device0.createCommandEncoder({label: '\ufe82\u{1fa35}\u2916\u45bf\u098c\u00ce\u2a08\u2f26\u4ade\u4df9'});
+try {
+renderBundleEncoder1.setBindGroup(1, bindGroup0, []);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 3_760 */
+{offset: 800}, {width: 185, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let bindGroup1 = device0.createBindGroup({label: '\u4d6c\u0718\ub889\uc4e6', layout: bindGroupLayout0, entries: []});
+let commandEncoder4 = device0.createCommandEncoder({});
+let textureView2 = texture0.createView({});
+let renderBundle0 = renderBundleEncoder1.finish({});
+try {
+renderBundleEncoder0.setBindGroup(0, bindGroup0);
+} catch {}
+let commandEncoder5 = device0.createCommandEncoder();
+let renderPassEncoder0 = commandEncoder5.beginRenderPass({
+  label: '\u153e\u09d5\u{1f7d8}\u0611\u6c5a\u0156\u03c1\u{1fdca}\u09aa\u3c38\u0aec',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView1,
+    depthClearValue: 3.279431715575802,
+    stencilClearValue: 8317,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'discard',
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 1224812586,
+});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle0, renderBundle0, renderBundle0, renderBundle0, renderBundle0, renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(1, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder0.setViewport(0.9961, 0.5478, 0.00142, 0.3443, 0.9771, 0.9856);
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+  label: '\uf2eb\u{1f6bd}\u66a8\u7a19\u524b\u7b1b\uec5a\u{1fe05}\u7a44\u{1fcd5}',
+  layout: bindGroupLayout0,
+  entries: [],
+});
+let buffer0 = device0.createBuffer({label: '\u0340\u604d\uac95\uef17\ud608\u011e\u8915\u270a', size: 77190, usage: GPUBufferUsage.UNIFORM});
+let commandBuffer0 = commandEncoder2.finish({label: '\u0b0c\u06bc\u38e0\u877e\uf019\u7b40\u34bb\u82ae\u{1ff01}'});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(246);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 918.4, g: 244.2, b: -546.3, a: 136.5, });
+} catch {}
+try {
+device0.queue.label = '\u3ebc\u0e4c';
+} catch {}
+let texture2 = device0.createTexture({
+  label: '\ub9ee\uf801',
+  size: {width: 120, height: 24, depthOrArrayLayers: 245},
+  mipLevelCount: 5,
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8'],
+});
+try {
+renderPassEncoder0.setViewport(0.1087, 0.1008, 0.02298, 0.6627, 0.2908, 0.7341);
+} catch {}
+try {
+  await promise1;
+} catch {}
+let canvas1 = document.createElement('canvas');
+let bindGroup3 = device0.createBindGroup({label: '\u08e6\u{1fbc9}\uf29f\u02be\u106d', layout: bindGroupLayout0, entries: []});
+let pipelineLayout0 = device0.createPipelineLayout({label: '\u{1feb1}\u9c2d\u0257\u0806\u6082\uc7aa', bindGroupLayouts: [bindGroupLayout0]});
+let commandEncoder6 = device0.createCommandEncoder();
+let renderPassEncoder1 = commandEncoder6.beginRenderPass({
+  label: '\u{1fa2c}\u0a3d\ucbd7\ue922\u{1ff2b}',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView1,
+    depthClearValue: 3.4576678845726114,
+    stencilClearValue: 32690,
+    stencilLoadOp: 'load',
+    stencilStoreOp: 'discard',
+  },
+  occlusionQuerySet: querySet1,
+});
+try {
+renderPassEncoder1.setBlendConstant({ r: 519.9, g: 745.4, b: 194.0, a: -622.8, });
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(1, bindGroup3, []);
+} catch {}
+let buffer1 = device0.createBuffer({label: '\u86a6\u4a76', size: 32297, usage: GPUBufferUsage.COPY_SRC});
+let texture3 = device0.createTexture({
+  label: '\ud562\u03df\u93b0\udaad\u0f9e\u0523\u0d48\u3755\u5d31\u682b',
+  size: [1280, 20, 1],
+  mipLevelCount: 9,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['stencil8', 'stencil8', 'stencil8'],
+});
+let textureView3 = texture3.createView({label: '\u8b81\u9042\ud42b\ue4fa\u0418', aspect: 'stencil-only', baseMipLevel: 6, baseArrayLayer: 0});
+let computePassEncoder2 = commandEncoder3.beginComputePass({label: '\u{1fdac}\u0c05\u94c9\u0436\uafbd\u0336\u028b\u48f7\u{1ff11}\u7a65\u{1faec}'});
+let renderBundle1 = renderBundleEncoder1.finish();
+try {
+computePassEncoder2.setBindGroup(0, bindGroup1, new Uint32Array(166), 60, 0);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setViewport(0.2973, 0.9477, 0.4378, 0.00220, 0.09162, 0.4550);
+} catch {}
+try {
+commandEncoder4.copyBufferToTexture({
+  /* bytesInLastRow: 4160 widthInBlocks: 260 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 48 */
+  offset: 48,
+  rowsPerImage: 299,
+  buffer: buffer1,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 260, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+let gpuCanvasContext0 = canvas1.getContext('webgpu');
+let bindGroup4 = device0.createBindGroup({
+  label: '\uddbf\udfd7\u2a28\u08dc\uc381\ubfa9\u0a22\ud3f8\u028e\u0dc3\u8bb2',
+  layout: bindGroupLayout0,
+  entries: [],
+});
+let textureView4 = texture2.createView({
+  label: '\u08c7\u80bb\u0b19\u046a\ud090',
+  dimension: '2d',
+  format: 'stencil8',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 24,
+});
+let renderPassEncoder2 = commandEncoder4.beginRenderPass({
+  label: '\u{1fe31}\u0ef8\u9f52\u{1fdbe}\u88e1\ucfbb\u051a\u9a4f\ube86\u0676\uc58a',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView1,
+    depthClearValue: 8.65116788640843,
+    depthReadOnly: true,
+    stencilLoadOp: 'load',
+    stencilStoreOp: 'discard',
+  },
+});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup4, new Uint32Array(3888), 2890, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup0, new Uint32Array(2321), 1199, 0);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(200);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: -361.4, g: 386.5, b: 71.20, a: -188.3, });
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(2, bindGroup0, new Uint32Array(6536), 5605, 0);
+} catch {}
+let commandEncoder7 = device0.createCommandEncoder();
+let computePassEncoder3 = commandEncoder7.beginComputePass({label: '\u{1ff5e}\uc8b1\u5296\u2621\u388d\u194d\u0832\u05bb'});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({
+  label: '\u0b00\ud73e\uce78\u0c79\u{1f8ac}\udf03',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup4, new Uint32Array(8481), 7312, 0);
+} catch {}
+try {
+renderBundleEncoder0.insertDebugMarker('\u{1f7fb}');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 714,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let texture4 = device0.createTexture({
+  label: '\uc5cf\u{1fdbb}',
+  size: [60, 12, 1],
+  mipLevelCount: 5,
+  sampleCount: 1,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['stencil8', 'stencil8'],
+});
+let textureView5 = texture1.createView({
+  label: '\u{1fa96}\u0fcd\u{1fc79}\uea5d\uab8b\u7bc5\u8c43\ue30a\u{1fee8}\u{1f764}\u{1f87b}',
+  dimension: '2d-array',
+  baseMipLevel: 10,
+  mipLevelCount: 1,
+});
+try {
+renderPassEncoder1.executeBundles([renderBundle0, renderBundle1, renderBundle1, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(1951);
+} catch {}
+try {
+renderPassEncoder1.setViewport(0.1928, 0.9388, 0.7472, 0.00999, 0.5968, 0.6834);
+} catch {}
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 336,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let texture5 = device0.createTexture({
+  label: '\uc245\uba26\u021c\u01d7\u0dbe\u{1f69f}',
+  size: {width: 640, height: 10, depthOrArrayLayers: 94},
+  mipLevelCount: 10,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+adapter0.label = '\u0bc1\uaeb9\u{1fb05}';
+} catch {}
+let renderBundle2 = renderBundleEncoder1.finish({label: '\u455d\u{1f87f}\u6f4a\u0609\u01a1'});
+let externalTexture0 = device0.importExternalTexture({label: '\u6be5\u060a\u8912\u7d7e', source: video0, colorSpace: 'display-p3'});
+try {
+renderPassEncoder1.setScissorRect(1, 0, 0, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 6},
+  aspect: 'stencil-only',
+}, new Float64Array(new ArrayBuffer(24)), /* required buffer size: 1_725_936 */
+{offset: 912, bytesPerRow: 906, rowsPerImage: 56}, {width: 640, height: 0, depthOrArrayLayers: 35});
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({label: '\uceab\u30c1'});
+let texture6 = device0.createTexture({
+  label: '\u5f71\u7422\ucf22\u34cf',
+  size: {width: 640, height: 10, depthOrArrayLayers: 28},
+  mipLevelCount: 8,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8'],
+});
+let textureView6 = texture4.createView({
+  label: '\u{1f77c}\u78c2\ub3ef\ua6a6\u{1fe24}\u0aed\uee12\u0459\u15a9\u015b\u{1fb70}',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+});
+let renderBundle3 = renderBundleEncoder2.finish({label: '\ubfac\u7d80\uc997\u94e0'});
+let sampler2 = device0.createSampler({
+  label: '\u88fe\u390d\u440a\u7122\ueaf1',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 99.64,
+});
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle3, renderBundle3, renderBundle0, renderBundle0, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(2263);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'stencil-only',
+}, new ArrayBuffer(72), /* required buffer size: 2_067_989 */
+{offset: 483, bytesPerRow: 289, rowsPerImage: 98}, {width: 40, height: 0, depthOrArrayLayers: 74});
+} catch {}
+let video1 = await videoWithData();
+let videoFrame0 = new VideoFrame(canvas1, {timestamp: 0});
+let sampler3 = device0.createSampler({
+  label: '\u84ae\u00c9\ub4dc\u0ef7\u0265',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  compare: 'never',
+});
+try {
+renderPassEncoder0.setVertexBuffer(7349, undefined, 0);
+} catch {}
+let img0 = await imageWithData(56, 235, '#51d3a6b0', '#59bd74a4');
+let renderPassEncoder3 = commandEncoder8.beginRenderPass({
+  label: '\u0c45\u6623\u856e\u7b53\u{1fb64}\u{1fe6f}\u0177\u77ab\u79d9\u9bb3',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView5, depthReadOnly: true, stencilLoadOp: 'load', stencilStoreOp: 'discard'},
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 235342126,
+});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: [], depthStencilFormat: 'stencil8', depthReadOnly: true, stencilReadOnly: true});
+let renderBundle4 = renderBundleEncoder1.finish({});
+let sampler4 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 9.286,
+  lodMaxClamp: 31.82,
+  maxAnisotropy: 18,
+});
+let externalTexture1 = device0.importExternalTexture({source: videoFrame0, colorSpace: 'display-p3'});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(1276);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle2, renderBundle3, renderBundle2, renderBundle3, renderBundle2, renderBundle1, renderBundle2, renderBundle4, renderBundle0, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder1.setViewport(0.7302, 0.4027, 0.00738, 0.3912, 0.5556, 0.7152);
+} catch {}
+let imageBitmap0 = await createImageBitmap(canvas1);
+let querySet2 = device0.createQuerySet({label: '\uded5\u07d3\u8bd4\u0992', type: 'occlusion', count: 1089});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({label: '\uf08e\u837e', colorFormats: [], depthStencilFormat: 'stencil8', depthReadOnly: true});
+let renderBundle5 = renderBundleEncoder2.finish({label: '\ucf06\u4e65\ua0c6\u9afd'});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup0, new Uint32Array(5153), 2229, 0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle2, renderBundle0, renderBundle1, renderBundle0, renderBundle5, renderBundle2, renderBundle1, renderBundle1, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(2632);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(3, bindGroup0, new Uint32Array(3314), 1956, 0);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(8611, undefined, 0, 3511093419);
+} catch {}
+try {
+renderBundleEncoder4.insertDebugMarker('\u2f56');
+} catch {}
+let textureView7 = texture0.createView({label: '\u0317\u814d\u7280\uc2ec\u7337\u38ba'});
+let externalTexture2 = device0.importExternalTexture({source: video1, colorSpace: 'display-p3'});
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(2272);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(3881, undefined, 1543906359, 595832381);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let img1 = await imageWithData(219, 283, '#4971f5a0', '#fce80b0e');
+let commandEncoder9 = device0.createCommandEncoder({label: '\u{1feeb}\u0205\u5bf6\ucdaa\u{1faff}\u{1f7ca}\u3d3b\u8aeb\u0d52\u11a6'});
+let commandBuffer1 = commandEncoder9.finish();
+let texture7 = device0.createTexture({
+  label: '\u055e\u{1ff3f}\u{1ffb6}\u{1fd6a}\u05fb\u0cec\u{1faab}\u08fc',
+  size: {width: 160, height: 2, depthOrArrayLayers: 1},
+  mipLevelCount: 8,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder0.beginOcclusionQuery(1244);
+} catch {}
+try {
+renderPassEncoder3.setViewport(0.5169, 0.1097, 0.3444, 0.8252, 0.5365, 0.7992);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(8531, undefined, 0, 3565121723);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let videoFrame1 = new VideoFrame(canvas0, {timestamp: 0});
+let commandEncoder10 = device0.createCommandEncoder({label: '\u021d\u01e6\u{1f801}\u251b\u{1fab3}\u95db\u{1fbf7}\u0c09\u{1fe55}\u5664\u{1f721}'});
+let commandBuffer2 = commandEncoder10.finish();
+let texture8 = device0.createTexture({
+  label: '\u445e\u037e\u{1fc67}\u{1f6cb}\u0f2f\ued3c\udcfa\u0166\u{1f7cb}\u{1f9fa}\u49d3',
+  size: [60, 12, 4],
+  mipLevelCount: 2,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg16sint'],
+});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({label: '\u{1f9f7}\ud44a\u591c', colorFormats: [], depthStencilFormat: 'stencil8', depthReadOnly: true});
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(575);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: 364.3, g: 878.0, b: -140.1, a: 167.2, });
+} catch {}
+gc();
+let imageBitmap1 = await createImageBitmap(videoFrame1);
+let pipelineLayout1 = device0.createPipelineLayout({label: '\u{1fc3b}\u3e37\u0786\uc8cb\ub711', bindGroupLayouts: [bindGroupLayout1]});
+let commandEncoder11 = device0.createCommandEncoder();
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 1914});
+let commandBuffer3 = commandEncoder11.finish({label: '\u9aed\uc9b1\u08a1\u029b\u5519\uf28a\ua4a1\u841b\ub32d'});
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4058, undefined);
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+buffer1.destroy();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 68_961 */
+{offset: 225, bytesPerRow: 208, rowsPerImage: 109}, {width: 24, height: 4, depthOrArrayLayers: 4});
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+  label: '\u6b0f\u{1f648}\u{1face}\u{1fbf4}',
+  code: `@group(0) @binding(714)
+var<storage, read_write> n0: array<u32>;
+
+@compute @workgroup_size(2, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@location(7) a0: vec4<f16>) {
+
+}
+
+struct S0 {
+  @location(8) f0: vec4<f16>,
+  @location(2) f1: vec4<f16>,
+  @location(12) f2: vec4<i32>
+}
+struct VertexOutput0 {
+  @location(3) f0: vec3<u32>,
+  @location(9) f1: vec2<f32>,
+  @location(6) f2: vec2<u32>,
+  @location(7) f3: vec4<f16>,
+  @location(15) f4: vec2<i32>,
+  @builtin(position) f5: vec4<f32>,
+  @location(10) f6: vec4<u32>,
+  @location(11) f7: i32,
+  @location(4) f8: vec4<i32>,
+  @location(12) f9: vec3<f16>,
+  @location(13) f10: vec2<f32>,
+  @location(14) f11: vec2<f32>,
+  @location(8) f12: vec2<u32>,
+  @location(0) f13: i32,
+  @location(2) f14: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec3<i32>, @location(7) a1: vec4<f16>, a2: S0, @builtin(instance_index) a3: u32, @location(0) a4: vec4<i32>, @location(15) a5: vec2<u32>, @location(5) a6: i32, @location(6) a7: vec3<i32>, @location(13) a8: vec2<i32>, @location(11) a9: f32, @location(4) a10: vec2<f16>, @builtin(vertex_index) a11: u32, @location(14) a12: u32, @location(10) a13: vec2<u32>, @location(9) a14: vec3<u32>, @location(1) a15: vec2<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let pipelineLayout2 = device0.createPipelineLayout({
+  label: '\uad93\u0cde\u075e\u0823\uedea\u0245\u1543',
+  bindGroupLayouts: [bindGroupLayout2, bindGroupLayout1, bindGroupLayout2],
+});
+let commandEncoder12 = device0.createCommandEncoder({label: '\ud8ab\u{1fbaa}\u0371\u4f20\u6a1b\ucaf8\u05dc\u377c'});
+let querySet4 = device0.createQuerySet({label: '\u008e\u{1fd93}\u2ce3\uac35\u24d5\uc540', type: 'occlusion', count: 3923});
+let texture9 = device0.createTexture({
+  size: {width: 160, height: 2, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8'],
+});
+let renderPassEncoder4 = commandEncoder12.beginRenderPass({
+  label: '\u4107\u{1f650}',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView4,
+    depthClearValue: -3.956846105464697,
+    stencilClearValue: 36241,
+    stencilLoadOp: 'load',
+    stencilStoreOp: 'discard',
+  },
+  occlusionQuerySet: querySet3,
+  maxDrawCount: 424672218,
+});
+let renderBundle6 = renderBundleEncoder2.finish({label: '\u{1f7d4}\u417e\ue61a\u0bda\u7c37\u0933\u574e\uc53d'});
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(1643);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(1, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder1.setViewport(0.8639, 0.3652, 0.05756, 0.02405, 0.9994, 0.9998);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3068, undefined, 407889848, 2755597003);
+} catch {}
+try {
+renderBundleEncoder3.pushDebugGroup('\u55ca');
+} catch {}
+try {
+renderBundleEncoder3.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([commandBuffer2, commandBuffer1, commandBuffer3]);
+} catch {}
+let pipeline0 = device0.createRenderPipeline({
+  label: '\u0178\u5e68\uc7b0\u393c\u8866\ucb22\u0a75\u6dd1\u{1f912}\u0ee9',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0x65e8f2c1},
+  fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'less', failOp: 'increment-clamp', depthFailOp: 'decrement-clamp', passOp: 'invert'},
+    stencilBack: {compare: 'not-equal', failOp: 'increment-wrap', passOp: 'replace'},
+    stencilReadMask: 796427652,
+    stencilWriteMask: 1815500331,
+    depthBias: 1899256890,
+    depthBiasSlopeScale: 723.0929393386807,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 108,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x4', offset: 32, shaderLocation: 6}],
+      },
+      {
+        arrayStride: 284,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 16, shaderLocation: 10},
+          {format: 'sint8x2', offset: 4, shaderLocation: 0},
+          {format: 'sint8x2', offset: 26, shaderLocation: 12},
+          {format: 'float32x2', offset: 20, shaderLocation: 7},
+          {format: 'snorm16x2', offset: 92, shaderLocation: 1},
+          {format: 'sint8x2', offset: 46, shaderLocation: 3},
+          {format: 'uint16x4', offset: 20, shaderLocation: 14},
+          {format: 'unorm10-10-10-2', offset: 64, shaderLocation: 11},
+          {format: 'sint32', offset: 8, shaderLocation: 13},
+          {format: 'sint8x4', offset: 8, shaderLocation: 5},
+          {format: 'unorm16x4', offset: 20, shaderLocation: 2},
+          {format: 'snorm16x2', offset: 36, shaderLocation: 4},
+          {format: 'uint8x2', offset: 26, shaderLocation: 9},
+          {format: 'unorm16x4', offset: 8, shaderLocation: 8},
+          {format: 'uint32x4', offset: 20, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {unclippedDepth: true},
+});
+let textureView8 = texture8.createView({label: '\uefd5\u{1f885}\u92e0\ud3c1\u877d\u00ab\u5a62', baseMipLevel: 1});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(1, 0, 0, 1);
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+let texture10 = device0.createTexture({
+  label: '\u08ce\u{1f65d}\u{1f97a}\u0796\u0193\ud285\u{1ff93}\u02ce\u092e\u{1f980}',
+  size: [1280, 20, 1],
+  mipLevelCount: 7,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['stencil8'],
+});
+try {
+renderPassEncoder1.setBlendConstant({ r: 300.1, g: -14.99, b: 402.4, a: -722.7, });
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(25, 6, 5, 0);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(3130);
+} catch {}
+try {
+renderPassEncoder2.setViewport(0.4976, 0.1201, 0.08777, 0.2087, 0.5026, 0.6454);
+} catch {}
+try {
+  await promise2;
+} catch {}
+try {
+videoFrame0.close();
+} catch {}
+let texture11 = device0.createTexture({
+  size: [1280, 20, 162],
+  mipLevelCount: 5,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView9 = texture10.createView({
+  label: '\u0f6b\u7cb1\u{1f651}\uecfc\u0fe6\u2ab9\u24b3\u09ad',
+  aspect: 'stencil-only',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+});
+let renderBundle7 = renderBundleEncoder1.finish({label: '\u686d\u{1f7db}\u0edc'});
+try {
+renderPassEncoder3.beginOcclusionQuery(2071);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: -751.1, g: 921.1, b: -0.8494, a: -269.6, });
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(2139, undefined, 0, 1684246858);
+} catch {}
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  label: '\u4be9\u44e7\u2318\u2dd4\u{1fe2c}',
+  entries: [
+    {
+      binding: 486,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 745,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let textureView10 = texture4.createView({
+  label: '\u02b5\u0c10\u{1fde6}\u{1fbd4}\u50fa\u0988\u03df\u0313\uda5e\u{1fcf7}\u808f',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({
+  label: '\u059e\u5355\u6aa1\u{1ff1b}\uab1e\ua7ce\u0ccf',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+});
+let renderBundle8 = renderBundleEncoder1.finish({label: '\uf404\ue7a7\u04ba\ufd4b\u3a3a\u8b2c'});
+let externalTexture3 = device0.importExternalTexture({source: videoFrame0});
+try {
+renderPassEncoder2.setViewport(0.7430, 0.1722, 0.02044, 0.2819, 0.8143, 0.8287);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(6945, undefined, 1324331551, 1074423257);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout({
+  label: '\u0d5a\u62b0\ub87b\u0913\u7d16',
+  entries: [{binding: 580, visibility: GPUShaderStage.VERTEX, sampler: { type: 'comparison' }}],
+});
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(1, 0, 0, 1);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(3567);
+} catch {}
+let pipeline1 = device0.createComputePipeline({
+  label: '\u92a9\u{1fba2}',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let commandEncoder13 = device0.createCommandEncoder({label: '\u6190\u0130\u74b2\u7519\u{1fdaa}'});
+let textureView11 = texture6.createView({
+  label: '\u{1fad6}\u4a67\u5ea7\u03ae\u0a95\u795c\u813b',
+  dimension: '2d',
+  aspect: 'stencil-only',
+  baseMipLevel: 7,
+  baseArrayLayer: 13,
+});
+let externalTexture4 = device0.importExternalTexture({
+  label: '\u832d\u1e85\u684e\u{1fca8}\u{1fdac}\u1e2d\u26c5\u{1f8c8}',
+  source: video1,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder2.executeBundles([renderBundle1, renderBundle6, renderBundle4, renderBundle2, renderBundle4, renderBundle1, renderBundle6, renderBundle4]);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder13.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: {x: 222, y: 1, z: 0},
+  aspect: 'all',
+},
+{width: 30, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder2.insertDebugMarker('\u830f');
+} catch {}
+let querySet5 = device0.createQuerySet({label: '\uff75\u0201\u0404\u{1fad7}', type: 'occlusion', count: 38});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle7]);
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+let textureView12 = texture4.createView({
+  label: '\u4f73\u913c\uee96\u50be\u{1f82e}\u770e\ua661\u2074\ucd83\u0ae2',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  baseMipLevel: 1,
+  mipLevelCount: 3,
+});
+let computePassEncoder4 = commandEncoder13.beginComputePass();
+try {
+renderPassEncoder3.setViewport(0.5654, 0.7979, 0.08880, 0.06289, 0.3235, 0.5655);
+} catch {}
+let pipeline2 = device0.createComputePipeline({
+  label: '\u0ff8\ub5f2\u0258\u02e4',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let textureView13 = texture1.createView({dimension: '2d', aspect: 'stencil-only', baseMipLevel: 13, arrayLayerCount: 1});
+let renderBundle9 = renderBundleEncoder1.finish({});
+let sampler5 = device0.createSampler({
+  label: '\u07af\u0f03\u{1f71d}\u{1fccd}\uee79',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 30.93,
+  lodMaxClamp: 77.07,
+});
+try {
+renderPassEncoder2.setBlendConstant({ r: -603.5, g: 65.55, b: -889.0, a: -412.6, });
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(28, 6, 0, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder14 = device0.createCommandEncoder({});
+let sampler6 = device0.createSampler({
+  label: '\u17bf\u2ac2\u024e\u20fd\u{1fb65}\u{1fb88}\ua8a1\u0b28',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 94.40,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup1, new Uint32Array(5200), 1808, 0);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle0, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: 54.33, g: -89.62, b: 362.6, a: -290.7, });
+} catch {}
+try {
+buffer1.destroy();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new ArrayBuffer(72), /* required buffer size: 26_606 */
+{offset: 645, bytesPerRow: 1299}, {width: 1280, height: 20, depthOrArrayLayers: 1});
+} catch {}
+let pipeline3 = device0.createComputePipeline({layout: pipelineLayout1, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+let querySet6 = device0.createQuerySet({label: '\u169a\ubea3', type: 'occlusion', count: 3113});
+let commandBuffer4 = commandEncoder14.finish();
+let textureView14 = texture6.createView({
+  label: '\u02df\u190d\u3534\u835c',
+  dimension: '2d',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 8,
+});
+try {
+renderPassEncoder0.beginOcclusionQuery(24);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: 816.8, g: 140.0, b: 13.11, a: 780.0, });
+} catch {}
+try {
+renderPassEncoder1.setViewport(0.5876, 0.7337, 0.2890, 0.1826, 0.6378, 0.6832);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 671 */
+{offset: 651}, {width: 20, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let textureView15 = texture9.createView({
+  label: '\u{1ffbc}\uc0d2\u0d48\u{1f6b9}\u010a\u{1fb11}\u038a\u02ac\ub12f\u{1fa11}\u{1fe48}',
+  aspect: 'stencil-only',
+  mipLevelCount: 2,
+});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline1);
+} catch {}
+try {
+  await promise3;
+} catch {}
+let img2 = await imageWithData(278, 99, '#e0b41684', '#207dc0e8');
+try {
+computePassEncoder0.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup3, new Uint32Array(8099), 3935, 0);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle6, renderBundle8, renderBundle0, renderBundle1, renderBundle2, renderBundle5, renderBundle4, renderBundle5, renderBundle0, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: 765.8, g: 763.1, b: -510.2, a: 689.3, });
+} catch {}
+try {
+renderPassEncoder0.setViewport(0.4755, 0.2922, 0.3512, 0.06713, 0.5702, 0.9206);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(1015, undefined, 0, 2156008999);
+} catch {}
+document.body.prepend(img2);
+let texture12 = device0.createTexture({
+  label: '\ue63f\ue36d',
+  size: [30, 6, 1],
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8', 'stencil8', 'stencil8'],
+});
+let sampler7 = device0.createSampler({
+  label: '\u366e\u0c42\u{1f9a1}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 28.31,
+  compare: 'less',
+});
+try {
+computePassEncoder2.setPipeline(pipeline1);
+} catch {}
+let pipeline4 = device0.createComputePipeline({label: '\u71b4\ucca4\udff7', layout: 'auto', compute: {module: shaderModule0, entryPoint: 'compute0'}});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\u0e87\u0d03\u7d85\uf869\u4703',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  stencilReadOnly: false,
+});
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb'],
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise4 = device0.createRenderPipelineAsync({
+  label: '\u8366\u7342',
+  layout: pipelineLayout2,
+  fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'never', depthFailOp: 'decrement-wrap', passOp: 'keep'},
+    stencilBack: {compare: 'greater-equal', failOp: 'invert', depthFailOp: 'replace', passOp: 'increment-wrap'},
+    stencilReadMask: 530014680,
+    stencilWriteMask: 1683962653,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 44,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 16, shaderLocation: 6},
+          {format: 'sint32x2', offset: 0, shaderLocation: 0},
+          {format: 'sint32', offset: 4, shaderLocation: 3},
+          {format: 'snorm8x4', offset: 4, shaderLocation: 2},
+          {format: 'snorm16x4', offset: 0, shaderLocation: 7},
+          {format: 'uint8x4', offset: 0, shaderLocation: 10},
+          {format: 'sint8x4', offset: 8, shaderLocation: 12},
+          {format: 'sint8x2', offset: 0, shaderLocation: 13},
+          {format: 'uint32x3', offset: 0, shaderLocation: 9},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 4},
+          {format: 'uint16x2', offset: 8, shaderLocation: 14},
+          {format: 'snorm8x2', offset: 4, shaderLocation: 8},
+          {format: 'sint8x2', offset: 8, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 0, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 496,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 74, shaderLocation: 1},
+          {format: 'uint16x2', offset: 344, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let texture13 = device0.createTexture({
+  label: '\ua4a5\u009c\u0703\u{1f667}\ua097\u0ef2\u{1fd7b}\u0b00\ud24f',
+  size: [120, 24, 1],
+  mipLevelCount: 4,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+});
+let textureView16 = texture7.createView({
+  label: '\u547f\u0514\u7727\u09f2\ufb48\ub379\u0261\u{1f9fd}\u{1f95b}\u51b0',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder0.setBindGroup(0, bindGroup0);
+} catch {}
+let canvas2 = document.createElement('canvas');
+let imageBitmap2 = await createImageBitmap(imageBitmap1);
+let commandEncoder15 = device0.createCommandEncoder({label: '\u{1ffab}\u{1f8c3}\u091b\u0a76\u{1ff55}\u{1f81d}\uc2fc\u050b\u7001'});
+let computePassEncoder5 = commandEncoder15.beginComputePass({label: '\u{1f65c}\uae33\u8de3\u0faf\u7f37\u0b20\uc3b6\u{1ff7d}\u{1ffcb}\ud9ba\uf5a0'});
+let sampler8 = device0.createSampler({
+  label: '\u09d5\u{1ff8c}\u{1feb8}\u{1f9a5}\u83d0\u04d4\u0cde\u{1f9f9}\u0d5d\u08b7',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 5.579,
+  lodMaxClamp: 18.66,
+});
+let externalTexture5 = device0.importExternalTexture({source: video0, colorSpace: 'srgb'});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(159);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -962.9, g: -359.4, b: 962.8, a: 876.8, });
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(7294, undefined, 0, 3876627112);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline5 = device0.createRenderPipeline({
+  label: '\u{1fe42}\u37c4\u98fc\ue4bb\u0546\u{1fdbc}\u48b5\ue408',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0xd09a2518},
+  fragment: {module: shaderModule0, entryPoint: 'fragment0', targets: []},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'never', failOp: 'decrement-clamp', depthFailOp: 'replace', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'less-equal', failOp: 'decrement-clamp', depthFailOp: 'zero', passOp: 'zero'},
+    stencilReadMask: 397821758,
+    stencilWriteMask: 1327325257,
+    depthBias: 584059584,
+    depthBiasClamp: 764.2955765733602,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 164,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 42, shaderLocation: 4},
+          {format: 'sint32x3', offset: 80, shaderLocation: 5},
+          {format: 'sint8x4', offset: 28, shaderLocation: 0},
+          {format: 'uint32x2', offset: 36, shaderLocation: 14},
+          {format: 'float16x2', offset: 24, shaderLocation: 7},
+          {format: 'uint8x2', offset: 22, shaderLocation: 9},
+          {format: 'unorm16x2', offset: 16, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 8, shaderLocation: 11},
+          {format: 'sint32', offset: 28, shaderLocation: 13},
+          {format: 'sint8x2', offset: 8, shaderLocation: 3},
+          {format: 'float16x2', offset: 12, shaderLocation: 2},
+          {format: 'uint16x4', offset: 32, shaderLocation: 10},
+          {format: 'uint32x4', offset: 24, shaderLocation: 15},
+          {format: 'sint8x4', offset: 8, shaderLocation: 6},
+          {format: 'float16x4', offset: 0, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 408,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x2', offset: 92, shaderLocation: 12}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+let commandEncoder16 = device0.createCommandEncoder();
+let renderPassEncoder5 = commandEncoder16.beginRenderPass({
+  label: '\u98e4\u04c6\u048f\u8a04\u0360\udd90\u6cf0\ub6a4\ud5d0\u{1fd54}\u2c27',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView5, stencilReadOnly: true},
+  occlusionQuerySet: querySet4,
+  maxDrawCount: 607327488,
+});
+let sampler9 = device0.createSampler({
+  label: '\u2067\u02e0\u0161\u0555\u0240\u{1ffe5}\u09bd',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 67.75,
+  compare: 'greater',
+});
+try {
+computePassEncoder2.setPipeline(pipeline4);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(459, 922);
+let textureView17 = texture8.createView({mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 2});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({colorFormats: [], depthStencilFormat: 'stencil8', depthReadOnly: true, stencilReadOnly: true});
+let renderBundle10 = renderBundleEncoder8.finish({});
+try {
+computePassEncoder3.setBindGroup(3, bindGroup3, new Uint32Array(718), 563, 0);
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(1908);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(6613, undefined, 0, 2180768982);
+} catch {}
+try {
+buffer1.destroy();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise5 = device0.createComputePipelineAsync({
+  label: '\u{1f659}\u0402\u4b63\ub35e',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder17 = device0.createCommandEncoder();
+let commandBuffer5 = commandEncoder17.finish({label: '\u0785\ubd50\u{1f8d3}\u78b8\u{1fbd6}\u088b\u{1fd8a}\ud35f\u1e99\ub083'});
+let textureView18 = texture2.createView({
+  label: '\u9d75\u6574\u{1f91a}\u{1fa03}\u916d',
+  mipLevelCount: 1,
+  baseArrayLayer: 240,
+  arrayLayerCount: 4,
+});
+let renderBundle11 = renderBundleEncoder2.finish({label: '\u74af\u8b37\u1a05\ua039\u947e\u7420\u07db\u{1ff6b}\u245b'});
+try {
+computePassEncoder0.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(25, 5, 0, 1);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let querySet7 = device0.createQuerySet({label: '\u70c1\ub2fe', type: 'occlusion', count: 3214});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup4, new Uint32Array(4573), 1325, 0);
+} catch {}
+try {
+computePassEncoder3.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(306);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setViewport(0.9750, 0.5665, 0.01192, 0.3762, 0.2020, 0.6240);
+} catch {}
+let pipeline6 = device0.createComputePipeline({
+  label: '\u7548\u6537\u4240\u0506\uf557\ue869\u1b5f\u{1fb87}\u{1fbf1}\u3de7',
+  layout: 'auto',
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+gc();
+let offscreenCanvas1 = new OffscreenCanvas(659, 885);
+let imageBitmap3 = await createImageBitmap(video0);
+let buffer2 = device0.createBuffer({
+  label: '\u{1fcce}\u4a29\u0c7d',
+  size: 308877,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let querySet8 = device0.createQuerySet({label: '\u2513\uec6f\uf4c9\u0432\uf167', type: 'occlusion', count: 808});
+let textureView19 = texture7.createView({
+  label: '\u{1f99b}\u{1f628}\u0413\u8825',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  baseMipLevel: 0,
+  mipLevelCount: 5,
+});
+let sampler10 = device0.createSampler({
+  label: '\u{1fda9}\u{1fa30}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 78.11,
+  lodMaxClamp: 83.41,
+  maxAnisotropy: 16,
+});
+try {
+renderPassEncoder4.beginOcclusionQuery(326);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle11, renderBundle1, renderBundle3, renderBundle11, renderBundle5, renderBundle7, renderBundle0, renderBundle11, renderBundle1, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(3306);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder4.setVertexBuffer(2116, undefined, 2005176552);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let pipeline7 = await device0.createRenderPipelineAsync({
+  label: '\u4e8d\u62b8\u056d\u{1fa5b}\u9650\uf772\u0c2e\ud476\u{1ff59}',
+  layout: pipelineLayout2,
+  multisample: {count: 4, mask: 0x8866dd69},
+  fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'always', failOp: 'invert', depthFailOp: 'decrement-clamp', passOp: 'invert'},
+    stencilBack: {compare: 'greater-equal', failOp: 'increment-clamp', depthFailOp: 'decrement-clamp'},
+    stencilReadMask: 3156777510,
+    stencilWriteMask: 2128235110,
+    depthBias: 0,
+    depthBiasSlopeScale: 923.8995978721777,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 52, attributes: []},
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 96,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 32, shaderLocation: 7},
+          {format: 'sint16x2', offset: 4, shaderLocation: 5},
+          {format: 'sint32x4', offset: 40, shaderLocation: 0},
+          {format: 'float32x4', offset: 16, shaderLocation: 11},
+          {format: 'uint32', offset: 8, shaderLocation: 9},
+          {format: 'uint16x4', offset: 0, shaderLocation: 15},
+          {format: 'sint32x3', offset: 0, shaderLocation: 13},
+          {format: 'float32x3', offset: 16, shaderLocation: 8},
+          {format: 'uint8x4', offset: 16, shaderLocation: 10},
+          {format: 'float32x3', offset: 4, shaderLocation: 1},
+          {format: 'sint32', offset: 8, shaderLocation: 12},
+          {format: 'sint32', offset: 12, shaderLocation: 3},
+          {format: 'uint32x2', offset: 0, shaderLocation: 14},
+          {format: 'sint8x2', offset: 16, shaderLocation: 6},
+          {format: 'float32', offset: 4, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 316, attributes: []},
+      {
+        arrayStride: 52,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x4', offset: 16, shaderLocation: 2}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let videoFrame2 = new VideoFrame(canvas1, {timestamp: 0});
+let textureView20 = texture8.createView({
+  label: '\u05ec\uf054\u0db8\uc363\u{1f6d6}\u7b6d\u015f\uc6f6',
+  dimension: '2d',
+  baseMipLevel: 1,
+  baseArrayLayer: 2,
+});
+try {
+renderPassEncoder0.setViewport(0.5540, 0.9440, 0.09223, 0.03118, 0.8301, 0.9730);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 14828, new Int16Array(11070), 1374, 744);
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  label: '\u8334\u0156',
+  code: `@group(0) @binding(714)
+var<storage, read_write> type0: array<u32>;
+
+@compute @workgroup_size(6, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S2 {
+  @builtin(front_facing) f0: bool,
+  @builtin(sample_index) f1: u32
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(1) f1: vec2<f32>
+}
+
+@fragment
+fn fragment0(@location(11) a0: vec4<u32>, @location(0) a1: f32, a2: S2) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S1 {
+  @location(12) f0: u32,
+  @location(10) f1: f16,
+  @location(6) f2: vec3<i32>,
+  @location(3) f3: vec4<f16>,
+  @location(13) f4: vec3<i32>,
+  @location(8) f5: vec2<f16>
+}
+struct VertexOutput0 {
+  @builtin(position) f15: vec4<f32>,
+  @location(0) f16: f32,
+  @location(11) f17: vec4<u32>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(0) a1: u32, @location(15) a2: u32, @location(11) a3: vec3<f16>, @location(4) a4: vec4<u32>, a5: S1, @location(2) a6: f32, @location(5) a7: i32, @location(9) a8: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture14 = device0.createTexture({
+  label: '\u5e88\u668b\u6f25\u0d5c\u093d\u336b\ue657\u0c26\u02a7\u{1f6a3}\u0485',
+  size: {width: 640, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'stencil8',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView21 = texture14.createView({label: '\u0163\ua334\u0d7c\u76aa\u0205', baseMipLevel: 2, mipLevelCount: 1});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({colorFormats: [], depthStencilFormat: 'stencil8', sampleCount: 1, depthReadOnly: true});
+let externalTexture6 = device0.importExternalTexture({label: '\u63a8\u96d8\u975b\u0b54\u3dbd\u0a61\u2172\u4aa4', source: video1, colorSpace: 'display-p3'});
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(2193);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle8, renderBundle11, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(706);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(3, bindGroup0, new Uint32Array(7466), 4386, 0);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(1305, undefined, 750867004, 2988845322);
+} catch {}
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  label: '\ucb98\u0337',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let renderBundle12 = renderBundleEncoder9.finish({label: '\u0505\u0763\u08e6\u0405\u{1f72c}\u63c0\u7b40\u{1fc87}\u0e1b\u0dc0'});
+try {
+computePassEncoder2.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup3, new Uint32Array(2058), 1185, 0);
+} catch {}
+try {
+renderPassEncoder3.setViewport(0.5179, 0.1048, 0.1501, 0.4404, 0.5179, 0.6832);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(new ArrayBuffer(32)), /* required buffer size: 892 */
+{offset: 892, bytesPerRow: 303}, {width: 46, height: 6, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup5 = device0.createBindGroup({layout: bindGroupLayout0, entries: []});
+let textureView22 = texture8.createView({dimension: '2d-array', baseMipLevel: 1, baseArrayLayer: 0, arrayLayerCount: 3});
+let renderBundle13 = renderBundleEncoder4.finish({label: '\u4f81\u00ca\u0431\u071e\u023e\u7400\u0f6e'});
+try {
+renderPassEncoder3.executeBundles([renderBundle1, renderBundle1, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(0, 0, 1, 1);
+} catch {}
+let pipeline8 = device0.createComputePipeline({
+  label: '\u0c8a\ude3a\u{1f930}\ub3f7\u0491\uf792\u0d62\u{1fedd}\u744d',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipeline9 = await device0.createRenderPipelineAsync({
+  label: '\ub5a7\u{1fbb6}\uaf9c\u04aa\ua87f',
+  layout: pipelineLayout0,
+  fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-wrap', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'equal', failOp: 'replace', passOp: 'keep'},
+    stencilReadMask: 2544946463,
+    stencilWriteMask: 3681991187,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 668,
+        attributes: [
+          {format: 'sint8x4', offset: 24, shaderLocation: 5},
+          {format: 'float32x4', offset: 152, shaderLocation: 4},
+          {format: 'sint32x2', offset: 32, shaderLocation: 6},
+          {format: 'uint8x4', offset: 8, shaderLocation: 15},
+          {format: 'unorm8x4', offset: 100, shaderLocation: 8},
+          {format: 'sint8x4', offset: 100, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 164,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 0, shaderLocation: 11},
+          {format: 'uint8x4', offset: 28, shaderLocation: 10},
+          {format: 'float16x2', offset: 0, shaderLocation: 7},
+          {format: 'uint32x4', offset: 16, shaderLocation: 9},
+          {format: 'sint8x4', offset: 0, shaderLocation: 3},
+          {format: 'sint16x4', offset: 28, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 84, shaderLocation: 0},
+          {format: 'float32x2', offset: 352, shaderLocation: 1},
+          {format: 'float32x2', offset: 312, shaderLocation: 2},
+          {format: 'uint8x4', offset: 156, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw', unclippedDepth: true},
+});
+let buffer3 = device0.createBuffer({
+  label: '\ub61b\u{1f9fb}\u02e0\u0165\u2705',
+  size: 3682,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT,
+});
+let commandEncoder18 = device0.createCommandEncoder({label: '\u{1fb40}\u{1fe4b}\u1422\u{1ff19}\ub166'});
+let querySet9 = device0.createQuerySet({label: '\uf90a\u0166', type: 'occlusion', count: 3244});
+let textureView23 = texture14.createView({label: '\u1843\u{1fcb4}', aspect: 'stencil-only', baseMipLevel: 2});
+let computePassEncoder6 = commandEncoder18.beginComputePass({label: '\uca53\u7eb2\u138a\u{1f75a}\u{1fd49}\u3e68\u5ad0\u0658\u7f65\uf691\u05d3'});
+let externalTexture7 = device0.importExternalTexture({source: video0, colorSpace: 'display-p3'});
+try {
+computePassEncoder4.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle3, renderBundle11, renderBundle11]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -517.6, g: 644.0, b: 341.7, a: -746.3, });
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(968, undefined, 0, 1676034962);
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+  label: '\u01ec\u{1fce6}\u1c51\ud5a2\u26c8\u09ec\u03f4\u300c\u0973\u50ea\u{1fd04}',
+  layout: bindGroupLayout2,
+  entries: [{binding: 336, resource: sampler2}],
+});
+let commandEncoder19 = device0.createCommandEncoder({label: '\u6247\u{1ff19}'});
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 1490});
+let commandBuffer6 = commandEncoder19.finish({});
+let externalTexture8 = device0.importExternalTexture({label: '\u0bc6\u6c29\u{1f670}\u{1f91d}\u0210', source: videoFrame0, colorSpace: 'display-p3'});
+try {
+renderPassEncoder3.beginOcclusionQuery(1764);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -258.9, g: 484.7, b: 664.1, a: -404.6, });
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(2286, undefined, 3180377342, 1065956469);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(72), /* required buffer size: 1_350 */
+{offset: 710, rowsPerImage: 79}, {width: 640, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let img3 = await imageWithData(151, 244, '#cb464b31', '#797c4aba');
+let renderBundle14 = renderBundleEncoder5.finish();
+try {
+computePassEncoder2.dispatchWorkgroups(2, 2);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(30, 2, 0, 4);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(2727);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2900, undefined, 0, 2826891746);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(4444, undefined, 0, 578362230);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(80)), /* required buffer size: 164 */
+{offset: 164}, {width: 127, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let textureView24 = texture10.createView({baseMipLevel: 2, mipLevelCount: 4});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1, renderBundle0, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(0, 0, 1, 1);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5097, undefined);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(3, bindGroup4, []);
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline9);
+} catch {}
+let texture15 = device0.createTexture({
+  label: '\u{1fb91}\u7e26\u01c3\u01e2\u4bf9\u0064\u{1fca7}\u20a6\uefbf',
+  size: [640, 10, 231],
+  mipLevelCount: 10,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView25 = texture9.createView({label: '\u8797\u9d21', dimension: '2d-array', baseMipLevel: 3});
+let sampler11 = device0.createSampler({
+  label: '\u4b6a\ue521\ucbbd\u{1f9b6}\u0319\u0fe9',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 30.13,
+  lodMaxClamp: 38.31,
+  maxAnisotropy: 11,
+});
+let externalTexture9 = device0.importExternalTexture({source: videoFrame2});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup2, new Uint32Array(936), 871, 0);
+} catch {}
+try {
+computePassEncoder0.dispatchWorkgroups(5, 4, 5);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(3172);
+} catch {}
+let pipeline10 = device0.createComputePipeline({
+  label: '\u{1ff56}\u583f\ufd65\u0931\u{1fbb2}\ue783\u192f\u3aea\u0a59\u{1ff1c}\u2bfa',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(img3);
+let imageBitmap4 = await createImageBitmap(imageBitmap2);
+let bindGroup7 = device0.createBindGroup({label: '\u07a9\ud07a\u6105\u06f3\u05b7\u8323\u4cea', layout: bindGroupLayout0, entries: []});
+let commandEncoder20 = device0.createCommandEncoder();
+let textureView26 = texture14.createView({aspect: 'stencil-only', baseMipLevel: 1, mipLevelCount: 1});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({
+  label: '\u{1f611}\u641c\u02d2\u002c\u0536\u4034\u0de7\u09e6',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+});
+let externalTexture10 = device0.importExternalTexture({label: '\ucaea\u02c1\u4e18\u0807\u8933', source: videoFrame1, colorSpace: 'display-p3'});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(4254, undefined);
+} catch {}
+let promise6 = device0.popErrorScope();
+try {
+commandEncoder20.copyTextureToBuffer({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 160 widthInBlocks: 160 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2448 */
+  offset: 2032,
+  bytesPerRow: 256,
+  buffer: buffer2,
+}, {width: 160, height: 2, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder20.copyTextureToTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 8, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 40, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderBundleEncoder10.pushDebugGroup('\u5659');
+} catch {}
+try {
+device0.queue.submit([commandBuffer4, commandBuffer6]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 238936, new BigUint64Array(23794), 19208, 220);
+} catch {}
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  label: '\u0043\u03ee\u5d92\u34e8\u41d5\u{1f8d6}\ufaab\u014d\ue23f\u2962\u{1f757}',
+  entries: [
+    {
+      binding: 485,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {binding: 934, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let commandEncoder21 = device0.createCommandEncoder({label: '\ua220\uf32e\uc20b\uf242\ud90a\u01d2\u0541\u{1fabb}\ud892\uc669'});
+let textureView27 = texture3.createView({
+  label: '\u{1fea0}\u{1ffb3}\u06a0\u06d2\u{1fff0}\u0e82\u939d\u7fe5',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  baseMipLevel: 6,
+  mipLevelCount: 2,
+});
+let renderPassEncoder6 = commandEncoder20.beginRenderPass({
+  label: '\u{1fb74}\u{1f72c}\u9a71\u0774\u31b1\uf3d7',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView16,
+    depthReadOnly: true,
+    stencilClearValue: 58856,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'discard',
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet10,
+  maxDrawCount: 917631391,
+});
+let renderBundle15 = renderBundleEncoder6.finish({label: '\u8d8c\udf2d\u05a7\u8e39\u780d\u161a\u5ecd\u8727\u8cd6\ua43d'});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+computePassEncoder0.dispatchWorkgroupsIndirect(buffer3, 540);
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(27, 6, 1, 0);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(685, undefined, 0, 1282027716);
+} catch {}
+try {
+commandEncoder21.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 5 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 7696 */
+  offset: 7696,
+  buffer: buffer2,
+}, {width: 5, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder21.clearBuffer(buffer2, 101688, 111788);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+video0.width = 5;
+let commandEncoder22 = device0.createCommandEncoder({});
+let texture16 = device0.createTexture({
+  label: '\u4e88\u0f2d\u1ac4\u49fd\u94bf\u{1fc43}',
+  size: [60, 12, 1],
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView28 = texture9.createView({
+  label: '\u{1fe69}\u096a\ub3a3\u0996\u0b84\u364f\u084e\u6444\u06cf',
+  aspect: 'all',
+  baseMipLevel: 3,
+  baseArrayLayer: 0,
+});
+let renderPassEncoder7 = commandEncoder22.beginRenderPass({
+  label: '\u5a05\u66a2\ue582\u4497\u3640\u12d2\ua02f',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView4, depthClearValue: 2.516458900697234, depthReadOnly: false, stencilReadOnly: true},
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 787131507,
+});
+try {
+renderPassEncoder0.executeBundles([renderBundle15, renderBundle3, renderBundle10, renderBundle7, renderBundle1, renderBundle13, renderBundle3, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder3.setViewport(0.3398, 0.6106, 0.4771, 0.3245, 0.1895, 0.5931);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2553, undefined, 3107580847, 1053689572);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup5, new Uint32Array(9777), 4080, 0);
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(5363, undefined, 3010155536);
+} catch {}
+try {
+commandEncoder21.copyBufferToBuffer(buffer3, 1984, buffer2, 25724, 1476);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder21.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 36914 */
+  offset: 36912,
+  buffer: buffer2,
+}, {width: 2, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer2);
+} catch {}
+let texture17 = device0.createTexture({
+  size: {width: 1280, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  dimension: '2d',
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder8 = commandEncoder21.beginRenderPass({
+  label: '\u{1fc85}\u4cb7\ue6fb\u12b8\uccac\uffe8\u063b\u122e',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView4,
+    depthClearValue: 4.051858942079708,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'store',
+    stencilReadOnly: false,
+  },
+  maxDrawCount: 589685428,
+});
+let renderBundle16 = renderBundleEncoder0.finish({label: '\u94a7\u0276\u1cc3\u{1faf5}\ucd7a\u016b\u32dc\u2b80\u{1f948}\u30c0\u4fbb'});
+let externalTexture11 = device0.importExternalTexture({label: '\ua558\ufed9\u3e1a\u5272\u{1f99d}\u{1fffa}', source: video1, colorSpace: 'display-p3'});
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(1, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline9);
+} catch {}
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  label: '\u{1ffbe}\u0906\u2ede\u{1f6f3}\u0be5\u{1fcb3}\u0e0e\u0d50\u087a\u00a4\u0d6c',
+  entries: [
+    {
+      binding: 240,
+      visibility: 0,
+      texture: { viewDimension: '2d-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 597,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let texture18 = device0.createTexture({
+  label: '\u0791\u000a\u08f2\u3445\u5db2',
+  size: {width: 60, height: 12, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['stencil8'],
+});
+let textureView29 = texture6.createView({baseMipLevel: 3, mipLevelCount: 3, baseArrayLayer: 22, arrayLayerCount: 6});
+let renderBundle17 = renderBundleEncoder6.finish({label: '\u3f89\u94af'});
+let sampler12 = device0.createSampler({
+  label: '\uac74\u{1f7d6}\u{1f851}\u40a5\u{1f791}\u48bf',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 71.57,
+  lodMaxClamp: 77.70,
+});
+try {
+renderPassEncoder4.beginOcclusionQuery(1598);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(4504, undefined);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 30},
+  aspect: 'stencil-only',
+}, new ArrayBuffer(8), /* required buffer size: 198_111 */
+{offset: 156, bytesPerRow: 265, rowsPerImage: 249}, {width: 40, height: 0, depthOrArrayLayers: 4});
+} catch {}
+let pipeline11 = await promise5;
+let offscreenCanvas2 = new OffscreenCanvas(741, 883);
+let shaderModule2 = device0.createShaderModule({
+  label: '\u095e\u0f5b\u920c\u06ae\u0dbc\u5a0b\u96ea\u0d74\u68a5\u{1fd52}',
+  code: `@group(0) @binding(336)
+var<storage, read_write> parameter0: array<u32>;
+
+@compute @workgroup_size(3, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(6) f0: vec2<i32>,
+  @builtin(sample_mask) f1: u32
+}
+
+@fragment
+fn fragment0(@location(10) a0: f32, @location(2) a1: vec2<f32>, @location(14) a2: vec3<u32>, @location(9) a3: i32, @location(6) a4: f32, @location(5) a5: f32, @location(12) a6: vec3<i32>, @location(4) a7: u32, @location(8) a8: vec4<u32>, @location(15) a9: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S3 {
+  @location(6) f0: vec3<f32>,
+  @location(7) f1: vec2<i32>,
+  @location(11) f2: vec2<u32>,
+  @location(10) f3: vec4<f16>,
+  @location(2) f4: i32,
+  @location(5) f5: vec4<u32>,
+  @location(13) f6: vec4<f32>,
+  @location(1) f7: vec2<i32>,
+  @location(4) f8: vec3<f32>,
+  @builtin(instance_index) f9: u32,
+  @location(14) f10: i32
+}
+struct VertexOutput0 {
+  @location(6) f18: f32,
+  @location(9) f19: i32,
+  @location(14) f20: vec3<u32>,
+  @location(10) f21: f32,
+  @location(5) f22: f32,
+  @location(3) f23: vec4<f16>,
+  @builtin(position) f24: vec4<f32>,
+  @location(8) f25: vec4<u32>,
+  @location(4) f26: u32,
+  @location(0) f27: vec3<u32>,
+  @location(2) f28: vec2<f32>,
+  @location(12) f29: vec3<i32>,
+  @location(7) f30: vec4<f16>,
+  @location(15) f31: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: u32, @location(9) a1: vec3<f16>, a2: S3, @location(3) a3: vec4<u32>, @location(15) a4: vec3<i32>, @location(0) a5: f32, @location(12) a6: i32, @builtin(vertex_index) a7: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer4 = device0.createBuffer({
+  label: '\ub5e4\u{1fc4b}\u{1fea1}\u{1fb7e}\u{1f625}\uc4f6\u41e6\u{1fdec}',
+  size: 11343,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 1331});
+let textureView30 = texture0.createView({label: '\u145e\u9574\u0cca\u0f3c'});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({colorFormats: [], depthStencilFormat: 'stencil8'});
+let externalTexture12 = device0.importExternalTexture({label: '\u03b0\u{1f875}\u{1f670}\u4276\u023a\u8a62\u6cbd\u02f0', source: video1, colorSpace: 'srgb'});
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder7.beginOcclusionQuery(890);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(5192, undefined, 1410176924, 738183273);
+} catch {}
+try {
+computePassEncoder4.insertDebugMarker('\u{1f992}');
+} catch {}
+let texture19 = device0.createTexture({
+  size: {width: 60, height: 12, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8', 'stencil8', 'stencil8'],
+});
+let textureView31 = texture17.createView({dimension: '2d-array', aspect: 'stencil-only', baseMipLevel: 1, mipLevelCount: 3});
+let renderBundle18 = renderBundleEncoder3.finish();
+try {
+renderPassEncoder0.setBlendConstant({ r: 462.2, g: -785.9, b: -491.3, a: 52.38, });
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(2, bindGroup7, new Uint32Array(4700), 2681, 0);
+} catch {}
+try {
+renderBundleEncoder10.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 26_528 */
+{offset: 149, bytesPerRow: 1321}, {width: 1280, height: 20, depthOrArrayLayers: 1});
+} catch {}
+let texture20 = device0.createTexture({
+  label: '\ud8be\u{1ffce}\u47c8',
+  size: {width: 320, height: 5, depthOrArrayLayers: 202},
+  mipLevelCount: 9,
+  dimension: '2d',
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8', 'stencil8'],
+});
+let textureView32 = texture6.createView({
+  label: '\u3489\u0d4a\u29fa\u4aba\ue139',
+  dimension: '2d-array',
+  baseMipLevel: 6,
+  mipLevelCount: 1,
+  baseArrayLayer: 19,
+  arrayLayerCount: 7,
+});
+let externalTexture13 = device0.importExternalTexture({label: '\u{1fc71}\u0a44\u031c\u0a69\u8e5a\u0ad6', source: video0, colorSpace: 'srgb'});
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup2, []);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder3.setViewport(0.4225, 0.2644, 0.2389, 0.6025, 0.8709, 0.9895);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(9964, undefined, 81606658, 3006198588);
+} catch {}
+let canvas3 = document.createElement('canvas');
+try {
+renderPassEncoder4.setBlendConstant({ r: 179.8, g: -219.5, b: -589.7, a: -155.9, });
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(159);
+} catch {}
+try {
+renderPassEncoder0.setViewport(0.5092, 0.8882, 0.4178, 0.08977, 0.3606, 0.6443);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(7152, undefined, 0, 275256795);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 49608, new Float32Array(25275), 4279, 444);
+} catch {}
+let buffer5 = device0.createBuffer({
+  label: '\u35cc\u06dd\u{1f77b}\u{1fa64}\u{1fc18}\u0de3\u00b9\u{1fd41}\u0a7e\u9fb8',
+  size: 13003,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: false,
+});
+let commandEncoder23 = device0.createCommandEncoder({label: '\uc61a\u4f09\u048d\u90d5\u3e6d\ubf0c\u03b4\u1750'});
+let commandBuffer7 = commandEncoder23.finish();
+let texture21 = device0.createTexture({
+  size: [1280, 20, 43],
+  mipLevelCount: 7,
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  label: '\u0540\u3767\u03e6\ub44f\ue1df\u{1fd79}\u033a\u00d2',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler13 = device0.createSampler({
+  label: '\u{1fc1d}\u9e32\u9a99\u0692\u{1f95b}\u53ca\u8f36\u0c89\u{1fe12}\u{1fc29}',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'less',
+  maxAnisotropy: 19,
+});
+try {
+renderPassEncoder1.executeBundles([renderBundle5, renderBundle17, renderBundle4, renderBundle15, renderBundle18, renderBundle10, renderBundle12, renderBundle14]);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 559.0, g: -378.3, b: -857.5, a: -22.37, });
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(1229);
+} catch {}
+try {
+renderPassEncoder3.setViewport(0.2997, 0.01907, 0.6575, 0.3088, 0.9544, 0.9984);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(2716, undefined, 0, 2441482736);
+} catch {}
+let pipeline12 = device0.createComputePipeline({
+  label: '\u{1f8f3}\u021a\u29d9',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let imageBitmap5 = await createImageBitmap(offscreenCanvas1);
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let commandEncoder24 = device0.createCommandEncoder();
+let computePassEncoder7 = commandEncoder24.beginComputePass({label: '\u011b\u0500\u035d\ud682'});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({colorFormats: [], depthStencilFormat: 'stencil8', stencilReadOnly: true});
+let sampler14 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 19.57,
+  compare: 'greater-equal',
+});
+try {
+renderPassEncoder7.setScissorRect(5, 2, 22, 1);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(3, bindGroup3);
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  label: '\uca42\uc85d\uf9b9\uada2\ub83c\u0161\uac40\u69d4\ub42d\ud5db',
+  code: `@group(0) @binding(714)
+var<storage, read_write> field0: array<u32>;
+
+@compute @workgroup_size(4, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool) {
+
+}
+
+struct S4 {
+  @location(12) f0: f16,
+  @location(13) f1: vec3<f32>,
+  @location(1) f2: vec2<f32>,
+  @location(11) f3: vec2<i32>,
+  @location(14) f4: vec4<i32>,
+  @location(10) f5: vec2<f16>,
+  @location(4) f6: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec3<i32>, @location(3) a1: vec3<u32>, @builtin(instance_index) a2: u32, @location(6) a3: vec2<u32>, @builtin(vertex_index) a4: u32, @location(8) a5: vec4<u32>, @location(9) a6: vec4<u32>, @location(0) a7: vec4<f32>, @location(7) a8: vec4<f16>, a9: S4, @location(5) a10: vec3<f16>, @location(2) a11: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer6 = device0.createBuffer({label: '\u8637\u985a\u9301\u028c\u5259\u3b95\ue043', size: 218585, usage: GPUBufferUsage.VERTEX});
+let textureView33 = texture2.createView({
+  label: '\u0d17\u{1f9cb}\u0065\u8868\u052e\u{1fc1d}\u{1fcb8}\u0f19\u0b68\u24b6\ue0ca',
+  dimension: '2d-array',
+  baseMipLevel: 4,
+  baseArrayLayer: 106,
+  arrayLayerCount: 64,
+});
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup7, new Uint32Array(5878), 4580, 0);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 415.7, g: -571.7, b: -894.5, a: -465.9, });
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(2, buffer6);
+} catch {}
+try {
+renderBundleEncoder10.insertDebugMarker('\u0ca9');
+} catch {}
+gc();
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  label: '\u0c85\u036a\u9efb\u9623\uca06',
+  entries: [
+    {
+      binding: 781,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let buffer7 = device0.createBuffer({
+  label: '\ub133\u2536\u0e73\u0a89\uc3cb\uc7eb',
+  size: 184288,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+  mappedAtCreation: true,
+});
+let commandEncoder25 = device0.createCommandEncoder({label: '\u1edf\ud07a\u{1fea2}\udc6a\u6507\u{1f74e}\u4059\ua454\u{1f827}'});
+let texture22 = device0.createTexture({
+  label: '\uf0d9\u{1fa89}\u0d53\u{1fd12}\u0673\ua5c0\u99ef\ue095\ue0c0\u0531\u0a3e',
+  size: {width: 240, height: 48, depthOrArrayLayers: 190},
+  mipLevelCount: 3,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['stencil8'],
+});
+let computePassEncoder8 = commandEncoder25.beginComputePass();
+let renderBundle19 = renderBundleEncoder12.finish({label: '\u0b33\u{1f7eb}\ub43f\u{1f888}\u0e31\u{1fe65}\u91a0\u5654\ue78e'});
+try {
+computePassEncoder4.setPipeline(pipeline2);
+} catch {}
+try {
+texture1.destroy();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline13 = device0.createRenderPipeline({
+  label: '\u{1fbe1}\u3016\u16ed\u8f63\u0844\u{1fa2e}\u61b0\u81e0',
+  layout: pipelineLayout2,
+  multisample: {count: 4, mask: 0x959b8f82},
+  fragment: {module: shaderModule2, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {failOp: 'replace', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'less', failOp: 'increment-clamp', passOp: 'increment-wrap'},
+    stencilReadMask: 61110363,
+    stencilWriteMask: 2949467668,
+    depthBiasSlopeScale: -53.048545293059966,
+    depthBiasClamp: 985.1765871737887,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 628,
+        attributes: [
+          {format: 'uint32x4', offset: 88, shaderLocation: 3},
+          {format: 'snorm16x2', offset: 248, shaderLocation: 4},
+          {format: 'sint32x3', offset: 180, shaderLocation: 14},
+          {format: 'sint8x4', offset: 248, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 348, shaderLocation: 13},
+          {format: 'uint32', offset: 252, shaderLocation: 5},
+          {format: 'float16x4', offset: 1172, shaderLocation: 0},
+          {format: 'uint32', offset: 424, shaderLocation: 8},
+          {format: 'sint32', offset: 560, shaderLocation: 1},
+          {format: 'sint32x3', offset: 912, shaderLocation: 15},
+          {format: 'float32x4', offset: 4, shaderLocation: 10},
+          {format: 'sint8x2', offset: 338, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 168,
+        attributes: [
+          {format: 'float32x4', offset: 24, shaderLocation: 6},
+          {format: 'uint16x2', offset: 132, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 372, stepMode: 'instance', attributes: []},
+      {arrayStride: 232, stepMode: 'instance', attributes: []},
+      {arrayStride: 40, stepMode: 'instance', attributes: []},
+      {arrayStride: 128, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 52,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 2, shaderLocation: 9},
+          {format: 'sint32x4', offset: 4, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'front'},
+});
+let gpuCanvasContext1 = canvas3.getContext('webgpu');
+let img4 = await imageWithData(129, 275, '#4b852946', '#071f1d54');
+let bindGroupLayout8 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 577,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '3d' },
+    },
+  ],
+});
+let commandEncoder26 = device0.createCommandEncoder({label: '\u{1f696}\ue508\udcf9\u6e2a\ud842'});
+let textureView34 = texture0.createView({label: '\u{1f698}\u3434\u22ec\udb8c\u07a1\u{1fd75}'});
+let computePassEncoder9 = commandEncoder26.beginComputePass({label: '\u0ecd\u{1fac7}\u08fb\u827e\u{1fc80}\u24b8\ud129\u0b6f\u662b\u06eb'});
+let externalTexture14 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'srgb'});
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle18, renderBundle10, renderBundle18, renderBundle18, renderBundle10, renderBundle10, renderBundle10, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(20, 5, 8, 1);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(5, buffer6, 118676, 35344);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let promise7 = adapter0.requestAdapterInfo();
+let bindGroupLayout9 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 378,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let commandEncoder27 = device0.createCommandEncoder({});
+let computePassEncoder10 = commandEncoder27.beginComputePass({});
+try {
+computePassEncoder0.dispatchWorkgroups(3, 3, 2);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+  await promise6;
+} catch {}
+let bindGroup8 = device0.createBindGroup({
+  label: '\u0b06\u{1fbd2}\u7b13\u1f5e\uced4\u9498\ua111\uc4af\u0446\u{1f92e}\u0157',
+  layout: bindGroupLayout7,
+  entries: [{binding: 781, resource: {buffer: buffer0, offset: 38400, size: 2724}}],
+});
+let commandEncoder28 = device0.createCommandEncoder({label: '\u2278\u{1fcef}\ua1d5\u06f4\uee18\u{1f66b}\u41b8\ubff6\uae8b'});
+let textureView35 = texture17.createView({baseMipLevel: 3});
+let renderPassEncoder9 = commandEncoder28.beginRenderPass({
+  label: '\u718e\u567f\uc294\u8582\u{1fa26}\ue9a6\u{1f862}\ueff5\u{1fc56}\u6b69',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView13, depthReadOnly: true, stencilClearValue: 47964, stencilReadOnly: true},
+  occlusionQuerySet: querySet11,
+  maxDrawCount: 621162379,
+});
+let externalTexture15 = device0.importExternalTexture({
+  label: '\ua63e\u0ad0\ud2f9\u{1f75f}\u{1f84a}\u{1faff}\u03c1\uf83b\u{1fc61}',
+  source: video1,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder0.setBlendConstant({ r: 358.4, g: 634.9, b: -458.9, a: -261.7, });
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer7, 'uint32', 172836, 6940);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer6);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder3.insertDebugMarker('\udc87');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 5652, new DataView(new ArrayBuffer(17456)), 13100, 60);
+} catch {}
+let gpuCanvasContext2 = offscreenCanvas0.getContext('webgpu');
+let querySet12 = device0.createQuerySet({label: '\uebb6\u6e9f\u0af2\u1a69\u0965\u0ad2', type: 'occlusion', count: 1489});
+let textureView36 = texture15.createView({
+  label: '\u0778\u01e0\u098f\u{1ff76}\u04ee\u07aa\u2c25\uc632\u0e7e\u5fec',
+  baseMipLevel: 6,
+  mipLevelCount: 2,
+  baseArrayLayer: 123,
+  arrayLayerCount: 70,
+});
+let renderBundle20 = renderBundleEncoder13.finish({label: '\u0fbe\u800c'});
+try {
+computePassEncoder0.dispatchWorkgroups(5, 3, 1);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle20, renderBundle20, renderBundle18]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -845.8, g: -309.0, b: -678.0, a: 904.1, });
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(1, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer6);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(0, bindGroup4, []);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(5, buffer6, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(40), /* required buffer size: 11_633_383 */
+{offset: 327, bytesPerRow: 432, rowsPerImage: 176}, {width: 160, height: 1, depthOrArrayLayers: 154});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  code: `@group(2) @binding(336)
+var<storage, read_write> n1: array<u32>;
+@group(1) @binding(714)
+var<storage, read_write> type1: array<u32>;
+
+@compute @workgroup_size(5, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S5 {
+  @location(7) f0: f16,
+  @location(13) f1: i32,
+  @location(5) f2: vec2<u32>,
+  @location(1) f3: i32,
+  @location(3) f4: f16,
+  @location(11) f5: vec3<u32>,
+  @builtin(position) f6: vec4<f32>,
+  @location(4) f7: vec3<f16>,
+  @location(8) f8: i32,
+  @location(14) f9: f16,
+  @location(6) f10: vec4<f16>,
+  @builtin(sample_index) f11: u32,
+  @location(15) f12: vec4<f16>
+}
+
+@fragment
+fn fragment0(@location(9) a0: vec2<f16>, a1: S5, @builtin(sample_mask) a2: u32, @builtin(front_facing) a3: bool) {
+
+}
+
+struct VertexOutput0 {
+  @location(1) f32: i32,
+  @location(15) f33: vec4<f16>,
+  @location(13) f34: i32,
+  @location(14) f35: f16,
+  @location(11) f36: vec3<u32>,
+  @location(8) f37: i32,
+  @builtin(position) f38: vec4<f32>,
+  @location(6) f39: vec4<f16>,
+  @location(4) f40: vec3<f16>,
+  @location(3) f41: f16,
+  @location(7) f42: f16,
+  @location(5) f43: vec2<u32>,
+  @location(9) f44: vec2<f16>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(0) a1: vec4<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture23 = device0.createTexture({
+  label: '\u913f\u6e5f\u7d29\u5721\ud801\u{1ffc4}\u3230\ua194\u8b02',
+  size: [60, 12, 163],
+  mipLevelCount: 5,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView37 = texture12.createView({
+  label: '\u0de8\u0e98\u1cba\u{1fb59}\u07b9\u89c6\u0706\u0356\u08b7\u{1f998}\u0340',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  baseMipLevel: 2,
+});
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder3.setViewport(0.5461, 0.4061, 0.2567, 0.5033, 0.1351, 0.1962);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline9);
+} catch {}
+let arrayBuffer0 = buffer7.getMappedRange(143128, 144);
+let pipeline14 = device0.createComputePipeline({
+  label: '\ue7ee\u0511\u7e6a\u{1f603}\u{1f7f0}\u1c34\u084e',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise7;
+} catch {}
+let promise8 = navigator.gpu.requestAdapter();
+let canvas4 = document.createElement('canvas');
+let imageBitmap6 = await createImageBitmap(imageBitmap5);
+let commandEncoder29 = device0.createCommandEncoder({label: '\u02d5\u3754\uef23\u4343\u07ea'});
+let querySet13 = device0.createQuerySet({type: 'occlusion', count: 3151});
+let renderPassEncoder10 = commandEncoder29.beginRenderPass({
+  label: '\ub9d5\u0f92\u1e5f\u{1fc34}\u6dd7\u6452\u{1f6dd}\u3694\ud9e1\u5a05\u{1f673}',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView13,
+    depthReadOnly: false,
+    stencilClearValue: 17684,
+    stencilLoadOp: 'load',
+    stencilStoreOp: 'store',
+  },
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 682522235,
+});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({colorFormats: [], depthStencilFormat: 'stencil8', stencilReadOnly: false});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup7, new Uint32Array(6974), 2357, 0);
+} catch {}
+try {
+renderPassEncoder10.setScissorRect(1, 0, 0, 1);
+} catch {}
+try {
+renderPassEncoder4.setStencilReference(3173);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(6288, undefined, 0, 1208661377);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 35880, new Int16Array(24471), 22968, 160);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer8 = device0.createBuffer({label: '\u799d\u0196\u{1fa0b}\u0ab0\ude46', size: 355382, usage: GPUBufferUsage.COPY_DST});
+let texture24 = device0.createTexture({
+  label: '\u0498\u0d83\ud077\u{1fe30}\u{1fa8e}\uebf6\u09d2\u7b41',
+  size: [160, 2, 1],
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8'],
+});
+let externalTexture16 = device0.importExternalTexture({label: '\u{1fd78}\u{1ff35}\u4b6f\u13e1\u04e1', source: videoFrame2, colorSpace: 'display-p3'});
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(0, 0, 1, 0);
+} catch {}
+try {
+renderPassEncoder0.setViewport(0.7227, 0.4880, 0.1862, 0.2760, 0.4837, 0.8508);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline9);
+} catch {}
+let imageBitmap7 = await createImageBitmap(img3);
+let texture25 = device0.createTexture({
+  label: '\u92fb\u11c5\ucd03\u0c7e\u0b07\ub2a4\ude90',
+  size: [160, 2, 147],
+  mipLevelCount: 8,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture17 = device0.importExternalTexture({
+  label: '\u{1f7c2}\u{1fa02}\u010c\u{1ff23}\u498d\u081d\u8f63\u0ece\u35e9',
+  source: video1,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder9.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer7, 'uint16', 3158);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline9);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 13340, new Int16Array(12725), 10342, 852);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 52},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 4_895_445 */
+{offset: 25, bytesPerRow: 246, rowsPerImage: 199}, {width: 20, height: 1, depthOrArrayLayers: 101});
+} catch {}
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout6, bindGroupLayout9, bindGroupLayout9]});
+let sampler15 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 89.97,
+  lodMaxClamp: 96.02,
+});
+try {
+computePassEncoder2.dispatchWorkgroupsIndirect(buffer3, 3016);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: 277.8, g: 383.1, b: -785.3, a: -288.1, });
+} catch {}
+try {
+window.someLabel = sampler3.label;
+} catch {}
+let commandEncoder30 = device0.createCommandEncoder({label: '\u{1fa6e}\u0588\u00cf\u4bc1\ua10e\u20c1\u0745\ud8c8\u{1ffae}\ua1c4'});
+let renderPassEncoder11 = commandEncoder30.beginRenderPass({
+  label: '\u{1fa59}\u{1faf3}\u0e40',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView4, stencilReadOnly: true},
+  occlusionQuerySet: querySet13,
+  maxDrawCount: 322255215,
+});
+try {
+computePassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(1103);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(1, 0, 0, 1);
+} catch {}
+try {
+renderPassEncoder8.setViewport(19.86, 3.166, 3.679, 0.3445, 0.4011, 0.6784);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(3, buffer6, 120996, 2045);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(3, buffer6);
+} catch {}
+let commandEncoder31 = device0.createCommandEncoder({label: '\u0afd\u56bf\u284e\u{1ff9d}\u192a\u406d'});
+let texture26 = device0.createTexture({
+  label: '\u2ec2\ud149\u{1fcef}\u60e5\ub164\ua161\u0e2a',
+  size: [30, 6, 1],
+  mipLevelCount: 3,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8', 'stencil8', 'stencil8'],
+});
+let textureView38 = texture4.createView({
+  label: '\uffd2\u{1f72c}\u{1fcfd}\u1283\u6344\u274b\u{1f601}\u{1f85e}',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  baseMipLevel: 4,
+  mipLevelCount: 1,
+});
+let renderPassEncoder12 = commandEncoder31.beginRenderPass({
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView1,
+    depthReadOnly: true,
+    stencilLoadOp: 'load',
+    stencilStoreOp: 'discard',
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet7,
+  maxDrawCount: 919674918,
+});
+let sampler16 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 64.39,
+});
+try {
+renderPassEncoder8.setBlendConstant({ r: -477.6, g: 419.3, b: 795.4, a: 963.1, });
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline9);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+});
+} catch {}
+let querySet14 = device0.createQuerySet({label: '\u806a\u8343\ue521\u3033\u0b4e\u{1facf}\u01d2\u0c69\u{1fdd3}', type: 'occlusion', count: 1149});
+try {
+renderPassEncoder8.executeBundles([renderBundle18, renderBundle20, renderBundle8, renderBundle6, renderBundle19, renderBundle14, renderBundle4, renderBundle1, renderBundle15]);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer7, 'uint32');
+} catch {}
+let pipeline15 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule2, entryPoint: 'compute0'}});
+let commandEncoder32 = device0.createCommandEncoder();
+let renderPassEncoder13 = commandEncoder32.beginRenderPass({
+  label: '\u{1f7b9}\u2308\u{1f6cf}\u{1fd9a}\u03b3\u{1f719}',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView13,
+    depthClearValue: -5.027606376358744,
+    depthReadOnly: false,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'store',
+  },
+  maxDrawCount: 892659244,
+});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({colorFormats: [], depthStencilFormat: 'stencil8', depthReadOnly: true});
+let externalTexture18 = device0.importExternalTexture({source: videoFrame2, colorSpace: 'srgb'});
+try {
+computePassEncoder0.dispatchWorkgroups(4);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(1791);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 4824, new DataView(new ArrayBuffer(18919)), 3565, 4784);
+} catch {}
+let pipeline16 = await device0.createComputePipelineAsync({
+  label: '\u{1fd55}\uad4c\u0ee5\ue258\u4926\uf61d\u4b32\ucd25\u0dcf\u0598\u760f',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder33 = device0.createCommandEncoder({});
+let texture27 = device0.createTexture({
+  label: '\u94ad\u8aae\u{1f8b6}\u260b\u367d\ue4b2\ue607\u0791\u05fa',
+  size: {width: 30, height: 6, depthOrArrayLayers: 81},
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['stencil8', 'stencil8', 'stencil8'],
+});
+let renderPassEncoder14 = commandEncoder33.beginRenderPass({
+  label: '\ub082\u9077\u0135\u03b8\u{1fc31}\uda66\u{1f958}\u{1fe24}',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView1, depthReadOnly: false, stencilClearValue: 10522, stencilReadOnly: true},
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 1092993769,
+});
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle20, renderBundle11, renderBundle9, renderBundle9, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(3075);
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer7, 'uint32', 97076, 80320);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer7, 'uint16', 158240, 13178);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(6, buffer6, 0, 55123);
+} catch {}
+try {
+  await buffer4.mapAsync(GPUMapMode.WRITE, 5008, 1520);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 31752, new Int16Array(29566), 21975, 680);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 82},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 288_458 */
+{offset: 350, bytesPerRow: 318, rowsPerImage: 151}, {width: 20, height: 0, depthOrArrayLayers: 7});
+} catch {}
+let sampler17 = device0.createSampler({
+  label: '\u26ac\u1093\u6c4a\u0e9c\u{1fd30}\u084c\u867c\u003e',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 70.89,
+  lodMaxClamp: 96.30,
+  maxAnisotropy: 20,
+});
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle3, renderBundle19, renderBundle20, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(1, buffer6, 56716, 56656);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+let pipeline17 = device0.createComputePipeline({
+  label: '\uc744\u66ae\uc19a\u{1f910}\u0e7b\u826a\u0cde\uef64',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let imageBitmap8 = await createImageBitmap(video1);
+let bindGroup9 = device0.createBindGroup({label: '\u946a\uc073\ua434\u{1ff76}\u508a\u0211\u46d8\u5da2', layout: bindGroupLayout0, entries: []});
+let commandEncoder34 = device0.createCommandEncoder({label: '\ubfe9\ua805\u2200\u0251\u4e48\u{1f701}\u{1fafd}\ub7c2'});
+let renderPassEncoder15 = commandEncoder34.beginRenderPass({
+  label: '\u548b\uaba9\udccc\ubcb8',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView16, depthReadOnly: true, stencilLoadOp: 'load', stencilStoreOp: 'discard'},
+  occlusionQuerySet: querySet13,
+});
+let renderBundle21 = renderBundleEncoder14.finish();
+try {
+renderPassEncoder13.setScissorRect(0, 0, 0, 1);
+} catch {}
+try {
+renderPassEncoder15.setStencilReference(605);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(5, buffer6, 195516, 3225);
+} catch {}
+let arrayBuffer1 = buffer7.getMappedRange(167912, 1520);
+let canvas5 = document.createElement('canvas');
+let querySet15 = device0.createQuerySet({label: '\uc4e9\u76a0\ue28d\u2b4e\u8ca1\u0e84\uaae6\u{1f8e6}', type: 'occlusion', count: 2008});
+let textureView39 = texture19.createView({label: '\u5c51\u3b29\u2024\u0b2c\u01ab\u6a6e', dimension: '2d-array', baseMipLevel: 1});
+try {
+computePassEncoder6.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant({ r: 970.1, g: -359.9, b: -388.0, a: 804.6, });
+} catch {}
+try {
+renderPassEncoder11.setViewport(24.16, 0.06351, 0.7346, 4.066, 0.2788, 0.7189);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(0, buffer6, 62432);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder7.setPipeline(pipeline9);
+} catch {}
+let pipeline18 = device0.createRenderPipeline({
+  label: '\u{1fe20}\u{1f997}\u{1fef1}\u{1fa8c}\u034a\u77ff',
+  layout: pipelineLayout1,
+  fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'not-equal', failOp: 'increment-clamp', depthFailOp: 'invert', passOp: 'replace'},
+    stencilBack: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilReadMask: 1536687234,
+    stencilWriteMask: 4294967295,
+    depthBiasSlopeScale: -50.65980553194732,
+    depthBiasClamp: 154.17132294738013,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 680, shaderLocation: 7},
+          {format: 'uint32x3', offset: 468, shaderLocation: 9},
+          {format: 'snorm8x2', offset: 104, shaderLocation: 8},
+          {format: 'sint32x2', offset: 252, shaderLocation: 0},
+          {format: 'sint8x2', offset: 78, shaderLocation: 6},
+          {format: 'unorm10-10-10-2', offset: 556, shaderLocation: 2},
+          {format: 'uint32x4', offset: 248, shaderLocation: 10},
+          {format: 'uint32x2', offset: 1308, shaderLocation: 14},
+          {format: 'sint8x2', offset: 76, shaderLocation: 5},
+          {format: 'unorm8x2', offset: 292, shaderLocation: 1},
+          {format: 'unorm8x4', offset: 40, shaderLocation: 11},
+          {format: 'float16x4', offset: 332, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 668,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint32x3', offset: 344, shaderLocation: 15},
+          {format: 'sint32x3', offset: 20, shaderLocation: 3},
+          {format: 'sint32x2', offset: 116, shaderLocation: 12},
+          {format: 'sint8x4', offset: 184, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'front'},
+});
+let shaderModule5 = device0.createShaderModule({
+  label: '\u08df\u52ef\u09ec\u8c9c\uca12',
+  code: `@group(2) @binding(378)
+var<storage, read_write> global0: array<u32>;
+@group(1) @binding(378)
+var<storage, read_write> function0: array<u32>;
+@group(0) @binding(240)
+var<storage, read_write> field1: array<u32>;
+@group(0) @binding(597)
+var<storage, read_write> n2: array<u32>;
+
+@compute @workgroup_size(8, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0() {
+
+}
+
+
+
+@vertex
+fn vertex0(@location(10) a0: vec3<u32>, @location(6) a1: f16, @location(4) a2: vec3<u32>, @location(5) a3: vec3<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup8, new Uint32Array(210), 201, 1);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle21, renderBundle21, renderBundle21, renderBundle18, renderBundle20, renderBundle20, renderBundle20]);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer7, 'uint32', 10964, 78311);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer6);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer1), /* required buffer size: 3_507_019 */
+{offset: 510, bytesPerRow: 301, rowsPerImage: 64}, {width: 160, height: 2, depthOrArrayLayers: 183});
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+let pipeline19 = await promise4;
+try {
+  await promise9;
+} catch {}
+let imageBitmap9 = await createImageBitmap(videoFrame2);
+let commandEncoder35 = device0.createCommandEncoder({label: '\uc86b\u{1f98e}\u{1f695}'});
+let texture28 = device0.createTexture({
+  label: '\u{1f6ca}\u7d23\u066d\u059e\u5ff5\uab62\u{1fcff}\u0b1b\ub0eb\u0aa4\u36a0',
+  size: [240, 48, 54],
+  mipLevelCount: 6,
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView40 = texture22.createView({
+  label: '\u3e49\u{1f6aa}\u5d2c\u3245\ub1c6\u8d96\uf5f2\u1157\u{1fb92}',
+  mipLevelCount: 2,
+  baseArrayLayer: 38,
+  arrayLayerCount: 44,
+});
+let renderPassEncoder16 = commandEncoder35.beginRenderPass({
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView37,
+    depthClearValue: -6.879401705805941,
+    stencilClearValue: 8590,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'discard',
+    stencilReadOnly: false,
+  },
+  maxDrawCount: 721670336,
+});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup1, new Uint32Array(1435), 1150, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle4, renderBundle0, renderBundle9, renderBundle1, renderBundle21]);
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(7, 4, 11, 1);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer7, 'uint32', 148504, 29151);
+} catch {}
+try {
+adapter0.label = '\u3240\u4fb9';
+} catch {}
+let texture29 = device0.createTexture({
+  label: '\u{1ff7e}\ua477\uafe2',
+  size: [30, 6, 76],
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8', 'stencil8', 'stencil8'],
+});
+let textureView41 = texture14.createView({label: '\u1b21\u06dd\u{1f861}', dimension: '2d-array', baseMipLevel: 3, mipLevelCount: 1});
+try {
+renderPassEncoder12.beginOcclusionQuery(2596);
+} catch {}
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(0, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer7, 'uint16', 142584, 2581);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer7, 'uint32');
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let imageData1 = new ImageData(184, 96);
+let bindGroupLayout10 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 43,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {binding: 333, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 645,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let commandEncoder36 = device0.createCommandEncoder();
+let externalTexture19 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'display-p3'});
+try {
+computePassEncoder0.dispatchWorkgroups(5, 1, 2);
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(29, 2, 1, 0);
+} catch {}
+try {
+renderPassEncoder12.setViewport(0.1928, 0.6353, 0.4480, 0.1635, 0.5646, 0.9978);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(5, buffer6, 0, 116743);
+} catch {}
+try {
+commandEncoder36.copyBufferToBuffer(buffer4, 8212, buffer2, 7708, 160);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 876, new BigUint64Array(7548), 1967, 2368);
+} catch {}
+let pipeline20 = device0.createRenderPipeline({
+  label: '\uf3cf\u82d1\u02eb\uaede\ue1f2',
+  layout: pipelineLayout0,
+  fragment: {module: shaderModule4, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {
+      compare: 'greater-equal',
+      failOp: 'increment-wrap',
+      depthFailOp: 'decrement-wrap',
+      passOp: 'decrement-clamp',
+    },
+    stencilBack: {compare: 'less-equal', failOp: 'increment-wrap', depthFailOp: 'invert', passOp: 'decrement-clamp'},
+    stencilReadMask: 2721954387,
+    stencilWriteMask: 265279990,
+    depthBiasSlopeScale: 830.224455194261,
+    depthBiasClamp: 934.3821658841423,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 244, attributes: []},
+      {arrayStride: 136, stepMode: 'instance', attributes: []},
+      {arrayStride: 72, attributes: [{format: 'uint16x4', offset: 0, shaderLocation: 0}]},
+    ],
+  },
+});
+let gpuCanvasContext3 = canvas5.getContext('webgpu');
+let commandEncoder37 = device0.createCommandEncoder({label: '\u08a1\u2461\u{1f6c9}\ub665\u021f\u{1fd8f}\u0c0e\u6fb0\u{1f75b}\u3b10'});
+let texture30 = device0.createTexture({
+  label: '\uf9db\u0d5a\u87dc',
+  size: [640, 10, 115],
+  mipLevelCount: 1,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8', 'stencil8', 'stencil8'],
+});
+let computePassEncoder11 = commandEncoder36.beginComputePass();
+let renderPassEncoder17 = commandEncoder37.beginRenderPass({
+  label: '\u50c1\u8e3e\u479b\u0063\u0b69',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView4, stencilClearValue: 53283, stencilLoadOp: 'clear', stencilStoreOp: 'store'},
+  occlusionQuerySet: querySet9,
+  maxDrawCount: 1200975161,
+});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({
+  label: '\u{1f67d}\u04de\u{1fcf4}\u0f82\u0b81\u42b8\u90c2\u95a0\ud399',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+});
+let renderBundle22 = renderBundleEncoder8.finish({});
+try {
+renderPassEncoder12.executeBundles([renderBundle19, renderBundle21, renderBundle6, renderBundle15, renderBundle10, renderBundle0, renderBundle16]);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(3, buffer6, 0, 139830);
+} catch {}
+try {
+device0.queue.submit([commandBuffer7]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer0), /* required buffer size: 976 */
+{offset: 816, bytesPerRow: 406}, {width: 160, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let canvas6 = document.createElement('canvas');
+let shaderModule6 = device0.createShaderModule({
+  label: '\u8d35\u{1fe6c}\u7cb9\u08f1\u742a\u9b52\u{1f6d4}\ub7f2\uebeb\ueb7c',
+  code: `@group(0) @binding(240)
+var<storage, read_write> field2: array<u32>;
+@group(2) @binding(378)
+var<storage, read_write> type2: array<u32>;
+@group(0) @binding(597)
+var<storage, read_write> function1: array<u32>;
+
+@compute @workgroup_size(3, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S6 {
+  @builtin(front_facing) f0: bool,
+  @builtin(sample_mask) f1: u32
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(15) a0: f32, @location(10) a1: vec2<u32>, @location(4) a2: vec2<f32>, @builtin(sample_index) a3: u32, @location(5) a4: vec4<f16>, @location(1) a5: vec4<f16>, @location(2) a6: vec2<i32>, a7: S6, @builtin(position) a8: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(15) f45: f32,
+  @location(10) f46: vec2<u32>,
+  @location(2) f47: vec2<i32>,
+  @location(1) f48: vec4<f16>,
+  @location(4) f49: vec2<f32>,
+  @builtin(position) f50: vec4<f32>,
+  @location(5) f51: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(12) a0: f32, @location(0) a1: vec2<u32>, @location(3) a2: vec4<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder38 = device0.createCommandEncoder({label: '\u{1fd05}\u0965\u06bf\u1b72\u{1f85f}\u0bb4\u{1f9cc}'});
+let querySet16 = device0.createQuerySet({label: '\u705f\u048b\u1cc6', type: 'occlusion', count: 1646});
+let commandBuffer8 = commandEncoder38.finish({label: '\u03e5\uabcc\u{1fceb}\udd38\u1237\u{1fcaa}\u6c95\u619e\u{1fb77}\ube6e\ub108'});
+try {
+renderPassEncoder10.setIndexBuffer(buffer7, 'uint16', 172540, 465);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(5053, undefined, 0);
+} catch {}
+gc();
+let texture31 = device0.createTexture({
+  label: '\u01af\u{1ffb3}\u0670\u0eb8\ucead\u4823\uac75\u1d0e',
+  size: [120, 24, 1],
+  mipLevelCount: 7,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8'],
+});
+let textureView42 = texture29.createView({
+  label: '\u80ce\u2c0c\u8029',
+  format: 'stencil8',
+  baseMipLevel: 1,
+  baseArrayLayer: 22,
+  arrayLayerCount: 37,
+});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({
+  label: '\u4629\u{1fb69}\ub92e\u2026\u9dcc\uefd2\ubba3\u0516',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+});
+try {
+renderPassEncoder17.executeBundles([renderBundle8, renderBundle4, renderBundle17, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(26, 1, 2, 1);
+} catch {}
+try {
+renderPassEncoder12.setViewport(0.6930, 0.3050, 0.2197, 0.3920, 0.6155, 0.9907);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder16.setPipeline(pipeline9);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline21 = await device0.createComputePipelineAsync({
+  label: '\u{1fdf6}\u4830\u51a8\u39d8\uaa57\u{1fd48}\ued85\u6723',
+  layout: 'auto',
+  compute: {module: shaderModule3, entryPoint: 'compute0'},
+});
+let commandEncoder39 = device0.createCommandEncoder({label: '\ud96c\u6fb7\ucd49\u{1f6bc}\u103c\u0d24'});
+let querySet17 = device0.createQuerySet({type: 'occlusion', count: 1138});
+let textureView43 = texture29.createView({
+  label: '\u{1f6df}\u5981\ueb9c\u0481\u{1f9e8}\uf70c\u0c20\u0e82\uc1ad',
+  dimension: '2d',
+  aspect: 'stencil-only',
+  baseMipLevel: 1,
+  baseArrayLayer: 52,
+});
+let renderPassEncoder18 = commandEncoder39.beginRenderPass({
+  label: '\u031c\u0630\u1afc\u8f94\u0a59',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView39,
+    depthClearValue: -3.6690674144032354,
+    depthReadOnly: false,
+    stencilLoadOp: 'load',
+    stencilStoreOp: 'discard',
+  },
+  occlusionQuerySet: querySet10,
+  maxDrawCount: 115350414,
+});
+let sampler18 = device0.createSampler({
+  label: '\u0cdb\uf22d\u0c7a\ud610\u{1fbbb}\u0c20\u8e24\u0b48',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 82.44,
+  lodMaxClamp: 88.01,
+});
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(1861);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle5, renderBundle0, renderBundle7, renderBundle18, renderBundle19]);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer7, 'uint16', 177502);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline9);
+} catch {}
+try {
+  await buffer2.mapAsync(GPUMapMode.READ, 0, 1392);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 350 */
+{offset: 350}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+canvas2.getContext('2d');
+} catch {}
+let texture32 = device0.createTexture({
+  label: '\u85dc\u{1f8fe}\u076b\ud84b\u628e\u{1f831}\u{1f642}\u33cc\u5b3d\u41cd\u0531',
+  size: [160, 2, 98],
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8'],
+});
+let textureView44 = texture28.createView({dimension: '2d', aspect: 'stencil-only', baseMipLevel: 3, mipLevelCount: 1, baseArrayLayer: 19});
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup3, new Uint32Array(9371), 1042, 0);
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(9, 1, 8, 5);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(6, buffer6, 0, 98729);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(0, buffer6, 72036, 145228);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer1), /* required buffer size: 321 */
+{offset: 261}, {width: 60, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let textureView45 = texture0.createView({mipLevelCount: 1});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({colorFormats: [], depthStencilFormat: 'stencil8', depthReadOnly: true, stencilReadOnly: true});
+let renderBundle23 = renderBundleEncoder7.finish();
+let sampler19 = device0.createSampler({
+  label: '\u0629\uc768\u02d3\u{1f874}\u62b7\u5542\u{1fa0a}\u{1f6ec}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 72.87,
+  lodMaxClamp: 92.46,
+});
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(3, buffer6);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(3, bindGroup8, [8704]);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(7, buffer6, 0);
+} catch {}
+try {
+commandEncoder18.copyBufferToBuffer(buffer3, 1648, buffer2, 153576, 164);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.submit([commandBuffer8]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(0), /* required buffer size: 961 */
+{offset: 822, bytesPerRow: 15}, {width: 1, height: 10, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let shaderModule7 = device0.createShaderModule({
+  label: '\u0e4c\u{1faa8}\uc790\u{1f727}\ue426\u05a0\u8ee3\u1e32\ud310\u48a1',
+  code: `@group(0) @binding(240)
+var<storage, read_write> n3: array<u32>;
+@group(2) @binding(378)
+var<storage, read_write> n4: array<u32>;
+
+@compute @workgroup_size(3, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @location(12) a1: vec2<f32>, @location(11) a2: vec2<u32>, @location(7) a3: vec4<f32>) {
+
+}
+
+struct VertexOutput0 {
+  @location(4) f52: f16,
+  @location(11) f53: vec2<u32>,
+  @location(2) f54: vec3<u32>,
+  @location(12) f55: vec2<f32>,
+  @location(14) f56: vec4<f32>,
+  @location(1) f57: vec3<f16>,
+  @location(7) f58: vec4<f32>,
+  @location(6) f59: f16,
+  @location(5) f60: vec4<i32>,
+  @builtin(position) f61: vec4<f32>,
+  @location(10) f62: vec4<u32>,
+  @location(0) f63: vec3<f16>,
+  @location(3) f64: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(2) a0: f16, @location(10) a1: vec2<f32>, @location(12) a2: u32, @location(4) a3: i32, @location(9) a4: vec3<f16>, @location(5) a5: vec4<u32>, @location(13) a6: vec4<i32>, @location(1) a7: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView46 = texture7.createView({dimension: '2d', aspect: 'stencil-only', baseMipLevel: 1, mipLevelCount: 2});
+let renderPassEncoder19 = commandEncoder18.beginRenderPass({
+  label: '\u66d2\u2b16\uce67\ue228\u81f6',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView44,
+    depthClearValue: 7.427600742172277,
+    depthReadOnly: false,
+    stencilClearValue: 48727,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'discard',
+  },
+  occlusionQuerySet: querySet13,
+  maxDrawCount: 1102142175,
+});
+try {
+computePassEncoder0.dispatchWorkgroups(4, 4, 3);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(1159);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle18, renderBundle10, renderBundle4, renderBundle8, renderBundle10, renderBundle17, renderBundle19, renderBundle17, renderBundle20]);
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: 128.0, g: -932.3, b: -424.5, a: 259.6, });
+} catch {}
+try {
+querySet6.destroy();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 84156, new Float32Array(37984), 36240, 216);
+} catch {}
+let imageBitmap10 = await createImageBitmap(canvas0);
+let bindGroupLayout11 = pipeline17.getBindGroupLayout(0);
+let bindGroup10 = device0.createBindGroup({
+  label: '\u6a80\u6728\u{1f968}\u009b\u{1fef9}\uaef6',
+  layout: bindGroupLayout7,
+  entries: [{binding: 781, resource: {buffer: buffer0, offset: 40704, size: 31568}}],
+});
+let texture33 = device0.createTexture({
+  label: '\u0185\uc070\u0aa6\u9c9a\u5cfb\u05cf',
+  size: [640, 10, 1],
+  mipLevelCount: 7,
+  sampleCount: 1,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let externalTexture20 = device0.importExternalTexture({
+  label: '\u{1fa78}\u55dc\u04a5\u{1fc77}\u01d5\u7f5e\ufde2\u0390\u2e87',
+  source: videoFrame0,
+  colorSpace: 'display-p3',
+});
+let querySet18 = device0.createQuerySet({
+  label: '\u{1fbef}\ue0a0\u{1ff05}\u02ba\u{1ff2a}\u0ebe\ud29c\u1663\u778e\u60bb',
+  type: 'occlusion',
+  count: 2485,
+});
+let renderBundleEncoder20 = device0.createRenderBundleEncoder({
+  label: '\u8820\uecfe\u8255\u08af\u{1fcaa}',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder4.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 691.8, g: -166.6, b: 531.4, a: 113.2, });
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup5, new Uint32Array(9383), 2690, 0);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(0, buffer6, 213496, 2347);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, arrayBuffer0, /* required buffer size: 1_099 */
+{offset: 724, bytesPerRow: 69}, {width: 30, height: 6, depthOrArrayLayers: 1});
+} catch {}
+let pipeline22 = device0.createComputePipeline({
+  label: '\u{1fb7f}\u7ad7\u{1ffa6}',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(canvas4);
+let renderBundle24 = renderBundleEncoder9.finish({label: '\u0310\u085e\u98e4\ub8c3\u0068\u0ff9\u9b31'});
+let externalTexture21 = device0.importExternalTexture({
+  label: '\u0213\u{1fbc5}\u{1fd37}\u16e9\uac6c\u{1fca9}\u{1f7d8}\u3742\u169e\u{1ff5f}\u6acb',
+  source: videoFrame0,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder17.setBindGroup(1, bindGroup8, [36352]);
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(2255);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer6, 0, 103782);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 67676, new DataView(new ArrayBuffer(22972)), 19173, 520);
+} catch {}
+try {
+offscreenCanvas1.getContext('2d');
+} catch {}
+let pipelineLayout4 = device0.createPipelineLayout({label: '\u{1f7d1}\u09ac\u0eeb', bindGroupLayouts: [bindGroupLayout1]});
+let buffer9 = device0.createBuffer({
+  label: '\u{1faba}\u0252\u7648\u0fef\u464b\u04ae\u7291\u0081\u08e7\u{1f8b6}\ua4b0',
+  size: 101504,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder40 = device0.createCommandEncoder({label: '\u0fb3\uf251\u5b7c\u08f9\u667f\u040b\u{1f679}\u{1f7c1}'});
+let texture34 = device0.createTexture({
+  label: '\u2e7e\u{1f607}\u00ca\uc1b1\u{1fccf}',
+  size: [640, 10, 41],
+  mipLevelCount: 10,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView47 = texture11.createView({aspect: 'stencil-only', format: 'stencil8', baseMipLevel: 2, baseArrayLayer: 111});
+let renderPassEncoder20 = commandEncoder40.beginRenderPass({
+  label: '\u034e\u4ea3\u13cc\u0d43\u75c4',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView1,
+    depthReadOnly: true,
+    stencilClearValue: 3749,
+    stencilLoadOp: 'load',
+    stencilStoreOp: 'store',
+  },
+  occlusionQuerySet: querySet4,
+  maxDrawCount: 647296860,
+});
+try {
+computePassEncoder5.setPipeline(pipeline22);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer7, 'uint16', 152662, 3143);
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+let canvas7 = document.createElement('canvas');
+let offscreenCanvas3 = new OffscreenCanvas(674, 7);
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+renderPassEncoder13.setViewport(0.6477, 0.9622, 0.2124, 0.00313, 0.7700, 0.9361);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+document.body.prepend(canvas4);
+let buffer10 = device0.createBuffer({label: '\u1e6e\uf102\uea7e\u12e7\u324e', size: 225958, usage: GPUBufferUsage.COPY_DST});
+let renderBundle25 = renderBundleEncoder14.finish({});
+let sampler20 = device0.createSampler({
+  label: '\u0c76\u0fbc\u003e\u8f6c\uae97',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 97.63,
+  lodMaxClamp: 98.38,
+  compare: 'always',
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+commandEncoder7.copyBufferToBuffer(buffer4, 688, buffer8, 348720, 3896);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+offscreenCanvas2.getContext('2d');
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout({
+  label: '\u0256\u{1f637}\u0750\u04a8\uc8d9\uc3c5\u{1fef5}\u0f2a\u{1ff2d}\ucebd\u04f2',
+  bindGroupLayouts: [],
+});
+let commandEncoder41 = device0.createCommandEncoder({label: '\u{1f647}\u035c\u0588\u78d9\u08a3\u4ce3\u492f'});
+let textureView48 = texture4.createView({
+  label: '\u05e7\u{1fb5e}\u187d\u77b1\u{1fa55}\u{1fc86}\u5430',
+  aspect: 'stencil-only',
+  baseMipLevel: 0,
+  mipLevelCount: 4,
+});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({colorFormats: [], depthStencilFormat: 'stencil8', depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup10, [36608]);
+} catch {}
+try {
+renderPassEncoder12.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.setViewport(18.91, 5.628, 6.459, 0.01657, 0.5538, 0.9243);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder19.setVertexBuffer(0, buffer6, 0, 196482);
+} catch {}
+let imageData2 = new ImageData(124, 208);
+try {
+offscreenCanvas3.getContext('2d');
+} catch {}
+let commandEncoder42 = device0.createCommandEncoder({label: '\u76e0\uf4aa\uad02\u{1f934}\u{1f8c9}\u0229\uceca'});
+let texture35 = device0.createTexture({
+  label: '\u319d\u312b\u68ee\u{1fc1a}\u748d\u{1fadd}\u06d9\u0d49\u5c13\u10f7\u0e9d',
+  size: [160, 2, 1],
+  mipLevelCount: 3,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8'],
+});
+let textureView49 = texture26.createView({
+  label: '\u8ec1\u{1f92f}',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  format: 'stencil8',
+  baseMipLevel: 1,
+  baseArrayLayer: 0,
+});
+try {
+computePassEncoder0.dispatchWorkgroups(3, 3, 2);
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant({ r: 212.7, g: 894.3, b: -164.5, a: 709.0, });
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(2, buffer6, 0, 203612);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise10;
+} catch {}
+let imageData3 = new ImageData(172, 160);
+let commandEncoder43 = device0.createCommandEncoder({});
+let commandBuffer9 = commandEncoder43.finish({});
+let textureView50 = texture34.createView({dimension: '2d', aspect: 'stencil-only', mipLevelCount: 2, baseArrayLayer: 26});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup3, new Uint32Array(3164), 2690, 0);
+} catch {}
+try {
+renderPassEncoder19.setStencilReference(3068);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(1, bindGroup1, new Uint32Array(9944), 4499, 0);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(3, buffer6, 0, 120244);
+} catch {}
+try {
+commandEncoder7.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 2,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 15, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder7.clearBuffer(buffer10, 205640, 4104);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new BigInt64Array(arrayBuffer0), /* required buffer size: 2_299 */
+{offset: 567, bytesPerRow: 152, rowsPerImage: 35}, {width: 60, height: 12, depthOrArrayLayers: 1});
+} catch {}
+let pipeline23 = await device0.createComputePipelineAsync({
+  label: '\u0bbf\u{1fb87}\u467d\uab9a\u{1f6c8}\uc3e1\u721a\uf6b7\u{1ff97}\u0079\uaf18',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let videoFrame3 = new VideoFrame(canvas4, {timestamp: 0});
+let commandEncoder44 = device0.createCommandEncoder({label: '\u0576\u6d8e\u7489\u{1ff52}\ud7fc\u{1f687}\uea7e\u31bc'});
+let querySet19 = device0.createQuerySet({type: 'occlusion', count: 3580});
+let texture36 = device0.createTexture({
+  label: '\ube5d\u{1fcb6}\uc714\u356a\u{1fb5b}\u8633\u3a23\u{1f705}\u{1fe87}',
+  size: {width: 240, height: 48, depthOrArrayLayers: 196},
+  mipLevelCount: 8,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['stencil8', 'stencil8'],
+});
+let textureView51 = texture31.createView({
+  label: '\u22d7\u264a\u0446\u0465\u{1fc36}\u60da\ude2e\u08ef\uf8a5\u{1f65a}',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  format: 'stencil8',
+  baseMipLevel: 6,
+});
+let renderBundle26 = renderBundleEncoder16.finish({label: '\u0aa5\ue798'});
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder3.setViewport(0.4249, 0.4388, 0.5097, 0.1038, 0.8482, 0.9051);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(4, buffer6);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(2, buffer6, 111132, 93966);
+} catch {}
+try {
+commandEncoder41.clearBuffer(buffer10, 164176, 21400);
+dissociateBuffer(device0, buffer10);
+} catch {}
+let shaderModule8 = device0.createShaderModule({
+  code: `@group(0) @binding(714)
+var<storage, read_write> type3: array<u32>;
+
+@compute @workgroup_size(3, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(5) f1: vec2<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f65: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec4<f16>, @location(15) a1: f32, @location(5) a2: i32, @location(13) a3: vec4<f16>, @location(2) a4: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let textureView52 = texture31.createView({label: '\u0cbc\u{1febe}\u0e54', dimension: '2d-array', baseMipLevel: 5, mipLevelCount: 1});
+try {
+computePassEncoder0.dispatchWorkgroups(2);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant({ r: -276.7, g: -787.3, b: 564.7, a: 870.5, });
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(0, bindGroup5, new Uint32Array(2906), 831, 0);
+} catch {}
+try {
+commandEncoder44.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 1,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 640 widthInBlocks: 640 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 88 */
+  offset: 88,
+  bytesPerRow: 768,
+  buffer: buffer10,
+}, {width: 640, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.submit([commandBuffer9]);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend(img1);
+let textureView53 = texture5.createView({
+  label: '\u5c9a\u{1ff63}\u4358\u0088',
+  dimension: '2d',
+  baseMipLevel: 6,
+  mipLevelCount: 2,
+  baseArrayLayer: 36,
+});
+let renderPassEncoder21 = commandEncoder44.beginRenderPass({
+  label: '\ufd6a\u78c9\uaf84',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView39,
+    depthClearValue: -3.5043504526001135,
+    depthReadOnly: false,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'discard',
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet10,
+  maxDrawCount: 1062767789,
+});
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder8.setViewport(12.53, 0.04849, 16.24, 1.336, 0.8131, 0.9955);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 21372, new BigUint64Array(42555), 18546, 2760);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline24 = await device0.createRenderPipelineAsync({
+  label: '\u22a8\u7c84\ue7ec\ufe9f\u92fc\u876d\ue504\u0ef5\u0ba1\ue6f4',
+  layout: pipelineLayout1,
+  fragment: {module: shaderModule3, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'less', failOp: 'increment-wrap', depthFailOp: 'invert', passOp: 'replace'},
+    stencilBack: {compare: 'less', failOp: 'increment-wrap', depthFailOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilReadMask: 1469250343,
+    stencilWriteMask: 3992050825,
+    depthBias: -1184062013,
+    depthBiasClamp: 373.6561943680796,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 424, stepMode: 'instance', attributes: []},
+      {arrayStride: 404, attributes: [{format: 'float32x2', offset: 76, shaderLocation: 10}]},
+      {
+        arrayStride: 112,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm10-10-10-2', offset: 8, shaderLocation: 2}],
+      },
+      {
+        arrayStride: 312,
+        attributes: [
+          {format: 'snorm16x4', offset: 16, shaderLocation: 5},
+          {format: 'uint16x4', offset: 8, shaderLocation: 4},
+          {format: 'uint16x4', offset: 84, shaderLocation: 6},
+          {format: 'float32x4', offset: 64, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 92,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint32x4', offset: 8, shaderLocation: 11},
+          {format: 'sint8x4', offset: 8, shaderLocation: 15},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 13},
+          {format: 'uint32x4', offset: 0, shaderLocation: 3},
+          {format: 'unorm8x2', offset: 6, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 80,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x4', offset: 0, shaderLocation: 9}],
+      },
+      {
+        arrayStride: 68,
+        attributes: [
+          {format: 'snorm8x2', offset: 0, shaderLocation: 7},
+          {format: 'sint32x3', offset: 8, shaderLocation: 14},
+          {format: 'unorm16x2', offset: 0, shaderLocation: 0},
+          {format: 'uint8x4', offset: 12, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+});
+let textureView54 = texture36.createView({aspect: 'all', baseMipLevel: 6, baseArrayLayer: 165, arrayLayerCount: 17});
+let renderPassEncoder22 = commandEncoder7.beginRenderPass({
+  label: '\ub104\ub2c9\u2ada\ua1ad',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView44,
+    depthClearValue: -4.246091162754276,
+    stencilClearValue: 22201,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'store',
+  },
+  occlusionQuerySet: querySet18,
+  maxDrawCount: 375842522,
+});
+let renderBundle27 = renderBundleEncoder1.finish({label: '\u3c30\uedce'});
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: 429.8, g: 662.4, b: 365.3, a: -481.9, });
+} catch {}
+try {
+renderPassEncoder12.setViewport(0.1798, 0.3472, 0.3200, 0.6483, 0.2174, 0.8208);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 7752, new DataView(new ArrayBuffer(20850)), 11209, 132);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 7},
+  aspect: 'stencil-only',
+}, arrayBuffer1, /* required buffer size: 469_793 */
+{offset: 495, bytesPerRow: 93, rowsPerImage: 87}, {width: 20, height: 1, depthOrArrayLayers: 59});
+} catch {}
+let commandEncoder45 = device0.createCommandEncoder({label: '\ub703\u89b8\u{1fd71}'});
+let querySet20 = device0.createQuerySet({label: '\u7a13\u3c69\u052c\u0913\ue8bd\u0e06\u1727\ua424', type: 'occlusion', count: 3301});
+try {
+renderPassEncoder0.beginOcclusionQuery(943);
+} catch {}
+try {
+renderBundleEncoder21.setVertexBuffer(5, buffer6, 145172, 5276);
+} catch {}
+try {
+commandEncoder0.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 15, y: 5, z: 0},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture4,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 15, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+let commandBuffer10 = commandEncoder42.finish();
+let renderPassEncoder23 = commandEncoder41.beginRenderPass({
+  label: '\ud533\u{1fa03}\u4945\u05b4\u8bd3\u0b8a\u7d36\u{1ff8f}\u7a80\uf19a',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView43,
+    depthClearValue: 5.705005444479207,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'discard',
+    stencilReadOnly: false,
+  },
+  maxDrawCount: 22154158,
+});
+let sampler21 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 14.01,
+  lodMaxClamp: 37.55,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder8.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup10, [17664]);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(471);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder22.setPipeline(pipeline24);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(1, buffer6, 0, 94790);
+} catch {}
+let pipeline25 = device0.createComputePipeline({
+  label: '\u9ea8\u9e99\udf3e\u{1fe66}\u0ef7\ue2e0\u{1f714}\u5c8f\u{1f810}',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}},
+});
+let pipeline26 = device0.createRenderPipeline({
+  label: '\u02dc\ud6c4\u7efd\u{1f696}\uff0a\u9674\u0668\ua27f\u{1ffed}\ub82e\u0479',
+  layout: pipelineLayout5,
+  multisample: {mask: 0xa8aa5076},
+  fragment: {module: shaderModule3, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'never', failOp: 'replace', depthFailOp: 'increment-clamp', passOp: 'invert'},
+    stencilBack: {compare: 'greater', failOp: 'increment-wrap', depthFailOp: 'invert', passOp: 'increment-wrap'},
+    stencilReadMask: 3291737765,
+    stencilWriteMask: 4282799819,
+    depthBias: 1160947233,
+    depthBiasSlopeScale: 172.49653882664472,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 20,
+        attributes: [
+          {format: 'snorm8x2', offset: 0, shaderLocation: 2},
+          {format: 'snorm8x2', offset: 0, shaderLocation: 1},
+          {format: 'uint32x2', offset: 0, shaderLocation: 9},
+          {format: 'uint8x2', offset: 2, shaderLocation: 8},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 5},
+          {format: 'sint32', offset: 0, shaderLocation: 14},
+          {format: 'unorm16x2', offset: 4, shaderLocation: 0},
+          {format: 'uint32x4', offset: 0, shaderLocation: 6},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 7},
+          {format: 'float32x3', offset: 0, shaderLocation: 13},
+          {format: 'float32x3', offset: 0, shaderLocation: 10},
+          {format: 'sint16x2', offset: 0, shaderLocation: 11},
+          {format: 'uint8x2', offset: 0, shaderLocation: 4},
+          {format: 'float32x2', offset: 0, shaderLocation: 12},
+          {format: 'uint32x4', offset: 0, shaderLocation: 3},
+        ],
+      },
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 1092, attributes: []},
+      {
+        arrayStride: 76,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x2', offset: 4, shaderLocation: 15}],
+      },
+    ],
+  },
+});
+let bindGroup11 = device0.createBindGroup({label: '\u0f1f\u{1fc42}', layout: bindGroupLayout11, entries: []});
+let querySet21 = device0.createQuerySet({label: '\u7831\u2da9\u0ca0\u0e00\u593a\u2e37\u5d48\u5d7f\u4d58\u24c8', type: 'occlusion', count: 3824});
+let sampler22 = device0.createSampler({
+  label: '\u557c\u948c\u492e\u05f3\ufdcc\u43e5\uf0ff',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 66.45,
+  lodMaxClamp: 72.12,
+  compare: 'less',
+});
+let externalTexture22 = device0.importExternalTexture({
+  label: '\uaaf0\u3734\u7f06\u2f49\u8a33\uda04\u0bdf\u{1fc61}\u{1f788}',
+  source: videoFrame2,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder3.setBlendConstant({ r: -452.9, g: -987.9, b: -980.1, a: 501.8, });
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(21, 5, 3, 0);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline24);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(1, buffer6);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(1, bindGroup1, new Uint32Array(4774), 4322, 0);
+} catch {}
+let bindGroup12 = device0.createBindGroup({
+  label: '\u0879\u9500\u3466\u04d0\u5c13\ubebc\uba4a',
+  layout: bindGroupLayout2,
+  entries: [{binding: 336, resource: sampler10}],
+});
+let textureView55 = texture11.createView({label: '\u{1f6bf}\u097f', dimension: '2d', baseMipLevel: 1, mipLevelCount: 3, baseArrayLayer: 68});
+let computePassEncoder12 = commandEncoder45.beginComputePass({label: '\u4067\u0c80\ue12f'});
+let renderPassEncoder24 = commandEncoder0.beginRenderPass({
+  label: '\u4c41\u1294',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView39, stencilLoadOp: 'load', stencilStoreOp: 'discard'},
+  occlusionQuerySet: querySet12,
+});
+try {
+renderPassEncoder23.setBlendConstant({ r: -278.3, g: -487.5, b: 253.8, a: 805.9, });
+} catch {}
+try {
+renderPassEncoder17.setStencilReference(1260);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(4, buffer6, 0, 28726);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(6, buffer6, 0, 212270);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let img5 = await imageWithData(52, 150, '#cfa1b554', '#178a32d0');
+let sampler23 = device0.createSampler({
+  label: '\ud2cf\uf6b4\ub528\u9ba1\u0ef2\u0ee2\ub661\u2e04\u6aae',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 57.17,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder7.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(0, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(1661);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline24);
+} catch {}
+try {
+renderBundleEncoder20.setVertexBuffer(5, buffer6, 199352);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer1), /* required buffer size: 273 */
+{offset: 273, bytesPerRow: 3285}, {width: 205, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext4 = canvas6.getContext('webgpu');
+try {
+adapter0.label = '\u589f\u{1fcc1}\u08fd\uada7\ue8d9\u{1f7b1}\u39f5\u079f';
+} catch {}
+let commandEncoder46 = device0.createCommandEncoder({label: '\u2a9d\u633a\u5b85\ued3e\u9346\uda31\u874e\u1390\u048d'});
+let querySet22 = device0.createQuerySet({label: '\u08da\u0d1f\u3fa6\u01e3\uc92f\u63e2', type: 'occlusion', count: 1959});
+let textureView56 = texture26.createView({
+  label: '\ub9a9\u{1fb2c}\u{1f716}\u0544\u3a47\u42dd\u1572\u0ce9\u0ea7',
+  aspect: 'stencil-only',
+  baseMipLevel: 2,
+});
+let computePassEncoder13 = commandEncoder46.beginComputePass({});
+let renderBundleEncoder22 = device0.createRenderBundleEncoder({
+  label: '\u0a9d\u{1fd8e}\u01c8\u054e\u6bb2\u93cc',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  sampleCount: 1,
+  stencilReadOnly: true,
+});
+let renderBundle28 = renderBundleEncoder0.finish({label: '\u8385\ua1ac\u02db\uf3d2\u0246\u{1ffa3}\ud64d'});
+try {
+computePassEncoder2.dispatchWorkgroups(3, 4, 2);
+} catch {}
+try {
+renderPassEncoder20.setStencilReference(4047);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer6, 127124, 80564);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(4, buffer6, 0);
+} catch {}
+let pipeline27 = device0.createComputePipeline({
+  label: '\u{1f7b9}\u0a4f\u34e3\u0ec8\uf3da\u15ad\uee73',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}},
+});
+let querySet23 = device0.createQuerySet({label: '\u21ea\u122f\u0934\ufa7d\ue40b', type: 'occlusion', count: 415});
+let texture37 = device0.createTexture({
+  label: '\ub3d6\ud4ac\u068f\u7642\u{1f7ce}\u932b\ubcfd\u0f3a',
+  size: {width: 240, height: 48, depthOrArrayLayers: 1},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup8, [57344]);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(1624);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline26);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, arrayBuffer1, /* required buffer size: 552 */
+{offset: 472}, {width: 80, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder47 = device0.createCommandEncoder({label: '\u{1f80b}\u54d8\u08e0\u4a01\u447b\uccf5\u3b0e\u2702\u0a84\u09de'});
+let computePassEncoder14 = commandEncoder47.beginComputePass({label: '\u{1f6b3}\u{1f814}\u{1fd11}\u{1f80a}\ubc44\u{1fd7c}\u{1fd89}\ub63d\u892e'});
+let renderBundleEncoder23 = device0.createRenderBundleEncoder({
+  label: '\ucb93\u0aa9\u7fb6\uf701\u0124\u5a0e\u039f\u{1f89c}\uc9c3',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  depthReadOnly: true,
+});
+let renderBundle29 = renderBundleEncoder12.finish();
+try {
+computePassEncoder10.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup10, new Uint32Array(9449), 3324, 1);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 760.6, g: -549.1, b: -791.7, a: 768.5, });
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer7, 'uint16', 121136);
+} catch {}
+try {
+renderBundleEncoder17.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(6, buffer6, 0, 127150);
+} catch {}
+let pipeline28 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}}});
+let videoFrame4 = new VideoFrame(canvas5, {timestamp: 0});
+let bindGroup13 = device0.createBindGroup({
+  label: '\ua7ce\u{1fe8a}\ud050\ubae2\ufd25\u0087\u{1fa31}\u{1fabc}',
+  layout: bindGroupLayout4,
+  entries: [{binding: 580, resource: sampler14}],
+});
+let buffer11 = device0.createBuffer({
+  label: '\u{1fa44}\u9321\u{1ff24}\u{1fd0e}\u{1ffa6}\u6f97',
+  size: 60849,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: false,
+});
+let commandEncoder48 = device0.createCommandEncoder({label: '\u{1fcdc}\u6c2e\u{1f76d}\u080c\u{1f8b6}'});
+let textureView57 = texture2.createView({baseMipLevel: 3, baseArrayLayer: 90, arrayLayerCount: 115});
+let computePassEncoder15 = commandEncoder48.beginComputePass();
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderPassEncoder7.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer7, 'uint16', 33196, 102960);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(4, buffer6, 141688, 69889);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder23.setIndexBuffer(buffer7, 'uint32', 80800, 74958);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer1), /* required buffer size: 885 */
+{offset: 885}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let buffer12 = device0.createBuffer({
+  label: '\u00d4\u4d7f\u0a6c\u89c5\u021e\u10ef\u{1f989}\ua408\ue058\u0645',
+  size: 9964,
+  usage: GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let commandEncoder49 = device0.createCommandEncoder({});
+let textureView58 = texture25.createView({
+  label: '\u01c4\u48ac\u{1fb19}\u099e\u1214\ud8fd\u039a\u0929\u057f\uc375\u1b0e',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  baseMipLevel: 7,
+  baseArrayLayer: 10,
+  arrayLayerCount: 18,
+});
+let renderPassEncoder25 = commandEncoder49.beginRenderPass({
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView39, stencilClearValue: 62574, stencilLoadOp: 'load', stencilStoreOp: 'store'},
+  occlusionQuerySet: querySet22,
+  maxDrawCount: 1108425613,
+});
+let renderBundle30 = renderBundleEncoder11.finish();
+let sampler24 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMaxClamp: 69.58,
+});
+try {
+renderPassEncoder17.beginOcclusionQuery(3138);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer7, 'uint16', 148198, 29202);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(0, bindGroup8, [20480]);
+} catch {}
+offscreenCanvas2.width = 447;
+let commandEncoder50 = device0.createCommandEncoder({label: '\uba1e\u734c\ue98f\u0b3e\uae6a'});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({colorFormats: [], depthStencilFormat: 'stencil8', depthReadOnly: true});
+let sampler25 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 88.38,
+});
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup8, new Uint32Array(53), 48, 1);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(975);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder23.setVertexBuffer(0, buffer12, 0, 9912);
+} catch {}
+try {
+commandEncoder50.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 80 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 92828 */
+  offset: 92828,
+  buffer: buffer9,
+}, {
+  texture: texture35,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 80, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder50.copyTextureToBuffer({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 0, y: 12, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 240 widthInBlocks: 240 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 19684 */
+  offset: 19684,
+  buffer: buffer8,
+}, {width: 240, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder50.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 5,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture31,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline29 = device0.createRenderPipeline({
+  label: '\u0583\u{1f9e9}\u5ddd\u8dee',
+  layout: pipelineLayout4,
+  fragment: {module: shaderModule3, entryPoint: 'fragment0', targets: []},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'always', failOp: 'decrement-clamp', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'invert'},
+    stencilReadMask: 1940821764,
+    stencilWriteMask: 4258158141,
+    depthBias: 1197815151,
+    depthBiasClamp: 125.26614498940066,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 60,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm8x4', offset: 8, shaderLocation: 0},
+          {format: 'unorm8x2', offset: 2, shaderLocation: 12},
+          {format: 'uint32x2', offset: 8, shaderLocation: 4},
+          {format: 'float16x2', offset: 4, shaderLocation: 1},
+          {format: 'snorm8x4', offset: 4, shaderLocation: 2},
+          {format: 'uint32x2', offset: 4, shaderLocation: 3},
+          {format: 'sint32x4', offset: 0, shaderLocation: 15},
+          {format: 'uint32x2', offset: 24, shaderLocation: 8},
+          {format: 'sint8x2', offset: 6, shaderLocation: 14},
+          {format: 'float32', offset: 0, shaderLocation: 10},
+          {format: 'sint32x2', offset: 0, shaderLocation: 11},
+          {format: 'snorm16x2', offset: 8, shaderLocation: 7},
+          {format: 'unorm16x2', offset: 8, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 336,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32x4', offset: 192, shaderLocation: 5},
+          {format: 'uint16x2', offset: 0, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 200, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 116,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32', offset: 48, shaderLocation: 9}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'back', unclippedDepth: true},
+});
+document.body.prepend(canvas1);
+let canvas8 = document.createElement('canvas');
+let video2 = await videoWithData();
+let shaderModule9 = device0.createShaderModule({
+  code: `@group(2) @binding(336)
+var<storage, read_write> type4: array<u32>;
+@group(1) @binding(714)
+var<storage, read_write> local0: array<u32>;
+@group(0) @binding(336)
+var<storage, read_write> type5: array<u32>;
+
+@compute @workgroup_size(7, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(3) a0: f32, @location(14) a1: f16) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f66: vec4<f32>,
+  @location(3) f67: f32,
+  @location(14) f68: f16,
+  @location(5) f69: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec3<u32>, @location(13) a1: vec2<i32>, @location(6) a2: vec3<f32>, @location(5) a3: vec2<f16>, @location(3) a4: f16, @location(2) a5: i32, @location(9) a6: vec3<i32>, @location(0) a7: vec3<i32>, @builtin(instance_index) a8: u32, @location(14) a9: vec3<u32>, @location(1) a10: u32, @location(15) a11: vec2<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout12 = device0.createBindGroupLayout({
+  label: '\ue835\u{1fd07}\u97af\uf126\u3495\u{1f884}',
+  entries: [
+    {
+      binding: 536,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 903,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 40,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+  ],
+});
+let pipelineLayout6 = device0.createPipelineLayout({label: '\u52b1\u0bee', bindGroupLayouts: []});
+let externalTexture23 = device0.importExternalTexture({source: video2});
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(83);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: 660.2, g: 25.29, b: 914.6, a: -362.9, });
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(1, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder23.setViewport(11.27, 2.797, 0.1429, 0.01217, 0.07759, 0.4210);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(0, bindGroup13, new Uint32Array(3598), 1414, 0);
+} catch {}
+try {
+commandEncoder50.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 5793 */
+  offset: 5792,
+  bytesPerRow: 512,
+  buffer: buffer9,
+}, {
+  texture: texture31,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer9);
+} catch {}
+try {
+commandEncoder50.clearBuffer(buffer8, 147232, 17448);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 11},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 5_797_613 */
+{offset: 593, bytesPerRow: 275, rowsPerImage: 155}, {width: 20, height: 1, depthOrArrayLayers: 137});
+} catch {}
+let pipeline30 = device0.createComputePipeline({
+  label: '\ub447\ud49f\u0e33\u{1f6ae}\u10cc\u8a0b\u561c',
+  layout: 'auto',
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let textureView59 = texture0.createView({label: '\u461d\u0e4b\u0493'});
+let externalTexture24 = device0.importExternalTexture({label: '\ub5a5\u{1f6c6}', source: videoFrame3, colorSpace: 'srgb'});
+try {
+computePassEncoder2.dispatchWorkgroupsIndirect(buffer7, 153484);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup13, new Uint32Array(3652), 2419, 0);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle2, renderBundle19, renderBundle28, renderBundle12, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder19.setBlendConstant({ r: -41.14, g: 971.0, b: -191.9, a: -364.7, });
+} catch {}
+try {
+renderPassEncoder7.setViewport(24.39, 4.312, 4.357, 0.3994, 0.8199, 0.8650);
+} catch {}
+try {
+querySet15.destroy();
+} catch {}
+try {
+commandEncoder50.copyBufferToBuffer(buffer3, 1316, buffer2, 153668, 632);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture31,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new Uint16Array(arrayBuffer1), /* required buffer size: 820 */
+{offset: 820, bytesPerRow: 150}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let bindGroup14 = device0.createBindGroup({
+  label: '\u{1f773}\u287a\u51f7\u4010\u0f56\u9398\u2e81',
+  layout: bindGroupLayout4,
+  entries: [{binding: 580, resource: sampler14}],
+});
+let pipelineLayout7 = device0.createPipelineLayout({label: '\ua7a6\u49b8\u184e\u0649\u{1ff36}\u0e00\u0ce5\u60f4\u09f4', bindGroupLayouts: []});
+let renderBundleEncoder25 = device0.createRenderBundleEncoder({
+  label: '\u4086\u882a\u{1fe13}\u0507\u89d6\ufb75\u{1fe12}\ub6a2\u{1fa87}\u7596',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  depthReadOnly: true,
+});
+let sampler26 = device0.createSampler({
+  label: '\u7e89\u{1fd1a}\u0a50',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 66.28,
+  lodMaxClamp: 98.22,
+});
+try {
+computePassEncoder8.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline24);
+} catch {}
+let promise12 = device0.popErrorScope();
+try {
+commandEncoder50.copyBufferToTexture({
+  /* bytesInLastRow: 1232 widthInBlocks: 77 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 3392 */
+  offset: 3392,
+  bytesPerRow: 1280,
+  buffer: buffer1,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 77, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder50.copyTextureToBuffer({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 160 widthInBlocks: 160 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1688 */
+  offset: 1688,
+  bytesPerRow: 512,
+  buffer: buffer8,
+}, {width: 160, height: 2, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer8);
+} catch {}
+let querySet24 = device0.createQuerySet({type: 'occlusion', count: 2530});
+let texture38 = device0.createTexture({
+  label: '\u75d5\ua90b\u0a6e\uc89c\u085c',
+  size: {width: 120, height: 24, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  sampleCount: 1,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['stencil8'],
+});
+let renderBundleEncoder26 = device0.createRenderBundleEncoder({
+  label: '\u{1fed4}\u{1fe25}\u6506',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+let renderBundle31 = renderBundleEncoder10.finish({label: '\u4267\ue186'});
+try {
+computePassEncoder7.dispatchWorkgroupsIndirect(buffer7, 27948);
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(3, buffer12, 0, 3577);
+} catch {}
+try {
+commandEncoder50.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 15 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 35548 */
+  offset: 35548,
+  rowsPerImage: 132,
+  buffer: buffer8,
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder50.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture34,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 20, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder50.clearBuffer(buffer10, 152804, 37688);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder51 = device0.createCommandEncoder({});
+let querySet25 = device0.createQuerySet({type: 'occlusion', count: 2861});
+let sampler27 = device0.createSampler({
+  label: '\u{1fdc6}\uef8c\u{1fca3}\u02f3\u{1fee6}\u080a\u9794\u94ba\u9336\u{1fa1c}\u251f',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 60.01,
+  lodMaxClamp: 68.72,
+  maxAnisotropy: 4,
+});
+try {
+renderPassEncoder16.setVertexBuffer(5896, undefined, 0, 123738147);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(2, buffer6, 0, 173322);
+} catch {}
+try {
+buffer10.destroy();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline31 = device0.createRenderPipeline({
+  label: '\u0e84\uc7ab\u9a12\u05ff\uea0d\u00ca\u032d',
+  layout: 'auto',
+  multisample: {count: 1},
+  fragment: {module: shaderModule7, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'zero', depthFailOp: 'decrement-clamp', passOp: 'keep'},
+    stencilBack: {compare: 'not-equal', failOp: 'decrement-clamp', depthFailOp: 'replace', passOp: 'decrement-wrap'},
+    stencilReadMask: 1949412231,
+    stencilWriteMask: 714393359,
+    depthBias: 960121178,
+    depthBiasSlopeScale: 0.0,
+  },
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 204,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 0, shaderLocation: 4},
+          {format: 'uint16x4', offset: 0, shaderLocation: 12},
+          {format: 'float32x3', offset: 68, shaderLocation: 1},
+          {format: 'float16x2', offset: 0, shaderLocation: 10},
+          {format: 'uint32x2', offset: 24, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 668,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint16x2', offset: 20, shaderLocation: 13},
+          {format: 'unorm16x4', offset: 228, shaderLocation: 9},
+          {format: 'float16x4', offset: 156, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: true},
+});
+gc();
+let commandEncoder52 = device0.createCommandEncoder({label: '\uc015\u{1f7b0}'});
+let querySet26 = device0.createQuerySet({label: '\u0588\u6102\ub038', type: 'occlusion', count: 2697});
+let sampler28 = device0.createSampler({
+  label: '\u{1f91f}\u08fb\u6526\u072d\uecdd\ud8d7\u0dc3\u14e1\u5d43\u0cf8',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 2.065,
+  lodMaxClamp: 21.35,
+  maxAnisotropy: 10,
+});
+try {
+renderPassEncoder9.beginOcclusionQuery(269);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline26);
+} catch {}
+try {
+commandEncoder52.copyBufferToBuffer(buffer3, 2800, buffer2, 240484, 700);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 43076, new Int16Array(8537), 6320, 468);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+gc();
+let img6 = await imageWithData(190, 34, '#29014b18', '#abfbefa5');
+let imageData4 = new ImageData(32, 24);
+let querySet27 = device0.createQuerySet({label: '\u0447\u{1fe10}\u{1fe3e}\u{1fa2c}', type: 'occlusion', count: 1685});
+let texture39 = device0.createTexture({
+  label: '\u01bc\u{1f606}\ueece',
+  size: [30, 6, 1],
+  mipLevelCount: 4,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8', 'stencil8'],
+});
+let renderBundle32 = renderBundleEncoder19.finish();
+let sampler29 = device0.createSampler({
+  label: '\ud839\u{1ffa1}\u{1fe66}\u74d7',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 32.42,
+  lodMaxClamp: 35.90,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup9, new Uint32Array(1602), 326, 0);
+} catch {}
+try {
+renderPassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder13.setViewport(0.9891, 0.07899, 0.00811, 0.03113, 0.01707, 0.2571);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(6, buffer12, 0);
+} catch {}
+try {
+commandEncoder50.copyBufferToTexture({
+  /* bytesInLastRow: 3 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 32068 */
+  offset: 32068,
+  buffer: buffer1,
+}, {
+  texture: texture31,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder50.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 20 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 18604 */
+  offset: 18604,
+  buffer: buffer8,
+}, {width: 20, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder51.copyTextureToTexture({
+  texture: texture31,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture4,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder51.clearBuffer(buffer10, 141932, 28160);
+dissociateBuffer(device0, buffer10);
+} catch {}
+let pipeline32 = device0.createRenderPipeline({
+  label: '\u0125\u{1f782}\u{1f8e1}\u{1fbbc}\u0568\u633f',
+  layout: pipelineLayout2,
+  multisample: {mask: 0x20a6f655},
+  fragment: {module: shaderModule8, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {
+      compare: 'less-equal',
+      failOp: 'increment-clamp',
+      depthFailOp: 'increment-wrap',
+      passOp: 'decrement-wrap',
+    },
+    stencilBack: {compare: 'less', failOp: 'zero', depthFailOp: 'invert', passOp: 'decrement-wrap'},
+    stencilReadMask: 358239621,
+    stencilWriteMask: 4038815714,
+    depthBias: 686263875,
+    depthBiasSlopeScale: 652.5289793444078,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 852,
+        attributes: [
+          {format: 'float32', offset: 124, shaderLocation: 15},
+          {format: 'uint32', offset: 28, shaderLocation: 2},
+          {format: 'sint16x4', offset: 120, shaderLocation: 5},
+          {format: 'float32x4', offset: 116, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 132,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x4', offset: 20, shaderLocation: 13}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let commandEncoder53 = device0.createCommandEncoder();
+let texture40 = device0.createTexture({
+  label: '\ud217\u{1f822}\u{1fb7b}\u070a\u{1ff13}\u{1fed6}\ua228\ufffd\u0ea4\u037e\u66ac',
+  size: {width: 640, height: 10, depthOrArrayLayers: 22},
+  mipLevelCount: 3,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8'],
+});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup13, new Uint32Array(4029), 433, 0);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle22]);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(3, buffer6, 0, 77584);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder11.insertDebugMarker('\u0f70');
+} catch {}
+let pipeline33 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  multisample: {mask: 0x798cce95},
+  fragment: {module: shaderModule0, entryPoint: 'fragment0', targets: []},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'zero', passOp: 'decrement-wrap'},
+    stencilBack: {failOp: 'decrement-clamp', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilWriteMask: 3068612440,
+    depthBiasClamp: 505.6523388974575,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 764,
+        attributes: [
+          {format: 'unorm16x4', offset: 68, shaderLocation: 8},
+          {format: 'unorm16x2', offset: 400, shaderLocation: 11},
+          {format: 'float32x3', offset: 4, shaderLocation: 7},
+          {format: 'snorm8x2', offset: 204, shaderLocation: 4},
+          {format: 'sint32', offset: 312, shaderLocation: 3},
+          {format: 'sint32x4', offset: 0, shaderLocation: 13},
+          {format: 'uint32x4', offset: 176, shaderLocation: 10},
+          {format: 'sint16x2', offset: 160, shaderLocation: 12},
+          {format: 'uint8x4', offset: 148, shaderLocation: 14},
+          {format: 'uint8x4', offset: 44, shaderLocation: 15},
+          {format: 'sint16x2', offset: 32, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 496,
+        attributes: [
+          {format: 'sint16x4', offset: 56, shaderLocation: 6},
+          {format: 'sint16x4', offset: 60, shaderLocation: 0},
+          {format: 'uint8x2', offset: 20, shaderLocation: 9},
+        ],
+      },
+      {arrayStride: 384, stepMode: 'vertex', attributes: []},
+      {arrayStride: 352, attributes: [{format: 'unorm10-10-10-2', offset: 40, shaderLocation: 2}]},
+      {arrayStride: 452, stepMode: 'instance', attributes: []},
+      {arrayStride: 140, attributes: [{format: 'float32x2', offset: 40, shaderLocation: 1}]},
+    ],
+  },
+  primitive: {cullMode: 'back', unclippedDepth: true},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let textureView60 = texture27.createView({dimension: '2d', aspect: 'stencil-only', baseMipLevel: 1, baseArrayLayer: 52});
+let renderPassEncoder26 = commandEncoder51.beginRenderPass({
+  label: '\u3e6c\u{1f770}\u6b47\u6d9e\u09a8\u0e8a\u{1f62a}',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView16, depthReadOnly: true, stencilLoadOp: 'load', stencilStoreOp: 'discard'},
+  occlusionQuerySet: querySet18,
+});
+let renderBundleEncoder27 = device0.createRenderBundleEncoder({
+  label: '\u0cac\u31fa\u90b0\u{1f7c6}\u5593\ue188',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture25 = device0.importExternalTexture({label: '\u84de\u{1fcfc}\u{1fcb9}\u{1fdc5}\ub3da\uc68e', source: video1, colorSpace: 'display-p3'});
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle9, renderBundle23, renderBundle6, renderBundle26, renderBundle2, renderBundle19, renderBundle3, renderBundle8, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder23.setBlendConstant({ r: -166.2, g: 815.6, b: -118.6, a: -221.0, });
+} catch {}
+try {
+commandEncoder50.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 2545 */
+  offset: 2544,
+  bytesPerRow: 256,
+  buffer: buffer8,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+commandEncoder52.copyTextureToTexture({
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 29, y: 7, z: 33},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 9,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder50.clearBuffer(buffer8, 124168, 149992);
+dissociateBuffer(device0, buffer8);
+} catch {}
+let pipeline34 = await device0.createComputePipelineAsync({
+  label: '\u39cd\u2280\u0f43\u{1fd39}\u{1ff2f}\u0e72\u0777\ue744\u0471\u{1fd52}\u9c13',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let pipeline35 = await device0.createRenderPipelineAsync({
+  label: '\ud7fd\u9840\u6633\u42b1\u03eb\u0809\u{1ff45}\u02ed\u92c8',
+  layout: pipelineLayout3,
+  multisample: {count: 4, mask: 0x3220b138},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 24,
+        attributes: [
+          {format: 'snorm16x4', offset: 0, shaderLocation: 6},
+          {format: 'snorm16x4', offset: 0, shaderLocation: 5},
+          {format: 'sint16x4', offset: 0, shaderLocation: 9},
+          {format: 'sint32x4', offset: 0, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 0, shaderLocation: 3},
+          {format: 'sint16x4', offset: 0, shaderLocation: 0},
+          {format: 'uint16x4', offset: 0, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 1372,
+        attributes: [
+          {format: 'uint32x3', offset: 80, shaderLocation: 1},
+          {format: 'uint32x2', offset: 188, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 144,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint8x2', offset: 24, shaderLocation: 2}],
+      },
+      {arrayStride: 16, stepMode: 'instance', attributes: []},
+      {arrayStride: 572, attributes: [{format: 'uint8x2', offset: 42, shaderLocation: 15}]},
+    ],
+  },
+  primitive: {cullMode: 'front', unclippedDepth: true},
+});
+let gpuCanvasContext5 = canvas7.getContext('webgpu');
+let buffer13 = device0.createBuffer({size: 134186, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder54 = device0.createCommandEncoder({label: '\u77bc\uca56'});
+let renderBundle33 = renderBundleEncoder27.finish();
+let sampler30 = device0.createSampler({
+  label: '\uc7b4\u{1ff2d}\uc9b8',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 94.71,
+});
+let externalTexture26 = device0.importExternalTexture({
+  label: '\ub492\u{1f9e1}\u{1ff16}\u{1fc0d}\uff2f\u{1f9b4}\u{1f668}\ud73f\u{1fda2}\u05eb',
+  source: video0,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup10, [17920]);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(3, bindGroup2, new Uint32Array(5293), 1581, 0);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(7, buffer6, 0, 158967);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+commandEncoder50.copyBufferToBuffer(buffer11, 46860, buffer2, 69956, 7924);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder53.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 80 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 24528 */
+  offset: 24448,
+  bytesPerRow: 256,
+  buffer: buffer11,
+}, {
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 80, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer11);
+} catch {}
+let gpuCanvasContext6 = canvas8.getContext('webgpu');
+let commandBuffer11 = commandEncoder53.finish({});
+let texture41 = device0.createTexture({
+  label: '\u01ee\uc64b\u{1fef7}\u077d\u194a\u7e27',
+  size: {width: 30, height: 6, depthOrArrayLayers: 65},
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let renderPassEncoder27 = commandEncoder52.beginRenderPass({
+  label: '\u46d9\uf2c5\ufca0\uecf4\ub75b',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView56,
+    depthReadOnly: true,
+    stencilClearValue: 17603,
+    stencilLoadOp: 'load',
+    stencilStoreOp: 'discard',
+  },
+  occlusionQuerySet: querySet5,
+  maxDrawCount: 426673558,
+});
+let sampler31 = device0.createSampler({
+  label: '\ud58e\ubd60\u{1fee0}\u99bd',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 92.96,
+  lodMaxClamp: 98.22,
+});
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer7, 'uint16', 152878, 26080);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(0, bindGroup10, new Uint32Array(215), 151, 1);
+} catch {}
+try {
+commandEncoder54.copyBufferToBuffer(buffer13, 67008, buffer2, 288744, 8528);
+dissociateBuffer(device0, buffer13);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let pipeline36 = await device0.createComputePipelineAsync({
+  label: '\u2cc6\u0cf4\u06a2\u5ac2\u000d\uf247\u{1fadd}\u{1ff7e}\u{1fe9a}\u8ae2\udedc',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise12;
+} catch {}
+let textureView61 = texture35.createView({
+  label: '\u0fdf\u{1fd84}\u147d',
+  dimension: '2d-array',
+  format: 'stencil8',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+let renderPassEncoder28 = commandEncoder54.beginRenderPass({
+  label: '\u35fd\u00d2\u0e23\u0507\u96e6',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView61, stencilReadOnly: true},
+  occlusionQuerySet: querySet4,
+  maxDrawCount: 195830045,
+});
+let sampler32 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'repeat', lodMinClamp: 98.42, lodMaxClamp: 99.20});
+let externalTexture27 = device0.importExternalTexture({label: '\u0330\u076c\u0ef0\uf3ec', source: video1, colorSpace: 'display-p3'});
+try {
+computePassEncoder15.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder21.setPipeline(pipeline24);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline24);
+} catch {}
+try {
+  await buffer9.mapAsync(GPUMapMode.WRITE, 82352);
+} catch {}
+let pipeline37 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout4,
+  multisample: {count: 4, mask: 0x365ec786},
+  fragment: {module: shaderModule6, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {failOp: 'decrement-clamp', depthFailOp: 'increment-clamp', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilReadMask: 135505780,
+    stencilWriteMask: 900657690,
+    depthBias: -1083292397,
+    depthBiasSlopeScale: -14.035856330202478,
+    depthBiasClamp: 402.2737513794084,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 248,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x2', offset: 4, shaderLocation: 3}],
+      },
+      {arrayStride: 404, stepMode: 'instance', attributes: []},
+      {arrayStride: 180, attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 212, shaderLocation: 12},
+          {format: 'uint16x4', offset: 312, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: true},
+});
+let gpuCanvasContext7 = canvas4.getContext('webgpu');
+let img7 = await imageWithData(236, 144, '#e7e2a56a', '#d9ea9047');
+let imageBitmap11 = await createImageBitmap(imageBitmap8);
+let commandEncoder55 = device0.createCommandEncoder({label: '\u637f\u{1f93a}\ub4c0'});
+let computePassEncoder16 = commandEncoder50.beginComputePass({});
+let renderPassEncoder29 = commandEncoder55.beginRenderPass({
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView39, depthReadOnly: false, stencilLoadOp: 'clear', stencilStoreOp: 'discard'},
+  occlusionQuerySet: querySet4,
+  maxDrawCount: 82949454,
+});
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderPassEncoder25.setStencilReference(1947);
+} catch {}
+try {
+renderPassEncoder22.setViewport(20.67, 1.726, 7.708, 3.305, 0.04336, 0.8045);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer7, 'uint32', 21440);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline26);
+} catch {}
+let pipeline38 = await device0.createRenderPipelineAsync({
+  label: '\u9215\u0e03\u1709\ue1f1',
+  layout: 'auto',
+  fragment: {module: shaderModule5, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {
+      compare: 'not-equal',
+      failOp: 'decrement-clamp',
+      depthFailOp: 'increment-clamp',
+      passOp: 'increment-clamp',
+    },
+    stencilBack: {compare: 'not-equal', failOp: 'invert', depthFailOp: 'zero', passOp: 'invert'},
+    stencilReadMask: 87274034,
+    stencilWriteMask: 3507779964,
+    depthBias: -692715838,
+    depthBiasSlopeScale: -6.1320453127915755,
+    depthBiasClamp: 526.330778919469,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 32, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 28,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 0, shaderLocation: 4},
+          {format: 'float32', offset: 0, shaderLocation: 6},
+          {format: 'uint32x2', offset: 0, shaderLocation: 10},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'back', unclippedDepth: true},
+});
+let bindGroupLayout13 = device0.createBindGroupLayout({
+  label: '\ue830\ue647\u82c3\u7e7a\u{1fe4b}',
+  entries: [
+    {binding: 87, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 982,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let querySet28 = device0.createQuerySet({label: '\u131a\u{1ffa1}\uc009\uc83f\u9114', type: 'occlusion', count: 3943});
+let texture42 = device0.createTexture({
+  label: '\u{1fc9d}\u9ed6\u6208\u5a84\u00fb\u0e14\u65a7\u1270\u7c38\u2d68\ud16d',
+  size: {width: 120, height: 24, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['stencil8', 'stencil8', 'stencil8'],
+});
+let textureView62 = texture23.createView({label: '\uf83b\u820a', dimension: '2d', baseMipLevel: 2, mipLevelCount: 1, baseArrayLayer: 24});
+try {
+renderBundleEncoder26.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(6, buffer6, 104308, 50789);
+} catch {}
+let promise13 = buffer11.mapAsync(GPUMapMode.WRITE, 16800, 39292);
+try {
+device0.queue.writeTexture({
+  texture: texture31,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new Uint32Array(arrayBuffer1), /* required buffer size: 366 */
+{offset: 351}, {width: 15, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let canvas9 = document.createElement('canvas');
+let shaderModule10 = device0.createShaderModule({
+  code: `@group(2) @binding(378)
+var<storage, read_write> parameter1: array<u32>;
+@group(0) @binding(240)
+var<storage, read_write> field3: array<u32>;
+@group(0) @binding(597)
+var<storage, read_write> type6: array<u32>;
+
+@compute @workgroup_size(4, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(7) f1: u32
+}
+
+@fragment
+fn fragment0(@location(8) a0: f32, @location(7) a1: vec4<f16>, @location(14) a2: vec2<f32>, @location(12) a3: f16, @location(15) a4: vec4<f32>, @location(3) a5: vec4<i32>, @location(6) a6: vec4<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S7 {
+  @builtin(vertex_index) f0: u32,
+  @location(2) f1: vec3<u32>,
+  @location(14) f2: vec4<i32>,
+  @location(9) f3: vec4<u32>,
+  @location(13) f4: vec2<f32>,
+  @location(7) f5: f16
+}
+struct VertexOutput0 {
+  @location(13) f70: u32,
+  @location(12) f71: f16,
+  @location(0) f72: vec4<i32>,
+  @location(10) f73: i32,
+  @builtin(position) f74: vec4<f32>,
+  @location(15) f75: vec4<f32>,
+  @location(2) f76: vec4<f16>,
+  @location(9) f77: f32,
+  @location(8) f78: f32,
+  @location(4) f79: vec2<f16>,
+  @location(3) f80: vec4<i32>,
+  @location(6) f81: vec4<i32>,
+  @location(14) f82: vec2<f32>,
+  @location(5) f83: vec3<f32>,
+  @location(7) f84: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec3<i32>, @location(8) a1: vec4<u32>, @location(6) a2: vec4<u32>, @location(15) a3: vec3<u32>, @location(3) a4: i32, @location(12) a5: f16, @builtin(instance_index) a6: u32, @location(4) a7: f32, @location(0) a8: vec3<f16>, @location(1) a9: vec3<f32>, @location(10) a10: u32, a11: S7, @location(11) a12: vec4<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let commandEncoder56 = device0.createCommandEncoder();
+let querySet29 = device0.createQuerySet({label: '\uc049\ue723\u4da0\u229b\u0908\uc0a4\ue0d3\u9f7e', type: 'occlusion', count: 4038});
+let commandBuffer12 = commandEncoder56.finish({});
+let texture43 = device0.createTexture({
+  label: '\u032e\u3f0f\u26c0\u0f50\u411d\ua1d2\ucd7a',
+  size: {width: 160, height: 2, depthOrArrayLayers: 209},
+  mipLevelCount: 7,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['stencil8'],
+});
+let externalTexture28 = device0.importExternalTexture({label: '\u0fed\u{1f87e}', source: videoFrame2, colorSpace: 'display-p3'});
+let pipeline39 = device0.createRenderPipeline({
+  label: '\u46a4\u5007\u7de4\u{1fa5f}\uf418\u0d2f',
+  layout: pipelineLayout5,
+  fragment: {module: shaderModule5, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'greater', failOp: 'increment-wrap', depthFailOp: 'increment-clamp', passOp: 'invert'},
+    stencilBack: {compare: 'greater', failOp: 'keep', depthFailOp: 'increment-wrap', passOp: 'replace'},
+    stencilReadMask: 4294967295,
+    stencilWriteMask: 546404720,
+    depthBias: 137189406,
+    depthBiasSlopeScale: 62.62186847106912,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 124, stepMode: 'vertex', attributes: []},
+      {arrayStride: 184, attributes: [{format: 'uint16x4', offset: 20, shaderLocation: 10}]},
+      {
+        arrayStride: 284,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 28, shaderLocation: 6},
+          {format: 'uint8x2', offset: 216, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 580,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x4', offset: 16, shaderLocation: 5}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw', unclippedDepth: true},
+});
+let video3 = await videoWithData();
+try {
+canvas9.getContext('bitmaprenderer');
+} catch {}
+let querySet30 = device0.createQuerySet({label: '\u{1f655}\uae2b\u0062', type: 'occlusion', count: 2985});
+let textureView63 = texture14.createView({
+  label: '\u{1fa55}\u0f2d\ud6f4',
+  dimension: '2d-array',
+  format: 'stencil8',
+  baseMipLevel: 2,
+  mipLevelCount: 2,
+  baseArrayLayer: 0,
+});
+let renderBundleEncoder28 = device0.createRenderBundleEncoder({
+  label: '\uc595\u5048\u6e3e\u0f67\ud799\u9409\u6246\u7989\u0db7\u0776\u0d83',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+});
+let renderBundle34 = renderBundleEncoder23.finish();
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(25, 3, 5, 1);
+} catch {}
+try {
+computePassEncoder13.insertDebugMarker('\u00d4');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 10},
+  aspect: 'stencil-only',
+}, new ArrayBuffer(1_921_051), /* required buffer size: 1_921_051 */
+{offset: 281, bytesPerRow: 525, rowsPerImage: 63}, {width: 320, height: 5, depthOrArrayLayers: 59});
+} catch {}
+let pipeline40 = device0.createComputePipeline({
+  label: '\u{1f88e}\u59c3',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule2, entryPoint: 'compute0'},
+});
+let commandEncoder57 = device0.createCommandEncoder({label: '\ua3c5\u{1fd81}\udb17\ucd00\u{1fd52}\u7799\u59b8\u455d\u218c\ue59f'});
+let texture44 = device0.createTexture({
+  label: '\u6319\ucefa\u{1faa2}\u93ec\ude22\uc3bf\u85d3\u0f7e',
+  size: [240, 48, 1],
+  mipLevelCount: 4,
+  sampleCount: 1,
+  format: 'stencil8',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8', 'stencil8', 'stencil8'],
+});
+let renderPassEncoder30 = commandEncoder57.beginRenderPass({
+  label: '\u08ca\u{1f90b}\ub4c3',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView61,
+    depthClearValue: -3.5275556690773353,
+    depthReadOnly: false,
+    stencilClearValue: 25329,
+    stencilLoadOp: 'load',
+    stencilStoreOp: 'discard',
+  },
+  occlusionQuerySet: querySet3,
+  maxDrawCount: 1051858144,
+});
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup1, new Uint32Array(3554), 1461, 0);
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(1, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder22.setViewport(3.935, 2.531, 5.424, 2.218, 0.6902, 0.8118);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let arrayBuffer2 = buffer2.getMappedRange(0, 628);
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let textureView64 = texture13.createView({
+  label: '\uc185\u04ee\u{1fa1c}\u0b6b\u0cea\u8197',
+  dimension: '2d-array',
+  format: 'stencil8',
+  baseMipLevel: 2,
+});
+let sampler33 = device0.createSampler({
+  label: '\uaf51\u6d5d\u{1ff60}\ue583',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 30.23,
+  lodMaxClamp: 74.40,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder15.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(1379);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(2, buffer12, 8364, 1337);
+} catch {}
+let pipeline41 = device0.createComputePipeline({layout: pipelineLayout6, compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}}});
+let commandEncoder58 = device0.createCommandEncoder({});
+let renderPassEncoder31 = commandEncoder58.beginRenderPass({
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView4, stencilClearValue: 44592, stencilReadOnly: true},
+  occlusionQuerySet: querySet20,
+  maxDrawCount: 743628700,
+});
+try {
+renderPassEncoder11.setIndexBuffer(buffer7, 'uint32');
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(7, buffer6, 0);
+} catch {}
+try {
+renderBundleEncoder20.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder18.setIndexBuffer(buffer7, 'uint32', 132488, 44838);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(1949, undefined, 1489314474, 488336794);
+} catch {}
+let arrayBuffer3 = buffer7.getMappedRange(0, 24920);
+try {
+  await promise11;
+} catch {}
+document.body.prepend(canvas5);
+let offscreenCanvas4 = new OffscreenCanvas(862, 825);
+let commandEncoder59 = device0.createCommandEncoder({label: '\u0e05\u009b'});
+let renderBundle35 = renderBundleEncoder21.finish({label: '\ue7ae\ued61\u3f0a\u{1f701}\u8b77\u004f\ue0c7\uf9e1\ud2b1\u69e9\u0cf0'});
+try {
+computePassEncoder7.dispatchWorkgroups(5, 2);
+} catch {}
+try {
+renderPassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle23, renderBundle32, renderBundle9, renderBundle12, renderBundle32, renderBundle15, renderBundle16, renderBundle7, renderBundle26, renderBundle34]);
+} catch {}
+try {
+renderPassEncoder31.setViewport(16.03, 3.837, 3.488, 1.985, 0.2389, 0.2955);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(2, buffer6, 191120, 1727);
+} catch {}
+try {
+  await promise13;
+} catch {}
+let commandEncoder60 = device0.createCommandEncoder({label: '\u{1f8a7}\uac72\u14db\u14eb\u0a63\u3069\u0705\u9822\u0e03\u6532'});
+let renderPassEncoder32 = commandEncoder59.beginRenderPass({
+  label: '\u{1fd73}\u{1f89c}\u{1fda9}\uf0f1\u{1feaa}\u6658',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView44, stencilClearValue: 30287, stencilReadOnly: true},
+  occlusionQuerySet: querySet2,
+  maxDrawCount: 327106158,
+});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({label: '\uddcb\u{1f6c0}', colorFormats: [], depthStencilFormat: 'stencil8', depthReadOnly: true});
+let renderBundle36 = renderBundleEncoder13.finish({});
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder24.setStencilReference(1791);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer7, 'uint32');
+} catch {}
+try {
+commandEncoder60.copyTextureToBuffer({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 160 widthInBlocks: 160 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 215692 */
+  offset: 7820,
+  bytesPerRow: 256,
+  rowsPerImage: 7,
+  buffer: buffer8,
+}, {width: 160, height: 0, depthOrArrayLayers: 117});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let gpuCanvasContext8 = offscreenCanvas4.getContext('webgpu');
+let querySet31 = device0.createQuerySet({label: '\uac5a\u50f3\u0baf\u25c3', type: 'occlusion', count: 1542});
+let commandBuffer13 = commandEncoder60.finish({label: '\ua6c0\uf646\u{1fa63}\ud9a3\u9a59\u0917\u0ab8'});
+let textureView65 = texture8.createView({label: '\u858f\u1df4\uf73b\u36b9\u46ee\u{1ffae}\u0106', baseArrayLayer: 3});
+try {
+computePassEncoder4.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderPassEncoder28.beginOcclusionQuery(750);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle3, renderBundle7, renderBundle26, renderBundle12, renderBundle2, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer7, 'uint32');
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(6, buffer12, 8668, 947);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let bindGroup15 = device0.createBindGroup({
+  label: '\u9000\uabbd\u21e6\u{1f699}\uc27a\u{1f9a1}\u{1f9b8}\uebf5\u036b',
+  layout: bindGroupLayout4,
+  entries: [{binding: 580, resource: sampler22}],
+});
+let commandEncoder61 = device0.createCommandEncoder({label: '\u0563\u5bb9\u{1f6e4}\ud334\u3807\u5c0a\u{1fdf7}\u0187'});
+let textureView66 = texture36.createView({
+  label: '\u5fff\u0edf\u0a1c\u348b\u99ed\u0423\u6aa1',
+  dimension: '2d',
+  aspect: 'stencil-only',
+  baseMipLevel: 7,
+  baseArrayLayer: 2,
+});
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(4, 1, 3, 0);
+} catch {}
+try {
+renderPassEncoder17.setViewport(17.51, 5.291, 11.55, 0.06290, 0.6173, 0.9612);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer12, 6576, 1754);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(3, buffer12, 0, 9158);
+} catch {}
+try {
+commandEncoder61.copyTextureToBuffer({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 0, y: 11, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1280 widthInBlocks: 1280 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 11956 */
+  offset: 11956,
+  bytesPerRow: 1536,
+  rowsPerImage: 69,
+  buffer: buffer8,
+}, {width: 1280, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer8);
+} catch {}
+let img8 = await imageWithData(176, 48, '#790c6519', '#a6b11982');
+let bindGroup16 = device0.createBindGroup({
+  label: '\u853a\u08fc\u7191\u08b3\u{1ff0a}\u04b8\u60fe\u9a0d',
+  layout: bindGroupLayout2,
+  entries: [{binding: 336, resource: sampler21}],
+});
+let commandBuffer14 = commandEncoder61.finish({});
+let textureView67 = texture22.createView({
+  label: '\u0727\u4f67\u{1f9f2}\u{1fd24}\u5767\u743a',
+  dimension: '2d-array',
+  aspect: 'all',
+  format: 'stencil8',
+  baseArrayLayer: 127,
+  arrayLayerCount: 16,
+});
+let sampler34 = device0.createSampler({
+  label: '\u8d13\u005e\u{1fdb0}\u{1fe87}\u0588\u7267',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 76.70,
+  lodMaxClamp: 80.34,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder14.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(3, bindGroup4, new Uint32Array(9962), 5000, 0);
+} catch {}
+try {
+renderPassEncoder28.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder18.setViewport(21.01, 5.201, 7.591, 0.3577, 0.5073, 0.5236);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer7, 'uint16', 33096, 29218);
+} catch {}
+let buffer14 = device0.createBuffer({
+  label: '\u{1fe34}\u8138\u{1f654}\uabc6\u0136\u0ad4',
+  size: 6637,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let querySet32 = device0.createQuerySet({label: '\uf275\u51d8\u0a6c\u8606', type: 'occlusion', count: 3153});
+try {
+renderPassEncoder32.executeBundles([renderBundle20, renderBundle22, renderBundle36]);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline24);
+} catch {}
+let promise14 = buffer14.mapAsync(GPUMapMode.WRITE, 0, 792);
+let commandEncoder62 = device0.createCommandEncoder({label: '\u0240\u4c59\u{1fb59}\u2296\u{1fff4}\u2058\ud11e'});
+let computePassEncoder17 = commandEncoder62.beginComputePass();
+try {
+computePassEncoder14.setBindGroup(3, bindGroup6, new Uint32Array(4021), 1951, 0);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(3, buffer6, 47284, 80901);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let commandEncoder63 = device0.createCommandEncoder({});
+let texture45 = device0.createTexture({
+  label: '\u705c\u0052\u0e34',
+  size: {width: 640, height: 10, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8', 'stencil8', 'stencil8'],
+});
+let textureView68 = texture40.createView({label: '\ufde0\u6901\u09c7\u1a03', dimension: '2d', mipLevelCount: 1, baseArrayLayer: 15});
+let renderBundle37 = renderBundleEncoder2.finish({});
+try {
+renderPassEncoder22.setStencilReference(3442);
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline24);
+} catch {}
+try {
+commandEncoder63.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 14228 */
+  offset: 14228,
+  buffer: buffer1,
+}, {
+  texture: texture25,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'stencil-only',
+}, {width: 20, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder63.copyTextureToBuffer({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 60 widthInBlocks: 60 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 58184 */
+  offset: 58184,
+  bytesPerRow: 256,
+  buffer: buffer10,
+}, {width: 60, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder63.copyTextureToTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 40, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline42 = device0.createComputePipeline({
+  label: '\u0cee\u7889\ue6e1',
+  layout: 'auto',
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(video2);
+let imageData5 = new ImageData(88, 168);
+let commandEncoder64 = device0.createCommandEncoder();
+let textureView69 = texture44.createView({label: '\u{1fd72}\u0980\uaebd', dimension: '2d-array', aspect: 'stencil-only', baseMipLevel: 3});
+let computePassEncoder18 = commandEncoder64.beginComputePass();
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({
+  label: '\u{1f96b}\u7d9d\ucd5e\ue2a2\uad1a\ud873',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  depthReadOnly: true,
+});
+let renderBundle38 = renderBundleEncoder8.finish({label: '\u0e3a\u{1fc3d}'});
+try {
+computePassEncoder2.dispatchWorkgroupsIndirect(buffer3, 1508);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline22);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+renderPassEncoder15.pushDebugGroup('\u4c35');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 42 */
+{offset: 42}, {width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline43 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule3, entryPoint: 'compute0'}});
+let texture46 = device0.createTexture({
+  label: '\u{1fb21}\u6a01\u02e3\u025d\u{1fc92}\u{1f652}\u39cc\u056f',
+  size: {width: 160, height: 2, depthOrArrayLayers: 64},
+  mipLevelCount: 5,
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8', 'stencil8', 'stencil8'],
+});
+let textureView70 = texture7.createView({
+  label: '\u0212\u62e2\u{1f6b4}\ufcc8\uff89\u1cbe\u{1f993}\uda2f\ua414\ud03e\u0c39',
+  baseMipLevel: 2,
+  mipLevelCount: 5,
+});
+let computePassEncoder19 = commandEncoder63.beginComputePass();
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({label: '\u{1f7ef}\u049d', colorFormats: [], depthStencilFormat: 'stencil8', stencilReadOnly: true});
+try {
+computePassEncoder8.dispatchWorkgroups(1, 2, 4);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup3, new Uint32Array(3098), 2126, 0);
+} catch {}
+try {
+renderBundleEncoder17.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(3, buffer12);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline44 = await device0.createComputePipelineAsync({
+  label: '\u04ba\ud310\u96d4\u0032\ud0eb\u{1f8eb}\u2f9f\u5562\u163d\uf393',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}},
+});
+let canvas10 = document.createElement('canvas');
+let shaderModule11 = device0.createShaderModule({
+  label: '\u{1f8e8}\u{1f864}\ue44f\uc813\u{1fbfb}\u1a36\u0ab2',
+  code: `@group(0) @binding(714)
+var<storage, read_write> global1: array<u32>;
+
+@compute @workgroup_size(4, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) {
+
+}
+
+struct S8 {
+  @location(9) f0: vec4<f32>,
+  @location(13) f1: vec4<i32>,
+  @location(5) f2: f32,
+  @location(6) f3: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(10) a0: vec3<i32>, @location(2) a1: vec4<u32>, @location(4) a2: vec3<i32>, @builtin(instance_index) a3: u32, @location(1) a4: vec4<f32>, @location(11) a5: vec2<i32>, a6: S8, @location(3) a7: i32, @location(15) a8: vec3<u32>, @location(12) a9: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder65 = device0.createCommandEncoder();
+let texture47 = device0.createTexture({
+  label: '\u{1f703}\u{1fdef}\uca18\ub194\u{1f8b5}\uccd1\ud7d7\u5e45\u{1f94d}\u6ae3',
+  size: {width: 120, height: 24, depthOrArrayLayers: 1},
+  mipLevelCount: 7,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView71 = texture43.createView({baseMipLevel: 5, baseArrayLayer: 204, arrayLayerCount: 4});
+let externalTexture29 = device0.importExternalTexture({
+  label: '\u04db\u9c1f\uaa13\u68ce\u{1fb6d}\u{1fe24}\u6d83\ue4d2\u{1ff63}\u{1f980}',
+  source: video3,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder10.setBlendConstant({ r: -698.8, g: 480.3, b: -301.3, a: -269.3, });
+} catch {}
+try {
+renderPassEncoder24.setStencilReference(1151);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline9);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder65.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 80 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 9424 */
+  offset: 9344,
+  bytesPerRow: 256,
+  buffer: buffer4,
+}, {
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 80, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder65.copyTextureToBuffer({
+  texture: texture7,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 20 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 7916 */
+  offset: 7916,
+  buffer: buffer10,
+}, {width: 20, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.submit([commandBuffer12, commandBuffer13, commandBuffer14]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture31,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, arrayBuffer0, /* required buffer size: 451 */
+{offset: 38, bytesPerRow: 199, rowsPerImage: 174}, {width: 15, height: 3, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await promise14;
+} catch {}
+let commandEncoder66 = device0.createCommandEncoder();
+let querySet33 = device0.createQuerySet({label: '\u9c08\u0804\uf39f\u4947\ub00e\u6845\u{1f867}', type: 'occlusion', count: 31});
+let textureView72 = texture10.createView({
+  label: '\u{1fedd}\u0e33',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  mipLevelCount: 4,
+  baseArrayLayer: 0,
+});
+let renderPassEncoder33 = commandEncoder65.beginRenderPass({
+  label: '\ud69d\u1d1a\u193d\ue2e4\u17e1\ua032\u1ca9',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView61,
+    depthClearValue: 8.49662525467664,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'discard',
+  },
+  occlusionQuerySet: querySet3,
+  maxDrawCount: 644520528,
+});
+let renderBundle39 = renderBundleEncoder28.finish({label: '\u{1fca7}\u{1f7d3}\u0779\u832b\u3620\u0d43\u949c\u0827\ub8ba'});
+try {
+renderPassEncoder21.setScissorRect(23, 0, 0, 0);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer7, 'uint16', 111416);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(0, buffer12, 0, 2182);
+} catch {}
+try {
+commandEncoder66.copyBufferToBuffer(buffer9, 48848, buffer2, 255968, 41392);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder66.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture34,
+  mipLevel: 1,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 160, height: 2, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 36436, new Float32Array(55898), 34281, 4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'stencil-only',
+}, arrayBuffer2, /* required buffer size: 2_696_684 */
+{offset: 715, bytesPerRow: 253, rowsPerImage: 296}, {width: 1, height: 1, depthOrArrayLayers: 37});
+} catch {}
+let shaderModule12 = device0.createShaderModule({
+  label: '\u{1fa31}\u7135\u23e7\ue4c9\u97b0\u9083',
+  code: `@group(0) @binding(240)
+var<storage, read_write> n5: array<u32>;
+@group(0) @binding(597)
+var<storage, read_write> local1: array<u32>;
+@group(1) @binding(378)
+var<storage, read_write> global2: array<u32>;
+
+@compute @workgroup_size(1, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@location(1) a0: f32, @location(0) a1: vec3<f16>) {
+
+}
+
+struct S9 {
+  @location(11) f0: vec2<i32>,
+  @location(15) f1: vec4<f32>,
+  @builtin(instance_index) f2: u32,
+  @location(6) f3: vec4<f32>,
+  @location(12) f4: i32
+}
+struct VertexOutput0 {
+  @location(1) f85: f32,
+  @location(5) f86: vec3<f16>,
+  @location(8) f87: vec4<u32>,
+  @builtin(position) f88: vec4<f32>,
+  @location(0) f89: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(2) a0: vec2<u32>, @location(5) a1: vec4<f16>, @location(3) a2: u32, a3: S9, @location(13) a4: f16, @location(8) a5: vec4<f32>, @location(14) a6: vec4<u32>, @location(7) a7: vec4<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let textureView73 = texture46.createView({
+  label: '\u7a19\u015b\u40b5\u0c80\u{1f8ff}\u{1f981}\ucbe5\u{1fd25}',
+  aspect: 'stencil-only',
+  baseMipLevel: 1,
+  baseArrayLayer: 8,
+  arrayLayerCount: 26,
+});
+let sampler35 = device0.createSampler({
+  label: '\u4e1b\u9089\u{1f7de}\u9f29\ua39f\uf8ea\u{1fd81}\ubb5e\u0ee4\u{1fa59}',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 59.00,
+  lodMaxClamp: 76.59,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(118);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle4, renderBundle21, renderBundle14, renderBundle16, renderBundle20, renderBundle4, renderBundle8]);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: -530.2, g: 667.9, b: 756.2, a: -561.4, });
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(0, 0, 0, 1);
+} catch {}
+try {
+renderPassEncoder25.setIndexBuffer(buffer7, 'uint16', 167456, 2528);
+} catch {}
+try {
+commandEncoder36.copyTextureToBuffer({
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 40 widthInBlocks: 40 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 16040 */
+  offset: 16040,
+  buffer: buffer10,
+}, {width: 40, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, new ArrayBuffer(437_635), /* required buffer size: 437_635 */
+{offset: 279, bytesPerRow: 182, rowsPerImage: 89}, {width: 10, height: 1, depthOrArrayLayers: 28});
+} catch {}
+let img9 = await imageWithData(99, 171, '#8c66c7d1', '#70775d55');
+let buffer15 = device0.createBuffer({size: 20131, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder67 = device0.createCommandEncoder({label: '\u{1f925}\ue194\u{1fbf8}\u10c0'});
+let renderPassEncoder34 = commandEncoder36.beginRenderPass({
+  label: '\u563d\u0bd2\uc3e4',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView1, depthReadOnly: false, stencilClearValue: 29205, stencilReadOnly: true},
+  occlusionQuerySet: querySet11,
+});
+let sampler36 = device0.createSampler({
+  label: '\u{1f7af}\u5827\u7118\ud1c4\udd12\u03d0\u7372',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 62.11,
+});
+try {
+computePassEncoder2.setPipeline(pipeline43);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle16, renderBundle30, renderBundle27]);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(25, 5, 3, 0);
+} catch {}
+try {
+renderPassEncoder0.setViewport(0.7459, 0.4467, 0.2100, 0.4619, 0.8349, 0.9104);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer7, 'uint32', 167900, 11945);
+} catch {}
+try {
+renderPassEncoder34.setVertexBuffer(6, buffer12, 0, 7638);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(1, buffer6);
+} catch {}
+let pipeline45 = device0.createComputePipeline({
+  label: '\u{1fdfa}\u0d04\u6eee\u55d7\u{1fdc3}\u6777\u05a1\u1549\u{1fcd4}',
+  layout: 'auto',
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+let img10 = await imageWithData(260, 278, '#151d247a', '#eb7c5e29');
+let bindGroupLayout14 = device0.createBindGroupLayout({
+  label: '\u{1fe4c}\u19d6',
+  entries: [
+    {binding: 932, visibility: 0, externalTexture: {}},
+    {binding: 131, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let commandBuffer15 = commandEncoder66.finish({label: '\u02d9\u05a3'});
+let texture48 = device0.createTexture({
+  size: {width: 240, height: 48, depthOrArrayLayers: 10},
+  mipLevelCount: 6,
+  format: 'stencil8',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView74 = texture0.createView({label: '\u0cf8\ua444\u3c94\u4e4a\u04ab', baseArrayLayer: 0});
+try {
+computePassEncoder9.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.end();
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle10, renderBundle10, renderBundle32, renderBundle32]);
+} catch {}
+try {
+renderPassEncoder9.setViewport(0.8018, 0.6700, 0.07898, 0.1654, 0.9741, 0.9913);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline24);
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline24);
+} catch {}
+let pipeline46 = device0.createRenderPipeline({
+  label: '\u6374\u0148\u1a8c\u{1f75e}\uad2f\u8814',
+  layout: pipelineLayout2,
+  fragment: {module: shaderModule4, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'less-equal', failOp: 'increment-wrap'},
+    stencilBack: {compare: 'not-equal', failOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilReadMask: 3130832968,
+    depthBias: 0,
+    depthBiasClamp: 615.5043588519569,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 256, stepMode: 'instance', attributes: []},
+      {arrayStride: 44, stepMode: 'instance', attributes: []},
+      {arrayStride: 76, attributes: []},
+      {
+        arrayStride: 124,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x4', offset: 4, shaderLocation: 0}],
+      },
+    ],
+  },
+});
+let bindGroup17 = device0.createBindGroup({
+  label: '\u0b18\u0887',
+  layout: bindGroupLayout14,
+  entries: [{binding: 131, resource: externalTexture10}, {binding: 932, resource: externalTexture23}],
+});
+let textureView75 = texture25.createView({
+  label: '\ufbd5\u{1fbc0}\u{1f6a0}\u{1f73a}',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  baseMipLevel: 6,
+  mipLevelCount: 1,
+  baseArrayLayer: 16,
+  arrayLayerCount: 57,
+});
+let computePassEncoder20 = commandEncoder67.beginComputePass({label: '\u{1fabc}\u0808\ud038\u1391\u885a\u1bfb\u{1f7e8}\u0edb\u4270\uaea2\uc2f5'});
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(3, buffer12, 5000, 4063);
+} catch {}
+try {
+renderBundleEncoder31.setIndexBuffer(buffer7, 'uint32', 16772, 163409);
+} catch {}
+let promise15 = buffer15.mapAsync(GPUMapMode.WRITE, 11944, 616);
+let gpuCanvasContext9 = canvas10.getContext('webgpu');
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let bindGroup18 = device0.createBindGroup({
+  layout: bindGroupLayout14,
+  entries: [{binding: 932, resource: externalTexture29}, {binding: 131, resource: externalTexture6}],
+});
+let commandEncoder68 = device0.createCommandEncoder({});
+let textureView76 = texture18.createView({label: '\u3375\u8e66\u6b9b\u{1fb15}', dimension: '2d', baseMipLevel: 1});
+let renderPassEncoder35 = commandEncoder68.beginRenderPass({
+  label: '\u{1f7db}\ucd25\ua9f0\u4115\u{1fd2d}\u1854\u0b0a\u{1ff6f}\u353d\u094d\u66f5',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView43, stencilLoadOp: 'clear', stencilStoreOp: 'store'},
+  occlusionQuerySet: querySet31,
+  maxDrawCount: 594717830,
+});
+let renderBundleEncoder32 = device0.createRenderBundleEncoder({
+  label: '\uaf53\u{1ff36}\u0d51\u0111\u{1f843}',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  depthReadOnly: true,
+});
+let renderBundle40 = renderBundleEncoder18.finish();
+try {
+computePassEncoder9.setPipeline(pipeline17);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(3, bindGroup15);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup5, new Uint32Array(4776), 1890, 0);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(71);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -368.0, g: 534.5, b: -844.4, a: -783.8, });
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+texture27.destroy();
+} catch {}
+try {
+renderPassEncoder15.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 203 */
+{offset: 203, bytesPerRow: 77, rowsPerImage: 39}, {width: 40, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline47 = device0.createRenderPipeline({
+  label: '\u7b60\u4a3f\u070d\u3e61\u{1fcb4}\u5910',
+  layout: pipelineLayout0,
+  multisample: {count: 1, mask: 0x2693a67e},
+  fragment: {module: shaderModule8, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'equal', failOp: 'increment-wrap', depthFailOp: 'increment-clamp', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'less', depthFailOp: 'zero'},
+    stencilReadMask: 2978852807,
+    depthBias: -1487134638,
+    depthBiasSlopeScale: 157.40070631299892,
+    depthBiasClamp: 643.5031946810881,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 508,
+        attributes: [
+          {format: 'sint16x2', offset: 16, shaderLocation: 5},
+          {format: 'uint8x4', offset: 288, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 92,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 0, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 0, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 0, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'front'},
+});
+document.body.prepend(video2);
+let canvas11 = document.createElement('canvas');
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'stencil-only',
+}, arrayBuffer2, /* required buffer size: 5_481_504 */
+{offset: 184, bytesPerRow: 332, rowsPerImage: 127}, {width: 160, height: 0, depthOrArrayLayers: 131});
+} catch {}
+let imageBitmap12 = await createImageBitmap(imageData4);
+let renderBundleEncoder33 = device0.createRenderBundleEncoder({
+  label: '\u56ab\u0fc2\u{1fbbd}\uee3c\u6ff6',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+let externalTexture30 = device0.importExternalTexture({label: '\u0c06\uedea\ucf71\u0783\u{1fba1}\u07ba\u9aad', source: video3, colorSpace: 'srgb'});
+try {
+renderPassEncoder35.setScissorRect(0, 1, 0, 2);
+} catch {}
+let arrayBuffer4 = buffer12.getMappedRange(0, 4112);
+let shaderModule13 = device0.createShaderModule({
+  code: `@group(0) @binding(336)
+var<storage, read_write> function2: array<u32>;
+@group(2) @binding(336)
+var<storage, read_write> function3: array<u32>;
+@group(1) @binding(714)
+var<storage, read_write> parameter2: array<u32>;
+
+@compute @workgroup_size(5, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S10 {
+  @builtin(sample_index) f0: u32,
+  @builtin(sample_mask) f1: u32,
+  @builtin(front_facing) f2: bool,
+  @builtin(position) f3: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(7) f0: vec3<u32>,
+  @location(3) f1: u32
+}
+
+@fragment
+fn fragment0(a0: S10) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(8) a0: vec3<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let buffer16 = device0.createBuffer({
+  label: '\u8a50\u7338\ue10b\u5eaa\u7918\u547b\uea55\u3770\u{1f93d}',
+  size: 330191,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let querySet34 = device0.createQuerySet({
+  label: '\u2295\u{1fae5}\u0483\u016f\u2bfb\u{1f6a0}\u8198\ud7ef\u{1f899}',
+  type: 'occlusion',
+  count: 2114,
+});
+let sampler37 = device0.createSampler({
+  label: '\u08ac\u0e44\u067f\u0482\u0c82\ua61a\u675f',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 65.81,
+  lodMaxClamp: 84.67,
+  maxAnisotropy: 2,
+});
+let externalTexture31 = device0.importExternalTexture({source: video2, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder26.setPipeline(pipeline9);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline48 = device0.createRenderPipeline({
+  label: '\u0ce8\u{1fa3f}\u{1facc}\u02e4\u{1fec9}\u91ae\u0c6a\ua4b0',
+  layout: pipelineLayout4,
+  fragment: {module: shaderModule10, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'greater-equal', failOp: 'replace', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'replace', passOp: 'decrement-clamp'},
+    stencilWriteMask: 3341730192,
+    depthBiasSlopeScale: 161.40214718401586,
+  },
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 284,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 40, shaderLocation: 8},
+          {format: 'snorm16x4', offset: 4, shaderLocation: 11},
+          {format: 'sint32x4', offset: 48, shaderLocation: 5},
+          {format: 'uint8x4', offset: 0, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 12, shaderLocation: 4},
+          {format: 'uint32x2', offset: 24, shaderLocation: 10},
+          {format: 'unorm10-10-10-2', offset: 4, shaderLocation: 7},
+          {format: 'sint8x2', offset: 0, shaderLocation: 3},
+          {format: 'unorm16x2', offset: 36, shaderLocation: 1},
+          {format: 'snorm16x2', offset: 100, shaderLocation: 13},
+          {format: 'sint32', offset: 76, shaderLocation: 14},
+          {format: 'unorm8x4', offset: 20, shaderLocation: 12},
+          {format: 'uint8x4', offset: 20, shaderLocation: 6},
+          {format: 'uint32x4', offset: 40, shaderLocation: 2},
+          {format: 'snorm8x4', offset: 52, shaderLocation: 0},
+          {format: 'uint32x2', offset: 72, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', cullMode: 'front', unclippedDepth: true},
+});
+let commandEncoder69 = device0.createCommandEncoder({label: '\u8df5\u{1fb33}\uae04\u04d6\uef16\ueda5'});
+let textureView77 = texture35.createView({label: '\u8869\u209f\u{1fe68}\uc6b3', dimension: '2d-array', aspect: 'stencil-only', baseMipLevel: 2});
+let renderPassEncoder36 = commandEncoder69.beginRenderPass({
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView5,
+    depthClearValue: -2.416016732191009,
+    depthReadOnly: true,
+    stencilClearValue: 20768,
+    stencilReadOnly: true,
+  },
+  occlusionQuerySet: querySet3,
+  maxDrawCount: 87018272,
+});
+let renderBundle41 = renderBundleEncoder32.finish({label: '\ube8a\uf442\u{1f90a}\uc5c0\u04cb\u{1f826}\u0715'});
+let sampler38 = device0.createSampler({
+  label: '\u05fb\ud0be\u09ef\ua864\u0667\u{1f784}\u00ba\u0861\u1192',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.48,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder16.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle32, renderBundle25, renderBundle38, renderBundle7, renderBundle16, renderBundle6]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer7, 'uint16', 145186, 25415);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(1, buffer12, 6232, 1508);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(2, buffer6, 195716, 3759);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+let buffer17 = device0.createBuffer({
+  label: '\u1e5c\u2acd\u4bfe\u2933\u9e6c\u0c02\u0df3',
+  size: 4452,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let querySet35 = device0.createQuerySet({label: '\u2ef5\ua1e1\u0ca8\u755b\u0c55\u0c37\u0125', type: 'occlusion', count: 505});
+let textureView78 = texture31.createView({
+  label: '\u002c\u0c39\u89db\ufa11\u07dc\u51f4\u5a88\u014b\u1802',
+  dimension: '2d-array',
+  baseMipLevel: 4,
+  baseArrayLayer: 0,
+});
+let externalTexture32 = device0.importExternalTexture({
+  label: '\u25aa\u{1fd9d}\u153c\u0a8d\u0518\u0880\u{1fbad}\u02e6\u5296\u{1feda}',
+  source: video2,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder15.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(1, buffer17, 0, 2694);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder70 = device0.createCommandEncoder({label: '\u{1f7c2}\ufa82'});
+let texture49 = device0.createTexture({
+  label: '\u539b\uc37d\u03ec\u0bdf\u081d\u{1fe31}\u16e1\u04c8\u31d9',
+  size: [640, 10, 105],
+  mipLevelCount: 6,
+  dimension: '2d',
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8', 'stencil8'],
+});
+let renderPassEncoder37 = commandEncoder70.beginRenderPass({
+  label: '\u0545\u0263\u0fe6',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView39,
+    stencilClearValue: 38220,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'discard',
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet20,
+});
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler39 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 66.22,
+});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle36, renderBundle18, renderBundle22, renderBundle33, renderBundle38, renderBundle18, renderBundle10, renderBundle31]);
+} catch {}
+try {
+renderPassEncoder22.setStencilReference(721);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer17, 'uint32', 3588, 587);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(1, bindGroup11, new Uint32Array(4972), 2901, 0);
+} catch {}
+try {
+renderBundleEncoder24.setIndexBuffer(buffer17, 'uint32', 3220);
+} catch {}
+let canvas12 = document.createElement('canvas');
+let bindGroup19 = device0.createBindGroup({
+  label: '\u{1ffbe}\ue18b\ua830\ud7cd',
+  layout: bindGroupLayout4,
+  entries: [{binding: 580, resource: sampler9}],
+});
+let commandEncoder71 = device0.createCommandEncoder({label: '\u{1fcb9}\u60e1\u00a0\u07c7\ua471\u7f49\uc27b'});
+let querySet36 = device0.createQuerySet({type: 'occlusion', count: 1961});
+try {
+renderPassEncoder32.setBlendConstant({ r: -720.9, g: -68.00, b: 825.9, a: -557.7, });
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+canvas12.getContext('2d');
+} catch {}
+let commandEncoder72 = device0.createCommandEncoder({label: '\u{1f77b}\uc21c'});
+let querySet37 = device0.createQuerySet({label: '\u{1f6c7}\u2d84\u0dba', type: 'occlusion', count: 3506});
+let renderBundle42 = renderBundleEncoder17.finish({});
+let externalTexture33 = device0.importExternalTexture({label: '\u{1fa49}\u0581\u88e8\ub2f0', source: videoFrame1, colorSpace: 'display-p3'});
+try {
+renderPassEncoder3.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle15, renderBundle22, renderBundle30, renderBundle6, renderBundle42, renderBundle25, renderBundle3, renderBundle37]);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(11, 2, 2, 1);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(1, buffer12);
+} catch {}
+try {
+commandEncoder71.copyBufferToBuffer(buffer5, 11088, buffer2, 207748, 768);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder71.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 1,
+  origin: {x: 7, y: 3, z: 0},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture31,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 30, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 129832, new BigUint64Array(20349), 17150, 396);
+} catch {}
+document.body.prepend(img4);
+let imageBitmap13 = await createImageBitmap(videoFrame3);
+let pipelineLayout8 = device0.createPipelineLayout({bindGroupLayouts: [bindGroupLayout11]});
+let buffer18 = device0.createBuffer({
+  label: '\u097a\u450f\u86d3\ud475\u8842\uab73\ue560\u{1fead}',
+  size: 116716,
+  usage: GPUBufferUsage.COPY_SRC,
+  mappedAtCreation: true,
+});
+let textureView79 = texture37.createView({});
+let computePassEncoder21 = commandEncoder72.beginComputePass();
+let renderPassEncoder38 = commandEncoder71.beginRenderPass({
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView61, depthReadOnly: true, stencilClearValue: 13733, stencilReadOnly: true},
+  maxDrawCount: 275094424,
+});
+let sampler40 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 21.87,
+  lodMaxClamp: 81.94,
+  maxAnisotropy: 17,
+});
+try {
+renderPassEncoder3.setStencilReference(1084);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(4, buffer12, 9720, 243);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(2, bindGroup13, []);
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(0, bindGroup2, new Uint32Array(1321), 1010, 0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let pipeline49 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout1,
+  fragment: {module: shaderModule13, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {depthFailOp: 'decrement-clamp', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'greater', failOp: 'increment-clamp', depthFailOp: 'increment-clamp', passOp: 'replace'},
+    stencilWriteMask: 3263489455,
+    depthBias: -1892604247,
+    depthBiasSlopeScale: 317.2428249765856,
+    depthBiasClamp: 918.4511174576443,
+  },
+  vertex: {
+    module: shaderModule13,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {arrayStride: 228, stepMode: 'instance', attributes: []},
+      {arrayStride: 332, attributes: [{format: 'float16x4', offset: 16, shaderLocation: 8}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'ccw', unclippedDepth: true},
+});
+let videoFrame5 = new VideoFrame(img2, {timestamp: 0});
+let texture50 = device0.createTexture({
+  label: '\u5c68\u0a3b\u1e83\u{1f94c}\u051b\u4ceb\u0bcc',
+  size: [1280, 20, 227],
+  mipLevelCount: 3,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['stencil8', 'stencil8'],
+});
+let textureView80 = texture2.createView({
+  label: '\u{1f9dd}\u0b03\u0de3\u06d6\uf4b3\u05d9',
+  dimension: '2d',
+  format: 'stencil8',
+  baseMipLevel: 4,
+  baseArrayLayer: 184,
+});
+let renderBundle43 = renderBundleEncoder4.finish({label: '\u8e92\ubda7'});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup14, new Uint32Array(3614), 2655, 0);
+} catch {}
+try {
+renderPassEncoder22.setViewport(14.76, 0.5664, 6.641, 2.385, 0.2109, 0.5540);
+} catch {}
+let promise16 = device0.popErrorScope();
+try {
+renderBundleEncoder31.insertDebugMarker('\u0331');
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+canvas4.height = 233;
+let sampler41 = device0.createSampler({
+  label: '\u{1f6e3}\u1f43\u6386\u1778\ud268\ue2ee',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 97.84,
+  lodMaxClamp: 98.54,
+  compare: 'never',
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder16.setBindGroup(3, bindGroup15, new Uint32Array(7342), 4369, 0);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder25.end();
+} catch {}
+try {
+renderPassEncoder34.setBlendConstant({ r: 422.7, g: 835.0, b: -909.8, a: -306.4, });
+} catch {}
+try {
+renderPassEncoder27.setPipeline(pipeline9);
+} catch {}
+let pipeline50 = device0.createRenderPipeline({
+  label: '\u{1f82d}\u00b9\u{1fa56}\u0c7d\u34d9\u3513\u1a4f\uc4b7',
+  layout: pipelineLayout8,
+  multisample: {count: 4, mask: 0x4da24f41},
+  fragment: {module: shaderModule6, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'greater', failOp: 'increment-clamp', depthFailOp: 'keep', passOp: 'replace'},
+    stencilBack: {failOp: 'decrement-clamp', depthFailOp: 'replace', passOp: 'invert'},
+    stencilReadMask: 2998920209,
+    stencilWriteMask: 2143401972,
+    depthBias: 0,
+    depthBiasSlopeScale: 92.3666272182027,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 48,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x4', offset: 0, shaderLocation: 12}],
+      },
+      {
+        arrayStride: 268,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x4', offset: 24, shaderLocation: 3}],
+      },
+      {
+        arrayStride: 272,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x4', offset: 76, shaderLocation: 0}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'back', unclippedDepth: true},
+});
+try {
+renderPassEncoder26.beginOcclusionQuery(822);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer17, 'uint32', 2520, 119);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(3, buffer6, 0, 83799);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 11},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 1_497_192 */
+{offset: 916, bytesPerRow: 139, rowsPerImage: 69}, {width: 80, height: 1, depthOrArrayLayers: 157});
+} catch {}
+let pipeline51 = await device0.createComputePipelineAsync({layout: pipelineLayout1, compute: {module: shaderModule12, entryPoint: 'compute0', constants: {}}});
+let pipeline52 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout1,
+  fragment: {module: shaderModule13, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'less', failOp: 'decrement-clamp', depthFailOp: 'invert', passOp: 'invert'},
+    stencilBack: {compare: 'always', failOp: 'increment-wrap', depthFailOp: 'decrement-wrap', passOp: 'zero'},
+    stencilReadMask: 43072712,
+    stencilWriteMask: 4023704542,
+    depthBias: 2139180429,
+    depthBiasClamp: 641.5606636030526,
+  },
+  vertex: {
+    module: shaderModule13,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 964,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x4', offset: 72, shaderLocation: 8}],
+      },
+    ],
+  },
+});
+let imageData6 = new ImageData(84, 232);
+let bindGroupLayout15 = device0.createBindGroupLayout({
+  label: '\u781e\u{1fb84}',
+  entries: [
+    {binding: 510, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 811, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder73 = device0.createCommandEncoder({});
+let textureView81 = texture33.createView({label: '\u0e14\ufab0', dimension: '2d-array', mipLevelCount: 3, arrayLayerCount: 1});
+let computePassEncoder22 = commandEncoder73.beginComputePass();
+let renderBundle44 = renderBundleEncoder27.finish({label: '\udc17\u0e39\u13b4\u86fc\u9a53\u0868'});
+try {
+computePassEncoder16.setBindGroup(3, bindGroup1, new Uint32Array(9129), 6776, 0);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+  await promise15;
+} catch {}
+let video4 = await videoWithData();
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({
+  label: '\u{1fa1f}\u{1fb59}\u050a\u32d6\u{1ffba}\u004c',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  sampleCount: 1,
+});
+let externalTexture34 = device0.importExternalTexture({label: '\u0d9a\u0726\u0f3c\ue539\ub6eb\u{1fe7e}', source: videoFrame0, colorSpace: 'display-p3'});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup4, []);
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline34);
+} catch {}
+try {
+renderPassEncoder10.beginOcclusionQuery(395);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(1, buffer17, 0, 2629);
+} catch {}
+try {
+texture10.destroy();
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+renderBundleEncoder20.insertDebugMarker('\u{1f6de}');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 724, new Float32Array(17772), 4135, 2488);
+} catch {}
+let canvas13 = document.createElement('canvas');
+let commandEncoder74 = device0.createCommandEncoder({});
+let querySet38 = device0.createQuerySet({
+  label: '\u{1fa6f}\u071d\u1656\u97f3\ud0fe\ua503\ue022\u{1fae6}\u{1fadd}',
+  type: 'occlusion',
+  count: 153,
+});
+let textureView82 = texture30.createView({label: '\u6101\u005d\udf4f', format: 'stencil8', baseArrayLayer: 65, arrayLayerCount: 3});
+try {
+renderPassEncoder19.setBlendConstant({ r: -599.4, g: -444.6, b: -992.1, a: 507.6, });
+} catch {}
+try {
+renderPassEncoder14.setStencilReference(3623);
+} catch {}
+try {
+renderPassEncoder12.setViewport(0.07233, 0.6339, 0.7044, 0.2379, 0.3278, 0.4248);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer17, 'uint32', 4008, 41);
+} catch {}
+try {
+commandEncoder74.copyBufferToBuffer(buffer13, 71300, buffer10, 186296, 10904);
+dissociateBuffer(device0, buffer13);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder74.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 2,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture43,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer11]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 92396, new DataView(new ArrayBuffer(12116)), 12023, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8ClampedArray(new ArrayBuffer(0)), /* required buffer size: 84_686 */
+{offset: 514, bytesPerRow: 442, rowsPerImage: 181}, {width: 48, height: 10, depthOrArrayLayers: 2});
+} catch {}
+let pipeline53 = device0.createComputePipeline({
+  label: '\u{1ff77}\u242d\u{1fdd3}\u{1f914}\ubefc\u01e7\u{1f79c}\u86cc\u764a\u0341\u3f1e',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let pipeline54 = await device0.createRenderPipelineAsync({
+  label: '\u674b\u431b\u0993\u0757\u4457\u{1fe44}\u03cc\u{1fc89}\u0658\ufa75',
+  layout: pipelineLayout8,
+  multisample: {count: 4, mask: 0xc2e8a040},
+  fragment: {module: shaderModule9, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'replace', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'greater-equal', depthFailOp: 'invert', passOp: 'keep'},
+    stencilReadMask: 142670396,
+    stencilWriteMask: 3013137501,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 384,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 116, shaderLocation: 3},
+          {format: 'uint32x2', offset: 100, shaderLocation: 1},
+          {format: 'sint32', offset: 72, shaderLocation: 9},
+          {format: 'sint8x2', offset: 0, shaderLocation: 2},
+          {format: 'uint32', offset: 36, shaderLocation: 14},
+          {format: 'unorm16x4', offset: 4, shaderLocation: 5},
+          {format: 'sint8x2', offset: 52, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 200,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 184, shaderLocation: 6},
+          {format: 'uint16x4', offset: 0, shaderLocation: 15},
+          {format: 'sint32x4', offset: 8, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 16, stepMode: 'instance', attributes: []},
+      {arrayStride: 56, attributes: [{format: 'uint8x4', offset: 4, shaderLocation: 10}]},
+    ],
+  },
+  primitive: {cullMode: 'front'},
+});
+let bindGroupLayout16 = device0.createBindGroupLayout({
+  label: '\uc33c\u08f2\u9575\u0698\u6e71\u0e4f\u{1f7f2}\u00c4',
+  entries: [
+    {binding: 840, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 990,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 29238424, hasDynamicOffset: true },
+    },
+    {binding: 504, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let renderBundle45 = renderBundleEncoder9.finish({label: '\ua827\u{1fbea}\ub75d\ua800\u8491\uf7f0\ud78d\u8aee\u93eb'});
+try {
+renderPassEncoder16.setIndexBuffer(buffer17, 'uint32', 3320, 279);
+} catch {}
+try {
+renderBundleEncoder34.setVertexBuffer(2, buffer17, 3960, 346);
+} catch {}
+try {
+commandEncoder74.copyTextureToBuffer({
+  texture: texture29,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 15 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 93936 */
+  offset: 24816,
+  bytesPerRow: 256,
+  rowsPerImage: 5,
+  buffer: buffer16,
+}, {width: 15, height: 0, depthOrArrayLayers: 55});
+dissociateBuffer(device0, buffer16);
+} catch {}
+let canvas14 = document.createElement('canvas');
+let imageData7 = new ImageData(212, 116);
+try {
+canvas11.getContext('bitmaprenderer');
+} catch {}
+let querySet39 = device0.createQuerySet({type: 'occlusion', count: 3275});
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({colorFormats: [], depthStencilFormat: 'stencil8', sampleCount: 1, stencilReadOnly: true});
+let renderBundle46 = renderBundleEncoder36.finish({label: '\u01ec\uf9e2\u7bf3\uf4b2\ub949'});
+let externalTexture35 = device0.importExternalTexture({
+  label: '\u851c\uc789\u5789\u{1fee8}\u0cfa\u121d\u7d17\u0904',
+  source: videoFrame2,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder28.setBindGroup(0, bindGroup14, new Uint32Array(2617), 1025, 0);
+} catch {}
+try {
+renderPassEncoder19.beginOcclusionQuery(1856);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(1, bindGroup9, []);
+} catch {}
+try {
+commandEncoder74.copyTextureToTexture({
+  texture: texture1,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 1,
+  origin: {x: 50, y: 1, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 80, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 213084, new Int16Array(51506), 37901, 732);
+} catch {}
+try {
+canvas13.getContext('webgpu');
+} catch {}
+let commandEncoder75 = device0.createCommandEncoder({label: '\u22c8\u02b7\u6149\u{1fd15}\u3d18\u4e4a\u8f80\u{1f7d0}'});
+let textureView83 = texture30.createView({
+  label: '\u{1fbf4}\u3019\uec36\u{1f8e1}\u0b01\u5d63\u4190\ube0b\ub5d3',
+  aspect: 'stencil-only',
+  baseArrayLayer: 28,
+  arrayLayerCount: 58,
+});
+let renderPassEncoder39 = commandEncoder74.beginRenderPass({
+  label: '\u0b80\u22ac\ue2d1\uacda\u88bb\ueb0a\u0fc5',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView37,
+    depthClearValue: -0.20286638665919732,
+    stencilClearValue: 14606,
+    stencilLoadOp: 'load',
+    stencilStoreOp: 'store',
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet17,
+  maxDrawCount: 99500236,
+});
+try {
+computePassEncoder7.dispatchWorkgroupsIndirect(buffer7, 87344);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup19);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(1547);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(2_152_445), /* required buffer size: 2_152_445 */
+{offset: 180, bytesPerRow: 875, rowsPerImage: 175}, {width: 640, height: 10, depthOrArrayLayers: 15});
+} catch {}
+let gpuCanvasContext10 = canvas14.getContext('webgpu');
+let commandEncoder76 = device0.createCommandEncoder({label: '\u{1fd72}\u05c3\u0368'});
+let texture51 = device0.createTexture({
+  label: '\u1471\u0337\ua4cd\u0ea5\u62a0\u6b67',
+  size: [30, 6, 1],
+  mipLevelCount: 3,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8', 'stencil8'],
+});
+let renderPassEncoder40 = commandEncoder76.beginRenderPass({
+  label: '\u652d\ue782\u87ff\u2e3c\u{1f897}\u01ab\u0368\u{1fdeb}',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView56, stencilClearValue: 43739, stencilLoadOp: 'clear', stencilStoreOp: 'store'},
+  maxDrawCount: 848494361,
+});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup16, new Uint32Array(1576), 498, 0);
+} catch {}
+try {
+computePassEncoder8.dispatchWorkgroups(5, 5, 4);
+} catch {}
+try {
+computePassEncoder8.dispatchWorkgroupsIndirect(buffer7, 86860);
+} catch {}
+try {
+commandEncoder75.copyTextureToTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 294, y: 0, z: 4},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 160, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline55 = await device0.createRenderPipelineAsync({
+  label: '\ubfb0\u5238\u{1f894}',
+  layout: 'auto',
+  fragment: {module: shaderModule5, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'zero', depthFailOp: 'increment-wrap', passOp: 'replace'},
+    stencilBack: {compare: 'greater-equal', failOp: 'decrement-clamp', depthFailOp: 'invert', passOp: 'zero'},
+    stencilReadMask: 620093147,
+    stencilWriteMask: 2491845188,
+    depthBias: 0,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 36,
+        attributes: [
+          {format: 'unorm16x2', offset: 0, shaderLocation: 6},
+          {format: 'uint32x2', offset: 0, shaderLocation: 10},
+          {format: 'uint32x3', offset: 0, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 8, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let shaderModule14 = device0.createShaderModule({
+  label: '\u6046\u009a\ue5ac\u{1ffa3}\u{1fb70}\u1fc0\u0462\u7feb\u{1fc85}\u0ffd',
+  code: `@group(0) @binding(240)
+var<storage, read_write> field4: array<u32>;
+@group(0) @binding(597)
+var<storage, read_write> type7: array<u32>;
+@group(1) @binding(378)
+var<storage, read_write> local2: array<u32>;
+@group(2) @binding(378)
+var<storage, read_write> parameter3: array<u32>;
+
+@compute @workgroup_size(1, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec3<u32>
+}
+
+@fragment
+fn fragment0(@location(4) a0: vec2<u32>, @location(8) a1: vec4<f32>, @location(14) a2: vec3<i32>, @location(6) a3: vec4<i32>, @location(2) a4: vec4<f16>, @location(7) a5: f16, @builtin(sample_mask) a6: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(1) f90: vec4<u32>,
+  @location(3) f91: vec3<f16>,
+  @location(11) f92: vec3<u32>,
+  @location(7) f93: f16,
+  @location(13) f94: vec2<i32>,
+  @location(6) f95: vec4<i32>,
+  @location(8) f96: vec4<f32>,
+  @location(4) f97: vec2<u32>,
+  @location(10) f98: vec2<f32>,
+  @location(5) f99: vec4<i32>,
+  @location(15) f100: vec2<f32>,
+  @builtin(position) f101: vec4<f32>,
+  @location(14) f102: vec3<i32>,
+  @location(2) f103: vec4<f16>,
+  @location(0) f104: vec4<f32>,
+  @location(9) f105: vec4<u32>,
+  @location(12) f106: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(1) a0: f32, @location(12) a1: vec2<i32>, @location(6) a2: f32, @location(9) a3: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout17 = device0.createBindGroupLayout({
+  label: '\u06b4\u0829\ucb0b\u0e2a\u5f58\uea3d\uc314\u0c1e\ud24f\ua646',
+  entries: [
+    {binding: 607, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 329, visibility: 0, externalTexture: {}},
+    {
+      binding: 830,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let commandEncoder77 = device0.createCommandEncoder({label: '\ua906\u{1f7c1}\u{1f745}\u0dfa\u{1fcf4}\u8388\uc626\u4d91\u6e58'});
+let renderBundle47 = renderBundleEncoder1.finish({label: '\u0e50\u{1fd6b}\u7767\u1827\u0174'});
+let sampler42 = device0.createSampler({
+  label: '\u0b1a\u280b\u{1f824}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 19.18,
+  lodMaxClamp: 71.38,
+  maxAnisotropy: 11,
+});
+let externalTexture36 = device0.importExternalTexture({source: videoFrame3});
+try {
+renderPassEncoder22.setBlendConstant({ r: -517.3, g: -821.9, b: -831.7, a: 785.8, });
+} catch {}
+try {
+renderBundleEncoder30.setPipeline(pipeline24);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let bindGroup20 = device0.createBindGroup({
+  label: '\u084c\u06d8\u3741\ua857\u86e1\ua51b',
+  layout: bindGroupLayout4,
+  entries: [{binding: 580, resource: sampler14}],
+});
+let buffer19 = device0.createBuffer({label: '\u{1f8fd}\u54f0\u086f\ucf5e\u0ae6\u015d\u64c6', size: 236230, usage: GPUBufferUsage.COPY_SRC});
+let renderPassEncoder41 = commandEncoder75.beginRenderPass({
+  label: '\uf07d\ue979\u011c\u{1f6cc}\u18ff\u5bde\ued2c\u707e\u09b4',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView37, depthReadOnly: true, stencilLoadOp: 'load', stencilStoreOp: 'store'},
+  occlusionQuerySet: querySet12,
+  maxDrawCount: 644592555,
+});
+let renderBundleEncoder37 = device0.createRenderBundleEncoder({
+  label: '\u7b60\u0862\u6094\u2840\uff09\u92d8\uf8f1\u{1fc80}',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+});
+try {
+computePassEncoder7.dispatchWorkgroups(5, 5);
+} catch {}
+try {
+commandEncoder77.copyBufferToBuffer(buffer9, 50324, buffer2, 119768, 37056);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer2);
+} catch {}
+let buffer20 = device0.createBuffer({
+  label: '\ud721\uf7c0\u{1f6db}',
+  size: 227548,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let querySet40 = device0.createQuerySet({label: '\u9fb3\u0858\u0f99\u64ae\u9e40\u{1f79d}\u68e8', type: 'occlusion', count: 153});
+let renderPassEncoder42 = commandEncoder77.beginRenderPass({
+  label: '\u{1f759}\u3963\ue30e\u{1fdf7}\ue22e\u037d',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView43,
+    depthClearValue: 5.19888796050682,
+    depthReadOnly: false,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'store',
+    stencilReadOnly: false,
+  },
+  occlusionQuerySet: querySet29,
+  maxDrawCount: 441944608,
+});
+let renderBundle48 = renderBundleEncoder19.finish({label: '\ucd8c\u956e'});
+try {
+computePassEncoder16.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder39.setBlendConstant({ r: 523.2, g: 989.3, b: 519.2, a: -974.8, });
+} catch {}
+try {
+renderPassEncoder37.setScissorRect(13, 0, 7, 2);
+} catch {}
+let commandEncoder78 = device0.createCommandEncoder();
+let textureView84 = texture14.createView({
+  label: '\u7174\u0a05\u{1f714}\u293e\u{1ff98}\u{1f987}\u{1fc2f}\u0923\ua43b\u0185',
+  dimension: '2d-array',
+  baseMipLevel: 1,
+});
+let renderBundleEncoder38 = device0.createRenderBundleEncoder({
+  label: '\u0f1c\u0893\u{1fbab}\u9fc7',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder29.beginOcclusionQuery(2382);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder27.setScissorRect(0, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer7, 'uint16');
+} catch {}
+try {
+renderPassEncoder38.setVertexBuffer(1, buffer17, 0, 1565);
+} catch {}
+try {
+renderPassEncoder34.insertDebugMarker('\u{1fe91}');
+} catch {}
+try {
+pipeline39.label = '\u1e86\u0e47\u9824\u{1fc9d}\u068d';
+} catch {}
+let textureView85 = texture7.createView({label: '\u0907\u41d0\ubd7b\u0211\u{1f661}\ufbe7', aspect: 'all', baseMipLevel: 4, mipLevelCount: 2});
+let renderPassEncoder43 = commandEncoder78.beginRenderPass({
+  label: '\u7124\ud3a0\u{1fca2}\u{1f858}\u0433\u4aaf\u5a41\ub7a2\u4583\u{1fe43}',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView43,
+    depthReadOnly: true,
+    stencilClearValue: 60137,
+    stencilLoadOp: 'load',
+    stencilStoreOp: 'store',
+  },
+  maxDrawCount: 1028047197,
+});
+let renderBundle49 = renderBundleEncoder5.finish({});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(7, buffer12, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 1_064_419 */
+{offset: 447, bytesPerRow: 153, rowsPerImage: 122}, {width: 10, height: 1, depthOrArrayLayers: 58});
+} catch {}
+let textureView86 = texture9.createView({label: '\uae77\u0a64\u55c7\u77a1\u0c5d', dimension: '2d-array', mipLevelCount: 2, arrayLayerCount: 1});
+let renderBundle50 = renderBundleEncoder29.finish({label: '\u6e4a\ua92e\u47c2\u{1fbb4}'});
+try {
+renderPassEncoder1.beginOcclusionQuery(754);
+} catch {}
+try {
+renderPassEncoder29.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 529.9, g: -484.9, b: 548.2, a: -289.8, });
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(1, buffer12, 0, 3566);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(238), /* required buffer size: 238 */
+{offset: 238}, {width: 15, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline56 = await device0.createComputePipelineAsync({
+  label: '\u{1ffcb}\u0642\u49ca',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}},
+});
+let pipeline57 = device0.createRenderPipeline({
+  layout: pipelineLayout6,
+  fragment: {module: shaderModule4, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'less', failOp: 'increment-clamp', depthFailOp: 'increment-clamp', passOp: 'decrement-clamp'},
+    stencilReadMask: 813341099,
+    stencilWriteMask: 2771563263,
+    depthBias: 0,
+    depthBiasClamp: 728.5068434839578,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 296, attributes: []},
+      {
+        arrayStride: 704,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x2', offset: 10, shaderLocation: 0}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: true},
+});
+let shaderModule15 = device0.createShaderModule({
+  label: '\u{1fd49}\u{1fcb7}\u{1f746}\u47b2\u{1f6bf}\u0af5',
+  code: `
+
+@compute @workgroup_size(4, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec2<u32>,
+  @location(6) f1: vec2<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S11 {
+  @location(2) f0: vec4<f16>,
+  @location(5) f1: vec2<u32>,
+  @location(9) f2: i32,
+  @location(12) f3: vec2<i32>,
+  @location(15) f4: i32,
+  @location(10) f5: i32,
+  @location(11) f6: vec2<u32>,
+  @location(3) f7: vec2<f32>,
+  @location(1) f8: vec4<f16>,
+  @location(14) f9: vec2<f16>,
+  @location(0) f10: vec2<u32>,
+  @location(13) f11: vec2<i32>,
+  @location(7) f12: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(6) a0: i32, a1: S11, @location(8) a2: vec3<u32>, @location(4) a3: vec2<u32>, @builtin(instance_index) a4: u32, @builtin(vertex_index) a5: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let commandEncoder79 = device0.createCommandEncoder({});
+let commandBuffer16 = commandEncoder79.finish({label: '\u0509\u90cb\u{1fe18}\u1f59'});
+let externalTexture37 = device0.importExternalTexture({label: '\u0880\u006e\u{1fde6}\u{1fa4d}\u0738', source: videoFrame5, colorSpace: 'display-p3'});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder29.setStencilReference(820);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline24);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new ArrayBuffer(48), /* required buffer size: 4_076_611 */
+{offset: 429, bytesPerRow: 74, rowsPerImage: 301}, {width: 40, height: 1, depthOrArrayLayers: 184});
+} catch {}
+let renderBundle51 = renderBundleEncoder3.finish();
+let externalTexture38 = device0.importExternalTexture({label: '\u{1f6be}\u8797\u29b9\u039f\u1653', source: video0});
+try {
+computePassEncoder7.dispatchWorkgroupsIndirect(buffer7, 160472);
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline27);
+} catch {}
+try {
+renderPassEncoder24.setStencilReference(858);
+} catch {}
+try {
+renderPassEncoder31.setVertexBuffer(5, buffer12);
+} catch {}
+let imageBitmap14 = await createImageBitmap(canvas1);
+let bindGroupLayout18 = device0.createBindGroupLayout({label: '\ud102\ub241\u0e67', entries: []});
+let sampler43 = device0.createSampler({
+  label: '\u009e\u0ab3\u0cda\u26d7\u{1f7af}\u{1f702}\u0a33',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 79.93,
+  lodMaxClamp: 94.38,
+  compare: 'equal',
+});
+try {
+computePassEncoder7.dispatchWorkgroups(3);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+renderPassEncoder34.executeBundles([renderBundle51, renderBundle20, renderBundle31, renderBundle21, renderBundle51, renderBundle48, renderBundle22, renderBundle20, renderBundle10]);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline24);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(1, bindGroup8, [21760]);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(2, buffer6, 65384);
+} catch {}
+let videoFrame6 = videoFrame4.clone();
+let textureView87 = texture0.createView({label: '\ub65a\ubcc7\u5a4e\u6d7e'});
+try {
+renderPassEncoder17.setBindGroup(3, bindGroup10, [5888]);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(186);
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(15, 0, 0, 1);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(4, buffer6, 62080, 26598);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture49,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'stencil-only',
+}, new Uint8ClampedArray(arrayBuffer4), /* required buffer size: 1_255_907 */
+{offset: 83, bytesPerRow: 152, rowsPerImage: 102}, {width: 80, height: 0, depthOrArrayLayers: 82});
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let img11 = await imageWithData(13, 261, '#271c83c7', '#b50ce427');
+let commandEncoder80 = device0.createCommandEncoder();
+try {
+computePassEncoder10.setBindGroup(0, bindGroup20, new Uint32Array(621), 430, 0);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(3, bindGroup4);
+} catch {}
+let pipeline58 = device0.createRenderPipeline({
+  label: '\u{1fb94}\u6e33\u0cfd\u0720\u{1f625}',
+  layout: pipelineLayout0,
+  fragment: {module: shaderModule13, entryPoint: 'fragment0', targets: []},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    stencilFront: {compare: 'greater', failOp: 'invert', depthFailOp: 'replace', passOp: 'replace'},
+    stencilBack: {
+      compare: 'less-equal',
+      failOp: 'increment-clamp',
+      depthFailOp: 'decrement-wrap',
+      passOp: 'increment-clamp',
+    },
+    stencilReadMask: 1937848355,
+    stencilWriteMask: 4096539290,
+    depthBias: 918483295,
+    depthBiasClamp: 316.9392449200487,
+  },
+  vertex: {
+    module: shaderModule13,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 968, stepMode: 'instance', attributes: []},
+      {arrayStride: 640, attributes: []},
+      {
+        arrayStride: 320,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x4', offset: 160, shaderLocation: 8}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+try {
+  await promise16;
+} catch {}
+let bindGroupLayout19 = pipeline7.getBindGroupLayout(1);
+let textureView88 = texture26.createView({dimension: '2d-array', mipLevelCount: 2});
+try {
+renderPassEncoder41.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(1, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder17.setViewport(26.94, 4.742, 0.1708, 0.8674, 0.4172, 0.7158);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline58);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 13932, new Int16Array(40170), 30723, 992);
+} catch {}
+let promise17 = device0.queue.onSubmittedWorkDone();
+let pipeline59 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}}});
+canvas13.width = 88;
+let buffer21 = device0.createBuffer({size: 253292, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: true});
+let commandEncoder81 = device0.createCommandEncoder({});
+let textureView89 = texture17.createView({label: '\u05e2\u069f\ubda0', dimension: '2d-array', aspect: 'all', mipLevelCount: 3});
+let externalTexture39 = device0.importExternalTexture({source: videoFrame5, colorSpace: 'display-p3'});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup17, []);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(1, bindGroup2, new Uint32Array(7466), 1879, 0);
+} catch {}
+try {
+renderPassEncoder39.setBlendConstant({ r: -710.0, g: -714.5, b: -130.3, a: 347.4, });
+} catch {}
+try {
+commandEncoder81.insertDebugMarker('\uc8ac');
+} catch {}
+let renderBundle52 = renderBundleEncoder36.finish({label: '\u9e87\u0939\u{1f65a}\u1fcb\uaa56\u4a18\u9516\uf414\u{1f7f4}'});
+let externalTexture40 = device0.importExternalTexture({label: '\u764a\u08d0', source: video3, colorSpace: 'srgb'});
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+renderPassEncoder42.setBindGroup(0, bindGroup2, new Uint32Array(2491), 1522, 0);
+} catch {}
+try {
+renderPassEncoder27.setStencilReference(2380);
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(7, buffer17, 2288, 1219);
+} catch {}
+try {
+renderBundleEncoder33.setIndexBuffer(buffer7, 'uint16', 167232);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(2, buffer17);
+} catch {}
+try {
+commandEncoder81.clearBuffer(buffer8, 131192, 91724);
+dissociateBuffer(device0, buffer8);
+} catch {}
+let videoFrame7 = new VideoFrame(img10, {timestamp: 0});
+let commandEncoder82 = device0.createCommandEncoder({label: '\u59bf\u66f9\u9eb3\uace4\ud5ed\u4f45\u7cd4\u{1ff08}\u4060\ub66e\u17ef'});
+let textureView90 = texture16.createView({
+  label: '\u87b0\u568a\u5815\u02b6\ue93d',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  baseMipLevel: 1,
+  baseArrayLayer: 0,
+});
+let computePassEncoder23 = commandEncoder82.beginComputePass({label: '\u0c95\u0ff0\u{1fa90}\u01bd\u0681\u5d71\ud9cc\u0f5f\u0526\ub498'});
+try {
+computePassEncoder21.setPipeline(pipeline34);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle13, renderBundle17, renderBundle50, renderBundle25, renderBundle15, renderBundle34, renderBundle14, renderBundle46]);
+} catch {}
+try {
+renderPassEncoder28.setBlendConstant({ r: -588.8, g: -86.15, b: -145.9, a: -130.1, });
+} catch {}
+try {
+renderPassEncoder38.setStencilReference(172);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer17, 'uint32', 2284, 1588);
+} catch {}
+let promise18 = buffer13.mapAsync(GPUMapMode.WRITE, 66072, 12672);
+let pipeline60 = await device0.createComputePipelineAsync({
+  label: '\u95e6\u{1fdf0}',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let imageBitmap15 = await createImageBitmap(canvas6);
+let commandBuffer17 = commandEncoder81.finish({label: '\uc574\u6531\u{1fd3d}\u37cf\u074f'});
+let computePassEncoder24 = commandEncoder80.beginComputePass();
+let renderBundle53 = renderBundleEncoder26.finish({});
+let sampler44 = device0.createSampler({
+  label: '\uc1d1\u96e9\u782e\ue6a5\u{1fd99}\u{1f961}\uf202',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 24.62,
+  lodMaxClamp: 68.38,
+});
+try {
+renderPassEncoder36.setBindGroup(2, bindGroup6, new Uint32Array(860), 292, 0);
+} catch {}
+try {
+renderPassEncoder41.setBlendConstant({ r: 69.94, g: 683.7, b: 192.5, a: -909.1, });
+} catch {}
+try {
+renderPassEncoder33.setVertexBuffer(7, buffer17, 0, 3800);
+} catch {}
+let pipeline61 = device0.createRenderPipeline({
+  label: '\u224d\u9fa1\uc8ad\u0b6e\u{1f87a}\u63d9\u0245\uaad9',
+  layout: pipelineLayout3,
+  multisample: {mask: 0xd2034f2a},
+  fragment: {module: shaderModule15, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'less', failOp: 'zero', depthFailOp: 'decrement-wrap', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'greater-equal', failOp: 'decrement-clamp', depthFailOp: 'keep', passOp: 'zero'},
+    stencilReadMask: 82983436,
+    stencilWriteMask: 1581130929,
+    depthBiasClamp: 202.61118396833808,
+  },
+  vertex: {
+    module: shaderModule15,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 80,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 24, shaderLocation: 10},
+          {format: 'float32x3', offset: 4, shaderLocation: 2},
+          {format: 'snorm16x4', offset: 24, shaderLocation: 7},
+          {format: 'uint32x4', offset: 16, shaderLocation: 11},
+          {format: 'snorm16x2', offset: 4, shaderLocation: 14},
+          {format: 'uint8x2', offset: 0, shaderLocation: 4},
+          {format: 'sint32', offset: 28, shaderLocation: 6},
+          {format: 'sint8x2', offset: 34, shaderLocation: 9},
+        ],
+      },
+      {arrayStride: 180, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 312,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 12, shaderLocation: 0},
+          {format: 'float32x2', offset: 28, shaderLocation: 1},
+          {format: 'sint32x4', offset: 28, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 168,
+        attributes: [
+          {format: 'uint16x2', offset: 36, shaderLocation: 5},
+          {format: 'sint32', offset: 20, shaderLocation: 13},
+          {format: 'uint32x3', offset: 20, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 56, shaderLocation: 3},
+          {format: 'sint32x2', offset: 24, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+});
+let video5 = await videoWithData();
+let querySet41 = device0.createQuerySet({label: '\ub14c\u6abf', type: 'occlusion', count: 3381});
+let texture52 = device0.createTexture({
+  label: '\ufcda\uf186\u{1f75c}\u2f1c',
+  size: {width: 120, height: 24, depthOrArrayLayers: 224},
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16uint', 'rgba16uint', 'rgba16uint'],
+});
+let externalTexture41 = device0.importExternalTexture({label: '\u{1fa08}\u{1f874}\u{1f60f}\u{1f9c7}\uce32\u35a2\u0c07\u0fcc', source: videoFrame4});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup11, new Uint32Array(6705), 257, 0);
+} catch {}
+try {
+renderPassEncoder24.setBlendConstant({ r: -112.9, g: -106.8, b: -633.3, a: 467.5, });
+} catch {}
+try {
+renderPassEncoder35.setViewport(8.063, 1.059, 0.1420, 0.5730, 0.5864, 0.6587);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline24);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 10588, new Float32Array(16864), 2377, 432);
+} catch {}
+let commandEncoder83 = device0.createCommandEncoder({});
+let renderBundle54 = renderBundleEncoder0.finish({label: '\u1056\u9ef2\uce76\u010b\u58f1'});
+try {
+renderPassEncoder37.setStencilReference(4032);
+} catch {}
+try {
+renderPassEncoder17.setViewport(14.43, 0.04299, 3.456, 3.171, 0.4798, 0.6321);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(2, buffer17, 0);
+} catch {}
+let promise19 = device0.queue.onSubmittedWorkDone();
+let pipeline62 = device0.createComputePipeline({
+  label: '\u0472\ub4f2\u2460\ue186\u0754',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule13, entryPoint: 'compute0', constants: {}},
+});
+let pipeline63 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0xfe155670},
+  fragment: {module: shaderModule4, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'equal', failOp: 'keep', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'invert'},
+    stencilReadMask: 2474183301,
+    stencilWriteMask: 3634768909,
+    depthBias: -263574117,
+    depthBiasSlopeScale: 982.4961389625037,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 216, stepMode: 'instance', attributes: []},
+      {arrayStride: 124, attributes: []},
+      {arrayStride: 56, stepMode: 'instance', attributes: [{format: 'uint32', offset: 0, shaderLocation: 0}]},
+    ],
+  },
+});
+let bindGroupLayout20 = device0.createBindGroupLayout({label: '\u0fef\udf23\u{1fead}\u{1fa53}\udb94\u{1ff24}\u03c1', entries: []});
+let commandEncoder84 = device0.createCommandEncoder({});
+let querySet42 = device0.createQuerySet({label: '\u9afa\u076d\u7725\u0df6', type: 'occlusion', count: 1040});
+let texture53 = device0.createTexture({
+  label: '\ud470\u79e8\u02fe\u{1fe36}\u0321\ua28c',
+  size: [60, 12, 43],
+  mipLevelCount: 2,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16uint', 'rgba16uint', 'rgba16uint'],
+});
+let textureView91 = texture53.createView({
+  label: '\u1698\u{1fe3c}\uf1df\u07fa\u{1fb5a}\u8947\u0124\uaf66\u{1ffd5}',
+  dimension: '2d',
+  baseMipLevel: 1,
+  baseArrayLayer: 19,
+});
+let computePassEncoder25 = commandEncoder84.beginComputePass({label: '\u00e6\u38c2\u{1fa9e}'});
+let renderPassEncoder44 = commandEncoder83.beginRenderPass({
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView80, stencilReadOnly: true},
+  occlusionQuerySet: querySet28,
+  maxDrawCount: 21626989,
+});
+let renderBundleEncoder39 = device0.createRenderBundleEncoder({
+  label: '\u4168\u{1fbea}\ud07d\u9ea2\u0ac5\u{1f9f2}\uba72',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  stencilReadOnly: true,
+});
+let renderBundle55 = renderBundleEncoder11.finish({});
+try {
+renderPassEncoder29.setStencilReference(3132);
+} catch {}
+try {
+renderPassEncoder30.setViewport(27.57, 0.3929, 28.20, 0.2768, 0.9253, 0.9306);
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer7, 'uint32');
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(4, buffer17, 0, 2560);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 2_998_467 */
+{offset: 795, bytesPerRow: 177, rowsPerImage: 292}, {width: 160, height: 0, depthOrArrayLayers: 59});
+} catch {}
+try {
+window.someLabel = externalTexture41.label;
+} catch {}
+let bindGroupLayout21 = device0.createBindGroupLayout({label: '\u0341\u7c94\u{1fe4c}\ue5bd\uafa0', entries: []});
+let bindGroup21 = device0.createBindGroup({
+  label: '\u8cb2\u63fd\u0b52\u074c\u{1fb3e}',
+  layout: bindGroupLayout13,
+  entries: [{binding: 982, resource: sampler24}, {binding: 87, resource: externalTexture41}],
+});
+let pipelineLayout9 = device0.createPipelineLayout({
+  label: '\ua676\u0a54\u{1fddf}\u658d\u0846\u59ac\u8029\u02aa\ub48d\uc18c\u012b',
+  bindGroupLayouts: [bindGroupLayout7, bindGroupLayout13],
+});
+let querySet43 = device0.createQuerySet({type: 'occlusion', count: 2253});
+let textureView92 = texture44.createView({
+  label: '\u0797\uc502\u84ba\u29ec\u{1ffdd}\u6138\u01e1\u{1fcb4}\u{1f6de}',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  baseMipLevel: 2,
+  baseArrayLayer: 0,
+});
+let externalTexture42 = device0.importExternalTexture({label: '\u09ec\u3a75\uec53\uc58e\u0dbe\u0813\u493f\uaf52\u0bcc', source: videoFrame1});
+try {
+renderPassEncoder31.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(4, 6, 16, 0);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer7, 'uint32');
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(4, buffer17);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 58 */
+{offset: 58}, {width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let textureView93 = texture30.createView({label: '\uedb9\u0b20\uc5df\u0598', baseArrayLayer: 102, arrayLayerCount: 1});
+let renderBundle56 = renderBundleEncoder1.finish({label: '\u2e18\u0b5e\u69a8\u024b\ude18\u0cbd\u0f9a\u{1f81f}'});
+let externalTexture43 = device0.importExternalTexture({
+  label: '\u9a4e\u0308\ucf47\u{1f758}\ue6e5\u9b01\u0b0d\u8993\u767a\uf208',
+  source: video1,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder0.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+  await promise18;
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(718, 155);
+let bindGroupLayout22 = device0.createBindGroupLayout({
+  label: '\ue057\u{1fc94}\u08cf\ubb9c\u0cb6\u00c8\u0176\uf15f\u00d2',
+  entries: [
+    {
+      binding: 939,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 290,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 77,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder85 = device0.createCommandEncoder({});
+let texture54 = device0.createTexture({
+  label: '\u7268\u02fb\u9f1d\u0393\u859d\u7816\u6cd9\u05ed\ub518\u681b\u{1fafa}',
+  size: {width: 320},
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8unorm', 'r8unorm', 'r8unorm'],
+});
+let computePassEncoder26 = commandEncoder85.beginComputePass({});
+let externalTexture44 = device0.importExternalTexture({source: video1, colorSpace: 'srgb'});
+try {
+computePassEncoder7.dispatchWorkgroups(3, 5, 5);
+} catch {}
+try {
+renderPassEncoder28.setBlendConstant({ r: -510.9, g: 748.2, b: -76.39, a: -851.5, });
+} catch {}
+try {
+renderPassEncoder14.setScissorRect(0, 0, 1, 0);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(5, buffer17, 0, 2880);
+} catch {}
+let pipeline64 = await device0.createRenderPipelineAsync({
+  label: '\ua099\u183e\u909e',
+  layout: pipelineLayout3,
+  fragment: {module: shaderModule14, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'not-equal', failOp: 'decrement-clamp', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'greater-equal', failOp: 'invert', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilReadMask: 3584747675,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 404, attributes: [{format: 'unorm10-10-10-2', offset: 20, shaderLocation: 1}]},
+      {arrayStride: 0, stepMode: 'vertex', attributes: []},
+      {arrayStride: 84, attributes: [{format: 'sint8x2', offset: 8, shaderLocation: 9}]},
+      {arrayStride: 660, attributes: [{format: 'float16x4', offset: 96, shaderLocation: 6}]},
+      {arrayStride: 524, attributes: []},
+      {arrayStride: 64, attributes: [{format: 'sint8x4', offset: 4, shaderLocation: 12}]},
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+gc();
+let imageBitmap16 = await createImageBitmap(video4);
+let textureView94 = texture25.createView({
+  label: '\u6b7a\u{1f912}\u7ed6\u9ff2\u7dff\u{1f84e}\u07ee\ue64a\u23f9',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 6,
+  mipLevelCount: 1,
+  baseArrayLayer: 13,
+  arrayLayerCount: 1,
+});
+let sampler45 = device0.createSampler({
+  label: '\u{1f980}\u0999\u023a\u{1f9b3}\u{1f765}\u08f2',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 12.36,
+  lodMaxClamp: 50.60,
+  maxAnisotropy: 10,
+});
+try {
+renderPassEncoder30.setStencilReference(4033);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 10936, new DataView(new ArrayBuffer(59717)), 31037, 9364);
+} catch {}
+try {
+offscreenCanvas5.getContext('webgl2');
+} catch {}
+let commandEncoder86 = device0.createCommandEncoder({label: '\ue45e\u77fb\u0017\u6e02'});
+let renderBundle57 = renderBundleEncoder38.finish({});
+try {
+renderPassEncoder35.setStencilReference(1466);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline9);
+} catch {}
+let promise20 = buffer4.mapAsync(GPUMapMode.WRITE, 0, 4556);
+try {
+  await promise19;
+} catch {}
+let commandEncoder87 = device0.createCommandEncoder({label: '\u5716\u{1f937}\u02d9\u0fb4\u9a0d\u5a3f'});
+let textureView95 = texture21.createView({
+  label: '\u{1fa65}\u{1ffeb}\u71dc\u{1f722}\u0563\u2c6d\u{1f66f}\u0db7\u01db\u8b0e',
+  dimension: '2d',
+  baseMipLevel: 5,
+  baseArrayLayer: 32,
+});
+let computePassEncoder27 = commandEncoder86.beginComputePass({});
+try {
+computePassEncoder10.setPipeline(pipeline34);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle26, renderBundle55, renderBundle24, renderBundle45, renderBundle55, renderBundle14, renderBundle16, renderBundle38]);
+} catch {}
+try {
+renderPassEncoder34.setBlendConstant({ r: -732.4, g: -0.7598, b: 354.5, a: -373.0, });
+} catch {}
+try {
+renderPassEncoder36.setIndexBuffer(buffer17, 'uint32', 3156);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder24.setVertexBuffer(0, buffer17, 0, 1545);
+} catch {}
+let commandEncoder88 = device0.createCommandEncoder({label: '\uf626\ua613'});
+let querySet44 = device0.createQuerySet({label: '\u0dcb\u037c\u63e4\u8ae3\u019d', type: 'occlusion', count: 2635});
+let commandBuffer18 = commandEncoder88.finish({});
+try {
+renderPassEncoder21.setPipeline(pipeline58);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(2, bindGroup8, [31232]);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(4602, undefined, 0, 300583994);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 9836, new DataView(new ArrayBuffer(258)), 202, 20);
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(183, 741);
+let texture55 = device0.createTexture({
+  label: '\ucbb5\u8336\u0377\uaf7b\ufef1\ue6cb\u07b8\u26b6\u0ae4\u0cae',
+  size: [640, 10, 55],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r32sint', 'r32sint'],
+});
+let textureView96 = texture10.createView({
+  label: '\u{1ff3c}\u0d19',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  baseMipLevel: 3,
+  mipLevelCount: 2,
+});
+let renderPassEncoder45 = commandEncoder87.beginRenderPass({
+  label: '\u{1f6fe}\u0053\u049f\uf3a0\u{1f66f}\u{1fcd9}\u08b8\u24ee\u{1f915}\ube48\u739d',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView4,
+    depthClearValue: -2.6173670198869425,
+    depthReadOnly: false,
+    stencilClearValue: 54403,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'store',
+  },
+  occlusionQuerySet: querySet9,
+  maxDrawCount: 485227649,
+});
+try {
+renderPassEncoder23.end();
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer17, 'uint32', 3104, 304);
+} catch {}
+try {
+computePassEncoder2.insertDebugMarker('\u0909');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 55820, new Int16Array(38782), 23554, 2516);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture47,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new Int16Array(arrayBuffer2), /* required buffer size: 661 */
+{offset: 661, rowsPerImage: 175}, {width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline65 = await device0.createComputePipelineAsync({
+  label: '\uc6ab\u0415\u085c\u0ae8\u29d7\u07a1\u01d6\u3439\ue242\ub352',
+  layout: pipelineLayout9,
+  compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}},
+});
+let pipeline66 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {count: 4, mask: 0xac28ed98},
+  fragment: {module: shaderModule4, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'never', failOp: 'invert', depthFailOp: 'increment-wrap'},
+    stencilBack: {compare: 'greater', failOp: 'zero', depthFailOp: 'invert', passOp: 'replace'},
+    stencilReadMask: 4007042033,
+    stencilWriteMask: 2376148585,
+    depthBias: 285284965,
+    depthBiasSlopeScale: 486.41950706333716,
+    depthBiasClamp: 180.41136241135854,
+  },
+  vertex: {
+    module: shaderModule4,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 60, stepMode: 'instance', attributes: []},
+      {arrayStride: 636, stepMode: 'instance', attributes: []},
+      {arrayStride: 104, attributes: [{format: 'uint32x4', offset: 20, shaderLocation: 0}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+try {
+offscreenCanvas6.getContext('webgpu');
+} catch {}
+let bindGroupLayout23 = device0.createBindGroupLayout({
+  label: '\u6b4c\ue604\u{1f63e}',
+  entries: [
+    {
+      binding: 511,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 312,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '1d' },
+    },
+  ],
+});
+let querySet45 = device0.createQuerySet({type: 'occlusion', count: 3995});
+let externalTexture45 = device0.importExternalTexture({source: videoFrame5, colorSpace: 'display-p3'});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup11, new Uint32Array(6385), 2612, 0);
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle8, renderBundle34, renderBundle53, renderBundle19, renderBundle46, renderBundle36, renderBundle30, renderBundle51]);
+} catch {}
+try {
+renderPassEncoder40.setVertexBuffer(7, buffer17);
+} catch {}
+try {
+window.someLabel = externalTexture37.label;
+} catch {}
+let bindGroupLayout24 = device0.createBindGroupLayout({
+  label: '\ue9b8\ubfd5\u{1fc8a}\u01bc\u4dbb\u09fe\u0ce8',
+  entries: [
+    {binding: 822, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 424, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 403,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder89 = device0.createCommandEncoder({label: '\u5b0a\u{1fa80}\u0a4c\uc7d6\uaedd'});
+try {
+renderPassEncoder34.executeBundles([renderBundle38, renderBundle22, renderBundle57, renderBundle32, renderBundle20, renderBundle20, renderBundle36]);
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(1, 0, 0, 1);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(4, buffer6, 69724, 119195);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(7, buffer6, 56516, 25789);
+} catch {}
+let arrayBuffer5 = buffer20.getMappedRange();
+try {
+commandEncoder89.copyBufferToBuffer(buffer5, 5036, buffer16, 88212, 700);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder89.copyTextureToTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 15},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 80, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 25164, new DataView(new ArrayBuffer(53293)), 3664, 112);
+} catch {}
+let commandEncoder90 = device0.createCommandEncoder({label: '\ufd3a\u1ce0\u8cc5\u5e5a\u0281\uf5c3\u491e\u04f9\u4baf'});
+let texture56 = device0.createTexture({
+  label: '\u01d5\u7b3b\u7220\u2f38',
+  size: {width: 240, height: 48, depthOrArrayLayers: 178},
+  mipLevelCount: 8,
+  dimension: '2d',
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['depth24plus', 'depth24plus'],
+});
+let computePassEncoder28 = commandEncoder89.beginComputePass({});
+let renderBundle58 = renderBundleEncoder29.finish({label: '\u07f6\u08e5\ub343\u0daa\u{1ff24}\uf68b'});
+try {
+renderPassEncoder22.executeBundles([renderBundle3, renderBundle30, renderBundle58, renderBundle50, renderBundle7, renderBundle4, renderBundle38, renderBundle57]);
+} catch {}
+try {
+renderPassEncoder0.setViewport(0.8216, 0.5302, 0.09073, 0.4133, 0.2010, 0.6265);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(5, buffer12, 4296, 3244);
+} catch {}
+try {
+commandEncoder90.copyBufferToBuffer(buffer18, 3240, buffer2, 277504, 23832);
+dissociateBuffer(device0, buffer18);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder90.clearBuffer(buffer10, 94668, 69156);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.submit([commandBuffer15]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 73280, new DataView(new ArrayBuffer(7670)), 1221, 160);
+} catch {}
+let pipeline67 = device0.createComputePipeline({
+  label: '\u067e\u0a5b\u{1f986}\u0d6e\u0169\ud7b3\u6c06\u028d\u{1f9c0}\u0e2b',
+  layout: pipelineLayout9,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+let computePassEncoder29 = commandEncoder90.beginComputePass({label: '\u080f\ud129\u0a52\u0e17\u95b0\u{1f8ce}\u53f2\ue24a\u{1ff1a}'});
+let sampler46 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 4.549,
+  lodMaxClamp: 58.38,
+});
+try {
+computePassEncoder8.dispatchWorkgroups(4, 5, 1);
+} catch {}
+try {
+renderPassEncoder26.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder40.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder39.setPipeline(pipeline24);
+} catch {}
+let pipeline68 = device0.createRenderPipeline({
+  label: '\u{1fc85}\u1318\u875d\u4513\ubbdc\uad27\u{1ff2f}\u6043\u{1ffe0}\u0d49',
+  layout: pipelineLayout9,
+  multisample: {mask: 0xff863e56},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater-equal', failOp: 'zero', depthFailOp: 'increment-clamp', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'greater', failOp: 'decrement-clamp', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilReadMask: 660152150,
+    depthBias: 1189752445,
+    depthBiasSlopeScale: 652.7213542435989,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 936,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32x3', offset: 84, shaderLocation: 13},
+          {format: 'unorm16x2', offset: 68, shaderLocation: 15},
+          {format: 'uint32x2', offset: 44, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 936,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 212, shaderLocation: 5},
+          {format: 'float32', offset: 44, shaderLocation: 8},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'back', unclippedDepth: true},
+});
+let video6 = await videoWithData();
+let renderBundle59 = renderBundleEncoder13.finish({label: '\u39ce\uf3f3\ue9f1\u041e\u{1fc4a}\u{1f71f}\u{1f8f6}\u068c\ufe11'});
+try {
+renderPassEncoder11.setViewport(21.97, 0.5279, 5.381, 0.5351, 0.6977, 0.7213);
+} catch {}
+try {
+  await buffer16.mapAsync(GPUMapMode.READ, 139128, 167624);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 12344, new BigUint64Array(5475), 1155, 792);
+} catch {}
+gc();
+let textureView97 = texture48.createView({label: '\u{1fb36}\uccff\u{1f9c0}', baseMipLevel: 1, mipLevelCount: 3, baseArrayLayer: 4});
+let renderBundle60 = renderBundleEncoder16.finish({label: '\u{1fa82}\u910d\u1e48\u31c6\u0be5'});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup15, new Uint32Array(8645), 7923, 0);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer17, 'uint32', 1420, 1524);
+} catch {}
+try {
+renderBundleEncoder37.setBindGroup(3, bindGroup3);
+} catch {}
+let videoFrame8 = videoFrame1.clone();
+let renderBundleEncoder40 = device0.createRenderBundleEncoder({
+  label: '\u92a0\ub33a\u0613\ud9ac\u{1fd7c}\u6a5b',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder18.setStencilReference(1953);
+} catch {}
+try {
+renderBundleEncoder35.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder30.insertDebugMarker('\u01d2');
+} catch {}
+let bindGroup22 = device0.createBindGroup({label: '\u0886\ua2cc\u0247\u2a9b', layout: bindGroupLayout21, entries: []});
+let pipelineLayout10 = device0.createPipelineLayout({
+  label: '\ue382\u{1f9c1}\u{1ffad}',
+  bindGroupLayouts: [bindGroupLayout13, bindGroupLayout7, bindGroupLayout8, bindGroupLayout24],
+});
+let commandEncoder91 = device0.createCommandEncoder({label: '\u{1f803}\u81ad\u{1f9d3}\ub024\ueee7\u{1f7b3}\u9d8d\u{1f960}\u{1fe19}\u05b7'});
+let renderPassEncoder46 = commandEncoder91.beginRenderPass({
+  label: '\u0b84\u04ee\u51c4\ub837\u{1fbc3}\u{1fb40}\ubf1a',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView44,
+    depthClearValue: -9.08358842604816,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'discard',
+  },
+  maxDrawCount: 1090234275,
+});
+try {
+computePassEncoder12.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder46.executeBundles([renderBundle34, renderBundle58, renderBundle34, renderBundle38, renderBundle30, renderBundle59, renderBundle44, renderBundle11, renderBundle52]);
+} catch {}
+try {
+renderPassEncoder39.setBlendConstant({ r: 514.9, g: 261.1, b: -985.9, a: 255.7, });
+} catch {}
+try {
+renderPassEncoder31.setIndexBuffer(buffer17, 'uint16');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 206564, new Float32Array(32109), 26506, 372);
+} catch {}
+let promise21 = device0.createComputePipelineAsync({
+  label: '\u7976\u{1f7ed}\u0f7e\uc597\uba42\ueeb5\uc9ab\ub6c4',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let bindGroupLayout25 = device0.createBindGroupLayout({
+  label: '\u02b5\u4565\u04cf\u4c6e\uce2f',
+  entries: [
+    {binding: 716, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 232, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+  ],
+});
+let querySet46 = device0.createQuerySet({label: '\u0321\u0968\u0c69', type: 'occlusion', count: 361});
+let textureView98 = texture33.createView({label: '\ub1c7\uda62\u7bb1', baseMipLevel: 5, arrayLayerCount: 1});
+let renderBundleEncoder41 = device0.createRenderBundleEncoder({label: '\u{1ff5f}\u1f55\u6d8b', colorFormats: [], depthStencilFormat: 'stencil8'});
+let externalTexture46 = device0.importExternalTexture({label: '\u{1f7b8}\u0556\u{1fc98}\u0e87\u6ad2\ud308', source: video2, colorSpace: 'display-p3'});
+try {
+computePassEncoder29.setBindGroup(3, bindGroup14, new Uint32Array(2183), 1024, 0);
+} catch {}
+try {
+renderPassEncoder40.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(15, 5, 15, 1);
+} catch {}
+try {
+renderPassEncoder41.setViewport(3.077, 0.9053, 3.337, 0.05559, 0.3431, 0.9211);
+} catch {}
+let canvas15 = document.createElement('canvas');
+let bindGroupLayout26 = device0.createBindGroupLayout({label: '\u6f20\u0ec4\u9555\u055f\u9d09\ubbc1\ud05d\u0ddf', entries: []});
+let pipelineLayout11 = device0.createPipelineLayout({
+  label: '\u0106\ub162\u{1fb31}\u1088\u9728\u1ad1\uec26\u0245\ud7ff',
+  bindGroupLayouts: [bindGroupLayout13, bindGroupLayout22],
+});
+let buffer22 = device0.createBuffer({label: '\u088a\u59d5\uf73c\u592a', size: 250262, usage: GPUBufferUsage.INDEX});
+let commandEncoder92 = device0.createCommandEncoder({label: '\u087e\u{1f999}\u{1fcea}\ueb71\u6b27\u02b8\u1fa4\u75a7\u1f11\u628d\u079d'});
+let textureView99 = texture3.createView({label: '\u{1fd49}\u0873\u{1fb1f}\u63b3\ucd32\u{1f7ef}', baseMipLevel: 1, mipLevelCount: 7});
+let computePassEncoder30 = commandEncoder92.beginComputePass();
+try {
+renderPassEncoder10.beginOcclusionQuery(951);
+} catch {}
+try {
+renderPassEncoder32.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline24);
+} catch {}
+try {
+renderPassEncoder29.setVertexBuffer(6, buffer12, 1368, 4291);
+} catch {}
+try {
+renderBundleEncoder31.setVertexBuffer(7, buffer6, 0, 47582);
+} catch {}
+let pipeline69 = await promise21;
+let textureView100 = texture56.createView({
+  label: '\u004e\u{1fd4a}\u7c38\u0c57\u2459\ubb78\u5edc\u{1fff6}\u444a\u9a4d',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 3,
+  baseArrayLayer: 112,
+});
+try {
+renderPassEncoder0.setViewport(0.8879, 0.2195, 0.00943, 0.6187, 0.3125, 0.3395);
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(buffer7, 'uint16', 118348, 23563);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let commandEncoder93 = device0.createCommandEncoder();
+let textureView101 = texture24.createView({label: '\u8bf1\u53a5\u0428\u0fe0\u21a5\u9a32\u1f31\u652e\u06b5\u00df\u02a5', mipLevelCount: 1});
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder39.setScissorRect(4, 0, 2, 0);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder25.setPipeline(pipeline9);
+} catch {}
+try {
+commandEncoder93.copyBufferToBuffer(buffer14, 1984, buffer16, 61904, 4180);
+dissociateBuffer(device0, buffer14);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder93.copyTextureToBuffer({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 18},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 30 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 225062 */
+  offset: 16392,
+  bytesPerRow: 256,
+  rowsPerImage: 270,
+  buffer: buffer10,
+}, {width: 30, height: 6, depthOrArrayLayers: 4});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'stencil-only',
+}, new Uint8ClampedArray(new ArrayBuffer(40)), /* required buffer size: 463_898 */
+{offset: 362, bytesPerRow: 184, rowsPerImage: 229}, {width: 40, height: 1, depthOrArrayLayers: 12});
+} catch {}
+let canvas16 = document.createElement('canvas');
+let offscreenCanvas7 = new OffscreenCanvas(369, 786);
+let bindGroup23 = device0.createBindGroup({
+  label: '\u{1fcd2}\u2a84\u{1fc5b}\u{1fb08}\u6935\u{1f850}\u{1fa6d}\u01b9\ua4bc',
+  layout: bindGroupLayout21,
+  entries: [],
+});
+try {
+renderPassEncoder35.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(1286);
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(3996);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(6, buffer6, 0, 130386);
+} catch {}
+try {
+commandEncoder93.copyBufferToBuffer(buffer15, 13528, buffer10, 203408, 2888);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+renderBundleEncoder31.pushDebugGroup('\u{1fcd7}');
+} catch {}
+let gpuCanvasContext11 = canvas15.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let bindGroupLayout27 = device0.createBindGroupLayout({
+  label: '\u3e65\u0c81\u08c0\u00f2\ucd2b',
+  entries: [
+    {binding: 258, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 927,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 623,
+      visibility: 0,
+      storageTexture: { format: 'r32float', access: 'write-only', viewDimension: '2d' },
+    },
+  ],
+});
+let bindGroupLayout28 = pipeline5.getBindGroupLayout(0);
+let textureView102 = texture38.createView({label: '\u{1f7dd}\u0ef7\u0d5b', baseMipLevel: 2});
+try {
+computePassEncoder21.end();
+} catch {}
+try {
+renderPassEncoder46.setScissorRect(23, 5, 5, 0);
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(5, buffer12, 2576, 2296);
+} catch {}
+try {
+commandEncoder93.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 80 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 4648 */
+  offset: 4648,
+  buffer: buffer18,
+}, {
+  texture: texture35,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {width: 80, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer18);
+} catch {}
+try {
+commandEncoder72.clearBuffer(buffer10, 196600, 12756);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+renderBundleEncoder15.insertDebugMarker('\u{1fce3}');
+} catch {}
+try {
+  await promise17;
+} catch {}
+let textureView103 = texture46.createView({
+  label: '\u3e85\u1fe0\u0394\u{1fa87}\u{1ff7b}\u{1f819}\u0afa\u9d37\udafc\u{1f82f}',
+  dimension: '2d',
+  baseMipLevel: 4,
+  baseArrayLayer: 56,
+});
+let renderPassEncoder47 = commandEncoder72.beginRenderPass({
+  label: '\u05d3\u{1f879}\uc418\u6f34\u5eb0\u49b7\u{1fd19}',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView5, stencilClearValue: 30144, stencilLoadOp: 'clear', stencilStoreOp: 'discard'},
+  occlusionQuerySet: querySet18,
+  maxDrawCount: 121838533,
+});
+let renderBundleEncoder42 = device0.createRenderBundleEncoder({
+  label: '\u{1fafb}\uf32a\u0f62\u{1fb1b}\u{1fc8c}\ua637\u6272\u40dd',
+  colorFormats: ['r32sint', 'r8sint', 'rgb10a2uint', 'rgba16sint', 'r8sint'],
+});
+try {
+renderPassEncoder42.setViewport(4.830, 1.760, 0.6484, 0.7490, 0.4527, 0.5173);
+} catch {}
+try {
+commandEncoder93.copyBufferToBuffer(buffer5, 7316, buffer16, 33992, 3604);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+renderBundleEncoder31.popDebugGroup();
+} catch {}
+let pipeline70 = device0.createComputePipeline({
+  label: '\u0156\u0a06\ud299\uc2dd',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext12 = canvas16.getContext('webgpu');
+let bindGroupLayout29 = pipeline54.getBindGroupLayout(0);
+let bindGroup24 = device0.createBindGroup({layout: bindGroupLayout26, entries: []});
+let buffer23 = device0.createBuffer({
+  label: '\u{1fa28}\u878d\u192f\u9043\u0427\u8224\ucb5f\u01ef',
+  size: 30240,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let textureView104 = texture4.createView({aspect: 'stencil-only', baseMipLevel: 2, mipLevelCount: 1});
+let sampler47 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 40.28,
+  lodMaxClamp: 69.73,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder14.setBindGroup(3, bindGroup24, new Uint32Array(2395), 2223, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(336);
+} catch {}
+try {
+renderBundleEncoder22.setVertexBuffer(2, buffer6, 0, 123610);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer23, 588, new Int16Array(53867), 10798, 820);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 26},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 127_399 */
+{offset: 687, bytesPerRow: 58, rowsPerImage: 26}, {width: 40, height: 1, depthOrArrayLayers: 85});
+} catch {}
+let gpuCanvasContext13 = offscreenCanvas7.getContext('webgpu');
+video2.height = 203;
+let renderPassEncoder48 = commandEncoder93.beginRenderPass({
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView94,
+    depthClearValue: 2.2373878677494226,
+    depthReadOnly: false,
+    stencilLoadOp: 'clear',
+    stencilStoreOp: 'store',
+  },
+  occlusionQuerySet: querySet18,
+  maxDrawCount: 874022050,
+});
+let externalTexture47 = device0.importExternalTexture({label: '\u0e36\u096b\u1254\ub193\u6c68\uae44\u0b10\u{1f6a0}', source: videoFrame2, colorSpace: 'srgb'});
+try {
+computePassEncoder8.dispatchWorkgroups(3, 4, 5);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderPassEncoder39.beginOcclusionQuery(398);
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant({ r: 271.2, g: -4.128, b: 8.261, a: 428.8, });
+} catch {}
+try {
+renderPassEncoder32.setScissorRect(14, 3, 2, 1);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer7, 'uint32', 98432, 2336);
+} catch {}
+let arrayBuffer6 = buffer2.getMappedRange(632, 76);
+let pipeline71 = await device0.createRenderPipelineAsync({
+  label: '\ub579\u{1fab3}\u868b\u{1f7a6}\ud642',
+  layout: pipelineLayout10,
+  fragment: {module: shaderModule1, entryPoint: 'fragment0', targets: []},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilBack: {compare: 'less', failOp: 'invert', depthFailOp: 'invert', passOp: 'zero'},
+    stencilReadMask: 2470028721,
+    stencilWriteMask: 390624327,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 440,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 28, shaderLocation: 11},
+          {format: 'uint16x4', offset: 44, shaderLocation: 12},
+          {format: 'sint32x4', offset: 8, shaderLocation: 13},
+          {format: 'float32x2', offset: 12, shaderLocation: 2},
+          {format: 'uint16x2', offset: 160, shaderLocation: 4},
+          {format: 'sint16x2', offset: 68, shaderLocation: 9},
+          {format: 'float16x4', offset: 32, shaderLocation: 10},
+          {format: 'uint8x4', offset: 196, shaderLocation: 15},
+          {format: 'float32x4', offset: 88, shaderLocation: 3},
+          {format: 'uint16x2', offset: 16, shaderLocation: 0},
+          {format: 'sint8x2', offset: 164, shaderLocation: 5},
+          {format: 'sint16x4', offset: 108, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 56, stepMode: 'vertex', attributes: []},
+      {arrayStride: 308, stepMode: 'instance', attributes: []},
+      {arrayStride: 40, attributes: [{format: 'snorm16x2', offset: 20, shaderLocation: 8}]},
+    ],
+  },
+  primitive: {cullMode: 'none', unclippedDepth: true},
+});
+canvas0.width = 1994;
+let offscreenCanvas8 = new OffscreenCanvas(554, 469);
+try {
+externalTexture24.label = '\u0475\u0df0\ub5bc\u7c8a\u4895\u{1f7d9}\u3b02\u6b26';
+} catch {}
+let textureView105 = texture30.createView({label: '\u0e6e\ub987\ubdb2\uc246\u19ca\u06be\u25b8\u{1fd30}', baseArrayLayer: 49, arrayLayerCount: 6});
+let renderBundleEncoder43 = device0.createRenderBundleEncoder({
+  label: '\u2171\u5987\ue8f3\u84ae\ubea7\u{1fb40}',
+  colorFormats: ['r32sint', 'r8sint', 'rgb10a2uint', 'rgba16sint', 'r8sint'],
+  depthReadOnly: true,
+});
+let sampler48 = device0.createSampler({
+  label: '\u74cd\u337c\u0eac\u{1fe7a}\ub5a9',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 17.76,
+});
+try {
+computePassEncoder18.end();
+} catch {}
+try {
+renderPassEncoder37.beginOcclusionQuery(3208);
+} catch {}
+try {
+renderPassEncoder30.setBlendConstant({ r: 302.1, g: -477.4, b: -35.54, a: -603.4, });
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(3, buffer12);
+} catch {}
+let commandEncoder94 = device0.createCommandEncoder();
+let textureView106 = texture32.createView({label: '\u0bcc\uc4f5', dimension: '2d', baseArrayLayer: 7, arrayLayerCount: 1});
+let renderBundle61 = renderBundleEncoder42.finish({label: '\u04e5\ue822\u0fb9\u{1fed4}\u0e80\u4d47'});
+try {
+computePassEncoder16.setPipeline(pipeline69);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle34, renderBundle59, renderBundle29, renderBundle16]);
+} catch {}
+try {
+renderBundleEncoder24.setPipeline(pipeline26);
+} catch {}
+try {
+commandEncoder64.insertDebugMarker('\ueae3');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline72 = device0.createComputePipeline({
+  label: '\u7e5c\ud22e',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let querySet47 = device0.createQuerySet({
+  label: '\u{1fb61}\u0ab6\u0862\u9021\u0746\u{1f616}\u041a\uea94\u0836\u0b55',
+  type: 'occlusion',
+  count: 3955,
+});
+let texture57 = device0.createTexture({
+  label: '\u017a\uda27\u{1f690}\u450c\u{1fbe2}\u{1fd67}\u{1fa4a}\u06e6\ufa30\u{1fe81}',
+  size: [1280, 20, 125],
+  mipLevelCount: 6,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['stencil8'],
+});
+let renderBundleEncoder44 = device0.createRenderBundleEncoder({
+  label: '\u3fa4\u73e3\u2d6b\u589f\u1478\u94eb\u7d8e\u8ef5',
+  colorFormats: ['r32sint', 'r8sint', 'rgb10a2uint', 'rgba16sint', 'r8sint'],
+  stencilReadOnly: true,
+});
+let renderBundle62 = renderBundleEncoder10.finish({label: '\u{1f8f1}\u4218\u9300\u0515\u0684\u0835\u0478\u055f\u2934\u0422\u055d'});
+let externalTexture48 = device0.importExternalTexture({source: video5, colorSpace: 'display-p3'});
+try {
+computePassEncoder15.setPipeline(pipeline70);
+} catch {}
+try {
+renderPassEncoder37.setStencilReference(2480);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(4, buffer6);
+} catch {}
+try {
+renderBundleEncoder25.setBindGroup(1, bindGroup19, []);
+} catch {}
+try {
+commandEncoder94.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 40 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 23320 */
+  offset: 23280,
+  buffer: buffer1,
+}, {
+  texture: texture35,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {width: 40, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder64.copyTextureToTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 0, y: 7, z: 28},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 16, y: 12, z: 0},
+  aspect: 'all',
+},
+{width: 640, height: 1, depthOrArrayLayers: 1});
+} catch {}
+gc();
+try {
+sampler11.label = '\u0f7f\u{1fa49}\u{1f84f}\u{1ff1a}\u013b';
+} catch {}
+let bindGroup25 = device0.createBindGroup({
+  layout: bindGroupLayout17,
+  entries: [
+    {binding: 329, resource: externalTexture36},
+    {binding: 830, resource: sampler35},
+    {binding: 607, resource: externalTexture38},
+  ],
+});
+let commandEncoder95 = device0.createCommandEncoder({label: '\u3206\u{1f7cf}\ub923\u0c22\u062e\u0f9f'});
+let querySet48 = device0.createQuerySet({
+  label: '\ue74b\u0a0f\uad04\u{1f8c9}\u0908\u0ad3\u{1fe95}\u3235\u{1fa9b}\u{1f634}',
+  type: 'occlusion',
+  count: 3087,
+});
+let externalTexture49 = device0.importExternalTexture({source: video5, colorSpace: 'display-p3'});
+try {
+renderPassEncoder21.setBlendConstant({ r: -826.7, g: -515.5, b: 795.8, a: -385.8, });
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(3, buffer6);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(0, bindGroup18, new Uint32Array(4401), 3559, 0);
+} catch {}
+try {
+commandEncoder94.copyTextureToBuffer({
+  texture: texture38,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 7 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 39388 */
+  offset: 39388,
+  bytesPerRow: 256,
+  rowsPerImage: 110,
+  buffer: buffer8,
+}, {width: 7, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer8);
+} catch {}
+let pipeline73 = await device0.createRenderPipelineAsync({
+  label: '\u{1fcfe}\u{1f795}\ua7c9\uef4f\u{1ffab}\u1c6f\u056e\u0c09\udb38\u07cd',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0x46cb8a5d},
+  fragment: {module: shaderModule14, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'not-equal', failOp: 'invert'},
+    stencilBack: {compare: 'greater-equal', failOp: 'decrement-wrap', depthFailOp: 'replace', passOp: 'invert'},
+    stencilReadMask: 1623391617,
+    stencilWriteMask: 3706339741,
+    depthBias: 929625821,
+    depthBiasSlopeScale: 433.04529180744873,
+    depthBiasClamp: 779.873592912099,
+  },
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 900,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x2', offset: 560, shaderLocation: 1}],
+      },
+      {
+        arrayStride: 144,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x2', offset: 8, shaderLocation: 12}],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 16, attributes: []},
+      {arrayStride: 40, attributes: []},
+      {
+        arrayStride: 596,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 260, shaderLocation: 9},
+          {format: 'snorm16x4', offset: 176, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'ccw'},
+});
+let gpuCanvasContext14 = offscreenCanvas8.getContext('webgpu');
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+canvas13.width = 632;
+let promise22 = adapter0.requestAdapterInfo();
+let buffer24 = device0.createBuffer({
+  label: '\u60da\u0040\u{1ff40}\u03c4\u0704\u0b0d\u0c90\u0c51\u0453',
+  size: 3314,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let querySet49 = device0.createQuerySet({label: '\u995c\u0ab5\u03e3\u09c1\u0a5a\u4563\u9308\ude90\u{1ff78}', type: 'occlusion', count: 1341});
+let texture58 = device0.createTexture({
+  size: [1280, 20, 125],
+  mipLevelCount: 10,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler49 = device0.createSampler({
+  label: '\u09c2\u147c\u08de\u9129\u{1f89e}\uaae3\u2102\u2295\ue2a3',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 99.87,
+});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup17, new Uint32Array(6373), 3044, 0);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(47);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle35, renderBundle18, renderBundle10, renderBundle18, renderBundle48]);
+} catch {}
+try {
+renderPassEncoder28.setIndexBuffer(buffer22, 'uint32', 33000, 65755);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline58);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(3, buffer12, 0, 763);
+} catch {}
+try {
+commandEncoder64.copyTextureToBuffer({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 60 widthInBlocks: 60 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 29732 */
+  offset: 29732,
+  buffer: buffer23,
+}, {width: 60, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer23);
+} catch {}
+try {
+commandEncoder94.clearBuffer(buffer16, 24800, 91432);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let querySet50 = device0.createQuerySet({
+  label: '\u{1fdaa}\u085b\u9bdb\uf2af\u86e9\ua23e\u0ec8\u1513\u{1ff85}\u082a\u2cd4',
+  type: 'occlusion',
+  count: 2195,
+});
+let texture59 = gpuCanvasContext6.getCurrentTexture();
+let renderBundleEncoder45 = device0.createRenderBundleEncoder({colorFormats: ['r32sint', 'r8sint', 'rgb10a2uint', 'rgba16sint', 'r8sint'], stencilReadOnly: true});
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(0, bindGroup22, new Uint32Array(6703), 1349, 0);
+} catch {}
+try {
+renderPassEncoder47.end();
+} catch {}
+try {
+renderPassEncoder45.setScissorRect(22, 2, 3, 2);
+} catch {}
+let pipeline74 = await device0.createRenderPipelineAsync({
+  label: '\u8557\u0a44',
+  layout: pipelineLayout3,
+  multisample: {count: 4, mask: 0xef83704d},
+  fragment: {module: shaderModule7, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {failOp: 'increment-clamp', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'less-equal', failOp: 'invert', depthFailOp: 'increment-clamp', passOp: 'decrement-clamp'},
+    stencilReadMask: 2946354229,
+    stencilWriteMask: 2143393782,
+    depthBias: 1381275519,
+    depthBiasSlopeScale: 638.098165226448,
+  },
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 152,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 64, shaderLocation: 10},
+          {format: 'sint32x4', offset: 68, shaderLocation: 13},
+          {format: 'uint32x4', offset: 8, shaderLocation: 5},
+          {format: 'float32x3', offset: 16, shaderLocation: 9},
+          {format: 'snorm8x4', offset: 44, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 84,
+        attributes: [
+          {format: 'sint32x4', offset: 0, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 0, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 284, attributes: []},
+      {arrayStride: 140, attributes: []},
+      {arrayStride: 748, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 164,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint32', offset: 44, shaderLocation: 12}],
+      },
+    ],
+  },
+});
+let bindGroupLayout30 = device0.createBindGroupLayout({
+  label: '\u02dc\u67ad\u0cbc\u044f\u73a6\uff27\u651b',
+  entries: [
+    {binding: 762, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 855, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let bindGroup26 = device0.createBindGroup({
+  label: '\ua35b\u{1ff94}\u{1fe4a}\u68c7\u82e3\u0392\ue265\u6c8a',
+  layout: bindGroupLayout11,
+  entries: [],
+});
+let commandEncoder96 = device0.createCommandEncoder({label: '\u0bf4\ua605\u{1fa12}\u0131\ud8f9\u0663\ud74c\uf15b\u05fd\u7085\u7e03'});
+let texture60 = device0.createTexture({
+  label: '\u0752\u6cc3\u07e7\ua2ee\ue6db\u4114\u12fd\u0c4b',
+  size: {width: 30, height: 6, depthOrArrayLayers: 2},
+  mipLevelCount: 4,
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16uint'],
+});
+let textureView107 = texture54.createView({aspect: 'all'});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder27.setBindGroup(1, bindGroup4, new Uint32Array(3281), 752, 0);
+} catch {}
+try {
+renderPassEncoder36.beginOcclusionQuery(1854);
+} catch {}
+try {
+renderPassEncoder39.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle9, renderBundle49, renderBundle39, renderBundle45, renderBundle23, renderBundle62]);
+} catch {}
+try {
+renderPassEncoder29.setScissorRect(13, 6, 1, 0);
+} catch {}
+let pipeline75 = device0.createComputePipeline({
+  label: '\u0d10\u{1f8aa}\u{1f875}\u0888\u3b24\ub40e',
+  layout: pipelineLayout9,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+let querySet51 = device0.createQuerySet({label: '\u9e41\ucc2b\u0919\u0e7d\u{1fab2}', type: 'occlusion', count: 1760});
+let texture61 = device0.createTexture({
+  size: [240, 48, 212],
+  mipLevelCount: 8,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView108 = texture1.createView({label: '\u0807\uea87\u{1f86a}\u{1fe35}', dimension: '2d-array', baseMipLevel: 2, mipLevelCount: 5});
+let computePassEncoder31 = commandEncoder95.beginComputePass({label: '\u2af6\u715e\u70f1\u1099\udc91\u07a9\u09b7\u1ee6\u784c'});
+let renderBundleEncoder46 = device0.createRenderBundleEncoder({
+  label: '\u0544\u0c5a\u{1f608}',
+  colorFormats: ['r32sint', 'r8sint', 'rgb10a2uint', 'rgba16sint', 'r8sint'],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+let renderBundle63 = renderBundleEncoder29.finish({label: '\ucc9f\u13f9\u7bf9\u92ff\u{1fe6c}\u0914\u{1f9d2}\u48d3\u{1fc39}\u2715'});
+try {
+computePassEncoder8.dispatchWorkgroups(1, 2);
+} catch {}
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+renderPassEncoder24.setBlendConstant({ r: -199.1, g: 968.7, b: -12.79, a: 568.0, });
+} catch {}
+try {
+renderPassEncoder29.setStencilReference(1607);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(1, buffer12);
+} catch {}
+try {
+commandEncoder96.clearBuffer(buffer8, 210680, 38324);
+dissociateBuffer(device0, buffer8);
+} catch {}
+let commandEncoder97 = device0.createCommandEncoder({label: '\u{1fab4}\u795e\u1a1c\uf01b\u5aca'});
+let textureView109 = texture40.createView({
+  label: '\u0f1a\ub7ee\u{1feb4}\uf4ab\u0fb7\ue9fa\u08d9\u3033\u{1fc9a}\u6684',
+  aspect: 'stencil-only',
+  mipLevelCount: 1,
+  baseArrayLayer: 10,
+  arrayLayerCount: 6,
+});
+let externalTexture50 = device0.importExternalTexture({
+  label: '\u{1fcf0}\u19b3\uc4f6\ua234\ub0e9\u711b\uc35e\u06ba\u3d6c',
+  source: video6,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup6, []);
+} catch {}
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder24.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(3, buffer17);
+} catch {}
+let textureView110 = texture41.createView({label: '\u{1fcdb}\u{1f969}\u0368\u{1fe34}\u{1f932}\ud15c\u714e\u0de6\u0614', baseArrayLayer: 64});
+let computePassEncoder32 = commandEncoder64.beginComputePass({label: '\u65c3\u008e\ufea9'});
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder35.setPipeline(pipeline58);
+} catch {}
+let promise23 = buffer5.mapAsync(GPUMapMode.WRITE, 5184, 3892);
+try {
+commandEncoder94.copyTextureToTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 40, y: 10, z: 0},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture51,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas0.height = 759;
+let video7 = await videoWithData();
+let renderBundle64 = renderBundleEncoder38.finish({label: '\u{1fbbc}\u089c\u0a84'});
+try {
+computePassEncoder31.setBindGroup(0, bindGroup0, new Uint32Array(1276), 524, 0);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(7, buffer6, 150204);
+} catch {}
+try {
+commandEncoder46.copyBufferToTexture({
+  /* bytesInLastRow: 60 widthInBlocks: 60 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 8196 */
+  offset: 8196,
+  bytesPerRow: 256,
+  buffer: buffer1,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 60, height: 12, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 5, height: 1, depthOrArrayLayers: 125}
+*/
+{
+  source: video7,
+  origin: { x: 2, y: 0 },
+  flipY: true,
+}, {
+  texture: texture58,
+  mipLevel: 8,
+  origin: {x: 1, y: 1, z: 56},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas7.width = 2220;
+let renderPassEncoder49 = commandEncoder94.beginRenderPass({
+  label: '\ub574\u4078\uf454',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView101, stencilClearValue: 11728, stencilReadOnly: true},
+  occlusionQuerySet: querySet39,
+  maxDrawCount: 477845075,
+});
+try {
+renderPassEncoder18.setBlendConstant({ r: -96.49, g: -49.64, b: -983.1, a: 353.9, });
+} catch {}
+try {
+renderPassEncoder43.setStencilReference(2029);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(0, buffer6, 0, 3767);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img6,
+  origin: { x: 0, y: 2 },
+  flipY: false,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView111 = texture1.createView({
+  label: '\u{1f755}\u{1f682}\u9d98\u{1f6ae}\u1c9c',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+  baseMipLevel: 1,
+  mipLevelCount: 5,
+});
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup20);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer22, 'uint32', 99808, 25241);
+} catch {}
+try {
+commandEncoder96.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture43,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 13},
+  aspect: 'stencil-only',
+}, arrayBuffer2, /* required buffer size: 2_592_525 */
+{offset: 705, bytesPerRow: 119, rowsPerImage: 121}, {width: 5, height: 0, depthOrArrayLayers: 181});
+} catch {}
+gc();
+try {
+window.someLabel = textureView46.label;
+} catch {}
+let texture62 = device0.createTexture({
+  label: '\u{1fac4}\udf36\udb9d\u38dc\u0767\u0508\u0daa',
+  size: {width: 240, height: 48, depthOrArrayLayers: 448},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16uint', 'rgba16uint'],
+});
+let textureView112 = texture13.createView({label: '\u044a\ufac9\u{1f6cb}', dimension: '2d-array', baseMipLevel: 2, mipLevelCount: 1});
+let computePassEncoder33 = commandEncoder97.beginComputePass({});
+try {
+computePassEncoder22.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder38.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle32, renderBundle46, renderBundle52, renderBundle36, renderBundle35, renderBundle25]);
+} catch {}
+try {
+renderPassEncoder26.setStencilReference(832);
+} catch {}
+try {
+renderPassEncoder24.setPipeline(pipeline26);
+} catch {}
+let adapter2 = await navigator.gpu.requestAdapter({});
+let querySet52 = device0.createQuerySet({
+  label: '\u0b31\u0060\u6070\u5b37\ucd53\ub32a\u4bb1\u5f19\u8a8a\u01af\u{1f7d6}',
+  type: 'occlusion',
+  count: 3038,
+});
+let textureView113 = texture51.createView({
+  label: '\u0b4a\u{1ffe8}\udfe4\u{1f8c1}\u0cbe\u0a4b\u0f50',
+  dimension: '2d-array',
+  aspect: 'stencil-only',
+});
+let externalTexture51 = device0.importExternalTexture({label: '\u0851\uda79', source: video0, colorSpace: 'display-p3'});
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+renderPassEncoder39.setScissorRect(7, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder22.setStencilReference(2099);
+} catch {}
+try {
+commandEncoder46.copyBufferToBuffer(buffer1, 18412, buffer2, 175196, 9988);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let texture63 = device0.createTexture({
+  label: '\uc888\u{1f852}\u02c0\uf736\u0213\uc29d\u85a7\u0a90',
+  size: [60, 12, 112],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16sint', 'rgba16sint'],
+});
+let textureView114 = texture17.createView({aspect: 'stencil-only', baseMipLevel: 1});
+let renderBundle65 = renderBundleEncoder42.finish({label: '\u{1fad6}\u{1fb57}\uee6d\u08c0\u087e\u06a8\u6bdf\u{1fcf6}\u9e61'});
+let externalTexture52 = device0.importExternalTexture({label: '\ucaf3\u0d61\u09d3\ue2ed\uc76d\u{1f738}\u0c48\u047b\u2398', source: videoFrame0});
+try {
+renderPassEncoder49.setViewport(58.22, 0.6475, 26.19, 0.2759, 0.1871, 0.3752);
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(2958, undefined, 2765838015);
+} catch {}
+let promise24 = buffer23.mapAsync(GPUMapMode.READ);
+try {
+commandEncoder96.copyBufferToBuffer(buffer11, 29676, buffer16, 52256, 17780);
+dissociateBuffer(device0, buffer11);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder96.copyTextureToBuffer({
+  texture: texture39,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, {
+  /* bytesInLastRow: 15 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 1252 */
+  offset: 1252,
+  bytesPerRow: 512,
+  rowsPerImage: 226,
+  buffer: buffer10,
+}, {width: 15, height: 3, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder46.clearBuffer(buffer8, 206820, 140780);
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let img12 = await imageWithData(245, 206, '#7b2e447c', '#0441d5ce');
+let imageBitmap17 = await createImageBitmap(canvas3);
+let buffer25 = device0.createBuffer({
+  label: '\u0e37\u01bc\u79a3\u{1ff2b}\u0485\u{1fb25}\u0672\u{1f7d0}',
+  size: 82343,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let querySet53 = device0.createQuerySet({
+  label: '\ud26e\ucc94\u0cf7\u{1fca0}\u25f1\u{1fc53}\u{1f74d}\u7ce8\u7e30\u32cb',
+  type: 'occlusion',
+  count: 1154,
+});
+let computePassEncoder34 = commandEncoder46.beginComputePass({label: '\u{1fa5e}\u{1fe0e}\u{1fe2e}\u{1fa70}\ubbe6\u445a\u9da6\udf7f'});
+try {
+computePassEncoder8.dispatchWorkgroupsIndirect(buffer3, 2592);
+} catch {}
+try {
+computePassEncoder29.end();
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup12, []);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+commandEncoder90.copyTextureToBuffer({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 22896 */
+  offset: 22896,
+  buffer: buffer8,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 85948, new Int16Array(25390), 4818, 88);
+} catch {}
+let commandEncoder98 = device0.createCommandEncoder({label: '\u0216\u02e2\u9387\u00f2\u{1fd3c}'});
+let querySet54 = device0.createQuerySet({label: '\u{1f9ec}\u0cd2\u{1f81c}\u019a\u0a01\ue929\ubfbe', type: 'occlusion', count: 2679});
+let commandBuffer19 = commandEncoder98.finish();
+let renderPassEncoder50 = commandEncoder90.beginRenderPass({
+  label: '\u0192\u4ded\u7a66',
+  colorAttachments: [],
+  depthStencilAttachment: {
+    view: textureView93,
+    depthClearValue: -9.6232403240307,
+    stencilClearValue: 59582,
+    stencilReadOnly: true,
+  },
+  occlusionQuerySet: querySet45,
+  maxDrawCount: 1086536621,
+});
+let renderBundle66 = renderBundleEncoder39.finish({label: '\u{1f85a}\u0bf3'});
+try {
+computePassEncoder20.setBindGroup(1, bindGroup2, new Uint32Array(5538), 4920, 0);
+} catch {}
+try {
+renderPassEncoder10.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: -778.1, g: 522.3, b: 80.75, a: -121.8, });
+} catch {}
+try {
+renderPassEncoder26.setScissorRect(29, 0, 31, 1);
+} catch {}
+try {
+renderPassEncoder46.setViewport(22.91, 4.529, 3.759, 0.8510, 0.1597, 0.2461);
+} catch {}
+try {
+renderPassEncoder35.setVertexBuffer(7422, undefined, 1833661993);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(5, buffer6, 79808, 27723);
+} catch {}
+try {
+commandEncoder96.copyBufferToBuffer(buffer4, 8220, buffer23, 14952, 868);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer23);
+} catch {}
+try {
+commandEncoder96.copyTextureToTexture({
+  texture: texture25,
+  mipLevel: 2,
+  origin: {x: 8, y: 0, z: 8},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture5,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder7.pushDebugGroup('\u5945');
+} catch {}
+let imageData8 = new ImageData(48, 16);
+let bindGroupLayout31 = device0.createBindGroupLayout({
+  label: '\u1aa8\u{1f876}',
+  entries: [
+    {
+      binding: 617,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let buffer26 = device0.createBuffer({size: 149804, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE, mappedAtCreation: true});
+let renderBundle67 = renderBundleEncoder35.finish({label: '\u4f54\u0821\u{1fd19}\u0879\u0b02\u0c6a\ud0ad\u{1faad}\uac1d'});
+try {
+renderPassEncoder39.setScissorRect(1, 0, 4, 1);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(3115);
+} catch {}
+try {
+renderPassEncoder49.setViewport(5.947, 0.7277, 103.1, 0.2435, 0.8332, 0.8563);
+} catch {}
+try {
+renderPassEncoder49.setVertexBuffer(7, buffer12, 3776, 554);
+} catch {}
+try {
+renderBundleEncoder34.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+renderBundleEncoder43.setIndexBuffer(buffer24, 'uint16', 1006, 1693);
+} catch {}
+try {
+commandEncoder96.copyBufferToTexture({
+  /* bytesInLastRow: 30 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 15034 */
+  offset: 15004,
+  buffer: buffer1,
+}, {
+  texture: texture19,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 30, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder96.copyTextureToTexture({
+  texture: texture25,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 4,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder96.resolveQuerySet(querySet35, 459, 39, buffer26, 145408);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise25 = device0.queue.onSubmittedWorkDone();
+let bindGroupLayout32 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 870,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 333,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {binding: 831, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder99 = device0.createCommandEncoder({});
+let texture64 = gpuCanvasContext12.getCurrentTexture();
+let textureView115 = texture20.createView({
+  label: '\u8297\u{1f920}\u19b8\u2728',
+  dimension: '2d',
+  baseMipLevel: 6,
+  mipLevelCount: 1,
+  baseArrayLayer: 195,
+  arrayLayerCount: 1,
+});
+let externalTexture53 = device0.importExternalTexture({
+  label: '\u0644\u158f\u049f\u0a6f\u007b\u0335\u38a7\u0998\u52fe',
+  source: videoFrame4,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder29.beginOcclusionQuery(80);
+} catch {}
+try {
+renderPassEncoder29.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder44.setBlendConstant({ r: 147.5, g: 602.6, b: -324.6, a: -9.697, });
+} catch {}
+try {
+renderPassEncoder27.setScissorRect(4, 1, 2, 0);
+} catch {}
+try {
+commandEncoder96.resolveQuerySet(querySet35, 258, 208, buffer26, 40960);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 77_025 */
+{offset: 977, bytesPerRow: 194, rowsPerImage: 196}, {width: 15, height: 0, depthOrArrayLayers: 3});
+} catch {}
+let pipeline76 = device0.createRenderPipeline({
+  layout: pipelineLayout3,
+  multisample: {count: 4, mask: 0xe4771ac3},
+  fragment: {module: shaderModule12, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'never', failOp: 'invert', depthFailOp: 'increment-clamp', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'invert'},
+    stencilReadMask: 2187371613,
+    stencilWriteMask: 1748083440,
+    depthBiasClamp: 647.6358807854245,
+  },
+  vertex: {
+    module: shaderModule12,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 428,
+        attributes: [
+          {format: 'uint32', offset: 96, shaderLocation: 3},
+          {format: 'float32x3', offset: 36, shaderLocation: 15},
+          {format: 'unorm10-10-10-2', offset: 80, shaderLocation: 5},
+          {format: 'snorm16x4', offset: 104, shaderLocation: 13},
+          {format: 'uint32x2', offset: 76, shaderLocation: 2},
+          {format: 'sint32', offset: 200, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 12, shaderLocation: 6},
+          {format: 'unorm10-10-10-2', offset: 56, shaderLocation: 8},
+          {format: 'uint32x3', offset: 56, shaderLocation: 14},
+          {format: 'sint32x4', offset: 16, shaderLocation: 12},
+          {format: 'sint32x2', offset: 64, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front'},
+});
+let commandBuffer20 = commandEncoder96.finish({label: '\u002e\u78b7\u30aa'});
+try {
+renderPassEncoder27.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+renderPassEncoder45.beginOcclusionQuery(1876);
+} catch {}
+try {
+renderPassEncoder36.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder39.setScissorRect(7, 0, 0, 0);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(0, buffer6);
+} catch {}
+try {
+commandEncoder99.copyTextureToBuffer({
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 80 widthInBlocks: 80 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 21788 */
+  offset: 21788,
+  buffer: buffer10,
+}, {width: 80, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder99.resolveQuerySet(querySet17, 1049, 57, buffer26, 30720);
+} catch {}
+let videoFrame9 = new VideoFrame(imageBitmap16, {timestamp: 0});
+let texture65 = device0.createTexture({
+  label: '\u0533\u4686\u8145\u0377\u{1fcf9}\u9c32\u158b\u22a6\u{1fc88}',
+  size: {width: 120, height: 24, depthOrArrayLayers: 148},
+  mipLevelCount: 5,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderBundle68 = renderBundleEncoder31.finish({});
+try {
+renderPassEncoder41.setBindGroup(1, bindGroup25);
+} catch {}
+try {
+renderPassEncoder19.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder43.setStencilReference(1481);
+} catch {}
+let commandEncoder100 = device0.createCommandEncoder();
+let commandBuffer21 = commandEncoder100.finish({label: '\u556b\u0bea\ue2b5\u3bba\ub048\ud8b0\u0bc6\u{1ff98}\u{1fd55}'});
+let texture66 = device0.createTexture({
+  label: '\u{1fb7a}\ud0ea\u9de6\ud87d',
+  size: {width: 240, height: 48, depthOrArrayLayers: 448},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView116 = texture35.createView({
+  label: '\uece3\u8c7b\u06fd\u04f5\ub710\u374d\udf64\u3d9a\u{1fc4d}\u7933',
+  aspect: 'stencil-only',
+  format: 'stencil8',
+  baseMipLevel: 2,
+});
+let externalTexture54 = device0.importExternalTexture({
+  label: '\u36b6\u0923\u0a57\u{1fcd2}\u{1fa68}\uadb1\u091d\u2a7f\u087b\u{1fb83}',
+  source: videoFrame2,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder45.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(12, 6, 12, 0);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder46.setIndexBuffer(buffer24, 'uint32');
+} catch {}
+try {
+  await buffer11.mapAsync(GPUMapMode.WRITE, 0, 11456);
+} catch {}
+let pipelineLayout12 = device0.createPipelineLayout({
+  label: '\u07c3\u{1f81d}\ua7af\u{1fb86}\u{1fa61}\u7cc4\u{1f9a1}',
+  bindGroupLayouts: [bindGroupLayout16],
+});
+let commandEncoder101 = device0.createCommandEncoder({label: '\u032f\u01fa\u594d\u0c42'});
+let externalTexture55 = device0.importExternalTexture({
+  label: '\u{1ff42}\u0c4f\u7529\ud719\u008f\uc87a\u03b9\u061b\u{1fa5e}',
+  source: videoFrame0,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder50.executeBundles([renderBundle22, renderBundle33]);
+} catch {}
+try {
+renderPassEncoder27.setVertexBuffer(3, buffer6, 0, 217467);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline58);
+} catch {}
+try {
+  await buffer25.mapAsync(GPUMapMode.READ, 0, 65640);
+} catch {}
+try {
+device0.queue.submit([commandBuffer20, commandBuffer21, commandBuffer17]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise26 = device0.createRenderPipelineAsync({
+  label: '\u7a3a\u045a\u0586\u22eb\u{1fcb7}\u6e0b\u0d52\u715d\uc772\u8faf',
+  layout: 'auto',
+  fragment: {module: shaderModule3, entryPoint: 'fragment0', constants: {}, targets: []},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'equal', failOp: 'increment-wrap', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'not-equal', failOp: 'increment-clamp', depthFailOp: 'decrement-clamp', passOp: 'zero'},
+    stencilWriteMask: 2031115309,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 788,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 48, shaderLocation: 7},
+          {format: 'sint32x2', offset: 56, shaderLocation: 14},
+          {format: 'sint32x3', offset: 280, shaderLocation: 15},
+          {format: 'unorm8x4', offset: 64, shaderLocation: 2},
+          {format: 'float32x4', offset: 64, shaderLocation: 1},
+          {format: 'snorm8x4', offset: 188, shaderLocation: 13},
+          {format: 'sint32x4', offset: 160, shaderLocation: 11},
+          {format: 'float16x2', offset: 12, shaderLocation: 12},
+          {format: 'uint32x4', offset: 136, shaderLocation: 6},
+          {format: 'uint8x2', offset: 100, shaderLocation: 3},
+          {format: 'uint32x3', offset: 260, shaderLocation: 4},
+          {format: 'uint16x2', offset: 252, shaderLocation: 9},
+          {format: 'float32x2', offset: 128, shaderLocation: 0},
+          {format: 'float32x2', offset: 244, shaderLocation: 5},
+          {format: 'uint16x4', offset: 48, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 308,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x4', offset: 24, shaderLocation: 10}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', unclippedDepth: true},
+});
+try {
+  await promise23;
+} catch {}
+try {
+computePassEncoder24.setBindGroup(2, bindGroup26);
+} catch {}
+try {
+computePassEncoder8.dispatchWorkgroups(5, 4, 5);
+} catch {}
+try {
+renderPassEncoder32.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder31.beginOcclusionQuery(1112);
+} catch {}
+try {
+renderPassEncoder37.setBlendConstant({ r: 336.8, g: 270.7, b: 76.36, a: -219.5, });
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(2, buffer6, 186724, 27637);
+} catch {}
+try {
+renderPassEncoder40.pushDebugGroup('\u682d');
+} catch {}
+let pipeline77 = await promise26;
+let canvas17 = document.createElement('canvas');
+let buffer27 = device0.createBuffer({
+  label: '\u5653\u078e\u5221\u495a',
+  size: 226794,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE,
+});
+let texture67 = device0.createTexture({
+  label: '\u0319\u01bd\u8614\ua628',
+  size: [640, 10, 250],
+  mipLevelCount: 5,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8sint'],
+});
+try {
+renderBundleEncoder15.draw(15);
+} catch {}
+try {
+renderBundleEncoder15.drawIndexed(262, 142);
+} catch {}
+try {
+renderBundleEncoder15.drawIndirect(buffer24, 96);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(2, buffer12, 4256, 2417);
+} catch {}
+try {
+buffer26.unmap();
+} catch {}
+try {
+commandEncoder101.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 11},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 331, y: 1, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 15, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline78 = await device0.createComputePipelineAsync({
+  label: '\u{1fdc2}\u{1f7ea}\u0169\u0519\u0585\u560f\u{1fc95}\u03b7\u{1f833}',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule15, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext15 = canvas17.getContext('webgpu');
+let textureView117 = texture46.createView({label: '\u8dff\u{1f7bc}\u019d', dimension: '2d', baseMipLevel: 1, mipLevelCount: 3, baseArrayLayer: 20});
+try {
+renderPassEncoder27.beginOcclusionQuery(8);
+} catch {}
+try {
+renderPassEncoder14.setStencilReference(3450);
+} catch {}
+try {
+renderPassEncoder39.setIndexBuffer(buffer22, 'uint16', 232934, 6815);
+} catch {}
+try {
+renderPassEncoder46.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder15.drawIndirect(buffer24, 1172);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(6, buffer12);
+} catch {}
+try {
+commandEncoder101.copyBufferToBuffer(buffer5, 9372, buffer2, 249800, 2472);
+dissociateBuffer(device0, buffer5);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder101.copyBufferToTexture({
+  /* bytesInLastRow: 320 widthInBlocks: 320 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 100360 */
+  offset: 7368,
+  bytesPerRow: 512,
+  rowsPerImage: 177,
+  buffer: buffer19,
+}, {
+  texture: texture40,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'stencil-only',
+}, {width: 320, height: 5, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer19);
+} catch {}
+try {
+commandEncoder99.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 18332 */
+  offset: 18332,
+  rowsPerImage: 116,
+  buffer: buffer27,
+}, {width: 2, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer27);
+} catch {}
+try {
+commandEncoder99.copyTextureToTexture({
+  texture: texture17,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture34,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 160, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+}, new Uint8ClampedArray(new ArrayBuffer(48)), /* required buffer size: 78 */
+{offset: 78}, {width: 160, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap18 = await createImageBitmap(img11);
+try {
+externalTexture36.label = '\u{1ff74}\u3d9e';
+} catch {}
+let bindGroup27 = device0.createBindGroup({
+  label: '\u{1f9ca}\u{1fadc}\u4874\u0f83\u{1fc95}\u04b6\u1866\u{1fc6e}\u0969\u{1fa45}\u99cb',
+  layout: bindGroupLayout21,
+  entries: [],
+});
+let commandEncoder102 = device0.createCommandEncoder({label: '\u3773\u{1fd43}\u6987\u793c'});
+let renderBundleEncoder47 = device0.createRenderBundleEncoder({
+  label: '\u{1f718}\u4ab6\u{1ff77}\uc771\u7210\u664a\u0b51\u8a5c\u0a0f\u31d9\u2eea',
+  colorFormats: ['r32sint', 'r8sint', 'rgb10a2uint', 'rgba16sint', 'r8sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup4, new Uint32Array(9085), 6174, 0);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder15.drawIndexed(132);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(6, buffer17);
+} catch {}
+try {
+commandEncoder99.copyBufferToBuffer(buffer9, 22316, buffer2, 269516, 6060);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer2);
+} catch {}
+try {
+commandEncoder101.copyTextureToTexture({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 40, y: 3, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture60,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder101.clearBuffer(buffer10, 120420, 6688);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas14,
+  origin: { x: 45, y: 42 },
+  flipY: true,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame10 = new VideoFrame(canvas12, {timestamp: 0});
+try {
+externalTexture54.label = '\u4445\u06c5\u8b05\u{1fb02}\u07e6\u4a42\ub882\u1d9b\ub34c\u537a';
+} catch {}
+let commandEncoder103 = device0.createCommandEncoder();
+let textureView118 = texture67.createView({
+  label: '\ud7aa\u6c4c\u67d6\uf01c\u656d\uabed\u0392\u080b\u41dd',
+  mipLevelCount: 2,
+  baseArrayLayer: 218,
+  arrayLayerCount: 4,
+});
+let renderBundle69 = renderBundleEncoder40.finish({label: '\u97a8\u6750\u1799\ua1a4\u{1fec5}\u{1ffcb}\u93ad\u083d'});
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(1001);
+} catch {}
+try {
+commandEncoder103.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 36, y: 2, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 10, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer27, 32280, new BigUint64Array(13085), 2605, 1756);
+} catch {}
+try {
+device0.destroy();
+} catch {}
+offscreenCanvas7.width = 370;
+try {
+adapter2.label = '\ub31c\u0c13';
+} catch {}
+let videoFrame11 = new VideoFrame(video3, {timestamp: 0});
+let commandEncoder104 = device0.createCommandEncoder({label: '\uc069\u9a65\u0762'});
+let computePassEncoder35 = commandEncoder104.beginComputePass({label: '\u6075\u7a91\u{1fccc}\ud422\u0e00\ubf3f\u012e\u{1ffc7}\u2047'});
+try {
+renderPassEncoder44.beginOcclusionQuery(2624);
+} catch {}
+try {
+renderPassEncoder29.executeBundles([renderBundle35, renderBundle10, renderBundle64, renderBundle9, renderBundle29]);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+renderBundleEncoder15.drawIndexed(15, 216);
+} catch {}
+try {
+commandEncoder99.copyTextureToBuffer({
+  texture: texture19,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 30 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 3812 */
+  offset: 3812,
+  bytesPerRow: 256,
+  rowsPerImage: 206,
+  buffer: buffer27,
+}, {width: 30, height: 6, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer27);
+} catch {}
+try {
+computePassEncoder7.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'stencil-only',
+}, new Uint16Array(arrayBuffer3), /* required buffer size: 844 */
+{offset: 844}, {width: 20, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+let commandEncoder105 = device0.createCommandEncoder({label: '\u0644\ud849\uf5d3\ua4f3\u0ab0\uca60\u987d'});
+let renderBundleEncoder48 = device0.createRenderBundleEncoder({
+  label: '\u6c6a\u0674\u8a7e',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+try {
+computePassEncoder8.dispatchWorkgroups(3);
+} catch {}
+try {
+computePassEncoder31.setPipeline(pipeline65);
+} catch {}
+try {
+renderPassEncoder24.beginOcclusionQuery(933);
+} catch {}
+try {
+renderPassEncoder50.setScissorRect(472, 8, 102, 1);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(0, bindGroup24);
+} catch {}
+try {
+renderBundleEncoder15.drawIndexed(151, 650, 689_112_321, 267_292_040, 75_094_610);
+} catch {}
+try {
+renderBundleEncoder15.drawIndexedIndirect(buffer24, 1068);
+} catch {}
+try {
+commandEncoder105.copyBufferToBuffer(buffer21, 226856, buffer25, 21160, 2948);
+dissociateBuffer(device0, buffer21);
+dissociateBuffer(device0, buffer25);
+} catch {}
+try {
+commandEncoder101.clearBuffer(buffer10, 7012, 25364);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas16,
+  origin: { x: 30, y: 10 },
+  flipY: true,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise20;
+} catch {}
+let video8 = await videoWithData();
+let offscreenCanvas9 = new OffscreenCanvas(447, 641);
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+let imageBitmap19 = await createImageBitmap(canvas17);
+let promise27 = adapter1.requestAdapterInfo();
+let bindGroupLayout33 = device0.createBindGroupLayout({
+  label: '\u0ae4\u45d5\ueced\u8564\ufd71\u03a1\ubc3d\u8a09',
+  entries: [
+    {
+      binding: 715,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {binding: 486, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let bindGroup28 = device0.createBindGroup({
+  label: '\u0f45\u{1f72f}\u0f52\u003d\u{1fbfa}\u0f5d\u3614\ub869\u{1fb59}\u8597',
+  layout: bindGroupLayout13,
+  entries: [{binding: 982, resource: sampler48}, {binding: 87, resource: externalTexture15}],
+});
+let buffer28 = device0.createBuffer({
+  label: '\u03f2\uf8d7\u{1fced}\ufdb3\u0f87\u02d1\u6e0f\u0920\u081a\u7479\u0748',
+  size: 177188,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+try {
+computePassEncoder8.dispatchWorkgroups(3, 1, 2);
+} catch {}
+try {
+computePassEncoder16.dispatchWorkgroupsIndirect(buffer3, 924);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder37.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder26.setViewport(66.21, 0.5929, 0.03842, 0.1598, 0.7914, 0.8744);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(4, buffer17, 512, 3573);
+} catch {}
+try {
+commandEncoder105.clearBuffer(buffer16, 99688, 201508);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+renderPassEncoder40.popDebugGroup();
+} catch {}
+let gpuCanvasContext16 = offscreenCanvas9.getContext('webgpu');
+offscreenCanvas4.width = 2176;
+let offscreenCanvas10 = new OffscreenCanvas(791, 94);
+try {
+offscreenCanvas10.getContext('webgl2');
+} catch {}
+let img13 = await imageWithData(237, 42, '#872e3b9f', '#b72a25a7');
+let imageBitmap20 = await createImageBitmap(canvas3);
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let offscreenCanvas11 = new OffscreenCanvas(927, 98);
+let videoFrame12 = videoFrame8.clone();
+let gpuCanvasContext17 = offscreenCanvas11.getContext('webgpu');
+let videoFrame13 = videoFrame0.clone();
+try {
+renderBundleEncoder39.label = '\u816a\u6b9d\u0c6b\u2d7d\u0d1f\uf51a\u078e';
+} catch {}
+document.body.prepend(canvas17);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+gc();
+let imageBitmap21 = await createImageBitmap(videoFrame8);
+let imageData9 = new ImageData(180, 248);
+let imageBitmap22 = await createImageBitmap(videoFrame9);
+let imageBitmap23 = await createImageBitmap(video0);
+let videoFrame14 = new VideoFrame(imageBitmap9, {timestamp: 0});
+canvas8.height = 517;
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+try {
+  await promise27;
+} catch {}
+let offscreenCanvas12 = new OffscreenCanvas(269, 691);
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise22;
+} catch {}
+let imageData10 = new ImageData(16, 104);
+let img14 = await imageWithData(140, 183, '#9fd4f42c', '#3376369c');
+let imageBitmap24 = await createImageBitmap(imageBitmap17);
+try {
+  await promise25;
+} catch {}
+try {
+  await promise24;
+} catch {}
+try {
+offscreenCanvas12.getContext('webgpu');
+} catch {}
+document.body.prepend(canvas10);
+let imageData11 = new ImageData(36, 192);
+document.body.prepend(canvas12);
+let canvas18 = document.createElement('canvas');
+let offscreenCanvas13 = new OffscreenCanvas(751, 403);
+try {
+offscreenCanvas13.getContext('bitmaprenderer');
+} catch {}
+offscreenCanvas1.height = 82;
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let offscreenCanvas14 = new OffscreenCanvas(1023, 772);
+let video9 = await videoWithData();
+let imageBitmap25 = await createImageBitmap(imageBitmap19);
+try {
+offscreenCanvas14.getContext('2d');
+} catch {}
+document.body.prepend(canvas7);
+let offscreenCanvas15 = new OffscreenCanvas(587, 12);
+try {
+canvas18.getContext('2d');
+} catch {}
+let canvas19 = document.createElement('canvas');
+let offscreenCanvas16 = new OffscreenCanvas(607, 211);
+let img15 = await imageWithData(92, 165, '#5976c558', '#f9d2a3ea');
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+try {
+renderBundleEncoder0.label = '\u{1fed9}\u6e6d';
+} catch {}
+let canvas20 = document.createElement('canvas');
+let gpuCanvasContext18 = canvas19.getContext('webgpu');
+gc();
+try {
+canvas20.getContext('webgpu');
+} catch {}
+canvas20.height = 125;
+let imageBitmap26 = await createImageBitmap(video0);
+let videoFrame15 = new VideoFrame(img12, {timestamp: 0});
+try {
+externalTexture0.label = '\u0981\u{1fddf}\u3f02\u06ad\u9e14\u2a0d\u5aeb\u{1fbbe}\u06d6\u08c3\u{1f81f}';
+} catch {}
+document.body.prepend(img9);
+let img16 = await imageWithData(212, 101, '#7b4273f1', '#fc0f0431');
+let videoFrame16 = new VideoFrame(videoFrame14, {timestamp: 0});
+try {
+offscreenCanvas15.getContext('webgl');
+} catch {}
+gc();
+let gpuCanvasContext19 = offscreenCanvas16.getContext('webgpu');
+let video10 = await videoWithData();
+let img17 = await imageWithData(232, 164, '#c4d7e292', '#41dbcc4a');
+video0.width = 248;
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let promise28 = navigator.gpu.requestAdapter({});
+offscreenCanvas9.height = 524;
+document.body.prepend(img10);
+let videoFrame17 = new VideoFrame(canvas8, {timestamp: 0});
+let img18 = await imageWithData(243, 114, '#afd023ed', '#3a3b3f54');
+let img19 = await imageWithData(184, 194, '#41b980b9', '#34c1aa1d');
+let imageBitmap27 = await createImageBitmap(img10);
+canvas19.width = 606;
+let video11 = await videoWithData();
+document.body.prepend(video7);
+try {
+adapter1.label = '\u{1ff30}\ua968\u{1ff3d}\u5128\u{1fa8f}\u9c41\u6757\u{1f7b9}\u{1fe30}\u1a22\u375f';
+} catch {}
+let img20 = await imageWithData(198, 82, '#e8aecfb0', '#158ad6ab');
+let video12 = await videoWithData();
+try {
+bindGroup24.label = '\u7b28\u0cc5\u0b35\u9ee1\u1595';
+} catch {}
+let offscreenCanvas17 = new OffscreenCanvas(454, 369);
+let gpuCanvasContext20 = offscreenCanvas17.getContext('webgpu');
+let canvas21 = document.createElement('canvas');
+let offscreenCanvas18 = new OffscreenCanvas(734, 802);
+let canvas22 = document.createElement('canvas');
+let offscreenCanvas19 = new OffscreenCanvas(52, 384);
+let commandEncoder106 = device0.createCommandEncoder({label: '\uac02\uab40\ud5bb\udbd3'});
+let renderBundleEncoder49 = device0.createRenderBundleEncoder({
+  label: '\u0330\u019f\uede8\u0092\u0291\u{1fa27}\u71e2\u8619\u6320\u0e0f\u0fc6',
+  colorFormats: ['r32sint', 'r8sint', 'rgb10a2uint', 'rgba16sint', 'r8sint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup4, new Uint32Array(4345), 103, 0);
+} catch {}
+try {
+computePassEncoder0.end();
+} catch {}
+try {
+renderPassEncoder30.setBindGroup(1, bindGroup20, new Uint32Array(7462), 5443, 0);
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(270);
+} catch {}
+try {
+renderPassEncoder43.executeBundles([renderBundle34, renderBundle30]);
+} catch {}
+try {
+renderBundleEncoder15.drawIndexed(130, 324);
+} catch {}
+try {
+renderBundleEncoder15.drawIndexedIndirect(buffer24, 64);
+} catch {}
+try {
+renderBundleEncoder33.setPipeline(pipeline26);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let gpuCanvasContext21 = offscreenCanvas19.getContext('webgpu');
+try {
+canvas22.getContext('webgl');
+} catch {}
+let gpuCanvasContext22 = offscreenCanvas18.getContext('webgpu');
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let offscreenCanvas20 = new OffscreenCanvas(780, 973);
+let imageBitmap28 = await createImageBitmap(img12);
+let gpuCanvasContext23 = offscreenCanvas20.getContext('webgpu');
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend(video3);
+let img21 = await imageWithData(158, 263, '#9a0bd82d', '#0ff6d657');
+let buffer29 = device0.createBuffer({
+  label: '\u0737\u{1f7a0}\u{1fe05}\ua81b\u0481',
+  size: 387162,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+});
+let querySet55 = device0.createQuerySet({label: '\uc28e\u3fde\u0553\u947c\u{1f742}\u{1f78c}\ufef9\uae58', type: 'occlusion', count: 4007});
+let texture68 = device0.createTexture({
+  label: '\u9bab\u0459\u0acf\u{1f64b}\u0bea\u070a\u0156\u{1fbd3}\u0665\u6e8f\u1fb7',
+  size: [240, 48, 1],
+  mipLevelCount: 2,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView119 = texture68.createView({label: '\u{1f7d5}\ub7db', dimension: '2d-array', aspect: 'stencil-only'});
+let renderBundleEncoder50 = device0.createRenderBundleEncoder({
+  label: '\u5cf8\u082d\udae2\u506b\u041e\u0469\u{1f78c}\u30bc\u2f17\u407b',
+  colorFormats: ['rg11b10ufloat', 'rg8sint', 'r32uint', 'rgba16uint', 'r8unorm'],
+  depthStencilFormat: 'depth24plus',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder46.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+renderPassEncoder50.setBlendConstant({ r: -182.3, g: -227.9, b: 389.7, a: -539.6, });
+} catch {}
+try {
+renderPassEncoder48.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder15.draw(178, 13, 1_776_465_593, 598_210_374);
+} catch {}
+try {
+renderBundleEncoder15.drawIndexed(137, 114, 736_564_888, 422_540_805, 463_063_296);
+} catch {}
+try {
+renderBundleEncoder48.setPipeline(pipeline26);
+} catch {}
+try {
+renderPassEncoder41.pushDebugGroup('\u305b');
+} catch {}
+try {
+renderPassEncoder41.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext18.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'srgb',
+});
+} catch {}
+let pipeline79 = await device0.createComputePipelineAsync({
+  label: '\uf1f6\u{1fc14}\u{1fc20}\u7ce3\uf316\u{1f976}',
+  layout: pipelineLayout12,
+  compute: {module: shaderModule12, entryPoint: 'compute0', constants: {}},
+});
+video12.height = 152;
+let videoFrame18 = new VideoFrame(canvas12, {timestamp: 0});
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let imageData12 = new ImageData(68, 76);
+let gpuCanvasContext24 = canvas21.getContext('webgpu');
+gc();
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let textureView120 = texture17.createView({
+  label: '\ufd79\uad81\u5ee5\u0c1c\u09dd\u2536\u5886\ud8f1\u7868\u0570\u0171',
+  aspect: 'stencil-only',
+  baseMipLevel: 3,
+});
+let sampler50 = device0.createSampler({
+  label: '\u0f0c\u8da4\ud080',
+  addressModeU: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 47.94,
+  lodMaxClamp: 56.87,
+  maxAnisotropy: 11,
+});
+let externalTexture56 = device0.importExternalTexture({label: '\ud550\u65b5\uc893\u{1fb84}\u{1fb16}\uada6\ua713', source: video7, colorSpace: 'srgb'});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder50.beginOcclusionQuery(2975);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle5, renderBundle25, renderBundle21, renderBundle20]);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(1414);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline58);
+} catch {}
+try {
+renderPassEncoder39.setVertexBuffer(1, buffer12, 3312, 2902);
+} catch {}
+try {
+renderBundleEncoder45.setBindGroup(1, bindGroup13, new Uint32Array(3020), 635, 0);
+} catch {}
+try {
+renderBundleEncoder15.drawIndirect(buffer24, 556);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(7, buffer17);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer3), /* required buffer size: 685 */
+{offset: 655, bytesPerRow: 102}, {width: 30, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 125}
+*/
+{
+  source: img15,
+  origin: { x: 17, y: 122 },
+  flipY: false,
+}, {
+  texture: texture58,
+  mipLevel: 9,
+  origin: {x: 0, y: 0, z: 97},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap29 = await createImageBitmap(offscreenCanvas2);
+let device1 = await adapter2.requestDevice({
+  label: '\u{1fcb8}\u5e5c\u{1ff69}\u0ebe\uf0d9',
+  defaultQueue: {label: '\u3d33\u2c69\u5604\u07dc\u{1f863}\u{1f6d3}\uf5dd\ub9c3'},
+  requiredFeatures: [
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'bgra8unorm-storage',
+  ],
+});
+let img22 = await imageWithData(287, 105, '#daf98f62', '#433b4787');
+let buffer30 = device1.createBuffer({label: '\u00d2\u00f1\u{1f6e5}\u0bdc\u0a60\uc2c6\u4c64', size: 179534, usage: GPUBufferUsage.COPY_SRC});
+let querySet56 = device1.createQuerySet({
+  label: '\u{1f7ce}\u{1f7a9}\u{1fcd3}\u{1f868}\u54d2\u869d\u06eb\u02b7\u{1f6c8}\u0fca\u08e8',
+  type: 'occlusion',
+  count: 1498,
+});
+try {
+buffer30.destroy();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+commandEncoder86.label = '\ub51b\ua223\udae9\ucdc6\u06ac\u3f18\u547c\u01d1\u015a\u454d';
+} catch {}
+let canvas23 = document.createElement('canvas');
+let texture69 = device1.createTexture({
+  size: [960, 80, 210],
+  mipLevelCount: 10,
+  format: 'astc-5x5-unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['astc-5x5-unorm', 'astc-5x5-unorm-srgb'],
+});
+try {
+gpuCanvasContext21.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let gpuCanvasContext25 = canvas23.getContext('webgpu');
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let commandEncoder107 = device1.createCommandEncoder({label: '\u0e1b\u1cb3\u{1fdc2}\ue43e'});
+let computePassEncoder36 = commandEncoder107.beginComputePass({});
+let querySet57 = device1.createQuerySet({type: 'occlusion', count: 1102});
+let texture70 = device1.createTexture({
+  label: '\u5c7a\uce54\u08cf\u{1fa54}\u0764\u{1f89d}\u01b1\uc77f\u452a\u0f38',
+  size: {width: 366, height: 3, depthOrArrayLayers: 985},
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm-srgb'],
+});
+try {
+querySet57.destroy();
+} catch {}
+let texture71 = device1.createTexture({
+  size: [960, 80, 1],
+  mipLevelCount: 10,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg16sint', 'rg16sint', 'rg16sint'],
+});
+let textureView121 = texture69.createView({
+  label: '\ub2f3\u0e8d\u3326\u{1fa72}\u00db\u05a7\u9dd6\u03e5\u8fcd\ud6e3',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 5,
+  mipLevelCount: 1,
+  baseArrayLayer: 78,
+});
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+buffer30.destroy();
+} catch {}
+try {
+gpuCanvasContext21.unconfigure();
+} catch {}
+document.body.prepend(video9);
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+let imageBitmap30 = await createImageBitmap(imageData11);
+video5.width = 100;
+let textureView122 = texture70.createView({label: '\u{1f656}\u0270\u0f2c\uc9f4\uba8b', baseMipLevel: 8, mipLevelCount: 1});
+let renderBundleEncoder51 = device1.createRenderBundleEncoder({
+  label: '\u0e28\u0bef\u{1f6f7}\u2327',
+  colorFormats: ['rg11b10ufloat', 'rgb10a2uint', 'rgba16float', 'r8uint', 'r8uint', 'r16sint'],
+});
+try {
+renderBundleEncoder51.setVertexBuffer(9602, undefined, 3015201485, 1275059263);
+} catch {}
+try {
+buffer30.destroy();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: offscreenCanvas15,
+  origin: { x: 237, y: 1 },
+  flipY: false,
+}, {
+  texture: texture70,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame19 = new VideoFrame(videoFrame1, {timestamp: 0});
+try {
+querySet57.label = '\ua56f\u{1f9b4}\u3607';
+} catch {}
+let textureView123 = texture69.createView({mipLevelCount: 3, baseArrayLayer: 85, arrayLayerCount: 110});
+try {
+buffer30.unmap();
+} catch {}
+let buffer31 = device1.createBuffer({
+  label: '\u20db\u{1fa17}\u{1f848}\ua20e\u9de2\u0001\uc7d0',
+  size: 45360,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let renderBundle70 = renderBundleEncoder51.finish();
+let promise29 = device1.queue.onSubmittedWorkDone();
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 22, height: 1, depthOrArrayLayers: 61}
+*/
+{
+  source: img11,
+  origin: { x: 1, y: 50 },
+  flipY: false,
+}, {
+  texture: texture70,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let video13 = await videoWithData();
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let buffer32 = device1.createBuffer({
+  label: '\ubacb\u2cdd\ub22d\u{1f81f}\u06d9',
+  size: 32047,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let textureView124 = texture69.createView({
+  label: '\u785a\u378d\u09d5\u0257',
+  dimension: '2d',
+  format: 'astc-5x5-unorm-srgb',
+  baseMipLevel: 1,
+  mipLevelCount: 3,
+  baseArrayLayer: 112,
+});
+let sampler51 = device1.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 52.91,
+  lodMaxClamp: 78.72,
+});
+let externalTexture57 = device1.importExternalTexture({label: '\u{1f858}\u020c\ud76a', source: videoFrame4, colorSpace: 'display-p3'});
+let offscreenCanvas21 = new OffscreenCanvas(962, 716);
+let textureView125 = texture70.createView({
+  label: '\u2295\ucafe\u0731\u8664\u09fa\u{1f81b}\u03a0\u0e25\u4d4d\u6042',
+  baseMipLevel: 5,
+  mipLevelCount: 3,
+});
+let sampler52 = device1.createSampler({
+  label: '\ue631\u483c\u7015\u2605\u0274\u7352\uc775',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 1.653,
+  lodMaxClamp: 49.80,
+  maxAnisotropy: 8,
+});
+try {
+device1.queue.writeTexture({
+  texture: texture70,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(56)), /* required buffer size: 594_805 */
+{offset: 805, bytesPerRow: 99, rowsPerImage: 300}, {width: 3, height: 0, depthOrArrayLayers: 21});
+} catch {}
+let gpuCanvasContext26 = offscreenCanvas21.getContext('webgpu');
+let video14 = await videoWithData();
+let offscreenCanvas22 = new OffscreenCanvas(213, 168);
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+canvas21.height = 411;
+let gpuCanvasContext27 = offscreenCanvas22.getContext('webgpu');
+try {
+  await promise29;
+} catch {}
+let offscreenCanvas23 = new OffscreenCanvas(708, 63);
+let commandEncoder108 = device1.createCommandEncoder({label: '\ud6ec\u0687'});
+let textureView126 = texture70.createView({label: '\u88d2\u0202', format: 'bgra8unorm-srgb', baseMipLevel: 2});
+let renderBundleEncoder52 = device1.createRenderBundleEncoder({
+  label: '\u{1ff40}\u0fb3\u3c10\ude8b\u0ebf',
+  colorFormats: ['rg11b10ufloat', 'rgb10a2uint', 'rgba16float', 'r8uint', 'r8uint', 'r16sint'],
+  depthReadOnly: true,
+});
+let sampler53 = device1.createSampler({
+  label: '\u9254\u{1fe88}\uf95a\ue410',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 78.73,
+  lodMaxClamp: 82.13,
+  maxAnisotropy: 1,
+});
+try {
+gpuCanvasContext23.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm'],
+});
+} catch {}
+let commandEncoder109 = device1.createCommandEncoder({label: '\uf85c\u0eb6\uaed7\u1234'});
+let computePassEncoder37 = commandEncoder108.beginComputePass({label: '\u29ec\u6573\u94d2\u8cbf\u5c25\u7599\u3e18'});
+let externalTexture58 = device1.importExternalTexture({label: '\u673a\uc31c\u3072\udccc\u{1ff07}\u4a15', source: video11});
+let texture72 = device1.createTexture({
+  size: [128],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView127 = texture70.createView({
+  label: '\u{1fea3}\ud5b0\u{1f61b}\u72be\ud508\u516a\u0019',
+  format: 'bgra8unorm-srgb',
+  baseMipLevel: 4,
+  mipLevelCount: 2,
+});
+try {
+  await buffer31.mapAsync(GPUMapMode.WRITE, 27088, 4744);
+} catch {}
+try {
+commandEncoder109.copyTextureToTexture({
+  texture: texture70,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture70,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder109.insertDebugMarker('\u{1fada}');
+} catch {}
+let video15 = await videoWithData();
+try {
+offscreenCanvas23.getContext('bitmaprenderer');
+} catch {}
+let textureView128 = texture71.createView({baseMipLevel: 2, mipLevelCount: 2});
+try {
+renderBundleEncoder52.setVertexBuffer(4600, undefined);
+} catch {}
+let video16 = await videoWithData();
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+canvas21.width = 400;
+try {
+adapter0.label = '\u0913\u0fdf\u0b5a\u0603\u{1f6fc}';
+} catch {}
+let commandEncoder110 = device1.createCommandEncoder({});
+let renderBundleEncoder53 = device1.createRenderBundleEncoder({
+  label: '\u{1fce6}\ua46d\ubfbc\u0f71\ue4aa\ubc84\u0dcb',
+  colorFormats: ['rg11b10ufloat', 'rgb10a2uint', 'rgba16float', 'r8uint', 'r8uint', 'r16sint'],
+});
+try {
+renderBundleEncoder53.insertDebugMarker('\ub76f');
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 11, height: 1, depthOrArrayLayers: 30}
+*/
+{
+  source: imageBitmap17,
+  origin: { x: 28, y: 7 },
+  flipY: true,
+}, {
+  texture: texture70,
+  mipLevel: 5,
+  origin: {x: 1, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap31 = await createImageBitmap(video2);
+document.body.prepend(canvas5);
+let offscreenCanvas24 = new OffscreenCanvas(315, 321);
+let externalTexture59 = device1.importExternalTexture({label: '\ubca5\ud0a2', source: video1});
+try {
+  await device1.popErrorScope();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int32Array(new ArrayBuffer(32)), /* required buffer size: 717 */
+{offset: 365}, {width: 88, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let promise30 = adapter2.requestAdapterInfo();
+video0.height = 163;
+try {
+offscreenCanvas24.getContext('2d');
+} catch {}
+let querySet58 = device1.createQuerySet({
+  label: '\u{1fa06}\u0dd5\u0e30\udfa1\u{1fa26}\u1e7a\u{1f85f}\u{1f8d1}\u38d2\uec03',
+  type: 'occlusion',
+  count: 418,
+});
+let renderBundle71 = renderBundleEncoder51.finish();
+let externalTexture60 = device1.importExternalTexture({source: video15, colorSpace: 'srgb'});
+let textureView129 = texture69.createView({label: '\u5e9e\uc783', baseMipLevel: 9, baseArrayLayer: 151, arrayLayerCount: 8});
+let renderBundleEncoder54 = device1.createRenderBundleEncoder({
+  label: '\u05da\u6ee9\u{1fd7c}\u0689\u6aa5\u09fa\u0de2\u91b6',
+  colorFormats: ['rg11b10ufloat', 'rgb10a2uint', 'rgba16float', 'r8uint', 'r8uint', 'r16sint'],
+});
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise30;
+} catch {}
+let commandEncoder111 = device1.createCommandEncoder();
+let textureView130 = texture72.createView({label: '\u{1fd4b}\uae3d\u9c42\uec25\uf95a'});
+let renderBundleEncoder55 = device1.createRenderBundleEncoder({
+  label: '\uf0c9\u{1f72b}\u7589\u06b0\u0d06\u0039\uf908\ua88b\u9ec8\u086b',
+  colorFormats: ['rg11b10ufloat', 'rgb10a2uint', 'rgba16float', 'r8uint', 'r8uint', 'r16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture61 = device1.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+let computePassEncoder38 = commandEncoder110.beginComputePass({label: '\u0e3d\u{1f98c}\uf25c\u06b4\u{1f891}\u4348\u{1feeb}\u{1fe58}\uab09\u033d'});
+let sampler54 = device1.createSampler({
+  label: '\u{1fff6}\u3500\u{1fd13}\u417f\u0399\u5ae7\u2318\u9730',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 84.46,
+  maxAnisotropy: 14,
+});
+try {
+gpuCanvasContext26.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder112 = device1.createCommandEncoder();
+let querySet59 = device1.createQuerySet({type: 'occlusion', count: 3439});
+let texture73 = device1.createTexture({
+  size: {width: 128},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg11b10ufloat', 'rg11b10ufloat'],
+});
+let renderBundleEncoder56 = device1.createRenderBundleEncoder({
+  label: '\u077f\u02cc\uaf2d\u0014\u7f3c\u04a0\ub98a\u{1f9d5}\u{1fde3}',
+  colorFormats: ['rg11b10ufloat', 'rgb10a2uint', 'rgba16float', 'r8uint', 'r8uint', 'r16sint'],
+  depthReadOnly: true,
+});
+let renderBundle72 = renderBundleEncoder55.finish();
+let externalTexture62 = device1.importExternalTexture({source: video12, colorSpace: 'display-p3'});
+let arrayBuffer7 = buffer31.getMappedRange(27088, 4216);
+try {
+buffer30.unmap();
+} catch {}
+try {
+renderBundleEncoder54.insertDebugMarker('\u{1f9af}');
+} catch {}
+let offscreenCanvas25 = new OffscreenCanvas(89, 572);
+let textureView131 = texture73.createView({label: '\u{1f85a}\u68e4\u0f86\u06ab\u73ba\u0bc5\u79f0', aspect: 'all'});
+let renderBundleEncoder57 = device1.createRenderBundleEncoder({
+  colorFormats: ['rg11b10ufloat', 'rgb10a2uint', 'rgba16float', 'r8uint', 'r8uint', 'r16sint'],
+  depthReadOnly: false,
+});
+try {
+renderBundleEncoder56.setVertexBuffer(4239, undefined, 4115781261);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+buffer32.destroy();
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+try {
+device1.label = '\u80a9\u4aab\uac17\u09d4\u1dd5\ubba6\u8be9\u74b2\u0cfe\u{1fcd2}\u0c0d';
+} catch {}
+let commandEncoder113 = device1.createCommandEncoder({label: '\u0daf\ue623\u0935'});
+try {
+device1.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder113.copyBufferToTexture({
+  /* bytesInLastRow: 360 widthInBlocks: 90 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 15652 */
+  offset: 15652,
+  buffer: buffer30,
+}, {
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 90, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+commandEncoder112.pushDebugGroup('\u0ec2');
+} catch {}
+try {
+commandEncoder112.popDebugGroup();
+} catch {}
+let img23 = await imageWithData(188, 295, '#7ef66ba9', '#8607cc94');
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let texture74 = device1.createTexture({
+  label: '\u{1fbf2}\u{1f640}\u7383',
+  size: {width: 120, height: 10, depthOrArrayLayers: 51},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r8uint', 'r8uint', 'r8uint'],
+});
+let computePassEncoder39 = commandEncoder109.beginComputePass({label: '\u9cbf\u{1f706}\ua356\u016e'});
+let renderBundleEncoder58 = device1.createRenderBundleEncoder({
+  label: '\u0d44\ud47a\u8f93\u{1fe20}\ude8d\ube71\u{1f8b2}\ub0c3',
+  colorFormats: ['rg11b10ufloat', 'rgb10a2uint', 'rgba16float', 'r8uint', 'r8uint', 'r16sint'],
+  depthReadOnly: true,
+});
+let renderBundle73 = renderBundleEncoder51.finish({label: '\u{1f965}\u8cbb\ua282\u{1fec5}'});
+try {
+renderBundleEncoder58.setVertexBuffer(3966, undefined, 0, 4190280765);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let imageData13 = new ImageData(228, 52);
+let buffer33 = device1.createBuffer({
+  label: '\ue594\u01b8\u0b27\u0b3f\u3add\u43fb\uf6e1\u046c',
+  size: 226087,
+  usage: GPUBufferUsage.STORAGE,
+});
+let querySet60 = device1.createQuerySet({label: '\ud34e\u077d\u0d6f', type: 'occlusion', count: 2697});
+let sampler55 = device1.createSampler({
+  label: '\uf824\u01aa\u59f0\uc76d\u{1f6a3}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.00,
+  maxAnisotropy: 3,
+});
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 366, height: 3, depthOrArrayLayers: 985}
+*/
+{
+  source: imageBitmap19,
+  origin: { x: 6, y: 6 },
+  flipY: false,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 218},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let imageBitmap32 = await createImageBitmap(imageBitmap30);
+let querySet61 = device1.createQuerySet({
+  label: '\u6d24\u094b\uffd2\u{1fdbf}\ucc74\u0d8a\uc525\u0281\u01d7\u0ce1\ud582',
+  type: 'occlusion',
+  count: 2123,
+});
+let textureView132 = texture69.createView({dimension: '2d', baseMipLevel: 5, mipLevelCount: 2, baseArrayLayer: 64});
+let computePassEncoder40 = commandEncoder112.beginComputePass({label: '\u{1fd58}\u0deb\u{1f814}\ud972'});
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let querySet62 = device1.createQuerySet({label: '\u0ba7\u{1fd5a}\u03eb\u{1fb0b}', type: 'occlusion', count: 2184});
+let commandBuffer22 = commandEncoder113.finish({label: '\ucf6a\ud633\ue888\u1170\u02af\u{1f936}\u0be5\u048d\u{1f8aa}\u{1fdfc}'});
+let textureView133 = texture70.createView({format: 'bgra8unorm-srgb', baseMipLevel: 6, baseArrayLayer: 0, arrayLayerCount: 1});
+let computePassEncoder41 = commandEncoder111.beginComputePass({label: '\u0a0c\u6cb3\ud168\u036f\u5783\u6b08\uf065\u2231\u0ca5\u2854\u0dce'});
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: video2,
+  origin: { x: 0, y: 4 },
+  flipY: false,
+}, {
+  texture: texture70,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+try {
+offscreenCanvas25.getContext('2d');
+} catch {}
+let texture75 = device1.createTexture({
+  size: [260, 1, 593],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView134 = texture70.createView({
+  label: '\u88b5\u0c71\u6b38',
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+});
+let renderBundle74 = renderBundleEncoder51.finish({});
+let externalTexture63 = device1.importExternalTexture({source: videoFrame17, colorSpace: 'srgb'});
+try {
+buffer32.unmap();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture70,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 7},
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 998_674 */
+{offset: 274, bytesPerRow: 325, rowsPerImage: 192}, {width: 8, height: 0, depthOrArrayLayers: 17});
+} catch {}
+try {
+gpuCanvasContext26.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder114 = device1.createCommandEncoder({label: '\u8a04\u01fe\u814c'});
+let textureView135 = texture73.createView({label: '\u{1fe5f}\u0b1b\u{1f793}\ue6cb\u5472\u{1fbdf}\uacc5\u8a9f\udb44', dimension: '1d'});
+let computePassEncoder42 = commandEncoder114.beginComputePass();
+let renderBundleEncoder59 = device1.createRenderBundleEncoder({
+  label: '\ub516\u0279',
+  colorFormats: ['rg11b10ufloat', 'rgb10a2uint', 'rgba16float', 'r8uint', 'r8uint', 'r16sint'],
+  stencilReadOnly: true,
+});
+let renderBundle75 = renderBundleEncoder51.finish({label: '\u0cf1\udfe3'});
+try {
+computePassEncoder38.end();
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+renderBundleEncoder58.insertDebugMarker('\u{1fe4b}');
+} catch {}
+try {
+gpuCanvasContext17.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+});
+} catch {}
+let video17 = await videoWithData();
+let commandEncoder115 = device1.createCommandEncoder({label: '\u0047\u929b\u566e\u0c59\u{1f639}\u4a89\u086a\uf647\u41ba\u592f\u{1f98f}'});
+let textureView136 = texture69.createView({
+  label: '\u0b35\u554a\u{1ffd2}\u9187\u333b\u{1fff4}',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 9,
+  baseArrayLayer: 70,
+});
+let computePassEncoder43 = commandEncoder110.beginComputePass({label: '\ud215\u08c1\u{1fb9c}\u{1f863}'});
+let querySet63 = device1.createQuerySet({label: '\u56cf\ua761\u{1fd1e}\u1e4b\u9c45\u0bd3\u039b', type: 'occlusion', count: 1164});
+try {
+renderBundleEncoder56.setVertexBuffer(9739, undefined, 0, 1943470786);
+} catch {}
+try {
+commandEncoder115.copyBufferToTexture({
+  /* bytesInLastRow: 144 widthInBlocks: 36 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4940 */
+  offset: 4796,
+  rowsPerImage: 107,
+  buffer: buffer32,
+}, {
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 36, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 11, height: 1, depthOrArrayLayers: 30}
+*/
+{
+  source: offscreenCanvas17,
+  origin: { x: 7, y: 104 },
+  flipY: false,
+}, {
+  texture: texture70,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 16},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame20 = new VideoFrame(imageBitmap24, {timestamp: 0});
+let offscreenCanvas26 = new OffscreenCanvas(565, 903);
+let videoFrame21 = new VideoFrame(videoFrame17, {timestamp: 0});
+let imageData14 = new ImageData(248, 224);
+let commandBuffer23 = commandEncoder115.finish({});
+let texture76 = device1.createTexture({
+  size: {width: 960, height: 80, depthOrArrayLayers: 1},
+  mipLevelCount: 10,
+  format: 'astc-10x8-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let renderBundleEncoder60 = device1.createRenderBundleEncoder({
+  label: '\u065a\u0fe1\u6c0d\u41fd\u69db\ue648',
+  colorFormats: ['rg11b10ufloat', 'rgb10a2uint', 'rgba16float', 'r8uint', 'r8uint', 'r16sint'],
+  stencilReadOnly: false,
+});
+try {
+renderBundleEncoder60.setVertexBuffer(7979, undefined, 0, 334367341);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 45, height: 1, depthOrArrayLayers: 123}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 14, y: 58 },
+  flipY: false,
+}, {
+  texture: texture70,
+  mipLevel: 3,
+  origin: {x: 20, y: 0, z: 26},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundleEncoder61 = device1.createRenderBundleEncoder({
+  label: '\ueaf5\u8fac\u6317\u0599',
+  colorFormats: ['rg11b10ufloat', 'rgb10a2uint', 'rgba16float', 'r8uint', 'r8uint', 'r16sint'],
+});
+let sampler56 = device1.createSampler({
+  label: '\uf33b\u0438\u{1f876}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.69,
+  compare: 'not-equal',
+  maxAnisotropy: 6,
+});
+let textureView137 = texture70.createView({label: '\u5705\u{1f970}\u0391\u448c\u{1f681}\u{1f960}', baseMipLevel: 7});
+let renderBundleEncoder62 = device1.createRenderBundleEncoder({
+  label: '\u{1f7ac}\u{1fad2}\u{1ffc5}\u0a78',
+  colorFormats: ['rg11b10ufloat', 'rgb10a2uint', 'rgba16float', 'r8uint', 'r8uint', 'r16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle76 = renderBundleEncoder61.finish({label: '\u905a\u92df\ud2ce\uc946\u{1fd48}\u0fb1\u4c0d\u0765\u0488'});
+let renderBundle77 = renderBundleEncoder60.finish();
+let promise31 = device1.popErrorScope();
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 91, height: 1, depthOrArrayLayers: 246}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 136, y: 28 },
+  flipY: false,
+}, {
+  texture: texture70,
+  mipLevel: 2,
+  origin: {x: 7, y: 0, z: 87},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 39, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img15);
+let offscreenCanvas27 = new OffscreenCanvas(634, 371);
+try {
+  await promise31;
+} catch {}
+let buffer34 = device1.createBuffer({
+  label: '\u8253\u9698\u0504\u0288\u05ff\u0070\u0e10',
+  size: 388,
+  usage: GPUBufferUsage.INDIRECT,
+  mappedAtCreation: false,
+});
+let commandEncoder116 = device1.createCommandEncoder({label: '\u0d12\u052f\uac89\u8c62\ue029\u330f\u0bcf'});
+try {
+commandEncoder116.copyBufferToTexture({
+  /* bytesInLastRow: 184 widthInBlocks: 46 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8648 */
+  offset: 8648,
+  bytesPerRow: 512,
+  buffer: buffer32,
+}, {
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 46, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture71,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(new ArrayBuffer(8)), /* required buffer size: 271 */
+{offset: 271}, {width: 58, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas28 = new OffscreenCanvas(733, 958);
+let sampler57 = device1.createSampler({
+  label: '\u5a77\u{1f95a}\u3118\u{1ff62}\u05c2\u3853\u7d8e\u01cc\u8aec\uac1e',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 63.69,
+  lodMaxClamp: 64.42,
+  maxAnisotropy: 10,
+});
+try {
+device1.queue.writeTexture({
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 470, y: 24, z: 0},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 1_579 */
+{offset: 555, bytesPerRow: 624}, {width: 250, height: 16, depthOrArrayLayers: 1});
+} catch {}
+offscreenCanvas8.height = 1428;
+let imageData15 = new ImageData(112, 4);
+let commandBuffer24 = commandEncoder116.finish({label: '\u0ae6\ub7db\u0098\u{1fd6c}\u4702\uc458\u03cf\u{1fdd3}\u93d8\u0396'});
+let texture77 = device1.createTexture({
+  label: '\u{1ff7f}\u7730\u2d15',
+  size: [1467, 12, 58],
+  mipLevelCount: 7,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+});
+let renderBundle78 = renderBundleEncoder53.finish({label: '\u{1ff98}\u902a\ubc1a\u6741\u7676\u0f50\u0846\u1ffa'});
+try {
+renderBundleEncoder62.setVertexBuffer(437, undefined);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+let arrayBuffer8 = buffer31.getMappedRange(31304, 156);
+let offscreenCanvas29 = new OffscreenCanvas(965, 831);
+let video18 = await videoWithData();
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+gc();
+let querySet64 = device1.createQuerySet({label: '\u7c80\u{1ff8f}\ubdeb\u{1f9d0}\uc375\u{1fe67}', type: 'occlusion', count: 2997});
+let texture78 = device1.createTexture({
+  label: '\u{1fcca}\u{1fbcc}',
+  size: {width: 480, height: 40, depthOrArrayLayers: 206},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint', 'rgb10a2uint'],
+});
+offscreenCanvas19.height = 2280;
+let renderBundle79 = renderBundleEncoder54.finish({label: '\uef60\u0056\u54b4\u{1fced}\u17be\u08a9\u0b62\ub608\u5828\u3a17\u0af3'});
+let sampler58 = device1.createSampler({
+  label: '\u0a77\u58d0\u0d4e\ucb8e\ud989\u0c25\u05c2\u0427\u{1f99a}\u8cc3\u50b0',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 95.98,
+  lodMaxClamp: 99.46,
+  maxAnisotropy: 18,
+});
+try {
+renderBundleEncoder62.setVertexBuffer(3315, undefined, 2133500753);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm', 'rgba8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: imageData5,
+  origin: { x: 0, y: 44 },
+  flipY: false,
+}, {
+  texture: texture70,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let sampler59 = device1.createSampler({
+  label: '\uc1a8\u0ede\u{1f6b1}\ua9b7\u0c58\u648c\u5af5\u0cb5\u36ce\u190a',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 51.77,
+  lodMaxClamp: 99.55,
+});
+let externalTexture64 = device1.importExternalTexture({
+  label: '\uaa74\u0d0d\u723f\u1e8c\u{1fe52}\u{1f817}\u{1fba9}\u0192',
+  source: videoFrame9,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder41.end();
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let canvas24 = document.createElement('canvas');
+let texture79 = device1.createTexture({
+  label: '\u503e\ue0c7\uf73e\u016e\u{1f90a}\ud1a6',
+  size: {width: 64},
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8uint'],
+});
+let renderBundle80 = renderBundleEncoder57.finish();
+try {
+renderBundleEncoder56.setVertexBuffer(3039, undefined, 0);
+} catch {}
+video2.height = 69;
+video18.height = 28;
+let bindGroupLayout34 = device1.createBindGroupLayout({
+  label: '\uccc7\ud1d9\uba62\u{1fbf6}\u{1f6c1}',
+  entries: [{binding: 714, visibility: GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let bindGroup29 = device1.createBindGroup({
+  label: '\u{1fe91}\u703c',
+  layout: bindGroupLayout34,
+  entries: [{binding: 714, resource: externalTexture62}],
+});
+let pipelineLayout13 = device1.createPipelineLayout({bindGroupLayouts: [bindGroupLayout34, bindGroupLayout34, bindGroupLayout34]});
+let commandEncoder117 = device1.createCommandEncoder({});
+let texture80 = device1.createTexture({
+  size: {width: 260, height: 1, depthOrArrayLayers: 764},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16sint', 'r16sint'],
+});
+let sampler60 = device1.createSampler({
+  label: '\u3950\u{1f657}\u0427\u6f11\u978f\u{1fa11}\u050f\ua3c1\u8637\u95fa',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 31.64,
+  compare: 'greater',
+});
+try {
+commandEncoder117.copyTextureToTexture({
+  texture: texture80,
+  mipLevel: 1,
+  origin: {x: 23, y: 0, z: 62},
+  aspect: 'all',
+},
+{
+  texture: texture80,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 26, height: 0, depthOrArrayLayers: 4});
+} catch {}
+let bindGroupLayout35 = device1.createBindGroupLayout({
+  label: '\u{1f785}\u04f3\u1bac\u{1fcd7}\u7609\u{1fabe}\u{1fb5c}\u69b7\u{1fe90}\u2b67',
+  entries: [
+    {
+      binding: 198,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+let querySet65 = device1.createQuerySet({
+  label: '\u0bcd\u614b\u087a\u064a\ue18c\ub85d\u7b9a\u{1fa8b}\u03dd\u273e',
+  type: 'occlusion',
+  count: 3852,
+});
+let textureView138 = texture76.createView({label: '\u48c9\ub38f\u0205\ud296\u4cb9\ub818\u{1ff56}\u{1f99d}', baseMipLevel: 8});
+try {
+renderBundleEncoder56.setVertexBuffer(6538, undefined, 1204638182, 1245448131);
+} catch {}
+try {
+buffer32.unmap();
+} catch {}
+try {
+commandEncoder111.copyBufferToTexture({
+  /* bytesInLastRow: 136 widthInBlocks: 34 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1172 */
+  offset: 1036,
+  buffer: buffer32,
+}, {
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 34, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture71,
+  mipLevel: 5,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 137 */
+{offset: 137}, {width: 15, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle81 = renderBundleEncoder59.finish();
+let shaderModule16 = device1.createShaderModule({
+  label: '\ud404\u0748\u059b\u{1f64f}\u19c0\u{1f7fe}\u0fb3\u7c04\uda5b\u8321\u450e',
+  code: `@group(2) @binding(714)
+var<storage, read_write> field5: array<u32>;
+@group(0) @binding(714)
+var<storage, read_write> global3: array<u32>;
+@group(1) @binding(714)
+var<storage, read_write> field6: array<u32>;
+
+@compute @workgroup_size(2, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: u32,
+  @location(1) f1: vec4<u32>,
+  @location(5) f2: vec3<i32>,
+  @location(3) f3: u32,
+  @location(2) f4: vec4<f32>,
+  @location(0) f5: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(15) a0: vec4<i32>, @location(8) a1: f16, @location(3) a2: vec3<u32>, @location(4) a3: f16, @location(12) a4: vec3<i32>, @location(11) a5: vec2<f16>, @location(2) a6: vec2<u32>, @location(6) a7: vec3<f16>, @location(0) a8: i32, @location(5) a9: u32, @location(1) a10: vec2<u32>, @location(9) a11: vec4<i32>, @location(10) a12: f32, @location(14) a13: u32, @location(7) a14: vec2<f16>, @location(13) a15: vec2<f16>, @builtin(front_facing) a16: bool, @builtin(position) a17: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S12 {
+  @location(5) f0: vec4<f16>,
+  @location(4) f1: vec2<f16>,
+  @location(3) f2: vec2<f16>
+}
+struct VertexOutput0 {
+  @builtin(position) f107: vec4<f32>,
+  @location(12) f108: vec3<i32>,
+  @location(7) f109: vec2<f16>,
+  @location(10) f110: f32,
+  @location(4) f111: f16,
+  @location(9) f112: vec4<i32>,
+  @location(8) f113: f16,
+  @location(13) f114: vec2<f16>,
+  @location(5) f115: u32,
+  @location(15) f116: vec4<i32>,
+  @location(6) f117: vec3<f16>,
+  @location(3) f118: vec3<u32>,
+  @location(11) f119: vec2<f16>,
+  @location(2) f120: vec2<u32>,
+  @location(14) f121: u32,
+  @location(1) f122: vec2<u32>,
+  @location(0) f123: i32
+}
+
+@vertex
+fn vertex0(@location(7) a0: u32, @location(15) a1: f32, @location(9) a2: vec4<f16>, @location(14) a3: i32, @location(10) a4: f32, @location(12) a5: vec4<f32>, @location(2) a6: i32, @location(1) a7: u32, @builtin(vertex_index) a8: u32, @builtin(instance_index) a9: u32, @location(11) a10: vec2<f32>, @location(13) a11: vec2<u32>, @location(0) a12: vec4<u32>, @location(8) a13: i32, @location(6) a14: vec3<f16>, a15: S12) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer35 = device1.createBuffer({
+  label: '\u0e7e\u05ca\u70aa\u{1ff9f}\u9122\u{1f686}\ud625\u0d39',
+  size: 292010,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT,
+  mappedAtCreation: false,
+});
+let computePassEncoder44 = commandEncoder117.beginComputePass({label: '\u{1fb5a}\u06cb\u0bf2\u09ad\ucecf\u57f8\u{1fa14}\u4be3\u8524'});
+let sampler61 = device1.createSampler({
+  label: '\ua809\u{1f783}\u23ba\u{1faf4}\u452b\u056d\u6df0',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 6.091,
+  lodMaxClamp: 54.75,
+  compare: 'never',
+});
+let externalTexture65 = device1.importExternalTexture({
+  label: '\uf84f\u110f\u074e\u{1fd12}\u0383\u0872\u9ca2\u2796\ud3b2\u0c51',
+  source: video16,
+  colorSpace: 'display-p3',
+});
+try {
+commandEncoder111.copyTextureToBuffer({
+  texture: texture70,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5680 */
+  offset: 5672,
+  rowsPerImage: 252,
+  buffer: buffer35,
+}, {width: 2, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer35, 26712, new DataView(new ArrayBuffer(15776)), 10140, 520);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer6), /* required buffer size: 629 */
+{offset: 629, bytesPerRow: 101}, {width: 21, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: imageBitmap7,
+  origin: { x: 0, y: 86 },
+  flipY: true,
+}, {
+  texture: texture70,
+  mipLevel: 7,
+  origin: {x: 0, y: 1, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline80 = device1.createComputePipeline({
+  label: '\u08ea\ub8a3\u2010\uf38e\u5511\uaaba\u{1fe08}\ub7e3\u{1fbee}\u59d1\u2d53',
+  layout: pipelineLayout13,
+  compute: {module: shaderModule16, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let imageData16 = new ImageData(236, 96);
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let videoFrame22 = new VideoFrame(imageBitmap9, {timestamp: 0});
+try {
+offscreenCanvas29.getContext('2d');
+} catch {}
+let bindGroup30 = device1.createBindGroup({
+  label: '\u04a3\ufff5\u0c96\ud5c7\u310b\u7bad\uaf4d\uda5e\u0167\ud4c0\u0aa6',
+  layout: bindGroupLayout34,
+  entries: [{binding: 714, resource: externalTexture61}],
+});
+let textureView139 = texture78.createView({baseMipLevel: 2});
+let computePassEncoder45 = commandEncoder111.beginComputePass();
+let sampler62 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 28.88,
+  lodMaxClamp: 97.29,
+});
+try {
+computePassEncoder40.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+computePassEncoder37.end();
+} catch {}
+try {
+computePassEncoder43.setPipeline(pipeline80);
+} catch {}
+try {
+renderBundleEncoder52.setBindGroup(0, bindGroup29, new Uint32Array(9555), 7772, 0);
+} catch {}
+try {
+commandEncoder108.copyBufferToBuffer(buffer32, 12148, buffer35, 290208, 992);
+dissociateBuffer(device1, buffer32);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+computePassEncoder44.insertDebugMarker('\u94bf');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer35, 115628, new Float32Array(1452), 1392, 4);
+} catch {}
+let canvas25 = document.createElement('canvas');
+let video19 = await videoWithData();
+let querySet66 = device1.createQuerySet({label: '\u{1fb8d}\u0f77\ud51d\ue0f3\u0378\u{1f69b}', type: 'occlusion', count: 174});
+let texture81 = device1.createTexture({
+  label: '\u93f9\u{1ff80}\u0857\u38f3\uc3f1\u{1fa55}',
+  size: {width: 480, height: 40, depthOrArrayLayers: 206},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg11b10ufloat'],
+});
+let computePassEncoder46 = commandEncoder108.beginComputePass({label: '\ufbea\uf090\uebdd\u0ebc\uc591\ud4b5\u0724\u5a5f\u15e5\u674c\uec00'});
+let renderBundle82 = renderBundleEncoder55.finish({label: '\u0411\u{1fb69}\u085e\u{1feb8}\u49b0\u9618\u84e9\u{1fc96}'});
+let sampler63 = device1.createSampler({
+  label: '\u{1fd95}\u00b4\u{1ff53}\u4701\u0396\u0e07\u{1fc97}\u0abd\ua1e3\u06c4',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 46.00,
+  lodMaxClamp: 92.68,
+});
+try {
+computePassEncoder42.setBindGroup(3, bindGroup29, new Uint32Array(1996), 1122, 0);
+} catch {}
+try {
+renderBundleEncoder52.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+canvas24.getContext('webgl2');
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let imageBitmap33 = await createImageBitmap(videoFrame12);
+try {
+adapter0.label = '\u6e8d\u24ae\u{1f828}\u0581\u{1fc1f}\u{1f9c3}\u8893';
+} catch {}
+let textureView140 = texture71.createView({
+  label: '\u{1f8ff}\u{1f770}\u2cb8\u5402\uce14\u{1fc71}\u0cd3\u524f',
+  aspect: 'all',
+  baseMipLevel: 6,
+  mipLevelCount: 1,
+});
+try {
+renderBundleEncoder52.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+computePassEncoder39.insertDebugMarker('\ue486');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 936 */
+{offset: 936, rowsPerImage: 44}, {width: 28, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let shaderModule17 = device1.createShaderModule({
+  label: '\u6f22\u1881\ua4ef\uad8e\u8bab\u{1f6f2}\u034a\u00e6\u237e\uc59a',
+  code: `@group(2) @binding(714)
+var<storage, read_write> function4: array<u32>;
+@group(0) @binding(714)
+var<storage, read_write> parameter4: array<u32>;
+@group(1) @binding(714)
+var<storage, read_write> field7: array<u32>;
+
+@compute @workgroup_size(4, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec4<u32>,
+  @location(3) f1: vec3<u32>,
+  @location(1) f2: vec4<u32>,
+  @location(0) f3: vec4<f32>,
+  @location(2) f4: vec4<f32>,
+  @location(5) f5: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(front_facing) a1: bool, @builtin(sample_index) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(13) a0: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup31 = device1.createBindGroup({layout: bindGroupLayout34, entries: [{binding: 714, resource: externalTexture58}]});
+let textureView141 = texture75.createView({label: '\u{1f957}\ue5d2\u{1fd1f}\u08b2\u{1ff03}\u03c1\ue7b8\u0721\u050d\u0939'});
+let renderBundle83 = renderBundleEncoder51.finish({label: '\u{1f7f4}\u{1fe8c}\u{1fb0b}\ue5dd\u0728\u0c47\u0072\u9b34\uc29b\ufa91'});
+let sampler64 = device1.createSampler({
+  label: '\u{1f9f8}\u3818\ua185\u03e9\u2394\u0cd2',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 75.68,
+  lodMaxClamp: 87.55,
+});
+try {
+computePassEncoder46.setPipeline(pipeline80);
+} catch {}
+try {
+computePassEncoder46.pushDebugGroup('\u00c1');
+} catch {}
+gc();
+let videoFrame23 = new VideoFrame(offscreenCanvas7, {timestamp: 0});
+try {
+adapter2.label = '\u07f0\u0d0e\u566b\ud0c8';
+} catch {}
+let commandEncoder118 = device1.createCommandEncoder({label: '\u{1ffbc}\u{1f96e}'});
+let textureView142 = texture77.createView({dimension: '2d-array', baseMipLevel: 3, mipLevelCount: 2, baseArrayLayer: 22, arrayLayerCount: 24});
+let renderBundleEncoder63 = device1.createRenderBundleEncoder({
+  label: '\ue281\u08e4\u0149\u0a58\u6fb3\u0c65',
+  colorFormats: ['rg11b10ufloat', 'rgb10a2uint', 'rgba16float', 'r8uint', 'r8uint', 'r16sint'],
+  stencilReadOnly: true,
+});
+let renderBundle84 = renderBundleEncoder55.finish({label: '\u2961\ucc10\ue7ce\uc853'});
+let externalTexture66 = device1.importExternalTexture({label: '\u4239\ubb76\u3a9d\u{1fb7f}\u{1fdd4}\u0969', source: video2, colorSpace: 'display-p3'});
+try {
+commandEncoder118.copyBufferToBuffer(buffer31, 26824, buffer35, 26276, 3700);
+dissociateBuffer(device1, buffer31);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+commandEncoder118.copyTextureToTexture({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture81,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 3},
+  aspect: 'all',
+},
+{width: 79, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder44.insertDebugMarker('\u04c3');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 536 */
+{offset: 536, bytesPerRow: 350}, {width: 85, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule18 = device1.createShaderModule({
+  label: '\u9e04\u{1fc0c}\u{1f807}\u92a0\ue00c\u0f5c\u494c\ufb59\u0476\u0bd7\u4c6e',
+  code: `@group(0) @binding(714)
+var<storage, read_write> function5: array<u32>;
+
+@compute @workgroup_size(7, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(4) f1: u32,
+  @location(5) f2: vec4<i32>,
+  @location(3) f3: vec2<u32>,
+  @location(1) f4: vec4<u32>,
+  @builtin(sample_mask) f5: u32,
+  @location(2) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(7) a0: vec4<f16>, @location(9) a1: vec2<u32>, @location(2) a2: vec2<u32>, @location(4) a3: vec4<i32>, @builtin(sample_index) a4: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S13 {
+  @location(0) f0: f16,
+  @builtin(vertex_index) f1: u32,
+  @location(3) f2: f16
+}
+struct VertexOutput0 {
+  @builtin(position) f124: vec4<f32>,
+  @location(7) f125: vec4<f16>,
+  @location(15) f126: vec2<f16>,
+  @location(14) f127: vec4<u32>,
+  @location(4) f128: vec4<i32>,
+  @location(5) f129: vec2<i32>,
+  @location(10) f130: vec3<f16>,
+  @location(11) f131: vec3<f16>,
+  @location(9) f132: vec2<u32>,
+  @location(3) f133: vec4<u32>,
+  @location(2) f134: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec3<f32>, @builtin(instance_index) a1: u32, @location(2) a2: f16, @location(6) a3: vec2<f32>, @location(5) a4: f16, @location(7) a5: f32, a6: S13, @location(13) a7: vec4<u32>, @location(4) a8: f16, @location(12) a9: vec2<f16>, @location(11) a10: vec2<f32>, @location(15) a11: u32, @location(10) a12: vec4<f32>, @location(8) a13: vec2<u32>, @location(14) a14: f16, @location(1) a15: vec4<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder119 = device1.createCommandEncoder({label: '\u{1fbc2}\u89d4\ucbda\ua105'});
+let texture82 = device1.createTexture({
+  label: '\u3c2a\u3a86\u0c2a\u0eeb\u{1fa82}\u{1f756}\u{1f84e}\u5fe7\u8c69\u{1f63d}',
+  size: {width: 16},
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder64 = device1.createRenderBundleEncoder({
+  label: '\u0429\u93e5\ub8e8\u{1f7c6}\udce3\u0727\u00fd\ud59f\ue4ad\ufc6f',
+  colorFormats: ['rg11b10ufloat', 'rgb10a2uint', 'rgba16float', 'r8uint', 'r8uint', 'r16sint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder46.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+commandEncoder119.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 2464 */
+  offset: 2464,
+  buffer: buffer30,
+}, {
+  texture: texture76,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+commandEncoder119.copyTextureToBuffer({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 240 widthInBlocks: 60 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8996 */
+  offset: 8996,
+  buffer: buffer35,
+}, {width: 60, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+commandEncoder119.clearBuffer(buffer35, 103764, 8032);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+offscreenCanvas28.getContext('webgl');
+} catch {}
+try {
+querySet59.label = '\ub62e\u09d0\u{1fcdd}\u056c\uf722\u0dfc\u7282\u0b40\ua991';
+} catch {}
+let pipelineLayout14 = device1.createPipelineLayout({
+  label: '\ued4f\uc79f\u0ac6\u0ac0',
+  bindGroupLayouts: [bindGroupLayout34, bindGroupLayout34, bindGroupLayout34],
+});
+let commandEncoder120 = device1.createCommandEncoder({label: '\uc431\u0ced\u0ecf\u{1ff76}'});
+let texture83 = device1.createTexture({
+  size: [366],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg11b10ufloat', 'rg11b10ufloat'],
+});
+let textureView143 = texture81.createView({format: 'rg11b10ufloat', baseMipLevel: 5, mipLevelCount: 1});
+let renderBundleEncoder65 = device1.createRenderBundleEncoder({
+  label: '\u7fb5\u0c8f',
+  colorFormats: ['rgba16float', 'r16float', 'r8uint', 'rg16float', 'rgba8unorm', 'rg32sint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup30, []);
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline80);
+} catch {}
+try {
+commandEncoder118.pushDebugGroup('\u0ecb');
+} catch {}
+try {
+computePassEncoder42.insertDebugMarker('\u{1fc7c}');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 22, height: 1, depthOrArrayLayers: 61}
+*/
+{
+  source: offscreenCanvas19,
+  origin: { x: 8, y: 92 },
+  flipY: true,
+}, {
+  texture: texture70,
+  mipLevel: 4,
+  origin: {x: 2, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline81 = device1.createComputePipeline({
+  label: '\u{1f64f}\u1889\u0826\u0af9\u{1f827}\u062d\u{1f95c}\u0e34\u{1fb30}\u{1f61a}\u02d3',
+  layout: pipelineLayout14,
+  compute: {module: shaderModule18, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+document.body.prepend(video9);
+let videoFrame24 = new VideoFrame(video7, {timestamp: 0});
+try {
+window.someLabel = externalTexture35.label;
+} catch {}
+let commandEncoder121 = device1.createCommandEncoder({});
+let computePassEncoder47 = commandEncoder121.beginComputePass({label: '\u34e5\uc723\u{1fe59}\u{1f67c}\ua5cb\u28e6\u77c4\u56df\u0b65\u366e'});
+try {
+commandEncoder118.clearBuffer(buffer35, 282512, 8572);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+commandEncoder118.insertDebugMarker('\u0425');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer35, 9192, new Float32Array(50430), 47932, 212);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture76,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer6), /* required buffer size: 69 */
+{offset: 69}, {width: 10, height: 0, depthOrArrayLayers: 1});
+} catch {}
+canvas17.height = 199;
+try {
+window.someLabel = externalTexture32.label;
+} catch {}
+let texture84 = device0.createTexture({
+  label: '\u74bb\u{1f908}\u68f1\u{1faf3}\u5101\ub0a5\ue713\udcc3',
+  size: [30],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder66 = device0.createRenderBundleEncoder({
+  label: '\u7006\u{1f90e}\u{1fd0c}\u09a1\u{1fde7}\ub488\uc18d\ud16c\u0b29',
+  colorFormats: ['r32sint', 'r8sint', 'rgb10a2uint', 'rgba16sint', 'r8sint'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let renderBundle85 = renderBundleEncoder28.finish({label: '\ue98c\ud742\u0ea2\u{1fcb9}'});
+try {
+renderPassEncoder48.setStencilReference(2575);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+renderBundleEncoder66.setBindGroup(3, bindGroup6, new Uint32Array(6035), 5076, 0);
+} catch {}
+try {
+renderBundleEncoder15.draw(508);
+} catch {}
+try {
+renderBundleEncoder15.drawIndexed(247, 53, 2_721_906_294);
+} catch {}
+let promise32 = device0.queue.onSubmittedWorkDone();
+try {
+offscreenCanvas26.getContext('bitmaprenderer');
+} catch {}
+let bindGroupLayout36 = pipeline80.getBindGroupLayout(2);
+let commandEncoder122 = device1.createCommandEncoder({label: '\u043a\u{1fa27}\u0744\u7ff8\u2633\u376c\ua481\u6d41\u96db\ue550\u0790'});
+let texture85 = device1.createTexture({
+  label: '\ucdc1\ubc1f\uba25',
+  size: [520],
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r16float', 'r16float'],
+});
+let textureView144 = texture71.createView({
+  label: '\u{1f9ce}\u063f\u{1f84d}\u{1fe26}\u69fa\u3e2e\ub46d\ucdb9',
+  dimension: '2d-array',
+  baseMipLevel: 3,
+  mipLevelCount: 4,
+});
+let renderBundleEncoder67 = device1.createRenderBundleEncoder({
+  colorFormats: ['rg11b10ufloat', 'rgb10a2uint', 'rgba16float', 'r8uint', 'r8uint', 'r16sint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder36.setBindGroup(2, bindGroup30, new Uint32Array(4721), 4710, 0);
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline81);
+} catch {}
+try {
+commandEncoder120.copyBufferToBuffer(buffer30, 108440, buffer35, 49816, 69520);
+dissociateBuffer(device1, buffer30);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+commandEncoder118.copyBufferToTexture({
+  /* bytesInLastRow: 88 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3740 */
+  offset: 3652,
+  bytesPerRow: 256,
+  buffer: buffer30,
+}, {
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 22, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+commandEncoder119.copyTextureToBuffer({
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 13 widthInBlocks: 13 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 36501 */
+  offset: 36488,
+  buffer: buffer35,
+}, {width: 13, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+commandEncoder118.clearBuffer(buffer35, 276820, 1836);
+dissociateBuffer(device1, buffer35);
+} catch {}
+let imageBitmap34 = await createImageBitmap(offscreenCanvas10);
+let videoFrame25 = new VideoFrame(imageBitmap10, {timestamp: 0});
+let shaderModule19 = device1.createShaderModule({
+  label: '\u{1f875}\u{1fd94}\uf670\uf1c1',
+  code: `@group(0) @binding(714)
+var<storage, read_write> type8: array<u32>;
+@group(1) @binding(714)
+var<storage, read_write> local3: array<u32>;
+
+@compute @workgroup_size(1, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec2<f32>,
+  @location(4) f1: vec4<f32>,
+  @location(2) f2: vec2<u32>,
+  @location(1) f3: vec3<f32>,
+  @location(5) f4: vec4<i32>,
+  @location(0) f5: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(position) a1: vec4<f32>, @builtin(sample_mask) a2: u32, @builtin(sample_index) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S14 {
+  @location(12) f0: vec3<i32>,
+  @location(3) f1: vec4<u32>,
+  @location(5) f2: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(0) a0: vec2<f32>, @location(14) a1: vec3<f16>, @location(15) a2: vec4<f16>, @location(9) a3: vec2<f32>, @location(4) a4: i32, a5: S14, @location(10) a6: vec4<i32>, @location(11) a7: vec3<f16>, @location(13) a8: vec4<f32>, @location(6) a9: vec4<f32>, @location(7) a10: vec3<i32>, @location(8) a11: i32, @location(1) a12: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer36 = device1.createBuffer({label: '\ue82e\u8316', size: 577989, usage: GPUBufferUsage.INDEX});
+let texture86 = device1.createTexture({
+  label: '\u4777\u8dda\u2849\u7394\ua4dc\u{1fb34}\uc1e9',
+  size: {width: 1040, height: 1, depthOrArrayLayers: 31},
+  mipLevelCount: 6,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rg32sint', 'rg32sint', 'rg32sint'],
+});
+let textureView145 = texture69.createView({
+  label: '\u3a0e\u{1fd15}\u{1f823}\u{1fa00}',
+  dimension: '2d',
+  baseMipLevel: 0,
+  mipLevelCount: 6,
+  baseArrayLayer: 58,
+  arrayLayerCount: 1,
+});
+let sampler65 = device1.createSampler({
+  label: '\u{1fd1c}\u0d3e\u4b74\u44b6\u8e87\u{1fbb2}\uc3cc\u6cec',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 35.91,
+  lodMaxClamp: 41.55,
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder67.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+commandEncoder118.popDebugGroup();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 183, height: 1, depthOrArrayLayers: 492}
+*/
+{
+  source: canvas11,
+  origin: { x: 105, y: 30 },
+  flipY: false,
+}, {
+  texture: texture70,
+  mipLevel: 1,
+  origin: {x: 42, y: 0, z: 234},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 26, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise33 = device1.createRenderPipelineAsync({
+  layout: pipelineLayout13,
+  fragment: {
+  module: shaderModule18,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg11b10ufloat',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'zero'},
+  },
+  writeMask: 0,
+}, {format: 'rgb10a2uint'}, {
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'src-alpha', dstFactor: 'dst'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'r8uint', writeMask: GPUColorWrite.ALL}, {format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'r16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'less', failOp: 'decrement-wrap', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'equal', failOp: 'zero', depthFailOp: 'invert', passOp: 'increment-wrap'},
+    stencilReadMask: 3432478936,
+    stencilWriteMask: 3175842609,
+    depthBiasSlopeScale: 394.0819479002218,
+    depthBiasClamp: 434.14365434211186,
+  },
+  vertex: {
+    module: shaderModule18,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 180,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 32, shaderLocation: 4},
+          {format: 'float32x4', offset: 0, shaderLocation: 14},
+          {format: 'float32x2', offset: 0, shaderLocation: 11},
+          {format: 'float16x4', offset: 20, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 12, shaderLocation: 3},
+          {format: 'uint16x4', offset: 44, shaderLocation: 15},
+          {format: 'float32x3', offset: 40, shaderLocation: 6},
+          {format: 'float32', offset: 44, shaderLocation: 7},
+          {format: 'sint8x4', offset: 8, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 4, shaderLocation: 0},
+          {format: 'uint32x3', offset: 4, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 32, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'float32x4', offset: 492, shaderLocation: 10},
+          {format: 'float32x2', offset: 376, shaderLocation: 9},
+          {format: 'snorm16x4', offset: 484, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 256, attributes: []},
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {arrayStride: 116, stepMode: 'instance', attributes: []},
+      {arrayStride: 488, stepMode: 'vertex', attributes: [{format: 'uint32', offset: 40, shaderLocation: 8}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'ccw', unclippedDepth: true},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let querySet67 = device1.createQuerySet({type: 'occlusion', count: 1398});
+let textureView146 = texture72.createView({label: '\uf66e\u300e\u5869\u0908\u{1fe18}\u0218\u0a76\u{1fc0b}', format: 'rgb10a2uint'});
+try {
+renderBundleEncoder58.setIndexBuffer(buffer36, 'uint32', 247072, 139616);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+try {
+commandEncoder119.clearBuffer(buffer35, 111468, 150716);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+device1.queue.submit([commandBuffer23]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer35, 21900, new Int16Array(43983), 672, 9564);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let video20 = await videoWithData();
+let shaderModule20 = device1.createShaderModule({
+  code: `@group(1) @binding(714)
+var<storage, read_write> function6: array<u32>;
+@group(2) @binding(714)
+var<storage, read_write> function7: array<u32>;
+
+@compute @workgroup_size(1, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: u32,
+  @location(1) f1: vec4<u32>,
+  @location(0) f2: vec3<f32>,
+  @location(3) f3: vec4<u32>,
+  @location(2) f4: vec4<f32>,
+  @location(5) f5: i32
+}
+
+@fragment
+fn fragment0(@location(0) a0: vec3<u32>, @builtin(sample_mask) a1: u32, @location(10) a2: vec3<u32>, @location(13) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S15 {
+  @location(6) f0: vec4<f16>,
+  @location(7) f1: vec4<u32>
+}
+struct VertexOutput0 {
+  @location(13) f135: u32,
+  @location(10) f136: vec3<u32>,
+  @location(14) f137: vec3<u32>,
+  @location(1) f138: vec3<f16>,
+  @location(0) f139: vec3<u32>,
+  @location(15) f140: vec2<f32>,
+  @location(6) f141: vec3<i32>,
+  @location(11) f142: vec2<f32>,
+  @location(9) f143: vec3<u32>,
+  @builtin(position) f144: vec4<f32>,
+  @location(7) f145: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(2) a0: f32, @location(3) a1: vec2<u32>, @location(12) a2: vec3<f32>, a3: S15, @location(5) a4: vec3<f16>, @location(8) a5: vec3<f16>, @location(0) a6: vec4<u32>, @location(13) a7: vec3<i32>, @builtin(vertex_index) a8: u32, @location(9) a9: f16, @location(1) a10: f16, @location(11) a11: vec3<f32>, @builtin(instance_index) a12: u32, @location(4) a13: f16, @location(15) a14: vec2<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout37 = device1.createBindGroupLayout({
+  label: '\u{1fc89}\ud8f2\uaad1\u7f8c\u4124\u091a',
+  entries: [
+    {
+      binding: 967,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32float', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 597,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+try {
+commandEncoder120.copyTextureToBuffer({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 48, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1076 */
+  offset: 1076,
+  buffer: buffer35,
+}, {width: 4, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+computePassEncoder46.popDebugGroup();
+} catch {}
+let renderBundleEncoder68 = device1.createRenderBundleEncoder({
+  colorFormats: ['rg11b10ufloat', 'rgb10a2uint', 'rgba16float', 'r8uint', 'r8uint', 'r16sint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle86 = renderBundleEncoder64.finish({label: '\u{1fe3a}\udd9f\ufef8\u{1f901}\u44d3\u0f99\u031c\uc113\ua3db'});
+try {
+computePassEncoder36.setBindGroup(2, bindGroup29, new Uint32Array(8200), 453, 0);
+} catch {}
+try {
+gpuCanvasContext26.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer5), /* required buffer size: 872 */
+{offset: 576, rowsPerImage: 260}, {width: 74, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline82 = device1.createComputePipeline({
+  label: '\u{1fb49}\u6626\u{1feb8}\u263a\ua0a3',
+  layout: pipelineLayout13,
+  compute: {module: shaderModule17, entryPoint: 'compute0'},
+});
+let textureView147 = texture75.createView({baseMipLevel: 0});
+try {
+computePassEncoder42.setPipeline(pipeline82);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder120.copyTextureToBuffer({
+  texture: texture86,
+  mipLevel: 5,
+  origin: {x: 7, y: 0, z: 17},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 25208 */
+  offset: 25208,
+  bytesPerRow: 0,
+  rowsPerImage: 211,
+  buffer: buffer35,
+}, {width: 0, height: 1, depthOrArrayLayers: 4});
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+commandEncoder119.clearBuffer(buffer35, 25644, 238844);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+device1.queue.submit([commandBuffer22]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer35, 64328, new Float32Array(34733), 33977, 40);
+} catch {}
+let promise34 = device1.queue.onSubmittedWorkDone();
+try {
+  await promise32;
+} catch {}
+let canvas26 = document.createElement('canvas');
+let bindGroup32 = device1.createBindGroup({layout: bindGroupLayout34, entries: [{binding: 714, resource: externalTexture64}]});
+let renderBundleEncoder69 = device1.createRenderBundleEncoder({
+  label: '\u0923\u378f\u07c1\u39e0\u07c3',
+  colorFormats: ['rg11b10ufloat', 'rgb10a2uint', 'rgba16float', 'r8uint', 'r8uint', 'r16sint'],
+});
+try {
+renderBundleEncoder63.setBindGroup(1, bindGroup31);
+} catch {}
+try {
+renderBundleEncoder65.setIndexBuffer(buffer36, 'uint32', 473688, 33859);
+} catch {}
+try {
+commandEncoder122.copyTextureToBuffer({
+  texture: texture86,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 72 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 181384 */
+  offset: 9352,
+  bytesPerRow: 256,
+  rowsPerImage: 48,
+  buffer: buffer35,
+}, {width: 9, height: 0, depthOrArrayLayers: 15});
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+commandEncoder119.pushDebugGroup('\u{1fd96}');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture81,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 6},
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(48)), /* required buffer size: 7_826_857 */
+{offset: 37, bytesPerRow: 562, rowsPerImage: 240}, {width: 102, height: 7, depthOrArrayLayers: 59});
+} catch {}
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+let video21 = await videoWithData();
+document.body.prepend(video15);
+let arrayBuffer9 = buffer31.getMappedRange(31464, 120);
+try {
+commandEncoder119.copyBufferToBuffer(buffer32, 15972, buffer35, 85680, 3884);
+dissociateBuffer(device1, buffer32);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+commandEncoder122.clearBuffer(buffer35, 176088, 72736);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 409 */
+{offset: 409}, {width: 53, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+canvas26.getContext('2d');
+} catch {}
+try {
+window.someLabel = externalTexture56.label;
+} catch {}
+try {
+  await promise34;
+} catch {}
+let commandBuffer25 = commandEncoder122.finish({});
+try {
+renderBundleEncoder56.setIndexBuffer(buffer36, 'uint32');
+} catch {}
+try {
+renderBundleEncoder67.setVertexBuffer(1655, undefined);
+} catch {}
+try {
+commandEncoder119.copyBufferToBuffer(buffer31, 24232, buffer35, 119100, 19248);
+dissociateBuffer(device1, buffer31);
+dissociateBuffer(device1, buffer35);
+} catch {}
+let pipeline83 = device1.createRenderPipeline({
+  label: '\u{1fe3a}\u{1fb95}\uc9bd\u{1feda}\u054b\u{1fffd}\uac51\u046d\u07cf\u7308',
+  layout: pipelineLayout13,
+  fragment: {
+  module: shaderModule20,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg11b10ufloat'}, {format: 'rgb10a2uint'}, {format: 'rgba16float', writeMask: GPUColorWrite.RED}, {format: 'r8uint', writeMask: 0}, {format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r16sint'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {failOp: 'invert', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'greater-equal', failOp: 'decrement-clamp', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilReadMask: 3038975431,
+    stencilWriteMask: 3606916177,
+    depthBias: 0,
+    depthBiasSlopeScale: 0.0,
+    depthBiasClamp: -63.5898525565399,
+  },
+  vertex: {
+    module: shaderModule20,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 600,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 192, shaderLocation: 4},
+          {format: 'unorm8x2', offset: 14, shaderLocation: 6},
+          {format: 'float32', offset: 24, shaderLocation: 5},
+          {format: 'snorm8x2', offset: 26, shaderLocation: 12},
+          {format: 'float32', offset: 120, shaderLocation: 1},
+          {format: 'sint32x4', offset: 36, shaderLocation: 13},
+          {format: 'float16x2', offset: 388, shaderLocation: 2},
+          {format: 'uint32', offset: 20, shaderLocation: 3},
+          {format: 'uint16x2', offset: 36, shaderLocation: 7},
+          {format: 'float32x3', offset: 96, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 292,
+        attributes: [
+          {format: 'sint8x4', offset: 92, shaderLocation: 15},
+          {format: 'float16x2', offset: 4, shaderLocation: 11},
+          {format: 'uint32', offset: 12, shaderLocation: 0},
+          {format: 'snorm8x4', offset: 72, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let canvas27 = document.createElement('canvas');
+let img24 = await imageWithData(148, 135, '#bcd49997', '#c5f767c2');
+let commandEncoder123 = device1.createCommandEncoder({});
+let textureView148 = texture77.createView({
+  label: '\u5e37\ub04e\u62d8\ucb5e\u4486\u1283\u5fa2\u{1f789}',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+  baseArrayLayer: 32,
+  arrayLayerCount: 1,
+});
+let computePassEncoder48 = commandEncoder123.beginComputePass({label: '\ua5c8\ubc77\u4b8b'});
+let renderBundleEncoder70 = device1.createRenderBundleEncoder({
+  label: '\u4b86\udc96\u8247',
+  colorFormats: ['rgba16float', 'r16float', 'r8uint', 'rg16float', 'rgba8unorm', 'rg32sint'],
+  stencilReadOnly: true,
+});
+let renderBundle87 = renderBundleEncoder53.finish({});
+try {
+renderBundleEncoder70.setIndexBuffer(buffer36, 'uint16', 469260, 22045);
+} catch {}
+try {
+  await device1.popErrorScope();
+} catch {}
+try {
+commandEncoder118.copyTextureToBuffer({
+  texture: texture76,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 33504 */
+  offset: 33504,
+  buffer: buffer35,
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 22, height: 1, depthOrArrayLayers: 61}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 1, y: 29 },
+  flipY: false,
+}, {
+  texture: texture70,
+  mipLevel: 4,
+  origin: {x: 3, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let img25 = await imageWithData(31, 283, '#19faf1ee', '#0d85372b');
+let gpuCanvasContext28 = canvas25.getContext('webgpu');
+let imageData17 = new ImageData(140, 176);
+let promise35 = adapter0.requestAdapterInfo();
+let sampler66 = device1.createSampler({
+  label: '\u7ca1\u7e41\u{1fcb7}\u6226\u3c41\u05cd\u0878\u0899\u2f45\u0ff9',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 79.52,
+  lodMaxClamp: 88.57,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder45.setPipeline(pipeline82);
+} catch {}
+try {
+commandEncoder119.clearBuffer(buffer35, 107336, 145456);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let textureView149 = texture77.createView({
+  label: '\u{1ffef}\u{1f771}\u0dfe\u0868',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 5,
+  baseArrayLayer: 14,
+});
+let sampler67 = device1.createSampler({
+  label: '\uce99\u{1f868}\u{1fe2f}\u1654',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 60.66,
+  lodMaxClamp: 62.49,
+});
+try {
+computePassEncoder39.setPipeline(pipeline80);
+} catch {}
+try {
+renderBundleEncoder69.setBindGroup(1, bindGroup32);
+} catch {}
+try {
+renderBundleEncoder70.setVertexBuffer(4969, undefined);
+} catch {}
+try {
+commandEncoder119.copyBufferToBuffer(buffer30, 100700, buffer35, 98720, 17948);
+dissociateBuffer(device1, buffer30);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+commandEncoder119.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2476 */
+  offset: 2460,
+  bytesPerRow: 256,
+  buffer: buffer32,
+}, {
+  texture: texture81,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 4, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+commandEncoder119.clearBuffer(buffer35, 190152, 11484);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline84 = await device1.createComputePipelineAsync({
+  label: '\ua077\uea19',
+  layout: pipelineLayout13,
+  compute: {module: shaderModule16, entryPoint: 'compute0', constants: {}},
+});
+let pipeline85 = device1.createRenderPipeline({
+  label: '\u{1fdf9}\u{1fc28}\u{1fdf5}\u217c\u{1fa1f}',
+  layout: pipelineLayout13,
+  fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg11b10ufloat',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA,
+}, {format: 'rgb10a2uint', writeMask: 0}, {
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'constant', dstFactor: 'src-alpha'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'dst-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r8uint'}, {format: 'r16sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule16,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 212, attributes: []},
+      {
+        arrayStride: 24,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint8x4', offset: 0, shaderLocation: 0},
+          {format: 'float16x2', offset: 0, shaderLocation: 5},
+          {format: 'sint16x2', offset: 0, shaderLocation: 2},
+          {format: 'unorm16x2', offset: 0, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 20, shaderLocation: 7},
+          {format: 'uint8x2', offset: 244, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 196, shaderLocation: 4},
+          {format: 'float16x4', offset: 1284, shaderLocation: 10},
+          {format: 'unorm16x4', offset: 168, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 80,
+        attributes: [
+          {format: 'sint16x4', offset: 8, shaderLocation: 14},
+          {format: 'snorm16x4', offset: 0, shaderLocation: 12},
+          {format: 'unorm10-10-10-2', offset: 8, shaderLocation: 9},
+          {format: 'uint32x2', offset: 16, shaderLocation: 1},
+          {format: 'float32x2', offset: 16, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 200, attributes: []},
+      {arrayStride: 76, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 756,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x4', offset: 28, shaderLocation: 11}],
+      },
+      {arrayStride: 572, attributes: [{format: 'sint32', offset: 152, shaderLocation: 8}]},
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'back', unclippedDepth: true},
+});
+let bindGroupLayout38 = device1.createBindGroupLayout({
+  label: '\u0a8c\uc90e\u{1fedf}\u{1f634}\u9160\u03eb\u171f\uc27e\u05f1\u08db\ua4ee',
+  entries: [
+    {
+      binding: 952,
+      visibility: 0,
+      texture: { viewDimension: '2d-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 584,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let pipelineLayout15 = device1.createPipelineLayout({
+  label: '\u5525\u0d89\u0bd1\u3cd6\u{1fe38}\u7580',
+  bindGroupLayouts: [bindGroupLayout35, bindGroupLayout37],
+});
+let querySet68 = device1.createQuerySet({label: '\u02d9\u3f7f\u0512\u363d\uef6c\u00f6\u{1f7b3}', type: 'occlusion', count: 3234});
+let textureView150 = texture85.createView({aspect: 'all'});
+let renderBundleEncoder71 = device1.createRenderBundleEncoder({
+  label: '\u04d4\ude6e\u{1ffdc}\ud9fe\u0cd5\u03bb\u{1fe03}',
+  colorFormats: ['rg11b10ufloat', 'rgb10a2uint', 'rgba16float', 'r8uint', 'r8uint', 'r16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder69.setBindGroup(3, bindGroup32);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer35, 5560, new BigUint64Array(22513), 17800, 904);
+} catch {}
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let bindGroup33 = device1.createBindGroup({
+  label: '\ufc15\u0eb6\u086c\ua246\u{1ff7b}\ude31\udab7\ucec2\u1118',
+  layout: bindGroupLayout36,
+  entries: [{binding: 714, resource: externalTexture61}],
+});
+let commandEncoder124 = device1.createCommandEncoder({});
+let texture87 = device1.createTexture({
+  size: [128],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm', 'rgba8unorm'],
+});
+let externalTexture67 = device1.importExternalTexture({label: '\ua9e3\uc497\u032f\u1a7f', source: videoFrame16, colorSpace: 'srgb'});
+try {
+commandEncoder120.copyTextureToBuffer({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 252 widthInBlocks: 63 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 19384 */
+  offset: 19384,
+  buffer: buffer35,
+}, {width: 63, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let offscreenCanvas30 = new OffscreenCanvas(391, 936);
+let commandEncoder125 = device1.createCommandEncoder({label: '\u{1fafd}\u3ba6\u{1fdb1}\ucfad\u0874'});
+let textureView151 = texture81.createView({label: '\u2c7c\u78bf', mipLevelCount: 3});
+let renderBundle88 = renderBundleEncoder62.finish({});
+try {
+computePassEncoder40.setPipeline(pipeline82);
+} catch {}
+try {
+commandEncoder118.copyTextureToBuffer({
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 38 widthInBlocks: 38 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 5178 */
+  offset: 5140,
+  buffer: buffer35,
+}, {width: 38, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer35, 7832, new BigUint64Array(6550), 2459, 844);
+} catch {}
+let pipeline86 = device1.createRenderPipeline({
+  layout: pipelineLayout14,
+  multisample: {mask: 0xfaf7bfd2},
+  fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg11b10ufloat',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'src', dstFactor: 'one-minus-dst'},
+  },
+  writeMask: GPUColorWrite.ALPHA,
+}, {format: 'rgb10a2uint'}, {format: 'rgba16float', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r16sint', writeMask: GPUColorWrite.ALPHA}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'not-equal', failOp: 'decrement-clamp', depthFailOp: 'increment-clamp', passOp: 'replace'},
+    stencilBack: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'decrement-wrap', passOp: 'zero'},
+    stencilReadMask: 4146936962,
+    stencilWriteMask: 3152553956,
+    depthBias: 0,
+    depthBiasSlopeScale: -44.2317343875414,
+    depthBiasClamp: 474.99992393615616,
+  },
+  vertex: {
+    module: shaderModule16,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 56,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 4, shaderLocation: 7},
+          {format: 'uint16x2', offset: 8, shaderLocation: 0},
+          {format: 'float32', offset: 12, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 980,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 8, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 344, shaderLocation: 15},
+          {format: 'sint16x4', offset: 156, shaderLocation: 8},
+          {format: 'unorm16x2', offset: 20, shaderLocation: 12},
+          {format: 'unorm10-10-10-2', offset: 156, shaderLocation: 6},
+          {format: 'float16x2', offset: 4, shaderLocation: 5},
+          {format: 'sint16x4', offset: 4, shaderLocation: 2},
+          {format: 'unorm8x4', offset: 48, shaderLocation: 3},
+          {format: 'float16x4', offset: 140, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 772, attributes: []},
+      {arrayStride: 880, attributes: []},
+      {
+        arrayStride: 84,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x2', offset: 0, shaderLocation: 4}],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32', offset: 212, shaderLocation: 10},
+          {format: 'uint32x4', offset: 160, shaderLocation: 1},
+          {format: 'sint16x4', offset: 360, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+try {
+renderBundle88.label = '\ue4b1\uf05f\u21bc';
+} catch {}
+let commandEncoder126 = device1.createCommandEncoder();
+let textureView152 = texture73.createView({
+  label: '\u{1fb84}\uf2dd\u{1fe88}\u8cfc\u{1fb3a}\u02b4\u0511\u6623\u{1fb13}\u07a9',
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+let computePassEncoder49 = commandEncoder118.beginComputePass({label: '\ua53b\u00c6'});
+let renderBundle89 = renderBundleEncoder52.finish();
+let video22 = await videoWithData();
+let bindGroupLayout39 = device1.createBindGroupLayout({label: '\u293c\u2d3f\u75f9\u7c44\ua050\uc5e2', entries: []});
+let pipelineLayout16 = device1.createPipelineLayout({
+  label: '\u1e56\u8b1a\u300b\ufb15\u0919\u{1fe74}\u{1fb46}\ubbbe\u09b9\u5a96\u{1f9fe}',
+  bindGroupLayouts: [bindGroupLayout38],
+});
+let renderBundleEncoder72 = device1.createRenderBundleEncoder({
+  label: '\u5a50\u069a\u3338\u0e29\udea0\u02d3',
+  colorFormats: ['rgba16float', 'r16float', 'r8uint', 'rg16float', 'rgba8unorm', 'rg32sint'],
+  depthReadOnly: true,
+});
+let renderBundle90 = renderBundleEncoder62.finish();
+try {
+renderBundleEncoder68.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+renderBundleEncoder70.setBindGroup(0, bindGroup32, new Uint32Array(8545), 6748, 0);
+} catch {}
+try {
+gpuCanvasContext25.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let computePassEncoder50 = commandEncoder120.beginComputePass({});
+try {
+renderBundleEncoder58.setPipeline(pipeline85);
+} catch {}
+try {
+commandEncoder124.copyTextureToTexture({
+  texture: texture70,
+  mipLevel: 3,
+  origin: {x: 5, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 41, y: 0, z: 12},
+  aspect: 'all',
+},
+{width: 31, height: 1, depthOrArrayLayers: 3});
+} catch {}
+try {
+commandEncoder119.popDebugGroup();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 11, height: 1, depthOrArrayLayers: 30}
+*/
+{
+  source: img12,
+  origin: { x: 14, y: 5 },
+  flipY: true,
+}, {
+  texture: texture70,
+  mipLevel: 5,
+  origin: {x: 2, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+offscreenCanvas30.getContext('webgl2');
+} catch {}
+let querySet69 = device1.createQuerySet({type: 'occlusion', count: 698});
+let commandBuffer26 = commandEncoder124.finish();
+let sampler68 = device1.createSampler({
+  label: '\u0ee0\u8749\u5aba\u0207\u{1fe11}\u5a72\u{1fdc3}\u54c5\u4153\u492e',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 17.64,
+  lodMaxClamp: 59.88,
+});
+try {
+renderBundleEncoder58.setBindGroup(2, bindGroup31);
+} catch {}
+try {
+renderBundleEncoder58.setIndexBuffer(buffer36, 'uint16', 416388, 145022);
+} catch {}
+try {
+commandEncoder119.copyBufferToBuffer(buffer30, 76888, buffer35, 118648, 87980);
+dissociateBuffer(device1, buffer30);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+commandEncoder126.copyTextureToTexture({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 89, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 91, height: 1, depthOrArrayLayers: 246}
+*/
+{
+  source: video9,
+  origin: { x: 2, y: 0 },
+  flipY: true,
+}, {
+  texture: texture70,
+  mipLevel: 2,
+  origin: {x: 28, y: 0, z: 37},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline87 = device1.createComputePipeline({
+  label: '\u7022\uaa22\u{1fab9}\u65d3\u69d5\uc890\u03bf',
+  layout: 'auto',
+  compute: {module: shaderModule19, entryPoint: 'compute0', constants: {}},
+});
+try {
+offscreenCanvas27.getContext('2d');
+} catch {}
+try {
+  await promise35;
+} catch {}
+gc();
+let renderBundle91 = renderBundleEncoder59.finish({label: '\u702e\u00b1\u{1f74d}\u8c01\u{1ff57}\u8d8f\u00cc\u3389\u9471\u03c9\u0a13'});
+let externalTexture68 = device1.importExternalTexture({source: videoFrame3, colorSpace: 'display-p3'});
+try {
+commandEncoder119.copyBufferToBuffer(buffer32, 19488, buffer35, 60280, 7812);
+dissociateBuffer(device1, buffer32);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+commandEncoder125.copyBufferToTexture({
+  /* bytesInLastRow: 468 widthInBlocks: 117 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 12532 */
+  offset: 12532,
+  buffer: buffer30,
+}, {
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 117, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+renderBundleEncoder63.insertDebugMarker('\u1bf4');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 22, height: 1, depthOrArrayLayers: 61}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 26, y: 6 },
+  flipY: false,
+}, {
+  texture: texture70,
+  mipLevel: 4,
+  origin: {x: 2, y: 0, z: 13},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext29 = canvas27.getContext('webgpu');
+let commandBuffer27 = commandEncoder119.finish();
+let texture88 = device1.createTexture({
+  size: {width: 1467},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView153 = texture72.createView({label: '\u{1fcf9}\u9cb7\u05e6\ua0c1\u0089\u02d8\u{1fde0}\u0d78\u{1f935}', mipLevelCount: 1});
+try {
+commandEncoder126.copyBufferToTexture({
+  /* bytesInLastRow: 972 widthInBlocks: 243 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4104 */
+  offset: 4104,
+  buffer: buffer30,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 42, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 243, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer30);
+} catch {}
+document.body.prepend(video18);
+let imageData18 = new ImageData(76, 124);
+let querySet70 = device1.createQuerySet({label: '\u03d5\u0465\u3b16\u{1fcc5}\u{1f63a}\u0068\u6f1e\ua683\uca13', type: 'occlusion', count: 1372});
+let texture89 = device1.createTexture({
+  size: {width: 1040, height: 1, depthOrArrayLayers: 9},
+  mipLevelCount: 10,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm'],
+});
+let textureView154 = texture86.createView({
+  label: '\u45be\u93ec\u0595\u0e99\u0d8b',
+  format: 'rg32sint',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 26,
+  arrayLayerCount: 4,
+});
+let computePassEncoder51 = commandEncoder125.beginComputePass({label: '\u0150\u{1f940}\u317d\u{1fdb9}\u9353'});
+let pipeline88 = await device1.createComputePipelineAsync({
+  label: '\ud377\u0dbd\uf0ec\u{1fd46}\uc81e\u0ec2\u{1ff44}\u04ab\u003a',
+  layout: pipelineLayout14,
+  compute: {module: shaderModule19, entryPoint: 'compute0', constants: {}},
+});
+let imageData19 = new ImageData(144, 156);
+try {
+window.someLabel = externalTexture58.label;
+} catch {}
+let querySet71 = device1.createQuerySet({label: '\uc4b9\ud273\u90ac\u05ee\u0c2c\ua3e7\u023d\u341e\u0c41', type: 'occlusion', count: 3029});
+let texture90 = gpuCanvasContext12.getCurrentTexture();
+let externalTexture69 = device1.importExternalTexture({label: '\u{1fb95}\u02e0', source: video0});
+try {
+renderBundleEncoder63.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+commandEncoder126.copyBufferToTexture({
+  /* bytesInLastRow: 160 widthInBlocks: 40 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 9744 */
+  offset: 9744,
+  rowsPerImage: 69,
+  buffer: buffer32,
+}, {
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 40, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer32);
+} catch {}
+let pipeline89 = device1.createComputePipeline({
+  label: '\u89e7\uea51\u1c55\u{1fab4}\u4bb0\u1044\u0ab8',
+  layout: pipelineLayout16,
+  compute: {module: shaderModule17, entryPoint: 'compute0', constants: {}},
+});
+let pipeline90 = device1.createRenderPipeline({
+  label: '\u3f82\u5fae\u5577',
+  layout: pipelineLayout16,
+  multisample: {mask: 0x28eeafe4},
+  fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg11b10ufloat',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst', dstFactor: 'dst-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'r16sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-clamp', depthFailOp: 'increment-wrap'},
+    stencilBack: {compare: 'greater-equal', failOp: 'decrement-wrap', depthFailOp: 'replace', passOp: 'keep'},
+    stencilReadMask: 2255181755,
+    depthBiasSlopeScale: 710.1102008353133,
+    depthBiasClamp: 946.7864337529156,
+  },
+  vertex: {
+    module: shaderModule16,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 420,
+        attributes: [
+          {format: 'float32x2', offset: 152, shaderLocation: 12},
+          {format: 'uint32', offset: 84, shaderLocation: 0},
+          {format: 'sint32', offset: 64, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 48, shaderLocation: 11},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 3},
+          {format: 'uint32x2', offset: 64, shaderLocation: 1},
+          {format: 'float16x2', offset: 172, shaderLocation: 6},
+          {format: 'float32x2', offset: 28, shaderLocation: 5},
+          {format: 'uint8x4', offset: 140, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 440, attributes: []},
+      {arrayStride: 224, attributes: []},
+      {arrayStride: 616, attributes: []},
+      {
+        arrayStride: 148,
+        attributes: [
+          {format: 'unorm8x4', offset: 44, shaderLocation: 10},
+          {format: 'snorm16x2', offset: 8, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 28,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 0, shaderLocation: 2},
+          {format: 'sint8x4', offset: 0, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 0, shaderLocation: 4},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 15},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 16,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x2', offset: 0, shaderLocation: 7}],
+      },
+    ],
+  },
+  primitive: {unclippedDepth: true},
+});
+let offscreenCanvas31 = new OffscreenCanvas(131, 160);
+try {
+renderBundle75.label = '\ud6bb\u9fb2\uee37\u5934';
+} catch {}
+let shaderModule21 = device1.createShaderModule({
+  label: '\u{1fe52}\u9608\udee2\u0805\ufc94',
+  code: `@group(1) @binding(714)
+var<storage, read_write> field8: array<u32>;
+@group(2) @binding(714)
+var<storage, read_write> function8: array<u32>;
+@group(0) @binding(714)
+var<storage, read_write> n6: array<u32>;
+
+@compute @workgroup_size(2, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec2<f32>,
+  @location(1) f1: f32,
+  @location(5) f2: vec3<i32>,
+  @location(4) f3: vec4<f32>,
+  @location(0) f4: vec4<f32>,
+  @location(2) f5: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(14) a0: vec4<f32>, @location(11) a1: u32, @location(0) a2: vec3<f32>, @location(10) a3: vec4<u32>, @builtin(sample_index) a4: u32, @builtin(sample_mask) a5: u32, @builtin(position) a6: vec4<f32>, @builtin(front_facing) a7: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(11) f146: u32,
+  @builtin(position) f147: vec4<f32>,
+  @location(0) f148: vec3<f32>,
+  @location(14) f149: vec4<f32>,
+  @location(10) f150: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec4<i32>, @location(2) a1: vec3<u32>, @location(15) a2: vec4<u32>, @builtin(instance_index) a3: u32, @location(4) a4: i32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let bindGroupLayout40 = device1.createBindGroupLayout({
+  label: '\u0bcd\ub804',
+  entries: [
+    {
+      binding: 168,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 697,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 935,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+try {
+computePassEncoder51.setPipeline(pipeline84);
+} catch {}
+try {
+renderBundleEncoder71.setBindGroup(1, bindGroup31, []);
+} catch {}
+try {
+renderBundleEncoder68.setBindGroup(0, bindGroup29, new Uint32Array(6317), 4056, 0);
+} catch {}
+try {
+commandEncoder126.copyBufferToTexture({
+  /* bytesInLastRow: 332 widthInBlocks: 83 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 32080 */
+  offset: 32080,
+  buffer: buffer30,
+}, {
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 83, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+commandEncoder126.clearBuffer(buffer35, 4828, 160072);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer35, 54088, new BigUint64Array(64122), 37361, 3340);
+} catch {}
+document.body.prepend(img2);
+try {
+window.someLabel = renderBundle80.label;
+} catch {}
+let commandEncoder127 = device1.createCommandEncoder({});
+let texture91 = device1.createTexture({
+  label: '\u{1fe0e}\udda7\ub225\u82f9\u{1fbe6}\ub1cb\ua88c\u{1f9b9}\uca1e\ue26f\u0f88',
+  size: {width: 1467},
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+});
+try {
+renderBundleEncoder68.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+renderBundleEncoder56.setIndexBuffer(buffer36, 'uint32', 22572);
+} catch {}
+try {
+  await device1.popErrorScope();
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+try {
+renderBundleEncoder65.insertDebugMarker('\ua1db');
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 7}
+*/
+{
+  source: offscreenCanvas18,
+  origin: { x: 94, y: 61 },
+  flipY: false,
+}, {
+  texture: texture70,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img16);
+try {
+externalTexture68.label = '\ub12c\u7db8\u{1f909}\u7a35\u0683\u0e67\u44f6\u{1f9eb}\u3858';
+} catch {}
+let texture92 = device1.createTexture({
+  size: [16, 1, 99],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8unorm', 'rg8unorm'],
+});
+let textureView155 = texture75.createView({label: '\ua0c3\ub35b\u59f3', mipLevelCount: 1});
+let computePassEncoder52 = commandEncoder126.beginComputePass({label: '\uf3d3\u11c4\u{1f8b1}\u5fb1'});
+try {
+computePassEncoder50.setBindGroup(1, bindGroup31);
+} catch {}
+try {
+commandEncoder127.copyTextureToTexture({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 20, height: 1, depthOrArrayLayers: 1});
+} catch {}
+video6.height = 194;
+let canvas28 = document.createElement('canvas');
+try {
+offscreenCanvas31.getContext('webgpu');
+} catch {}
+let bindGroup34 = device1.createBindGroup({
+  label: '\u3011\u{1f9fd}\u3dea\u0123\u47ab\u6e49\u58f0\u1c69\u6817\u9c6e\u80c8',
+  layout: bindGroupLayout34,
+  entries: [{binding: 714, resource: externalTexture69}],
+});
+let commandEncoder128 = device1.createCommandEncoder({label: '\u{1fdf0}\u{1f764}\udd59\u{1f88d}\u{1ff40}\u02c0\u4f09'});
+let texture93 = device1.createTexture({
+  label: '\uc960\u{1fc9c}\ub1d6\u0919\u{1fe7c}\ua60d\udad1\ue25a\u{1faf6}\u01c9',
+  size: {width: 366, height: 3, depthOrArrayLayers: 58},
+  mipLevelCount: 4,
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg8uint'],
+});
+let renderBundleEncoder73 = device1.createRenderBundleEncoder({
+  colorFormats: ['rgba16float', 'r16float', 'r8uint', 'rg16float', 'rgba8unorm', 'rg32sint'],
+  sampleCount: 1,
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let sampler69 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 96.04,
+  lodMaxClamp: 98.62,
+  maxAnisotropy: 12,
+});
+try {
+renderBundleEncoder63.setIndexBuffer(buffer36, 'uint16', 57966);
+} catch {}
+try {
+  await device1.popErrorScope();
+} catch {}
+try {
+commandEncoder127.copyBufferToTexture({
+  /* bytesInLastRow: 184 widthInBlocks: 92 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 37864 */
+  offset: 37864,
+  rowsPerImage: 247,
+  buffer: buffer30,
+}, {
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 63, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 92, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 5, height: 1, depthOrArrayLayers: 15}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 2, y: 4 },
+  flipY: true,
+}, {
+  texture: texture70,
+  mipLevel: 6,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas32 = new OffscreenCanvas(114, 790);
+let gpuCanvasContext30 = canvas28.getContext('webgpu');
+let commandEncoder129 = device1.createCommandEncoder({label: '\u0910\u{1f87b}\u0814\u8e26\u{1f7bc}\u{1faa4}\u82a9\u{1fd93}\u2ed5\u{1f8d3}\u6053'});
+try {
+commandEncoder129.clearBuffer(buffer35, 199684, 31096);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 91, height: 1, depthOrArrayLayers: 246}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 4, y: 1 },
+  flipY: true,
+}, {
+  texture: texture70,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 82},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video15.height = 284;
+try {
+adapter0.label = '\u{1f8b7}\u0fc8\ua916\u{1ff99}\ud293\u{1fc8f}\u0a88\u08dd';
+} catch {}
+let textureView156 = texture86.createView({
+  label: '\u3fcc\uedbf\ua75d\u8978\u63c3\u4929\u{1faf1}',
+  aspect: 'all',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 17,
+  arrayLayerCount: 13,
+});
+let renderBundle92 = renderBundleEncoder70.finish({label: '\u085e\u0096\u0b13\u{1f6f4}'});
+let externalTexture70 = device1.importExternalTexture({label: '\u6c61\ufa00\u0693', source: video3, colorSpace: 'srgb'});
+try {
+computePassEncoder39.setBindGroup(1, bindGroup34, new Uint32Array(8931), 3823, 0);
+} catch {}
+try {
+buffer31.destroy();
+} catch {}
+try {
+commandEncoder127.copyTextureToTexture({
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 43, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 332, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder128.clearBuffer(buffer35, 194988, 31660);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer35, 27168, new DataView(new ArrayBuffer(62992)), 26243, 24716);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture90,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer8), /* required buffer size: 694 */
+{offset: 694}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let imageBitmap35 = await createImageBitmap(canvas22);
+let bindGroup35 = device1.createBindGroup({
+  label: '\u{1fcf8}\uec01\u{1fe77}\u{1f9ab}\u0f06\ua2ef\u{1fa26}\u1c4c',
+  layout: bindGroupLayout39,
+  entries: [],
+});
+let computePassEncoder53 = commandEncoder129.beginComputePass({});
+let renderBundleEncoder74 = device1.createRenderBundleEncoder({
+  colorFormats: ['rg11b10ufloat', 'rgb10a2uint', 'rgba16float', 'r8uint', 'r8uint', 'r16sint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+try {
+computePassEncoder44.setBindGroup(2, bindGroup29);
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline84);
+} catch {}
+try {
+renderBundleEncoder73.setVertexBuffer(382, undefined);
+} catch {}
+let promise36 = device1.queue.onSubmittedWorkDone();
+try {
+  await promise36;
+} catch {}
+let renderBundleEncoder75 = device1.createRenderBundleEncoder({
+  colorFormats: ['rg8sint', 'rgba32float', 'rg8unorm', 'rg8uint', 'rgba8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder39.setBindGroup(3, bindGroup31, []);
+} catch {}
+try {
+commandEncoder127.copyBufferToBuffer(buffer31, 10208, buffer35, 232548, 10012);
+dissociateBuffer(device1, buffer31);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+commandEncoder127.clearBuffer(buffer35, 58272, 22024);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 183, height: 1, depthOrArrayLayers: 492}
+*/
+{
+  source: canvas20,
+  origin: { x: 17, y: 11 },
+  flipY: false,
+}, {
+  texture: texture70,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 159},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 36, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder130 = device1.createCommandEncoder({label: '\u0ff2\uaf1e\u1778\u{1f669}\u0816\u0447\udbef\u0fe8\u06ab\u{1f69a}'});
+let commandBuffer28 = commandEncoder128.finish({label: '\u58b9\uc383\u5110\u0d98\u{1fda4}\uffa1\u{1f607}\u409e\u09a3\u{1fb6d}\u{1ffbd}'});
+let promise37 = device1.popErrorScope();
+try {
+commandEncoder127.copyBufferToTexture({
+  /* bytesInLastRow: 408 widthInBlocks: 204 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 46478 */
+  offset: 46478,
+  buffer: buffer30,
+}, {
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 44, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 204, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer30);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 295 */
+{offset: 295}, {width: 82, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let externalTexture71 = device1.importExternalTexture({source: video4, colorSpace: 'srgb'});
+try {
+commandEncoder127.copyTextureToBuffer({
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 62 widthInBlocks: 62 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 26726 */
+  offset: 26726,
+  buffer: buffer35,
+}, {width: 62, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer35, 238760, new Int16Array(36224), 14064, 1848);
+} catch {}
+try {
+externalTexture64.label = '\u2814\u2e8f';
+} catch {}
+let commandEncoder131 = device1.createCommandEncoder();
+let renderBundle93 = renderBundleEncoder72.finish();
+try {
+computePassEncoder36.setPipeline(pipeline81);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+try {
+commandEncoder130.copyBufferToBuffer(buffer31, 41424, buffer35, 260632, 1552);
+dissociateBuffer(device1, buffer31);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+commandEncoder131.clearBuffer(buffer35, 262996, 28692);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+device1.queue.submit([commandBuffer26]);
+} catch {}
+canvas28.width = 776;
+try {
+window.someLabel = externalTexture70.label;
+} catch {}
+let buffer37 = device1.createBuffer({
+  label: '\u1fe0\u{1f886}\u06d8\ub6c5\u6157\ud778\u35d1',
+  size: 156660,
+  usage: GPUBufferUsage.COPY_DST,
+  mappedAtCreation: true,
+});
+let commandEncoder132 = device1.createCommandEncoder({label: '\u7c05\u0e88\ua876\u5ff2\u06b4\u02b3\u0c50\u606f\u236b'});
+let textureView157 = texture71.createView({
+  label: '\u{1f8a6}\u405b\u{1f7e3}\u1650\u7cda\uf454\u00f9\u8392',
+  dimension: '2d-array',
+  baseMipLevel: 5,
+  mipLevelCount: 2,
+  baseArrayLayer: 0,
+});
+let externalTexture72 = device1.importExternalTexture({source: video11, colorSpace: 'srgb'});
+try {
+computePassEncoder42.setPipeline(pipeline87);
+} catch {}
+try {
+renderBundleEncoder56.setBindGroup(3, bindGroup31);
+} catch {}
+try {
+commandEncoder130.copyBufferToBuffer(buffer32, 14844, buffer37, 9004, 5992);
+dissociateBuffer(device1, buffer32);
+dissociateBuffer(device1, buffer37);
+} catch {}
+try {
+gpuCanvasContext30.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline91 = device1.createComputePipeline({
+  label: '\u1cf8\u896f\u449c\u15e6\uad0e',
+  layout: 'auto',
+  compute: {module: shaderModule20, entryPoint: 'compute0'},
+});
+let gpuCanvasContext31 = offscreenCanvas32.getContext('webgpu');
+try {
+  await promise37;
+} catch {}
+try {
+computePassEncoder52.label = '\ud6a2\u01f8\u4713\u0a1d\ud8eb';
+} catch {}
+let commandEncoder133 = device1.createCommandEncoder({label: '\ua827\u49a6\u32f8\u0685\u021d\u8421\u{1f9a0}'});
+let texture94 = device1.createTexture({
+  label: '\u2bd2\ud0ec\u0586\u002c\u76d9',
+  size: [960, 80, 413],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r16float', 'r16float'],
+});
+let textureView158 = texture83.createView({label: '\u0828\u4934\u23e8\u8088\u{1f86f}\u860f\u0b65\u0c54\u04e3\u679e', dimension: '1d'});
+try {
+commandEncoder132.copyTextureToTexture({
+  texture: texture73,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture81,
+  mipLevel: 1,
+  origin: {x: 56, y: 3, z: 68},
+  aspect: 'all',
+},
+{width: 5, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+renderBundleEncoder75.insertDebugMarker('\u01fa');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer35, 16656, new Int16Array(55613), 2122, 10188);
+} catch {}
+let video23 = await videoWithData();
+let promise38 = adapter2.requestAdapterInfo();
+let bindGroup36 = device1.createBindGroup({
+  label: '\u30d9\ud04d\u392e\u0047\u{1fb4a}',
+  layout: bindGroupLayout36,
+  entries: [{binding: 714, resource: externalTexture63}],
+});
+let texture95 = device1.createTexture({
+  label: '\u0748\ua73b\uf60a\ue743\u08a6\uf4dc\u06f6\u53c3\u00bd',
+  size: [480],
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16sint', 'rg16sint'],
+});
+let textureView159 = texture69.createView({
+  label: '\u27ed\u8813\u{1fc68}\uc8b3\u0182',
+  format: 'astc-5x5-unorm-srgb',
+  baseMipLevel: 7,
+  baseArrayLayer: 78,
+  arrayLayerCount: 109,
+});
+let renderBundle94 = renderBundleEncoder71.finish({});
+let externalTexture73 = device1.importExternalTexture({label: '\ubaff\u94b6\u25ba\u0a68\u{1f939}', source: video15});
+try {
+renderBundleEncoder73.setVertexBuffer(3956, undefined, 602530515);
+} catch {}
+try {
+commandEncoder132.copyTextureToBuffer({
+  texture: texture80,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 58 widthInBlocks: 29 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 32122 */
+  offset: 11642,
+  bytesPerRow: 256,
+  rowsPerImage: 5,
+  buffer: buffer35,
+}, {width: 29, height: 0, depthOrArrayLayers: 17});
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer35, 6368, new Float32Array(43245), 39107, 1032);
+} catch {}
+let bindGroupLayout41 = device1.createBindGroupLayout({
+  label: '\u5267\u0515\ua19c\u0d65\u06aa\u0975\u4b97',
+  entries: [
+    {binding: 926, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 0,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 397,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let textureView160 = texture72.createView({
+  label: '\u9751\u0279\u076c\u144b\u{1fd75}\u0bb0\u{1f87d}\u1b9e\u{1f930}\u4ca3',
+  aspect: 'all',
+  baseMipLevel: 0,
+});
+let renderBundle95 = renderBundleEncoder70.finish({label: '\u{1fe66}\u8ba5\ub69b'});
+try {
+computePassEncoder46.setBindGroup(3, bindGroup35, new Uint32Array(4274), 3110, 0);
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline89);
+} catch {}
+try {
+commandEncoder127.copyTextureToTexture({
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 38, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 31, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 378, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder133.clearBuffer(buffer37);
+dissociateBuffer(device1, buffer37);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer35, 16948, new Float32Array(6834), 2114, 328);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 22, height: 1, depthOrArrayLayers: 61}
+*/
+{
+  source: img22,
+  origin: { x: 79, y: 31 },
+  flipY: true,
+}, {
+  texture: texture70,
+  mipLevel: 4,
+  origin: {x: 3, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout42 = device1.createBindGroupLayout({
+  label: '\u{1f970}\u014d\u{1f7b1}\udb8b',
+  entries: [
+    {
+      binding: 753,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 797, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+  ],
+});
+let commandEncoder134 = device1.createCommandEncoder({label: '\u0a3d\ub94c\ub157\u{1fc40}\uaca2\u{1fd8d}\u03f3\u0e52\u{1ff67}'});
+let textureView161 = texture74.createView({mipLevelCount: 6});
+try {
+computePassEncoder51.end();
+} catch {}
+try {
+renderBundleEncoder68.setPipeline(pipeline85);
+} catch {}
+try {
+renderBundleEncoder69.setVertexBuffer(9060, undefined);
+} catch {}
+let texture96 = device1.createTexture({
+  size: {width: 32},
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r16float'],
+});
+let renderBundleEncoder76 = device1.createRenderBundleEncoder({
+  label: '\u1490\u9f7c\u02f2\u0065\u8018\ue570\u598d\u{1f6b8}\u6945\u636f\u8ff3',
+  colorFormats: ['rg8uint', 'rgba16float', 'rg16sint'],
+});
+try {
+renderBundleEncoder58.setBindGroup(0, bindGroup35, new Uint32Array(6941), 4782, 0);
+} catch {}
+try {
+computePassEncoder50.setBindGroup(0, bindGroup31, new Uint32Array(3387), 1423, 0);
+} catch {}
+try {
+commandEncoder132.copyBufferToBuffer(buffer31, 34132, buffer37, 147660, 336);
+dissociateBuffer(device1, buffer31);
+dissociateBuffer(device1, buffer37);
+} catch {}
+try {
+commandEncoder131.copyTextureToBuffer({
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 52, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 5592 widthInBlocks: 699 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 27216 */
+  offset: 27216,
+  buffer: buffer35,
+}, {width: 699, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture93,
+  mipLevel: 2,
+  origin: {x: 10, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(675_247), /* required buffer size: 675_247 */
+{offset: 823, bytesPerRow: 116, rowsPerImage: 153}, {width: 12, height: 0, depthOrArrayLayers: 39});
+} catch {}
+let pipeline92 = await promise33;
+canvas0.width = 477;
+let offscreenCanvas33 = new OffscreenCanvas(375, 821);
+let bindGroup37 = device1.createBindGroup({
+  label: '\uace6\u070f\u925c\u{1fcac}\ua8c4\u07c9\ue551\u0887',
+  layout: bindGroupLayout34,
+  entries: [{binding: 714, resource: externalTexture67}],
+});
+let commandEncoder135 = device1.createCommandEncoder({label: '\u0215\u6f73\u0530\u{1fb54}\u2662\u1dc4\u{1f837}\u0635\ube4e\ub706'});
+let querySet72 = device1.createQuerySet({
+  label: '\uaaf3\u3c05\ubad1\u5589\u2416\u076e\u1ac2\u0b2a\u{1f85a}\u{1faed}',
+  type: 'occlusion',
+  count: 1372,
+});
+let renderBundle96 = renderBundleEncoder60.finish();
+try {
+renderBundleEncoder75.setIndexBuffer(buffer36, 'uint16', 500956, 15382);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 11, height: 1, depthOrArrayLayers: 30}
+*/
+{
+  source: videoFrame19,
+  origin: { x: 17, y: 7 },
+  flipY: false,
+}, {
+  texture: texture70,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+video6.width = 44;
+let imageBitmap36 = await createImageBitmap(videoFrame20);
+let buffer38 = device1.createBuffer({label: '\u6a81\u24bf', size: 80809, usage: GPUBufferUsage.STORAGE});
+let commandEncoder136 = device1.createCommandEncoder({label: '\ua276\u{1ff64}\u6b73\u507c\u{1f93c}\ue1be\u285d\u07a5\u19f5\u072f'});
+let textureView162 = texture92.createView({
+  label: '\u4f59\u{1fd02}\ue9ba\u0fa4\u{1ffa3}\u7199',
+  dimension: '2d',
+  baseArrayLayer: 43,
+  arrayLayerCount: 1,
+});
+let computePassEncoder54 = commandEncoder132.beginComputePass({label: '\u0062\u3f96\u8f03\u{1fe5d}\u0e23'});
+try {
+device1.queue.writeBuffer(buffer35, 40000, new BigUint64Array(24841), 22299, 160);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext32 = offscreenCanvas33.getContext('webgpu');
+gc();
+let bindGroupLayout43 = device1.createBindGroupLayout({
+  label: '\u63ae\ud805\u0c5c\u{1f98c}\ud907\u{1f9e4}\ue7d5',
+  entries: [
+    {
+      binding: 309,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let textureView163 = texture88.createView({});
+let renderBundle97 = renderBundleEncoder76.finish({label: '\u{1ff74}\u0bf3\u4211\u{1fc1a}'});
+let pipeline93 = device1.createRenderPipeline({
+  label: '\u5b65\u{1fe82}\u244e\u2dc6\u0dc9\ud3e0',
+  layout: pipelineLayout15,
+  fragment: {
+  module: shaderModule20,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg11b10ufloat',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.GREEN}, {
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r8uint'}, {format: 'r16sint'}],
+},
+  vertex: {
+    module: shaderModule20,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 68,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x2', offset: 44, shaderLocation: 0}],
+      },
+      {
+        arrayStride: 224,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 36, shaderLocation: 7},
+          {format: 'sint16x4', offset: 76, shaderLocation: 15},
+          {format: 'sint8x2', offset: 6, shaderLocation: 13},
+          {format: 'float32x4', offset: 4, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 16,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32', offset: 0, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 12},
+          {format: 'float32x3', offset: 0, shaderLocation: 11},
+          {format: 'float16x2', offset: 0, shaderLocation: 2},
+          {format: 'float32', offset: 0, shaderLocation: 5},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 0, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 0, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 780,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x4', offset: 40, shaderLocation: 3}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw', unclippedDepth: true},
+});
+canvas14.height = 139;
+let textureView164 = texture73.createView({mipLevelCount: 1});
+let computePassEncoder55 = commandEncoder136.beginComputePass({label: '\u69c0\u3996\u{1fc56}\u203c'});
+try {
+renderBundleEncoder67.setVertexBuffer(7938, undefined, 0, 214714149);
+} catch {}
+try {
+commandEncoder134.copyBufferToBuffer(buffer30, 155372, buffer35, 112812, 13220);
+dissociateBuffer(device1, buffer30);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+commandEncoder135.clearBuffer(buffer35, 3568, 217892);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer35, 13028, new Float32Array(38579), 34932, 1172);
+} catch {}
+canvas9.height = 247;
+let imageBitmap37 = await createImageBitmap(video0);
+let commandBuffer29 = commandEncoder134.finish({label: '\ufaf4\u{1f754}'});
+let texture97 = device1.createTexture({
+  label: '\uc417\u0748\u040b\u71f5\u2669\u9a84\u8a5e\u0f57',
+  size: [120],
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba16float', 'rgba16float'],
+});
+let textureView165 = texture95.createView({});
+try {
+renderBundleEncoder74.setPipeline(pipeline93);
+} catch {}
+try {
+commandEncoder125.copyTextureToTexture({
+  texture: texture94,
+  mipLevel: 3,
+  origin: {x: 15, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder130.clearBuffer(buffer37);
+dissociateBuffer(device1, buffer37);
+} catch {}
+let promise39 = device1.queue.onSubmittedWorkDone();
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 5, height: 1, depthOrArrayLayers: 15}
+*/
+{
+  source: imageBitmap7,
+  origin: { x: 14, y: 0 },
+  flipY: true,
+}, {
+  texture: texture70,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = externalTexture41.label;
+} catch {}
+let img26 = await imageWithData(133, 31, '#d2c0f5de', '#7a11a3aa');
+let commandEncoder137 = device1.createCommandEncoder({label: '\u77df\udb0f\u0f8c\u04e8\u9042\ua833\u495d\u0322\u4ce0\u5cd0'});
+let textureView166 = texture93.createView({label: '\u{1fe5c}\u{1fc7b}', dimension: '2d', baseMipLevel: 3, baseArrayLayer: 1});
+let externalTexture74 = device1.importExternalTexture({source: video2, colorSpace: 'display-p3'});
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+let img27 = await imageWithData(188, 121, '#e2052e53', '#8861e0f2');
+let commandEncoder138 = device1.createCommandEncoder({label: '\u8682\u{1fdb5}\u070b\uffb9\u7e09\u040a\u{1fa60}'});
+let renderBundle98 = renderBundleEncoder56.finish({label: '\u113d\ufcdc\ud665\u0ae5\u646f\ue84f'});
+let sampler70 = device1.createSampler({
+  label: '\u{1f79c}\u0284',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 91.13,
+  lodMaxClamp: 94.25,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder49.setPipeline(pipeline81);
+} catch {}
+try {
+renderBundleEncoder73.setIndexBuffer(buffer36, 'uint32', 184340, 344619);
+} catch {}
+try {
+device1.queue.submit([commandBuffer28, commandBuffer27]);
+} catch {}
+let pipeline94 = await device1.createComputePipelineAsync({layout: pipelineLayout13, compute: {module: shaderModule21, entryPoint: 'compute0', constants: {}}});
+let bindGroupLayout44 = device1.createBindGroupLayout({
+  label: '\u0a63\u{1fa5d}\u993a\u{1fa68}',
+  entries: [
+    {
+      binding: 319,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 821,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d-array' },
+    },
+  ],
+});
+let bindGroup38 = device1.createBindGroup({
+  label: '\u{1fda3}\uc86b\ufc84\ub3b1\u144f\u0f7f\u836c\u8734\u7a22\u{1fe23}',
+  layout: bindGroupLayout42,
+  entries: [{binding: 753, resource: sampler68}, {binding: 797, resource: externalTexture61}],
+});
+let querySet73 = device1.createQuerySet({type: 'occlusion', count: 1333});
+let externalTexture75 = device1.importExternalTexture({
+  label: '\u574d\u3728\u{1fe74}\u664d\u{1fd1a}\udb65\ub82d\u65ad\u031f\ub6ea',
+  source: video14,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder54.setBindGroup(1, bindGroup34, new Uint32Array(6840), 1373, 0);
+} catch {}
+try {
+computePassEncoder53.end();
+} catch {}
+try {
+device1.pushErrorScope('internal');
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 41, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer4), /* required buffer size: 926 */
+{offset: 926, rowsPerImage: 169}, {width: 53, height: 1, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let videoFrame26 = new VideoFrame(img5, {timestamp: 0});
+let commandEncoder139 = device1.createCommandEncoder();
+try {
+renderBundleEncoder63.setBindGroup(1, bindGroup31);
+} catch {}
+try {
+renderBundleEncoder75.setVertexBuffer(885, undefined);
+} catch {}
+let promise40 = device1.queue.onSubmittedWorkDone();
+let textureView167 = texture93.createView({label: '\u{1fce8}\u4662\u802d\u00df\u689a', dimension: '2d', baseArrayLayer: 52});
+let computePassEncoder56 = commandEncoder127.beginComputePass({});
+try {
+computePassEncoder49.end();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 3}
+*/
+{
+  source: video6,
+  origin: { x: 1, y: 0 },
+  flipY: true,
+}, {
+  texture: texture70,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline95 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout13,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule19,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgba16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'r16float', writeMask: 0}, {format: 'r8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {
+  format: 'rgba8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'zero'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rg32sint'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'not-equal', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'invert'},
+    stencilBack: {compare: 'never', failOp: 'invert', depthFailOp: 'replace', passOp: 'invert'},
+    stencilReadMask: 1005804031,
+    stencilWriteMask: 784901701,
+    depthBiasSlopeScale: 92.67890109349088,
+    depthBiasClamp: 635.3724878459666,
+  },
+  vertex: {
+    module: shaderModule19,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 188, attributes: []},
+      {
+        arrayStride: 44,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 24, shaderLocation: 6},
+          {format: 'float32x4', offset: 0, shaderLocation: 11},
+          {format: 'sint16x4', offset: 8, shaderLocation: 1},
+          {format: 'sint8x2', offset: 0, shaderLocation: 8},
+          {format: 'sint16x4', offset: 0, shaderLocation: 4},
+          {format: 'sint32x2', offset: 0, shaderLocation: 5},
+          {format: 'sint32x3', offset: 12, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 480,
+        attributes: [
+          {format: 'snorm16x4', offset: 48, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 68, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 38, shaderLocation: 0},
+          {format: 'sint8x4', offset: 216, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 312, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 528,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 216, shaderLocation: 7},
+          {format: 'unorm16x2', offset: 112, shaderLocation: 9},
+          {format: 'float32', offset: 0, shaderLocation: 15},
+        ],
+      },
+      {arrayStride: 0, attributes: [{format: 'uint8x2', offset: 94, shaderLocation: 3}]},
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+let commandEncoder140 = device1.createCommandEncoder();
+let querySet74 = device1.createQuerySet({type: 'occlusion', count: 869});
+let textureView168 = texture94.createView({
+  label: '\u6c6b\u027c\ub674\u5e55\u95a8\ua43a\u086e\u{1f6a2}\uac72',
+  aspect: 'all',
+  baseMipLevel: 3,
+  mipLevelCount: 2,
+});
+let renderBundleEncoder77 = device1.createRenderBundleEncoder({
+  colorFormats: ['rgba16float', 'r16float', 'r8uint', 'rg16float', 'rgba8unorm', 'rg32sint'],
+  sampleCount: 1,
+  depthReadOnly: false,
+});
+let externalTexture76 = device1.importExternalTexture({source: video9});
+try {
+renderBundleEncoder58.setIndexBuffer(buffer36, 'uint32', 96568, 294535);
+} catch {}
+try {
+renderBundleEncoder75.setVertexBuffer(4639, undefined, 0, 2602886842);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(arrayBuffer5), /* required buffer size: 922 */
+{offset: 922}, {width: 42, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline96 = device1.createRenderPipeline({
+  label: '\u6f9e\u{1fd2b}\u{1f79d}\u1659',
+  layout: pipelineLayout15,
+  multisample: {count: 4, mask: 0xdf8c6bc3},
+  fragment: {
+  module: shaderModule20,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg11b10ufloat', writeMask: GPUColorWrite.GREEN}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}, {format: 'rgba16float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'r8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {
+  format: 'r16sint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule20,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 364,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm16x4', offset: 68, shaderLocation: 12},
+          {format: 'float32x2', offset: 92, shaderLocation: 4},
+          {format: 'snorm16x4', offset: 24, shaderLocation: 1},
+          {format: 'uint16x2', offset: 132, shaderLocation: 0},
+          {format: 'snorm8x2', offset: 2, shaderLocation: 9},
+          {format: 'uint16x4', offset: 132, shaderLocation: 7},
+          {format: 'unorm8x2', offset: 38, shaderLocation: 8},
+          {format: 'unorm16x2', offset: 48, shaderLocation: 2},
+          {format: 'snorm16x4', offset: 96, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 20,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 2, shaderLocation: 11},
+          {format: 'sint32x2', offset: 0, shaderLocation: 15},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 5},
+          {format: 'sint32x4', offset: 0, shaderLocation: 13},
+          {format: 'uint32x4', offset: 0, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {unclippedDepth: true},
+});
+try {
+  await promise40;
+} catch {}
+gc();
+let canvas29 = document.createElement('canvas');
+try {
+canvas29.getContext('webgl2');
+} catch {}
+video12.height = 140;
+let textureView169 = texture88.createView({label: '\uc64a\uf4ff\u9285\ue367\u0c75\u3d74\u{1fb5e}\u0d7a'});
+try {
+commandEncoder133.copyTextureToTexture({
+  texture: texture94,
+  mipLevel: 5,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 103, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 11, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext15.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageBitmap38 = await createImageBitmap(imageBitmap20);
+let commandEncoder141 = device1.createCommandEncoder({label: '\u23a3\u9839\u{1f975}\ue594\u5c21\u0722\u0fdf'});
+try {
+renderBundleEncoder74.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+renderBundleEncoder73.setIndexBuffer(buffer36, 'uint32', 454376, 55845);
+} catch {}
+try {
+renderBundleEncoder74.setPipeline(pipeline93);
+} catch {}
+try {
+  await promise39;
+} catch {}
+let imageBitmap39 = await createImageBitmap(imageBitmap38);
+let commandEncoder142 = device1.createCommandEncoder({label: '\u3eff\u2bdc\ucb43\u0822'});
+let texture98 = device1.createTexture({
+  label: '\u74de\u{1f6d6}\u4763\u{1fa0f}\u{1f693}\u0c83\u1b98\u{1f9a4}\ucb1f',
+  size: {width: 16, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16sint', 'rg16sint'],
+});
+try {
+renderBundleEncoder75.setBindGroup(3, bindGroup31, new Uint32Array(7813), 4869, 0);
+} catch {}
+try {
+querySet65.destroy();
+} catch {}
+try {
+commandEncoder137.copyTextureToTexture({
+  texture: texture93,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'all',
+},
+{
+  texture: texture93,
+  mipLevel: 1,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 18, height: 0, depthOrArrayLayers: 1});
+} catch {}
+gc();
+try {
+adapter0.label = '\u{1fed6}\u058d\u0c1b\uaf2c\u0156\u{1fcd1}\u{1f9c4}\ub4a2\u016d\u6925';
+} catch {}
+let bindGroup39 = device1.createBindGroup({
+  label: '\u0ef4\u5bb7\u031e\u5676\u0a54\uad80',
+  layout: bindGroupLayout36,
+  entries: [{binding: 714, resource: externalTexture64}],
+});
+let buffer39 = device1.createBuffer({
+  label: '\u363f\u288f\u7c2f\u8b08\uca7d',
+  size: 168220,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder143 = device1.createCommandEncoder();
+let textureView170 = texture89.createView({dimension: '2d', baseMipLevel: 9, baseArrayLayer: 1});
+let renderBundle99 = renderBundleEncoder75.finish({label: '\u4b3d\u0d4a\u0479\ubc9b\u491d\u9c03'});
+try {
+renderBundleEncoder68.setPipeline(pipeline85);
+} catch {}
+try {
+commandEncoder131.clearBuffer(buffer39, 64920);
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer39, 168220, new BigUint64Array(51751), 29446, 0);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 120, height: 10, depthOrArrayLayers: 51}
+*/
+{
+  source: imageData16,
+  origin: { x: 2, y: 26 },
+  flipY: true,
+}, {
+  texture: texture94,
+  mipLevel: 3,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 12, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let video24 = await videoWithData();
+let commandBuffer30 = commandEncoder118.finish({label: '\u050e\u{1f91f}\u6720\uba07\u{1fe27}\u97fd\u255b\u{1f6ae}\u{1f95e}\ue8bc'});
+let textureView171 = texture82.createView({format: 'r8uint', mipLevelCount: 1});
+try {
+commandEncoder141.copyTextureToBuffer({
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 11 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 18843 */
+  offset: 18843,
+  rowsPerImage: 185,
+  buffer: buffer35,
+}, {width: 11, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext20.unconfigure();
+} catch {}
+video10.height = 49;
+let img28 = await imageWithData(44, 142, '#657e6084', '#158e5aa0');
+try {
+renderBundleEncoder58.setBindGroup(2, bindGroup32, new Uint32Array(1505), 1134, 0);
+} catch {}
+try {
+device1.destroy();
+} catch {}
+try {
+adapter0.label = '\u8be7\u0173\u28ea\u1beb\uac83';
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let offscreenCanvas34 = new OffscreenCanvas(507, 706);
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+let img29 = await imageWithData(24, 208, '#ad95f066', '#c1e874f3');
+try {
+adapter2.label = '\u{1fb63}\u0abf\uebb8\u73ae';
+} catch {}
+try {
+sampler6.label = '\ua15e\uc002\u2547\u19ef\u05f4\u7aab\u{1f89b}\u0724\u{1ff9e}';
+} catch {}
+let canvas30 = document.createElement('canvas');
+let canvas31 = document.createElement('canvas');
+try {
+gpuCanvasContext28.unconfigure();
+} catch {}
+try {
+  await promise38;
+} catch {}
+let canvas32 = document.createElement('canvas');
+document.body.prepend(img21);
+let canvas33 = document.createElement('canvas');
+canvas27.width = 2359;
+canvas15.height = 361;
+let promise41 = adapter0.requestAdapterInfo();
+try {
+canvas33.getContext('2d');
+} catch {}
+try {
+adapter2.label = '\u4823\ud1f7';
+} catch {}
+try {
+window.someLabel = shaderModule9.label;
+} catch {}
+let offscreenCanvas35 = new OffscreenCanvas(275, 743);
+let video25 = await videoWithData();
+gc();
+let imageBitmap40 = await createImageBitmap(canvas1);
+canvas14.width = 252;
+let videoFrame27 = new VideoFrame(videoFrame13, {timestamp: 0});
+try {
+offscreenCanvas34.getContext('webgl2');
+} catch {}
+let gpuCanvasContext33 = canvas31.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+window.someLabel = textureView114.label;
+} catch {}
+gc();
+try {
+adapter2.label = '\u3360\u91fc\u71ba\u{1ff5f}\u0d35\u{1f7cf}\u0794\u0426\u00ce\u{1fe63}';
+} catch {}
+let imageBitmap41 = await createImageBitmap(canvas9);
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let canvas34 = document.createElement('canvas');
+try {
+renderBundleEncoder58.setPipeline(pipeline85);
+} catch {}
+try {
+commandEncoder138.copyBufferToBuffer(buffer30, 72616, buffer35, 235976, 42256);
+dissociateBuffer(device1, buffer30);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+device1.queue.submit([commandBuffer24, commandBuffer30]);
+} catch {}
+video22.height = 25;
+gc();
+video7.height = 25;
+let img30 = await imageWithData(51, 293, '#054b12cb', '#c65211dd');
+let gpuCanvasContext34 = canvas34.getContext('webgpu');
+let pipelineLayout17 = device0.createPipelineLayout({
+  label: '\u0d85\u0486\ud07c\u88e8\ub2d1\u{1f828}\uf1f2\uf281\u53c1\u0a96\ub84d',
+  bindGroupLayouts: [bindGroupLayout2],
+});
+let computePassEncoder57 = commandEncoder1.beginComputePass({label: '\u37e6\u5ae5\u0960\ucddc\u0500\uc1ab\u5c22\u95dc'});
+let renderBundleEncoder78 = device0.createRenderBundleEncoder({
+  label: '\u6919\u81b7\u79c3\u27b2\u649e\uefe5\u04c5',
+  colorFormats: [],
+  depthStencilFormat: 'stencil8',
+  sampleCount: 1,
+});
+let externalTexture77 = device0.importExternalTexture({label: '\u0dc2\u069f\u5fa4\u{1f84c}\u39a4\u00e3\uc082\u0c76', source: videoFrame15});
+try {
+renderPassEncoder14.beginOcclusionQuery(3053);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder11.setViewport(10.81, 1.489, 18.96, 3.199, 0.5660, 0.6692);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline58);
+} catch {}
+try {
+renderBundleEncoder22.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder15.draw(128, 89, 228_481_959, 260_603_425);
+} catch {}
+try {
+renderBundleEncoder41.setIndexBuffer(buffer24, 'uint32', 712, 460);
+} catch {}
+try {
+commandEncoder101.clearBuffer(buffer10, 74212, 100144);
+dissociateBuffer(device0, buffer10);
+} catch {}
+try {
+commandEncoder105.resolveQuerySet(querySet9, 1546, 1345, buffer26, 32256);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture31,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer6), /* required buffer size: 597 */
+{offset: 597, bytesPerRow: 188}, {width: 15, height: 3, depthOrArrayLayers: 0});
+} catch {}
+gc();
+try {
+canvas32.getContext('bitmaprenderer');
+} catch {}
+let video26 = await videoWithData();
+try {
+  await promise41;
+} catch {}
+let bindGroupLayout45 = device0.createBindGroupLayout({
+  label: '\u{1f6bc}\u{1fbb1}\u4f64\u0ea6\u{1f630}\u2a49',
+  entries: [
+    {
+      binding: 660,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: true },
+    },
+    {
+      binding: 559,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 130,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let bindGroup40 = device0.createBindGroup({
+  label: '\u609f\u0ad6\u0379\u957c\u143e\u08a0\ub1b4\u02d3\u{1fc14}\ud4b2\u6dcd',
+  layout: bindGroupLayout13,
+  entries: [{binding: 87, resource: externalTexture48}, {binding: 982, resource: sampler25}],
+});
+let commandBuffer31 = commandEncoder99.finish({});
+let texture99 = gpuCanvasContext15.getCurrentTexture();
+let renderPassEncoder51 = commandEncoder101.beginRenderPass({
+  label: '\uc662\u{1f70c}\u71fd\u{1ffa7}\u0b6b\u4ef4\u{1fd63}\u{1feaa}\u0bc8\ucdca',
+  colorAttachments: [],
+  depthStencilAttachment: {view: textureView61, depthClearValue: -0.4972783488765522, stencilReadOnly: true},
+  occlusionQuerySet: querySet8,
+  maxDrawCount: 591121374,
+});
+try {
+renderPassEncoder26.beginOcclusionQuery(55);
+} catch {}
+try {
+renderPassEncoder43.setVertexBuffer(1, buffer17, 2424, 1983);
+} catch {}
+try {
+renderBundleEncoder44.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder15.draw(48, 231, 663_004_643, 293_909_983);
+} catch {}
+try {
+renderBundleEncoder15.drawIndexed(66, 152, 197_335_023);
+} catch {}
+try {
+renderBundleEncoder15.drawIndexedIndirect(buffer3, 408);
+} catch {}
+try {
+renderBundleEncoder15.drawIndirect(buffer24, 828);
+} catch {}
+try {
+renderBundleEncoder33.setPipeline(pipeline58);
+} catch {}
+try {
+renderBundleEncoder49.setVertexBuffer(1, buffer17, 0, 346);
+} catch {}
+let img31 = await imageWithData(135, 166, '#5e83184f', '#aa5fd919');
+document.body.prepend(img30);
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+try {
+videoFrame4.close();
+} catch {}
+let offscreenCanvas36 = new OffscreenCanvas(743, 279);
+let video27 = await videoWithData();
+let gpuCanvasContext35 = offscreenCanvas35.getContext('webgpu');
+canvas17.height = 182;
+canvas30.height = 519;
+let canvas35 = document.createElement('canvas');
+let gpuCanvasContext36 = canvas35.getContext('webgpu');
+let imageData20 = new ImageData(192, 164);
+try {
+offscreenCanvas36.getContext('bitmaprenderer');
+} catch {}
+document.body.prepend(img13);
+let offscreenCanvas37 = new OffscreenCanvas(1003, 655);
+let bindGroup41 = device0.createBindGroup({label: '\u2d7c\ub632\u{1f7b6}\u{1fdfe}\u1d81\u0f6d\u3e46', layout: bindGroupLayout29, entries: []});
+let commandEncoder144 = device0.createCommandEncoder({label: '\u0519\u075e\uf6cb'});
+let externalTexture78 = device0.importExternalTexture({label: '\u086a\u0c82\u{1fe40}\u0467', source: video10, colorSpace: 'display-p3'});
+try {
+renderPassEncoder24.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(1, bindGroup19, new Uint32Array(9850), 3849, 0);
+} catch {}
+try {
+commandEncoder103.copyTextureToTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'stencil-only',
+},
+{width: 60, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext25.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 3},
+  aspect: 'stencil-only',
+}, arrayBuffer4, /* required buffer size: 1_440_570 */
+{offset: 120, bytesPerRow: 825, rowsPerImage: 291}, {width: 640, height: 0, depthOrArrayLayers: 7});
+} catch {}
+let pipeline97 = await device0.createComputePipelineAsync({
+  label: '\udb7f\u{1fbb1}\u9977\u0cbb\u{1fbcd}\u730f\u04b7\u3586',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(video7);
+let img32 = await imageWithData(276, 279, '#40cd8cf3', '#2ff1e34d');
+let texture100 = device1.createTexture({
+  label: '\ucf8b\u6ec4\uf742\u8f3a\u{1fcde}\u{1ff39}\u4911\u7272\uf765\u0ce6\u65cb',
+  size: [32, 1, 108],
+  mipLevelCount: 6,
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg16sint', 'rg16sint', 'rg16sint'],
+});
+let renderBundleEncoder79 = device1.createRenderBundleEncoder({
+  label: '\u{1fe55}\u1df5\u{1f7ac}\uc468\u{1fd8e}\u{1ff3d}\u0148\u9de1\ufbe0\ua2c3',
+  colorFormats: ['rgba16float', 'r16float', 'r8uint', 'rg16float', 'rgba8unorm', 'rg32sint'],
+});
+let externalTexture79 = device1.importExternalTexture({label: '\u245a\u9952\u5c04\u017d\u{1f6f3}\u3a8a', source: videoFrame1, colorSpace: 'srgb'});
+try {
+computePassEncoder54.setBindGroup(2, bindGroup38);
+} catch {}
+try {
+computePassEncoder40.setBindGroup(3, bindGroup33, new Uint32Array(6459), 4951, 0);
+} catch {}
+try {
+commandEncoder139.clearBuffer(buffer37);
+dissociateBuffer(device1, buffer37);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 75, y: 1, z: 5},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 3_263_994 */
+{offset: 974, bytesPerRow: 779, rowsPerImage: 231}, {width: 142, height: 31, depthOrArrayLayers: 19});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 22, height: 1, depthOrArrayLayers: 61}
+*/
+{
+  source: imageBitmap12,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture70,
+  mipLevel: 4,
+  origin: {x: 14, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView172 = texture82.createView({label: '\u0c13\u7ad1\u4a2a'});
+let renderBundleEncoder80 = device1.createRenderBundleEncoder({
+  label: '\u7e21\ub7aa\uf071\u0b8a',
+  colorFormats: ['rg11b10ufloat', 'rgb10a2uint', 'rgba16float', 'r8uint', 'r8uint', 'r16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle100 = renderBundleEncoder60.finish({label: '\u31e0\u7116\u57ff\u841c\u{1fe75}\u0d0f\u{1f661}\u0729'});
+let sampler71 = device1.createSampler({
+  label: '\u{1f878}\u9bda\u67e6\uc3a9\uf6d5\u0b14\u0029\u{1f6d4}',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 48.79,
+  lodMaxClamp: 88.46,
+  maxAnisotropy: 7,
+});
+let externalTexture80 = device1.importExternalTexture({source: video23, colorSpace: 'srgb'});
+try {
+commandEncoder131.copyBufferToBuffer(buffer32, 3264, buffer39, 163556, 1132);
+dissociateBuffer(device1, buffer32);
+dissociateBuffer(device1, buffer39);
+} catch {}
+let canvas36 = document.createElement('canvas');
+let canvas37 = document.createElement('canvas');
+let renderBundle101 = renderBundleEncoder56.finish({label: '\u01c5\u0eec\u0652\u3a04\u7a7e\ufa44\u{1f740}\u7cf5\u0307'});
+try {
+computePassEncoder48.setPipeline(pipeline81);
+} catch {}
+try {
+renderBundleEncoder69.setPipeline(pipeline93);
+} catch {}
+try {
+device1.queue.submit([commandBuffer29]);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer39, 42488, new Int16Array(23989), 19059);
+} catch {}
+let canvas38 = document.createElement('canvas');
+let videoFrame28 = new VideoFrame(canvas25, {timestamp: 0});
+let gpuCanvasContext37 = canvas30.getContext('webgpu');
+let gpuCanvasContext38 = canvas36.getContext('webgpu');
+let gpuCanvasContext39 = offscreenCanvas37.getContext('webgpu');
+let gpuCanvasContext40 = canvas38.getContext('webgpu');
+document.body.prepend(img7);
+let offscreenCanvas38 = new OffscreenCanvas(654, 458);
+try {
+adapter1.label = '\u8d69\ue3d7\u0747\u19f4\u{1fa86}\u03d5';
+} catch {}
+let offscreenCanvas39 = new OffscreenCanvas(673, 748);
+try {
+gpuCanvasContext24.unconfigure();
+} catch {}
+let imageData21 = new ImageData(12, 236);
+let promise42 = adapter1.requestAdapterInfo();
+try {
+  await promise42;
+} catch {}
+let gpuCanvasContext41 = canvas37.getContext('webgpu');
+canvas15.width = 926;
+let canvas39 = document.createElement('canvas');
+video12.width = 263;
+try {
+offscreenCanvas38.getContext('bitmaprenderer');
+} catch {}
+let videoFrame29 = new VideoFrame(offscreenCanvas27, {timestamp: 0});
+let img33 = await imageWithData(242, 245, '#b04b91b1', '#1044da0c');
+let imageData22 = new ImageData(248, 152);
+let img34 = await imageWithData(10, 290, '#92673ed4', '#f118324e');
+let video28 = await videoWithData();
+let offscreenCanvas40 = new OffscreenCanvas(638, 791);
+let textureView173 = texture88.createView({label: '\ube1f\u0302\ud047'});
+let computePassEncoder58 = commandEncoder130.beginComputePass();
+try {
+computePassEncoder47.setBindGroup(0, bindGroup29, new Uint32Array(7377), 2372, 0);
+} catch {}
+try {
+renderBundleEncoder69.setBindGroup(3, bindGroup38, []);
+} catch {}
+try {
+commandEncoder135.copyBufferToBuffer(buffer32, 4048, buffer35, 50268, 2904);
+dissociateBuffer(device1, buffer32);
+dissociateBuffer(device1, buffer35);
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+gc();
+let gpuCanvasContext42 = offscreenCanvas39.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let offscreenCanvas41 = new OffscreenCanvas(440, 62);
+video27.height = 135;
+let video29 = await videoWithData();
+let img35 = await imageWithData(197, 93, '#ad4fe30a', '#ba643992');
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let pipelineLayout18 = device1.createPipelineLayout({label: '\u0a08\uec14\u353f', bindGroupLayouts: [bindGroupLayout44, bindGroupLayout38]});
+let commandBuffer32 = commandEncoder125.finish();
+let sampler72 = device1.createSampler({
+  label: '\u1a47\ud0a7\ucd64\ue36c\uca56\ua6a4\ua09d\u061b\u{1fc64}',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 17.10,
+  lodMaxClamp: 46.78,
+});
+let externalTexture81 = device1.importExternalTexture({
+  label: '\u060b\u{1fd3f}\ud4fe\u706b\u3673\uce99\u97ab',
+  source: videoFrame11,
+  colorSpace: 'display-p3',
+});
+try {
+device1.queue.writeBuffer(buffer39, 12048, new Float32Array(15924));
+} catch {}
+let pipeline98 = device1.createComputePipeline({
+  label: '\ud624\u2ac9\u{1f845}\u0edf\u{1f658}\u070b\ucb8b\ua940',
+  layout: pipelineLayout14,
+  compute: {module: shaderModule17, entryPoint: 'compute0', constants: {}},
+});
+let pipeline99 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout15,
+  multisample: {mask: 0x34fcbf10},
+  fragment: {
+  module: shaderModule16,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg11b10ufloat', writeMask: 0}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba16float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r8uint', writeMask: 0}, {format: 'r8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r16sint', writeMask: GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule16,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 220,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x3', offset: 32, shaderLocation: 14},
+          {format: 'unorm8x2', offset: 32, shaderLocation: 9},
+          {format: 'sint32', offset: 0, shaderLocation: 2},
+          {format: 'uint32x3', offset: 40, shaderLocation: 7},
+          {format: 'snorm8x2', offset: 106, shaderLocation: 11},
+          {format: 'snorm16x4', offset: 48, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 188,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 12, shaderLocation: 12},
+          {format: 'snorm8x4', offset: 0, shaderLocation: 10},
+          {format: 'unorm8x2', offset: 12, shaderLocation: 15},
+          {format: 'unorm8x4', offset: 24, shaderLocation: 5},
+          {format: 'sint32', offset: 88, shaderLocation: 8},
+          {format: 'float32', offset: 4, shaderLocation: 6},
+          {format: 'uint8x2', offset: 2, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 84, attributes: []},
+      {
+        arrayStride: 388,
+        attributes: [
+          {format: 'uint8x2', offset: 60, shaderLocation: 13},
+          {format: 'uint32x4', offset: 84, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 0, attributes: [{format: 'snorm16x4', offset: 464, shaderLocation: 4}]},
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front', unclippedDepth: true},
+});
+canvas21.width = 274;
+gc();
+let imageData23 = new ImageData(156, 176);
+let videoFrame30 = new VideoFrame(videoFrame25, {timestamp: 0});
+let offscreenCanvas42 = new OffscreenCanvas(418, 572);
+let video30 = await videoWithData();
+let imageData24 = new ImageData(112, 72);
+let gpuCanvasContext43 = offscreenCanvas42.getContext('webgpu');
+let offscreenCanvas43 = new OffscreenCanvas(521, 526);
+let texture101 = device0.createTexture({
+  label: '\u{1f7c5}\u07fc\u0e6f\u29e1\ud017\u00ff',
+  size: [240],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'r8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView174 = texture40.createView({
+  label: '\ua1a1\u5d35\u00ff\u0891\u{1fbdc}\u173e\u0d50\u0c7f',
+  dimension: '2d',
+  mipLevelCount: 2,
+  baseArrayLayer: 15,
+});
+let renderBundleEncoder81 = device0.createRenderBundleEncoder({
+  label: '\u8b0d\u48bf\u0a4c\u0822\ue272\u{1fdd1}\u0c2e\u4aa8\u{1ffc8}\u0bf9\u016a',
+  colorFormats: ['r32sint', 'r8sint', 'rgb10a2uint', 'rgba16sint', 'r8sint'],
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder51.end();
+} catch {}
+try {
+renderPassEncoder30.beginOcclusionQuery(179);
+} catch {}
+try {
+renderPassEncoder40.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder15.drawIndexedIndirect(buffer24, 256);
+} catch {}
+try {
+commandEncoder106.copyTextureToTexture({
+  texture: texture58,
+  mipLevel: 6,
+  origin: {x: 4, y: 0, z: 36},
+  aspect: 'all',
+},
+{
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 113, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer27, 23460, new Float32Array(56630), 13656, 4908);
+} catch {}
+gc();
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let adapter3 = await promise28;
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let offscreenCanvas44 = new OffscreenCanvas(794, 254);
+document.body.prepend(canvas28);
+let imageBitmap42 = await createImageBitmap(offscreenCanvas25);
+try {
+offscreenCanvas41.getContext('2d');
+} catch {}
+let offscreenCanvas45 = new OffscreenCanvas(75, 573);
+let canvas40 = document.createElement('canvas');
+document.body.prepend(canvas15);
+let gpuCanvasContext44 = canvas39.getContext('webgpu');
+try {
+canvas40.getContext('webgl2');
+} catch {}
+let canvas41 = document.createElement('canvas');
+let textureView175 = texture98.createView({dimension: '2d', baseMipLevel: 1});
+let renderBundle102 = renderBundleEncoder80.finish({label: '\u0e39\ue7fc\ueb56\u0d67\u354f'});
+try {
+commandEncoder138.copyTextureToTexture({
+  texture: texture77,
+  mipLevel: 1,
+  origin: {x: 78, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture91,
+  mipLevel: 0,
+  origin: {x: 78, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 360, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm-srgb'],
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer35, 212904, new BigUint64Array(21572), 13519, 3136);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+canvas27.width = 1339;
+let gpuCanvasContext45 = offscreenCanvas43.getContext('webgpu');
+let promise43 = adapter3.requestDevice({
+  label: '\ub2a8\u7896',
+  requiredFeatures: [
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 11,
+    maxColorAttachmentBytesPerSample: 59,
+    maxVertexAttributes: 24,
+    maxVertexBufferArrayStride: 14117,
+    maxStorageTexturesPerShaderStage: 34,
+    maxStorageBuffersPerShaderStage: 30,
+    maxDynamicStorageBuffersPerPipelineLayout: 43248,
+    maxDynamicUniformBuffersPerPipelineLayout: 41460,
+    maxBindingsPerBindGroup: 9514,
+    maxTextureArrayLayers: 827,
+    maxTextureDimension1D: 15479,
+    maxTextureDimension2D: 9159,
+    maxVertexBuffers: 11,
+    maxBindGroupsPlusVertexBuffers: 26,
+    minStorageBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 183164631,
+    maxStorageBufferBindingSize: 208808980,
+    maxUniformBuffersPerShaderStage: 31,
+    maxSampledTexturesPerShaderStage: 19,
+    maxInterStageShaderVariables: 62,
+    maxInterStageShaderComponents: 85,
+    maxSamplersPerShaderStage: 20,
+  },
+});
+let videoFrame31 = new VideoFrame(canvas34, {timestamp: 0});
+let computePassEncoder59 = commandEncoder102.beginComputePass({label: '\u0b3c\u{1ff72}\ua45d\uf69e\u7ffa\u{1f7b2}\ub545\u06e3\uc4e2\ub77f'});
+try {
+renderPassEncoder43.setViewport(1.091, 2.001, 0.6506, 0.2476, 0.2528, 0.9795);
+} catch {}
+try {
+renderBundleEncoder78.setVertexBuffer(5, buffer17, 2892, 286);
+} catch {}
+try {
+commandEncoder144.copyBufferToBuffer(buffer4, 136, buffer16, 310568, 2136);
+dissociateBuffer(device0, buffer4);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder103.insertDebugMarker('\uac75');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture99,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer9), /* required buffer size: 612 */
+{offset: 612}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas8,
+  origin: { x: 61, y: 198 },
+  flipY: true,
+}, {
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let offscreenCanvas46 = new OffscreenCanvas(148, 298);
+try {
+gpuCanvasContext36.unconfigure();
+} catch {}
+let canvas42 = document.createElement('canvas');
+try {
+canvas42.getContext('2d');
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+document.body.prepend(video17);
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+video22.height = 273;
+let imageBitmap43 = await createImageBitmap(canvas38);
+let computePassEncoder60 = commandEncoder144.beginComputePass();
+let renderBundle103 = renderBundleEncoder43.finish({label: '\u08b6\u{1f847}\u{1f97a}\u0738\u9f17'});
+let sampler73 = device0.createSampler({
+  label: '\u707c\u09f9',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 11.61,
+  lodMaxClamp: 50.48,
+});
+try {
+computePassEncoder32.setPipeline(pipeline25);
+} catch {}
+try {
+renderPassEncoder48.setBlendConstant({ r: -486.1, g: 167.5, b: 601.0, a: -317.8, });
+} catch {}
+try {
+renderPassEncoder32.setVertexBuffer(4, buffer17, 0, 3097);
+} catch {}
+try {
+renderBundleEncoder15.drawIndexedIndirect(buffer3, 84);
+} catch {}
+try {
+commandEncoder105.copyBufferToBuffer(buffer20, 68136, buffer28, 122804, 31008);
+dissociateBuffer(device0, buffer20);
+dissociateBuffer(device0, buffer28);
+} catch {}
+try {
+commandEncoder103.resolveQuerySet(querySet43, 382, 1034, buffer26, 93184);
+} catch {}
+try {
+renderBundleEncoder81.pushDebugGroup('\u0c6e');
+} catch {}
+try {
+computePassEncoder30.insertDebugMarker('\u3b32');
+} catch {}
+let gpuCanvasContext46 = offscreenCanvas44.getContext('webgpu');
+let canvas43 = document.createElement('canvas');
+let video31 = await videoWithData();
+let imageBitmap44 = await createImageBitmap(canvas5);
+try {
+window.someLabel = externalTexture72.label;
+} catch {}
+document.body.prepend(canvas32);
+let adapter4 = await navigator.gpu.requestAdapter({});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+canvas43.getContext('webgl2');
+} catch {}
+gc();
+let video32 = await videoWithData();
+gc();
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+offscreenCanvas40.getContext('bitmaprenderer');
+} catch {}
+let promise44 = adapter2.requestAdapterInfo();
+let imageBitmap45 = await createImageBitmap(offscreenCanvas4);
+let imageBitmap46 = await createImageBitmap(offscreenCanvas23);
+let imageBitmap47 = await createImageBitmap(offscreenCanvas11);
+gc();
+try {
+canvas41.getContext('bitmaprenderer');
+} catch {}
+let imageBitmap48 = await createImageBitmap(imageBitmap27);
+let offscreenCanvas47 = new OffscreenCanvas(644, 133);
+let adapter5 = await navigator.gpu.requestAdapter({});
+try {
+offscreenCanvas47.getContext('2d');
+} catch {}
+let gpuCanvasContext47 = offscreenCanvas46.getContext('webgpu');
+let video33 = await videoWithData();
+let gpuCanvasContext48 = offscreenCanvas45.getContext('webgpu');
+let imageData25 = new ImageData(132, 120);
+offscreenCanvas6.width = 229;
+let video34 = await videoWithData();
+let videoFrame32 = new VideoFrame(imageBitmap31, {timestamp: 0});
+let imageData26 = new ImageData(20, 132);
+try {
+adapter0.label = '\u1963\u7d51\u{1f63d}\u00c5\u21c6\u0d02\u9e31\u2d6b\u{1fe31}\u{1ff1b}';
+} catch {}
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let video35 = await videoWithData();
+let video36 = await videoWithData();
+try {
+gpuCanvasContext29.unconfigure();
+} catch {}
+try {
+  await promise44;
+} catch {}
+document.body.prepend(canvas30);
+try {
+gpuCanvasContext43.unconfigure();
+} catch {}
+document.body.prepend(img27);
+offscreenCanvas10.width = 77;
+let canvas44 = document.createElement('canvas');
+try {
+canvas44.getContext('bitmaprenderer');
+} catch {}
+gc();
+let canvas45 = document.createElement('canvas');
+let offscreenCanvas48 = new OffscreenCanvas(483, 230);
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+gc();
+let gpuCanvasContext49 = canvas45.getContext('webgpu');
+let canvas46 = document.createElement('canvas');
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let canvas47 = document.createElement('canvas');
+let imageBitmap49 = await createImageBitmap(canvas30);
+let video37 = await videoWithData();
+let commandEncoder145 = device1.createCommandEncoder({});
+let textureView176 = texture73.createView({label: '\ud6a8\u{1fa4c}\u0583\u4b73\u0132\u{1f853}\ud592\u3c04\u{1fece}\u54c8', aspect: 'all'});
+try {
+renderBundleEncoder58.setBindGroup(3, bindGroup33);
+} catch {}
+try {
+renderBundleEncoder69.setVertexBuffer(599, undefined, 3896164118);
+} catch {}
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+let gpuCanvasContext50 = canvas46.getContext('webgpu');
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+gc();
+let imageBitmap50 = await createImageBitmap(videoFrame5);
+let imageData27 = new ImageData(136, 212);
+canvas18.width = 191;
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let gpuCanvasContext51 = offscreenCanvas48.getContext('webgpu');
+let canvas48 = document.createElement('canvas');
+let imageBitmap51 = await createImageBitmap(canvas45);
+try {
+canvas47.getContext('webgpu');
+} catch {}
+let gpuCanvasContext52 = canvas48.getContext('webgpu');
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+try {
+externalTexture50.label = '\u{1f9e9}\u8477\u0cba\u{1fb3e}\u006b\u080d';
+} catch {}
+let video38 = await videoWithData();
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+document.body.prepend(video28);
+document.body.prepend(canvas16);
+try {
+externalTexture39.label = '\u02b7\uf817\u{1f68c}\ued7c\u1552\u03cb\u0772';
+} catch {}
+try {
+adapter3.label = '\u03e8\u78e8\u030e\u84ca\u8494\ub8ca\u5c3e\u16d0\u{1fc3e}\u45c4\u0473';
+} catch {}
+document.body.prepend(img28);
+let offscreenCanvas49 = new OffscreenCanvas(853, 758);
+try {
+offscreenCanvas49.getContext('bitmaprenderer');
+} catch {}
+let offscreenCanvas50 = new OffscreenCanvas(593, 201);
+let imageData28 = new ImageData(44, 56);
+let shaderModule22 = device0.createShaderModule({
+  label: '\u{1ff02}\u{1f82d}',
+  code: `@group(0) @binding(504)
+var<storage, read_write> function9: array<u32>;
+@group(0) @binding(840)
+var<storage, read_write> function10: array<u32>;
+
+@compute @workgroup_size(3, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec3<i32>,
+  @location(2) f1: vec4<u32>,
+  @location(1) f2: vec3<i32>,
+  @location(3) f3: vec4<i32>,
+  @location(7) f4: vec2<i32>,
+  @location(4) f5: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(15) a0: vec3<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(15) f151: vec3<i32>,
+  @builtin(position) f152: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(0) a0: vec4<f32>, @location(9) a1: vec4<f32>, @builtin(instance_index) a2: u32, @location(5) a3: vec2<f16>, @builtin(vertex_index) a4: u32, @location(14) a5: vec4<f16>, @location(2) a6: vec2<i32>, @location(11) a7: vec2<f32>, @location(4) a8: i32, @location(13) a9: i32, @location(3) a10: u32, @location(10) a11: vec2<i32>, @location(8) a12: vec4<f16>, @location(6) a13: vec3<i32>, @location(1) a14: f32, @location(7) a15: vec3<u32>, @location(15) a16: vec3<f16>, @location(12) a17: vec2<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout46 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 98,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '2d' },
+    },
+  ],
+});
+let bindGroup42 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [{binding: 781, resource: {buffer: buffer0, offset: 38656, size: 33416}}],
+});
+let computePassEncoder61 = commandEncoder106.beginComputePass({label: '\u7d54\u0f6a\u{1fe6f}'});
+let renderBundle104 = renderBundleEncoder10.finish({label: '\u{1f6c0}\u01b2\u9b2e\u5505'});
+try {
+renderPassEncoder10.setScissorRect(1, 0, 0, 1);
+} catch {}
+try {
+renderPassEncoder26.setStencilReference(2506);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer17, 'uint16');
+} catch {}
+try {
+renderBundleEncoder15.drawIndexed(285, 203);
+} catch {}
+try {
+renderBundleEncoder15.drawIndexedIndirect(buffer3, 1244);
+} catch {}
+try {
+renderBundleEncoder37.setIndexBuffer(buffer22, 'uint16', 78778, 32894);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 160, height: 2, depthOrArrayLayers: 125}
+*/
+{
+  source: canvas1,
+  origin: { x: 36, y: 30 },
+  flipY: false,
+}, {
+  texture: texture58,
+  mipLevel: 3,
+  origin: {x: 10, y: 0, z: 22},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame33 = new VideoFrame(offscreenCanvas32, {timestamp: 0});
+let gpuCanvasContext53 = offscreenCanvas50.getContext('webgpu');
+let imageBitmap52 = await createImageBitmap(imageBitmap2);
+let video39 = await videoWithData();
+let video40 = await videoWithData();
+try {
+externalTexture59.label = '\u6cf6\u091e\u09de\u07a9\u0077\ue6ce\u28ca\ud961\u0adf\u08f8';
+} catch {}
+let bindGroup43 = device0.createBindGroup({
+  label: '\ua8f0\u0de9\uc60e\u3931\u4139\u{1fbda}\u605d',
+  layout: bindGroupLayout30,
+  entries: [{binding: 855, resource: externalTexture45}, {binding: 762, resource: externalTexture25}],
+});
+let commandEncoder146 = device0.createCommandEncoder({label: '\uef03\u8d5b\u6043\u{1fed1}\u126c\u09b4\u5c15'});
+let computePassEncoder62 = commandEncoder103.beginComputePass({label: '\u{1fa3b}\u0fdf\u0566\u256b'});
+let renderBundle105 = renderBundleEncoder10.finish();
+let sampler74 = device0.createSampler({
+  label: '\u0a08\u94b7',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 16.69,
+  lodMaxClamp: 25.41,
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder32.dispatchWorkgroups(5, 4, 5);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(205);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(0, bindGroup23, []);
+} catch {}
+try {
+renderBundleEncoder15.draw(197);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+commandEncoder105.clearBuffer(buffer27, 143964, 81448);
+dissociateBuffer(device0, buffer27);
+} catch {}
+try {
+commandEncoder105.resolveQuerySet(querySet7, 949, 372, buffer26, 141824);
+} catch {}
+gc();
+let img36 = await imageWithData(49, 17, '#7fdc0b56', '#e2453412');
+try {
+adapter2.label = '\u1aab\u{1f9f9}\ud1c5';
+} catch {}
+let videoFrame34 = new VideoFrame(canvas6, {timestamp: 0});
+let canvas49 = document.createElement('canvas');
+let imageBitmap53 = await createImageBitmap(imageData27);
+try {
+canvas49.getContext('webgl2');
+} catch {}
+let textureView177 = texture70.createView({label: '\u{1f74f}\u0fe6\u5b06\u{1f900}', format: 'bgra8unorm-srgb', mipLevelCount: 1});
+try {
+computePassEncoder46.setBindGroup(3, bindGroup34);
+} catch {}
+try {
+computePassEncoder44.setPipeline(pipeline82);
+} catch {}
+try {
+renderBundleEncoder79.setIndexBuffer(buffer36, 'uint16', 167828, 133337);
+} catch {}
+try {
+commandEncoder143.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 25564 */
+  offset: 25564,
+  buffer: buffer31,
+}, {
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer31);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer35, 4276, new Int16Array(25152), 14852, 1764);
+} catch {}
+gc();
+canvas22.width = 121;
+document.body.prepend(canvas38);
+let imageData29 = new ImageData(140, 188);
+let canvas50 = document.createElement('canvas');
+let device2 = await promise0;
+let img37 = await imageWithData(239, 82, '#b7ac0206', '#4059afa7');
+let imageBitmap54 = await createImageBitmap(video33);
+gc();
+let video41 = await videoWithData();
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let imageBitmap55 = await createImageBitmap(canvas23);
+try {
+canvas50.getContext('bitmaprenderer');
+} catch {}
+let canvas51 = document.createElement('canvas');
+let renderBundleEncoder82 = device2.createRenderBundleEncoder({
+  label: '\u87ad\u012f\u0ea9',
+  colorFormats: ['r16float'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler75 = device2.createSampler({
+  label: '\u0805\ub4bd\u4350',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 92.18,
+  lodMaxClamp: 93.68,
+  maxAnisotropy: 12,
+});
+let promise45 = device2.queue.onSubmittedWorkDone();
+let adapter6 = await promise8;
+let imageBitmap56 = await createImageBitmap(imageBitmap50);
+let gpuCanvasContext54 = canvas51.getContext('webgpu');
+let canvas52 = document.createElement('canvas');
+let gpuCanvasContext55 = canvas52.getContext('webgpu');
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+let querySet75 = device2.createQuerySet({label: '\u05ac\u02ad\u0acd\u606f\ub320\u7da7\u{1fe56}\udbc9', type: 'occlusion', count: 514});
+try {
+gpuCanvasContext27.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise46 = device2.queue.onSubmittedWorkDone();
+let canvas53 = document.createElement('canvas');
+let bindGroupLayout47 = device2.createBindGroupLayout({
+  label: '\u55cf\u{1f96a}\u0e21\u281d\u01e8',
+  entries: [
+    {
+      binding: 1831,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {
+      binding: 30,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 4721, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let commandEncoder147 = device2.createCommandEncoder();
+video15.height = 187;
+let querySet76 = device2.createQuerySet({label: '\ue90a\u{1f96c}\u{1fb7c}\u{1f8e9}\ua410\u06e7\u261a\u0347', type: 'occlusion', count: 1054});
+let sampler76 = device2.createSampler({
+  label: '\u60f3\u{1fb87}\u{1fd6d}\u81d6\u{1ff6c}\u9a3e\u6f44',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMinClamp: 38.79,
+  lodMaxClamp: 40.17,
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer40 = device2.createBuffer({
+  label: '\u6789\u1109\u02d1\u81ed\u8f5a\u{1fb0f}',
+  size: 925178,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+let commandEncoder148 = device2.createCommandEncoder();
+let texture102 = device2.createTexture({
+  label: '\u0893\u049b\u20da\udb78\ubd8b',
+  size: [64, 30, 1],
+  mipLevelCount: 5,
+  format: 'r16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder83 = device2.createRenderBundleEncoder({colorFormats: ['r16float'], sampleCount: 4, depthReadOnly: false, stencilReadOnly: true});
+try {
+gpuCanvasContext43.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+canvas34.width = 3158;
+try {
+gpuCanvasContext40.unconfigure();
+} catch {}
+try {
+querySet67.label = '\u0810\u{1ff64}\u9a64\ucbd8\u0286\u{1f8db}\u1c27';
+} catch {}
+let offscreenCanvas51 = new OffscreenCanvas(961, 191);
+try {
+canvas53.getContext('webgpu');
+} catch {}
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+canvas51.height = 142;
+let pipelineLayout19 = device2.createPipelineLayout({
+  label: '\u6dfe\uad51\u8ef7\u7214\u40e2\u03c5\u158a\u{1f8ec}',
+  bindGroupLayouts: [bindGroupLayout47, bindGroupLayout47, bindGroupLayout47, bindGroupLayout47],
+});
+let querySet77 = device2.createQuerySet({label: '\u{1f6ae}\u730a\uf927\u1bcd\u6d57\u{1feab}\u0972\u2046\u1010', type: 'occlusion', count: 1609});
+let renderBundle106 = renderBundleEncoder83.finish({label: '\u{1f777}\u8018\ua78d'});
+try {
+renderBundleEncoder82.setIndexBuffer(buffer40, 'uint16');
+} catch {}
+try {
+renderBundleEncoder82.setVertexBuffer(8, buffer40);
+} catch {}
+try {
+buffer40.unmap();
+} catch {}
+let gpuCanvasContext56 = offscreenCanvas51.getContext('webgpu');
+let texture103 = device2.createTexture({
+  label: '\u{1ffc2}\ue130',
+  size: [712],
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderBundleEncoder82.setIndexBuffer(buffer40, 'uint16', 350124, 400526);
+} catch {}
+video29.width = 21;
+try {
+  await promise45;
+} catch {}
+let querySet78 = device2.createQuerySet({label: '\uad10\u2041\u{1fd9c}\u327f\u74ad\u8318\u0000\u0370', type: 'occlusion', count: 3189});
+let renderBundleEncoder84 = device2.createRenderBundleEncoder({
+  label: '\ube43\u2c28\u2abd\u0035\u0556\u500e\udec9\u0ac5',
+  colorFormats: ['r16float'],
+  sampleCount: 4,
+  depthReadOnly: false,
+});
+try {
+renderBundleEncoder84.setVertexBuffer(5, buffer40, 898488, 4423);
+} catch {}
+let video42 = await videoWithData();
+let commandEncoder149 = device2.createCommandEncoder({label: '\u0034\u{1fa38}\ubfa5\u96d6\u80d4\u0cf2\ue2d8\ucf13\u711c\u68c3\u0138'});
+let computePassEncoder63 = commandEncoder149.beginComputePass({label: '\u0b60\u0224\ua6a9\ucb51\u7b1b\u01b6\uac08\u2963'});
+try {
+renderBundleEncoder82.setVertexBuffer(1, buffer40, 0, 461371);
+} catch {}
+let video43 = await videoWithData();
+try {
+  await promise46;
+} catch {}
+document.body.prepend(img5);
+gc();
+try {
+gpuCanvasContext51.unconfigure();
+} catch {}
+let texture104 = device2.createTexture({
+  size: {width: 64, height: 30, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'r16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView178 = texture104.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+renderBundleEncoder82.setVertexBuffer(2, buffer40, 0);
+} catch {}
+let offscreenCanvas52 = new OffscreenCanvas(318, 597);
+let imageData30 = new ImageData(168, 124);
+let video44 = await videoWithData();
+let pipelineLayout20 = device2.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder150 = device2.createCommandEncoder({label: '\u0bff\u27c2\u0522\u{1fdc4}\u5c07\uf28e\u5004\u001c\u{1fe26}\u9339\uf9af'});
+let querySet79 = device2.createQuerySet({type: 'occlusion', count: 92});
+let textureView179 = texture103.createView({label: '\u05a3\ua581\u{1f667}\u0bdf\u0a2e\u{1f748}\udd20\u0dd2\u0be7\u0055\u{1fd1f}'});
+let externalTexture82 = device2.importExternalTexture({label: '\u2347\u04e4\udcb4\u0f89\u{1fda1}', source: video12, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder84.setVertexBuffer(1, buffer40, 0, 834953);
+} catch {}
+try {
+renderBundleEncoder82.pushDebugGroup('\u4f18');
+} catch {}
+try {
+computePassEncoder63.insertDebugMarker('\u0de4');
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+externalTexture60.label = '\ud45c\u6f12\u17d6\u67b8\u56bf\u{1fe7e}\u5e77\u05ff\uc691\u{1ff37}';
+} catch {}
+let texture105 = device2.createTexture({
+  label: '\u12b0\u52c3\u44f6\u18b3\ud7eb\ucdc0\u0680\u530b\ua4d0\u04a3',
+  size: {width: 180, height: 60, depthOrArrayLayers: 247},
+  format: 'etc2-rgb8unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['etc2-rgb8unorm-srgb', 'etc2-rgb8unorm'],
+});
+let externalTexture83 = device2.importExternalTexture({
+  label: '\uc129\u2502\u{1fae2}\ufa5e\u055a\u{1f6ec}\u3128',
+  source: videoFrame1,
+  colorSpace: 'display-p3',
+});
+try {
+device2.addEventListener('uncapturederror', e => { log('device2.uncapturederror'); log(e); e.label = device2.label; });
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder151 = device1.createCommandEncoder({});
+let texture106 = device1.createTexture({
+  size: [2080, 1, 1],
+  mipLevelCount: 2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba8unorm-srgb'],
+});
+let textureView180 = texture70.createView({
+  label: '\u0dba\u{1fa0a}\u8918\u0532\ub164\u{1f6e0}\udc13\u0274',
+  format: 'bgra8unorm-srgb',
+  baseMipLevel: 5,
+  mipLevelCount: 3,
+});
+let videoFrame35 = new VideoFrame(img33, {timestamp: 0});
+let computePassEncoder64 = commandEncoder145.beginComputePass({label: '\u0491\u2aa4\u{1faf0}\ua1a4\u{1f79b}\u16e3\u3787\u{1ffe5}\u7794'});
+let externalTexture84 = device1.importExternalTexture({label: '\uafdb\u033a\u240f\u0673\u009e\u0ade\u{1fc1a}\u{1fae4}\u0b57', source: video24});
+try {
+renderBundleEncoder68.setBindGroup(1, bindGroup35);
+} catch {}
+try {
+commandEncoder151.clearBuffer(buffer39, 61532);
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+gpuCanvasContext38.unconfigure();
+} catch {}
+try {
+offscreenCanvas52.getContext('webgpu');
+} catch {}
+gc();
+let renderBundle107 = renderBundleEncoder84.finish({});
+canvas11.width = 1580;
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+let video45 = await videoWithData();
+let offscreenCanvas53 = new OffscreenCanvas(251, 714);
+let bindGroupLayout48 = device2.createBindGroupLayout({
+  label: '\u0588\u0361\uf86a\u0632\ua0b9\u04c2\u{1fe10}\u4349\u{1fe53}\u638b',
+  entries: [
+    {binding: 498, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 6665,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 3049,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 65776613, hasDynamicOffset: false },
+    },
+  ],
+});
+let pipelineLayout21 = device2.createPipelineLayout({
+  label: '\u{1fb84}\u750b\u3321\u5363\u956f\u{1f9b6}\u{1fa48}\u{1f647}',
+  bindGroupLayouts: [bindGroupLayout47, bindGroupLayout47, bindGroupLayout48, bindGroupLayout47, bindGroupLayout48],
+});
+let buffer41 = device2.createBuffer({
+  label: '\u00cc\u04b7\u{1f703}\u6f89\ud9c7\u2749\u03ba',
+  size: 63403,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandBuffer33 = commandEncoder148.finish({});
+let textureView181 = texture105.createView({dimension: '2d', baseArrayLayer: 223});
+let renderBundleEncoder85 = device2.createRenderBundleEncoder({
+  label: '\u2970\u{1fe11}\u0c2d\u{1f704}\u{1fb41}',
+  colorFormats: ['r16float'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder82.setIndexBuffer(buffer40, 'uint16', 704608, 32900);
+} catch {}
+try {
+computePassEncoder63.insertDebugMarker('\ua300');
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let img38 = await imageWithData(217, 78, '#594e8999', '#43c42b7a');
+let texture107 = device2.createTexture({
+  label: '\uf686\uc4c1',
+  size: {width: 16},
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r16float', 'r16float', 'r16float'],
+});
+let computePassEncoder65 = commandEncoder150.beginComputePass({label: '\u{1fe3e}\u0800\u79f4\u36df\ue363\u2ecc\udec2'});
+let renderBundle108 = renderBundleEncoder83.finish({label: '\u{1f63f}\u4a12\ueece\u90fc\u0778'});
+try {
+commandEncoder147.copyBufferToBuffer(buffer40, 521588, buffer41, 1608, 40764);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+renderBundleEncoder82.insertDebugMarker('\ucb93');
+} catch {}
+let shaderModule23 = device2.createShaderModule({
+  label: '\u{1fa8b}\u6ff6\u{1fea4}\u{1f6f8}\uf08f\u{1fc77}\u230f\u052f\u140f\u4ded',
+  code: `@group(0) @binding(30)
+var<storage, read_write> global4: array<u32>;
+@group(0) @binding(4721)
+var<storage, read_write> type9: array<u32>;
+@group(3) @binding(4721)
+var<storage, read_write> parameter5: array<u32>;
+@group(3) @binding(30)
+var<storage, read_write> parameter6: array<u32>;
+@group(1) @binding(1831)
+var<storage, read_write> n7: array<u32>;
+@group(0) @binding(1831)
+var<storage, read_write> type10: array<u32>;
+@group(1) @binding(4721)
+var<storage, read_write> type11: array<u32>;
+@group(3) @binding(1831)
+var<storage, read_write> n8: array<u32>;
+@group(2) @binding(1831)
+var<storage, read_write> function11: array<u32>;
+
+@compute @workgroup_size(3, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: f32,
+  @location(4) f2: vec3<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S16 {
+  @location(26) f0: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec3<i32>, @location(19) a1: vec4<u32>, @location(21) a2: f32, @builtin(vertex_index) a3: u32, @location(20) a4: vec4<f16>, @location(3) a5: vec4<f32>, a6: S16, @builtin(instance_index) a7: u32, @location(24) a8: vec2<i32>, @location(16) a9: f32, @location(2) a10: vec2<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let texture108 = device2.createTexture({
+  label: '\u5435\u{1fb36}\u{1fd48}\u7b58\u1e6c\uf38d\u{1fb5c}\u{1f64f}\u0d59',
+  size: [178, 7, 280],
+  mipLevelCount: 3,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16float', 'r16float'],
+});
+let textureView182 = texture105.createView({
+  label: '\u{1ff1f}\uce05\u0991\u19c5\u0b91\u27ce',
+  format: 'etc2-rgb8unorm',
+  baseArrayLayer: 220,
+  arrayLayerCount: 9,
+});
+try {
+renderBundleEncoder85.setIndexBuffer(buffer40, 'uint16', 571254, 98230);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer41, 15420, new Float32Array(56569), 54080, 288);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture108,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 12},
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(72)), /* required buffer size: 1_571_812 */
+{offset: 310, bytesPerRow: 476, rowsPerImage: 17}, {width: 113, height: 4, depthOrArrayLayers: 195});
+} catch {}
+let pipeline100 = await device2.createRenderPipelineAsync({
+  label: '\u20bc\u93bf\u021b\uf61a\u6d62\u{1fe24}\u{1fefd}\u0c9c\u039a',
+  layout: pipelineLayout21,
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {failOp: 'invert', depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilBack: {failOp: 'increment-clamp', depthFailOp: 'decrement-clamp'},
+    stencilWriteMask: 1845023128,
+    depthBias: -1323733433,
+    depthBiasSlopeScale: 365.8873392438206,
+    depthBiasClamp: 617.4034470183534,
+  },
+  vertex: {
+    module: shaderModule23,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 488,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 8, shaderLocation: 14},
+          {format: 'snorm16x2', offset: 28, shaderLocation: 3},
+        ],
+      },
+      {arrayStride: 344, attributes: [{format: 'snorm16x2', offset: 4, shaderLocation: 21}]},
+      {
+        arrayStride: 516,
+        stepMode: 'vertex',
+        attributes: [{format: 'unorm8x2', offset: 106, shaderLocation: 2}],
+      },
+      {arrayStride: 40, attributes: [{format: 'uint32', offset: 20, shaderLocation: 26}]},
+      {
+        arrayStride: 108,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 20, shaderLocation: 24},
+          {format: 'float16x2', offset: 24, shaderLocation: 16},
+          {format: 'snorm8x4', offset: 0, shaderLocation: 20},
+          {format: 'uint32x2', offset: 4, shaderLocation: 19},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let gpuCanvasContext57 = offscreenCanvas53.getContext('webgpu');
+try {
+device2.queue.writeTexture({
+  texture: texture108,
+  mipLevel: 1,
+  origin: {x: 15, y: 0, z: 2},
+  aspect: 'all',
+}, new DataView(arrayBuffer4), /* required buffer size: 539_144 */
+{offset: 245, bytesPerRow: 135, rowsPerImage: 210}, {width: 57, height: 2, depthOrArrayLayers: 20});
+} catch {}
+let promise47 = device2.queue.onSubmittedWorkDone();
+let imageData31 = new ImageData(252, 88);
+let commandEncoder152 = device2.createCommandEncoder({label: '\u402c\u080f\u{1fff2}\u0de7\u{1ff19}\u6076\u0c71\u0209'});
+let texture109 = device2.createTexture({
+  size: [180, 60, 68],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r16float'],
+});
+try {
+device2.queue.writeTexture({
+  texture: texture108,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(22_504_521), /* required buffer size: 22_504_521 */
+{offset: 45, bytesPerRow: 382, rowsPerImage: 224}, {width: 46, height: 1, depthOrArrayLayers: 264});
+} catch {}
+try {
+gpuCanvasContext49.unconfigure();
+} catch {}
+let video46 = await videoWithData();
+let commandEncoder153 = device2.createCommandEncoder({label: '\ue4c6\u{1fa08}\u{1fb22}\u{1f735}\u0026\u554b\u09b0\u191c\u0d7d\u6302\u{1fe97}'});
+let commandBuffer34 = commandEncoder152.finish();
+try {
+device2.pushErrorScope('out-of-memory');
+} catch {}
+try {
+querySet78.destroy();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture108,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 50},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 35_173 */
+{offset: 901, bytesPerRow: 336, rowsPerImage: 102}, {width: 57, height: 0, depthOrArrayLayers: 2});
+} catch {}
+document.body.prepend(video34);
+let imageBitmap57 = await createImageBitmap(imageBitmap39);
+try {
+  await promise47;
+} catch {}
+let offscreenCanvas54 = new OffscreenCanvas(517, 543);
+try {
+adapter4.label = '\u0ebc\uf995\u03ed\ucd98\u01da\u089f\udc5a\ufcaa\u01e4\u3bd1\u00fa';
+} catch {}
+let commandEncoder154 = device2.createCommandEncoder();
+let texture110 = device2.createTexture({
+  label: '\u0224\u05ea\u782b\u5cb1\u4f42\u0de7\u0976\uc713\u{1f89a}\ua8d8\u81f6',
+  size: {width: 45},
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16float', 'r16float', 'r16float'],
+});
+let renderBundleEncoder86 = device2.createRenderBundleEncoder({
+  label: '\u859e\u0b83\u079d\u37f9\uc1eb\u{1ff73}\u2c6a\u0d41\ued69',
+  colorFormats: ['r16float'],
+  sampleCount: 4,
+});
+let sampler77 = device2.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 81.04,
+});
+try {
+commandEncoder154.copyBufferToBuffer(buffer40, 10608, buffer41, 35424, 11876);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder154.copyTextureToBuffer({
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 48, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 662 widthInBlocks: 331 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 32282 */
+  offset: 31620,
+  buffer: buffer41,
+}, {width: 331, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder147.copyTextureToTexture({
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture108,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 50},
+  aspect: 'all',
+},
+{width: 11, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder147.clearBuffer(buffer41, 61964, 992);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(139), /* required buffer size: 139 */
+{offset: 139, bytesPerRow: 151}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline101 = device2.createRenderPipeline({
+  label: '\u{1fce8}\uf16f\u042d\u0bfd\uddd5\u3f26\u0ba8\u687d\u{1fc31}\u0676',
+  layout: pipelineLayout19,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule23,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16float', writeMask: GPUColorWrite.ALL}],
+},
+  vertex: {
+    module: shaderModule23,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 132,
+        attributes: [
+          {format: 'uint16x4', offset: 32, shaderLocation: 19},
+          {format: 'float16x2', offset: 4, shaderLocation: 21},
+        ],
+      },
+      {arrayStride: 232, stepMode: 'vertex', attributes: []},
+      {arrayStride: 180, attributes: [{format: 'float32', offset: 16, shaderLocation: 16}]},
+      {
+        arrayStride: 216,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 4, shaderLocation: 20},
+          {format: 'sint32', offset: 24, shaderLocation: 14},
+          {format: 'uint16x2', offset: 60, shaderLocation: 26},
+        ],
+      },
+      {
+        arrayStride: 132,
+        attributes: [
+          {format: 'snorm8x2', offset: 14, shaderLocation: 2},
+          {format: 'sint32x3', offset: 52, shaderLocation: 24},
+        ],
+      },
+      {arrayStride: 460, attributes: []},
+      {
+        arrayStride: 676,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 90, shaderLocation: 3}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'ccw', unclippedDepth: true},
+});
+let offscreenCanvas55 = new OffscreenCanvas(354, 10);
+let video47 = await videoWithData();
+let textureView183 = texture108.createView({
+  label: '\u0240\ua269\u472a\u{1fc67}\u{1fd17}\uebdf\u00bd\u30bf\u4974\u038f\u0901',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+let renderBundleEncoder87 = device2.createRenderBundleEncoder({
+  label: '\u5c52\u640a\u4c82\u{1fa73}\u{1f9be}',
+  colorFormats: ['r16float'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture85 = device2.importExternalTexture({label: '\ua392\ufbc6\u096f\u0922\u00ed\uff7c\ue815\u0f0e', source: video22, colorSpace: 'srgb'});
+try {
+commandEncoder154.clearBuffer(buffer41, 11480, 26700);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer41, 500, new Int16Array(4212), 1012, 476);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer6), /* required buffer size: 747 */
+{offset: 677}, {width: 35, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline102 = device2.createRenderPipeline({
+  label: '\u0e05\u{1f9e2}\u{1fcdd}\u0518\ub06f\u{1fa27}\uda93\u{1fef2}',
+  layout: pipelineLayout21,
+  fragment: {
+  module: shaderModule23,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'src-alpha', dstFactor: 'zero'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule23,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 564,
+        attributes: [
+          {format: 'float32x3', offset: 28, shaderLocation: 3},
+          {format: 'float32', offset: 112, shaderLocation: 20},
+          {format: 'unorm10-10-10-2', offset: 84, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 56,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x4', offset: 4, shaderLocation: 19}],
+      },
+      {
+        arrayStride: 832,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 192, shaderLocation: 21},
+          {format: 'unorm10-10-10-2', offset: 72, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 160,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 60, shaderLocation: 24},
+          {format: 'uint32x2', offset: 8, shaderLocation: 26},
+          {format: 'sint32x3', offset: 4, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+});
+video13.height = 151;
+let imageBitmap58 = await createImageBitmap(imageData30);
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let commandEncoder155 = device2.createCommandEncoder({});
+let computePassEncoder66 = commandEncoder155.beginComputePass();
+let renderBundle109 = renderBundleEncoder87.finish({label: '\u8bde\u{1f6d9}\u8c4e\u{1fb31}\u413e\u{1f9f2}\ue694\u7eac\ud299\u0136\u07ad'});
+try {
+renderBundleEncoder82.setPipeline(pipeline101);
+} catch {}
+try {
+commandEncoder153.copyBufferToBuffer(buffer40, 476160, buffer41, 48832, 13992);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder147.copyTextureToTexture({
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 169, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 28, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 401 */
+{offset: 401, bytesPerRow: 49}, {width: 8, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext58 = offscreenCanvas55.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let canvas54 = document.createElement('canvas');
+let querySet80 = device2.createQuerySet({type: 'occlusion', count: 546});
+let textureView184 = texture108.createView({label: '\u13d0\u0d0e\u03f0\u0a94\u280c\u61af\u4ce6\u{1fb4f}\u922f\u09ab\ud609', baseMipLevel: 2});
+let computePassEncoder67 = commandEncoder153.beginComputePass({label: '\u{1ff10}\u6eab\u{1fb0d}\ud011\u0938\u026b\uc77a\uc986\u0d44'});
+let sampler78 = device2.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 86.87,
+});
+try {
+renderBundleEncoder82.setVertexBuffer(2, buffer40, 0);
+} catch {}
+try {
+  await buffer41.mapAsync(GPUMapMode.READ, 0, 24516);
+} catch {}
+let imageBitmap59 = await createImageBitmap(imageBitmap1);
+let buffer42 = device2.createBuffer({label: '\u39ba\u62fd\uedd0', size: 218292, usage: GPUBufferUsage.COPY_DST, mappedAtCreation: true});
+let textureView185 = texture105.createView({label: '\u4f5f\u0143', baseArrayLayer: 114, arrayLayerCount: 129});
+let sampler79 = device2.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 40.35,
+  lodMaxClamp: 52.21,
+  maxAnisotropy: 3,
+});
+let externalTexture86 = device2.importExternalTexture({label: '\u0411\u9489\u88a4\u108c\u6abb\u601f\u28ec\u03fb', source: videoFrame15, colorSpace: 'srgb'});
+try {
+renderBundleEncoder85.setIndexBuffer(buffer40, 'uint16', 392920, 156316);
+} catch {}
+try {
+commandEncoder147.copyBufferToBuffer(buffer40, 325916, buffer41, 12972, 11428);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder147.copyTextureToTexture({
+  texture: texture103,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 45, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise48 = device2.createRenderPipelineAsync({
+  label: '\u02cd\u{1fc1f}\u1788',
+  layout: pipelineLayout20,
+  multisample: {count: 4},
+  fragment: {
+  module: shaderModule23,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL,
+}],
+},
+  vertex: {
+    module: shaderModule23,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 80,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 0, shaderLocation: 19},
+          {format: 'snorm8x4', offset: 4, shaderLocation: 20},
+          {format: 'unorm10-10-10-2', offset: 8, shaderLocation: 16},
+          {format: 'sint32', offset: 0, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 680,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x3', offset: 176, shaderLocation: 2}],
+      },
+      {
+        arrayStride: 640,
+        attributes: [
+          {format: 'float32', offset: 20, shaderLocation: 3},
+          {format: 'float16x2', offset: 16, shaderLocation: 21},
+          {format: 'sint32x4', offset: 8, shaderLocation: 24},
+        ],
+      },
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 192, attributes: [{format: 'uint16x2', offset: 4, shaderLocation: 26}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw'},
+});
+offscreenCanvas2.height = 2462;
+let img39 = await imageWithData(45, 111, '#a03a2d72', '#80f797c9');
+try {
+adapter4.label = '\u41ac\uc7d3';
+} catch {}
+try {
+offscreenCanvas54.getContext('webgpu');
+} catch {}
+let shaderModule24 = device2.createShaderModule({
+  label: '\u68c7\u0e58',
+  code: `@group(0) @binding(1831)
+var<storage, read_write> field9: array<u32>;
+@group(1) @binding(1831)
+var<storage, read_write> local4: array<u32>;
+@group(4) @binding(498)
+var<storage, read_write> global5: array<u32>;
+@group(3) @binding(30)
+var<storage, read_write> global6: array<u32>;
+@group(1) @binding(4721)
+var<storage, read_write> local5: array<u32>;
+@group(3) @binding(4721)
+var<storage, read_write> global7: array<u32>;
+@group(4) @binding(6665)
+var<storage, read_write> global8: array<u32>;
+@group(0) @binding(30)
+var<storage, read_write> type12: array<u32>;
+@group(3) @binding(1831)
+var<storage, read_write> global9: array<u32>;
+@group(2) @binding(3049)
+var<storage, read_write> field10: array<u32>;
+@group(0) @binding(4721)
+var<storage, read_write> n9: array<u32>;
+
+@compute @workgroup_size(5, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S18 {
+  @builtin(sample_mask) f0: u32,
+  @builtin(front_facing) f1: bool,
+  @builtin(position) f2: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(5) f0: vec2<u32>,
+  @location(0) f1: vec2<f32>
+}
+
+@fragment
+fn fragment0(a0: S18) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S17 {
+  @location(11) f0: vec2<i32>,
+  @location(6) f1: vec4<f32>,
+  @builtin(instance_index) f2: u32,
+  @location(10) f3: vec3<f16>,
+  @location(2) f4: vec3<f32>,
+  @location(18) f5: vec2<f16>,
+  @location(16) f6: vec4<i32>,
+  @location(12) f7: vec2<f32>,
+  @location(9) f8: vec4<f16>,
+  @location(22) f9: i32,
+  @builtin(vertex_index) f10: u32,
+  @location(20) f11: vec3<f16>,
+  @location(0) f12: u32,
+  @location(26) f13: vec3<f16>,
+  @location(3) f14: f16,
+  @location(19) f15: vec4<f32>,
+  @location(27) f16: vec3<i32>,
+  @location(23) f17: vec4<f32>,
+  @location(17) f18: vec2<f32>,
+  @location(21) f19: vec3<u32>,
+  @location(5) f20: vec4<i32>,
+  @location(15) f21: f16,
+  @location(25) f22: vec4<f32>,
+  @location(7) f23: vec4<f16>,
+  @location(1) f24: vec4<f16>,
+  @location(13) f25: vec3<i32>
+}
+
+@vertex
+fn vertex0(a0: S17, @location(24) a1: vec3<f16>, @location(14) a2: vec3<i32>, @location(4) a3: vec4<u32>, @location(8) a4: vec4<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder156 = device2.createCommandEncoder({});
+let texture111 = device2.createTexture({
+  label: '\u23a8\u{1f81e}\u10e1\u7165\u{1f70c}\u5d01\u0b34\u03a2',
+  size: [2730],
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16float', 'r16float'],
+});
+let textureView186 = texture110.createView({label: '\u{1f7b0}\u00e3\u0c35\u074c\u398e\uaea4\u0060\u035a\u3ecd\u8a5c\u00b1', baseArrayLayer: 0});
+let externalTexture87 = device2.importExternalTexture({label: '\u{1fe43}\uf3cc\u0323\u0e86\u{1f9d6}', source: video46, colorSpace: 'srgb'});
+try {
+commandEncoder156.copyBufferToBuffer(buffer40, 916460, buffer41, 31148, 1776);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer41);
+} catch {}
+let gpuCanvasContext59 = canvas54.getContext('webgpu');
+offscreenCanvas25.height = 181;
+let offscreenCanvas56 = new OffscreenCanvas(382, 382);
+let canvas55 = document.createElement('canvas');
+let computePassEncoder68 = commandEncoder154.beginComputePass({});
+let renderBundle110 = renderBundleEncoder87.finish({label: '\u0062\u001b\u0247\ud937\u40cc\u0856\u{1fc64}\u0744'});
+let externalTexture88 = device2.importExternalTexture({label: '\u8a89\u4af4\u{1fa6e}\u37b7\u0cb5\u{1fa35}\u0f8a', source: videoFrame17});
+try {
+renderBundleEncoder85.setPipeline(pipeline101);
+} catch {}
+try {
+commandEncoder156.clearBuffer(buffer41, 32024, 30256);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+renderBundleEncoder82.popDebugGroup();
+} catch {}
+video25.width = 244;
+let canvas56 = document.createElement('canvas');
+let imageData32 = new ImageData(36, 128);
+let commandEncoder157 = device2.createCommandEncoder({});
+let querySet81 = device2.createQuerySet({
+  label: '\u{1f6f6}\u969a\u0d6f\ub178\u7cef\ud85a\u{1fa5f}\u{1f6d4}\u{1f957}',
+  type: 'occlusion',
+  count: 3304,
+});
+let texture112 = device2.createTexture({
+  label: '\u03dd\u{1ff0c}\u{1fb85}\u{1fad7}\ue3d6\u42dc\u{1fcf8}\u52be\uf0f5\u{1fb46}\ud107',
+  size: [64],
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r16float', 'r16float'],
+});
+try {
+renderBundleEncoder82.setVertexBuffer(9, buffer40, 0, 912222);
+} catch {}
+try {
+  await device2.popErrorScope();
+} catch {}
+try {
+commandEncoder147.copyTextureToTexture({
+  texture: texture112,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture108,
+  mipLevel: 1,
+  origin: {x: 23, y: 0, z: 39},
+  aspect: 'all',
+},
+{width: 12, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = renderBundleEncoder27.label;
+} catch {}
+gc();
+let shaderModule25 = device2.createShaderModule({
+  code: `@group(3) @binding(30)
+var<storage, read_write> local6: array<u32>;
+@group(4) @binding(6665)
+var<storage, read_write> global10: array<u32>;
+@group(2) @binding(6665)
+var<storage, read_write> function12: array<u32>;
+@group(0) @binding(30)
+var<storage, read_write> local7: array<u32>;
+@group(1) @binding(4721)
+var<storage, read_write> field11: array<u32>;
+@group(3) @binding(4721)
+var<storage, read_write> field12: array<u32>;
+@group(0) @binding(1831)
+var<storage, read_write> parameter7: array<u32>;
+@group(2) @binding(3049)
+var<storage, read_write> n10: array<u32>;
+@group(0) @binding(4721)
+var<storage, read_write> type13: array<u32>;
+@group(4) @binding(498)
+var<storage, read_write> global11: array<u32>;
+@group(4) @binding(3049)
+var<storage, read_write> type14: array<u32>;
+@group(1) @binding(30)
+var<storage, read_write> local8: array<u32>;
+@group(1) @binding(1831)
+var<storage, read_write> n11: array<u32>;
+
+@compute @workgroup_size(6, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(3) f1: f32
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S19 {
+  @location(16) f0: vec2<i32>,
+  @location(22) f1: i32
+}
+
+@vertex
+fn vertex0(@location(0) a0: vec3<u32>, @location(18) a1: vec2<f32>, @location(10) a2: i32, @location(27) a3: vec2<i32>, @location(24) a4: vec4<u32>, @location(19) a5: vec4<i32>, @location(21) a6: i32, @location(20) a7: f32, @location(2) a8: vec4<i32>, @location(25) a9: vec3<u32>, @location(26) a10: f32, @location(4) a11: vec2<f32>, @location(5) a12: u32, @location(3) a13: vec3<u32>, @location(17) a14: vec3<i32>, @location(6) a15: vec4<i32>, @location(9) a16: vec3<i32>, @location(14) a17: vec4<f32>, @location(12) a18: vec4<u32>, @location(13) a19: vec4<i32>, @location(11) a20: f16, @location(1) a21: vec2<f32>, a22: S19, @location(7) a23: vec4<f32>, @location(23) a24: vec3<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let pipelineLayout22 = device2.createPipelineLayout({
+  label: '\u{1fc78}\u70c9\u9139\u01fc\u0e45\u{1f66a}\u58b7\uda57',
+  bindGroupLayouts: [bindGroupLayout47, bindGroupLayout48, bindGroupLayout48, bindGroupLayout48, bindGroupLayout48, bindGroupLayout48],
+});
+try {
+renderBundleEncoder86.setIndexBuffer(buffer40, 'uint32', 395524, 390907);
+} catch {}
+let arrayBuffer10 = buffer41.getMappedRange(16992, 6704);
+try {
+commandEncoder157.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 42370 */
+  offset: 42370,
+  buffer: buffer40,
+}, {
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 14, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer40);
+} catch {}
+try {
+commandEncoder147.clearBuffer(buffer41, 22424, 37800);
+dissociateBuffer(device2, buffer41);
+} catch {}
+let gpuCanvasContext60 = canvas56.getContext('webgpu');
+gc();
+document.body.prepend(img35);
+video24.width = 289;
+let shaderModule26 = device1.createShaderModule({
+  code: `@group(0) @binding(714)
+var<storage, read_write> global12: array<u32>;
+@group(1) @binding(714)
+var<storage, read_write> type15: array<u32>;
+
+@compute @workgroup_size(5, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(4) f1: u32,
+  @location(2) f2: vec4<f32>,
+  @location(1) f3: vec4<u32>,
+  @location(5) f4: vec4<i32>,
+  @location(3) f5: u32,
+  @builtin(sample_mask) f6: u32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S20 {
+  @location(2) f0: vec4<f16>,
+  @location(4) f1: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec4<f32>, @location(8) a1: vec3<u32>, a2: S20, @location(6) a3: vec3<u32>, @location(13) a4: vec2<f16>, @location(14) a5: f32, @location(11) a6: vec3<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout49 = device1.createBindGroupLayout({label: '\u7b0d\u4f2c\u6804\u6dc2\u0947\u3a50\ua230\u{1f834}', entries: []});
+let commandEncoder158 = device1.createCommandEncoder({label: '\u{1f647}\u0081\ue606\ubac6\uc699\u2b5d\u31b1\u{1f89f}\ua876\u{1fd0e}'});
+let sampler80 = device1.createSampler({
+  label: '\uc3d7\u9b22\udb1e\u17fd\u{1ff07}\u177d\uc14f',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 11.99,
+  lodMaxClamp: 12.36,
+});
+try {
+computePassEncoder50.setBindGroup(1, bindGroup36, new Uint32Array(330), 8, 0);
+} catch {}
+try {
+renderBundleEncoder74.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+renderBundleEncoder68.setPipeline(pipeline93);
+} catch {}
+try {
+  await buffer39.mapAsync(GPUMapMode.READ);
+} catch {}
+try {
+commandEncoder129.copyBufferToBuffer(buffer31, 30256, buffer39, 5076, 5108);
+dissociateBuffer(device1, buffer31);
+dissociateBuffer(device1, buffer39);
+} catch {}
+try {
+commandEncoder141.copyBufferToTexture({
+  /* bytesInLastRow: 360 widthInBlocks: 90 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10748 */
+  offset: 10748,
+  buffer: buffer32,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 90, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer32);
+} catch {}
+try {
+commandEncoder158.copyTextureToTexture({
+  texture: texture77,
+  mipLevel: 0,
+  origin: {x: 155, y: 0, z: 17},
+  aspect: 'all',
+},
+{
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 21, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer35, 14856, new BigUint64Array(30322), 13506, 552);
+} catch {}
+let pipeline103 = await device1.createComputePipelineAsync({
+  label: '\u01f3\ubf4d\udc51\u0f00\u{1ffac}\uaec7',
+  layout: pipelineLayout16,
+  compute: {module: shaderModule17, entryPoint: 'compute0', constants: {}},
+});
+let textureView187 = texture112.createView({label: '\ua114\u63b4\u0d30\u921f\u22f0\ufb44\ue932\ua12c\u06d6\u{1fcc0}', arrayLayerCount: 1});
+let computePassEncoder69 = commandEncoder157.beginComputePass({label: '\u3908\u{1fcc7}\u0fec\ue832\u0067\u0431\u{1f9cf}'});
+let renderBundle111 = renderBundleEncoder86.finish({label: '\u86cb\u683a\u9c7c\ue0c3\ua646\u{1fbf4}\u09c1\u{1f842}'});
+try {
+commandEncoder147.copyBufferToTexture({
+  /* bytesInLastRow: 2068 widthInBlocks: 1034 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 6160 */
+  offset: 6160,
+  buffer: buffer40,
+}, {
+  texture: texture111,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1034, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer40);
+} catch {}
+try {
+commandEncoder156.copyTextureToTexture({
+  texture: texture112,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture108,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 24, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.submit([commandBuffer34, commandBuffer33]);
+} catch {}
+let pipeline104 = await device2.createComputePipelineAsync({layout: pipelineLayout20, compute: {module: shaderModule23, entryPoint: 'compute0', constants: {}}});
+let gpuCanvasContext61 = offscreenCanvas56.getContext('webgpu');
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let commandEncoder159 = device2.createCommandEncoder({label: '\ub572\u29f5\u02ec\uc94c\u20f5\u0ccb\ueb35\u02ea\u0bbf\u08d2\u110b'});
+let querySet82 = device2.createQuerySet({label: '\u{1f6d2}\u{1feaa}\ufcba', type: 'occlusion', count: 2277});
+let texture113 = device2.createTexture({
+  label: '\ua644\u043e',
+  size: {width: 2730},
+  dimension: '1d',
+  format: 'r16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16float', 'r16float', 'r16float'],
+});
+let renderBundleEncoder88 = device2.createRenderBundleEncoder({
+  label: '\u{1f7d0}\u97d6\u68dc\u{1fa31}\ucf94\u{1fd55}',
+  colorFormats: ['r16float'],
+  sampleCount: 4,
+  stencilReadOnly: false,
+});
+let renderBundle112 = renderBundleEncoder86.finish({label: '\u{1fb3a}\u097a\u{1ff04}\u0700\ue2d5\u25e8'});
+let sampler81 = device2.createSampler({
+  label: '\u{1f87f}\u{1fe7f}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 53.52,
+  lodMaxClamp: 56.17,
+});
+try {
+renderBundleEncoder82.setVertexBuffer(3, buffer40, 195472, 703054);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+adapter3.label = '\u3cab\udb30';
+} catch {}
+offscreenCanvas43.height = 366;
+offscreenCanvas11.height = 2079;
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+gc();
+let bindGroupLayout50 = device2.createBindGroupLayout({
+  entries: [
+    {
+      binding: 5582,
+      visibility: 0,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder160 = device2.createCommandEncoder();
+let commandBuffer35 = commandEncoder147.finish({label: '\ucbf3\u{1ffc5}'});
+let texture114 = device2.createTexture({
+  label: '\u0f72\ucef3\ub94b\u{1f6ea}',
+  size: [32, 15, 124],
+  mipLevelCount: 3,
+  format: 'r16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16float', 'r16float'],
+});
+let renderBundle113 = renderBundleEncoder82.finish();
+try {
+renderBundleEncoder88.setVertexBuffer(5, buffer40);
+} catch {}
+try {
+gpuCanvasContext51.unconfigure();
+} catch {}
+let commandEncoder161 = device2.createCommandEncoder({label: '\u01fa\ua613'});
+let textureView188 = texture111.createView({label: '\u{1f76a}\ua715', baseArrayLayer: 0});
+let computePassEncoder70 = commandEncoder156.beginComputePass({label: '\u3ce1\u0210\u09aa\u12f9\u{1f73e}\u93b3'});
+let renderBundleEncoder89 = device2.createRenderBundleEncoder({
+  label: '\ue479\u{1fa13}\u0f40\u{1faa2}\uc8a9\u3573',
+  colorFormats: ['r16float'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle114 = renderBundleEncoder88.finish({label: '\u0406\u0030'});
+try {
+renderBundleEncoder85.setIndexBuffer(buffer40, 'uint32');
+} catch {}
+try {
+commandEncoder160.copyBufferToBuffer(buffer40, 210152, buffer42, 129768, 44768);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer42);
+} catch {}
+let pipeline105 = await promise48;
+let textureView189 = texture111.createView({label: '\u30ec\u0073\u{1f64a}\u{1ffc4}\uac81\u0ea7\ubb22\u{1f92d}'});
+let renderBundleEncoder90 = device2.createRenderBundleEncoder({colorFormats: ['r16float'], sampleCount: 4, depthReadOnly: true});
+try {
+computePassEncoder69.setPipeline(pipeline104);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(arrayBuffer9), /* required buffer size: 593 */
+{offset: 593}, {width: 22, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let video48 = await videoWithData();
+let querySet83 = device2.createQuerySet({label: '\u8ce5\u4c56\u2bd3\u09d5\ue1dc', type: 'occlusion', count: 1318});
+let texture115 = device2.createTexture({
+  label: '\u2424\u1893\u0232\udcfe\u3a9e\u6c19\u9263\u{1f96f}\u0fde',
+  size: [5460, 20, 1],
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView190 = texture112.createView({baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+let renderBundle115 = renderBundleEncoder84.finish();
+let sampler82 = device2.createSampler({
+  label: '\uf338\u0d58\u0831\ucb97',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+});
+try {
+renderBundleEncoder89.setPipeline(pipeline101);
+} catch {}
+try {
+renderBundleEncoder90.setVertexBuffer(2049, undefined, 3175747051, 175939567);
+} catch {}
+try {
+commandEncoder160.copyBufferToBuffer(buffer40, 833092, buffer41, 5952, 3904);
+dissociateBuffer(device2, buffer40);
+dissociateBuffer(device2, buffer41);
+} catch {}
+try {
+commandEncoder159.copyTextureToTexture({
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture108,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 41},
+  aspect: 'all',
+},
+{width: 2, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let imageBitmap60 = await createImageBitmap(imageBitmap56);
+let gpuCanvasContext62 = canvas55.getContext('webgpu');
+let commandEncoder162 = device2.createCommandEncoder({label: '\u{1ffa1}\ufcef\u0cce\ufb70\u{1f994}\uaeac\u68df\u{1fd38}\u7e84\uccd8\u72f2'});
+let textureView191 = texture110.createView({
+  label: '\u0810\u87eb\u05df\u497c\u{1f759}\u3c14\u{1fad4}\u7f4c\u{1fedf}\u{1ff2d}\u{1f79d}',
+  format: 'r16float',
+});
+let sampler83 = device2.createSampler({
+  label: '\u24ba\u325a\u0732\u{1f662}\u{1f946}\u379b\u0a4b\u0a5b\u{1f8c8}\u0893',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 84.59,
+  lodMaxClamp: 88.81,
+  maxAnisotropy: 9,
+});
+try {
+renderBundleEncoder90.setIndexBuffer(buffer40, 'uint32', 202792, 615367);
+} catch {}
+let pipeline106 = device2.createRenderPipeline({
+  label: '\u01d2\u6c4e\ua662\u{1fd4f}\u7cc0\u5d73\u5e75\u{1faf1}\u37f0\u0db0',
+  layout: pipelineLayout20,
+  multisample: {count: 4, mask: 0xb4a5ef3a},
+  fragment: {
+  module: shaderModule25,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: GPUColorWrite.BLUE,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {
+      compare: 'not-equal',
+      failOp: 'decrement-clamp',
+      depthFailOp: 'increment-wrap',
+      passOp: 'decrement-clamp',
+    },
+    stencilBack: {compare: 'greater-equal', failOp: 'invert', depthFailOp: 'invert', passOp: 'decrement-clamp'},
+    stencilReadMask: 3904657619,
+    stencilWriteMask: 3387945984,
+    depthBias: 0,
+    depthBiasClamp: 154.3568350959236,
+  },
+  vertex: {
+    module: shaderModule25,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 724,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 180, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 420, shaderLocation: 26},
+          {format: 'sint16x2', offset: 16, shaderLocation: 2},
+          {format: 'uint8x4', offset: 304, shaderLocation: 0},
+          {format: 'sint16x2', offset: 112, shaderLocation: 6},
+          {format: 'uint16x4', offset: 44, shaderLocation: 25},
+          {format: 'sint32x3', offset: 176, shaderLocation: 17},
+          {format: 'sint32x4', offset: 360, shaderLocation: 9},
+          {format: 'unorm10-10-10-2', offset: 12, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 488,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 204, shaderLocation: 14},
+          {format: 'sint32', offset: 48, shaderLocation: 19},
+          {format: 'sint32', offset: 16, shaderLocation: 21},
+          {format: 'sint32x3', offset: 80, shaderLocation: 22},
+          {format: 'sint16x4', offset: 28, shaderLocation: 13},
+          {format: 'sint32x4', offset: 112, shaderLocation: 16},
+          {format: 'snorm16x2', offset: 104, shaderLocation: 20},
+          {format: 'unorm8x2', offset: 202, shaderLocation: 7},
+          {format: 'float32', offset: 16, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 616,
+        attributes: [
+          {format: 'sint32x3', offset: 28, shaderLocation: 10},
+          {format: 'unorm8x2', offset: 28, shaderLocation: 18},
+          {format: 'uint32x3', offset: 176, shaderLocation: 12},
+          {format: 'uint8x4', offset: 40, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 84,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 8, shaderLocation: 24},
+          {format: 'snorm16x4', offset: 16, shaderLocation: 23},
+          {format: 'uint8x2', offset: 2, shaderLocation: 5},
+          {format: 'sint32x3', offset: 4, shaderLocation: 27},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw', unclippedDepth: true},
+});
+let imageBitmap61 = await createImageBitmap(canvas25);
+let commandEncoder163 = device2.createCommandEncoder({label: '\u0bb6\ud51f\u0d01\u0d1d\u{1fdf6}\ua755\u8e04\u0e29\u{1febd}\u3d9b\u0902'});
+try {
+commandEncoder163.copyBufferToTexture({
+  /* bytesInLastRow: 70 widthInBlocks: 35 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 12010 */
+  offset: 12010,
+  rowsPerImage: 181,
+  buffer: buffer40,
+}, {
+  texture: texture110,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 35, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer40);
+} catch {}
+try {
+device2.queue.submit([commandBuffer35]);
+} catch {}
+let pipeline107 = device2.createRenderPipeline({
+  label: '\u5315\u007b\uf86a\u{1fe8a}\u05f7\u0c24',
+  layout: pipelineLayout19,
+  fragment: {
+  module: shaderModule24,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'src-alpha'},
+  },
+}],
+},
+  vertex: {
+    module: shaderModule24,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1420,
+        attributes: [
+          {format: 'float32', offset: 8, shaderLocation: 8},
+          {format: 'unorm8x2', offset: 372, shaderLocation: 18},
+          {format: 'unorm8x4', offset: 612, shaderLocation: 25},
+          {format: 'sint32x2', offset: 48, shaderLocation: 14},
+          {format: 'sint32x4', offset: 724, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 164, shaderLocation: 15},
+          {format: 'float32x2', offset: 132, shaderLocation: 6},
+          {format: 'sint16x2', offset: 924, shaderLocation: 22},
+          {format: 'float16x2', offset: 344, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 316, attributes: []},
+      {
+        arrayStride: 688,
+        attributes: [
+          {format: 'uint8x2', offset: 50, shaderLocation: 4},
+          {format: 'snorm16x4', offset: 4, shaderLocation: 23},
+          {format: 'uint16x4', offset: 148, shaderLocation: 21},
+          {format: 'uint8x2', offset: 52, shaderLocation: 0},
+          {format: 'sint16x2', offset: 100, shaderLocation: 13},
+          {format: 'snorm8x2', offset: 108, shaderLocation: 20},
+          {format: 'sint16x4', offset: 288, shaderLocation: 5},
+          {format: 'unorm16x2', offset: 44, shaderLocation: 19},
+          {format: 'float16x2', offset: 68, shaderLocation: 26},
+          {format: 'float32x2', offset: 72, shaderLocation: 7},
+          {format: 'sint8x2', offset: 22, shaderLocation: 16},
+          {format: 'unorm8x2', offset: 106, shaderLocation: 17},
+          {format: 'float32x3', offset: 160, shaderLocation: 12},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 24},
+        ],
+      },
+      {
+        arrayStride: 200,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 40, shaderLocation: 1},
+          {format: 'snorm16x2', offset: 0, shaderLocation: 3},
+        ],
+      },
+      {arrayStride: 1736, stepMode: 'instance', attributes: []},
+      {arrayStride: 380, attributes: [{format: 'sint32x2', offset: 40, shaderLocation: 27}]},
+      {
+        arrayStride: 32,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x2', offset: 0, shaderLocation: 9}],
+      },
+      {
+        arrayStride: 56,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 4, shaderLocation: 10}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let pipelineLayout23 = device2.createPipelineLayout({
+  label: '\u{1f811}\u{1f746}\u02df\uc92d\ud97b\ua7ec\u059b\u{1fbdb}',
+  bindGroupLayouts: [bindGroupLayout48, bindGroupLayout50, bindGroupLayout50],
+});
+let querySet84 = device2.createQuerySet({
+  label: '\u03e6\u00e7\u{1fad3}\u23cc\u0ac5\u53b2\ua431\u{1f7aa}\ubfb3\u{1f8bc}\uc4f9',
+  type: 'occlusion',
+  count: 2140,
+});
+let textureView192 = texture104.createView({label: '\u{1fc19}\u4f0b\u{1fd53}\ue52e\u{1ff5c}\u07a4\uf79a', baseMipLevel: 2, mipLevelCount: 1});
+let renderBundleEncoder91 = device2.createRenderBundleEncoder({label: '\udc85\u7ee1\u0607', colorFormats: ['r16float'], sampleCount: 4, stencilReadOnly: true});
+let videoFrame36 = new VideoFrame(imageBitmap44, {timestamp: 0});
+let commandEncoder164 = device2.createCommandEncoder({label: '\ub13b\u4588\u0176\ub3bb\ua9d2\u{1f8cc}'});
+let commandBuffer36 = commandEncoder161.finish();
+let texture116 = device2.createTexture({
+  label: '\u0aed\ue659\u0434\u081a\uf4f3\u872b\u0cc8\u07de\u000c\u0bda\u0e7e',
+  size: {width: 2730, height: 10, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  sampleCount: 1,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16float', 'r16float'],
+});
+let renderBundle116 = renderBundleEncoder87.finish({label: '\u093e\u0470\u{1fc7a}\u0db6\uf699\u{1fb40}\u0b02\u12a0\u015c'});
+try {
+computePassEncoder69.setPipeline(pipeline104);
+} catch {}
+let arrayBuffer11 = buffer42.getMappedRange(0, 81396);
+try {
+commandEncoder159.copyTextureToTexture({
+  texture: texture116,
+  mipLevel: 3,
+  origin: {x: 163, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture108,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 36},
+  aspect: 'all',
+},
+{width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let device3 = await promise43;
+let img40 = await imageWithData(256, 77, '#247782d5', '#d8cdc3eb');
+let imageBitmap62 = await createImageBitmap(video38);
+let buffer43 = device3.createBuffer({
+  label: '\u2140\u9b49\u9de6\u6fd1\u60fe',
+  size: 47734,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder165 = device3.createCommandEncoder({label: '\u0efb\u{1f722}\u53a6'});
+let computePassEncoder71 = commandEncoder165.beginComputePass({label: '\u{1f9cc}\u{1f75f}\u148d'});
+let externalTexture89 = device3.importExternalTexture({source: video31, colorSpace: 'srgb'});
+let canvas57 = document.createElement('canvas');
+let querySet85 = device3.createQuerySet({type: 'occlusion', count: 1757});
+let texture117 = device3.createTexture({
+  label: '\ue800\uda3b',
+  size: [1536, 8, 1],
+  mipLevelCount: 9,
+  format: 'etc2-rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['etc2-rgba8unorm'],
+});
+let textureView193 = texture117.createView({label: '\u0564\u04f4\uf4cd', dimension: '2d-array', baseMipLevel: 7, mipLevelCount: 1});
+let renderBundleEncoder92 = device3.createRenderBundleEncoder({
+  label: '\u2765\u{1f94e}\u21f0',
+  colorFormats: ['rgba16sint', 'rgba32uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+externalTexture89.label = '\u032d\udfed\u{1feeb}\u{1f9d5}';
+} catch {}
+let externalTexture90 = device3.importExternalTexture({
+  label: '\u8ed3\u{1fefe}\u{1f9a8}\u4a21\u00d4\u899e\u89e2\u0320',
+  source: video18,
+  colorSpace: 'display-p3',
+});
+let promise49 = buffer43.mapAsync(GPUMapMode.WRITE, 40512, 3856);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let videoFrame37 = new VideoFrame(imageBitmap4, {timestamp: 0});
+let bindGroupLayout51 = device3.createBindGroupLayout({
+  label: '\uc868\u{1f9e2}\u0187\u1d92\u9cab\u84a4\u4056',
+  entries: [
+    {
+      binding: 2242,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let pipelineLayout24 = device3.createPipelineLayout({
+  label: '\ud23b\ufdbd\ueec8\u087c',
+  bindGroupLayouts: [bindGroupLayout51, bindGroupLayout51, bindGroupLayout51],
+});
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let buffer44 = device3.createBuffer({
+  label: '\u0958\u96fb\ubd93\u186e\u{1f6c7}\u2996\u063f\u{1fefd}\u0518',
+  size: 348619,
+  usage: GPUBufferUsage.INDIRECT,
+});
+let commandEncoder166 = device3.createCommandEncoder();
+let computePassEncoder72 = commandEncoder166.beginComputePass({label: '\u{1f793}\uf560\u{1f667}\ud3cc\u0b07\u{1fa97}\u18a4\u0511\u{1f73c}\u4439\u0df7'});
+let renderBundleEncoder93 = device3.createRenderBundleEncoder({
+  label: '\u4c19\u71eb',
+  colorFormats: ['rgba16sint', 'rgba32uint'],
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let img41 = await imageWithData(21, 279, '#8516ecb3', '#a08f031c');
+let shaderModule27 = device3.createShaderModule({
+  code: `@group(1) @binding(2242)
+var<storage, read_write> field13: array<u32>;
+@group(2) @binding(2242)
+var<storage, read_write> local9: array<u32>;
+
+@compute @workgroup_size(3, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<i32>,
+  @builtin(sample_mask) f1: u32,
+  @location(1) f2: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(sample_mask) a1: u32, @builtin(position) a2: vec4<f32>, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S21 {
+  @location(19) f0: vec2<i32>,
+  @location(5) f1: vec2<f32>,
+  @location(20) f2: vec3<i32>,
+  @location(9) f3: vec4<f32>,
+  @builtin(instance_index) f4: u32,
+  @location(2) f5: vec2<f16>,
+  @location(23) f6: vec3<u32>,
+  @location(17) f7: f16,
+  @location(6) f8: vec4<f32>,
+  @location(10) f9: f32,
+  @location(15) f10: vec2<i32>,
+  @location(22) f11: vec2<u32>,
+  @location(12) f12: vec2<f16>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(3) a1: vec3<i32>, @location(13) a2: vec4<u32>, @location(11) a3: u32, @location(21) a4: vec3<u32>, a5: S21, @location(1) a6: vec2<i32>, @location(18) a7: vec3<u32>, @location(4) a8: vec2<f32>, @location(0) a9: f32, @location(14) a10: vec2<i32>, @location(16) a11: vec3<f16>, @location(8) a12: vec4<u32>, @location(7) a13: vec3<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture118 = device3.createTexture({
+  label: '\u07b8\u5a9e\u41fe\uef3b\u6780\u0eb4\u3f29\u0186\u0974\u01cf\ue856',
+  size: [384, 2, 221],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView194 = texture118.createView({label: '\ua264\u3701\ude4e\u7154\u{1fd82}', baseMipLevel: 3, mipLevelCount: 1});
+let sampler84 = device3.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMinClamp: 8.109,
+  lodMaxClamp: 32.82,
+});
+try {
+computePassEncoder72.end();
+} catch {}
+let video49 = await videoWithData();
+offscreenCanvas30.height = 1142;
+let commandEncoder167 = device3.createCommandEncoder({label: '\ua3ea\u7ef2\u8750'});
+let querySet86 = device3.createQuerySet({label: '\u0a5f\u0621\u0ce6\u4632', type: 'occlusion', count: 3118});
+let commandBuffer37 = commandEncoder167.finish({label: '\u{1f691}\u183e\u72b6'});
+let texture119 = device3.createTexture({
+  label: '\uf28a\ueeac\u2eaf\ue535\u077e\u{1f62a}\u0b7d\u{1fe38}\u{1f98c}\u0d63\u0669',
+  size: [384, 2, 1],
+  mipLevelCount: 3,
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16sint', 'rgba16sint', 'rgba16sint'],
+});
+let textureView195 = texture118.createView({label: '\u068b\u{1fd6e}\uf544', baseMipLevel: 2, mipLevelCount: 3});
+let computePassEncoder73 = commandEncoder166.beginComputePass({label: '\u{1fb25}\u0205\u0b7d\u{1fec8}\u099e\ub8c1'});
+let renderBundle117 = renderBundleEncoder92.finish({});
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame36.close();
+videoFrame37.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -588,6 +588,8 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
 
         if (zeroColorTargets) {
             mtlDescriptor.defaultRasterSampleCount = textureView.sampleCount();
+            if (!mtlDescriptor.defaultRasterSampleCount)
+                return RenderPassEncoder::createInvalid(*this, m_device, @"no color targets and depth-stencil texture is nil");
             mtlDescriptor.renderTargetWidth = metalDepthStencilTexture.width;
             mtlDescriptor.renderTargetHeight = metalDepthStencilTexture.height;
         }


### PR DESCRIPTION
#### 49d05e7c47e481ae8ac68149f29b4314b1334240
<pre>
[WebGPU] renderCommandEncoderWithDescriptor can fail if depthStencil texture is nil
<a href="https://bugs.webkit.org/show_bug.cgi?id=275229">https://bugs.webkit.org/show_bug.cgi?id=275229</a>
&lt;radar://129354666&gt;

Reviewed by Dan Glastonbury.

If there are zero color textures and the depth stencil texture is destroyed,
the render pass will be invalid, so create it invalid initially.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::beginRenderPass):

Canonical link: <a href="https://commits.webkit.org/279802@main">https://commits.webkit.org/279802@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1858e4b3cc402e54e27a048f82f4b8c77bcaa7b0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54605 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57886 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5339 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5342 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44225 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3595 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56700 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32169 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47293 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25351 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28965 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4628 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3479 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59476 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29839 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/4982 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51651 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30988 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47379 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11943 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31967 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30776 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->