### PR TITLE
[WebGPU] RenderBundleEncoder attempts to add commands during iteration

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-275232-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-275232-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it does not crash

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-275232.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-275232.html
@@ -1,0 +1,23706 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ */
+function pseudoSubmit(device) {
+  for (let i = 0; i < 63; i++) {
+    device.createCommandEncoder();
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let promise0 = navigator.gpu.requestAdapter({});
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+  ],
+  requiredLimits: {
+    maxBindGroups: 11,
+    maxColorAttachmentBytesPerSample: 37,
+    maxVertexAttributes: 21,
+    maxVertexBufferArrayStride: 52918,
+    maxStorageTexturesPerShaderStage: 27,
+    maxStorageBuffersPerShaderStage: 31,
+    maxDynamicStorageBuffersPerPipelineLayout: 8886,
+    maxDynamicUniformBuffersPerPipelineLayout: 58103,
+    maxBindingsPerBindGroup: 7023,
+    maxTextureArrayLayers: 1385,
+    maxTextureDimension1D: 12191,
+    maxTextureDimension2D: 12366,
+    maxVertexBuffers: 10,
+    maxBindGroupsPlusVertexBuffers: 30,
+    minStorageBufferOffsetAlignment: 128,
+    minUniformBufferOffsetAlignment: 64,
+    maxUniformBufferBindingSize: 255738254,
+    maxStorageBufferBindingSize: 259302915,
+    maxUniformBuffersPerShaderStage: 24,
+    maxSampledTexturesPerShaderStage: 30,
+    maxInterStageShaderVariables: 37,
+    maxInterStageShaderComponents: 79,
+    maxSamplersPerShaderStage: 21,
+  },
+});
+let adapter1 = await navigator.gpu.requestAdapter();
+let sampler0 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 98.53});
+let offscreenCanvas0 = new OffscreenCanvas(1, 1004);
+let promise1 = device0.popErrorScope();
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let img0 = await imageWithData(235, 264, '#f571e215', '#8b7ec1cd');
+let commandEncoder0 = device0.createCommandEncoder({label: '\u9b8a\uef4e\u071a\ud3cb\u3d49\uf7d0\u2d38\u0336\u0062\u0042\u0012'});
+let texture0 = device0.createTexture({
+  label: '\u{1fd32}\u805e\u{1fdec}',
+  size: {width: 120, height: 60, depthOrArrayLayers: 573},
+  mipLevelCount: 6,
+  dimension: '2d',
+  format: 'eac-r11snorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['eac-r11snorm', 'eac-r11snorm'],
+});
+let textureView0 = texture0.createView({mipLevelCount: 6, baseArrayLayer: 289, arrayLayerCount: 91});
+let commandEncoder1 = device0.createCommandEncoder({label: '\u{1f629}\u0b8d\u07a3'});
+let commandBuffer0 = commandEncoder1.finish();
+offscreenCanvas0.width = 316;
+let buffer0 = device0.createBuffer({label: '\u0784\u7354\u274d\u4935\u{1f6fc}\u9195\uc4a5', size: 106993, usage: GPUBufferUsage.STORAGE});
+let commandEncoder2 = device0.createCommandEncoder({label: '\u2c98\uc097\ue92b\uc494\u021e'});
+let buffer1 = device0.createBuffer({label: '\u{1fec2}\u0b62', size: 227351, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let querySet0 = device0.createQuerySet({label: '\u078a\u4883\u4491\u0eb3\u730c\u6828', type: 'occlusion', count: 3102});
+let texture1 = device0.createTexture({
+  label: '\u{1fb97}\u1726\u8bef',
+  size: [960, 480, 1],
+  mipLevelCount: 6,
+  format: 'astc-8x6-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView1 = texture0.createView({label: '\u{1f753}\u{1f94d}\u02fd\u{1fda1}', dimension: '2d', baseMipLevel: 3, baseArrayLayer: 178});
+let promise2 = device0.popErrorScope();
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 2,
+  origin: {x: 0, y: 6, z: 0},
+  aspect: 'all',
+}, new Float32Array(new ArrayBuffer(56)), /* required buffer size: 2_304 */
+{offset: 972, bytesPerRow: 482}, {width: 184, height: 18, depthOrArrayLayers: 1});
+} catch {}
+gc();
+let device1 = await adapter1.requestDevice({
+  label: '\u{1fac4}\uc358\uf3f5\uc2dc\u7c46\u65c9',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+});
+let bindGroupLayout0 = device1.createBindGroupLayout({
+  label: '\u{1ffbb}\u{1fbc2}\u0a64',
+  entries: [
+    {
+      binding: 575,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 568,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '1d', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let pipelineLayout0 = device1.createPipelineLayout({
+  label: '\u{1fde1}\u70f5\u{1fb01}\u05d7\u{1f787}\uec21\u0857\u2886',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout0],
+});
+let querySet1 = device1.createQuerySet({type: 'occlusion', count: 889});
+let sampler1 = device1.createSampler({
+  label: '\u0205\u{1f89f}\u0213\u1229\u0c4b\u{1f686}\u6f07\ue675',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 81.21,
+  lodMaxClamp: 87.05,
+  compare: 'always',
+});
+let shaderModule0 = device1.createShaderModule({
+  label: '\u0f1a\u094e\u6aa1\u09bf\u0299\u0242',
+  code: `@group(0) @binding(568)
+var<storage, read_write> function0: array<u32>;
+@group(0) @binding(575)
+var<storage, read_write> field0: array<u32>;
+@group(1) @binding(568)
+var<storage, read_write> local0: array<u32>;
+@group(1) @binding(575)
+var<storage, read_write> n0: array<u32>;
+
+@compute @workgroup_size(4, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(5) f1: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(2) a0: vec3<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder3 = device1.createCommandEncoder({label: '\u0f66\udda9\u{1f751}\u97e7\u3299\u9459\ud8f8'});
+let texture2 = device1.createTexture({
+  label: '\u9671\u852d\u0fcb\u0cc6\u08db\ue170\u23e6\u1adc',
+  size: [1920, 12, 209],
+  mipLevelCount: 4,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm'],
+});
+let textureView2 = texture2.createView({label: '\u0520\u{1f76f}\u01e6\u0729', mipLevelCount: 1, baseArrayLayer: 144, arrayLayerCount: 5});
+let computePassEncoder0 = commandEncoder3.beginComputePass({label: '\u03bb\u6689\ue4bb\u030e\u2c31\u{1f6d0}\u7e7d\u0a99'});
+try {
+computePassEncoder0.end();
+} catch {}
+let textureView3 = texture1.createView({label: '\u{1fa4e}\uba04\u067e\u4709\u7087\u08c0\uc388\u0537', mipLevelCount: 2, arrayLayerCount: 1});
+let texture3 = device1.createTexture({
+  label: '\ud48e\u09bc\u3f14\uf4fb\u5072',
+  size: {width: 4490, height: 5, depthOrArrayLayers: 49},
+  mipLevelCount: 6,
+  format: 'astc-10x5-unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder1 = commandEncoder3.beginComputePass({label: '\u{1fa05}\u05e1\uae2a\u{1fb93}\ue165\u{1f907}\u{1f8b4}\u605a'});
+let renderBundleEncoder0 = device1.createRenderBundleEncoder({
+  label: '\u13ee\uf919\ucf6f\u{1fd2b}',
+  colorFormats: ['bgra8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler2 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 56.08,
+  maxAnisotropy: 1,
+});
+let video0 = await videoWithData();
+let querySet2 = device0.createQuerySet({
+  label: '\u6593\u{1fa14}\u67bf\ufce8\u5827\u541d\u{1fa2b}\u03b9\ub14f\u0475\u08fd',
+  type: 'occlusion',
+  count: 2052,
+});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint']});
+try {
+renderBundleEncoder1.setVertexBuffer(3430, undefined, 0, 905563955);
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(querySet2, 532, 1373, buffer1, 14080);
+} catch {}
+try {
+  await promise1;
+} catch {}
+gc();
+let video1 = await videoWithData();
+let commandEncoder4 = device1.createCommandEncoder({label: '\u4328\u39b7\u2570\u{1fa17}\u1eb8'});
+let textureView4 = texture3.createView({dimension: '2d', baseMipLevel: 4, baseArrayLayer: 31});
+try {
+renderBundleEncoder0.setVertexBuffer(4398, undefined, 0);
+} catch {}
+let textureView5 = texture0.createView({
+  label: '\uf1ae\u018f\u{1fb13}\u8bae\u7133\u726e\u53c1\u37ed',
+  dimension: '2d-array',
+  baseMipLevel: 3,
+  mipLevelCount: 2,
+  baseArrayLayer: 361,
+  arrayLayerCount: 49,
+});
+let promise3 = device0.queue.onSubmittedWorkDone();
+let commandEncoder5 = device0.createCommandEncoder({label: '\u8740\u0fa4\u0d7e\u8c31\ufed7\ufc5a\u{1fbd3}\ud283\u{1fb9d}\u61b2'});
+let querySet3 = device0.createQuerySet({label: '\ub9ff\ub3db\uef71\u6853', type: 'occlusion', count: 852});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint']});
+try {
+commandEncoder5.resolveQuerySet(querySet3, 319, 453, buffer1, 40192);
+} catch {}
+let canvas0 = document.createElement('canvas');
+let img1 = await imageWithData(97, 67, '#75bba05b', '#03fb72cf');
+let querySet4 = device0.createQuerySet({label: '\u022d\u{1fc3d}\u02a4\ub561\u89be\u153c', type: 'occlusion', count: 185});
+let texture4 = device0.createTexture({
+  size: {width: 120, height: 60, depthOrArrayLayers: 29},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView6 = texture4.createView({
+  label: '\u0967\u{1f756}\u0fea\u0be0\u6890\u6763\u8676\u0a59\u80d7\u{1f65b}',
+  format: 'rgba8uint',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+});
+let externalTexture0 = device0.importExternalTexture({label: '\u0a6c\u2a2c\u136e\ueedb\ufcad\ud600\ud80a', source: video1, colorSpace: 'srgb'});
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+let querySet5 = device1.createQuerySet({type: 'occlusion', count: 579});
+let externalTexture1 = device1.importExternalTexture({label: '\u05f1\u{1f628}\u7372', source: video1, colorSpace: 'srgb'});
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(4720, undefined);
+} catch {}
+let pipeline0 = await device1.createComputePipelineAsync({
+  label: '\u090a\u{1fdae}\u0654\u0dba',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+document.body.prepend(canvas0);
+let textureView7 = texture0.createView({
+  label: '\u{1fbdd}\uf9d9\u0cfe\u0051\u063e\ubcf2',
+  dimension: '2d',
+  mipLevelCount: 2,
+  baseArrayLayer: 171,
+});
+let externalTexture2 = device0.importExternalTexture({label: '\u{1faa4}\uec64\u17dd\u9538\u0201', source: video0, colorSpace: 'srgb'});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView8 = texture3.createView({
+  label: '\u6f4b\u07f5\u9210\u0cb2\uc87e\u8911\u{1f66e}\ud49f\u86da\u7491\uae2d',
+  baseMipLevel: 5,
+  baseArrayLayer: 9,
+  arrayLayerCount: 18,
+});
+let computePassEncoder2 = commandEncoder4.beginComputePass({});
+let renderBundle0 = renderBundleEncoder0.finish({label: '\u{1f828}\u0f40\u09ec\u3c86\u0e31\u5c0a\u0943\u{1f853}'});
+let gpuCanvasContext1 = offscreenCanvas0.getContext('webgpu');
+offscreenCanvas0.height = 837;
+let buffer2 = device1.createBuffer({label: '\u06c3\ub479\u0c93', size: 19709, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder6 = device1.createCommandEncoder({label: '\u0d5d\u0f46'});
+let texture5 = device1.createTexture({
+  label: '\u0ad2\u239a\u59fc\u1f03',
+  size: {width: 1920, height: 12, depthOrArrayLayers: 947},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb'],
+});
+let renderBundle1 = renderBundleEncoder0.finish({label: '\u{1feae}\uc7ba\u397b\u{1fe7a}\uf0ac\u0b0f\u3df5'});
+try {
+device1.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 8},
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 380_457 */
+{offset: 609, bytesPerRow: 392, rowsPerImage: 51}, {width: 95, height: 0, depthOrArrayLayers: 20});
+} catch {}
+gc();
+let pipelineLayout1 = device1.createPipelineLayout({label: '\u0e89\u024a\u7aa0\u0edc\u6b2b\u0afb\u05e5', bindGroupLayouts: []});
+let commandEncoder7 = device1.createCommandEncoder();
+let externalTexture3 = device1.importExternalTexture({source: video1});
+try {
+commandEncoder6.clearBuffer(buffer2, 19276, 252);
+dissociateBuffer(device1, buffer2);
+} catch {}
+try {
+adapter0.label = '\u71f7\ue268\ua1fe\u6a71\u148b\u7cb9\uebfb';
+} catch {}
+let bindGroupLayout1 = device1.createBindGroupLayout({
+  label: '\u{1ff8e}\u0a7c\uf6fa\ued8b\u36d3\u77d7\u7baf\u0530\u0786\u920f',
+  entries: [
+    {
+      binding: 320,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 148,
+      visibility: 0,
+      texture: { viewDimension: 'cube', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let querySet6 = device1.createQuerySet({label: '\u9761\u0b01\u{1f648}\u09e6\u0b28\u566b\u0daa\u03ce', type: 'occlusion', count: 72});
+let computePassEncoder3 = commandEncoder6.beginComputePass({label: '\uf4db\u02ca\u31de\ub0b6\u{1fbf2}\ud08d\ue020'});
+let renderBundle2 = renderBundleEncoder0.finish({label: '\u{1fec8}\u7d62\ud8e8\u09c6\u{1fce9}\u{1ffe5}\u8e0f\u{1f629}'});
+let sampler3 = device1.createSampler({
+  label: '\u2ebc\u516c',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 38.98,
+  lodMaxClamp: 83.92,
+  maxAnisotropy: 4,
+});
+let externalTexture4 = device1.importExternalTexture({label: '\u6370\ube92\u0621\u5e07', source: video1});
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+device1.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder7.clearBuffer(buffer2, 12688, 264);
+dissociateBuffer(device1, buffer2);
+} catch {}
+let pipeline1 = await device1.createRenderPipelineAsync({
+  label: '\u{1fcae}\u4e1c',
+  layout: pipelineLayout1,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: [{format: 'bgra8unorm'}]},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 1464, attributes: []},
+      {arrayStride: 0, attributes: []},
+      {arrayStride: 472, stepMode: 'instance', attributes: []},
+      {arrayStride: 412, attributes: []},
+      {arrayStride: 56, attributes: []},
+      {arrayStride: 440, attributes: []},
+      {
+        arrayStride: 68,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x2', offset: 0, shaderLocation: 2}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'back'},
+});
+document.body.prepend(video1);
+let bindGroupLayout2 = device1.createBindGroupLayout({entries: [{binding: 644, visibility: GPUShaderStage.COMPUTE, externalTexture: {}}]});
+let commandEncoder8 = device1.createCommandEncoder();
+let renderBundleEncoder3 = device1.createRenderBundleEncoder({label: '\u4e41\u2312\u3cfc\u08e3\ua3d9\ubafe', colorFormats: ['bgra8unorm'], stencilReadOnly: true});
+let externalTexture5 = device1.importExternalTexture({label: '\u9e07\ubc9b\u1635\ub782\ufeff\u763c\u{1f80f}\u5456\u{1fc47}', source: video0});
+let renderBundle3 = renderBundleEncoder1.finish({label: '\u0e59\u87ad\u5de7\u1275\u00ba\uc3d2\u77cb\u90bb\u{1f703}\u532b'});
+try {
+renderBundleEncoder2.setVertexBuffer(1649, undefined, 0, 646839987);
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(60, 229);
+let buffer3 = device1.createBuffer({size: 50051, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE});
+let textureView9 = texture2.createView({label: '\u0643\uac55', format: 'bgra8unorm', mipLevelCount: 3, baseArrayLayer: 76, arrayLayerCount: 85});
+let computePassEncoder4 = commandEncoder3.beginComputePass({label: '\u3479\u157a\u0f13\u0247\u{1f7c7}\u2ab1\u{1ff4d}\u{1fee1}'});
+try {
+commandEncoder4.resolveQuerySet(querySet1, 447, 178, buffer3, 42752);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer2, 1288, new Int16Array(62549), 10815, 112);
+} catch {}
+let pipeline2 = await device1.createComputePipelineAsync({
+  label: '\uee11\u52cb\uf05c',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipeline3 = device1.createRenderPipeline({
+  label: '\u{1f793}\uee01\ub27e\u0602\u8e30\u64f7\u{1f682}',
+  layout: 'auto',
+  multisample: {count: 4, mask: 0x4b944ff5},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'constant', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'keep'},
+    stencilBack: {compare: 'less-equal', failOp: 'increment-wrap', depthFailOp: 'increment-wrap', passOp: 'replace'},
+    depthBiasClamp: 571.8453047136204,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [{arrayStride: 312, attributes: [{format: 'snorm8x2', offset: 60, shaderLocation: 2}]}],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let querySet7 = device0.createQuerySet({label: '\u00bf\u0f5f\u37be\u45ec\u066a', type: 'occlusion', count: 1479});
+let texture6 = device0.createTexture({
+  label: '\u6b7f\uc47d\u{1fac6}',
+  size: [312, 1, 154],
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\u3349\u0da2\u5ab3\uddab\u9bf0\u0100\ua572\u0ce5\u0d48\u{1fae1}\u0eac',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+offscreenCanvas1.height = 773;
+let buffer4 = device1.createBuffer({
+  label: '\ud7b4\u{1fb49}\u8d3a\u01d7\u006b\u45ad',
+  size: 56824,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let computePassEncoder5 = commandEncoder4.beginComputePass({label: '\u0a2f\ue2fa\u4271\u3ea3'});
+try {
+computePassEncoder3.setPipeline(pipeline2);
+} catch {}
+try {
+commandEncoder7.copyBufferToBuffer(buffer4, 7108, buffer2, 6392, 8800);
+dissociateBuffer(device1, buffer4);
+dissociateBuffer(device1, buffer2);
+} catch {}
+try {
+commandEncoder7.resolveQuerySet(querySet5, 267, 262, buffer3, 8192);
+} catch {}
+let pipeline4 = device1.createComputePipeline({
+  label: '\u0667\u105d\u1fcb\u{1f7e0}\u6805',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+offscreenCanvas1.width = 415;
+try {
+renderBundleEncoder4.setVertexBuffer(6467, undefined, 0, 3441733046);
+} catch {}
+try {
+  await promise2;
+} catch {}
+let querySet8 = device1.createQuerySet({label: '\u{1f624}\uc1e2\u0312\u1de6\uf7ca', type: 'occlusion', count: 623});
+let commandBuffer1 = commandEncoder8.finish({});
+let sampler4 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 87.11,
+  lodMaxClamp: 95.44,
+});
+try {
+renderBundleEncoder3.setVertexBuffer(4761, undefined);
+} catch {}
+try {
+commandEncoder7.resolveQuerySet(querySet8, 386, 185, buffer3, 44544);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 6,
+  origin: {x: 7, y: 0, z: 5},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 8_107 */
+{offset: 103, bytesPerRow: 27, rowsPerImage: 296}, {width: 3, height: 1, depthOrArrayLayers: 2});
+} catch {}
+let pipeline5 = device1.createRenderPipeline({
+  layout: pipelineLayout1,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.ALPHA}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 280, stepMode: 'instance', attributes: []},
+      {arrayStride: 864, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 148,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 26, shaderLocation: 2}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'none', unclippedDepth: true},
+});
+let imageBitmap0 = await createImageBitmap(img0);
+let textureView10 = texture3.createView({label: '\udf0f\ue2cf', dimension: '2d', baseMipLevel: 2, mipLevelCount: 2, baseArrayLayer: 34});
+let sampler5 = device1.createSampler({magFilter: 'nearest', mipmapFilter: 'nearest', lodMaxClamp: 33.14, compare: 'less-equal'});
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder9 = device0.createCommandEncoder();
+let querySet9 = device0.createQuerySet({label: '\u{1fb04}\u90f0\u60a3\u{1fc39}\uc8b4', type: 'occlusion', count: 1243});
+let textureView11 = texture0.createView({dimension: '2d', baseMipLevel: 2, mipLevelCount: 2, baseArrayLayer: 449});
+let externalTexture6 = device0.importExternalTexture({source: video0, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder4.setVertexBuffer(9296, undefined, 2219870398, 244678417);
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(querySet0, 2186, 520, buffer1, 21760);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 0, y: 150, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(72)), /* required buffer size: 448 */
+{offset: 448, bytesPerRow: 2060}, {width: 896, height: 78, depthOrArrayLayers: 0});
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+let adapter2 = await navigator.gpu.requestAdapter();
+try {
+offscreenCanvas1.getContext('bitmaprenderer');
+} catch {}
+let buffer5 = device1.createBuffer({size: 197071, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let querySet10 = device1.createQuerySet({type: 'occlusion', count: 2620});
+let sampler6 = device1.createSampler({
+  label: '\u019e\u9048\u{1f9aa}\u08d9\u5006',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 92.10,
+  lodMaxClamp: 94.25,
+});
+try {
+commandEncoder7.copyBufferToBuffer(buffer4, 17716, buffer3, 47596, 2328);
+dissociateBuffer(device1, buffer4);
+dissociateBuffer(device1, buffer3);
+} catch {}
+try {
+computePassEncoder4.insertDebugMarker('\uee53');
+} catch {}
+let texture7 = device1.createTexture({
+  label: '\u{1f6c5}\u321d\u0316',
+  size: {width: 240, height: 1, depthOrArrayLayers: 1876},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder6 = commandEncoder7.beginComputePass({label: '\u00c8\u99b0\u{1f652}\u64e8\u0746\u9945\ud0ee\u0183'});
+try {
+device1.queue.writeBuffer(buffer3, 8044, new DataView(new ArrayBuffer(50038)), 3211, 4304);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 6,
+  origin: {x: 10, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(32), /* required buffer size: 8_456 */
+{offset: 256, bytesPerRow: 40, rowsPerImage: 41}, {width: 0, height: 0, depthOrArrayLayers: 6});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 240, height: 1, depthOrArrayLayers: 1876}
+*/
+{
+  source: img1,
+  origin: { x: 26, y: 5 },
+  flipY: true,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 27},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 28, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout2 = device1.createPipelineLayout({
+  label: '\ub258\ud688\u969e\u5aa7\u0433\u{1fad5}\u03e4',
+  bindGroupLayouts: [bindGroupLayout2, bindGroupLayout0, bindGroupLayout0, bindGroupLayout1],
+});
+let textureView12 = texture3.createView({
+  label: '\u{1fa31}\u7951\u6ef6\u07b2\ude57\u658a\u{1fe4c}',
+  baseMipLevel: 4,
+  mipLevelCount: 1,
+  baseArrayLayer: 28,
+  arrayLayerCount: 9,
+});
+let renderBundleEncoder5 = device1.createRenderBundleEncoder({
+  label: '\ub5b4\u0642\u0998\u{1ff44}\uf275\u0c20\u653e\ub37d',
+  colorFormats: ['bgra8unorm'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let arrayBuffer0 = buffer4.getMappedRange(35912, 6684);
+try {
+device1.queue.writeBuffer(buffer2, 1576, new Float32Array(41575), 34308, 132);
+} catch {}
+let computePassEncoder7 = commandEncoder9.beginComputePass({label: '\u23de\u04d3\u16dd\u6ca9\u0b10'});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({
+  label: '\ud211\u{1f624}\u0a31\u{1f7d1}\u{1f75f}\u24dd\u8e91',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  depthReadOnly: true,
+});
+let renderBundle4 = renderBundleEncoder6.finish({label: '\uc75f\u031b'});
+let externalTexture7 = device0.importExternalTexture({source: video0});
+try {
+commandEncoder5.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 4,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(querySet7, 1082, 230, buffer1, 69888);
+} catch {}
+let renderBundle5 = renderBundleEncoder3.finish();
+try {
+buffer3.unmap();
+} catch {}
+let pipeline6 = device1.createComputePipeline({
+  label: '\u{1f97b}\u1eaa\ucd28\u053e\u5f78\u{1fa80}\u0c3b\u015a',
+  layout: 'auto',
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder10 = device1.createCommandEncoder();
+let textureView13 = texture5.createView({label: '\ua754\u56bf\uf3d8\u{1fefc}', baseMipLevel: 6});
+let renderBundleEncoder7 = device1.createRenderBundleEncoder({
+  label: '\ueed3\u0b51\u0daf\u93fa\u{1fda3}\u5baa',
+  colorFormats: ['bgra8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+commandEncoder10.copyBufferToBuffer(buffer4, 504, buffer2, 9188, 56);
+dissociateBuffer(device1, buffer4);
+dissociateBuffer(device1, buffer2);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 30, height: 1, depthOrArrayLayers: 234}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 7, y: 191 },
+  flipY: true,
+}, {
+  texture: texture7,
+  mipLevel: 3,
+  origin: {x: 3, y: 0, z: 61},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline7 = await device1.createRenderPipelineAsync({
+  label: '\u054a\ud81f\uabf5\ud98a\uc85f',
+  layout: pipelineLayout2,
+  multisample: {mask: 0xd501fcbd},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [{arrayStride: 0, attributes: [{format: 'unorm8x4', offset: 376, shaderLocation: 2}]}],
+  },
+});
+let commandEncoder11 = device0.createCommandEncoder({});
+let texture8 = device0.createTexture({
+  label: '\uc3f6\u{1fd4f}\ubb0a\u{1fccd}\u0347\u{1feb3}',
+  size: {width: 312, height: 1, depthOrArrayLayers: 1853},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint'],
+});
+let computePassEncoder8 = commandEncoder2.beginComputePass({label: '\u4573\u8547\u791c\u01fb\ub5b6'});
+let sampler7 = device0.createSampler({
+  label: '\ue7ce\u{1fa41}\u0994\uce12\u5d4a\ue97f\uf43d',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.78,
+  maxAnisotropy: 2,
+});
+try {
+commandEncoder5.resolveQuerySet(querySet7, 631, 590, buffer1, 192512);
+} catch {}
+try {
+  await promise3;
+} catch {}
+let img2 = await imageWithData(18, 206, '#d889fdb4', '#adb60b03');
+let textureView14 = texture4.createView({aspect: 'all', mipLevelCount: 2, baseArrayLayer: 0});
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 2,
+  origin: {x: 5, y: 0, z: 1},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer0), /* required buffer size: 108_911 */
+{offset: 724, bytesPerRow: 223, rowsPerImage: 120}, {width: 8, height: 6, depthOrArrayLayers: 5});
+} catch {}
+offscreenCanvas0.width = 1368;
+let texture9 = device0.createTexture({
+  label: '\u{1fb96}\u076b\ua94c\u0e27\u{1ff93}\u4f66\u3143\udd9b\u{1f77b}\u8a20\u062c',
+  size: {width: 312, height: 1, depthOrArrayLayers: 1038},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint'],
+});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  label: '\u0c2d\ucfca\u{1fa4f}\u5c22\u{1fad4}\u{1fec1}',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  depthReadOnly: true,
+});
+let renderBundle6 = renderBundleEncoder6.finish();
+let sampler8 = device0.createSampler({
+  label: '\ub2c1\u6ebe\uddd1\u9a3f\ub2cb\u1139\u55db\ua118\u366d\u{1fd69}',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 49.68,
+  lodMaxClamp: 98.74,
+});
+try {
+commandEncoder0.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 2,
+  origin: {x: 37, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+commandEncoder11.resolveQuerySet(querySet0, 2572, 456, buffer1, 104960);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 12},
+  aspect: 'all',
+}, new Uint16Array(new ArrayBuffer(72)), /* required buffer size: 1_847_628 */
+{offset: 682, bytesPerRow: 150, rowsPerImage: 152}, {width: 73, height: 1, depthOrArrayLayers: 82});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let buffer6 = device0.createBuffer({
+  label: '\u30c0\u08b2\u{1fac6}\ufbce\u{1fab2}\u932c\u{1fe00}\u2759\u3bfe\udd67',
+  size: 94827,
+  usage: GPUBufferUsage.COPY_DST,
+});
+let commandEncoder12 = device0.createCommandEncoder({label: '\u025d\u352c\ubc6f\u792c\u71c1\u02a2\uba45\ubc02\uecdf\uaf8c\u0838'});
+let texture10 = device0.createTexture({
+  size: {width: 1248, height: 1, depthOrArrayLayers: 217},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint', 'rgba8uint'],
+});
+try {
+renderBundleEncoder4.setVertexBuffer(5095, undefined, 1892160408, 1895721864);
+} catch {}
+try {
+computePassEncoder8.pushDebugGroup('\u1805');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer7 = device0.createBuffer({size: 270518, usage: GPUBufferUsage.MAP_READ});
+let textureView15 = texture9.createView({mipLevelCount: 2});
+let renderBundle7 = renderBundleEncoder2.finish({label: '\u586b\u4c1d\u{1f8dc}\u126d\ud6f5\u04f8'});
+let sampler9 = device0.createSampler({
+  label: '\u2bbc\u{1f600}\u600d\u{1f997}\u402c\u7728\u0ce4\u0530\u5a87',
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 88.66,
+  lodMaxClamp: 96.85,
+  maxAnisotropy: 11,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 6},
+  aspect: 'all',
+}, new ArrayBuffer(5_412_030), /* required buffer size: 5_412_030 */
+{offset: 624, bytesPerRow: 357, rowsPerImage: 286}, {width: 26, height: 0, depthOrArrayLayers: 54});
+} catch {}
+let imageData0 = new ImageData(56, 92);
+let commandEncoder13 = device0.createCommandEncoder({label: '\u9ff0\u0d30\udb7c\ue9d3\u{1f825}\u6ace'});
+let computePassEncoder9 = commandEncoder11.beginComputePass({});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\u{1f7fc}\u{1f696}',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+buffer7.unmap();
+} catch {}
+let commandBuffer2 = commandEncoder9.finish({label: '\ud269\u5294\u973f\u{1f6d2}\u0437\u{1fe60}\u01f2\ub0fa\u66c8'});
+let renderBundle8 = renderBundleEncoder6.finish({});
+try {
+commandEncoder0.resolveQuerySet(querySet3, 46, 765, buffer1, 189696);
+} catch {}
+let canvas1 = document.createElement('canvas');
+let commandEncoder14 = device1.createCommandEncoder({label: '\u2bb6\u6695\u7e87\u2e97\u33dd\u602e\u{1f752}\u96e8\u6277\u{1f827}\u124d'});
+let sampler10 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 40.63,
+  lodMaxClamp: 44.67,
+});
+try {
+device1.queue.writeBuffer(buffer3, 3288, new Float32Array(14246), 6072, 3952);
+} catch {}
+let pipeline8 = device1.createRenderPipeline({
+  label: '\udceb\u7978',
+  layout: pipelineLayout2,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 68,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x2', offset: 0, shaderLocation: 2}],
+      },
+    ],
+  },
+});
+let commandEncoder15 = device0.createCommandEncoder({label: '\u0031\u4c9b\u01de\u06d3\ufa33\u0a41'});
+let textureView16 = texture6.createView({label: '\u{1fe0a}\u48d3', baseMipLevel: 6, mipLevelCount: 2, baseArrayLayer: 0});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  label: '\u0309\u0216\u08a8\uc4a2\u00d1\ue1dd',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  depthReadOnly: true,
+});
+let querySet11 = device0.createQuerySet({
+  label: '\u7a7b\u{1fd8c}\ud1d5\u6db8\u0285\u826b\u0db5\u{1f655}\u4b1b\u0f62\u0e53',
+  type: 'occlusion',
+  count: 2224,
+});
+let computePassEncoder10 = commandEncoder13.beginComputePass();
+let renderBundle9 = renderBundleEncoder9.finish({label: '\ueda9\u0f60\u{1fc81}\u5767\uaac3'});
+try {
+renderBundleEncoder8.setVertexBuffer(7785, undefined, 3132370299, 1139564508);
+} catch {}
+try {
+commandEncoder0.resolveQuerySet(querySet7, 1314, 9, buffer1, 17152);
+} catch {}
+try {
+  await promise4;
+} catch {}
+let bindGroup0 = device1.createBindGroup({
+  label: '\u9456\u{1fe13}\u{1f6f6}\u910c\u7d92\u6271\u04fe',
+  layout: bindGroupLayout2,
+  entries: [{binding: 644, resource: externalTexture1}],
+});
+let texture11 = device1.createTexture({
+  size: {width: 240, height: 1, depthOrArrayLayers: 150},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm'],
+});
+let textureView17 = texture5.createView({label: '\uc8ec\u6f97\u5af6\u25c9\u026c', baseMipLevel: 4, mipLevelCount: 2});
+let renderBundleEncoder11 = device1.createRenderBundleEncoder({
+  label: '\u4abd\ucda4\u{1f842}\u{1fbbd}\u4df2\u9ca3\u8ee7\u0dfc',
+  colorFormats: ['bgra8unorm'],
+  depthReadOnly: true,
+});
+let renderBundle10 = renderBundleEncoder5.finish({label: '\u2e92\u886b'});
+try {
+renderBundleEncoder7.setVertexBuffer(8194, undefined, 1600395746, 2192733699);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let video2 = await videoWithData();
+let buffer8 = device1.createBuffer({
+  label: '\ua377\u{1f8a2}\u049d\u9552',
+  size: 932381,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT,
+});
+let commandEncoder16 = device1.createCommandEncoder({label: '\ua1bb\u0a9a\u0086\u1c13'});
+let texture12 = device1.createTexture({
+  label: '\u05aa\u1202\u5248\u216d\uc838\u4f3a\u778a\u3cb9\u8af0\ub049\udf8f',
+  size: {width: 480, height: 3, depthOrArrayLayers: 38},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView18 = texture11.createView({label: '\ucd20\u0d30\u07c7', baseMipLevel: 2});
+let renderBundle11 = renderBundleEncoder7.finish({label: '\u8479\ue8bf\ucaaa\u{1ff26}'});
+try {
+commandEncoder7.copyBufferToBuffer(buffer8, 450744, buffer2, 15204, 2884);
+dissociateBuffer(device1, buffer8);
+dissociateBuffer(device1, buffer2);
+} catch {}
+try {
+commandEncoder7.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 14, y: 0, z: 15},
+  aspect: 'all',
+},
+{width: 24, height: 1, depthOrArrayLayers: 30});
+} catch {}
+let querySet12 = device0.createQuerySet({label: '\u6008\u68f9\uaeec\ue90c\u11bb\u087c\u19d2\ua6b2\uc2c5', type: 'occlusion', count: 1704});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'], depthReadOnly: true});
+let renderBundle12 = renderBundleEncoder10.finish({label: '\u0c68\u2af6'});
+try {
+commandEncoder12.clearBuffer(buffer6, 43084, 6308);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 8952, new DataView(new ArrayBuffer(6167)), 4186, 320);
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(751, 202);
+let video3 = await videoWithData();
+let textureView19 = texture8.createView({
+  label: '\u4157\u0947\u{1ff37}\ud278\u075c\u0b75\u9d9f\u00be\u98d9\u300e\u5c31',
+  baseMipLevel: 4,
+  mipLevelCount: 1,
+});
+try {
+device0.queue.writeBuffer(buffer6, 17032, new Float32Array(5171), 865, 388);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let shaderModule1 = device1.createShaderModule({
+  label: '\u27a4\ub30c',
+  code: `@group(0) @binding(568)
+var<storage, read_write> local1: array<u32>;
+@group(1) @binding(568)
+var<storage, read_write> local2: array<u32>;
+@group(0) @binding(575)
+var<storage, read_write> global0: array<u32>;
+
+@compute @workgroup_size(1, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@location(2) a0: vec4<u32>, @builtin(sample_index) a1: u32, @location(1) a2: f32) -> @location(200) vec4<f32> {
+return vec4<f32>();
+}
+
+struct VertexOutput0 {
+  @location(2) f0: vec4<u32>,
+  @location(4) f1: f32,
+  @builtin(position) f2: vec4<f32>,
+  @location(5) f3: vec4<f32>,
+  @location(13) f4: vec4<u32>,
+  @location(1) f5: f32,
+  @location(11) f6: vec3<u32>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder17 = device1.createCommandEncoder({label: '\u026b\u0910\u{1ff59}\u{1f736}\u27b6\u042b'});
+let textureView20 = texture2.createView({
+  label: '\u0f49\u{1fe60}\u{1fef4}',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 15,
+});
+try {
+device1.pushErrorScope('internal');
+} catch {}
+try {
+  await device1.popErrorScope();
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer8, 508768, buffer5, 52212, 80196);
+dissociateBuffer(device1, buffer8);
+dissociateBuffer(device1, buffer5);
+} catch {}
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 865},
+  aspect: 'all',
+},
+{width: 207, height: 1, depthOrArrayLayers: 13});
+} catch {}
+try {
+commandEncoder17.clearBuffer(buffer3, 23624, 860);
+dissociateBuffer(device1, buffer3);
+} catch {}
+try {
+commandEncoder10.pushDebugGroup('\u{1fbd1}');
+} catch {}
+let pipeline9 = await device1.createComputePipelineAsync({
+  label: '\u936b\u0ea0\u79ed\u{1f889}\u640c\u59f3\u9ea8\u1160',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let video4 = await videoWithData();
+let commandEncoder18 = device1.createCommandEncoder();
+let sampler11 = device1.createSampler({
+  label: '\u3efe\u0601\u{1fe9b}\u0c3d\ub679\ua45a',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 73.97,
+  lodMaxClamp: 93.56,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(0, bindGroup0, new Uint32Array(1805), 1625, 0);
+} catch {}
+try {
+device1.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder14.copyBufferToBuffer(buffer4, 54096, buffer5, 62024, 1660);
+dissociateBuffer(device1, buffer4);
+dissociateBuffer(device1, buffer5);
+} catch {}
+try {
+commandEncoder6.clearBuffer(buffer3, 14344, 19328);
+dissociateBuffer(device1, buffer3);
+} catch {}
+let bindGroupLayout3 = device1.createBindGroupLayout({label: '\u07c1\u410e\u144c\u72e5\u9c3f\u{1f60d}\u402b\u{1fd65}\ud662', entries: []});
+let textureView21 = texture5.createView({
+  label: '\u{1ff13}\u0c21\u1f8f\u{1ff33}\u34b5\u5b6f',
+  format: 'bgra8unorm-srgb',
+  baseMipLevel: 4,
+  mipLevelCount: 2,
+});
+let renderBundleEncoder13 = device1.createRenderBundleEncoder({colorFormats: ['bgra8unorm']});
+let renderBundle13 = renderBundleEncoder3.finish({label: '\uf57c\u07ab\uaeb1\ub1d7\ua12a\u{1fa84}\u3110\ud528'});
+let sampler12 = device1.createSampler({
+  label: '\u6532\ubbd5\u065d',
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 62.74,
+  lodMaxClamp: 96.04,
+});
+let externalTexture8 = device1.importExternalTexture({label: '\u0861\u969b\u{1fe92}\u370e', source: video2, colorSpace: 'srgb'});
+try {
+commandEncoder16.copyBufferToBuffer(buffer4, 56540, buffer5, 47800, 120);
+dissociateBuffer(device1, buffer4);
+dissociateBuffer(device1, buffer5);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 3},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 1_855_220 */
+{offset: 168, bytesPerRow: 1587, rowsPerImage: 146}, {width: 359, height: 1, depthOrArrayLayers: 9});
+} catch {}
+let pipeline10 = await device1.createRenderPipelineAsync({
+  label: '\uf90d\u0b34\u0bea\u0c25\u04fe\u08b8',
+  layout: pipelineLayout1,
+  multisample: {mask: 0x63f2f218},
+  fragment: {module: shaderModule0, entryPoint: 'fragment0', constants: {}, targets: [{format: 'bgra8unorm'}]},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 328,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x2', offset: 48, shaderLocation: 2}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+let commandEncoder19 = device0.createCommandEncoder();
+let externalTexture9 = device0.importExternalTexture({label: '\u57d8\u4e4b\ud97c\u02b8\ue255\u0f79\u2bf5\u0547\u62ab', source: video3});
+let device2 = await adapter2.requestDevice({
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 6,
+    maxColorAttachmentBytesPerSample: 44,
+    maxVertexAttributes: 18,
+    maxVertexBufferArrayStride: 27015,
+    maxStorageTexturesPerShaderStage: 12,
+    maxStorageBuffersPerShaderStage: 18,
+    maxDynamicStorageBuffersPerPipelineLayout: 35482,
+    maxDynamicUniformBuffersPerPipelineLayout: 47115,
+    maxBindingsPerBindGroup: 6099,
+    maxTextureArrayLayers: 1902,
+    maxTextureDimension1D: 11913,
+    maxTextureDimension2D: 15641,
+    maxVertexBuffers: 10,
+    maxBindGroupsPlusVertexBuffers: 26,
+    minStorageBufferOffsetAlignment: 64,
+    maxUniformBufferBindingSize: 267590021,
+    maxStorageBufferBindingSize: 195600932,
+    maxUniformBuffersPerShaderStage: 36,
+    maxSampledTexturesPerShaderStage: 25,
+    maxInterStageShaderVariables: 114,
+    maxInterStageShaderComponents: 102,
+    maxSamplersPerShaderStage: 19,
+  },
+});
+try {
+adapter0.label = '\u{1f7c7}\u41d0\u{1ffc9}\u9509\uf774\u0816\u0a7f\u0cc1\u060f\uc79e\u0092';
+} catch {}
+let commandEncoder20 = device2.createCommandEncoder({label: '\u0b29\u9f52\u{1ff4a}\u26f3\u{1f840}\u8896'});
+try {
+commandEncoder20.pushDebugGroup('\ue229');
+} catch {}
+let bindGroup1 = device1.createBindGroup({
+  label: '\u{1f62f}\u48b8',
+  layout: bindGroupLayout2,
+  entries: [{binding: 644, resource: externalTexture8}],
+});
+let commandEncoder21 = device1.createCommandEncoder();
+try {
+renderBundleEncoder13.setBindGroup(1, bindGroup0, new Uint32Array(9118), 120, 0);
+} catch {}
+try {
+commandEncoder17.copyBufferToBuffer(buffer4, 48300, buffer2, 8020, 1088);
+dissociateBuffer(device1, buffer4);
+dissociateBuffer(device1, buffer2);
+} catch {}
+try {
+commandEncoder21.resolveQuerySet(querySet5, 260, 298, buffer3, 15872);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer3, 8564, new BigUint64Array(1122), 38, 16);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let canvas2 = document.createElement('canvas');
+try {
+gpuCanvasContext0.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(698, 567);
+let querySet13 = device0.createQuerySet({label: '\ueeea\u3679\u4591', type: 'occlusion', count: 3124});
+let textureView22 = texture10.createView({label: '\u695d\ucc30\u6bc9\u461e\u457d\u1de9', dimension: '3d', format: 'rgba8uint', baseMipLevel: 3});
+let computePassEncoder11 = commandEncoder5.beginComputePass({label: '\u6b2f\u0edf\u21d2\ucca1\ua153\uefd7\u476a\u1d8f\u5ed0'});
+let sampler13 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 77.99,
+});
+let externalTexture10 = device0.importExternalTexture({label: '\u91a9\u6989\ud21b\u0848\u36d6\u{1fe3e}\u0260\u7199', source: video3, colorSpace: 'srgb'});
+try {
+computePassEncoder8.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(arrayBuffer0), /* required buffer size: 30 */
+{offset: 30, bytesPerRow: 149}, {width: 8, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let buffer9 = device0.createBuffer({size: 39232, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: true});
+let texture13 = device0.createTexture({
+  label: '\u{1fb68}\u05ba\ua254\u22cf\u{1ffbc}\u1944\u{1f611}\u028d\uc24f\u00a7\u6a64',
+  size: {width: 240, height: 120, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint', 'rgb10a2uint'],
+});
+let textureView23 = texture4.createView({label: '\ub4a8\uac52', baseMipLevel: 2});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({
+  label: '\u{1faab}\ubbd2',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+commandEncoder12.copyBufferToBuffer(buffer9, 2088, buffer6, 44376, 12636);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 1,
+  origin: {x: 21, y: 0, z: 26},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 16_840_480 */
+{offset: 64, bytesPerRow: 104, rowsPerImage: 193}, {width: 4, height: 1, depthOrArrayLayers: 840});
+} catch {}
+document.body.prepend(img0);
+let imageData1 = new ImageData(44, 212);
+let commandEncoder22 = device2.createCommandEncoder({label: '\u{1fc77}\u{1f85b}\u6c27\u0f79\uca69\ucd4f\u{1fc30}\ud070\u{1fef2}\udadb'});
+let texture14 = device2.createTexture({
+  label: '\u26c8\u984e\u03cb\u0d5a\u{1fd6f}\u{1fe83}\u591b\uf884\u21ac',
+  size: {width: 45},
+  dimension: '1d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm'],
+});
+let textureView24 = texture14.createView({label: '\u6014\u{1fe31}\u06cb\ucbf7\uef74\uadcd', aspect: 'all'});
+let externalTexture11 = device2.importExternalTexture({label: '\u7784\uc62b\ud2ae\u7d3d\u0da2', source: video2, colorSpace: 'display-p3'});
+document.body.prepend(video3);
+let bindGroupLayout4 = device2.createBindGroupLayout({
+  entries: [
+    {
+      binding: 944,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 5733,
+      visibility: 0,
+      texture: { viewDimension: 'cube-array', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 2288, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'comparison' }},
+  ],
+});
+let commandEncoder23 = device2.createCommandEncoder({label: '\u05d4\u09b0\u802f\u0aaf\u8a89\u{1f9e5}'});
+let querySet14 = device2.createQuerySet({label: '\ucfe4\u2c6f\u{1f604}\ubaf5\u{1f7db}\u0e37\u00da', type: 'occlusion', count: 1955});
+let sampler14 = device2.createSampler({
+  label: '\u5fc6\ud74b',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 88.95,
+  lodMaxClamp: 97.98,
+});
+let externalTexture12 = device2.importExternalTexture({
+  label: '\u6b46\u4273\ub4f7\u8014\u062e\u3dc5\u0950\u4b05\u2774\u{1f855}',
+  source: video2,
+  colorSpace: 'display-p3',
+});
+let imageData2 = new ImageData(88, 76);
+let bindGroupLayout5 = device2.createBindGroupLayout({
+  label: '\u{1f9ce}\ucf68\u0554\ueaf0\u0b39\u026e\u9a32',
+  entries: [
+    {binding: 1173, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 3996,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {binding: 2764, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder24 = device2.createCommandEncoder({});
+let externalTexture13 = device2.importExternalTexture({
+  label: '\u{1fb48}\u6c7d\u{1ffd8}\ufb02\u725c\u{1fc2b}\u051c\u512a\uf9b5\u48d9',
+  source: video0,
+  colorSpace: 'display-p3',
+});
+try {
+gpuCanvasContext0.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 790 */
+{offset: 790, rowsPerImage: 132}, {width: 22, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let video5 = await videoWithData();
+let commandEncoder25 = device0.createCommandEncoder();
+let querySet15 = device0.createQuerySet({
+  label: '\u0ab7\u0ee3\u{1feed}\ub133\u4ad8\u189e\u{1f780}\u{1fd7a}\u4340',
+  type: 'occlusion',
+  count: 1531,
+});
+let texture15 = gpuCanvasContext1.getCurrentTexture();
+let renderBundle14 = renderBundleEncoder4.finish({label: '\u0d4d\u0eed\u7cd7\u5649\u43ba\u{1f7e5}'});
+try {
+commandEncoder12.copyBufferToBuffer(buffer9, 1552, buffer6, 23308, 27156);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder15.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 3,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 11360 */
+  offset: 11360,
+  bytesPerRow: 256,
+  buffer: buffer6,
+}, {width: 2, height: 6, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder12.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 1,
+  origin: {x: 343, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 17, height: 0, depthOrArrayLayers: 4});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let querySet16 = device2.createQuerySet({type: 'occlusion', count: 1233});
+let texture16 = gpuCanvasContext1.getCurrentTexture();
+let textureView25 = texture14.createView({
+  label: '\u9ce5\u{1f96b}\u39a8\u0e4e\u0028\u1c2b\ufeb0\u0c8d\u{1feef}\u33cc',
+  format: 'bgra8unorm-srgb',
+});
+let video6 = await videoWithData();
+let buffer10 = device1.createBuffer({
+  label: '\u8021\ud879\u05f4\u0984\u{1f8ff}\ue6c8\u0d9f\u569e\u05f4',
+  size: 292544,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let renderBundleEncoder15 = device1.createRenderBundleEncoder({label: '\ubc7b\ub61b\u{1f7da}\u5816\u092c\uf91d\u{1fe70}', colorFormats: ['bgra8unorm']});
+try {
+renderBundleEncoder15.setPipeline(pipeline10);
+} catch {}
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 37, y: 0, z: 34},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 222, y: 1, z: 299},
+  aspect: 'all',
+},
+{width: 99, height: 0, depthOrArrayLayers: 21});
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(6_853_280), /* required buffer size: 6_853_280 */
+{offset: 5, bytesPerRow: 143, rowsPerImage: 213}, {width: 15, height: 0, depthOrArrayLayers: 226});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 240, height: 1, depthOrArrayLayers: 1876}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 60, y: 598 },
+  flipY: false,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 435},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline11 = await device1.createRenderPipelineAsync({
+  label: '\uf55c\u0a7d\u05e0\ua8ae\ue82b',
+  layout: 'auto',
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {failOp: 'invert', depthFailOp: 'invert', passOp: 'zero'},
+    stencilBack: {compare: 'equal', failOp: 'decrement-clamp', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilReadMask: 2706622781,
+    stencilWriteMask: 1237150124,
+    depthBias: 2078003067,
+    depthBiasSlopeScale: 619.3348383982868,
+    depthBiasClamp: 156.35788315061257,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 24, attributes: []},
+      {arrayStride: 16, attributes: [{format: 'snorm8x2', offset: 6, shaderLocation: 2}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', cullMode: 'back', unclippedDepth: true},
+});
+canvas2.height = 522;
+try {
+adapter1.label = '\udfa6\u{1fbcd}\u8c0c\u{1fa85}';
+} catch {}
+let commandEncoder26 = device1.createCommandEncoder();
+try {
+computePassEncoder5.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline10);
+} catch {}
+try {
+commandEncoder18.clearBuffer(buffer2, 816, 10560);
+dissociateBuffer(device1, buffer2);
+} catch {}
+try {
+commandEncoder18.resolveQuerySet(querySet1, 115, 290, buffer3, 6144);
+} catch {}
+try {
+commandEncoder17.pushDebugGroup('\u{1ff7a}');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer2, 3888, new Float32Array(47918), 38228, 24);
+} catch {}
+document.body.prepend(canvas0);
+let canvas3 = document.createElement('canvas');
+let imageData3 = new ImageData(192, 12);
+let commandEncoder27 = device1.createCommandEncoder({label: '\ue0af\u92da\u{1f6bf}\udf22'});
+let texture17 = device1.createTexture({
+  size: {width: 1920, height: 12, depthOrArrayLayers: 946},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler15 = device1.createSampler({
+  label: '\u053f\u3e1e\ub66f\u6bdc\u202a\u333e\u{1fa3d}\ud652\u2e4f',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 18.65,
+  maxAnisotropy: 3,
+});
+try {
+commandEncoder10.copyBufferToBuffer(buffer4, 50188, buffer5, 149648, 3884);
+dissociateBuffer(device1, buffer4);
+dissociateBuffer(device1, buffer5);
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer3, 10080, 30756);
+dissociateBuffer(device1, buffer3);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline12 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout1,
+  multisample: {mask: 0x1725d1f5},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'one-minus-src'},
+    alpha: {operation: 'subtract', srcFactor: 'dst', dstFactor: 'src-alpha'},
+  },
+}],
+},
+  vertex: {module: shaderModule1, entryPoint: 'vertex0', buffers: []},
+});
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+let buffer11 = device0.createBuffer({label: '\u0817\u002e\u0c3d\u3386\u6397\ud875\u0413', size: 20534, usage: GPUBufferUsage.INDEX});
+let querySet17 = device0.createQuerySet({label: '\u{1f8b3}\u007c', type: 'occlusion', count: 3020});
+let textureView26 = texture10.createView({label: '\u{1fb18}\udbca', baseMipLevel: 2, mipLevelCount: 1});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  label: '\u24e4\u744c\ud5a3\u0e78\ubff3\u0de9',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+commandEncoder15.copyBufferToBuffer(buffer9, 32104, buffer6, 36376, 2420);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let texture18 = device0.createTexture({
+  size: [1248, 1, 42],
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg8uint', 'rgb10a2uint', 'rgb10a2uint'],
+});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'], depthReadOnly: true});
+try {
+commandEncoder15.clearBuffer(buffer6, 51872, 16432);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder19.resolveQuerySet(querySet9, 602, 60, buffer1, 172032);
+} catch {}
+document.body.prepend(canvas0);
+let canvas4 = document.createElement('canvas');
+try {
+offscreenCanvas3.getContext('webgpu');
+} catch {}
+let commandEncoder28 = device1.createCommandEncoder({label: '\u{1f7df}\u{1fb95}'});
+let querySet18 = device1.createQuerySet({label: '\ud5c0\u{1fe3b}', type: 'occlusion', count: 1676});
+let texture19 = device1.createTexture({
+  label: '\u720d\u08d9\u0928\u091b\u36dc\u{1fbee}\u2129\u{1fd84}\u0a94\u996f\u06da',
+  size: {width: 480},
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView27 = texture5.createView({format: 'bgra8unorm-srgb', baseMipLevel: 2, mipLevelCount: 1});
+let renderBundleEncoder18 = device1.createRenderBundleEncoder({colorFormats: ['bgra8unorm'], depthReadOnly: true});
+let renderBundle15 = renderBundleEncoder13.finish({label: '\u{1fec0}\u025c\u6f81'});
+let externalTexture14 = device1.importExternalTexture({label: '\ue527\u0af6\u452f\u971d\ubdbc\u784f\u{1f8f4}\u3d51\u6de6\u{1ff68}', source: video2});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup0, new Uint32Array(6242), 4995, 0);
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline9);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(4975, undefined);
+} catch {}
+try {
+commandEncoder17.resolveQuerySet(querySet8, 248, 215, buffer3, 4608);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer3, 4152, new BigUint64Array(64111), 1179, 1064);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder29 = device0.createCommandEncoder({label: '\u{1fbda}\u{1f722}\u{1fa87}\u721a\u4acc\u0b23'});
+let querySet19 = device0.createQuerySet({label: '\u0560\u7f3d\u9c52\u70aa\u03cd\u07fb', type: 'occlusion', count: 897});
+let textureView28 = texture10.createView({
+  label: '\u0654\u5751\u{1fb4b}\ua505\u6136\uefad\u948e',
+  format: 'rgba8uint',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+});
+try {
+commandEncoder25.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 2,
+  origin: {x: 12, y: 0, z: 31},
+  aspect: 'all',
+},
+{width: 77, height: 1, depthOrArrayLayers: 15});
+} catch {}
+try {
+commandEncoder25.clearBuffer(buffer6, 16756, 73400);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let gpuCanvasContext2 = canvas2.getContext('webgpu');
+let commandBuffer3 = commandEncoder25.finish({label: '\u07b5\u6878\u{1fb41}\ud469'});
+let texture20 = device0.createTexture({
+  label: '\u6441\u02b6\u057c\u{1ff84}\uc208\u39d9\u0c11\u312b\u0cd9\uabf1',
+  size: {width: 1248, height: 1, depthOrArrayLayers: 234},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView29 = texture0.createView({dimension: '2d', baseMipLevel: 3, mipLevelCount: 1, baseArrayLayer: 202});
+let computePassEncoder12 = commandEncoder19.beginComputePass();
+try {
+commandEncoder12.copyBufferToBuffer(buffer9, 30016, buffer6, 66172, 5684);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder15.resolveQuerySet(querySet3, 482, 280, buffer1, 115456);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 9008, new BigUint64Array(63799), 62543, 744);
+} catch {}
+let querySet20 = device0.createQuerySet({
+  label: '\u0c94\u{1f9a0}\u{1ff0a}\u010e\u0cd6\u6e87\u{1f661}\u0ab1\u{1fce6}',
+  type: 'occlusion',
+  count: 633,
+});
+let texture21 = device0.createTexture({
+  label: '\u{1f700}\ude17\u0b5d\u0284\u{1f6bc}\u05a2\uc7b3\u098f\u0140\u3502\u0284',
+  size: [156, 1, 960],
+  mipLevelCount: 4,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView30 = texture0.createView({
+  label: '\u5e4e\uac2a\u4db5\u01ad\u{1fcdc}\u353d\u0a98\u3188\u0be0\ue400\u8da5',
+  dimension: '2d',
+  baseMipLevel: 5,
+  baseArrayLayer: 452,
+});
+let renderBundle16 = renderBundleEncoder17.finish();
+let sampler16 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 61.95,
+  lodMaxClamp: 90.70,
+});
+try {
+device0.queue.writeBuffer(buffer6, 11708, new DataView(new ArrayBuffer(28)), 18, 0);
+} catch {}
+let videoFrame0 = new VideoFrame(imageBitmap0, {timestamp: 0});
+let renderBundle17 = renderBundleEncoder15.finish({label: '\u60a3\u0c1b\u09ae\ud76c\u0e40\uc424\u0720\ubfae\ub6e9'});
+let sampler17 = device1.createSampler({
+  label: '\u{1fcd3}\u{1ffe1}\u0cd3',
+  addressModeU: 'clamp-to-edge',
+  lodMinClamp: 92.31,
+  lodMaxClamp: 95.48,
+  compare: 'never',
+});
+let externalTexture15 = device1.importExternalTexture({label: '\u0a33\u{1fbcf}\ub5e7\u{1fec1}', source: video0, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder18.setVertexBuffer(4104, undefined, 0, 3546604277);
+} catch {}
+try {
+commandEncoder10.copyBufferToBuffer(buffer4, 36512, buffer10, 8892, 3860);
+dissociateBuffer(device1, buffer4);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+commandEncoder7.clearBuffer(buffer10);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline13 = device1.createRenderPipeline({
+  label: '\u9ffe\u0fbd\uc454\ub0ae\u02ec\u0c90\ue0fd\u0a57\u0e4d',
+  layout: 'auto',
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'never', failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'greater', failOp: 'invert', depthFailOp: 'invert', passOp: 'increment-wrap'},
+    stencilReadMask: 1890065591,
+    stencilWriteMask: 4294967295,
+    depthBias: 337123199,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 268, stepMode: 'instance', attributes: []},
+      {arrayStride: 80, attributes: [{format: 'float16x4', offset: 16, shaderLocation: 2}]},
+    ],
+  },
+});
+let buffer12 = device0.createBuffer({label: '\u09f7\u0a3a\u00f9', size: 17750, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let querySet21 = device0.createQuerySet({type: 'occlusion', count: 3985});
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint']});
+let promise5 = device0.popErrorScope();
+try {
+commandEncoder15.resolveQuerySet(querySet13, 2590, 267, buffer1, 193792);
+} catch {}
+try {
+computePassEncoder10.insertDebugMarker('\u8336');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 46},
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(16)), /* required buffer size: 15_770_520 */
+{offset: 432, bytesPerRow: 642, rowsPerImage: 89}, {width: 178, height: 0, depthOrArrayLayers: 277});
+} catch {}
+let imageBitmap1 = await createImageBitmap(offscreenCanvas3);
+let commandEncoder30 = device0.createCommandEncoder({label: '\u{1f942}\u555d\u2cb9\u4562'});
+let textureView31 = texture13.createView({
+  label: '\uc8bc\u087c\ub91c\u099c\u0648\u{1fd66}\u{1f6bc}\ue528',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+  mipLevelCount: 2,
+});
+try {
+renderBundleEncoder8.setVertexBuffer(1110, undefined, 1948121246, 1980025876);
+} catch {}
+try {
+commandEncoder29.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 1,
+  origin: {x: 10, y: 3, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 21, y: 0, z: 27},
+  aspect: 'all',
+},
+{width: 27, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 30564, new BigUint64Array(50998), 1921, 1608);
+} catch {}
+let videoFrame1 = new VideoFrame(img0, {timestamp: 0});
+let commandBuffer4 = commandEncoder24.finish({label: '\u{1fe29}\u7362\u{1fecf}\u55fc\u08c4\uee8a\u0d0f\uae4c\u8d55'});
+let renderBundleEncoder20 = device2.createRenderBundleEncoder({
+  label: '\u0e87\u76d5\u013b',
+  colorFormats: ['rgb10a2uint', 'rgba8sint', 'bgra8unorm-srgb', 'rg16sint', 'r8unorm'],
+});
+let externalTexture16 = device2.importExternalTexture({label: '\u{1fe04}\ua65a\u{1f8d0}\u3744\u{1f849}\u{1f76e}\u0a73\udb58\u01bf\u07cb', source: video0});
+try {
+device2.pushErrorScope('internal');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 53 */
+{offset: 53}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext3 = canvas1.getContext('webgpu');
+let canvas5 = document.createElement('canvas');
+let imageBitmap2 = await createImageBitmap(imageBitmap0);
+let imageData4 = new ImageData(16, 204);
+try {
+renderBundleEncoder20.setVertexBuffer(6928, undefined, 1440940173, 2177108706);
+} catch {}
+try {
+renderBundleEncoder20.insertDebugMarker('\u6b5c');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(592), /* required buffer size: 592 */
+{offset: 464, bytesPerRow: 384}, {width: 32, height: 1, depthOrArrayLayers: 1});
+} catch {}
+gc();
+let pipelineLayout3 = device2.createPipelineLayout({bindGroupLayouts: [bindGroupLayout5]});
+let texture22 = device2.createTexture({
+  size: {width: 90},
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+device2.pushErrorScope('validation');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device2,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let gpuCanvasContext4 = offscreenCanvas2.getContext('webgpu');
+try {
+adapter2.label = '\u{1ffce}\u{1f663}\u077c\u5287\u446a';
+} catch {}
+let texture23 = device0.createTexture({
+  size: [960, 480, 361],
+  mipLevelCount: 5,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder13 = commandEncoder15.beginComputePass({label: '\u{1f943}\u{1fbd0}\u07e4'});
+let renderBundle18 = renderBundleEncoder10.finish();
+let sampler18 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 3.280,
+  lodMaxClamp: 78.06,
+  maxAnisotropy: 16,
+});
+try {
+device0.queue.writeBuffer(buffer6, 1916, new BigUint64Array(29673), 25104, 1140);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer13 = device2.createBuffer({
+  label: '\u{1fbd1}\u0923\u{1ff5d}',
+  size: 86983,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: false,
+});
+let textureView32 = texture16.createView({dimension: '2d'});
+let renderBundle19 = renderBundleEncoder20.finish({label: '\ua954\u1409\u040d\u{1fbf8}\u38b5\u0e22\u26df'});
+try {
+commandEncoder20.clearBuffer(buffer13, 1676, 46196);
+dissociateBuffer(device2, buffer13);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer13, 19264, new Int16Array(57848), 41300, 412);
+} catch {}
+let pipelineLayout4 = device1.createPipelineLayout({
+  label: '\u46fa\u70f1\u0060\u{1ff03}',
+  bindGroupLayouts: [bindGroupLayout3, bindGroupLayout3, bindGroupLayout2],
+});
+let commandEncoder31 = device1.createCommandEncoder({label: '\u{1ff09}\u0bcd\u3091\ud19a\u7196\u0acf'});
+let sampler19 = device1.createSampler({
+  label: '\u556a\u902b\u09ae\u{1fca0}\ud533\u094f\ub8e8',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 77.48,
+  lodMaxClamp: 88.11,
+});
+let externalTexture17 = device1.importExternalTexture({label: '\u5a2d\u{1fb58}', source: videoFrame0, colorSpace: 'srgb'});
+try {
+computePassEncoder4.end();
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer5, 69508, 33068);
+dissociateBuffer(device1, buffer5);
+} catch {}
+try {
+commandEncoder31.insertDebugMarker('\u0954');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer5, 74516, new BigUint64Array(46202), 6657, 3036);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageData5 = new ImageData(244, 16);
+try {
+canvas5.getContext('webgl');
+} catch {}
+let texture24 = device0.createTexture({
+  size: {width: 624},
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+try {
+commandEncoder30.copyBufferToBuffer(buffer12, 12300, buffer6, 40128, 3856);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder0.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 1,
+  origin: {x: 12, y: 19, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 9},
+  aspect: 'all',
+},
+{width: 9, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder29.resolveQuerySet(querySet7, 90, 92, buffer1, 209920);
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 1108, new Float32Array(49421), 45230, 492);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let videoFrame2 = new VideoFrame(video3, {timestamp: 0});
+let commandEncoder32 = device1.createCommandEncoder({label: '\ub498\ub55e\uc1e6\u04f7\u053d\uefbd\u5327'});
+let textureView33 = texture5.createView({
+  label: '\u0afa\uab32\uf7dc\u{1f85a}\u06f9\ub8b0',
+  format: 'bgra8unorm-srgb',
+  baseMipLevel: 3,
+  mipLevelCount: 2,
+});
+try {
+renderBundleEncoder18.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder18.setBindGroup(1, bindGroup1, new Uint32Array(3212), 2673, 0);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline12);
+} catch {}
+try {
+commandEncoder17.clearBuffer(buffer2, 8736, 4660);
+dissociateBuffer(device1, buffer2);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+});
+} catch {}
+try {
+device1.queue.submit([commandBuffer1]);
+} catch {}
+let gpuCanvasContext5 = canvas4.getContext('webgpu');
+let shaderModule2 = device2.createShaderModule({
+  code: `@group(0) @binding(2764)
+var<storage, read_write> n1: array<u32>;
+@group(0) @binding(1173)
+var<storage, read_write> local3: array<u32>;
+@group(0) @binding(3996)
+var<storage, read_write> parameter0: array<u32>;
+
+@compute @workgroup_size(6, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S0 {
+  @location(104) f0: vec4<f16>,
+  @location(4) f1: vec2<i32>,
+  @location(10) f2: vec4<f32>,
+  @location(9) f3: vec3<u32>,
+  @location(19) f4: vec4<u32>,
+  @location(1) f5: vec2<u32>,
+  @location(52) f6: vec2<i32>,
+  @builtin(position) f7: vec4<f32>,
+  @location(25) f8: vec3<i32>,
+  @location(107) f9: i32,
+  @location(87) f10: vec2<i32>,
+  @builtin(sample_mask) f11: u32,
+  @builtin(sample_index) f12: u32,
+  @location(6) f13: i32,
+  @location(33) f14: vec4<f32>,
+  @location(64) f15: vec2<u32>,
+  @location(50) f16: vec3<f32>,
+  @location(101) f17: u32,
+  @location(77) f18: f16,
+  @builtin(front_facing) f19: bool,
+  @location(58) f20: vec4<u32>,
+  @location(21) f21: vec3<f32>,
+  @location(11) f22: vec4<u32>,
+  @location(55) f23: vec4<f16>
+}
+struct FragmentOutput0 {
+  @location(4) f0: f32,
+  @builtin(sample_mask) f1: u32,
+  @location(2) f2: vec4<f32>,
+  @location(1) f3: vec4<i32>,
+  @location(3) f4: vec4<i32>,
+  @location(0) f5: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(14) a0: vec4<u32>, @location(57) a1: vec4<f32>, a2: S0, @location(110) a3: u32, @location(48) a4: vec2<u32>, @location(26) a5: vec4<i32>, @location(86) a6: f16, @location(98) a7: vec4<f32>, @location(17) a8: f16, @location(72) a9: vec3<f16>, @location(81) a10: f16, @location(63) a11: u32, @location(37) a12: vec2<f16>, @location(66) a13: f16, @location(47) a14: vec2<u32>, @location(44) a15: vec3<i32>, @location(73) a16: vec2<u32>, @location(71) a17: vec4<f16>, @location(93) a18: f32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(64) f7: vec2<u32>,
+  @location(14) f8: vec4<u32>,
+  @location(19) f9: vec4<u32>,
+  @location(58) f10: vec4<u32>,
+  @location(101) f11: u32,
+  @location(87) f12: vec2<i32>,
+  @location(25) f13: vec3<i32>,
+  @location(93) f14: f32,
+  @location(1) f15: vec2<u32>,
+  @location(52) f16: vec2<i32>,
+  @location(73) f17: vec2<u32>,
+  @location(9) f18: vec3<u32>,
+  @location(21) f19: vec3<f32>,
+  @location(104) f20: vec4<f16>,
+  @location(71) f21: vec4<f16>,
+  @location(33) f22: vec4<f32>,
+  @builtin(position) f23: vec4<f32>,
+  @location(55) f24: vec4<f16>,
+  @location(44) f25: vec3<i32>,
+  @location(17) f26: f16,
+  @location(86) f27: f16,
+  @location(11) f28: vec4<u32>,
+  @location(4) f29: vec2<i32>,
+  @location(66) f30: f16,
+  @location(77) f31: f16,
+  @location(48) f32: vec2<u32>,
+  @location(57) f33: vec4<f32>,
+  @location(37) f34: vec2<f16>,
+  @location(98) f35: vec4<f32>,
+  @location(81) f36: f16,
+  @location(107) f37: i32,
+  @location(63) f38: u32,
+  @location(6) f39: i32,
+  @location(47) f40: vec2<u32>,
+  @location(10) f41: vec4<f32>,
+  @location(50) f42: vec3<f32>,
+  @location(72) f43: vec3<f16>,
+  @location(26) f44: vec4<i32>,
+  @location(110) f45: u32
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec2<u32>, @location(1) a1: i32, @location(13) a2: vec2<u32>, @location(14) a3: vec4<i32>, @builtin(vertex_index) a4: u32, @builtin(instance_index) a5: u32, @location(10) a6: vec2<u32>, @location(0) a7: vec3<f16>, @location(5) a8: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let bindGroupLayout6 = device2.createBindGroupLayout({label: '\uc8e5\ub72e\ue24a\u0dc2\udce2\u8c88\u{1fe5f}\u299c', entries: []});
+let commandEncoder33 = device2.createCommandEncoder({label: '\u{1fdeb}\u51a3\u0490\u0159\uef89'});
+let textureView34 = texture22.createView({
+  label: '\u99f0\uf394\u82a9\udc89\u92df\u52d9\u039f\u{1f647}\u71a8\u0809\u6446',
+  aspect: 'all',
+  mipLevelCount: 1,
+});
+try {
+device2.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 663 */
+{offset: 663, rowsPerImage: 243}, {width: 26, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline14 = device2.createRenderPipeline({
+  layout: pipelineLayout3,
+  multisample: {mask: 0xe7745726},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rg16sint', writeMask: 0}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL,
+}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 828,
+        attributes: [
+          {format: 'snorm16x2', offset: 68, shaderLocation: 0},
+          {format: 'uint32x4', offset: 16, shaderLocation: 3},
+          {format: 'uint16x4', offset: 104, shaderLocation: 13},
+          {format: 'uint16x4', offset: 52, shaderLocation: 10},
+          {format: 'sint32', offset: 80, shaderLocation: 14},
+          {format: 'sint8x2', offset: 50, shaderLocation: 1},
+          {format: 'uint32', offset: 104, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', unclippedDepth: true},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let imageData6 = new ImageData(20, 24);
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  label: '\ucb0e\u8ba8\u311e\u078f\uc8a3\u0756\u8c10\u96a2\uc1ee\u6086\ued7e',
+  entries: [
+    {
+      binding: 1456,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+let bindGroup2 = device0.createBindGroup({
+  label: '\u0b1b\u010e\u0f7d\u2838\u0585\u05df\u3a75\u{1fcd7}\ufa6f',
+  layout: bindGroupLayout7,
+  entries: [{binding: 1456, resource: sampler16}],
+});
+let textureView35 = texture0.createView({
+  label: '\u7d4e\uaa35\u0542\u84c6\u0958\u9306\uba8f\u4e0f\uccf3\u0958',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 4,
+  baseArrayLayer: 70,
+  arrayLayerCount: 1,
+});
+let computePassEncoder14 = commandEncoder0.beginComputePass({});
+let renderBundleEncoder21 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler20 = device0.createSampler({
+  label: '\ud6a1\u1e8a\u{1f9f7}\u56f5\u018c\u28cc\u0f15\u02e2\udbd0\u5ead\u2cab',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 91.76,
+  lodMaxClamp: 93.50,
+});
+try {
+commandEncoder12.copyBufferToBuffer(buffer9, 5476, buffer6, 4372, 21860);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let gpuCanvasContext6 = canvas3.getContext('webgpu');
+let commandBuffer5 = commandEncoder26.finish({label: '\ucb15\ue6d8\u{1ff2c}\u0ea1\u68c8'});
+let renderBundle20 = renderBundleEncoder7.finish({label: '\u07a1\u905a\u{1f76c}'});
+let sampler21 = device1.createSampler({
+  label: '\u09fe\u4fd4\u2aa9\u9b96\u{1ff9d}\u{1fb0a}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMinClamp: 55.66,
+  lodMaxClamp: 98.91,
+});
+let externalTexture18 = device1.importExternalTexture({label: '\u02ab\uac5d\u4bfb\u09c9', source: video5, colorSpace: 'srgb'});
+try {
+renderBundleEncoder11.draw(176, 109);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexed(43, 264, 149_393_168, 29_739_788, 62_261_329);
+} catch {}
+try {
+commandEncoder32.copyBufferToBuffer(buffer4, 41480, buffer5, 194996, 1244);
+dissociateBuffer(device1, buffer4);
+dissociateBuffer(device1, buffer5);
+} catch {}
+try {
+commandEncoder10.popDebugGroup();
+} catch {}
+let pipeline15 = await device1.createComputePipelineAsync({
+  label: '\u0e19\u938d\u77a3\u1eef\uccf3\u5061\u41f9\u0c05',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let textureView36 = texture12.createView({label: '\ubef3\u01a1\u{1f8f3}\u{1fe38}\u7baa', baseMipLevel: 1});
+let computePassEncoder15 = commandEncoder31.beginComputePass({label: '\u{1fdf8}\ufa5d\ubc6a\u{1f692}\u5e20\u01dc\u0eee'});
+let renderBundle21 = renderBundleEncoder3.finish();
+let externalTexture19 = device1.importExternalTexture({source: videoFrame0, colorSpace: 'srgb'});
+try {
+renderBundleEncoder11.drawIndexedIndirect(buffer8, 4216);
+} catch {}
+try {
+renderBundleEncoder11.drawIndirect(buffer8, 50016);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline10);
+} catch {}
+try {
+commandEncoder17.copyTextureToBuffer({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 88 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 11368 */
+  offset: 11368,
+  buffer: buffer2,
+}, {width: 22, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer2);
+} catch {}
+try {
+commandEncoder21.clearBuffer(buffer5, 195216, 884);
+dissociateBuffer(device1, buffer5);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 57},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 32_673_664 */
+{offset: 408, bytesPerRow: 236, rowsPerImage: 217}, {width: 45, height: 0, depthOrArrayLayers: 639});
+} catch {}
+document.body.prepend(img2);
+let commandEncoder34 = device1.createCommandEncoder({label: '\u08a7\u0b1d\u52ed\ua21f'});
+let querySet22 = device1.createQuerySet({label: '\u004a\u0faa\u9465\u79dc\u02a2', type: 'occlusion', count: 3668});
+let commandBuffer6 = commandEncoder27.finish({label: '\ue91c\u00d3\ua29a\u{1f89d}\u39e9\u3e2c'});
+let texture25 = device1.createTexture({
+  label: '\u060f\u{1fee6}\u{1f6e1}\u02ca\ue2c8\ub955\u67ce\u0203\u09fc\u{1ff29}',
+  size: [1920, 12, 209],
+  mipLevelCount: 10,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm', 'bgra8unorm-srgb'],
+});
+let renderBundleEncoder22 = device1.createRenderBundleEncoder({
+  label: '\u{1fb71}\ubd5a\u6a23\u{1f8b9}',
+  colorFormats: ['bgra8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+let renderBundle22 = renderBundleEncoder22.finish({label: '\u11af\u4968\ua9ea\u{1f765}'});
+let externalTexture20 = device1.importExternalTexture({label: '\uf558\ub50e\uab0b', source: video1, colorSpace: 'srgb'});
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+renderBundleEncoder18.setPipeline(pipeline12);
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer3, 23996, 16128);
+dissociateBuffer(device1, buffer3);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer2, 648, new Float32Array(43177), 39600, 412);
+} catch {}
+try {
+  await promise5;
+} catch {}
+let video7 = await videoWithData();
+let commandEncoder35 = device1.createCommandEncoder({label: '\u0253\u62a7'});
+try {
+renderBundleEncoder18.draw(271, 112, 1_094_635_413, 284_150_975);
+} catch {}
+try {
+renderBundleEncoder18.drawIndirect(buffer8, 42720);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline10);
+} catch {}
+try {
+commandEncoder14.copyTextureToTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 2,
+  origin: {x: 29, y: 1, z: 33},
+  aspect: 'all',
+},
+{width: 140, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder7.resolveQuerySet(querySet5, 45, 184, buffer3, 2048);
+} catch {}
+let pipeline16 = device1.createComputePipeline({
+  label: '\u09c3\u3541\u0e08\u{1f88d}\u{1ff7d}\u6548\u{1fad0}\u6a90',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let renderBundleEncoder23 = device2.createRenderBundleEncoder({
+  label: '\u{1fada}\ueb20\uaf42\uf349\ua36d\u78fb\u0070',
+  colorFormats: ['rgb10a2uint', 'rgba8sint', 'bgra8unorm-srgb', 'rg16sint', 'r8unorm'],
+  depthReadOnly: true,
+});
+let renderBundle23 = renderBundleEncoder20.finish({label: '\u5808\ud5ec'});
+let sampler22 = device2.createSampler({
+  label: '\u1009\u{1ffed}\ue52e\u0905\u2896\u1302',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 36.33,
+  lodMaxClamp: 64.39,
+});
+try {
+renderBundleEncoder23.setPipeline(pipeline14);
+} catch {}
+try {
+commandEncoder33.clearBuffer(buffer13, 41536, 24888);
+dissociateBuffer(device2, buffer13);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer13, 12176, new DataView(new ArrayBuffer(40025)), 34790, 2764);
+} catch {}
+let textureView37 = texture9.createView({label: '\u377c\ua9f0\uc3bf\uf306\u{1fa67}\uae34\u0e27', baseMipLevel: 2, mipLevelCount: 2});
+let renderBundleEncoder24 = device0.createRenderBundleEncoder({
+  label: '\u9527\u0371\u{1fe48}\u0d43\u38d4\ufabe',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+});
+let renderBundle24 = renderBundleEncoder4.finish({label: '\u81ab\u{1fd31}\u{1f616}\u{1f835}\ud0aa'});
+try {
+renderBundleEncoder21.setBindGroup(9, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(4, bindGroup2, new Uint32Array(1693), 1388, 0);
+} catch {}
+try {
+commandEncoder30.clearBuffer(buffer6, 6648, 14416);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 8164, new BigUint64Array(60384), 40564, 640);
+} catch {}
+let imageData7 = new ImageData(8, 52);
+let videoFrame3 = new VideoFrame(canvas2, {timestamp: 0});
+let buffer14 = device2.createBuffer({size: 55228, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE, mappedAtCreation: true});
+let texture26 = device2.createTexture({
+  label: '\u{1fcc3}\u6996\u7c1f\uf0df\u{1f615}\ufd28\u0908',
+  size: [2640, 4, 1078],
+  mipLevelCount: 10,
+  format: 'etc2-rgb8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView38 = texture26.createView({
+  label: '\u775c\u{1fd07}\u{1f8d2}\u0137\u440d\u1890\u092f\ub1d6\u7212\u7c97',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 5,
+  mipLevelCount: 4,
+  baseArrayLayer: 566,
+});
+let computePassEncoder16 = commandEncoder33.beginComputePass({label: '\u{1fd79}\u{1fd8e}\u{1fa7e}'});
+let renderBundle25 = renderBundleEncoder23.finish();
+let sampler23 = device2.createSampler({
+  label: '\ub039\uc10b\ucd3a',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 22.59,
+  lodMaxClamp: 86.77,
+});
+try {
+device2.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(new ArrayBuffer(64)), /* required buffer size: 92 */
+{offset: 92, rowsPerImage: 62}, {width: 21, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+adapter1.label = '\u41e6\u9713\u0930\u08f7\ua70b\u{1ff2e}\u0542\ue1ec';
+} catch {}
+let commandEncoder36 = device1.createCommandEncoder({label: '\uecdb\u{1fdea}\uf861\uc4ed\u9e2e\u00f9\u{1fbd5}\u{1f7b0}\u{1f732}'});
+let querySet23 = device1.createQuerySet({label: '\u{1f6ca}\u0498\ud447', type: 'occlusion', count: 3545});
+let textureView39 = texture5.createView({label: '\u0fbf\u{1f94a}\u5ce3\u9710\u{1f8fc}\u0451\u0310', baseMipLevel: 3, mipLevelCount: 3});
+let renderBundle26 = renderBundleEncoder15.finish({label: '\u34d6\u05ca'});
+try {
+commandEncoder34.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 148},
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 55, y: 0, z: 19},
+  aspect: 'all',
+},
+{width: 44, height: 0, depthOrArrayLayers: 62});
+} catch {}
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let renderBundleEncoder25 = device2.createRenderBundleEncoder({
+  label: '\u354c\u0c36\u00b1\u0140\u05d5\u00bf\u1574',
+  colorFormats: ['rgb10a2uint', 'rgba8sint', 'bgra8unorm-srgb', 'rg16sint', 'r8unorm'],
+  stencilReadOnly: false,
+});
+try {
+commandEncoder20.copyBufferToBuffer(buffer14, 8732, buffer13, 65928, 1596);
+dissociateBuffer(device2, buffer14);
+dissociateBuffer(device2, buffer13);
+} catch {}
+try {
+commandEncoder20.clearBuffer(buffer13, 59472, 12280);
+dissociateBuffer(device2, buffer13);
+} catch {}
+let renderBundleEncoder26 = device1.createRenderBundleEncoder({colorFormats: ['bgra8unorm']});
+try {
+computePassEncoder5.setBindGroup(3, bindGroup1, new Uint32Array(4307), 136, 0);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline12);
+} catch {}
+try {
+commandEncoder3.copyBufferToBuffer(buffer8, 540044, buffer5, 26144, 138940);
+dissociateBuffer(device1, buffer8);
+dissociateBuffer(device1, buffer5);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 120, height: 1, depthOrArrayLayers: 209}
+*/
+{
+  source: video5,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture25,
+  mipLevel: 4,
+  origin: {x: 15, y: 0, z: 48},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline17 = await device1.createComputePipelineAsync({
+  label: '\u6428\u9e20',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+canvas0.height = 225;
+let canvas6 = document.createElement('canvas');
+let imageBitmap3 = await createImageBitmap(imageData6);
+let shaderModule3 = device2.createShaderModule({
+  label: '\uec4b\u{1f71d}\u73b1\u09c1\u3415\u039e\u27be\uc1c2\u009e',
+  code: `@group(0) @binding(2764)
+var<storage, read_write> local4: array<u32>;
+@group(0) @binding(1173)
+var<storage, read_write> parameter1: array<u32>;
+
+@compute @workgroup_size(6, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec2<f32>,
+  @location(2) f1: vec4<f32>,
+  @location(3) f2: vec3<i32>,
+  @location(5) f3: vec3<i32>,
+  @location(0) f4: vec4<u32>,
+  @location(1) f5: vec4<i32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S1 {
+  @location(15) f0: vec2<u32>,
+  @builtin(vertex_index) f1: u32,
+  @location(2) f2: f32
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec2<f16>, @location(12) a1: vec2<f32>, a2: S1, @location(0) a3: vec3<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout8 = device2.createBindGroupLayout({
+  label: '\uedfc\u24e5\uad27\ufc24\u91a0\uae09\u641a\u8167\u53b2\u{1fcf9}\u8a97',
+  entries: [
+    {
+      binding: 37,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 1359,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32uint', access: 'read-only', viewDimension: '1d' },
+    },
+  ],
+});
+let externalTexture21 = device2.importExternalTexture({source: video7, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder25.setPipeline(pipeline14);
+} catch {}
+try {
+renderBundleEncoder25.setVertexBuffer(6578, undefined, 0);
+} catch {}
+let arrayBuffer1 = buffer14.getMappedRange();
+try {
+commandEncoder22.clearBuffer(buffer13, 13336, 24460);
+dissociateBuffer(device2, buffer13);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(974), /* required buffer size: 974 */
+{offset: 974}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline18 = await device2.createComputePipelineAsync({
+  label: '\u{1fd65}\u16f1',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let img3 = await imageWithData(266, 248, '#8cb2bb9e', '#66b744d6');
+let bindGroup3 = device1.createBindGroup({layout: bindGroupLayout3, entries: []});
+let textureView40 = texture7.createView({label: '\u2ed0\u{1fa06}\ub287\uc982', baseMipLevel: 1});
+let renderBundleEncoder27 = device1.createRenderBundleEncoder({label: '\uf6fc\uf28c\ucdbe\u095c\u9b23\u404f', colorFormats: ['bgra8unorm'], stencilReadOnly: true});
+let sampler24 = device1.createSampler({
+  label: '\u0774\u06df',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 51.48,
+  lodMaxClamp: 60.31,
+});
+try {
+renderBundleEncoder11.draw(46, 7, 159_276_881);
+} catch {}
+let arrayBuffer2 = buffer4.getMappedRange(19568, 8892);
+let pipeline19 = await device1.createComputePipelineAsync({
+  label: '\u043a\ua8e1\u0d65\u0633\u112b\u0e07\ud254\u{1fa56}\u05ee\u0533\u26b5',
+  layout: 'auto',
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let bindGroup4 = device1.createBindGroup({
+  label: '\u42eb\u{1fae7}\u0dfa\u{1fa34}\u0cbd\uef9c\uae6a\u{1ff66}',
+  layout: bindGroupLayout2,
+  entries: [{binding: 644, resource: externalTexture3}],
+});
+let commandEncoder37 = device1.createCommandEncoder({label: '\ue6e1\uf79e\u{1fb22}\u{1fddd}\u715c\u029e\u{1fc0d}\u30e3\u{1fc15}'});
+let textureView41 = texture2.createView({
+  label: '\u82db\u{1fb00}\u7833\u{1fe38}\u{1fe3e}\u5cba\ued00',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 1,
+  arrayLayerCount: 97,
+});
+let computePassEncoder17 = commandEncoder37.beginComputePass();
+try {
+renderBundleEncoder11.draw(21, 301, 951_259_184, 570_703_373);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexed(139, 10, 255_501_972, 193_420_852, 169_278_755);
+} catch {}
+try {
+renderBundleEncoder18.drawIndirect(buffer8, 341848);
+} catch {}
+try {
+renderBundleEncoder26.setVertexBuffer(5463, undefined, 0, 1039276876);
+} catch {}
+try {
+  await buffer10.mapAsync(GPUMapMode.READ, 120600, 40708);
+} catch {}
+try {
+commandEncoder3.copyTextureToTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 162, y: 0, z: 71},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 2,
+  origin: {x: 0, y: 1, z: 18},
+  aspect: 'all',
+},
+{width: 479, height: 0, depthOrArrayLayers: 107});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer5, 17712, new DataView(new ArrayBuffer(55861)), 32772, 720);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 443_750 */
+{offset: 180, bytesPerRow: 478, rowsPerImage: 103}, {width: 116, height: 1, depthOrArrayLayers: 10});
+} catch {}
+let pipeline20 = await device1.createComputePipelineAsync({
+  label: '\u3df0\ua7c2',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let promise6 = device1.createRenderPipelineAsync({
+  label: '\u172f\u{1f6b2}',
+  layout: pipelineLayout1,
+  multisample: {count: 4, mask: 0xce4b1679},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {module: shaderModule1, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'point-list', frontFace: 'cw', unclippedDepth: true},
+});
+canvas0.width = 1097;
+gc();
+let imageBitmap4 = await createImageBitmap(imageData1);
+let imageData8 = new ImageData(104, 136);
+let buffer15 = device0.createBuffer({
+  label: '\u6a3d\u{1f9d5}\ua708\u015e\u{1ff3f}\u8b8c\u0523\u5e64',
+  size: 384689,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: false,
+});
+let textureView42 = texture9.createView({label: '\u41fb\u{1fe79}\u0568', dimension: '3d', baseMipLevel: 1, mipLevelCount: 2});
+let renderBundle27 = renderBundleEncoder17.finish();
+try {
+computePassEncoder13.setBindGroup(10, bindGroup2, new Uint32Array(4351), 610, 0);
+} catch {}
+try {
+commandEncoder29.resolveQuerySet(querySet13, 322, 2074, buffer1, 103424);
+} catch {}
+document.body.prepend(canvas6);
+let imageBitmap5 = await createImageBitmap(canvas1);
+let imageData9 = new ImageData(228, 140);
+let bindGroup5 = device1.createBindGroup({
+  label: '\u{1f944}\u{1fdcc}\u9eb6\u0c2e\u{1f963}\u7aa4\uf267\u5b6f',
+  layout: bindGroupLayout3,
+  entries: [],
+});
+let querySet24 = device1.createQuerySet({label: '\u004c\u{1fe2b}\u2d49\u0e6b\u5eec', type: 'occlusion', count: 3988});
+let commandBuffer7 = commandEncoder16.finish({});
+let renderBundle28 = renderBundleEncoder7.finish({label: '\u9a28\u33d9\u{1faa7}\u961d\uba31\ud460\u0940\ua0fd'});
+let sampler25 = device1.createSampler({
+  label: '\ude05\u{1f741}\ue310',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 35.54,
+  lodMaxClamp: 80.89,
+  maxAnisotropy: 12,
+});
+try {
+renderBundleEncoder18.draw(180, 86, 984_867_941, 418_914_151);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexed(332, 15);
+} catch {}
+try {
+device1.queue.submit([commandBuffer5, commandBuffer6]);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 60, height: 1, depthOrArrayLayers: 469}
+*/
+{
+  source: canvas5,
+  origin: { x: 60, y: 20 },
+  flipY: false,
+}, {
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 17, y: 0, z: 7},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 18, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline21 = await device1.createRenderPipelineAsync({
+  label: '\u03da\u0902',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-src'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {module: shaderModule1, entryPoint: 'vertex0', buffers: []},
+  primitive: {cullMode: 'none', unclippedDepth: true},
+});
+let bindGroupLayout9 = device0.createBindGroupLayout({label: '\u089f\u8f93\ud21d\ud93c\u0753\u00eb', entries: []});
+let pipelineLayout5 = device0.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout7, bindGroupLayout7, bindGroupLayout7, bindGroupLayout9, bindGroupLayout7, bindGroupLayout9],
+});
+let texture27 = device0.createTexture({
+  size: [120, 60, 1],
+  dimension: '2d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r16uint'],
+});
+let textureView43 = texture23.createView({
+  label: '\u1286\u12b9\ua14b\ue937\u{1ff77}\u2689\u0269\u{1f648}\u060c',
+  dimension: '2d',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 326,
+});
+let externalTexture22 = device0.importExternalTexture({
+  label: '\u7021\u1ed4\u10bb\u{1f6ee}\u{1f790}\u8fe0\u{1fdb3}\u02f8\u{1fa46}\u0a0d',
+  source: videoFrame0,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder8.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+commandEncoder30.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 14816 */
+  offset: 14816,
+  buffer: buffer12,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer12);
+} catch {}
+let gpuCanvasContext7 = canvas6.getContext('webgpu');
+let adapter3 = await navigator.gpu.requestAdapter({});
+let commandEncoder38 = device1.createCommandEncoder({label: '\uf3d2\u{1fbe7}\u1b94\u54a8\u7e72\u{1fa8f}\u{1f93f}\u{1fc8a}\u{1fe71}\ua26d'});
+let computePassEncoder18 = commandEncoder3.beginComputePass();
+try {
+renderBundleEncoder27.setBindGroup(0, bindGroup3, []);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexedIndirect(buffer8, 65088);
+} catch {}
+try {
+commandEncoder10.clearBuffer(buffer5, 107628, 13908);
+dissociateBuffer(device1, buffer5);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 3, height: 1, depthOrArrayLayers: 209}
+*/
+{
+  source: img3,
+  origin: { x: 49, y: 40 },
+  flipY: true,
+}, {
+  texture: texture25,
+  mipLevel: 9,
+  origin: {x: 0, y: 0, z: 32},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  label: '\u0f6e\uc83c\u0345',
+  code: `@group(0) @binding(1456)
+var<storage, read_write> global1: array<u32>;
+@group(4) @binding(1456)
+var<storage, read_write> global2: array<u32>;
+@group(2) @binding(1456)
+var<storage, read_write> local5: array<u32>;
+
+@compute @workgroup_size(4, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: u32,
+  @location(3) f1: vec4<u32>,
+  @location(1) f2: vec4<u32>,
+  @location(0) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(27) f46: f32,
+  @builtin(position) f47: vec4<f32>,
+  @location(25) f48: vec4<f32>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView44 = texture9.createView({label: '\u0156\u1af9\u0e60\u0c4f\u0b4d\u0395\u{1fa9b}\u0b03\u{1fc50}\u8749\u0cad', mipLevelCount: 1});
+let computePassEncoder19 = commandEncoder30.beginComputePass({label: '\u458e\u6634\ud52d\u06ba\u22f3\u0a41\u6833'});
+let externalTexture23 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'srgb'});
+try {
+renderBundleEncoder16.setBindGroup(6, bindGroup2, new Uint32Array(5510), 1830, 0);
+} catch {}
+let arrayBuffer3 = buffer9.getMappedRange();
+try {
+commandEncoder12.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 120, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 8, y: 0, z: 210},
+  aspect: 'all',
+},
+{width: 124, height: 0, depthOrArrayLayers: 33});
+} catch {}
+try {
+commandEncoder12.clearBuffer(buffer6, 32536, 58764);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let pipeline22 = device0.createComputePipeline({
+  label: '\uf460\u{1fce0}\u086e\ueefe\u04f6\udf26',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+canvas0.height = 88;
+let textureView45 = texture16.createView({label: '\u50e1\u7daf\u7018\u9726\u5a93\u0526\u2e20\u6a85'});
+let renderBundleEncoder28 = device2.createRenderBundleEncoder({
+  label: '\u0f86\u03c1\u1d1d\u0672\u079b\u054e\uac33\u0793\u88d4',
+  colorFormats: ['rgb10a2uint', 'rgba8sint', 'bgra8unorm-srgb', 'rg16sint', 'r8unorm'],
+});
+try {
+computePassEncoder16.pushDebugGroup('\u{1f67c}');
+} catch {}
+let pipeline23 = await device2.createComputePipelineAsync({
+  label: '\ucf15\uad7f\u03ed\u{1fdce}\u{1f678}\u{1fdce}\u{1fe3a}\u{1fe2c}\uac53',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+let imageBitmap6 = await createImageBitmap(imageData4);
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({
+  label: '\ue84d\u7248\u{1f732}\ucc3c\u0dc5\u2c24\u816e\u{1f945}\u{1f89a}\ue76e',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+commandEncoder12.resolveQuerySet(querySet7, 1064, 59, buffer1, 167168);
+} catch {}
+let pipelineLayout6 = device2.createPipelineLayout({bindGroupLayouts: [bindGroupLayout8]});
+let textureView46 = texture22.createView({label: '\u0603\u770c\u0cbb\u526e\u0821\ue20b\u18cd\u7b7d\u5f02'});
+let imageBitmap7 = await createImageBitmap(imageBitmap2);
+let querySet25 = device1.createQuerySet({
+  label: '\ub42e\u0569\u{1fdc0}\u551f\u{1f806}\u5ae0\u{1ff04}\u11e1\u752b\u9e3e',
+  type: 'occlusion',
+  count: 3838,
+});
+let texture28 = device1.createTexture({
+  label: '\uba15\uc187',
+  size: {width: 960, height: 6, depthOrArrayLayers: 209},
+  mipLevelCount: 2,
+  format: 'astc-10x6-unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['astc-10x6-unorm-srgb', 'astc-10x6-unorm-srgb'],
+});
+let textureView47 = texture2.createView({
+  label: '\u0e57\u2b25\u032b\u42eb\u1332\ue5af\u00e1',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 114,
+  arrayLayerCount: 74,
+});
+let computePassEncoder20 = commandEncoder6.beginComputePass();
+let renderBundle29 = renderBundleEncoder22.finish({label: '\uf000\u09d3\uefc5\u53ce\u472c\u67f7\u{1fc33}\u5c6a'});
+let externalTexture24 = device1.importExternalTexture({label: '\u{1f8d7}\u6b93\u7b38', source: video6, colorSpace: 'srgb'});
+try {
+computePassEncoder18.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder18.draw(248);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexedIndirect(buffer8, 147032);
+} catch {}
+try {
+renderBundleEncoder11.drawIndirect(buffer8, 200000);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline21);
+} catch {}
+try {
+commandEncoder17.copyBufferToBuffer(buffer8, 100076, buffer5, 38288, 20656);
+dissociateBuffer(device1, buffer8);
+dissociateBuffer(device1, buffer5);
+} catch {}
+try {
+commandEncoder32.clearBuffer(buffer3, 2952, 34208);
+dissociateBuffer(device1, buffer3);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer5, 276, new BigUint64Array(26022), 9765, 2592);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 21},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 34_120_976 */
+{offset: 323, bytesPerRow: 553, rowsPerImage: 131}, {width: 87, height: 0, depthOrArrayLayers: 472});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 15, height: 1, depthOrArrayLayers: 209}
+*/
+{
+  source: canvas3,
+  origin: { x: 21, y: 18 },
+  flipY: true,
+}, {
+  texture: texture25,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 49},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup6 = device0.createBindGroup({layout: bindGroupLayout9, entries: []});
+let commandBuffer8 = commandEncoder29.finish({label: '\u33b7\u3354\u67c4\uaeb4'});
+let texture29 = device0.createTexture({
+  label: '\u{1ffbf}\u0305\u0670\ub985\ubbe8\u6675\u0c16\u0476\u0f67\u{1f8b3}',
+  size: [240, 120, 59],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder30 = device0.createRenderBundleEncoder({
+  label: '\u0fec\ue807\uc7a6',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle30 = renderBundleEncoder2.finish({label: '\ub6ae\u0b4d\u2c96\u{1fa50}\uf42e\u02c6\u0a8c'});
+try {
+computePassEncoder19.setBindGroup(10, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(3, bindGroup6);
+} catch {}
+let arrayBuffer4 = buffer9.getMappedRange(39232, 0);
+try {
+commandEncoder12.copyBufferToBuffer(buffer15, 107260, buffer6, 19312, 18348);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 4600, new Int16Array(40634), 24648, 56);
+} catch {}
+let imageBitmap8 = await createImageBitmap(canvas1);
+let texture30 = device2.createTexture({
+  label: '\u7321\u9b79\ub343\u4ef0\u{1fb8e}\ua88d\u6bff\u065a\u9cb3\u6be3',
+  size: [285, 1, 1],
+  mipLevelCount: 6,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+try {
+computePassEncoder16.setPipeline(pipeline23);
+} catch {}
+let commandEncoder39 = device1.createCommandEncoder();
+let querySet26 = device1.createQuerySet({label: '\ue9a6\u3906\u853b\u{1fcfe}\u03ac\u7009', type: 'occlusion', count: 850});
+let textureView48 = texture11.createView({aspect: 'all', baseMipLevel: 2});
+let computePassEncoder21 = commandEncoder34.beginComputePass();
+try {
+computePassEncoder20.setBindGroup(1, bindGroup0, new Uint32Array(2468), 1032, 0);
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline16);
+} catch {}
+try {
+renderBundleEncoder11.draw(475);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexedIndirect(buffer8, 1504);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline21);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer5, 38468, new BigUint64Array(23561), 23184, 16);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 480, height: 3, depthOrArrayLayers: 236}
+*/
+{
+  source: img3,
+  origin: { x: 27, y: 22 },
+  flipY: true,
+}, {
+  texture: texture17,
+  mipLevel: 2,
+  origin: {x: 42, y: 0, z: 181},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline24 = await promise6;
+try {
+  await adapter1.requestAdapterInfo();
+} catch {}
+let buffer16 = device0.createBuffer({
+  label: '\u8237\u2e29\u923e\u06be\u1383\u378a\u0c77\u3114\u{1faaf}\u4385',
+  size: 308620,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let commandEncoder40 = device0.createCommandEncoder({label: '\u48b8\u9441\u04a1\u0ec2\u0acb\ud94e\u30e3\u{1fe8e}\u09c6\ub782\u08d7'});
+let texture31 = device0.createTexture({
+  label: '\udba9\u{1fb24}\ub917\ufbbd\u037e\u5a2b\u7be4\u17f0',
+  size: {width: 624, height: 1, depthOrArrayLayers: 1264},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder13.setPipeline(pipeline22);
+} catch {}
+try {
+commandEncoder12.clearBuffer(buffer6, 83432, 9408);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder40.resolveQuerySet(querySet7, 356, 1013, buffer1, 168960);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 26300, new DataView(new ArrayBuffer(14730)), 11556, 636);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 5, y: 7, z: 1},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer2), /* required buffer size: 48_744 */
+{offset: 788, bytesPerRow: 128, rowsPerImage: 46}, {width: 21, height: 7, depthOrArrayLayers: 9});
+} catch {}
+let promise7 = adapter3.requestAdapterInfo();
+let shaderModule5 = device0.createShaderModule({
+  label: '\u7819\u0ae8',
+  code: `@group(1) @binding(1456)
+var<storage, read_write> local6: array<u32>;
+@group(2) @binding(1456)
+var<storage, read_write> type0: array<u32>;
+@group(0) @binding(1456)
+var<storage, read_write> parameter2: array<u32>;
+@group(4) @binding(1456)
+var<storage, read_write> parameter3: array<u32>;
+
+@compute @workgroup_size(3, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(1) f1: vec4<u32>,
+  @location(3) f2: vec4<u32>,
+  @location(2) f3: u32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S2 {
+  @location(17) f0: vec4<i32>,
+  @location(0) f1: vec4<i32>,
+  @location(9) f2: vec2<f16>,
+  @location(19) f3: u32,
+  @location(14) f4: vec4<f32>,
+  @location(2) f5: f32
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(15) a1: f16, @location(7) a2: vec3<u32>, @location(16) a3: vec4<u32>, @location(3) a4: vec3<u32>, @location(12) a5: f16, @builtin(vertex_index) a6: u32, @location(6) a7: vec3<i32>, @location(18) a8: f32, @location(20) a9: f16, a10: S2, @location(10) a11: f16, @location(1) a12: u32, @location(13) a13: vec4<f16>, @location(5) a14: vec2<u32>, @location(11) a15: vec4<f16>, @location(4) a16: vec3<u32>, @location(8) a17: vec4<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let commandBuffer9 = commandEncoder12.finish({label: '\u04e9\u0867\u7ea1\u0c6d'});
+let textureView49 = texture24.createView({label: '\u911e\u{1f7b9}'});
+let computePassEncoder22 = commandEncoder40.beginComputePass({label: '\u4024\u0bd5\uc18a\u7246\u8cf3\u5296\u01c8\u6a02'});
+let renderBundle31 = renderBundleEncoder2.finish({label: '\u0507\ue36d\u0318\ue370\u{1fad9}\u07d9\u3a40\u03ea\u{1fb32}'});
+let promise8 = device0.queue.onSubmittedWorkDone();
+let pipeline25 = device0.createRenderPipeline({
+  label: '\u060d\u131f\u810e\u064c\u{1f9f7}\u4f16\u0796\u4b98\u004e\ufbb1\u0d4a',
+  layout: pipelineLayout5,
+  multisample: {count: 4, mask: 0x636cb8e0},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgb10a2uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba8uint'}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgb10a2uint'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'less-equal', failOp: 'increment-clamp', depthFailOp: 'invert', passOp: 'decrement-clamp'},
+    stencilBack: {depthFailOp: 'zero', passOp: 'decrement-wrap'},
+    stencilReadMask: 2802504802,
+    stencilWriteMask: 287290720,
+    depthBiasClamp: 575.734088803464,
+  },
+  vertex: {module: shaderModule4, entryPoint: 'vertex0', buffers: []},
+  primitive: {unclippedDepth: true},
+});
+try {
+  await promise7;
+} catch {}
+let commandEncoder41 = device2.createCommandEncoder({label: '\u0be1\u0319\u5321\u7ce2\u0aca\u5b4c\uc5bd\u02b6\u{1fa2e}\ub278'});
+try {
+computePassEncoder16.setPipeline(pipeline18);
+} catch {}
+try {
+commandEncoder41.clearBuffer(buffer13, 26612, 14420);
+dissociateBuffer(device2, buffer13);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer13, 18056, new BigUint64Array(15984), 9064, 1920);
+} catch {}
+let pipeline26 = await device2.createComputePipelineAsync({
+  label: '\u1ba6\u6ea1\uab25\u{1f9f4}\u1fe4',
+  layout: pipelineLayout3,
+  compute: {module: shaderModule2, entryPoint: 'compute0'},
+});
+gc();
+let videoFrame4 = new VideoFrame(imageBitmap8, {timestamp: 0});
+let bindGroupLayout10 = device0.createBindGroupLayout({label: '\u09e2\ucd5a\u{1fd07}\u2f8e\u{1fb7b}\u627c\u0020\u{1ff0c}', entries: []});
+let querySet27 = device0.createQuerySet({label: '\uece4\u{1feff}', type: 'occlusion', count: 2971});
+let texture32 = device0.createTexture({
+  label: '\u0fb2\u559a\ud4df\u5d43\ufa65\u3099\u0788\u{1f8a0}\ua723\u222d',
+  size: {width: 156},
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint'],
+});
+let textureView50 = texture15.createView({label: '\u0491\u2e5a\u{1fcb2}\u985f\u7549\u0c0f\u8156\u81d9\u{1fe99}', dimension: '2d-array'});
+canvas4.height = 338;
+let renderBundleEncoder31 = device0.createRenderBundleEncoder({
+  label: '\u058a\u{1f967}\u{1fe42}\udf18\u0aa3',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle32 = renderBundleEncoder21.finish();
+try {
+computePassEncoder19.end();
+} catch {}
+let promise9 = device0.createComputePipelineAsync({
+  label: '\u62e4\u033c\u0c56\uf771\u3c04\u0562\u0241\u3006',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+let commandBuffer10 = commandEncoder23.finish({label: '\u0c42\u6362\u473e\ua76f\u053d\u{1f882}\u93c1'});
+let renderBundleEncoder32 = device2.createRenderBundleEncoder({
+  label: '\u0824\u0458\u9c20\u3bbf\ubd50\u06cd\u{1faf2}\u01dc\ude68',
+  colorFormats: ['rgb10a2uint', 'rgba8sint', 'bgra8unorm-srgb', 'rg16sint', 'r8unorm'],
+  sampleCount: 1,
+});
+let sampler26 = device2.createSampler({
+  label: '\u7582\udcd6\u0452\u09af',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 31.16,
+  maxAnisotropy: 17,
+});
+try {
+renderBundleEncoder25.setVertexBuffer(6850, undefined);
+} catch {}
+try {
+device2.destroy();
+} catch {}
+let imageData10 = new ImageData(80, 24);
+let commandEncoder42 = device1.createCommandEncoder({label: '\u0931\u{1fc9b}\uc309\u9e44\u{1f6b8}\u9537\u03d8\u0df2\u836e\u9515\u0059'});
+let querySet28 = device1.createQuerySet({label: '\u9279\u027f\uedc8\ud5c5\u777b\u5b9f\u07d7\u6acc\u27a1\ua563', type: 'occlusion', count: 3560});
+let renderBundle33 = renderBundleEncoder26.finish({label: '\u1b23\u0f4f\u0ff5'});
+try {
+renderBundleEncoder27.drawIndexedIndirect(buffer8, 404084);
+} catch {}
+let querySet29 = device0.createQuerySet({type: 'occlusion', count: 1968});
+let textureView51 = texture8.createView({label: '\u0a1b\ufa4a\u{1f9bf}\u031d\u8bb2\u0ee6\u0c6d', baseMipLevel: 2, mipLevelCount: 2});
+let renderBundle34 = renderBundleEncoder4.finish({label: '\u3506\u709b\u07fa\ueea9\u0d09\u085d\u9490'});
+try {
+computePassEncoder12.setBindGroup(5, bindGroup6, new Uint32Array(4379), 1473, 0);
+} catch {}
+try {
+computePassEncoder22.end();
+} catch {}
+try {
+renderBundleEncoder31.setBindGroup(10, bindGroup6, new Uint32Array(9377), 4899, 0);
+} catch {}
+try {
+commandEncoder30.resolveQuerySet(querySet4, 154, 18, buffer1, 224256);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm'],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 2,
+  origin: {x: 80, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 179_927 */
+{offset: 531, bytesPerRow: 298, rowsPerImage: 86}, {width: 30, height: 0, depthOrArrayLayers: 8});
+} catch {}
+let bindGroupLayout11 = device0.createBindGroupLayout({
+  label: '\u3f0f\u97b4\u0b46\u6c99\u2f90\u97f8',
+  entries: [{binding: 3074, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}}],
+});
+let textureView52 = texture27.createView({label: '\uac7d\uc7d4\u00f6\ube41\u9c5c\u{1fab9}\u8895\ud930\uc086', dimension: '2d-array'});
+let renderBundleEncoder33 = device0.createRenderBundleEncoder({
+  label: '\u9802\u223b\u6f5f\ue95a\u1b08',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  sampleCount: 1,
+});
+let renderBundle35 = renderBundleEncoder24.finish({label: '\u0c18\u081c\u0e9b\u9558\u{1feac}\u63ac\ub4fa\u0a18'});
+try {
+renderBundleEncoder16.setBindGroup(9, bindGroup6);
+} catch {}
+try {
+computePassEncoder11.insertDebugMarker('\u7e3e');
+} catch {}
+let pipeline27 = device0.createComputePipeline({
+  label: '\u74fd\u0d03\u795e\u{1f710}\uf5e5\u{1fde3}\u3d10\u0aa5\u8e10\u956f',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+let video8 = await videoWithData();
+let textureView53 = texture28.createView({
+  label: '\ube9e\u8805\ub05a\u6d42\u{1fdb9}\u5318\u90eb\u{1f942}\u3143',
+  format: 'astc-10x6-unorm-srgb',
+  baseMipLevel: 1,
+  baseArrayLayer: 69,
+  arrayLayerCount: 49,
+});
+let computePassEncoder23 = commandEncoder36.beginComputePass({label: '\u0712\uc8a9\u{1fbcc}\u048c'});
+let renderBundle36 = renderBundleEncoder15.finish({label: '\u4e1c\u0540'});
+try {
+renderBundleEncoder18.draw(30, 46, 1_076_489_141, 1_295_819_294);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexed(0);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexedIndirect(buffer8, 65324);
+} catch {}
+try {
+renderBundleEncoder27.drawIndirect(buffer8, 7024);
+} catch {}
+try {
+commandEncoder7.copyBufferToBuffer(buffer8, 228456, buffer2, 3580, 5276);
+dissociateBuffer(device1, buffer8);
+dissociateBuffer(device1, buffer2);
+} catch {}
+try {
+commandEncoder39.copyBufferToTexture({
+  /* bytesInLastRow: 412 widthInBlocks: 103 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 492168 */
+  offset: 4332,
+  bytesPerRow: 512,
+  rowsPerImage: 238,
+  buffer: buffer8,
+}, {
+  texture: texture17,
+  mipLevel: 3,
+  origin: {x: 19, y: 0, z: 8},
+  aspect: 'all',
+}, {width: 103, height: 1, depthOrArrayLayers: 5});
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer2, 4976, new BigUint64Array(48550), 17171, 196);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(8, bindGroup6, new Uint32Array(2664), 562, 0);
+} catch {}
+try {
+computePassEncoder14.end();
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer11, 'uint16');
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+commandEncoder40.copyBufferToBuffer(buffer12, 4864, buffer6, 72300, 876);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder0.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 129, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 642},
+  aspect: 'all',
+},
+{width: 287, height: 0, depthOrArrayLayers: 20});
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+gc();
+let commandEncoder43 = device1.createCommandEncoder({label: '\ue358\u0bd1\u{1f91d}\u085e\u8e4d\u0127\u63bf\u018b\u{1febe}\u6842\u8b02'});
+let texture33 = device1.createTexture({
+  size: [960],
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm', 'bgra8unorm'],
+});
+let renderBundle37 = renderBundleEncoder0.finish({label: '\u{1fdd5}\u0605\uc851\u08ca\u0390\u0826\u5e04\u370a\u0725\ucd28\u5a65'});
+try {
+renderBundleEncoder18.draw(150, 143);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(2392, undefined, 0, 3365434338);
+} catch {}
+try {
+  await buffer2.mapAsync(GPUMapMode.READ, 0, 6244);
+} catch {}
+let commandEncoder44 = device0.createCommandEncoder({});
+let textureView54 = texture15.createView({label: '\uf77b\ua16c\ub405\u{1fff0}\ud3cc\u{1fb4e}\u{1feba}\udade\ud1f5\u8aa4', baseArrayLayer: 0});
+let sampler27 = device0.createSampler({
+  label: '\u44d4\ucf61\u0344\u{1fbd8}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 50.13,
+  lodMaxClamp: 67.70,
+  maxAnisotropy: 20,
+});
+let externalTexture25 = device0.importExternalTexture({label: '\u2f7b\u{1f6ee}\u9ae0\u0507\uff2f\u0537', source: video3});
+try {
+commandEncoder44.copyTextureToBuffer({
+  texture: texture29,
+  mipLevel: 3,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 6 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 92980 */
+  offset: 14126,
+  bytesPerRow: 256,
+  rowsPerImage: 299,
+  buffer: buffer6,
+}, {width: 3, height: 10, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.submit([commandBuffer8]);
+} catch {}
+let pipeline28 = await promise9;
+try {
+  await promise8;
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let video9 = await videoWithData();
+let imageBitmap9 = await createImageBitmap(video2);
+let textureView55 = texture0.createView({
+  label: '\u1a44\ucae6\u4802\u0773\uf105\ud61c',
+  baseMipLevel: 4,
+  baseArrayLayer: 187,
+  arrayLayerCount: 145,
+});
+let sampler28 = device0.createSampler({
+  label: '\u{1f813}\u05a6\ua9a0\u0e25\uf7c5\u0440\u{1f603}\u4ace',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 29.12,
+  lodMaxClamp: 98.33,
+  compare: 'equal',
+  maxAnisotropy: 18,
+});
+try {
+commandEncoder40.copyBufferToBuffer(buffer12, 15904, buffer6, 49768, 608);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder44.copyTextureToTexture({
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 59, y: 51, z: 33},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 18, height: 1, depthOrArrayLayers: 47});
+} catch {}
+try {
+renderBundleEncoder31.pushDebugGroup('\u9365');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 36, y: 0, z: 142},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer1), /* required buffer size: 1_942_397 */
+{offset: 944, bytesPerRow: 339, rowsPerImage: 69}, {width: 56, height: 0, depthOrArrayLayers: 84});
+} catch {}
+let shaderModule6 = device1.createShaderModule({
+  code: `
+
+@compute @workgroup_size(8, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S3 {
+  @location(14) f0: vec3<f32>,
+  @location(15) f1: vec3<u32>,
+  @location(0) f2: vec4<f16>,
+  @builtin(sample_mask) f3: u32,
+  @builtin(sample_index) f4: u32,
+  @builtin(front_facing) f5: bool,
+  @builtin(position) f6: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>
+}
+
+@fragment
+fn fragment0(a0: S3) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(0) f49: vec4<f16>,
+  @builtin(position) f50: vec4<f32>,
+  @location(14) f51: vec3<f32>,
+  @location(15) f52: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec4<f32>, @location(10) a1: vec2<f32>, @location(11) a2: u32, @location(4) a3: vec3<u32>, @location(0) a4: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder45 = device1.createCommandEncoder({label: '\u{1f7e0}\uf4cc'});
+let computePassEncoder24 = commandEncoder17.beginComputePass({label: '\ub6d4\u9156\u38bc\ud643'});
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder32.copyBufferToBuffer(buffer8, 342928, buffer5, 29208, 146192);
+dissociateBuffer(device1, buffer8);
+dissociateBuffer(device1, buffer5);
+} catch {}
+try {
+commandEncoder31.clearBuffer(buffer5, 110832, 72156);
+dissociateBuffer(device1, buffer5);
+} catch {}
+try {
+commandEncoder10.resolveQuerySet(querySet26, 660, 4, buffer3, 4096);
+} catch {}
+let pipeline29 = device1.createComputePipeline({
+  label: '\u0aa5\u43ca\u8763\u0044\uf151\u3cf8\u{1fcee}\u{1f9d0}\u0a48',
+  layout: 'auto',
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let pipeline30 = device1.createRenderPipeline({
+  label: '\ucc14\u2184',
+  layout: pipelineLayout2,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {
+      compare: 'less-equal',
+      failOp: 'decrement-clamp',
+      depthFailOp: 'decrement-wrap',
+      passOp: 'increment-wrap',
+    },
+    stencilBack: {failOp: 'increment-wrap', depthFailOp: 'invert', passOp: 'replace'},
+    stencilReadMask: 4294967295,
+    stencilWriteMask: 2423645461,
+    depthBiasSlopeScale: 604.2123737120934,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 204,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x2', offset: 12, shaderLocation: 2}],
+      },
+    ],
+  },
+});
+let textureView56 = texture3.createView({
+  label: '\u{1fb49}\ue95e\u99e5\ud9ee\u064f\udb6a\u{1f721}\u9628\u5682\u1ee9\u9058',
+  dimension: '2d',
+  baseMipLevel: 4,
+  baseArrayLayer: 12,
+});
+try {
+renderBundleEncoder27.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexedIndirect(buffer8, 68312);
+} catch {}
+let canvas7 = document.createElement('canvas');
+try {
+canvas7.getContext('bitmaprenderer');
+} catch {}
+let commandEncoder46 = device1.createCommandEncoder({});
+let texture34 = device1.createTexture({
+  size: {width: 480},
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm'],
+});
+let textureView57 = texture17.createView({label: '\u{1fb5e}\u0ce9\u2451'});
+try {
+computePassEncoder23.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder27.draw(147, 75, 747_047_243, 541_562_709);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexed(39, 32);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline12);
+} catch {}
+let pipeline31 = device1.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}}});
+let canvas8 = document.createElement('canvas');
+let shaderModule7 = device0.createShaderModule({
+  label: '\udeb5\u36b8\u1d3f\u0b00\u0136\u{1fb53}',
+  code: `@group(4) @binding(1456)
+var<storage, read_write> global3: array<u32>;
+@group(1) @binding(1456)
+var<storage, read_write> local7: array<u32>;
+
+@compute @workgroup_size(4, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S4 {
+  @location(20) f0: f16,
+  @location(35) f1: vec2<f32>,
+  @location(27) f2: i32,
+  @location(36) f3: vec2<u32>,
+  @location(22) f4: vec2<f16>,
+  @location(32) f5: vec2<u32>,
+  @location(8) f6: vec4<f16>,
+  @location(23) f7: vec4<f16>
+}
+struct FragmentOutput0 {
+  @location(3) f0: vec4<u32>,
+  @location(5) f1: vec2<i32>,
+  @location(2) f2: vec3<u32>,
+  @location(0) f3: vec4<u32>,
+  @location(1) f4: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(7) a0: vec3<f32>, @location(16) a1: vec2<f32>, a2: S4, @location(30) a3: vec3<f16>, @location(5) a4: vec2<f16>, @location(31) a5: vec4<f32>, @location(10) a6: vec4<f16>, @location(29) a7: vec4<f32>, @builtin(sample_index) a8: u32, @location(24) a9: vec4<i32>, @location(3) a10: vec3<i32>, @location(21) a11: vec2<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(36) f53: vec2<u32>,
+  @builtin(position) f54: vec4<f32>,
+  @location(10) f55: vec4<f16>,
+  @location(27) f56: i32,
+  @location(3) f57: vec3<i32>,
+  @location(16) f58: vec2<f32>,
+  @location(7) f59: vec3<f32>,
+  @location(23) f60: vec4<f16>,
+  @location(29) f61: vec4<f32>,
+  @location(21) f62: vec2<u32>,
+  @location(35) f63: vec2<f32>,
+  @location(31) f64: vec4<f32>,
+  @location(22) f65: vec2<f16>,
+  @location(5) f66: vec2<f16>,
+  @location(20) f67: f16,
+  @location(30) f68: vec3<f16>,
+  @location(26) f69: vec3<i32>,
+  @location(24) f70: vec4<i32>,
+  @location(32) f71: vec2<u32>,
+  @location(8) f72: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec2<i32>, @location(0) a1: vec4<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let pipelineLayout7 = device0.createPipelineLayout({
+  label: '\u071c\u096b',
+  bindGroupLayouts: [bindGroupLayout11, bindGroupLayout7, bindGroupLayout11, bindGroupLayout7, bindGroupLayout10, bindGroupLayout10, bindGroupLayout7, bindGroupLayout11, bindGroupLayout7, bindGroupLayout10],
+});
+let buffer17 = device0.createBuffer({
+  label: '\ufd37\u3c91\uc3e3\u5464\u002c\u299f\u3773\u{1f90e}\u8e72\u9b2b\ued70',
+  size: 70767,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandBuffer11 = commandEncoder40.finish({label: '\u0a84\u28e0\u409f\uc6c2\u80e8\uee88'});
+let externalTexture26 = device0.importExternalTexture({label: '\u76fd\u034e\uee02\u{1f721}\u0254\u1a7d', source: video1, colorSpace: 'srgb'});
+try {
+commandEncoder44.clearBuffer(buffer16);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder0.resolveQuerySet(querySet19, 260, 521, buffer1, 174080);
+} catch {}
+try {
+adapter2.label = '\u039c\u{1fe70}\u8a1f\u{1fbc1}\uca17\ubc32\u{1f97f}\uf519\u69bc';
+} catch {}
+let commandEncoder47 = device1.createCommandEncoder({label: '\u4ee4\u{1f96f}\ub2cc\u4268\u76c5\u6b35\u5e2a\u{1fe01}\u{1fe3b}'});
+let textureView58 = texture3.createView({dimension: '2d', baseMipLevel: 1, mipLevelCount: 4, baseArrayLayer: 6});
+let computePassEncoder25 = commandEncoder43.beginComputePass({label: '\uc15b\ueda5\ub53e\u{1fd26}\u3d85\u0976\ue83c\u0d52\u{1fa0a}\u5b9c\ucf64'});
+let externalTexture27 = device1.importExternalTexture({label: '\u{1ff66}\u3315\uad74\u{1fc93}\u02e1\u{1f9f1}\u0cbf', source: video6, colorSpace: 'srgb'});
+try {
+renderBundleEncoder18.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder27.draw(132);
+} catch {}
+let querySet30 = device1.createQuerySet({label: '\u0658\u{1f87e}\u0ab4', type: 'occlusion', count: 983});
+let textureView59 = texture33.createView({
+  label: '\u279e\u99f8\u0fc6\u{1f9e0}\ubf6b\u{1fcf3}\u{1f85f}\u0200\u29cf\u7f25\u7322',
+  baseMipLevel: 0,
+});
+let computePassEncoder26 = commandEncoder42.beginComputePass();
+try {
+renderBundleEncoder18.setVertexBuffer(3950, undefined, 2480701349, 499125809);
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 45},
+  aspect: 'all',
+},
+{
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 188, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder31.resolveQuerySet(querySet28, 837, 1223, buffer3, 7168);
+} catch {}
+let canvas9 = document.createElement('canvas');
+let texture35 = gpuCanvasContext7.getCurrentTexture();
+let sampler29 = device0.createSampler({
+  label: '\u{1fca3}\u{1f775}\u9042\u31ab\u{1fcc5}\u0bb0',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 74.34,
+});
+try {
+renderBundleEncoder19.setVertexBuffer(6986, undefined, 0, 4152446884);
+} catch {}
+try {
+commandEncoder44.resolveQuerySet(querySet20, 41, 517, buffer1, 158976);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline32 = device0.createComputePipeline({
+  label: '\u0b92\u{1fa32}\u7d34\u0ece\u0160\u034a\u0faf\ua6e4\u0cc1\u01e3\u0529',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule7, entryPoint: 'compute0'},
+});
+let commandEncoder48 = device0.createCommandEncoder();
+let textureView60 = texture9.createView({label: '\u{1fc62}\u0439\u0af9\u{1fd52}\u00e4\u{1f77b}\u2ad3\u{1f89f}\u7a63', baseMipLevel: 1});
+let sampler30 = device0.createSampler({
+  label: '\ua5a2\u7ec6\u{1fdbb}\u09e0\u{1f7be}',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 20.52,
+  lodMaxClamp: 92.77,
+});
+try {
+computePassEncoder13.setPipeline(pipeline22);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(5, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(473, undefined, 0);
+} catch {}
+try {
+commandEncoder48.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 26318 */
+  offset: 1202,
+  bytesPerRow: 512,
+  rowsPerImage: 21,
+  buffer: buffer17,
+}, {
+  texture: texture29,
+  mipLevel: 3,
+  origin: {x: 5, y: 1, z: 0},
+  aspect: 'all',
+}, {width: 14, height: 8, depthOrArrayLayers: 3});
+dissociateBuffer(device0, buffer17);
+} catch {}
+try {
+commandEncoder44.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 26, y: 15, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 4, y: 5, z: 0},
+  aspect: 'all',
+},
+{width: 100, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 699_979 */
+{offset: 139, bytesPerRow: 1215, rowsPerImage: 12}, {width: 285, height: 0, depthOrArrayLayers: 49});
+} catch {}
+let bindGroupLayout12 = device0.createBindGroupLayout({
+  label: '\u49c0\u0af5\uc09f',
+  entries: [
+    {
+      binding: 5002,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8snorm', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 3465,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 4645,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({
+  label: '\uabf7\u6ec2\u0052\u0d58\u2515\u7f8d\u1720\ue185',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture28 = device0.importExternalTexture({label: '\ud7d8\ua26e', source: video9, colorSpace: 'display-p3'});
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder30.copyBufferToBuffer(buffer12, 10436, buffer6, 88940, 5524);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder0.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 50112 */
+  offset: 50112,
+  buffer: buffer15,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder30.clearBuffer(buffer16);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder0.resolveQuerySet(querySet15, 1441, 73, buffer1, 7424);
+} catch {}
+try {
+renderBundleEncoder31.popDebugGroup();
+} catch {}
+let offscreenCanvas4 = new OffscreenCanvas(793, 684);
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+try {
+offscreenCanvas4.getContext('webgpu');
+} catch {}
+video3.height = 86;
+let pipelineLayout8 = device0.createPipelineLayout({
+  label: '\u03c5\u{1ff04}\udebe\u023d\u14e4',
+  bindGroupLayouts: [bindGroupLayout10, bindGroupLayout10, bindGroupLayout10, bindGroupLayout7, bindGroupLayout10],
+});
+let commandEncoder49 = device0.createCommandEncoder();
+let texture36 = device0.createTexture({
+  label: '\ub68f\u0fa1\u0d71\u{1fa36}\ua4d4\u65e4\u08c0',
+  size: [624, 1, 889],
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba8uint', 'rgba8uint'],
+});
+let externalTexture29 = device0.importExternalTexture({source: video9, colorSpace: 'display-p3'});
+try {
+computePassEncoder8.setPipeline(pipeline32);
+} catch {}
+let arrayBuffer5 = buffer16.getMappedRange(302520);
+try {
+commandEncoder48.resolveQuerySet(querySet2, 800, 776, buffer1, 5376);
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let img4 = await imageWithData(176, 296, '#c4dea3b3', '#f1d8b545');
+let imageData11 = new ImageData(116, 72);
+let buffer18 = device1.createBuffer({
+  label: '\u0871\u3315\u0e43\u2763\u9454',
+  size: 398996,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: false,
+});
+let textureView61 = texture5.createView({
+  label: '\u{1fb5e}\u{1fbc0}\u1e55\u580e\ucab9\u0c43\u0c1c\u{1fb25}\ucfff',
+  format: 'bgra8unorm-srgb',
+  baseMipLevel: 6,
+});
+let computePassEncoder27 = commandEncoder39.beginComputePass({label: '\ue216\u0b78\ud216'});
+try {
+renderBundleEncoder18.setBindGroup(2, bindGroup5, new Uint32Array(2545), 618, 0);
+} catch {}
+try {
+renderBundleEncoder11.draw(155, 120, 339_653_746, 47_273_954);
+} catch {}
+try {
+renderBundleEncoder18.drawIndexed(48, 86, 180_649_928);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexedIndirect(buffer8, 409436);
+} catch {}
+try {
+renderBundleEncoder11.drawIndirect(buffer8, 619424);
+} catch {}
+let video10 = await videoWithData();
+let commandEncoder50 = device0.createCommandEncoder();
+let sampler31 = device0.createSampler({
+  label: '\u0abb\uea39\uc01b\u1dd6',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 28.88,
+  lodMaxClamp: 84.29,
+});
+try {
+computePassEncoder9.setBindGroup(4, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(1472, undefined, 0, 3777849689);
+} catch {}
+try {
+commandEncoder50.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 28, y: 11, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 10, height: 1, depthOrArrayLayers: 3});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 24684, new Float32Array(52265), 39628, 1288);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer3), /* required buffer size: 252 */
+{offset: 252}, {width: 13, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap10 = await createImageBitmap(videoFrame2);
+try {
+adapter3.label = '\u5888\u05cb';
+} catch {}
+let sampler32 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 31.31,
+  lodMaxClamp: 39.67,
+  compare: 'not-equal',
+});
+try {
+renderBundleEncoder11.draw(81, 138);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexedIndirect(buffer8, 239576);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline12);
+} catch {}
+let gpuCanvasContext8 = canvas8.getContext('webgpu');
+let videoFrame5 = new VideoFrame(video10, {timestamp: 0});
+let bindGroup7 = device0.createBindGroup({label: '\u0ac9\u0f39\u6cc7\u01df\u2ae1\u03b9', layout: bindGroupLayout10, entries: []});
+let pipelineLayout9 = device0.createPipelineLayout({
+  label: '\u{1f6d2}\u6c19\u{1f677}\u49cd\u{1ff8a}\u1575\u3126\u2ee8\u03a8',
+  bindGroupLayouts: [bindGroupLayout9],
+});
+let commandEncoder51 = device0.createCommandEncoder({label: '\uf493\u{1fcd8}\u0fac\u{1f719}\u0372'});
+let querySet31 = device0.createQuerySet({label: '\u{1ff11}\u57a6\ufb03\u{1f6d5}\ueda4\u06cc\ua605\u07c1', type: 'occlusion', count: 1995});
+let texture37 = device0.createTexture({
+  label: '\u90f8\u89a4\u0b10\u05cf\u0fc7\ue2de\ud48e',
+  size: {width: 1248, height: 1, depthOrArrayLayers: 544},
+  mipLevelCount: 4,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r16uint'],
+});
+let textureView62 = texture10.createView({aspect: 'all', format: 'rgba8uint', baseMipLevel: 1, mipLevelCount: 1});
+try {
+renderBundleEncoder8.setBindGroup(10, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder8.setIndexBuffer(buffer11, 'uint32', 12400, 1873);
+} catch {}
+try {
+  await buffer7.mapAsync(GPUMapMode.READ, 0, 2620);
+} catch {}
+try {
+commandEncoder48.copyBufferToBuffer(buffer12, 11044, buffer16, 53008, 1336);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder48.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 1,
+  origin: {x: 8, y: 8, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 268 widthInBlocks: 67 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 30640 */
+  offset: 17060,
+  bytesPerRow: 512,
+  rowsPerImage: 36,
+  buffer: buffer6,
+}, {width: 67, height: 27, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder44.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(116, 641);
+let shaderModule8 = device1.createShaderModule({
+  label: '\u{1f74b}\u{1ff29}\uf962\ubda3\u04cd\uad06\u81e3\u3912\u{1fa65}',
+  code: `@group(0) @binding(644)
+var<storage, read_write> global4: array<u32>;
+@group(2) @binding(568)
+var<storage, read_write> type1: array<u32>;
+@group(1) @binding(575)
+var<storage, read_write> parameter4: array<u32>;
+@group(2) @binding(575)
+var<storage, read_write> type2: array<u32>;
+@group(3) @binding(148)
+var<storage, read_write> n2: array<u32>;
+
+@compute @workgroup_size(3, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @location(9) a1: vec3<i32>, @location(1) a2: vec2<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(8) f73: vec4<i32>,
+  @location(13) f74: f32,
+  @location(0) f75: i32,
+  @location(12) f76: vec3<f16>,
+  @location(9) f77: vec3<i32>,
+  @location(15) f78: vec4<u32>,
+  @builtin(position) f79: vec4<f32>,
+  @location(1) f80: vec2<f32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec4<f16>, @location(10) a1: vec2<i32>, @location(5) a2: f32, @location(7) a3: f32, @location(8) a4: vec4<f32>, @location(2) a5: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder52 = device1.createCommandEncoder({label: '\u3e2c\u{1fbf0}\u0eaa\u03ed\u0d4c\u0616\u{1f963}'});
+try {
+computePassEncoder27.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup4, new Uint32Array(3611), 2886, 0);
+} catch {}
+try {
+renderBundleEncoder11.drawIndirect(buffer8, 305196);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline10);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 5,
+  origin: {x: 16, y: 0, z: 6},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 952 */
+{offset: 952}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let imageBitmap11 = await createImageBitmap(imageData0);
+let shaderModule9 = device0.createShaderModule({
+  code: `@group(3) @binding(1456)
+var<storage, read_write> parameter5: array<u32>;
+
+@compute @workgroup_size(1, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<u32>,
+  @builtin(sample_mask) f1: u32,
+  @location(5) f2: vec3<i32>,
+  @location(2) f3: vec3<u32>,
+  @location(1) f4: vec4<u32>,
+  @location(0) f5: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(16) a0: i32, @location(26) a1: vec2<u32>, @location(0) a2: f16, @location(14) a3: vec4<f16>, @location(8) a4: f16, @location(25) a5: vec2<f16>, @builtin(sample_mask) a6: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S5 {
+  @builtin(instance_index) f0: u32,
+  @location(2) f1: vec3<f16>
+}
+struct VertexOutput0 {
+  @location(25) f81: vec2<f16>,
+  @location(16) f82: i32,
+  @location(8) f83: f16,
+  @location(26) f84: vec2<u32>,
+  @builtin(position) f85: vec4<f32>,
+  @location(0) f86: f16,
+  @location(14) f87: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec2<f32>, @location(3) a1: f32, @builtin(vertex_index) a2: u32, @location(11) a3: vec4<f32>, @location(17) a4: vec3<i32>, @location(14) a5: vec4<i32>, a6: S5, @location(9) a7: vec2<u32>, @location(20) a8: vec2<f32>, @location(19) a9: vec4<f32>, @location(12) a10: vec3<i32>, @location(16) a11: vec2<f32>, @location(1) a12: vec3<f16>, @location(10) a13: f16, @location(4) a14: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let querySet32 = device0.createQuerySet({label: '\u50ba\u8394\u{1f884}\u{1f7df}\u8aac\u0a47', type: 'occlusion', count: 2495});
+let textureView63 = texture31.createView({label: '\u005b\u0ff9\u0544\ua4dd\u{1fcae}\u61b7\u0a29\u0fb9\u2b4c'});
+try {
+computePassEncoder10.setPipeline(pipeline22);
+} catch {}
+try {
+commandEncoder0.copyTextureToTexture({
+  texture: texture23,
+  mipLevel: 3,
+  origin: {x: 10, y: 1, z: 239},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 17, height: 0, depthOrArrayLayers: 85});
+} catch {}
+try {
+commandEncoder48.insertDebugMarker('\u0cc5');
+} catch {}
+let commandEncoder53 = device0.createCommandEncoder({label: '\ub9e5\ucfb8\u076b\uee99\u2d89\u{1f810}'});
+let querySet33 = device0.createQuerySet({label: '\u{1f9df}\ud31e\u06bc\u67c0\u90b8\ub20a\u{1f690}\u0f4d', type: 'occlusion', count: 1886});
+try {
+commandEncoder53.copyTextureToBuffer({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 42336 */
+  offset: 42336,
+  bytesPerRow: 256,
+  buffer: buffer6,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder49.clearBuffer(buffer16, 303796, 2384);
+dissociateBuffer(device0, buffer16);
+} catch {}
+let bindGroup8 = device0.createBindGroup({layout: bindGroupLayout11, entries: [{binding: 3074, resource: externalTexture9}]});
+let commandEncoder54 = device0.createCommandEncoder({label: '\u{1f6bd}\u{1fde0}\u69b7\u58e6'});
+let texture38 = device0.createTexture({
+  label: '\ucab9\u{1ff9d}\u0061\u032c',
+  size: {width: 120},
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32float', 'rg32float', 'rg32float'],
+});
+let renderBundle38 = renderBundleEncoder29.finish({label: '\u2b18\u4e1c\u0124\u{1f8be}\u06f5\ucc56\u{1f7b6}\uc10a'});
+try {
+renderBundleEncoder12.setBindGroup(0, bindGroup8, new Uint32Array(5201), 3612, 0);
+} catch {}
+try {
+commandEncoder53.resolveQuerySet(querySet33, 755, 213, buffer1, 221696);
+} catch {}
+let bindGroupLayout13 = pipeline32.getBindGroupLayout(5);
+try {
+renderBundleEncoder12.setBindGroup(8, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(2, bindGroup2, new Uint32Array(621), 425, 0);
+} catch {}
+try {
+commandEncoder48.copyBufferToBuffer(buffer12, 8132, buffer6, 41212, 4700);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder53.resolveQuerySet(querySet0, 2653, 90, buffer1, 176128);
+} catch {}
+try {
+renderBundleEncoder34.pushDebugGroup('\u054c');
+} catch {}
+try {
+canvas9.getContext('2d');
+} catch {}
+let buffer19 = device1.createBuffer({
+  label: '\u{1fd05}\u{1fdc2}\u0e4a\u07bc\u{1fc71}\u0a4c\u{1fda0}\u6193\u0ef1\ue129\u0468',
+  size: 12865,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let querySet34 = device1.createQuerySet({label: '\u48e9\ud77b\u5e25\u0813\u013d\u0d75\u03de\u4fda', type: 'occlusion', count: 127});
+let renderBundle39 = renderBundleEncoder18.finish();
+let externalTexture30 = device1.importExternalTexture({label: '\u7d0a\u761d', source: videoFrame1, colorSpace: 'srgb'});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup3, new Uint32Array(6664), 4162, 0);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexedIndirect(buffer8, 54708);
+} catch {}
+try {
+renderBundleEncoder27.drawIndirect(buffer8, 5576);
+} catch {}
+try {
+commandEncoder46.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 897, y: 0, z: 190},
+  aspect: 'all',
+},
+{width: 220, height: 1, depthOrArrayLayers: 11});
+} catch {}
+try {
+device1.queue.submit([commandBuffer7]);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 60, height: 1, depthOrArrayLayers: 29}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 45, y: 8 },
+  flipY: false,
+}, {
+  texture: texture17,
+  mipLevel: 5,
+  origin: {x: 55, y: 0, z: 10},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext9 = offscreenCanvas5.getContext('webgpu');
+let video11 = await videoWithData();
+let commandEncoder55 = device0.createCommandEncoder();
+let querySet35 = device0.createQuerySet({type: 'occlusion', count: 3039});
+let renderBundleEncoder35 = device0.createRenderBundleEncoder({
+  label: '\u30ae\u{1ff40}\ua355\u64f5',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  stencilReadOnly: true,
+});
+let renderBundle40 = renderBundleEncoder31.finish({label: '\uf07f\ucab9\u0ba1\u392a\u0026\u8543\u0110\u0544\ud69e\ub49b'});
+let sampler33 = device0.createSampler({
+  label: '\u{1f99a}\uc83e\u36da\u{1f655}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 26.00,
+  lodMaxClamp: 60.62,
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder34.popDebugGroup();
+} catch {}
+let buffer20 = device1.createBuffer({size: 153985, usage: GPUBufferUsage.STORAGE});
+let commandEncoder56 = device1.createCommandEncoder({});
+let texture39 = device1.createTexture({
+  label: '\u1ce4\u847d\u0c89\u0a92\u8d96\u{1f66d}\u06c1\ub15c\u02b4\u240b\u07cd',
+  size: [960, 6, 650],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb'],
+});
+let computePassEncoder28 = commandEncoder21.beginComputePass({label: '\u{1f93d}\u16cb\u0d57\uc56e\u0188\uaad3\u53ed\u0ec4\u0805\u01c9'});
+let renderBundleEncoder36 = device1.createRenderBundleEncoder({
+  label: '\u{1f996}\u0286\u9bb2\udf95\u0b33\u9d0e\u83ca',
+  colorFormats: ['bgra8unorm'],
+  stencilReadOnly: true,
+});
+let externalTexture31 = device1.importExternalTexture({label: '\u6ed3\ub7dd\u{1fd07}\u{1fb70}\u04bc', source: video6, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder27.setVertexBuffer(3751, undefined, 989319717, 1823236829);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer3, 47920, new BigUint64Array(43183), 22990, 56);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1920, height: 12, depthOrArrayLayers: 946}
+*/
+{
+  source: video6,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 166, y: 1, z: 18},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule10 = device0.createShaderModule({
+  label: '\u0564\ub0c8\udacf\u0ad3\uee91\ua6b2\udc99\u5419\u0154',
+  code: `@group(1) @binding(1456)
+var<storage, read_write> field1: array<u32>;
+
+@compute @workgroup_size(3, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(5) f0: vec3<f32>,
+  @location(1) f1: vec4<u32>,
+  @location(2) f2: u32,
+  @location(3) f3: vec4<u32>,
+  @location(0) f4: vec4<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(20) a0: vec2<u32>, @location(3) a1: f16) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup9 = device0.createBindGroup({layout: bindGroupLayout9, entries: []});
+let buffer21 = device0.createBuffer({
+  label: '\ufc97\uf961\uc887\u{1f8c7}\uc2b6\uc392\u0d0e\u{1fd8c}\u04c7\u50a0',
+  size: 60088,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let texture40 = device0.createTexture({
+  size: [624, 1, 1068],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint'],
+});
+try {
+commandEncoder51.copyBufferToBuffer(buffer17, 64776, buffer6, 73124, 5272);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let adapter4 = await promise0;
+document.body.prepend(video0);
+let imageData12 = new ImageData(216, 12);
+let textureView64 = texture8.createView({label: '\u78fb\u87bc\u21ce\u3ce8\u038e\u013f\u{1f9bf}\uf20a\u{1fec6}', mipLevelCount: 4});
+let computePassEncoder29 = commandEncoder51.beginComputePass({label: '\u0e2a\u79b2\u436d\uea4d'});
+let renderBundle41 = renderBundleEncoder19.finish();
+let sampler34 = device0.createSampler({
+  label: '\u263e\uca89\u4cf7\u0ad9',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 71.95,
+  maxAnisotropy: 10,
+});
+try {
+renderBundleEncoder14.setBindGroup(9, bindGroup9);
+} catch {}
+try {
+commandEncoder55.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 9424 */
+  offset: 9424,
+  bytesPerRow: 256,
+  buffer: buffer17,
+}, {
+  texture: texture1,
+  mipLevel: 3,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 30, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer17);
+} catch {}
+try {
+commandEncoder0.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 5,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 31, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder55.resolveQuerySet(querySet35, 778, 466, buffer1, 27904);
+} catch {}
+document.body.prepend(canvas5);
+let imageData13 = new ImageData(116, 24);
+let textureView65 = texture19.createView({label: '\uc213\u0883\u024d\ua5fb\ua5b8\u0730', baseMipLevel: 0});
+try {
+computePassEncoder21.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexedIndirect(buffer8, 27208);
+} catch {}
+try {
+renderBundleEncoder27.drawIndirect(buffer8, 421248);
+} catch {}
+let pipeline33 = await device1.createRenderPipelineAsync({
+  label: '\u0cea\u02c8\u64e3\uc843\u9c2f\u904e\u0b4e\ue42b\u4ef1\u7766',
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'one-minus-dst'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'greater', depthFailOp: 'zero'},
+    stencilBack: {compare: 'less-equal', failOp: 'zero', depthFailOp: 'decrement-wrap'},
+    stencilWriteMask: 3250139658,
+    depthBiasSlopeScale: -15.46617740155422,
+    depthBiasClamp: 986.6503967526091,
+  },
+  vertex: {module: shaderModule1, entryPoint: 'vertex0', buffers: []},
+});
+let pipelineLayout10 = device0.createPipelineLayout({
+  label: '\u4eb3\u32b6\u059d\uabaa\ufa8b\u042a\u{1fc32}\uc8a1\u{1fc82}',
+  bindGroupLayouts: [bindGroupLayout13, bindGroupLayout7, bindGroupLayout12, bindGroupLayout9],
+});
+let textureView66 = texture1.createView({
+  label: '\u03ee\u59d2\u168f\u1d36\u8187\ueac2\u8024\u0998',
+  dimension: '2d-array',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+});
+let pipeline34 = device0.createRenderPipeline({
+  label: '\u0c90\u{1f6b5}\u079c\u2734\uc0af\u{1f9bc}',
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.ALL}, {format: 'rgb10a2uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthCompare: 'always',
+    stencilFront: {compare: 'greater-equal', failOp: 'zero', depthFailOp: 'increment-clamp', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'equal', failOp: 'zero', depthFailOp: 'invert', passOp: 'invert'},
+    stencilReadMask: 670675933,
+    depthBiasClamp: 388.83672263371744,
+  },
+  vertex: {module: shaderModule4, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+let imageData14 = new ImageData(232, 52);
+let videoFrame6 = new VideoFrame(canvas3, {timestamp: 0});
+let querySet36 = device0.createQuerySet({
+  label: '\u34d3\u230f\ud765\u0d5f\uef00\u295a\ua2c2\u4daa\u0194\u{1fcad}',
+  type: 'occlusion',
+  count: 1920,
+});
+try {
+device0.queue.writeBuffer(buffer6, 1372, new Float32Array(23945), 14374, 2428);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline35 = await device0.createRenderPipelineAsync({
+  label: '\u{1f8f3}\uab06\u2aa8\u2e82\u0eaf\u{1fbe6}\u8bf7\u{1ffbf}\u{1f68d}\u{1faf2}',
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rgba8uint', writeMask: GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rgb10a2uint'}],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x2', offset: 6276, shaderLocation: 5}],
+      },
+      {
+        arrayStride: 7556,
+        stepMode: 'vertex',
+        attributes: [{format: 'unorm8x2', offset: 1248, shaderLocation: 0}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'back', unclippedDepth: true},
+});
+try {
+window.someLabel = renderBundleEncoder21.label;
+} catch {}
+let bindGroup10 = device0.createBindGroup({
+  label: '\u5634\udf92\u114e\u67e5\u0344\ubbb9\u5f80\u0fa7\ud2df\u2948\u0694',
+  layout: bindGroupLayout9,
+  entries: [],
+});
+let textureView67 = texture4.createView({dimension: '3d', baseMipLevel: 1});
+let computePassEncoder30 = commandEncoder44.beginComputePass({label: '\u02dc\u951c'});
+let renderBundleEncoder37 = device0.createRenderBundleEncoder({
+  label: '\u04cb\u{1fc8d}\u{1fea9}\uf534\u509f\u{1f708}',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle42 = renderBundleEncoder24.finish({label: '\u0dc5\u{1f62f}\uc2b3\u9b54\u078a\u9e4f\ud62a\ud9ce\u188e'});
+try {
+commandEncoder48.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8580 */
+  offset: 8580,
+  buffer: buffer6,
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder53.clearBuffer(buffer6, 83104, 6404);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 18584, new DataView(new ArrayBuffer(65265)), 11089, 11016);
+} catch {}
+let pipeline36 = device0.createRenderPipeline({
+  label: '\u085c\u{1f6b9}\ud93d',
+  layout: pipelineLayout5,
+  multisample: {count: 4, mask: 0x40a8785},
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    stencilFront: {compare: 'less', failOp: 'decrement-clamp', depthFailOp: 'invert', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'never', failOp: 'replace', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilReadMask: 775062911,
+    stencilWriteMask: 3185508377,
+    depthBias: -1960696408,
+    depthBiasSlopeScale: 353.7615827116472,
+  },
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 1528, attributes: [{format: 'snorm16x4', offset: 232, shaderLocation: 0}]},
+      {
+        arrayStride: 18804,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x4', offset: 1480, shaderLocation: 5}],
+      },
+    ],
+  },
+});
+offscreenCanvas1.height = 743;
+let bindGroup11 = device1.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 644, resource: externalTexture1}]});
+let pipelineLayout11 = device1.createPipelineLayout({
+  label: '\u0f1d\u149f\u079a\u32e6\u1d01\u056e\uaea7\ud931\u{1fb02}\u0a36\u0bae',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout1],
+});
+try {
+renderBundleEncoder27.drawIndirect(buffer8, 106364);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(4381, undefined, 900241480, 1097963873);
+} catch {}
+try {
+commandEncoder35.copyBufferToBuffer(buffer8, 166448, buffer2, 18016, 388);
+dissociateBuffer(device1, buffer8);
+dissociateBuffer(device1, buffer2);
+} catch {}
+try {
+commandEncoder10.copyTextureToTexture({
+  texture: texture25,
+  mipLevel: 2,
+  origin: {x: 6, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 258, y: 2, z: 290},
+  aspect: 'all',
+},
+{width: 59, height: 2, depthOrArrayLayers: 101});
+} catch {}
+try {
+commandEncoder38.resolveQuerySet(querySet10, 1525, 229, buffer3, 32768);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer4), /* required buffer size: 2_046 */
+{offset: 994}, {width: 263, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let promise10 = device1.queue.onSubmittedWorkDone();
+video9.width = 57;
+let bindGroup12 = device1.createBindGroup({
+  label: '\u01e1\u{1fb59}\u0d8f\u0515\u49a3\u04ff\u04e7\u{1f91f}\u00a0\ud70f\u{1f7b7}',
+  layout: bindGroupLayout2,
+  entries: [{binding: 644, resource: externalTexture18}],
+});
+let textureView68 = texture7.createView({dimension: '3d', mipLevelCount: 1});
+let renderPassEncoder0 = commandEncoder38.beginRenderPass({
+  label: '\u2ace\u57af\u8613\u4a0b\u{1fa8f}\u59bf\ud053\ud387',
+  colorAttachments: [{view: textureView68, depthSlice: 200, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet6,
+  maxDrawCount: 929113420,
+});
+let sampler35 = device1.createSampler({
+  label: '\u698f\u0ab8',
+  addressModeU: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 2.798,
+  lodMaxClamp: 7.200,
+  compare: 'always',
+});
+try {
+renderPassEncoder0.setBlendConstant({ r: 244.8, g: 189.3, b: -950.9, a: 251.3, });
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(3, bindGroup11, new Uint32Array(39), 30, 0);
+} catch {}
+try {
+renderBundleEncoder27.draw(51, 84, 465_850_565, 1_210_246_570);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexedIndirect(buffer8, 229560);
+} catch {}
+try {
+renderBundleEncoder27.drawIndirect(buffer8, 932364);
+} catch {}
+let promise11 = buffer19.mapAsync(GPUMapMode.READ, 9392, 1944);
+try {
+commandEncoder52.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 1,
+  origin: {x: 37, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture25,
+  mipLevel: 8,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise11;
+} catch {}
+let imageBitmap12 = await createImageBitmap(imageData6);
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+canvas2.width = 198;
+let bindGroup13 = device0.createBindGroup({label: '\u{1fd34}\u{1f9a8}\u11cb\ud7cc\u895c\u4bbe\u765f', layout: bindGroupLayout10, entries: []});
+let commandEncoder57 = device0.createCommandEncoder({label: '\u079d\uc1e5\u0679\u{1fe6e}\u2465\uaf86\ufdd2\u{1fdf5}\uff15'});
+let textureView69 = texture9.createView({label: '\u595e\u{1fa46}\udd20\u67ba\u{1fa65}\u{1f751}\u0cd5\u0c7a', mipLevelCount: 1});
+let renderBundle43 = renderBundleEncoder34.finish({label: '\u0a89\u{1fdb2}\u446d\u03bc\u{1fc3c}\u{1fe6e}\u9ee5\u5429\ub3ed'});
+try {
+commandEncoder53.copyBufferToTexture({
+  /* bytesInLastRow: 332 widthInBlocks: 83 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 15916 */
+  offset: 15584,
+  buffer: buffer12,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 83, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder50.clearBuffer(buffer16);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder50.resolveQuerySet(querySet27, 2304, 654, buffer1, 51712);
+} catch {}
+try {
+window.someLabel = textureView59.label;
+} catch {}
+let renderPassEncoder1 = commandEncoder32.beginRenderPass({
+  label: '\u4265\u{1ff0a}\ufcdd\u{1f748}\u3431\u0778\u7d4a\u{1fff7}\udae2',
+  colorAttachments: [{
+  view: textureView68,
+  depthSlice: 556,
+  clearValue: { r: -834.0, g: 924.0, b: -162.0, a: -432.4, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet26,
+  maxDrawCount: 84036295,
+});
+let externalTexture32 = device1.importExternalTexture({label: '\ub760\ub704\u7034\u7bcb', source: video8, colorSpace: 'display-p3'});
+try {
+renderPassEncoder1.setStencilReference(3985);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexed(275, 79, 197_687_762, 308_850_318);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexedIndirect(buffer8, 132392);
+} catch {}
+try {
+renderBundleEncoder27.drawIndirect(buffer8, 47404);
+} catch {}
+try {
+commandEncoder47.clearBuffer(buffer19, 3628, 2668);
+dissociateBuffer(device1, buffer19);
+} catch {}
+let pipeline37 = device1.createComputePipeline({
+  label: '\u0087\u1086\u1ce0\ub482',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise10;
+} catch {}
+let bindGroupLayout14 = device0.createBindGroupLayout({entries: [{binding: 224, visibility: 0, sampler: { type: 'non-filtering' }}]});
+let commandEncoder58 = device0.createCommandEncoder();
+let renderBundle44 = renderBundleEncoder17.finish({});
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder55.copyBufferToBuffer(buffer9, 17648, buffer6, 40096, 21408);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder54.copyTextureToBuffer({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 69, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 238 widthInBlocks: 119 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 19540 */
+  offset: 19540,
+  buffer: buffer6,
+}, {width: 119, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline38 = device0.createRenderPipeline({
+  label: '\u95b1\u75c1\u3a97\u2a43\u7da2\u5ad4\u{1f77e}\ue1ef',
+  layout: pipelineLayout10,
+  multisample: {},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r16uint'}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL}],
+},
+  vertex: {module: shaderModule4, entryPoint: 'vertex0', constants: {}, buffers: []},
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'ccw', cullMode: 'front'},
+});
+let video12 = await videoWithData();
+let imageBitmap13 = await createImageBitmap(video5);
+let commandEncoder59 = device0.createCommandEncoder();
+let renderBundle45 = renderBundleEncoder31.finish({label: '\ue7df\u11d1\u{1f941}\u{1f931}\u3210\u0092\u0b2a\uc22c\u4965'});
+try {
+renderBundleEncoder33.setIndexBuffer(buffer11, 'uint16');
+} catch {}
+try {
+commandEncoder0.copyBufferToTexture({
+  /* bytesInLastRow: 672 widthInBlocks: 42 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 34032 */
+  offset: 18000,
+  bytesPerRow: 768,
+  buffer: buffer15,
+}, {
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 8, y: 18, z: 0},
+  aspect: 'all',
+}, {width: 336, height: 126, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 4380, new DataView(new ArrayBuffer(39987)), 27797, 120);
+} catch {}
+let imageBitmap14 = await createImageBitmap(imageBitmap2);
+let commandEncoder60 = device0.createCommandEncoder({label: '\u{1fa64}\u05bc\u0c73\u{1fe53}'});
+let querySet37 = device0.createQuerySet({label: '\u9ca3\u{1fcf9}', type: 'occlusion', count: 3215});
+let textureView70 = texture38.createView({label: '\u0d31\ubd45\u{1f822}\u{1fe50}\uef6b\u048f', aspect: 'all'});
+try {
+computePassEncoder11.setBindGroup(9, bindGroup8, new Uint32Array(6721), 4311, 0);
+} catch {}
+try {
+commandEncoder0.copyBufferToBuffer(buffer17, 63616, buffer6, 65996, 3632);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let commandEncoder61 = device1.createCommandEncoder();
+let texture41 = gpuCanvasContext2.getCurrentTexture();
+let sampler36 = device1.createSampler({
+  label: '\u38aa\u{1fa1c}\u{1fe75}\u0c48\u{1fe9e}\u09b7\u7e2a\u0537\ue474',
+  addressModeU: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 84.96,
+  lodMaxClamp: 88.92,
+});
+let externalTexture33 = device1.importExternalTexture({
+  label: '\u{1f8d0}\u{1fa64}\u{1ff90}\ufc65\u2a43\u4114\u0b51\u75ef',
+  source: video2,
+  colorSpace: 'srgb',
+});
+try {
+renderPassEncoder1.beginOcclusionQuery(82);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexed(228, 231);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(2125, undefined, 2417183604, 1802467615);
+} catch {}
+try {
+commandEncoder18.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 16440 */
+  offset: 16440,
+  bytesPerRow: 0,
+  rowsPerImage: 278,
+  buffer: buffer8,
+}, {
+  texture: texture25,
+  mipLevel: 8,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 174});
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+commandEncoder18.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 3,
+  origin: {x: 8, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 364},
+  aspect: 'all',
+},
+{width: 6, height: 1, depthOrArrayLayers: 156});
+} catch {}
+try {
+commandEncoder31.resolveQuerySet(querySet18, 689, 863, buffer3, 27648);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer5, 6400, new Float32Array(58762), 44098, 968);
+} catch {}
+let pipeline39 = device1.createComputePipeline({layout: pipelineLayout1, compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}}});
+let renderBundleEncoder38 = device1.createRenderBundleEncoder({
+  label: '\u{1f8fb}\u048b\u{1ff89}\u{1fc25}\u0c3e\u{1fdbd}\u{1f6ff}',
+  colorFormats: ['bgra8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture34 = device1.importExternalTexture({label: '\uf954\u161f\uf3ff\u77fc\u0313\udea5', source: videoFrame0, colorSpace: 'srgb'});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 721.6, g: 419.1, b: -662.2, a: 284.8, });
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(181, 1, 22, 0);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(0, bindGroup3, new Uint32Array(4010), 2401, 0);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexed(261, 103, 1_489_789_135, 119_480_847, 432_448_537);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexedIndirect(buffer8, 371000);
+} catch {}
+try {
+commandEncoder46.copyTextureToBuffer({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 984 widthInBlocks: 246 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4 */
+  offset: 4,
+  bytesPerRow: 1024,
+  rowsPerImage: 225,
+  buffer: buffer5,
+}, {width: 246, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer5);
+} catch {}
+try {
+commandEncoder28.pushDebugGroup('\u6a41');
+} catch {}
+document.body.prepend(video3);
+let promise12 = navigator.gpu.requestAdapter({});
+let commandEncoder62 = device1.createCommandEncoder({label: '\u0e60\u{1fd90}\u0f70\u451a\u455a\u097c\u7f15'});
+let texture42 = gpuCanvasContext3.getCurrentTexture();
+let textureView71 = texture17.createView({label: '\u{1ffdc}\uab9c\u887b\u{1f890}\u0ea0\u03b4', baseMipLevel: 4});
+let renderBundleEncoder39 = device1.createRenderBundleEncoder({
+  label: '\u{1fb15}\uc12d\ufbac\u9f3c\u0c64\u{1fc23}\u0afc\ud0db',
+  colorFormats: ['bgra8unorm'],
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder0.executeBundles([renderBundle26, renderBundle0, renderBundle2, renderBundle33]);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 827.7, g: 548.3, b: -361.9, a: -332.3, });
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(63, 0, 67, 0);
+} catch {}
+try {
+renderPassEncoder1.setViewport(28.37, 0.5059, 30.64, 0.1886, 0.6842, 0.8332);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(9245, undefined, 0, 2967331833);
+} catch {}
+try {
+renderBundleEncoder27.draw(119);
+} catch {}
+try {
+renderBundleEncoder38.setPipeline(pipeline21);
+} catch {}
+try {
+commandEncoder45.copyBufferToTexture({
+  /* bytesInLastRow: 240 widthInBlocks: 60 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 67688 */
+  offset: 2168,
+  bytesPerRow: 256,
+  rowsPerImage: 85,
+  buffer: buffer8,
+}, {
+  texture: texture11,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, {width: 60, height: 1, depthOrArrayLayers: 4});
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+commandEncoder62.resolveQuerySet(querySet26, 786, 16, buffer3, 36352);
+} catch {}
+try {
+renderPassEncoder0.insertDebugMarker('\uccf1');
+} catch {}
+let offscreenCanvas6 = new OffscreenCanvas(395, 612);
+let videoFrame7 = new VideoFrame(imageBitmap6, {timestamp: 0});
+let textureView72 = texture31.createView({label: '\u3fa9\u07b8\u{1f782}\u0909\ufa59\u0fde'});
+let renderBundle46 = renderBundleEncoder1.finish({});
+let externalTexture35 = device0.importExternalTexture({source: videoFrame6, colorSpace: 'display-p3'});
+try {
+commandEncoder30.resolveQuerySet(querySet33, 1332, 16, buffer1, 133120);
+} catch {}
+try {
+device0.queue.submit([commandBuffer11]);
+} catch {}
+let commandEncoder63 = device0.createCommandEncoder();
+let sampler37 = device0.createSampler({
+  label: '\u4e7d\u{1f78f}\u0f77\u046b\u3037\u0256',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  lodMaxClamp: 97.99,
+  compare: 'equal',
+});
+try {
+renderBundleEncoder16.setVertexBuffer(4183, undefined, 0, 3432883271);
+} catch {}
+try {
+commandEncoder48.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 29184 */
+  offset: 29184,
+  buffer: buffer17,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer17);
+} catch {}
+try {
+commandEncoder55.resolveQuerySet(querySet4, 110, 11, buffer1, 202752);
+} catch {}
+try {
+computePassEncoder12.insertDebugMarker('\uac51');
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm'],
+  alphaMode: 'opaque',
+});
+} catch {}
+let gpuCanvasContext10 = offscreenCanvas6.getContext('webgpu');
+canvas2.height = 1041;
+let img5 = await imageWithData(299, 86, '#c3606d0f', '#a49d7106');
+let pipelineLayout12 = device0.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout13, bindGroupLayout10, bindGroupLayout10, bindGroupLayout11, bindGroupLayout9, bindGroupLayout12, bindGroupLayout7, bindGroupLayout12, bindGroupLayout7],
+});
+let commandBuffer12 = commandEncoder54.finish({label: '\u498f\u01f7\u945e\ue6a0\ub705\u09e2\u36b8'});
+let renderBundleEncoder40 = device0.createRenderBundleEncoder({
+  label: '\u79cb\ua7c3\u0cb4\u0352\ubb2c\uc78d\u{1f742}\u{1fc98}',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder11.setBindGroup(8, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline35);
+} catch {}
+try {
+commandEncoder49.copyTextureToTexture({
+  texture: texture8,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 23},
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 424},
+  aspect: 'all',
+},
+{width: 10, height: 0, depthOrArrayLayers: 39});
+} catch {}
+try {
+commandEncoder55.clearBuffer(buffer6, 47180, 30916);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 45, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 988 */
+{offset: 988}, {width: 19, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline40 = device0.createComputePipeline({
+  label: '\u0458\u{1fc7d}\u1e48\u{1f67e}\ufd39\u{1fcd4}\u0c41\u{1fd35}\u{1f7ce}\u{1fde8}',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+let img6 = await imageWithData(77, 79, '#4394c34e', '#6820fd11');
+let videoFrame8 = new VideoFrame(imageBitmap12, {timestamp: 0});
+let promise13 = adapter1.requestAdapterInfo();
+let bindGroupLayout15 = device0.createBindGroupLayout({
+  label: '\uf218\ub526\u0ab5\ucb6e\ubeae\u0e8c\u{1fc7a}',
+  entries: [
+    {
+      binding: 3066,
+      visibility: 0,
+      storageTexture: { format: 'rgba32sint', access: 'write-only', viewDimension: '1d' },
+    },
+    {
+      binding: 4687,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: 'cube-array', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 2915,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer22 = device0.createBuffer({size: 23327, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+renderBundleEncoder40.setBindGroup(4, bindGroup10, new Uint32Array(5444), 3865, 0);
+} catch {}
+try {
+renderBundleEncoder40.setIndexBuffer(buffer11, 'uint32');
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline35);
+} catch {}
+let pipeline41 = device0.createRenderPipeline({
+  label: '\ua832\u0bc8\u0aa4\uf943\u{1fd56}\u0fd1\u{1f9f0}\u{1f94c}',
+  layout: pipelineLayout9,
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8uint'}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'equal', failOp: 'increment-wrap', depthFailOp: 'decrement-wrap', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'not-equal', failOp: 'increment-clamp', depthFailOp: 'decrement-clamp', passOp: 'invert'},
+    stencilReadMask: 2105670971,
+    depthBias: -1625896243,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1872,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 384, shaderLocation: 19},
+          {format: 'snorm8x4', offset: 1064, shaderLocation: 2},
+          {format: 'float32', offset: 56, shaderLocation: 15},
+          {format: 'sint32x2', offset: 548, shaderLocation: 6},
+          {format: 'uint32x2', offset: 56, shaderLocation: 1},
+          {format: 'uint32x3', offset: 60, shaderLocation: 7},
+          {format: 'sint32x4', offset: 332, shaderLocation: 17},
+          {format: 'unorm10-10-10-2', offset: 276, shaderLocation: 10},
+          {format: 'uint16x4', offset: 36, shaderLocation: 4},
+          {format: 'unorm16x2', offset: 36, shaderLocation: 9},
+          {format: 'snorm8x2', offset: 166, shaderLocation: 20},
+        ],
+      },
+      {
+        arrayStride: 6452,
+        attributes: [
+          {format: 'snorm8x4', offset: 776, shaderLocation: 14},
+          {format: 'unorm10-10-10-2', offset: 228, shaderLocation: 11},
+          {format: 'uint16x4', offset: 916, shaderLocation: 5},
+          {format: 'uint8x2', offset: 996, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 42172,
+        attributes: [
+          {format: 'sint32', offset: 24, shaderLocation: 0},
+          {format: 'uint32', offset: 3352, shaderLocation: 16},
+          {format: 'float32x3', offset: 1532, shaderLocation: 18},
+          {format: 'float32x4', offset: 6256, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 7336, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 9944, attributes: []},
+      {
+        arrayStride: 10964,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x4', offset: 732, shaderLocation: 8}],
+      },
+    ],
+  },
+});
+let querySet38 = device1.createQuerySet({label: '\u42d1\u0d88\u{1fca1}\u28d5\u3ed7\u{1fa04}', type: 'occlusion', count: 72});
+let textureView73 = texture34.createView({label: '\u{1ffbb}\uc566\ue78b\u0a1f\u2aae\u06ea', baseMipLevel: 0, mipLevelCount: 1});
+let renderPassEncoder2 = commandEncoder45.beginRenderPass({
+  label: '\ub0f0\uf936\udeed\u4126',
+  colorAttachments: [{view: textureView68, depthSlice: 583, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet38,
+  maxDrawCount: 440771523,
+});
+let renderBundleEncoder41 = device1.createRenderBundleEncoder({
+  label: '\u010e\u31a7\u{1fd27}\u{1fa16}\u0915',
+  colorFormats: ['bgra8unorm'],
+  sampleCount: 1,
+  depthReadOnly: true,
+});
+let sampler38 = device1.createSampler({
+  label: '\u0306\u18d0\u0454\u069e\uc931\u04f7\u02e8\u0ac8\u{1fb6a}',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 19.48,
+});
+let externalTexture36 = device1.importExternalTexture({label: '\u03bc\u07b1\u9833\u14c8\u{1f7d3}', source: video9});
+try {
+renderPassEncoder2.beginOcclusionQuery(6);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(232);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(8043, undefined, 0, 2064757548);
+} catch {}
+let pipeline42 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout11,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'add', srcFactor: 'constant', dstFactor: 'src'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {module: shaderModule1, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'triangle-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let promise14 = adapter2.requestAdapterInfo();
+let shaderModule11 = device1.createShaderModule({
+  label: '\uc565\uf006',
+  code: `@group(0) @binding(568)
+var<storage, read_write> parameter6: array<u32>;
+@group(1) @binding(568)
+var<storage, read_write> n3: array<u32>;
+@group(0) @binding(575)
+var<storage, read_write> field2: array<u32>;
+@group(1) @binding(575)
+var<storage, read_write> n4: array<u32>;
+
+@compute @workgroup_size(1, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(6) f0: vec2<f32>,
+  @location(0) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(12) a0: f32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(10) f88: vec3<u32>,
+  @location(4) f89: vec2<f16>,
+  @location(12) f90: f32,
+  @location(5) f91: vec2<i32>,
+  @location(6) f92: vec2<f32>,
+  @builtin(position) f93: vec4<f32>,
+  @location(7) f94: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec3<f16>, @location(0) a1: vec3<f16>, @location(10) a2: vec2<u32>, @location(2) a3: vec2<f16>, @location(11) a4: vec2<i32>, @location(15) a5: u32, @location(7) a6: vec2<f16>, @location(4) a7: f16, @location(5) a8: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let pipelineLayout13 = device1.createPipelineLayout({
+  label: '\ufda0\u{1f646}\u8b01\u0e9d\u6a05\u3679\u06b8\u4fe1\uc759\u0978',
+  bindGroupLayouts: [bindGroupLayout0, bindGroupLayout3, bindGroupLayout0],
+});
+let buffer23 = device1.createBuffer({label: '\ubf04\u3d1e\u0df2\u62e8\u6e26\u0613', size: 24439, usage: GPUBufferUsage.MAP_WRITE});
+let commandEncoder64 = device1.createCommandEncoder({label: '\u94c0\ud9fa\u34ba\udfef\u506f\u6554\u7e2b\u{1fec9}\u45df\u7f40\u{1f830}'});
+let querySet39 = device1.createQuerySet({
+  label: '\u1f82\u0458\u{1fcd1}\u7581\uc9c7\u{1fcd0}\u693c\u086c\u939e\u5447',
+  type: 'occlusion',
+  count: 1792,
+});
+let computePassEncoder31 = commandEncoder14.beginComputePass({label: '\u0466\u{1fdc1}\u{1fb03}\u0ce1\u9bfa'});
+try {
+renderPassEncoder2.setBlendConstant({ r: 561.5, g: -131.9, b: 985.7, a: 340.6, });
+} catch {}
+try {
+renderPassEncoder2.setViewport(221.5, 0.5423, 7.671, 0.08089, 0.5603, 0.6192);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(2167, undefined, 4055395324);
+} catch {}
+try {
+renderBundleEncoder38.draw(284);
+} catch {}
+try {
+renderBundleEncoder38.drawIndexedIndirect(buffer8, 479004);
+} catch {}
+try {
+commandEncoder28.popDebugGroup();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 1,
+  origin: {x: 183, y: 1, z: 165},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 11_482_521 */
+{offset: 169, bytesPerRow: 1812, rowsPerImage: 96}, {width: 380, height: 1, depthOrArrayLayers: 67});
+} catch {}
+let imageBitmap15 = await createImageBitmap(imageBitmap9);
+let bindGroup14 = device1.createBindGroup({
+  label: '\u{1fa4b}\u4f45\u0466\udf2e\ue510\uc19e\u27e4\uc4d7\uaa16\uc080\u2c0b',
+  layout: bindGroupLayout2,
+  entries: [{binding: 644, resource: externalTexture5}],
+});
+let commandEncoder65 = device1.createCommandEncoder({});
+let texture43 = device1.createTexture({
+  label: '\u4a75\u9438\u8dee\ufe6b\u09fd',
+  size: {width: 1920, height: 12, depthOrArrayLayers: 1207},
+  mipLevelCount: 10,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder0.beginOcclusionQuery(41);
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(1637);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderBundleEncoder27.draw(110, 239, 285_316_107, 1_102_459_990);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexedIndirect(buffer8, 11344);
+} catch {}
+try {
+commandEncoder28.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 2,
+  origin: {x: 14, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 118852 */
+  offset: 26692,
+  bytesPerRow: 256,
+  rowsPerImage: 36,
+  buffer: buffer5,
+}, {width: 4, height: 0, depthOrArrayLayers: 11});
+dissociateBuffer(device1, buffer5);
+} catch {}
+try {
+commandEncoder61.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 44, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 2,
+  origin: {x: 74, y: 3, z: 1},
+  aspect: 'all',
+},
+{width: 270, height: 0, depthOrArrayLayers: 11});
+} catch {}
+try {
+commandEncoder62.resolveQuerySet(querySet38, 18, 40, buffer3, 29696);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer3, 4600, new Int16Array(12296), 1657, 1328);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1920, height: 12, depthOrArrayLayers: 946}
+*/
+{
+  source: video8,
+  origin: { x: 1, y: 0 },
+  flipY: true,
+}, {
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 385},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame9 = new VideoFrame(offscreenCanvas1, {timestamp: 0});
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+video5.width = 230;
+gc();
+let buffer24 = device1.createBuffer({
+  label: '\u88c6\ua306\u076b\u{1f6ac}\u{1f8d3}\u0130',
+  size: 349618,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let commandEncoder66 = device1.createCommandEncoder({});
+let renderPassEncoder3 = commandEncoder65.beginRenderPass({
+  label: '\u6828\u{1f93c}\u16bd\u23c2\u9bc6\u9c6e\u89e9',
+  colorAttachments: [{
+  view: textureView68,
+  depthSlice: 828,
+  clearValue: { r: 743.2, g: 556.1, b: 813.1, a: 3.255, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet30,
+});
+let externalTexture37 = device1.importExternalTexture({
+  label: '\u7d85\u6779\u6d64\u0fc7\u{1f70a}\u03e6\u0581\u{1fa60}\u0848\u8d62\uaf8f',
+  source: video6,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder31.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline31);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.setBlendConstant({ r: -667.7, g: 1.299, b: 378.3, a: 350.5, });
+} catch {}
+try {
+renderPassEncoder2.draw(6, 390, 44_964_875, 2_316_566_617);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer18, 773_662_291);
+} catch {}
+try {
+renderBundleEncoder27.draw(22, 209, 1_463_274_864, 64_304_949);
+} catch {}
+try {
+renderBundleEncoder36.setVertexBuffer(6968, undefined, 0, 640787908);
+} catch {}
+try {
+commandEncoder47.resolveQuerySet(querySet28, 3528, 15, buffer3, 8448);
+} catch {}
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let offscreenCanvas7 = new OffscreenCanvas(891, 107);
+let imageBitmap16 = await createImageBitmap(videoFrame1);
+let commandEncoder67 = device0.createCommandEncoder({label: '\u9f3e\u0776\u0bbc\u2efe\u1faa\u{1fbeb}\u036e\u6068\u060e\u{1fad4}\ucbae'});
+let querySet40 = device0.createQuerySet({label: '\uacec\u815a\u0402', type: 'occlusion', count: 3812});
+let texture44 = device0.createTexture({
+  size: {width: 312, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView74 = texture4.createView({
+  label: '\u01f5\u66d2\ue298\u012d\u012a\u43c4\u7a42\u3a32',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+try {
+computePassEncoder12.setPipeline(pipeline28);
+} catch {}
+try {
+querySet32.destroy();
+} catch {}
+let textureView75 = texture13.createView({label: '\u0f4f\u0564\uec14\u0aa9\u0937\uad53\u079d\u{1ff71}', baseMipLevel: 3});
+let renderBundle47 = renderBundleEncoder21.finish({label: '\u2040\u005f\ue0d2\u96ab\u{1f629}\u{1ffd3}\udb12\u39c0\uc8cf\u{1f94f}\u02a0'});
+try {
+renderBundleEncoder37.setPipeline(pipeline35);
+} catch {}
+try {
+renderBundleEncoder37.setVertexBuffer(3409, undefined, 3416758922, 374115316);
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(buffer12, 796, buffer6, 34092, 13728);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer6);
+} catch {}
+let imageBitmap17 = await createImageBitmap(videoFrame2);
+let commandBuffer13 = commandEncoder53.finish({label: '\ud2b6\uecff\u{1fa55}\u397c'});
+let texture45 = device0.createTexture({
+  label: '\ub6f0\u6cd5\u02ad\u4261\ud111\u08f0\u041a',
+  size: {width: 960, height: 480, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'r16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView76 = texture21.createView({
+  label: '\ua45d\ud0de\u4fa2\u{1fbe0}\u{1f6ac}',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 348,
+  arrayLayerCount: 139,
+});
+try {
+renderBundleEncoder14.setVertexBuffer(4673, undefined);
+} catch {}
+try {
+commandEncoder58.copyBufferToTexture({
+  /* bytesInLastRow: 136 widthInBlocks: 17 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 36856 */
+  offset: 36856,
+  buffer: buffer15,
+}, {
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 17, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer15);
+} catch {}
+let offscreenCanvas8 = new OffscreenCanvas(16, 984);
+try {
+offscreenCanvas7.getContext('bitmaprenderer');
+} catch {}
+let commandBuffer14 = commandEncoder58.finish({label: '\u824b\u0bd4\u{1f79f}\u0bfa\u829f\u3a89\u{1f881}'});
+let textureView77 = texture4.createView({label: '\u{1fcf1}\u094d\uee28', mipLevelCount: 2});
+let sampler39 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'clamp-to-edge', lodMinClamp: 21.86});
+let externalTexture38 = device0.importExternalTexture({source: video10, colorSpace: 'srgb'});
+try {
+computePassEncoder8.setPipeline(pipeline27);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer11, 'uint32', 12780, 1364);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline38);
+} catch {}
+try {
+commandEncoder63.clearBuffer(buffer22, 20536, 2160);
+dissociateBuffer(device0, buffer22);
+} catch {}
+try {
+commandEncoder57.resolveQuerySet(querySet15, 931, 521, buffer1, 73728);
+} catch {}
+let pipeline43 = device0.createComputePipeline({
+  label: '\u{1f684}\u85fa\u0a3e\u15c7\u017d\u0bff\u{1ff85}\u78ed\ued28',
+  layout: pipelineLayout9,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+try {
+offscreenCanvas8.getContext('2d');
+} catch {}
+let commandEncoder68 = device1.createCommandEncoder();
+let texture46 = device1.createTexture({
+  label: '\u7817\uefc5\u3974\uab0f\u{1ff31}\ud095',
+  size: {width: 960, height: 6, depthOrArrayLayers: 911},
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb'],
+});
+let renderPassEncoder4 = commandEncoder46.beginRenderPass({
+  label: '\uc845\u3993\ubcb4\ufa43\uebb4\u{1f71b}\u{1fb25}\u296b\u{1f843}\u8580\u0c8f',
+  colorAttachments: [{
+  view: textureView68,
+  depthSlice: 1061,
+  clearValue: { r: 336.4, g: -567.2, b: -670.8, a: -987.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet5,
+  maxDrawCount: 947309196,
+});
+let renderBundle48 = renderBundleEncoder26.finish();
+try {
+renderPassEncoder1.beginOcclusionQuery(731);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle20, renderBundle33, renderBundle17, renderBundle36, renderBundle1, renderBundle2, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder2.draw(78, 231, 1_766_047_654, 420_207_976);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer19, 1_452_619_845);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(2, bindGroup0, new Uint32Array(9393), 7124, 0);
+} catch {}
+try {
+renderBundleEncoder38.drawIndexedIndirect(buffer8, 95176);
+} catch {}
+try {
+renderBundleEncoder39.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(7415, undefined, 0, 2665807167);
+} catch {}
+try {
+buffer8.destroy();
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline44 = device1.createRenderPipeline({
+  layout: pipelineLayout2,
+  multisample: {count: 4, mask: 0x3bc70576},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'dst'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'less-equal', failOp: 'increment-wrap', depthFailOp: 'increment-wrap'},
+    stencilBack: {compare: 'not-equal', failOp: 'invert', depthFailOp: 'replace', passOp: 'zero'},
+    stencilReadMask: 4126576835,
+    stencilWriteMask: 2162224324,
+    depthBias: 336631758,
+  },
+  vertex: {module: shaderModule1, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+try {
+  await promise13;
+} catch {}
+let querySet41 = device1.createQuerySet({
+  label: '\u0ff9\uf39e\u1860\u904b\u9273\uff89\u9662\u{1f697}\u3f00\u213b',
+  type: 'occlusion',
+  count: 3522,
+});
+let renderBundle49 = renderBundleEncoder36.finish({label: '\uc0d2\uddbe\uf2c8\u07fc\uef29\ufdea\u001d\u038a\ub98f'});
+try {
+renderPassEncoder3.setBlendConstant({ r: -158.1, g: 535.3, b: -542.8, a: 65.54, });
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer18, 615_164_495);
+} catch {}
+try {
+renderBundleEncoder38.draw(68, 22);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexed(393);
+} catch {}
+try {
+commandEncoder7.clearBuffer(buffer24, 144788, 141876);
+dissociateBuffer(device1, buffer24);
+} catch {}
+try {
+commandEncoder61.resolveQuerySet(querySet41, 143, 2461, buffer3, 9728);
+} catch {}
+document.body.prepend(canvas1);
+let commandEncoder69 = device2.createCommandEncoder({label: '\ub5ea\u08b2\u0c69\u0b3a\u66a2\u0771\u8210'});
+let texture47 = device2.createTexture({
+  label: '\u0d45\u0113\uad04\u083a\u0724\u4240\u0d8e\u528d\u7ba6\u0f54',
+  size: [71, 1, 1795],
+  mipLevelCount: 2,
+  format: 'r8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r8unorm', 'r8unorm'],
+});
+let textureView78 = texture22.createView({label: '\ua937\u{1f6a0}\u748b', format: 'rgba8sint'});
+let renderBundle50 = renderBundleEncoder28.finish();
+try {
+commandEncoder20.copyBufferToBuffer(buffer14, 36684, buffer13, 83992, 1884);
+dissociateBuffer(device2, buffer14);
+dissociateBuffer(device2, buffer13);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer0), /* required buffer size: 968 */
+{offset: 936, rowsPerImage: 145}, {width: 8, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let promise15 = device2.queue.onSubmittedWorkDone();
+canvas8.height = 1721;
+let shaderModule12 = device1.createShaderModule({
+  label: '\u{1fdaa}\u64dc\u8ec6\u0612\u675a\u4cc6\u931c\u{1f6b2}',
+  code: `@group(3) @binding(320)
+var<storage, read_write> type3: array<u32>;
+@group(2) @binding(568)
+var<storage, read_write> field3: array<u32>;
+@group(1) @binding(575)
+var<storage, read_write> local8: array<u32>;
+@group(3) @binding(148)
+var<storage, read_write> n5: array<u32>;
+@group(2) @binding(575)
+var<storage, read_write> n6: array<u32>;
+@group(0) @binding(644)
+var<storage, read_write> parameter7: array<u32>;
+
+@compute @workgroup_size(4, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec3<u32>,
+  @builtin(sample_mask) f1: u32,
+  @location(0) f2: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_mask) a1: u32, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S6 {
+  @location(0) f0: vec2<u32>,
+  @location(6) f1: vec2<u32>,
+  @location(3) f2: i32,
+  @location(8) f3: vec3<u32>,
+  @location(10) f4: vec3<i32>,
+  @location(9) f5: f16,
+  @location(5) f6: u32,
+  @location(4) f7: vec3<f16>,
+  @location(12) f8: i32,
+  @location(13) f9: vec2<f16>,
+  @location(14) f10: vec3<i32>
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @builtin(vertex_index) a1: u32, @location(2) a2: vec3<i32>, a3: S6, @location(15) a4: vec4<i32>, @location(1) a5: vec2<u32>, @location(7) a6: vec3<i32>, @location(11) a7: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer25 = device1.createBuffer({size: 28227, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder70 = device1.createCommandEncoder({});
+let externalTexture39 = device1.importExternalTexture({label: '\u0a26\u{1f6b8}\ub589\u{1f92e}\u0d5f\ub851', source: video9});
+try {
+renderPassEncoder2.draw(20);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer25, 87_059_456);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer24, 570_516_164);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(0, bindGroup1, new Uint32Array(8092), 74, 0);
+} catch {}
+try {
+renderBundleEncoder27.draw(237);
+} catch {}
+try {
+renderBundleEncoder39.drawIndexedIndirect(buffer8, 484380);
+} catch {}
+try {
+commandEncoder66.copyBufferToTexture({
+  /* bytesInLastRow: 1896 widthInBlocks: 474 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1236 */
+  offset: 1236,
+  buffer: buffer18,
+}, {
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 474, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer18);
+} catch {}
+try {
+commandEncoder52.clearBuffer(buffer10);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture46,
+  mipLevel: 6,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(new ArrayBuffer(40)), /* required buffer size: 66_047 */
+{offset: 877, bytesPerRow: 98, rowsPerImage: 133}, {width: 6, height: 0, depthOrArrayLayers: 6});
+} catch {}
+let imageBitmap18 = await createImageBitmap(imageBitmap10);
+let imageData15 = new ImageData(68, 84);
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let imageData16 = new ImageData(244, 252);
+let texture48 = device1.createTexture({
+  label: '\ue73c\u2803\u{1fb9c}\u043f\u{1f68f}\ub6bc\u29b6\ueb09\u56bb\ua4eb',
+  size: {width: 480, height: 3, depthOrArrayLayers: 203},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let textureView79 = texture11.createView({label: '\u051b\u00b5\u{1fad9}\u{1fa56}', baseMipLevel: 1});
+let computePassEncoder32 = commandEncoder18.beginComputePass();
+try {
+renderPassEncoder1.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder38.drawIndexed(15, 3, 599_160_886, 238_853_529);
+} catch {}
+try {
+commandEncoder61.copyBufferToBuffer(buffer4, 38792, buffer3, 5908, 9076);
+dissociateBuffer(device1, buffer4);
+dissociateBuffer(device1, buffer3);
+} catch {}
+try {
+commandEncoder10.copyTextureToBuffer({
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 328 widthInBlocks: 82 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 9316 */
+  offset: 9316,
+  buffer: buffer24,
+}, {width: 82, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer24);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline45 = device1.createRenderPipeline({
+  label: '\u0e11\ubcc9\u0de4\u4b40\u{1f881}',
+  layout: pipelineLayout2,
+  fragment: {module: shaderModule12, entryPoint: 'fragment0', constants: {}, targets: [{format: 'bgra8unorm'}]},
+  vertex: {
+    module: shaderModule12,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 128,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 10, shaderLocation: 4},
+          {format: 'sint16x2', offset: 0, shaderLocation: 7},
+          {format: 'uint32x3', offset: 12, shaderLocation: 8},
+          {format: 'sint8x4', offset: 24, shaderLocation: 3},
+          {format: 'sint8x4', offset: 4, shaderLocation: 10},
+          {format: 'sint32', offset: 16, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 38, shaderLocation: 15},
+          {format: 'float32x3', offset: 56, shaderLocation: 9},
+          {format: 'sint32x2', offset: 268, shaderLocation: 2},
+          {format: 'unorm8x4', offset: 876, shaderLocation: 13},
+          {format: 'uint32', offset: 212, shaderLocation: 5},
+          {format: 'uint8x4', offset: 248, shaderLocation: 0},
+          {format: 'uint32x3', offset: 68, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 456,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32', offset: 16, shaderLocation: 14}],
+      },
+      {
+        arrayStride: 312,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 14, shaderLocation: 11},
+          {format: 'uint32x4', offset: 32, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', cullMode: 'back', unclippedDepth: true},
+});
+let commandEncoder71 = device0.createCommandEncoder({label: '\u0982\u{1f63a}\u1399\u0efa\u0b3a\u287d\u{1fa80}\u07c7\ua5cf\u1b85\ucd5a'});
+let textureView80 = texture18.createView({baseArrayLayer: 17, arrayLayerCount: 5});
+let computePassEncoder33 = commandEncoder50.beginComputePass({label: '\ue7ed\u3923\u01ae'});
+try {
+renderBundleEncoder14.setBindGroup(3, bindGroup7);
+} catch {}
+let texture49 = device0.createTexture({
+  label: '\u{1f7af}\udb61\u303b\uff8c',
+  size: [480],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint'],
+});
+let textureView81 = texture44.createView({
+  label: '\u4b3c\u{1f9c8}\u{1f947}\uf97f\u{1fab8}\u9d00\u{1f996}\u89f1\u1611\u0fc8\ubcb4',
+  dimension: '2d-array',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+  baseArrayLayer: 0,
+});
+let externalTexture40 = device0.importExternalTexture({label: '\u04ad\u7d08\u{1ff0a}', source: video0, colorSpace: 'display-p3'});
+try {
+computePassEncoder30.end();
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(5, bindGroup6);
+} catch {}
+try {
+commandEncoder63.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3440 */
+  offset: 3440,
+  buffer: buffer21,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer21);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer0), /* required buffer size: 31_534 */
+{offset: 111, bytesPerRow: 311, rowsPerImage: 101}, {width: 3, height: 1, depthOrArrayLayers: 2});
+} catch {}
+let pipeline46 = device0.createComputePipeline({
+  label: '\u0064\u0801\uec5c\u6561\u120f\ud985\u3e08\u{1f7b8}\u1847',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+let shaderModule13 = device0.createShaderModule({
+  label: '\u9661\ue1b1\ub8ea\u3ce6\u14ea\u3180\u0c0e\u5a42\u030b',
+  code: `@group(1) @binding(1456)
+var<storage, read_write> field4: array<u32>;
+@group(2) @binding(5002)
+var<storage, read_write> type4: array<u32>;
+
+@compute @workgroup_size(3, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(2) f1: vec2<u32>,
+  @location(3) f2: vec4<u32>,
+  @location(0) f3: vec4<u32>,
+  @location(1) f4: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S7 {
+  @location(11) f0: vec2<f16>,
+  @location(4) f1: vec2<f32>,
+  @location(19) f2: vec2<i32>,
+  @builtin(vertex_index) f3: u32,
+  @location(13) f4: vec4<u32>,
+  @location(16) f5: vec2<i32>,
+  @location(1) f6: vec2<f32>,
+  @location(7) f7: i32,
+  @builtin(instance_index) f8: u32,
+  @location(10) f9: vec2<f32>,
+  @location(8) f10: vec4<f32>,
+  @location(2) f11: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec2<f32>, @location(15) a1: vec3<f16>, @location(20) a2: f32, a3: S7, @location(5) a4: vec2<u32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let commandEncoder72 = device0.createCommandEncoder({label: '\u{1ffc2}\u0717\u0a43\u0818\u05d0\u{1fc07}\u81c0\u{1f853}'});
+let querySet42 = device0.createQuerySet({label: '\u{1f837}\u9b6c\ufb15\u{1f933}\u4cdc\uc19f\uf509\u0303', type: 'occlusion', count: 3714});
+let texture50 = device0.createTexture({
+  label: '\u20b6\u{1fe8c}\ubcab\uaa14\u0eb1\ua890\u211b\ueea8\u45c8\u{1fc00}\u50f8',
+  size: [120, 60, 860],
+  mipLevelCount: 7,
+  sampleCount: 1,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundle51 = renderBundleEncoder8.finish({label: '\u{1f9a5}\u6e04\u0225\ub373\u65f7'});
+try {
+renderBundleEncoder35.setBindGroup(6, bindGroup2, new Uint32Array(483), 342, 0);
+} catch {}
+try {
+renderBundleEncoder40.draw(2, 90, 194_202_963);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(174, 364, 27_095_849, 320_534_925, 854_469_046);
+} catch {}
+let promise16 = device0.popErrorScope();
+try {
+buffer16.unmap();
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(buffer9, 17460, buffer6, 20788, 10084);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 3,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 995_216 */
+{offset: 972, bytesPerRow: 269, rowsPerImage: 264}, {width: 10, height: 1, depthOrArrayLayers: 15});
+} catch {}
+let pipelineLayout14 = device1.createPipelineLayout({label: '\u{1fd7a}\u038e\u{1fa60}', bindGroupLayouts: [bindGroupLayout2]});
+let querySet43 = device1.createQuerySet({label: '\ue9e7\ud636\u0ed3\u45a9\uc696', type: 'occlusion', count: 3168});
+let textureView82 = texture17.createView({aspect: 'all', baseMipLevel: 3, mipLevelCount: 1});
+let computePassEncoder34 = commandEncoder10.beginComputePass({});
+let renderPassEncoder5 = commandEncoder31.beginRenderPass({
+  label: '\u040a\u08ef\u3bfc\ucd66',
+  colorAttachments: [{
+  view: textureView82,
+  depthSlice: 113,
+  clearValue: { r: 733.3, g: 3.306, b: 526.6, a: -172.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet39,
+});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup11, new Uint32Array(7309), 3964, 0);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(399);
+} catch {}
+try {
+renderPassEncoder1.draw(250, 35, 424_076_499, 286_446_857);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer10, 21_624_641);
+} catch {}
+try {
+renderBundleEncoder38.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder38.draw(45);
+} catch {}
+try {
+renderBundleEncoder27.drawIndirect(buffer8, 16000);
+} catch {}
+try {
+commandEncoder52.copyTextureToTexture({
+  texture: texture25,
+  mipLevel: 4,
+  origin: {x: 3, y: 0, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture46,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 96},
+  aspect: 'all',
+},
+{width: 43, height: 0, depthOrArrayLayers: 99});
+} catch {}
+try {
+renderBundleEncoder27.insertDebugMarker('\u9a35');
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let shaderModule14 = device0.createShaderModule({
+  label: '\u1a48\u2c0e\u0c58\u{1fdd8}\u1c5e\ue2b7\ua360',
+  code: `@group(2) @binding(5002)
+var<storage, read_write> field5: array<u32>;
+@group(2) @binding(3465)
+var<storage, read_write> global5: array<u32>;
+
+@compute @workgroup_size(4, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S8 {
+  @builtin(position) f0: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec4<u32>,
+  @location(0) f1: vec4<u32>,
+  @location(1) f2: vec4<u32>,
+  @location(3) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(front_facing) a1: bool, a2: S8, @builtin(sample_mask) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(1) a0: vec2<f16>, @location(9) a1: vec4<f32>, @location(5) a2: vec4<f32>, @builtin(instance_index) a3: u32, @location(3) a4: f16, @location(13) a5: vec4<i32>, @location(6) a6: vec3<i32>, @location(17) a7: vec2<f16>, @location(16) a8: f16, @location(4) a9: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture51 = device0.createTexture({
+  label: '\u{1f9c0}\u2643\u20ef\u{1f873}\uee39\u7972\ud55a\u5177\ub30d',
+  size: [240],
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint'],
+});
+let renderBundle52 = renderBundleEncoder33.finish({label: '\u79c4\u49f7\u{1fa2a}\u8594\u96f8\uc5ab\u424c\udfe5\uff03'});
+let externalTexture41 = device0.importExternalTexture({source: videoFrame9, colorSpace: 'srgb'});
+try {
+buffer7.destroy();
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(buffer15, 244520, buffer22, 1144, 13368);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer22);
+} catch {}
+try {
+commandEncoder49.clearBuffer(buffer16);
+dissociateBuffer(device0, buffer16);
+} catch {}
+let pipeline47 = device0.createRenderPipeline({
+  layout: pipelineLayout5,
+  multisample: {count: 4, mask: 0xfceca17d},
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba8uint'}, {format: 'r16uint', writeMask: 0}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'less', failOp: 'increment-clamp', passOp: 'decrement-clamp'},
+    stencilBack: {
+      compare: 'not-equal',
+      failOp: 'increment-clamp',
+      depthFailOp: 'increment-wrap',
+      passOp: 'increment-clamp',
+    },
+    stencilReadMask: 2726157425,
+    stencilWriteMask: 4294967295,
+    depthBiasClamp: 3.869118494552751,
+  },
+  vertex: {module: shaderModule4, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', unclippedDepth: true},
+});
+let commandEncoder73 = device1.createCommandEncoder({label: '\u08e3\u0446\uc5ce\u{1f7dc}\u5673\u28ec\u035e\uf9c9'});
+let computePassEncoder35 = commandEncoder64.beginComputePass();
+let sampler40 = device1.createSampler({
+  label: '\u{1f753}\u{1f6f5}\u0f5c\u050d\u0483\u{1f7ec}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 90.89,
+});
+try {
+renderPassEncoder5.setVertexBuffer(5754, undefined, 1066938915);
+} catch {}
+try {
+renderBundleEncoder39.draw(447, 34, 521_706_300);
+} catch {}
+try {
+renderBundleEncoder39.drawIndirect(buffer8, 23096);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline12);
+} catch {}
+let pipeline48 = await device1.createComputePipelineAsync({
+  label: '\udfd2\u{1fb5d}\ua52f\ub95b\u07ac\u6601\u0af2\u0f5a',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+let promise17 = device1.createRenderPipelineAsync({
+  label: '\u{1f944}\u{1fe08}\u0dbe\u{1ffa8}\ub2dd\u7854\u70af\u0a40',
+  layout: 'auto',
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less',
+    stencilFront: {compare: 'equal', failOp: 'invert', passOp: 'increment-clamp'},
+    stencilBack: {failOp: 'replace', depthFailOp: 'decrement-wrap', passOp: 'increment-clamp'},
+    stencilReadMask: 2725776724,
+    stencilWriteMask: 2868376969,
+    depthBiasSlopeScale: -37.777081746351115,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 596, attributes: [{format: 'unorm8x2', offset: 44, shaderLocation: 5}]},
+      {arrayStride: 1028, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 400,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32x4', offset: 60, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 144, shaderLocation: 2},
+          {format: 'sint16x2', offset: 12, shaderLocation: 10},
+          {format: 'float16x4', offset: 0, shaderLocation: 7},
+        ],
+      },
+      {arrayStride: 868, attributes: [{format: 'unorm16x4', offset: 132, shaderLocation: 8}]},
+    ],
+  },
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+try {
+  await promise16;
+} catch {}
+let buffer26 = device0.createBuffer({
+  label: '\u0b34\u3820',
+  size: 33237,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+});
+let texture52 = device0.createTexture({
+  size: [120],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView83 = texture23.createView({baseMipLevel: 1, mipLevelCount: 2, baseArrayLayer: 54, arrayLayerCount: 72});
+try {
+renderBundleEncoder40.drawIndexed(19, 92, 1_145_270_476, -1_951_601_087, 742_091_485);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer26, 4924);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+let promise18 = buffer17.mapAsync(GPUMapMode.WRITE, 0, 13624);
+try {
+commandEncoder55.copyBufferToBuffer(buffer9, 34660, buffer6, 18040, 1396);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder67.resolveQuerySet(querySet31, 1011, 978, buffer1, 43008);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 2012, new BigUint64Array(44394), 14714, 180);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 1,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer3), /* required buffer size: 39_882 */
+{offset: 422, bytesPerRow: 432, rowsPerImage: 72}, {width: 37, height: 20, depthOrArrayLayers: 2});
+} catch {}
+let promise19 = device0.createComputePipelineAsync({
+  label: '\u7218\u0ff6\u7d71\u7f8d\u7d99',
+  layout: pipelineLayout12,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+let shaderModule15 = device0.createShaderModule({
+  label: '\u4952\u0235\u64d0\u1253\u6dd4\u7d2f\u0411\u{1f622}\u0974',
+  code: `@group(5) @binding(5002)
+var<storage, read_write> type5: array<u32>;
+@group(8) @binding(1456)
+var<storage, read_write> field6: array<u32>;
+@group(7) @binding(4645)
+var<storage, read_write> n7: array<u32>;
+@group(7) @binding(5002)
+var<storage, read_write> type6: array<u32>;
+@group(7) @binding(3465)
+var<storage, read_write> n8: array<u32>;
+@group(5) @binding(4645)
+var<storage, read_write> n9: array<u32>;
+@group(6) @binding(1456)
+var<storage, read_write> local9: array<u32>;
+@group(5) @binding(3465)
+var<storage, read_write> field7: array<u32>;
+
+@compute @workgroup_size(5, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<u32>,
+  @location(4) f1: vec2<f32>,
+  @location(0) f2: vec4<u32>,
+  @location(3) f3: vec4<u32>,
+  @location(7) f4: vec3<f32>,
+  @location(2) f5: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(sample_mask) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S9 {
+  @location(3) f0: f32,
+  @location(6) f1: vec3<f32>,
+  @builtin(vertex_index) f2: u32,
+  @location(12) f3: vec3<f16>,
+  @location(11) f4: vec4<i32>,
+  @location(8) f5: vec4<f16>,
+  @location(16) f6: vec3<i32>,
+  @location(7) f7: vec3<f32>,
+  @location(9) f8: vec4<u32>,
+  @location(4) f9: u32,
+  @location(1) f10: vec2<f16>,
+  @location(20) f11: vec3<u32>,
+  @location(18) f12: f32
+}
+
+@vertex
+fn vertex0(a0: S9, @location(15) a1: vec2<f32>, @builtin(instance_index) a2: u32, @location(2) a3: f16, @location(19) a4: vec3<u32>, @location(0) a5: u32, @location(5) a6: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder74 = device0.createCommandEncoder({});
+let textureView84 = texture38.createView({label: '\u4eb4\u{1fbfc}\u00bd\u00f2', baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 1});
+try {
+commandEncoder63.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 3,
+  origin: {x: 14, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture37,
+  mipLevel: 1,
+  origin: {x: 179, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder44.clearBuffer(buffer22, 1900, 18224);
+dissociateBuffer(device0, buffer22);
+} catch {}
+let commandEncoder75 = device0.createCommandEncoder({});
+let querySet44 = device0.createQuerySet({label: '\u0155\u758a\u0d8d\uafad\u0ea8\u59cf', type: 'occlusion', count: 532});
+let textureView85 = texture49.createView({label: '\ud73c\u{1ff43}', baseArrayLayer: 0});
+let renderBundle53 = renderBundleEncoder35.finish({label: '\u6b94\u{1f734}\u229d\u7c4d\u{1f9e9}'});
+try {
+renderBundleEncoder40.draw(70, 138, 196_499_236, 1_147_891_127);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer26, 19324);
+} catch {}
+try {
+commandEncoder72.copyTextureToTexture({
+  texture: texture36,
+  mipLevel: 5,
+  origin: {x: 9, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 87},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 14});
+} catch {}
+try {
+commandEncoder72.resolveQuerySet(querySet40, 2855, 25, buffer1, 141312);
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let commandEncoder76 = device1.createCommandEncoder({});
+let renderBundleEncoder42 = device1.createRenderBundleEncoder({label: '\u{1fafd}\u8673\u9d94\uc114', colorFormats: ['bgra8unorm'], depthReadOnly: true});
+let sampler41 = device1.createSampler({
+  label: '\u{1fb29}\u{1fb1a}\u0a96',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 46.40,
+  lodMaxClamp: 97.09,
+});
+let externalTexture42 = device1.importExternalTexture({
+  label: '\ub959\u{1fddb}\u011b\u9737\u0cdf\u{1f876}\u499a\u5a40\uf026',
+  source: video5,
+  colorSpace: 'display-p3',
+});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup1, new Uint32Array(2923), 894, 0);
+} catch {}
+try {
+renderPassEncoder4.setBlendConstant({ r: 936.0, g: -450.8, b: 95.65, a: 539.6, });
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(156, 80, 881_931_221, 70_943_192, 1_466_938_756);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(3830, undefined, 0, 682152217);
+} catch {}
+try {
+renderBundleEncoder41.setPipeline(pipeline10);
+} catch {}
+try {
+commandEncoder28.copyBufferToBuffer(buffer18, 398672, buffer25, 7552, 292);
+dissociateBuffer(device1, buffer18);
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+commandEncoder70.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 37188 */
+  offset: 37184,
+  rowsPerImage: 180,
+  buffer: buffer18,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer18);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer2), /* required buffer size: 905 */
+{offset: 905, rowsPerImage: 0}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = commandEncoder37.label;
+} catch {}
+let commandEncoder77 = device1.createCommandEncoder();
+let commandBuffer15 = commandEncoder47.finish({});
+let textureView86 = texture2.createView({dimension: '2d', mipLevelCount: 3, baseArrayLayer: 91});
+let computePassEncoder36 = commandEncoder68.beginComputePass({label: '\ud9ff\u{1f846}\uf8b4\u314f\u0f75'});
+let renderPassEncoder6 = commandEncoder70.beginRenderPass({
+  label: '\u976f\u2a66\u0360\u{1fa05}\u36e5\u0992\u6112\uae01\u0457\u5f0e\u6a7a',
+  colorAttachments: [{
+  view: textureView68,
+  depthSlice: 417,
+  clearValue: { r: 343.3, g: -434.9, b: -810.1, a: 591.0, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet25,
+  maxDrawCount: 942242171,
+});
+try {
+computePassEncoder36.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(536);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle11]);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(140, 0, 61, 0);
+} catch {}
+try {
+renderPassEncoder1.draw(69);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(254, 35, 668_701_330, 326_909_817, 153_761_842);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer5, 1_419_071_187);
+} catch {}
+try {
+renderBundleEncoder11.setBindGroup(2, bindGroup4, new Uint32Array(605), 245, 0);
+} catch {}
+try {
+renderBundleEncoder39.drawIndexed(170);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(9998, undefined);
+} catch {}
+let commandEncoder78 = device1.createCommandEncoder({label: '\u{1fa49}\u{1f6b5}\u83f9\uc31b'});
+let textureView87 = texture41.createView({label: '\u6830\u{1f7e6}\u0087\u{1fcd4}\u{1fef7}'});
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle22, renderBundle29, renderBundle22, renderBundle29, renderBundle1, renderBundle39, renderBundle20]);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(283, 130, 3_592_577_265, 193_609_744, 533_001_522);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexed(227, 50, 130_952_101, 102_663_044, 397_888_843);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(376, undefined, 884161222, 225934963);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder76.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5880 */
+  offset: 5880,
+  bytesPerRow: 256,
+  buffer: buffer18,
+}, {
+  texture: texture43,
+  mipLevel: 6,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 20, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer18);
+} catch {}
+try {
+commandEncoder28.clearBuffer(buffer5, 92516, 102968);
+dissociateBuffer(device1, buffer5);
+} catch {}
+let promise20 = device1.createRenderPipelineAsync({
+  label: '\ubed5\u78a0\u{1f815}\uab65',
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'equal', failOp: 'increment-clamp', depthFailOp: 'increment-wrap'},
+    stencilBack: {failOp: 'replace', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilWriteMask: 2371417584,
+    depthBias: 0,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 476,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 364, shaderLocation: 8},
+          {format: 'sint16x2', offset: 96, shaderLocation: 10},
+        ],
+      },
+      {arrayStride: 312, attributes: [{format: 'float32', offset: 80, shaderLocation: 5}]},
+      {arrayStride: 48, attributes: [{format: 'float16x2', offset: 24, shaderLocation: 11}]},
+      {
+        arrayStride: 212,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 84, shaderLocation: 7},
+          {format: 'float16x2', offset: 0, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let commandEncoder79 = device1.createCommandEncoder();
+let texture53 = device1.createTexture({
+  label: '\ub9e4\u0dc0',
+  size: {width: 960},
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm-srgb'],
+});
+let textureView88 = texture43.createView({label: '\u09b0\u{1f773}\ue240\ue7b6\u071c\uafd7', baseMipLevel: 9});
+let renderBundleEncoder43 = device1.createRenderBundleEncoder({colorFormats: ['bgra8unorm'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder3.setBlendConstant({ r: 510.7, g: -303.2, b: -497.0, a: -735.9, });
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(3, 11, 435_548_787, -2_088_064_248, 1_300_623_462);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer18, 2_047_221_165);
+} catch {}
+try {
+renderBundleEncoder39.drawIndirect(buffer8, 215000);
+} catch {}
+try {
+commandEncoder28.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture43,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder28.resolveQuerySet(querySet43, 2885, 30, buffer3, 14848);
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\ufc66');
+} catch {}
+let pipeline49 = device1.createComputePipeline({
+  label: '\u{1fd68}\u001a\u5434',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule11, entryPoint: 'compute0', constants: {}},
+});
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let bindGroupLayout16 = device0.createBindGroupLayout({label: '\u3d3e\u01b0\u0930\u0e13\udcbf\u696d\u{1ff87}\uc4a7\u0a0d\u03c7\ud9f2', entries: []});
+let querySet45 = device0.createQuerySet({type: 'occlusion', count: 677});
+let texture54 = device0.createTexture({
+  label: '\u6e67\ud6f4\u{1fff8}\u7326\u53b8',
+  size: [624],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16sint', 'rgba16sint', 'rgba16sint'],
+});
+let textureView89 = texture9.createView({
+  label: '\u00e6\ude65\ucc97\u0448\u{1f6c1}\u7df3\u25f5\u0787',
+  baseMipLevel: 2,
+  mipLevelCount: 2,
+  baseArrayLayer: 0,
+});
+try {
+computePassEncoder9.setPipeline(pipeline32);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer26, 3648);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline35);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline50 = device0.createComputePipeline({
+  label: '\u3492\u0b4c\u{1fd37}\u4c43\ua435\ub277\u52be\u057f\u0005',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule13, entryPoint: 'compute0'},
+});
+try {
+  await promise18;
+} catch {}
+let commandEncoder80 = device1.createCommandEncoder({label: '\u7d52\uacc4\u0c8a\u{1fc14}'});
+try {
+renderBundleEncoder38.drawIndexed(41, 224, 667_937_354, -1_123_032_243, 199_508_938);
+} catch {}
+try {
+renderBundleEncoder11.drawIndirect(buffer8, 21156);
+} catch {}
+try {
+renderBundleEncoder38.setVertexBuffer(1713, undefined, 1593294123);
+} catch {}
+try {
+commandEncoder52.copyTextureToBuffer({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 55836 */
+  offset: 55836,
+  buffer: buffer24,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer24);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer3, 5000, new BigUint64Array(57694), 8712, 208);
+} catch {}
+let pipeline51 = await device1.createComputePipelineAsync({
+  label: '\u0d4b\u6958',
+  layout: pipelineLayout14,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+offscreenCanvas4.width = 83;
+let imageBitmap19 = await createImageBitmap(imageData10);
+try {
+  await adapter2.requestAdapterInfo();
+} catch {}
+let texture55 = device1.createTexture({
+  label: '\u{1fca6}\u08ea\u0985',
+  size: [960, 6, 1929],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm-srgb'],
+});
+let renderPassEncoder7 = commandEncoder79.beginRenderPass({
+  label: '\u0355\u067d\u91dc\ue94e',
+  colorAttachments: [{view: textureView68, depthSlice: 348, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet23,
+  maxDrawCount: 1197203432,
+});
+try {
+computePassEncoder5.setPipeline(pipeline16);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(1663);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(7712, undefined, 0, 2300996125);
+} catch {}
+try {
+renderBundleEncoder39.draw(122);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexedIndirect(buffer8, 278532);
+} catch {}
+try {
+renderBundleEncoder42.setPipeline(pipeline45);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 960, height: 6, depthOrArrayLayers: 209}
+*/
+{
+  source: offscreenCanvas0,
+  origin: { x: 455, y: 25 },
+  flipY: false,
+}, {
+  texture: texture25,
+  mipLevel: 1,
+  origin: {x: 41, y: 0, z: 65},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap20 = await createImageBitmap(imageBitmap18);
+let imageBitmap21 = await createImageBitmap(canvas2);
+try {
+  await promise14;
+} catch {}
+let imageData17 = new ImageData(172, 148);
+let buffer27 = device1.createBuffer({label: '\ud486\u4510', size: 38186, usage: GPUBufferUsage.VERTEX});
+let querySet46 = device1.createQuerySet({label: '\u1e15\u0437\u0bf6\u8712\uec56', type: 'occlusion', count: 2474});
+let textureView90 = texture42.createView({
+  label: '\u4f16\u6052\u01e8\u008e\u{1fcc5}\ubefd\u1143\uf96e\uaf94\u85a7\u0648',
+  dimension: '2d-array',
+  format: 'bgra8unorm-srgb',
+  baseArrayLayer: 0,
+});
+try {
+computePassEncoder23.setBindGroup(3, bindGroup1, new Uint32Array(6368), 1335, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer23, 252_570_097);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer18, 175_552_964);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder39.draw(267, 133, 310_639_939);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexed(258, 42, 1_564_792_447, 68_803_567, 93_969_751);
+} catch {}
+try {
+renderBundleEncoder11.drawIndirect(buffer8, 43716);
+} catch {}
+try {
+  await buffer24.mapAsync(GPUMapMode.READ, 75728, 123780);
+} catch {}
+try {
+commandEncoder78.copyBufferToBuffer(buffer8, 432544, buffer2, 16940, 2568);
+dissociateBuffer(device1, buffer8);
+dissociateBuffer(device1, buffer2);
+} catch {}
+try {
+commandEncoder61.clearBuffer(buffer24, 300752, 44332);
+dissociateBuffer(device1, buffer24);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+  await promise15;
+} catch {}
+let bindGroup15 = device1.createBindGroup({label: '\u0b8d\u4c5a', layout: bindGroupLayout3, entries: []});
+let commandEncoder81 = device1.createCommandEncoder({label: '\u314d\u0955\ud271\u4d58\ufb16'});
+let renderPassEncoder8 = commandEncoder52.beginRenderPass({
+  label: '\u6142\u{1fa17}\u2f8f\u4be6\u03d4\u06f3\u{1f613}\u7daa',
+  colorAttachments: [{view: textureView88, depthSlice: 0, loadOp: 'clear', storeOp: 'store'}],
+  maxDrawCount: 1072925015,
+});
+let renderBundle54 = renderBundleEncoder22.finish({label: '\u{1fdda}\u0600\ufe59\udeb1\u0d71\u05d4\u1b9a\ue2a8'});
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder6.beginOcclusionQuery(592);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(2, 1, 26, 0);
+} catch {}
+try {
+renderPassEncoder1.draw(86);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer2, 1_962_255_989);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer5, 53_614_469);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline21);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(1, buffer27, 11500, 12547);
+} catch {}
+try {
+  await device1.popErrorScope();
+} catch {}
+canvas4.width = 734;
+let querySet47 = device0.createQuerySet({label: '\u{1f9c5}\u0371\ud521\u056c\u028a', type: 'occlusion', count: 1998});
+let commandBuffer16 = commandEncoder49.finish({label: '\uec61\u7cec\u8aa5\ud1d7\u{1f65f}\u2caf\ud1ee\u07b6\u0bad\u{1ff99}'});
+try {
+renderBundleEncoder14.setBindGroup(7, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer26, 3400);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer26, 6380);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline38);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(755, undefined, 0);
+} catch {}
+try {
+commandEncoder44.copyTextureToTexture({
+  texture: texture50,
+  mipLevel: 2,
+  origin: {x: 0, y: 1, z: 71},
+  aspect: 'all',
+},
+{
+  texture: texture50,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder72.resolveQuerySet(querySet42, 2119, 1577, buffer1, 76800);
+} catch {}
+let promise21 = device0.createComputePipelineAsync({
+  label: '\u09a2\u0ed5\u05ca\u{1f99a}\ua52c\ubed3\u07ce\u94cc\u{1fd60}',
+  layout: pipelineLayout7,
+  compute: {module: shaderModule13, entryPoint: 'compute0', constants: {}},
+});
+let pipeline52 = device0.createRenderPipeline({
+  label: '\uef56\u8a28\u04bd\u08aa\u{1fbad}\u0120\u006c\u080d\u2d13\u4fb5',
+  layout: 'auto',
+  multisample: {count: 4, mask: 0x931e2f8c},
+  fragment: {
+  module: shaderModule13,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {
+      compare: 'greater-equal',
+      failOp: 'decrement-clamp',
+      depthFailOp: 'decrement-clamp',
+      passOp: 'increment-clamp',
+    },
+    stencilBack: {compare: 'greater', failOp: 'replace', depthFailOp: 'invert', passOp: 'replace'},
+    stencilWriteMask: 3081662297,
+    depthBias: -340484338,
+  },
+  vertex: {
+    module: shaderModule13,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 7004,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 152, shaderLocation: 7},
+          {format: 'float32x4', offset: 6052, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 2204, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 2836,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 200, shaderLocation: 10},
+          {format: 'uint32x4', offset: 564, shaderLocation: 13},
+          {format: 'sint32x4', offset: 592, shaderLocation: 19},
+          {format: 'snorm8x2', offset: 2260, shaderLocation: 15},
+          {format: 'float16x4', offset: 64, shaderLocation: 8},
+          {format: 'unorm16x2', offset: 208, shaderLocation: 6},
+          {format: 'uint32x2', offset: 68, shaderLocation: 5},
+          {format: 'sint8x2', offset: 136, shaderLocation: 16},
+          {format: 'snorm8x2', offset: 666, shaderLocation: 20},
+          {format: 'snorm16x2', offset: 256, shaderLocation: 4},
+          {format: 'uint16x2', offset: 316, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+let bindGroup16 = device1.createBindGroup({
+  label: '\u0f2c\u{1fb74}\u53b2\u9e73\u286b\u054f\u{1f9ef}\u05df\ucab3\u0d4c\u003a',
+  layout: bindGroupLayout2,
+  entries: [{binding: 644, resource: externalTexture42}],
+});
+let buffer28 = device1.createBuffer({
+  label: '\u1bf9\u018a\u{1fec1}\u0d6f\ufeec\u49b4\u248e\u{1f6e3}\uf526',
+  size: 62938,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let renderBundle55 = renderBundleEncoder18.finish();
+let externalTexture43 = device1.importExternalTexture({label: '\u{1fb80}\u70ff\u01d4\ua76e', source: video9, colorSpace: 'srgb'});
+try {
+renderPassEncoder3.setViewport(195.0, 0.1308, 37.15, 0.09329, 0.02658, 0.03613);
+} catch {}
+try {
+renderPassEncoder2.draw(102, 19, 996_487_232);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(29, 292, 543_133_253, 666_543_708, 2_083_688_196);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer3, 2_086_134_141);
+} catch {}
+try {
+renderBundleEncoder39.drawIndirect(buffer8, 187636);
+} catch {}
+try {
+renderBundleEncoder41.setPipeline(pipeline45);
+} catch {}
+try {
+commandEncoder61.copyBufferToBuffer(buffer18, 137676, buffer25, 22644, 3796);
+dissociateBuffer(device1, buffer18);
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+commandEncoder66.copyBufferToTexture({
+  /* bytesInLastRow: 1876 widthInBlocks: 469 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 16172 */
+  offset: 16172,
+  buffer: buffer8,
+}, {
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 469, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer25, 2848, new Float32Array(33018), 11900, 1640);
+} catch {}
+let pipeline53 = device1.createRenderPipeline({
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 516,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 0, shaderLocation: 10},
+          {format: 'unorm8x2', offset: 26, shaderLocation: 14},
+          {format: 'snorm8x2', offset: 4, shaderLocation: 4},
+          {format: 'float16x4', offset: 24, shaderLocation: 5},
+          {format: 'uint8x2', offset: 88, shaderLocation: 15},
+          {format: 'snorm16x2', offset: 68, shaderLocation: 2},
+          {format: 'snorm16x4', offset: 12, shaderLocation: 7},
+        ],
+      },
+      {arrayStride: 56, attributes: [{format: 'snorm16x2', offset: 4, shaderLocation: 0}]},
+      {
+        arrayStride: 464,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x4', offset: 20, shaderLocation: 11}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'none', unclippedDepth: true},
+});
+let imageBitmap22 = await createImageBitmap(canvas8);
+let bindGroup17 = device1.createBindGroup({
+  label: '\u07f1\u01ef\u99a3\u77b3\u9165\u{1fc8a}\u5a02\u009d\u0f59',
+  layout: bindGroupLayout2,
+  entries: [{binding: 644, resource: externalTexture17}],
+});
+let renderBundleEncoder44 = device1.createRenderBundleEncoder({label: '\u91c0\u08b9\u{1f6db}\u2d4b\ud207\u{1f76b}', colorFormats: ['bgra8unorm'], sampleCount: 1});
+let renderBundle56 = renderBundleEncoder44.finish({label: '\uf8e6\u5ad9\u0590\u6b05\u0b53'});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup3, new Uint32Array(4583), 1155, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(238, 115, 148_390_893);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer20, 935_721_365);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer27, 0, 19276);
+} catch {}
+try {
+renderBundleEncoder38.drawIndexed(357, 110, 265_109_430, 69_197_160, 1_569_120_702);
+} catch {}
+let promise22 = buffer23.mapAsync(GPUMapMode.WRITE, 0, 4440);
+try {
+commandEncoder76.copyBufferToTexture({
+  /* bytesInLastRow: 1416 widthInBlocks: 354 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 27324 */
+  offset: 27324,
+  bytesPerRow: 1792,
+  buffer: buffer8,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 354, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 76, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 3},
+  aspect: 'all',
+},
+{width: 98, height: 1, depthOrArrayLayers: 7});
+} catch {}
+try {
+commandEncoder28.resolveQuerySet(querySet41, 978, 191, buffer3, 20224);
+} catch {}
+let pipeline54 = device1.createRenderPipeline({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater', failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'zero'},
+    stencilBack: {compare: 'not-equal', failOp: 'invert', depthFailOp: 'decrement-wrap', passOp: 'decrement-clamp'},
+    stencilReadMask: 54252381,
+    stencilWriteMask: 3951977716,
+  },
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 476,
+        attributes: [
+          {format: 'unorm16x2', offset: 180, shaderLocation: 2},
+          {format: 'uint16x4', offset: 68, shaderLocation: 10},
+          {format: 'snorm16x4', offset: 48, shaderLocation: 14},
+          {format: 'unorm8x4', offset: 124, shaderLocation: 5},
+          {format: 'sint8x4', offset: 132, shaderLocation: 11},
+          {format: 'uint32', offset: 40, shaderLocation: 15},
+          {format: 'snorm16x4', offset: 108, shaderLocation: 4},
+          {format: 'snorm8x2', offset: 12, shaderLocation: 7},
+        ],
+      },
+      {arrayStride: 1268, attributes: []},
+      {arrayStride: 900, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 72,
+        stepMode: 'instance',
+        attributes: [{format: 'float16x2', offset: 12, shaderLocation: 0}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let bindGroup18 = device1.createBindGroup({
+  label: '\ueeb7\u{1f86b}\u{1f95f}',
+  layout: bindGroupLayout2,
+  entries: [{binding: 644, resource: externalTexture4}],
+});
+let buffer29 = device1.createBuffer({
+  label: '\u15fb\ubd9c\u9d90\uddfa\uebf5\u36d8\u7291\u369a',
+  size: 47370,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let renderPassEncoder9 = commandEncoder76.beginRenderPass({
+  label: '\u{1f63a}\u8efc',
+  colorAttachments: [{
+  view: textureView82,
+  depthSlice: 85,
+  clearValue: { r: -271.0, g: 744.2, b: 691.0, a: -766.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet23,
+  maxDrawCount: 897390064,
+});
+let renderBundleEncoder45 = device1.createRenderBundleEncoder({
+  label: '\u0541\u{1fa6b}\u{1f8bc}\u9c9b\u{1ff62}\u0600\uf7dc\u2f51\u{1fa92}',
+  colorFormats: ['bgra8unorm'],
+});
+let renderBundle57 = renderBundleEncoder45.finish({});
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+renderPassEncoder8.setViewport(2.740, 0.4868, 0.1904, 0.4688, 0.4261, 0.9586);
+} catch {}
+try {
+renderBundleEncoder39.setBindGroup(3, bindGroup3, new Uint32Array(2447), 1755, 0);
+} catch {}
+try {
+renderBundleEncoder11.draw(43, 332, 538_703_839, 1_550_692_335);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexedIndirect(buffer8, 84928);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(0, buffer27, 0);
+} catch {}
+try {
+commandEncoder61.copyBufferToBuffer(buffer4, 12536, buffer2, 12600, 236);
+dissociateBuffer(device1, buffer4);
+dissociateBuffer(device1, buffer2);
+} catch {}
+let pipeline55 = device1.createRenderPipeline({
+  label: '\u92f1\u04d2\u0c58\u0af2\udeda\u02fc\u8497\u07c0\u1ac3\u08bd\u{1fc6c}',
+  layout: pipelineLayout0,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {failOp: 'invert', passOp: 'invert'},
+    stencilBack: {compare: 'greater', failOp: 'invert', depthFailOp: 'invert', passOp: 'zero'},
+    depthBias: 1159272976,
+    depthBiasSlopeScale: 41.910606809379914,
+    depthBiasClamp: 410.80749849529593,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 112,
+        attributes: [
+          {format: 'float16x4', offset: 0, shaderLocation: 2},
+          {format: 'snorm16x2', offset: 44, shaderLocation: 7},
+          {format: 'snorm16x4', offset: 0, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 284,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x2', offset: 74, shaderLocation: 11},
+          {format: 'sint32x3', offset: 24, shaderLocation: 10},
+          {format: 'float32x3', offset: 28, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+});
+let imageData18 = new ImageData(68, 124);
+let querySet48 = device0.createQuerySet({
+  label: '\u079b\u0e77\u{1f7ee}\u1b40\u0093\u{1fed0}\u7193\u2e12\u2393\u0f24\uf404',
+  type: 'occlusion',
+  count: 1150,
+});
+let textureView91 = texture32.createView({label: '\u{1f8dd}\u083d\u64be\u4af1\u0994\u030a\u{1fe18}', baseMipLevel: 0, mipLevelCount: 1});
+let sampler42 = device0.createSampler({
+  label: '\u{1fbf4}\u{1fc29}',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 64.32,
+  lodMaxClamp: 97.03,
+  maxAnisotropy: 7,
+});
+let externalTexture44 = device0.importExternalTexture({source: video6});
+try {
+computePassEncoder12.setPipeline(pipeline46);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer26, 1376);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline38);
+} catch {}
+let arrayBuffer6 = buffer17.getMappedRange(0, 12680);
+try {
+commandEncoder74.copyBufferToTexture({
+  /* bytesInLastRow: 18 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 60920 */
+  offset: 21478,
+  bytesPerRow: 256,
+  rowsPerImage: 154,
+  buffer: buffer15,
+}, {
+  texture: texture20,
+  mipLevel: 6,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 9, height: 1, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(arrayBuffer0), /* required buffer size: 6 */
+{offset: 6}, {width: 108, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+gc();
+try {
+  await promise22;
+} catch {}
+let canvas10 = document.createElement('canvas');
+try {
+canvas10.getContext('webgpu');
+} catch {}
+try {
+window.someLabel = querySet45.label;
+} catch {}
+let texture56 = device0.createTexture({
+  label: '\u5b4d\u{1f667}',
+  size: {width: 480, height: 240, depthOrArrayLayers: 118},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView92 = texture20.createView({label: '\ua2d5\u3bf0\u{1fdd1}\ud6e2', baseMipLevel: 4, mipLevelCount: 1, arrayLayerCount: 1});
+let renderBundleEncoder46 = device0.createRenderBundleEncoder({
+  label: '\uada4\u8079\u0a98\u4cc7\u5d9a\u0c84\u4496\u4427\u0d86\ub856',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  depthReadOnly: true,
+});
+let renderBundle58 = renderBundleEncoder16.finish({label: '\uf777\u02ff\ue5f6\u5015\u{1ffb6}\u05a0\u30f5\ue948'});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup7, new Uint32Array(6676), 3246, 0);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer26, 2316);
+} catch {}
+try {
+commandEncoder55.clearBuffer(buffer16);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder72.resolveQuerySet(querySet45, 664, 5, buffer1, 57600);
+} catch {}
+try {
+adapter4.label = '\u0821\u0385\u0a04\u{1fcba}\u0b4b\uaa7d\u{1fe8e}\u0129\ue8cb\u0dd5';
+} catch {}
+gc();
+let bindGroupLayout17 = device0.createBindGroupLayout({
+  label: '\ua8d6\u{1f7ce}\u87d6\u0232\ub43f\u07b3\ua711\u913f\u0ecc',
+  entries: [
+    {
+      binding: 2105,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+    },
+    {binding: 5146, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+    {
+      binding: 5631,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let buffer30 = device0.createBuffer({label: '\uf185\u{1f614}\ud130\u{1fefa}', size: 401341, usage: GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder82 = device0.createCommandEncoder({label: '\u0d82\u50b1\u{1faa6}'});
+let querySet49 = device0.createQuerySet({label: '\u{1f656}\ude7c\u{1f86d}\u4aa4\u0ad5\u046b\u0991\u{1fc36}', type: 'occlusion', count: 3624});
+let commandBuffer17 = commandEncoder44.finish();
+try {
+texture40.destroy();
+} catch {}
+try {
+commandEncoder72.clearBuffer(buffer16);
+dissociateBuffer(device0, buffer16);
+} catch {}
+let promise23 = device0.createComputePipelineAsync({
+  label: '\uc233\u{1f624}\u0459\uc02b\u{1fc6e}\u{1fa35}\u{1fdfa}\u049f',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+let pipeline56 = await device0.createRenderPipelineAsync({
+  label: '\u42e4\u{1ff70}\u0a89\u6f77\u5d8d\u0b8e\u0d51\ube75\u0ad3',
+  layout: pipelineLayout9,
+  multisample: {count: 4, mask: 0x4b1d118d},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater', failOp: 'increment-clamp', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'greater-equal', failOp: 'zero', depthFailOp: 'decrement-clamp'},
+    stencilReadMask: 3147314370,
+    stencilWriteMask: 2871395544,
+    depthBiasSlopeScale: 976.5652891413592,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 32860,
+        attributes: [
+          {format: 'uint32x3', offset: 3604, shaderLocation: 16},
+          {format: 'snorm8x4', offset: 800, shaderLocation: 2},
+          {format: 'sint32x4', offset: 5364, shaderLocation: 0},
+          {format: 'uint32x4', offset: 360, shaderLocation: 1},
+          {format: 'float32x2', offset: 1360, shaderLocation: 20},
+          {format: 'sint16x2', offset: 1580, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 7180,
+        attributes: [
+          {format: 'float16x4', offset: 2444, shaderLocation: 18},
+          {format: 'sint32', offset: 2992, shaderLocation: 17},
+          {format: 'unorm8x2', offset: 2076, shaderLocation: 10},
+          {format: 'uint32x3', offset: 3104, shaderLocation: 4},
+          {format: 'float16x4', offset: 2100, shaderLocation: 15},
+          {format: 'uint16x2', offset: 672, shaderLocation: 3},
+          {format: 'snorm16x2', offset: 740, shaderLocation: 11},
+          {format: 'float32', offset: 668, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 6404, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 7076,
+        attributes: [
+          {format: 'uint32x2', offset: 1792, shaderLocation: 19},
+          {format: 'uint32', offset: 660, shaderLocation: 5},
+          {format: 'float32x2', offset: 2524, shaderLocation: 8},
+          {format: 'unorm16x4', offset: 16, shaderLocation: 9},
+          {format: 'float32x3', offset: 40, shaderLocation: 13},
+          {format: 'unorm8x4', offset: 904, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 424,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x4', offset: 20, shaderLocation: 7}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'back', unclippedDepth: true},
+});
+offscreenCanvas7.width = 105;
+let img7 = await imageWithData(143, 40, '#98595063', '#b3e0382a');
+let shaderModule16 = device1.createShaderModule({
+  label: '\u0e09\ua58c\ubb80',
+  code: `@group(2) @binding(575)
+var<storage, read_write> local10: array<u32>;
+@group(0) @binding(575)
+var<storage, read_write> function1: array<u32>;
+@group(2) @binding(568)
+var<storage, read_write> n10: array<u32>;
+
+@compute @workgroup_size(7, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S10 {
+  @location(12) f0: vec3<f32>,
+  @location(14) f1: vec3<i32>,
+  @location(4) f2: vec3<i32>,
+  @builtin(instance_index) f3: u32,
+  @location(9) f4: f32,
+  @location(15) f5: vec3<f16>,
+  @location(13) f6: u32,
+  @location(8) f7: vec4<i32>,
+  @location(10) f8: vec2<f16>
+}
+
+@vertex
+fn vertex0(a0: S10, @location(0) a1: vec3<f32>, @location(11) a2: vec3<i32>, @location(7) a3: f16, @location(1) a4: vec3<f32>, @location(6) a5: vec4<u32>, @location(2) a6: vec4<f16>, @location(5) a7: vec3<i32>, @location(3) a8: vec4<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView93 = texture46.createView({dimension: '3d', format: 'bgra8unorm', baseMipLevel: 1, mipLevelCount: 1});
+let renderBundleEncoder47 = device1.createRenderBundleEncoder({
+  label: '\ude4c\u{1f871}\u{1fd4a}\u8f93',
+  colorFormats: ['bgra8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder20.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(2666);
+} catch {}
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(44, 244, 2_108_929_980, 21_086_617, 573_176_008);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer20, 432_671_944);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer18, 4_131_091_173);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexed(111, 0, 2_226_607_711, 207_416_779, 328_670_106);
+} catch {}
+try {
+renderBundleEncoder41.setPipeline(pipeline45);
+} catch {}
+let video13 = await videoWithData();
+let computePassEncoder37 = commandEncoder75.beginComputePass({label: '\u0f3c\u146d\u{1f6d1}\ud18f'});
+try {
+computePassEncoder11.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder12.drawIndirect(buffer26, 17876);
+} catch {}
+try {
+renderBundleEncoder46.setPipeline(pipeline35);
+} catch {}
+let arrayBuffer7 = buffer17.getMappedRange(12680, 352);
+try {
+device0.queue.writeBuffer(buffer6, 5256, new BigUint64Array(8467), 440, 332);
+} catch {}
+document.body.prepend(img5);
+let videoFrame10 = videoFrame0.clone();
+let bindGroupLayout18 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 3128,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let computePassEncoder38 = commandEncoder74.beginComputePass({label: '\u979c\ud3e3\u{1fd31}\u0b14'});
+let renderBundleEncoder48 = device0.createRenderBundleEncoder({
+  label: '\u33ae\u11cf\u0a3e\u{1f915}\u04d3\u3374\u68de\u0ad7\u{1fadf}\u8810\ud4a0',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+});
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer26, 19120);
+} catch {}
+try {
+commandEncoder48.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 9},
+  aspect: 'all',
+},
+{
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 114, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder59.clearBuffer(buffer6, 54396, 1876);
+dissociateBuffer(device0, buffer6);
+} catch {}
+gc();
+let canvas11 = document.createElement('canvas');
+let imageData19 = new ImageData(84, 156);
+let bindGroup19 = device0.createBindGroup({layout: bindGroupLayout10, entries: []});
+let commandEncoder83 = device0.createCommandEncoder({label: '\u{1f967}\uf60d\u50de\u003f\u7475\ufb74\u{1fcca}\ua192\ua57a\u0123\u{1f9a0}'});
+let texture57 = device0.createTexture({
+  label: '\u3d05\u6719\u{1ff18}\ud6aa\u407e\u{1f75a}',
+  size: {width: 312},
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle59 = renderBundleEncoder31.finish({label: '\u047e\u01d2\u0600\uc5a2\u0b3a\u97d4\u{1fbaf}'});
+let arrayBuffer8 = buffer17.getMappedRange(13032, 76);
+try {
+commandEncoder57.copyBufferToBuffer(buffer17, 20396, buffer26, 2180, 27728);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+commandEncoder71.copyTextureToBuffer({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 43752 */
+  offset: 43752,
+  bytesPerRow: 256,
+  rowsPerImage: 287,
+  buffer: buffer6,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise24 = device0.createComputePipelineAsync({
+  label: '\u{1fc5f}\u944e',
+  layout: pipelineLayout12,
+  compute: {module: shaderModule14, entryPoint: 'compute0', constants: {}},
+});
+let bindGroup20 = device1.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 644, resource: externalTexture36}]});
+let pipelineLayout15 = device1.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder84 = device1.createCommandEncoder({label: '\u{1f86f}\u{1f999}\ub877\u{1fbdc}'});
+let sampler43 = device1.createSampler({
+  label: '\u31ed\u{1f6a9}\u0b6f\ufd78\ua4b5\u{1fbb8}\u9bba\u{1fde0}',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 78.78,
+  compare: 'always',
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder35.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder9.setViewport(97.71, 0.2460, 65.32, 0.06200, 0.8317, 0.8796);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(0, bindGroup18, new Uint32Array(9675), 6917, 0);
+} catch {}
+try {
+renderBundleEncoder38.draw(209, 112, 247_677_692, 1_496_376_491);
+} catch {}
+try {
+renderBundleEncoder39.drawIndexed(225, 105, 1_131_591_497, 512_822_401, 1_429_426_484);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer3, 11472, new Float32Array(45434), 11710, 1200);
+} catch {}
+let promise25 = device1.queue.onSubmittedWorkDone();
+let textureView94 = texture42.createView({label: '\u5bf2\u{1fd8a}\u04e1', format: 'bgra8unorm-srgb', mipLevelCount: 1});
+let computePassEncoder39 = commandEncoder62.beginComputePass({});
+let sampler44 = device1.createSampler({
+  label: '\u{1fe38}\u67c4\u{1f951}\ub87c\u0a42\u4407',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 94.90,
+  lodMaxClamp: 95.37,
+});
+let externalTexture45 = device1.importExternalTexture({source: video3, colorSpace: 'srgb'});
+try {
+computePassEncoder28.end();
+} catch {}
+try {
+renderPassEncoder1.draw(142, 339);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline45);
+} catch {}
+try {
+  await buffer25.mapAsync(GPUMapMode.READ, 0, 6984);
+} catch {}
+try {
+commandEncoder84.copyBufferToTexture({
+  /* bytesInLastRow: 3704 widthInBlocks: 926 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 28968 */
+  offset: 28968,
+  buffer: buffer18,
+}, {
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 926, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer18);
+} catch {}
+try {
+commandEncoder61.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 140, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture5,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 9},
+  aspect: 'all',
+},
+{width: 59, height: 0, depthOrArrayLayers: 15});
+} catch {}
+try {
+commandEncoder77.resolveQuerySet(querySet39, 1538, 0, buffer3, 21760);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 120, height: 1, depthOrArrayLayers: 938}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 441, y: 38 },
+  flipY: true,
+}, {
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 16, y: 0, z: 66},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline57 = await device1.createComputePipelineAsync({
+  label: '\u098d\u0e47\u0eb8',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule12, entryPoint: 'compute0'},
+});
+let promise26 = navigator.gpu.requestAdapter({});
+let shaderModule17 = device0.createShaderModule({
+  code: `@group(3) @binding(1456)
+var<storage, read_write> type7: array<u32>;
+
+@compute @workgroup_size(3, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec3<u32>,
+  @location(0) f1: vec4<u32>,
+  @location(3) f2: vec4<u32>,
+  @location(1) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>, @location(14) a2: f16, @location(1) a3: f16, @location(26) a4: vec2<f32>, @location(13) a5: f32, @builtin(front_facing) a6: bool, @builtin(sample_mask) a7: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S11 {
+  @location(20) f0: vec4<i32>,
+  @location(14) f1: vec3<i32>,
+  @location(5) f2: vec4<i32>
+}
+struct VertexOutput0 {
+  @builtin(position) f95: vec4<f32>,
+  @location(13) f96: f32,
+  @location(1) f97: f16,
+  @location(14) f98: f16,
+  @location(26) f99: vec2<f32>
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec4<u32>, @location(1) a1: vec4<f32>, a2: S11, @location(8) a3: vec2<u32>, @builtin(vertex_index) a4: u32, @location(9) a5: vec2<f32>, @location(10) a6: i32, @location(12) a7: vec3<i32>, @location(15) a8: vec3<f16>, @location(2) a9: vec2<u32>, @location(19) a10: vec3<f32>, @location(0) a11: vec4<f32>, @location(13) a12: i32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer31 = device0.createBuffer({label: '\u{1ffd4}\ue7f9', size: 82956, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder85 = device0.createCommandEncoder({});
+let renderBundleEncoder49 = device0.createRenderBundleEncoder({
+  label: '\u{1f928}\ucdbc\u{1ff95}',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle60 = renderBundleEncoder21.finish({label: '\u0292\u{1fce6}\ud310\u2332'});
+let sampler45 = device0.createSampler({
+  label: '\ufd90\u{1f86a}\u{1fb48}\u61f3\u0012\uce38\u0d8a\u5f7a\u01d6\u0c02\u6f74',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 66.74,
+  lodMaxClamp: 98.79,
+  maxAnisotropy: 6,
+});
+try {
+renderBundleEncoder12.draw(273, 76, 743_188_936, 33_259_685);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+commandEncoder82.copyBufferToBuffer(buffer9, 25168, buffer6, 81560, 2012);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder82.resolveQuerySet(querySet15, 679, 803, buffer1, 88832);
+} catch {}
+let textureView95 = texture13.createView({label: '\uba9f\ubc2c\u98c1\ufa97', format: 'rgb10a2uint', mipLevelCount: 3});
+let renderBundle61 = renderBundleEncoder33.finish({label: '\uaff3\u0c74\u81e9\u{1f68e}\u0b41\uc8e5\u{1f996}'});
+try {
+computePassEncoder9.setPipeline(pipeline43);
+} catch {}
+try {
+commandEncoder63.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 0, y: 32, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture20,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 15, height: 1, depthOrArrayLayers: 3});
+} catch {}
+try {
+commandEncoder63.clearBuffer(buffer31);
+dissociateBuffer(device0, buffer31);
+} catch {}
+try {
+  await promise25;
+} catch {}
+let commandEncoder86 = device1.createCommandEncoder({label: '\u43be\u8f86\ua8f9\u0749\u{1ff40}\u8969\uddc1\u3a81\u0465\ua78c'});
+let textureView96 = texture19.createView({label: '\ufe77\ue038\u522c\u47ff\u4102\u09b0\u3578\u43a7', baseArrayLayer: 0});
+let renderPassEncoder10 = commandEncoder28.beginRenderPass({
+  label: '\u0a47\u{1fd1a}',
+  colorAttachments: [{view: textureView82, depthSlice: 91, loadOp: 'clear', storeOp: 'store'}],
+  maxDrawCount: 343075813,
+});
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup11, []);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.draw(83, 168, 153_765_860);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer27, 0, 19639);
+} catch {}
+try {
+renderBundleEncoder39.draw(65, 29, 338_976_644, 1_175_750_986);
+} catch {}
+try {
+renderBundleEncoder41.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder47.setVertexBuffer(4, buffer27, 33344, 4267);
+} catch {}
+try {
+commandEncoder80.copyBufferToBuffer(buffer18, 347428, buffer29, 28440, 15272);
+dissociateBuffer(device1, buffer18);
+dissociateBuffer(device1, buffer29);
+} catch {}
+canvas1.height = 1456;
+let imageData20 = new ImageData(156, 184);
+let bindGroup21 = device0.createBindGroup({
+  label: '\u0ee2\uf4da',
+  layout: bindGroupLayout18,
+  entries: [{binding: 3128, resource: externalTexture44}],
+});
+let renderBundle62 = renderBundleEncoder35.finish({});
+try {
+computePassEncoder38.setPipeline(pipeline43);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(0, bindGroup2, []);
+} catch {}
+try {
+renderBundleEncoder40.draw(278, 71, 200_953_243, 1_070_671_993);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer26, 14936);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer26, 2308);
+} catch {}
+try {
+renderBundleEncoder49.setPipeline(pipeline35);
+} catch {}
+try {
+commandEncoder0.resolveQuerySet(querySet19, 724, 130, buffer30, 380416);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let canvas12 = document.createElement('canvas');
+let videoFrame11 = new VideoFrame(img4, {timestamp: 0});
+let imageData21 = new ImageData(168, 104);
+let texture58 = device0.createTexture({
+  label: '\u0b9f\u{1f731}\u0cab',
+  size: {width: 480},
+  dimension: '1d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder40 = commandEncoder48.beginComputePass({label: '\ub1c8\u3478\u430c\u{1f821}\u{1fe88}\u0bd1\u518e\u6b7f\u0f80\ub188\u0246'});
+try {
+computePassEncoder38.setBindGroup(8, bindGroup2);
+} catch {}
+try {
+computePassEncoder38.setBindGroup(2, bindGroup10, new Uint32Array(9691), 8473, 0);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(140, 402, 642_184_108);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer26, 6772);
+} catch {}
+try {
+renderBundleEncoder12.drawIndirect(buffer26, 268);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer11, 'uint16', 1746, 2470);
+} catch {}
+try {
+renderBundleEncoder12.setPipeline(pipeline35);
+} catch {}
+try {
+commandEncoder59.copyTextureToBuffer({
+  texture: texture36,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 720 */
+  offset: 720,
+  bytesPerRow: 0,
+  rowsPerImage: 201,
+  buffer: buffer16,
+}, {width: 0, height: 0, depthOrArrayLayers: 3});
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder72.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 2,
+  origin: {x: 3, y: 0, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 806},
+  aspect: 'all',
+},
+{width: 35, height: 0, depthOrArrayLayers: 6});
+} catch {}
+try {
+commandEncoder59.clearBuffer(buffer6, 68812, 732);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+device0.queue.submit([commandBuffer14, commandBuffer16]);
+} catch {}
+try {
+canvas12.getContext('webgpu');
+} catch {}
+let texture59 = device0.createTexture({
+  size: {width: 624, height: 1, depthOrArrayLayers: 150},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView97 = texture54.createView({label: '\ufee0\u{1f7b9}\u0ecc'});
+let sampler46 = device0.createSampler({
+  label: '\u{1f7cf}\u0f6c\u075f\u06de',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 24.19,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder29.setPipeline(pipeline27);
+} catch {}
+try {
+renderBundleEncoder37.setPipeline(pipeline35);
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(buffer17, 5692, buffer6, 77148, 5572);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder60.resolveQuerySet(querySet49, 2212, 1174, buffer1, 50432);
+} catch {}
+let pipeline58 = await device0.createComputePipelineAsync({
+  label: '\u028b\u2878\u0662',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule13, entryPoint: 'compute0', constants: {}},
+});
+try {
+canvas11.getContext('webgpu');
+} catch {}
+offscreenCanvas0.height = 152;
+let commandEncoder87 = device0.createCommandEncoder({});
+let commandBuffer18 = commandEncoder67.finish();
+let texture60 = device0.createTexture({
+  label: '\u{1fa70}\ua982\u09b0',
+  size: {width: 960},
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView98 = texture4.createView({label: '\u0273\uca63\u{1f993}\u028a', format: 'rgba8uint', baseMipLevel: 1, arrayLayerCount: 1});
+try {
+renderBundleEncoder40.drawIndexed(5, 13);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline38);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+commandEncoder0.resolveQuerySet(querySet35, 240, 1589, buffer1, 7936);
+} catch {}
+let textureView99 = texture3.createView({
+  label: '\uadba\u{1fc0d}\u3b14\u9cef\u{1f7ef}',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 5,
+  mipLevelCount: 1,
+  baseArrayLayer: 22,
+});
+let sampler47 = device1.createSampler({
+  label: '\u{1fb73}\u23fb',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 57.61,
+  lodMaxClamp: 98.52,
+});
+try {
+computePassEncoder18.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder8.setScissorRect(0, 0, 1, 1);
+} catch {}
+try {
+renderPassEncoder8.draw(13);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer3, 163_623_128);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline53);
+} catch {}
+try {
+commandEncoder78.copyBufferToBuffer(buffer4, 39112, buffer2, 13964, 1020);
+dissociateBuffer(device1, buffer4);
+dissociateBuffer(device1, buffer2);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer5, 22820, new DataView(new ArrayBuffer(64767)), 37044, 6672);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let bindGroupLayout19 = device0.createBindGroupLayout({
+  label: '\ua1b5\u0334\ucf69\u3fe8\u52f4\u{1fb28}\u3aaf',
+  entries: [
+    {
+      binding: 662,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+  ],
+});
+try {
+renderBundleEncoder12.setBindGroup(5, bindGroup19);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer26, 7952);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer26, 864);
+} catch {}
+try {
+commandEncoder71.copyBufferToBuffer(buffer15, 242760, buffer26, 2948, 5324);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer22, 3496, new Int16Array(62487), 637, 7256);
+} catch {}
+let bindGroup22 = device1.createBindGroup({layout: bindGroupLayout2, entries: [{binding: 644, resource: externalTexture1}]});
+let textureView100 = texture55.createView({label: '\u0b91\u5cce\u5d8e\u0d46\u0894\u00e1\u{1fb66}\u{1ff96}', arrayLayerCount: 1});
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer29, 883_758_054);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexedIndirect(buffer8, 424324);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder38.setVertexBuffer(6, buffer27, 24128, 459);
+} catch {}
+let promise27 = device1.popErrorScope();
+try {
+device1.queue.writeBuffer(buffer5, 11008, new BigUint64Array(37402), 9717, 2580);
+} catch {}
+let img8 = await imageWithData(243, 227, '#01162044', '#7a1caaba');
+let imageBitmap23 = await createImageBitmap(video7);
+let bindGroup23 = device1.createBindGroup({label: '\u08e2\u5f54\u4d87\u865a\u5324\uaded', layout: bindGroupLayout3, entries: []});
+let commandEncoder88 = device1.createCommandEncoder({});
+let computePassEncoder41 = commandEncoder7.beginComputePass({label: '\u0646\u0fba\u{1f601}\uc9a2\u0f22\u0c23'});
+let renderBundle63 = renderBundleEncoder5.finish({label: '\u{1fe77}\ua44f\u0122\u7e59\u{1fe8b}\u08f3\u0eeb\u62a5\u8285\u692b\u5d8d'});
+let externalTexture46 = device1.importExternalTexture({label: '\u{1f8cf}\u0338', source: video7, colorSpace: 'srgb'});
+try {
+renderPassEncoder6.beginOcclusionQuery(3836);
+} catch {}
+try {
+renderPassEncoder8.setBlendConstant({ r: -62.25, g: -890.2, b: 447.8, a: -956.7, });
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(2294);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder47.setBindGroup(1, bindGroup3);
+} catch {}
+try {
+renderBundleEncoder39.setPipeline(pipeline12);
+} catch {}
+try {
+  await device1.popErrorScope();
+} catch {}
+try {
+commandEncoder81.copyTextureToBuffer({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 12240 */
+  offset: 12240,
+  bytesPerRow: 256,
+  buffer: buffer5,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer5);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer3, 1920, new Int16Array(55127), 14618, 5724);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 578_735 */
+{offset: 719, bytesPerRow: 223, rowsPerImage: 72}, {width: 39, height: 0, depthOrArrayLayers: 37});
+} catch {}
+let promise28 = device1.createComputePipelineAsync({layout: pipelineLayout14, compute: {module: shaderModule12, entryPoint: 'compute0'}});
+let videoFrame12 = new VideoFrame(imageBitmap14, {timestamp: 0});
+let bindGroup24 = device0.createBindGroup({label: '\u9cd3\u{1f8e8}', layout: bindGroupLayout10, entries: []});
+let texture61 = device0.createTexture({
+  label: '\u2141\u05f7',
+  size: [1248],
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer26, 472);
+} catch {}
+try {
+commandEncoder85.copyBufferToBuffer(buffer26, 4480, buffer16, 249280, 21940);
+dissociateBuffer(device0, buffer26);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder57.clearBuffer(buffer16);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 330},
+  aspect: 'all',
+}, new Float64Array(new ArrayBuffer(64)), /* required buffer size: 4_865_254 */
+{offset: 527, bytesPerRow: 445, rowsPerImage: 163}, {width: 108, height: 11, depthOrArrayLayers: 68});
+} catch {}
+let pipeline59 = device0.createComputePipeline({
+  label: '\u5729\u{1f74a}\u7ac0\u{1f83b}\u9859\u{1fddb}\u873e\u0558\u8be6\ua667\u0976',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}},
+});
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let offscreenCanvas9 = new OffscreenCanvas(248, 181);
+try {
+offscreenCanvas9.getContext('bitmaprenderer');
+} catch {}
+let shaderModule18 = device0.createShaderModule({
+  code: `@group(2) @binding(5002)
+var<storage, read_write> function2: array<u32>;
+@group(2) @binding(3465)
+var<storage, read_write> local11: array<u32>;
+@group(2) @binding(4645)
+var<storage, read_write> type8: array<u32>;
+
+@compute @workgroup_size(6, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(1) f1: vec4<u32>,
+  @location(0) f2: vec4<u32>,
+  @location(2) f3: vec3<u32>,
+  @location(3) f4: vec4<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(7) a0: vec3<f16>, @location(14) a1: i32, @location(1) a2: f16, @location(19) a3: vec4<u32>, @location(9) a4: vec2<f16>, @location(13) a5: i32, @location(0) a6: u32, @location(20) a7: i32, @location(5) a8: vec4<i32>, @location(17) a9: vec2<f32>, @location(8) a10: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture62 = device0.createTexture({
+  size: [1248, 1, 757],
+  mipLevelCount: 10,
+  dimension: '2d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView101 = texture60.createView({label: '\u{1fb4c}\u5a3d\u0ae7\uf802\ub82a\u02f0\u76de'});
+try {
+computePassEncoder38.setPipeline(pipeline43);
+} catch {}
+try {
+renderBundleEncoder40.draw(272, 1);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(198, 213, 78_451_199);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer26, 3204);
+} catch {}
+try {
+commandEncoder63.copyBufferToTexture({
+  /* bytesInLastRow: 880 widthInBlocks: 220 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 18704 */
+  offset: 18704,
+  buffer: buffer26,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 52, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 220, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+commandEncoder57.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 351, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture59,
+  mipLevel: 4,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 7, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 1900, new BigUint64Array(13385), 5043, 236);
+} catch {}
+offscreenCanvas3.width = 188;
+let bindGroup25 = device1.createBindGroup({label: '\u{1fadc}\u{1fa1f}', layout: bindGroupLayout3, entries: []});
+let textureView102 = texture46.createView({label: '\u0d01\u002b\u08c2', dimension: '3d', baseMipLevel: 7, mipLevelCount: 1});
+let computePassEncoder42 = commandEncoder84.beginComputePass();
+let renderBundle64 = renderBundleEncoder39.finish({label: '\u60c1\u{1f707}\u2d99\u8eea\u{1f9aa}\u{1fd24}\u{1f831}\u0d0b\u9fbd'});
+let externalTexture47 = device1.importExternalTexture({source: video4, colorSpace: 'srgb'});
+try {
+computePassEncoder42.setBindGroup(3, bindGroup1, new Uint32Array(1842), 826, 0);
+} catch {}
+try {
+renderPassEncoder3.beginOcclusionQuery(301);
+} catch {}
+try {
+renderPassEncoder6.setStencilReference(711);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer19, 2_246_367_174);
+} catch {}
+try {
+renderBundleEncoder11.draw(27, 2);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(5, buffer27, 0, 3343);
+} catch {}
+try {
+commandEncoder80.copyTextureToBuffer({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3652 widthInBlocks: 913 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 14868 */
+  offset: 14868,
+  bytesPerRow: 4096,
+  buffer: buffer3,
+}, {width: 913, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer3);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 8,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 62_582 */
+{offset: 890, bytesPerRow: 97, rowsPerImage: 4}, {width: 1, height: 0, depthOrArrayLayers: 160});
+} catch {}
+let texture63 = device1.createTexture({
+  size: [1920, 12, 209],
+  mipLevelCount: 8,
+  format: 'astc-4x4-unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['astc-4x4-unorm', 'astc-4x4-unorm'],
+});
+let computePassEncoder43 = commandEncoder88.beginComputePass({label: '\u{1f6b3}\u706e\u98f7\u{1fce6}\u415a\u903f\u{1fa5f}'});
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle48, renderBundle15]);
+} catch {}
+try {
+renderPassEncoder2.setViewport(204.6, 0.01852, 26.85, 0.1542, 0.9517, 0.9746);
+} catch {}
+try {
+renderPassEncoder5.draw(123, 392, 189_695_551, 777_259_682);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer18, 978_228_121);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer27, 27704, 4759);
+} catch {}
+try {
+renderBundleEncoder47.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+renderBundleEncoder38.drawIndexedIndirect(buffer8, 615760);
+} catch {}
+try {
+renderBundleEncoder41.drawIndirect(buffer8, 108232);
+} catch {}
+try {
+renderBundleEncoder41.setVertexBuffer(0, buffer27);
+} catch {}
+let promise29 = buffer28.mapAsync(GPUMapMode.READ, 0, 180);
+try {
+commandEncoder56.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 9204 */
+  offset: 9204,
+  buffer: buffer18,
+}, {
+  texture: texture46,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer18);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+canvas10.height = 172;
+let querySet50 = device0.createQuerySet({label: '\u{1f898}\u763f\u6432\u9ceb', type: 'occlusion', count: 523});
+let textureView103 = texture23.createView({
+  label: '\u5fa7\u0d1c\u059a\udf11\u06a9\u{1fff1}\ub8a1',
+  aspect: 'all',
+  mipLevelCount: 4,
+  baseArrayLayer: 129,
+  arrayLayerCount: 38,
+});
+let computePassEncoder44 = commandEncoder83.beginComputePass({});
+let renderBundleEncoder50 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'], sampleCount: 1});
+let externalTexture48 = device0.importExternalTexture({source: video13, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup9, []);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(38, 174, 314_995_928, 30_037_318);
+} catch {}
+try {
+commandEncoder85.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 312678 */
+  offset: 17726,
+  bytesPerRow: 256,
+  rowsPerImage: 229,
+  buffer: buffer15,
+}, {
+  texture: texture29,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 20, height: 8, depthOrArrayLayers: 6});
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder0.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise30 = device0.queue.onSubmittedWorkDone();
+let video14 = await videoWithData();
+let textureView104 = texture6.createView({
+  label: '\u{1fb20}\u79ea\u0a2b\u92e5\u0d8e\u5af6\u83d3\u62e9\u75b5\ua573\u{1fd61}',
+  baseMipLevel: 2,
+  mipLevelCount: 2,
+  arrayLayerCount: 1,
+});
+let renderBundleEncoder51 = device0.createRenderBundleEncoder({
+  label: '\u2ddf\u{1ff23}\uf7ca',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture49 = device0.importExternalTexture({label: '\u6f2e\u0994\ub5a0\ue708\u02d9\u1da8', source: videoFrame3, colorSpace: 'srgb'});
+try {
+computePassEncoder13.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer26, 5504);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer26, 10488);
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(buffer17, 32740, buffer31, 78172, 952);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer31);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 17772, new Int16Array(39076), 696, 2396);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(244), /* required buffer size: 244 */
+{offset: 244, bytesPerRow: 568, rowsPerImage: 32}, {width: 182, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline60 = device0.createRenderPipeline({
+  layout: pipelineLayout12,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r16uint', writeMask: GPUColorWrite.BLUE}, {format: 'rgb10a2uint'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'never', failOp: 'invert', depthFailOp: 'replace', passOp: 'increment-wrap'},
+    stencilBack: {failOp: 'decrement-wrap', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilReadMask: 2939030690,
+    depthBiasSlopeScale: 713.5766215975265,
+  },
+  vertex: {module: shaderModule4, entryPoint: 'vertex0', buffers: []},
+});
+let promise31 = adapter0.requestAdapterInfo();
+let canvas13 = document.createElement('canvas');
+try {
+canvas13.getContext('2d');
+} catch {}
+let commandEncoder89 = device0.createCommandEncoder({label: '\u{1f89b}\ude2b\u6580\u06bd\u022f\u{1f639}\ud84d\u037a'});
+let textureView105 = texture57.createView({label: '\u0105\udef3\u5fb2\u{1f7b0}\u8e17', dimension: '1d'});
+try {
+computePassEncoder37.setBindGroup(5, bindGroup2, new Uint32Array(9891), 9842, 0);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(100, 181, 2_124_080_758, 346_911_849, 4_056_969);
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(buffer9, 15744, buffer31, 23760, 18420);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer31);
+} catch {}
+try {
+commandEncoder59.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6300 */
+  offset: 6300,
+  buffer: buffer26,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 20, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+commandEncoder82.resolveQuerySet(querySet15, 887, 297, buffer1, 6144);
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let imageData22 = new ImageData(84, 228);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let textureView106 = texture19.createView({label: '\u01dd\u2a52\u43ec\u0678\ub184', aspect: 'all', mipLevelCount: 1});
+let renderPassEncoder11 = commandEncoder56.beginRenderPass({
+  label: '\uc3f7\u3edf',
+  colorAttachments: [{view: textureView88, depthSlice: 0, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet24,
+  maxDrawCount: 367058414,
+});
+let externalTexture50 = device1.importExternalTexture({label: '\u0b8d\uebcc\u07e8\u4037\u23bb', source: video9});
+try {
+computePassEncoder26.end();
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(128, 0, 18, 1);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(2626);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(184, 81);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder41.drawIndexed(85);
+} catch {}
+try {
+renderBundleEncoder11.drawIndexedIndirect(buffer8, 111264);
+} catch {}
+try {
+commandEncoder66.copyTextureToTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 90, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 478, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 3, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: imageData8,
+  origin: { x: 22, y: 15 },
+  flipY: true,
+}, {
+  texture: texture43,
+  mipLevel: 9,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData23 = new ImageData(248, 64);
+let texture64 = device0.createTexture({
+  label: '\u03ba\u04a2\u49be\u094e\u4051\u0ee4\u85da\u{1f950}\u{1f9d2}\u{1fb76}',
+  size: [240, 120, 59],
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture65 = gpuCanvasContext3.getCurrentTexture();
+let textureView107 = texture57.createView({label: '\u09b5\u7550\u57f3\u0770\u49c2\u0bca', arrayLayerCount: 1});
+try {
+renderBundleEncoder40.setBindGroup(8, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer26, 4832);
+} catch {}
+try {
+commandEncoder85.copyBufferToBuffer(buffer15, 149960, buffer16, 122268, 140884);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder89.clearBuffer(buffer31, 70328, 12312);
+dissociateBuffer(device0, buffer31);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer6), /* required buffer size: 458 */
+{offset: 450, bytesPerRow: 40}, {width: 2, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData24 = new ImageData(164, 144);
+try {
+adapter4.label = '\u535c\u{1fba1}\u0430\u4bb9\u6523\u978e\u64e8\u6578\u778c\u40b7\u0812';
+} catch {}
+gc();
+let bindGroup26 = device0.createBindGroup({
+  label: '\u0dc4\uc2e7\u0266\u02c4\u0c4b',
+  layout: bindGroupLayout18,
+  entries: [{binding: 3128, resource: externalTexture23}],
+});
+let commandEncoder90 = device0.createCommandEncoder({label: '\u1726\u{1fa12}\u3e17\ue016\u8cb5\u{1fcda}\u136f\u069c'});
+let renderBundleEncoder52 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture51 = device0.importExternalTexture({label: '\ue497\u288b\u{1fd48}', source: videoFrame3, colorSpace: 'srgb'});
+try {
+computePassEncoder37.end();
+} catch {}
+try {
+computePassEncoder29.setPipeline(pipeline40);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(16, 30, 1_389_022_952, 751_537_345, 101_338_961);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer26, 5716);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer31, 12832, new Float32Array(44067), 26028, 1456);
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let img9 = await imageWithData(9, 232, '#ed0ef580', '#c63c2b93');
+let bindGroup27 = device1.createBindGroup({
+  label: '\u8374\u3aec\u{1fd8f}\uaa19\uc64c\ue55a\u8e7d\ub9bd\u{1f9f9}',
+  layout: bindGroupLayout2,
+  entries: [{binding: 644, resource: externalTexture32}],
+});
+let texture66 = device1.createTexture({
+  label: '\ue6d0\u{1f895}\u{1fd13}\u{1fd85}\u{1f7a0}\u{1f891}',
+  size: [960],
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm'],
+});
+let textureView108 = texture5.createView({
+  label: '\u6257\u{1f80b}\u0a0e\u5f92\u35ce\u2b38\u0cfc\u597a\u0351\u00cd\ue645',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+});
+let renderBundleEncoder53 = device1.createRenderBundleEncoder({
+  label: '\u50ce\u{1fc76}\udd18\u0faa\u036f\ubc32\u514e\u068e',
+  colorFormats: ['bgra8unorm'],
+  stencilReadOnly: true,
+});
+let renderBundle65 = renderBundleEncoder11.finish({});
+try {
+computePassEncoder27.setBindGroup(0, bindGroup14, new Uint32Array(8142), 1245, 0);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup0, new Uint32Array(3013), 1581, 0);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(2, 1, 1, 0);
+} catch {}
+try {
+renderPassEncoder10.setStencilReference(595);
+} catch {}
+try {
+renderBundleEncoder47.setPipeline(pipeline12);
+} catch {}
+try {
+commandEncoder86.resolveQuerySet(querySet43, 797, 2271, buffer3, 9472);
+} catch {}
+try {
+renderBundleEncoder41.insertDebugMarker('\u0038');
+} catch {}
+let pipeline61 = device1.createComputePipeline({
+  label: '\u{1f9c8}\u1c7d\u5b0e\u{1fb30}\u{1ffe2}\u{1feb8}\u7ff7\u0987\u728e',
+  layout: 'auto',
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise29;
+} catch {}
+let commandBuffer19 = commandEncoder75.finish({label: '\ub949\u7418\u7353\u13cc'});
+let textureView109 = texture8.createView({label: '\u0e29\u2b7d\u{1f996}', aspect: 'all', baseMipLevel: 3, mipLevelCount: 2});
+let computePassEncoder45 = commandEncoder82.beginComputePass();
+let renderBundleEncoder54 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle66 = renderBundleEncoder37.finish();
+try {
+renderBundleEncoder50.setBindGroup(1, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder40.draw(209, 25, 170_564_426, 190_540_411);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer26, 1812);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer8, /* required buffer size: 224 */
+{offset: 224}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline62 = device0.createComputePipeline({
+  label: '\u6243\u0a9a\ued66\ub36e\u0a65\u06f4\u{1ffd9}',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+let bindGroupLayout20 = pipeline27.getBindGroupLayout(1);
+let commandEncoder91 = device0.createCommandEncoder();
+let computePassEncoder46 = commandEncoder87.beginComputePass({label: '\u{1fd3c}\ue709\u{1f82d}\udf87\ud66f\u0a02\u02ec'});
+try {
+renderBundleEncoder46.setPipeline(pipeline35);
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(buffer12, 10744, buffer26, 848, 3004);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+commandEncoder30.copyTextureToBuffer({
+  texture: texture0,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 20},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 22344 */
+  offset: 22344,
+  bytesPerRow: 0,
+  rowsPerImage: 180,
+  buffer: buffer26,
+}, {width: 0, height: 0, depthOrArrayLayers: 218});
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+commandEncoder60.copyTextureToTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 591, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 33},
+  aspect: 'all',
+},
+{width: 10, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder72.clearBuffer(buffer31);
+dissociateBuffer(device0, buffer31);
+} catch {}
+try {
+commandEncoder71.resolveQuerySet(querySet32, 1393, 1044, buffer30, 20480);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 105528, new Float32Array(41572));
+} catch {}
+document.body.prepend(canvas9);
+let img10 = await imageWithData(138, 120, '#f0ad5f01', '#814bccb4');
+try {
+  await promise30;
+} catch {}
+let imageBitmap24 = await createImageBitmap(imageData21);
+let textureView110 = texture41.createView({label: '\u328e\u5923\u0945\u0058', dimension: '2d-array'});
+let renderBundleEncoder55 = device1.createRenderBundleEncoder({label: '\udf31\u0fd6\u1f98', colorFormats: ['bgra8unorm'], sampleCount: 1, depthReadOnly: false});
+let renderBundle67 = renderBundleEncoder26.finish();
+let sampler48 = device1.createSampler({
+  label: '\u{1ff74}\u1423\ue021\u0495\ud4bd\u0b2d\u{1f880}',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 76.75,
+  lodMaxClamp: 81.05,
+  maxAnisotropy: 12,
+});
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+renderPassEncoder5.setViewport(44.41, 0.4884, 97.02, 0.1962, 0.5042, 0.5118);
+} catch {}
+try {
+renderBundleEncoder38.draw(11, 365, 1_042_765_266);
+} catch {}
+try {
+renderBundleEncoder41.drawIndexed(1, 29, 290_746_307, -2_041_763_339, 2_213_159_558);
+} catch {}
+try {
+commandEncoder86.copyBufferToTexture({
+  /* bytesInLastRow: 56 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 121448 */
+  offset: 6704,
+  bytesPerRow: 256,
+  rowsPerImage: 32,
+  buffer: buffer18,
+}, {
+  texture: texture43,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 7},
+  aspect: 'all',
+}, {width: 14, height: 1, depthOrArrayLayers: 15});
+dissociateBuffer(device1, buffer18);
+} catch {}
+let bindGroup28 = device1.createBindGroup({
+  label: '\u4ae4\u{1fb0f}',
+  layout: bindGroupLayout2,
+  entries: [{binding: 644, resource: externalTexture37}],
+});
+let commandEncoder92 = device1.createCommandEncoder({label: '\u9cc6\ufb68\u1c86\u0969\u15fa\u0ec4\u056a'});
+let querySet51 = device1.createQuerySet({label: '\u{1f9b1}\u09c5\ufa65\ubeab\u0851\u{1f945}', type: 'occlusion', count: 2867});
+let textureView111 = texture41.createView({label: '\ueb9d\u{1f635}', dimension: '2d-array'});
+try {
+computePassEncoder27.setPipeline(pipeline29);
+} catch {}
+try {
+renderBundleEncoder47.draw(163, 91, 794_072_475, 313_714_606);
+} catch {}
+try {
+renderBundleEncoder47.drawIndexedIndirect(buffer8, 57196);
+} catch {}
+try {
+texture5.destroy();
+} catch {}
+try {
+commandEncoder35.copyBufferToTexture({
+  /* bytesInLastRow: 1568 widthInBlocks: 392 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 12508 */
+  offset: 12508,
+  buffer: buffer8,
+}, {
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 201, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 392, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+computePassEncoder25.insertDebugMarker('\u6956');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer5, 1384, new Float32Array(20406), 17579, 220);
+} catch {}
+let commandEncoder93 = device1.createCommandEncoder();
+let texture67 = gpuCanvasContext7.getCurrentTexture();
+let renderPassEncoder12 = commandEncoder92.beginRenderPass({
+  label: '\u0df6\uc250\u{1fb51}\ufe86\u0099\ucc4d\u07c3\u{1f87f}\u7517\u8fd9\u9601',
+  colorAttachments: [{
+  view: textureView88,
+  depthSlice: 1,
+  clearValue: { r: -82.99, g: -946.3, b: -424.0, a: -315.6, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet25,
+  maxDrawCount: 1107724665,
+});
+let sampler49 = device1.createSampler({
+  label: '\ua5b1\u9798\ucaf5',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 62.36,
+  lodMaxClamp: 70.91,
+  maxAnisotropy: 18,
+});
+let externalTexture52 = device1.importExternalTexture({source: video12, colorSpace: 'display-p3'});
+try {
+computePassEncoder24.end();
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup25, new Uint32Array(6106), 5654, 0);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(64);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(3697);
+} catch {}
+try {
+renderPassEncoder5.draw(0);
+} catch {}
+try {
+renderBundleEncoder38.draw(133, 57, 217_196_965, 356_970_965);
+} catch {}
+try {
+renderBundleEncoder42.setPipeline(pipeline45);
+} catch {}
+let arrayBuffer9 = buffer25.getMappedRange(6984, 0);
+try {
+device1.queue.writeBuffer(buffer29, 3992, new DataView(new ArrayBuffer(9039)), 4380, 564);
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+canvas5.width = 1110;
+let offscreenCanvas10 = new OffscreenCanvas(645, 377);
+let commandEncoder94 = device0.createCommandEncoder({label: '\u{1fdf7}\u035f\u{1f962}\uc081\u11d9\u0811\u762e\u{1ff6e}\u0838'});
+try {
+computePassEncoder11.setPipeline(pipeline32);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(110, 35, 160_128_488);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer26, 7036);
+} catch {}
+try {
+commandEncoder85.copyBufferToTexture({
+  /* bytesInLastRow: 260 widthInBlocks: 65 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 9264 */
+  offset: 9264,
+  buffer: buffer21,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 65, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer21);
+} catch {}
+try {
+commandEncoder71.clearBuffer(buffer16);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas7,
+  origin: { x: 0, y: 9 },
+  flipY: true,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+  await promise31;
+} catch {}
+let video15 = await videoWithData();
+let videoFrame13 = new VideoFrame(imageBitmap9, {timestamp: 0});
+let querySet52 = device2.createQuerySet({label: '\ue9a6\u22be\uab9a\ua71f\ub12e', type: 'occlusion', count: 1375});
+let texture68 = device2.createTexture({
+  label: '\u000e\uf993',
+  size: [22],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint'],
+});
+let textureView112 = texture26.createView({
+  label: '\ud7bb\u{1f634}\u3162\u06c1\u4271\uf695\u2061\u082c',
+  baseMipLevel: 7,
+  baseArrayLayer: 446,
+  arrayLayerCount: 365,
+});
+try {
+gpuCanvasContext8.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline63 = device2.createComputePipeline({
+  label: '\u{1ff08}\u0318\u{1fae3}\ue6e9\u08b4\u6147\u9da4\u47ad',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}},
+});
+gc();
+let bindGroupLayout21 = device0.createBindGroupLayout({
+  label: '\u5d99\u1b17\u{1fda2}\u01fe\u{1f9c7}\u{1fde4}\u8637\u025b\u9cc2',
+  entries: [{binding: 3562, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let bindGroup29 = device0.createBindGroup({
+  label: '\u{1f8ba}\u0f85\u0e7d\u3127\u06bc\u33e4\u{1f964}',
+  layout: bindGroupLayout19,
+  entries: [{binding: 662, resource: sampler16}],
+});
+let texture69 = device0.createTexture({
+  label: '\u120c\u0c9d\uf815\u0ba5\u4e80\u52f9\u{1f9f3}\u06bc',
+  size: {width: 156, height: 1, depthOrArrayLayers: 25},
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView113 = texture10.createView({label: '\u{1fc4d}\u019d', mipLevelCount: 3});
+let renderBundle68 = renderBundleEncoder16.finish({label: '\u0018\u5070\u22aa\u03c2\u0234\u{1fdf7}\uc8b4\u0d05\u1118\ub177'});
+try {
+computePassEncoder40.setBindGroup(9, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer26, 3168);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer11, 'uint32', 15408, 3063);
+} catch {}
+try {
+renderBundleEncoder51.setPipeline(pipeline38);
+} catch {}
+try {
+commandEncoder72.copyTextureToBuffer({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 6696 */
+  offset: 6696,
+  buffer: buffer26,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 130, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(new ArrayBuffer(56)), /* required buffer size: 184 */
+{offset: 124}, {width: 15, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 156, height: 1, depthOrArrayLayers: 25}
+*/
+{
+  source: imageData16,
+  origin: { x: 16, y: 10 },
+  flipY: false,
+}, {
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 78, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img11 = await imageWithData(141, 241, '#f5b1b6e7', '#37e25d87');
+let offscreenCanvas11 = new OffscreenCanvas(546, 421);
+let imageBitmap25 = await createImageBitmap(videoFrame4);
+let commandEncoder95 = device1.createCommandEncoder({});
+let renderPassEncoder13 = commandEncoder81.beginRenderPass({
+  label: '\ue1c0\u{1f919}\u011c\ua1d4\u78f4\ubfa6\u02ea\u03e9\u{1fdc3}\u3eb3',
+  colorAttachments: [{
+  view: textureView68,
+  depthSlice: 1607,
+  clearValue: { r: 989.2, g: -100.7, b: 536.6, a: -900.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 510093970,
+});
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup23, new Uint32Array(3728), 2728, 0);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(12);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle37, renderBundle49, renderBundle48, renderBundle64, renderBundle28]);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(46);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer28, 31_590_892);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer27, 0, 37010);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(3, buffer27, 15480, 321);
+} catch {}
+try {
+commandEncoder17.clearBuffer(buffer2, 2100, 14028);
+dissociateBuffer(device1, buffer2);
+} catch {}
+try {
+commandEncoder17.popDebugGroup();
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap10,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext11 = offscreenCanvas11.getContext('webgpu');
+let querySet53 = device1.createQuerySet({label: '\u0d95\u0976\u618c\u946c\u0699', type: 'occlusion', count: 3248});
+let textureView114 = texture28.createView({dimension: '2d', format: 'astc-10x6-unorm-srgb', baseArrayLayer: 70});
+let computePassEncoder47 = commandEncoder66.beginComputePass();
+let sampler50 = device1.createSampler({
+  label: '\u{1fce6}\u{1f7f8}\u{1faaf}\u{1fb2a}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 74.46,
+});
+try {
+renderPassEncoder12.setScissorRect(3, 1, 0, 0);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(2413);
+} catch {}
+try {
+renderPassEncoder1.setViewport(145.6, 0.04467, 24.67, 0.2360, 0.4561, 0.5064);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(466, 369, 921_453_656, 274_969_427, 179_146_326);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer24, 635_706_780);
+} catch {}
+try {
+renderBundleEncoder38.drawIndexed(269);
+} catch {}
+try {
+commandEncoder80.copyBufferToBuffer(buffer18, 133392, buffer29, 20280, 10436);
+dissociateBuffer(device1, buffer18);
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder80.copyBufferToTexture({
+  /* bytesInLastRow: 180 widthInBlocks: 45 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 179872 */
+  offset: 4588,
+  bytesPerRow: 256,
+  rowsPerImage: 18,
+  buffer: buffer8,
+}, {
+  texture: texture5,
+  mipLevel: 4,
+  origin: {x: 30, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 45, height: 1, depthOrArrayLayers: 39});
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+commandEncoder78.copyTextureToBuffer({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 148, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 42608 */
+  offset: 42608,
+  buffer: buffer29,
+}, {width: 2, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder17.clearBuffer(buffer25, 12280, 8140);
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+} catch {}
+try {
+  await promise27;
+} catch {}
+let imageBitmap26 = await createImageBitmap(canvas2);
+let imageBitmap27 = await createImageBitmap(imageBitmap4);
+let bindGroup30 = device1.createBindGroup({
+  label: '\u09aa\u{1f697}\u431a\u7fdb\u0ca6\u42ec\u82f3\u0ffc\u06b2\u01e4',
+  layout: bindGroupLayout2,
+  entries: [{binding: 644, resource: externalTexture18}],
+});
+let texture70 = device1.createTexture({
+  label: '\u00ea\u{1f6b4}\u6fc4\u193b\u3083',
+  size: [960, 6, 100],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm-srgb'],
+});
+let textureView115 = texture11.createView({mipLevelCount: 2, arrayLayerCount: 1});
+let sampler51 = device1.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 48.30,
+  lodMaxClamp: 99.48,
+  maxAnisotropy: 10,
+});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(49, 1, 104, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer18, 413_593_978);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderBundleEncoder42.setPipeline(pipeline53);
+} catch {}
+try {
+commandEncoder77.copyBufferToBuffer(buffer8, 737080, buffer2, 4140, 2772);
+dissociateBuffer(device1, buffer8);
+dissociateBuffer(device1, buffer2);
+} catch {}
+try {
+commandEncoder86.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 18, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 38, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 171, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer5, 24684, new Float32Array(14418), 5299, 1052);
+} catch {}
+let gpuCanvasContext12 = offscreenCanvas10.getContext('webgpu');
+let canvas14 = document.createElement('canvas');
+try {
+canvas14.getContext('2d');
+} catch {}
+let commandEncoder96 = device1.createCommandEncoder({label: '\uad36\u70f2\u27e8\u0dac\u0e43\uf4a1\uc9ed\u94e8\u0174\u116c'});
+let querySet54 = device1.createQuerySet({type: 'occlusion', count: 763});
+let commandBuffer20 = commandEncoder42.finish({label: '\u6fc7\u{1f9b5}\u0343'});
+let texture71 = device1.createTexture({size: [240], dimension: '1d', format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST});
+let textureView116 = texture25.createView({
+  label: '\u{1fe2f}\u4450\u{1f695}\u{1f9df}\u0eab\uabd5\u070c\u841f\u{1ff36}',
+  format: 'bgra8unorm-srgb',
+  baseMipLevel: 4,
+  mipLevelCount: 3,
+  baseArrayLayer: 90,
+  arrayLayerCount: 23,
+});
+let renderPassEncoder14 = commandEncoder86.beginRenderPass({
+  colorAttachments: [{
+  view: textureView68,
+  depthSlice: 1103,
+  clearValue: { r: -207.5, g: 521.9, b: 271.5, a: -926.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet38,
+  maxDrawCount: 540043170,
+});
+let renderBundleEncoder56 = device1.createRenderBundleEncoder({
+  label: '\u{1fe07}\uc2d4\u{1f8b3}\u90c4\uf610\u0f0c\u38c8',
+  colorFormats: ['bgra8unorm'],
+  sampleCount: 1,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup11, []);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle28]);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(3, bindGroup15, []);
+} catch {}
+try {
+renderBundleEncoder53.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(1, buffer27, 0);
+} catch {}
+try {
+commandEncoder96.copyBufferToTexture({
+  /* bytesInLastRow: 1880 widthInBlocks: 470 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6056 */
+  offset: 6056,
+  rowsPerImage: 147,
+  buffer: buffer8,
+}, {
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 470, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer8);
+} catch {}
+gc();
+gc();
+let videoFrame14 = new VideoFrame(img5, {timestamp: 0});
+let pipelineLayout16 = device1.createPipelineLayout({bindGroupLayouts: [bindGroupLayout2, bindGroupLayout3]});
+let querySet55 = device1.createQuerySet({label: '\u41de\u9b1e\u{1f821}\uaa8f\u73df', type: 'occlusion', count: 1844});
+let sampler52 = device1.createSampler({addressModeU: 'mirror-repeat', mipmapFilter: 'nearest', lodMaxClamp: 81.19});
+try {
+renderPassEncoder13.setBlendConstant({ r: -767.6, g: -785.7, b: -124.9, a: 688.7, });
+} catch {}
+try {
+renderPassEncoder5.setScissorRect(87, 0, 85, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(42, 14, 122_548_860);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer10, 1_037_296_275);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder38.draw(204, 191);
+} catch {}
+try {
+renderBundleEncoder38.drawIndirect(buffer8, 1360);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 208 */
+{offset: 208, rowsPerImage: 190}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap28 = await createImageBitmap(imageBitmap11);
+let img12 = await imageWithData(268, 273, '#a14c097f', '#1a3553db');
+let computePassEncoder48 = commandEncoder55.beginComputePass();
+try {
+renderBundleEncoder50.setBindGroup(7, bindGroup29);
+} catch {}
+try {
+renderBundleEncoder51.drawIndexed(456, 182, 559_928_415);
+} catch {}
+let pipelineLayout17 = device1.createPipelineLayout({bindGroupLayouts: [bindGroupLayout2, bindGroupLayout0, bindGroupLayout2]});
+let buffer32 = device1.createBuffer({label: '\u8209\u09fd', size: 87869, usage: GPUBufferUsage.MAP_READ});
+let textureView117 = texture19.createView({label: '\u{1fe6e}\ucd67\u07df\u{1f91a}\u0c47\u11e6\uf1ec'});
+let renderPassEncoder15 = commandEncoder77.beginRenderPass({
+  colorAttachments: [{
+  view: textureView82,
+  depthSlice: 101,
+  clearValue: { r: 504.4, g: -892.6, b: 811.9, a: 644.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet26,
+  maxDrawCount: 80813328,
+});
+let renderBundleEncoder57 = device1.createRenderBundleEncoder({
+  label: '\uabd3\u{1fce2}',
+  colorFormats: ['bgra8unorm'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder8.draw(444, 328, 860_886_001, 2_905_384_111);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(44, 320, 845_014_194, 1_095_996_080, 83_957_992);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer24, 706_438_798);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(4, buffer27);
+} catch {}
+try {
+renderBundleEncoder47.drawIndexed(63);
+} catch {}
+try {
+renderBundleEncoder42.setPipeline(pipeline45);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(0, buffer27, 0);
+} catch {}
+try {
+commandEncoder17.copyBufferToBuffer(buffer18, 333848, buffer19, 4192, 3324);
+dissociateBuffer(device1, buffer18);
+dissociateBuffer(device1, buffer19);
+} catch {}
+try {
+commandEncoder73.copyTextureToBuffer({
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 58240 */
+  offset: 58240,
+  bytesPerRow: 0,
+  buffer: buffer5,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer5);
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder21.insertDebugMarker('\u{1f604}');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer5, 9568, new BigUint64Array(34296), 25395, 28);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 180, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer8, /* required buffer size: 387 */
+{offset: 387}, {width: 376, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 60, height: 1, depthOrArrayLayers: 37}
+*/
+{
+  source: canvas1,
+  origin: { x: 94, y: 552 },
+  flipY: false,
+}, {
+  texture: texture43,
+  mipLevel: 5,
+  origin: {x: 11, y: 0, z: 15},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+video4.height = 275;
+let offscreenCanvas12 = new OffscreenCanvas(80, 561);
+let bindGroupLayout22 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 551,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder97 = device1.createCommandEncoder({label: '\u9074\uf293\u{1f64a}\u28fb\u{1feed}\u0919\u{1f865}\u8da1\u0a4f\u{1f91f}\uf0c0'});
+let renderPassEncoder16 = commandEncoder78.beginRenderPass({
+  label: '\ub8ff\u904c\u0df6\ucc3b\u1488\u08e9\u89ff',
+  colorAttachments: [{
+  view: textureView68,
+  depthSlice: 26,
+  clearValue: { r: -447.7, g: -849.1, b: 679.6, a: 230.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 417218938,
+});
+let renderBundleEncoder58 = device1.createRenderBundleEncoder({colorFormats: ['bgra8unorm'], depthReadOnly: true});
+let renderBundle69 = renderBundleEncoder55.finish({label: '\u1a42\u0865\u0397\u6328\u715b\u0c49\u17a9\u4366\u075e'});
+try {
+renderPassEncoder16.setStencilReference(2646);
+} catch {}
+try {
+renderPassEncoder5.setViewport(109.5, 0.5001, 40.97, 0.2021, 0.4318, 0.4827);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(5, 44);
+} catch {}
+try {
+renderBundleEncoder56.setPipeline(pipeline45);
+} catch {}
+try {
+commandEncoder61.copyBufferToTexture({
+  /* bytesInLastRow: 1224 widthInBlocks: 306 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5528 */
+  offset: 5528,
+  buffer: buffer8,
+}, {
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 306, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+commandEncoder17.copyTextureToBuffer({
+  texture: texture53,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1256 widthInBlocks: 314 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 35628 */
+  offset: 34372,
+  buffer: buffer3,
+}, {width: 314, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer3);
+} catch {}
+try {
+commandEncoder93.copyTextureToTexture({
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder17.clearBuffer(buffer25, 10512, 13432);
+dissociateBuffer(device1, buffer25);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer5, 42044, new DataView(new ArrayBuffer(8933)), 7221, 12);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let buffer33 = device1.createBuffer({
+  label: '\u27cb\u2930\u093b\u3e06\u0718\ua455\u50c8\u08b0\u054e\u7af7\u0e83',
+  size: 21204,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandEncoder98 = device1.createCommandEncoder({label: '\u{1fa8e}\ue395\u6212\u0d69\u5f04\u1735\u96bc\uaa72\u2ada'});
+let texture72 = device1.createTexture({
+  size: {width: 960, height: 6, depthOrArrayLayers: 160},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm'],
+});
+let renderPassEncoder17 = commandEncoder98.beginRenderPass({
+  label: '\u072f\u{1f673}\u{1f7cd}\u04c2',
+  colorAttachments: [{
+  view: textureView88,
+  depthSlice: 0,
+  clearValue: { r: 353.8, g: -894.8, b: -398.3, a: -310.1, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder13.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder16.setViewport(163.5, 0.2705, 76.37, 0.4949, 0.00513, 0.5459);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer3, 485_569_590);
+} catch {}
+try {
+renderBundleEncoder41.draw(2);
+} catch {}
+try {
+renderBundleEncoder53.drawIndirect(buffer8, 38924);
+} catch {}
+try {
+commandEncoder35.copyTextureToBuffer({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3020 widthInBlocks: 755 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 904 */
+  offset: 904,
+  rowsPerImage: 166,
+  buffer: buffer29,
+}, {width: 755, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder61.copyTextureToTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 129, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer5, 2224, new BigUint64Array(24742), 18000, 228);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let shaderModule19 = device0.createShaderModule({
+  label: '\u0a8c\uf516\u2132\uac1e\u{1f672}\uc368\ue72e\u{1ffd2}\u{1fbf0}\u{1fefd}',
+  code: `@group(2) @binding(5002)
+var<storage, read_write> parameter8: array<u32>;
+@group(2) @binding(3465)
+var<storage, read_write> global6: array<u32>;
+@group(1) @binding(1456)
+var<storage, read_write> function3: array<u32>;
+
+@compute @workgroup_size(1, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<u32>,
+  @location(0) f1: vec4<u32>,
+  @location(2) f2: u32,
+  @location(6) f3: vec4<f32>,
+  @location(4) f4: vec3<f32>,
+  @builtin(sample_mask) f5: u32,
+  @location(1) f6: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_mask) a1: u32, @builtin(sample_index) a2: u32, @builtin(position) a3: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S12 {
+  @location(15) f0: i32,
+  @location(10) f1: i32,
+  @location(8) f2: vec3<i32>,
+  @location(11) f3: vec3<f32>,
+  @location(19) f4: u32,
+  @location(9) f5: vec4<f32>,
+  @location(17) f6: vec2<f16>,
+  @location(6) f7: u32,
+  @location(20) f8: u32,
+  @location(5) f9: vec4<f32>,
+  @builtin(vertex_index) f10: u32,
+  @location(13) f11: vec4<f16>,
+  @location(0) f12: i32,
+  @location(1) f13: vec4<u32>,
+  @location(16) f14: vec3<f16>,
+  @location(4) f15: vec4<i32>,
+  @location(18) f16: vec4<f32>,
+  @location(2) f17: vec3<i32>,
+  @location(12) f18: vec3<u32>,
+  @location(3) f19: vec3<i32>,
+  @location(7) f20: vec2<f16>
+}
+
+@vertex
+fn vertex0(a0: S12, @location(14) a1: vec3<i32>, @builtin(instance_index) a2: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let bindGroup31 = device0.createBindGroup({layout: bindGroupLayout19, entries: [{binding: 662, resource: sampler20}]});
+let texture73 = device0.createTexture({
+  label: '\u{1ff24}\u9ff2\u0394\ud2f6\u000f\u6f3c\u{1ff48}\ud275',
+  size: [240, 120, 59],
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let renderBundle70 = renderBundleEncoder14.finish();
+let sampler53 = device0.createSampler({
+  label: '\uf0bf\u{1fb56}\u0c30',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 57.05,
+});
+try {
+renderBundleEncoder40.draw(201, 44, 393_476_758);
+} catch {}
+try {
+renderBundleEncoder51.drawIndexedIndirect(buffer26, 864);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer26, 5304);
+} catch {}
+try {
+commandEncoder63.copyTextureToBuffer({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2712 widthInBlocks: 678 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3248 */
+  offset: 3248,
+  rowsPerImage: 300,
+  buffer: buffer26,
+}, {width: 678, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+commandEncoder0.resolveQuerySet(querySet33, 555, 158, buffer30, 343296);
+} catch {}
+try {
+device0.queue.submit([commandBuffer17, commandBuffer18]);
+} catch {}
+let imageData25 = new ImageData(196, 100);
+let gpuCanvasContext13 = offscreenCanvas12.getContext('webgpu');
+let textureView118 = texture48.createView({label: '\u50fd\u0244\u2238\ua65a\u03ab\uc11a\u4d88\u{1fc8f}\u{1fb88}\u0594', baseMipLevel: 1});
+let renderPassEncoder18 = commandEncoder80.beginRenderPass({
+  label: '\uec00\ue5cb\u1997\u0fd0\u05d8\u64de\u86fa\u0753\u895d',
+  colorAttachments: [{
+  view: textureView88,
+  depthSlice: 1,
+  clearValue: { r: -659.8, g: -840.5, b: -594.6, a: -174.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet26,
+  maxDrawCount: 30526608,
+});
+try {
+computePassEncoder27.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(436);
+} catch {}
+try {
+renderPassEncoder13.setStencilReference(3316);
+} catch {}
+try {
+renderPassEncoder9.setViewport(235.6, 0.9292, 1.787, 0.04205, 0.4611, 0.9304);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer20, 60_780_713);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(4, buffer33, 0, 19892);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(2, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder38.draw(115, 41, 216_504_872, 968_604_034);
+} catch {}
+try {
+renderBundleEncoder47.drawIndirect(buffer8, 10640);
+} catch {}
+try {
+renderBundleEncoder53.setVertexBuffer(7, buffer33, 16156);
+} catch {}
+try {
+commandEncoder73.copyBufferToTexture({
+  /* bytesInLastRow: 2380 widthInBlocks: 595 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 16156 */
+  offset: 16156,
+  buffer: buffer8,
+}, {
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 595, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer5, 24828, new BigUint64Array(39423), 24890, 1616);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture66,
+  mipLevel: 0,
+  origin: {x: 248, y: 0, z: 0},
+  aspect: 'all',
+}, new Int32Array(new ArrayBuffer(64)), /* required buffer size: 880 */
+{offset: 880}, {width: 109, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup32 = device0.createBindGroup({
+  label: '\u5f44\u9fc2\u830e\u01ed\ue33c',
+  layout: bindGroupLayout19,
+  entries: [{binding: 662, resource: sampler31}],
+});
+let commandEncoder99 = device0.createCommandEncoder({label: '\u00d3\u946e\ub6dd\ua8c4\ua14d\ud072\u0acf'});
+let textureView119 = texture27.createView({
+  label: '\u2292\uc754\u51be\u5a5d\u0c93\u0ede\u07f3\ucf66\u{1f790}\u869c\uf683',
+  dimension: '2d-array',
+  format: 'r16uint',
+});
+let computePassEncoder49 = commandEncoder91.beginComputePass({label: '\u0b75\u5e03\u{1f8c4}\u0a77\uf812\ud0f2\u{1fee7}\u0bf0'});
+let externalTexture53 = device0.importExternalTexture({source: video4, colorSpace: 'srgb'});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(7, bindGroup32, new Uint32Array(9060), 4758, 0);
+} catch {}
+try {
+renderBundleEncoder51.draw(125, 91, 950_282_346, 65_983_206);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer26, 928);
+} catch {}
+try {
+renderBundleEncoder40.drawIndirect(buffer26, 7788);
+} catch {}
+try {
+commandEncoder94.clearBuffer(buffer26, 21376, 3588);
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+commandEncoder71.resolveQuerySet(querySet17, 934, 1987, buffer30, 156416);
+} catch {}
+let buffer34 = device2.createBuffer({
+  label: '\u08b3\u0d30\u0365\ua05a',
+  size: 412124,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: true,
+});
+let commandEncoder100 = device2.createCommandEncoder({label: '\u408b\u399c\ua5ec\uebb7\uff13\u7ce4\ube57\u0156'});
+let renderBundleEncoder59 = device2.createRenderBundleEncoder({
+  label: '\u0f4a\u11d1\u{1fd2b}\u{1f833}\u7fea\ufec1\u{1f878}\ub094\u{1fb2a}\uee9c',
+  colorFormats: ['rgb10a2uint', 'rgba8sint', 'bgra8unorm-srgb', 'rg16sint', 'r8unorm'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder25.setVertexBuffer(6894, undefined);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+try {
+commandEncoder100.copyBufferToBuffer(buffer14, 44068, buffer13, 12836, 4112);
+dissociateBuffer(device2, buffer14);
+dissociateBuffer(device2, buffer13);
+} catch {}
+try {
+commandEncoder20.resolveQuerySet(querySet16, 1033, 158, buffer34, 181504);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer13, 7868, new BigUint64Array(54577), 21487, 692);
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let commandBuffer21 = commandEncoder17.finish({label: '\u04e5\u09be\u{1fd4c}\u08c7'});
+let renderPassEncoder19 = commandEncoder21.beginRenderPass({
+  label: '\u0de9\u4981\uefd9\u0371\u07ac',
+  colorAttachments: [{
+  view: textureView88,
+  depthSlice: 0,
+  clearValue: { r: 854.7, g: 585.0, b: 705.5, a: -804.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet18,
+  maxDrawCount: 793691767,
+});
+try {
+computePassEncoder27.dispatchWorkgroupsIndirect(buffer33, 20944);
+} catch {}
+try {
+computePassEncoder47.setPipeline(pipeline15);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup27, new Uint32Array(4809), 333, 0);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle29]);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer29, 228_055_386);
+} catch {}
+try {
+renderBundleEncoder41.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder41.drawIndexedIndirect(buffer33, 3060);
+} catch {}
+try {
+commandEncoder35.copyBufferToBuffer(buffer8, 592008, buffer29, 32284, 3992);
+dissociateBuffer(device1, buffer8);
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+commandEncoder35.clearBuffer(buffer5, 26428, 71400);
+dissociateBuffer(device1, buffer5);
+} catch {}
+let pipeline64 = device1.createRenderPipeline({
+  label: '\u0941\u{1fd28}\u2003\u2d5d\u{1ff9d}\u2606\u0834',
+  layout: pipelineLayout11,
+  fragment: {module: shaderModule8, entryPoint: 'fragment0', targets: [{format: 'bgra8unorm'}]},
+  depthStencil: {
+    format: 'stencil8',
+    depthCompare: 'always',
+    stencilFront: {compare: 'less-equal', failOp: 'increment-wrap', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'greater', passOp: 'keep'},
+    stencilReadMask: 2692366505,
+    depthBias: -1617033312,
+    depthBiasSlopeScale: 225.0733067753933,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 140,
+        attributes: [
+          {format: 'sint32', offset: 0, shaderLocation: 10},
+          {format: 'snorm8x2', offset: 24, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 16, shaderLocation: 5},
+          {format: 'float32', offset: 8, shaderLocation: 7},
+          {format: 'snorm8x4', offset: 16, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 32, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 580,
+        stepMode: 'vertex',
+        attributes: [{format: 'float32x2', offset: 124, shaderLocation: 11}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let canvas15 = document.createElement('canvas');
+let shaderModule20 = device1.createShaderModule({
+  code: `@group(0) @binding(644)
+var<storage, read_write> function4: array<u32>;
+
+@compute @workgroup_size(5, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec3<i32>,
+  @location(0) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(9) a0: vec2<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S13 {
+  @location(12) f0: vec3<i32>,
+  @location(9) f1: vec3<f16>,
+  @location(1) f2: i32,
+  @location(8) f3: vec2<u32>,
+  @location(15) f4: vec2<i32>
+}
+struct VertexOutput0 {
+  @builtin(position) f100: vec4<f32>,
+  @location(2) f101: vec4<i32>,
+  @location(12) f102: vec3<f32>,
+  @location(11) f103: vec2<u32>,
+  @location(9) f104: vec2<u32>,
+  @location(7) f105: vec4<i32>,
+  @location(3) f106: i32,
+  @location(15) f107: vec2<i32>,
+  @location(1) f108: vec4<u32>,
+  @location(5) f109: f32
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec4<f16>, @location(2) a1: vec2<f16>, a2: S13, @location(13) a3: f32, @location(11) a4: vec4<f32>, @location(4) a5: vec2<u32>, @location(6) a6: vec4<f16>, @location(0) a7: vec2<f16>, @location(10) a8: i32, @location(3) a9: vec3<u32>, @location(14) a10: vec4<i32>, @location(7) a11: vec4<i32>, @builtin(vertex_index) a12: u32, @builtin(instance_index) a13: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout23 = device1.createBindGroupLayout({
+  label: '\u{1f7da}\u324d\ufad1\u321d\u886e\u0022\u0634\ua40c\u5af9\u9c04\u0127',
+  entries: [
+    {
+      binding: 710,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let commandEncoder101 = device1.createCommandEncoder({});
+let texture74 = device1.createTexture({
+  label: '\u{1f8f9}\u0505\u00ad\u8bee',
+  size: {width: 1920},
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder20 = commandEncoder35.beginRenderPass({
+  label: '\u7ae8\ufde8\ub02d\u631a\u9d1e\u{1fbaa}\u0f69\uc43e',
+  colorAttachments: [{
+  view: textureView88,
+  depthSlice: 0,
+  clearValue: { r: 660.2, g: -624.7, b: 773.5, a: -951.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet6,
+  maxDrawCount: 622071659,
+});
+try {
+computePassEncoder36.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+computePassEncoder43.setBindGroup(1, bindGroup23, new Uint32Array(2170), 1338, 0);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder16.setStencilReference(1475);
+} catch {}
+try {
+renderPassEncoder5.draw(569);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(15, 205, 577_141_261, 104_947_856, 1_019_671_443);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer28, 576_170_010);
+} catch {}
+try {
+renderBundleEncoder38.draw(202, 237);
+} catch {}
+try {
+renderBundleEncoder47.drawIndirect(buffer8, 153620);
+} catch {}
+try {
+renderBundleEncoder42.setPipeline(pipeline53);
+} catch {}
+try {
+device1.pushErrorScope('internal');
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline65 = device1.createComputePipeline({
+  label: '\u76b7\u{1fbac}\ue53b\ue884\u7176',
+  layout: pipelineLayout11,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+gc();
+let canvas16 = document.createElement('canvas');
+try {
+canvas15.getContext('2d');
+} catch {}
+let querySet56 = device0.createQuerySet({label: '\u3a8a\u2768\u5e90\ued62\u03e0\u0128\u2270', type: 'occlusion', count: 1167});
+let textureView120 = texture10.createView({label: '\u9aca\u0746\ud70f'});
+try {
+computePassEncoder29.end();
+} catch {}
+try {
+renderBundleEncoder51.drawIndexedIndirect(buffer26, 5816);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer11, 'uint32', 4700);
+} catch {}
+try {
+renderBundleEncoder48.setPipeline(pipeline35);
+} catch {}
+try {
+commandEncoder30.resolveQuerySet(querySet15, 1385, 38, buffer30, 224768);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 29168, new BigUint64Array(1007), 843, 36);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 512 */
+{offset: 80}, {width: 108, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline66 = device0.createComputePipeline({
+  label: '\u{1ff45}\u29be\u44b4\u05d1\ue8aa\u0ed7\u441c\u34ca',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}},
+});
+offscreenCanvas3.width = 291;
+canvas15.width = 1228;
+let commandEncoder102 = device0.createCommandEncoder({});
+let textureView121 = texture69.createView({label: '\u0a89\u7d88\ub785\u8de0\u0c15\u7434\u0074\u86b6\ua242'});
+let computePassEncoder50 = commandEncoder90.beginComputePass({label: '\u2446\u{1fe11}\uc18f'});
+let renderBundle71 = renderBundleEncoder21.finish({});
+let externalTexture54 = device0.importExternalTexture({source: video8});
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer26, 1812);
+} catch {}
+try {
+commandEncoder71.copyTextureToTexture({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder71.resolveQuerySet(querySet20, 543, 87, buffer1, 20224);
+} catch {}
+let img13 = await imageWithData(255, 114, '#b93424cc', '#622797b7');
+let commandBuffer22 = commandEncoder41.finish();
+let textureView122 = texture26.createView({
+  label: '\uca06\u112a\uf571\u024d\u854c\u078d\u0fa8\ub7ba',
+  baseMipLevel: 2,
+  mipLevelCount: 5,
+  baseArrayLayer: 484,
+  arrayLayerCount: 282,
+});
+try {
+renderBundleEncoder25.setVertexBuffer(4510, undefined, 1776558960, 478588503);
+} catch {}
+try {
+commandEncoder69.clearBuffer(buffer13, 180, 63976);
+dissociateBuffer(device2, buffer13);
+} catch {}
+try {
+commandEncoder20.insertDebugMarker('\u93ce');
+} catch {}
+let promise32 = device2.queue.onSubmittedWorkDone();
+document.body.prepend(video12);
+let commandEncoder103 = device0.createCommandEncoder({});
+let textureView123 = texture38.createView({label: '\u06d5\u{1fc87}\uf4b3\ubd4a\uead1\u{1f79e}\u35dc\u0f4b'});
+try {
+renderBundleEncoder52.setBindGroup(8, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder40.setBindGroup(6, bindGroup10, new Uint32Array(2464), 1366, 0);
+} catch {}
+try {
+renderBundleEncoder51.draw(369, 125, 575_266_366, 146_206_617);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(48, 196, 349_160_140, 812_820_801, 341_209_645);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(7007, undefined);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 520, new BigUint64Array(26414), 21863, 304);
+} catch {}
+try {
+  await promise32;
+} catch {}
+document.body.prepend(img7);
+let commandEncoder104 = device0.createCommandEncoder({label: '\u2b99\u0c5d\ub584\ude06\u0baf\u{1f78b}\u0846\u082f'});
+try {
+computePassEncoder50.setBindGroup(9, bindGroup13);
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline58);
+} catch {}
+try {
+renderBundleEncoder40.draw(3, 61);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer26, 12704);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm'],
+  colorSpace: 'srgb',
+});
+} catch {}
+let renderPassEncoder21 = commandEncoder93.beginRenderPass({
+  label: '\u{1ffe5}\u886f\u0d0e',
+  colorAttachments: [{
+  view: textureView82,
+  depthSlice: 7,
+  clearValue: { r: 99.21, g: 952.1, b: -642.3, a: 796.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet10,
+  maxDrawCount: 565939792,
+});
+let externalTexture55 = device1.importExternalTexture({label: '\ua54f\u{1f8c2}\u8f4b\u{1ffeb}\uad0f\u{1fb28}\u{1f66f}', source: video3});
+try {
+renderBundleEncoder47.draw(212, 9);
+} catch {}
+try {
+renderBundleEncoder47.drawIndexedIndirect(buffer33, 1288);
+} catch {}
+try {
+renderBundleEncoder27.drawIndirect(buffer8, 40708);
+} catch {}
+try {
+renderBundleEncoder58.setVertexBuffer(1775, undefined, 0, 4079754599);
+} catch {}
+try {
+commandEncoder96.copyTextureToBuffer({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 244 */
+  offset: 244,
+  buffer: buffer5,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer5);
+} catch {}
+try {
+renderPassEncoder0.insertDebugMarker('\u{1fab5}');
+} catch {}
+let buffer35 = device1.createBuffer({
+  label: '\u07cf\u8870\ub7d6\u6639\u0ebc',
+  size: 234536,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let texture75 = device1.createTexture({
+  label: '\u07b5\u9471\u0393\u1288\u0aa5',
+  size: [240],
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm'],
+});
+let computePassEncoder51 = commandEncoder97.beginComputePass({label: '\u{1fab9}\u0eef\u3c93\u{1f820}\u81d8\u{1f8b5}\u0fd1\ubc0e\ucd08'});
+let renderBundle72 = renderBundleEncoder53.finish();
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer33, 231_295_194);
+} catch {}
+try {
+renderBundleEncoder41.draw(391, 814, 619_174_247, 1_105_409_903);
+} catch {}
+try {
+renderBundleEncoder41.setPipeline(pipeline21);
+} catch {}
+video0.width = 179;
+try {
+canvas16.getContext('webgl');
+} catch {}
+let renderBundleEncoder60 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'], stencilReadOnly: true});
+try {
+renderBundleEncoder60.setBindGroup(4, bindGroup31, []);
+} catch {}
+try {
+renderBundleEncoder60.setBindGroup(4, bindGroup13, new Uint32Array(9119), 19, 0);
+} catch {}
+try {
+renderBundleEncoder54.setPipeline(pipeline35);
+} catch {}
+let videoFrame15 = new VideoFrame(imageBitmap1, {timestamp: 0});
+let commandBuffer23 = commandEncoder61.finish({label: '\u4f3c\u{1fa8b}\u14b7\uda89\u623e\u9b6b\ucf5d'});
+let texture76 = gpuCanvasContext1.getCurrentTexture();
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(31);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer4, 3_223_341_384);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(6, buffer27);
+} catch {}
+try {
+renderBundleEncoder57.setBindGroup(3, bindGroup28);
+} catch {}
+try {
+renderBundleEncoder58.setPipeline(pipeline45);
+} catch {}
+try {
+renderBundleEncoder58.setVertexBuffer(3, buffer27);
+} catch {}
+try {
+commandEncoder73.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 44, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 17, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder101.clearBuffer(buffer24, 132400, 66028);
+dissociateBuffer(device1, buffer24);
+} catch {}
+try {
+commandEncoder73.resolveQuerySet(querySet41, 2537, 977, buffer3, 19456);
+} catch {}
+let promise33 = device1.createComputePipelineAsync({
+  label: '\ub2c7\uecfc\u0469\ud70f\u{1fbee}\u0536\u{1f7e5}\u8128\u0b55\uea33\ud6eb',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule16, entryPoint: 'compute0'},
+});
+let bindGroup33 = device0.createBindGroup({
+  label: '\u05ce\u{1f878}\u{1f754}\u2384\ubd6c\u4337\u8b0d',
+  layout: bindGroupLayout20,
+  entries: [{binding: 1456, resource: sampler8}],
+});
+let commandEncoder105 = device0.createCommandEncoder({});
+let renderBundleEncoder61 = device0.createRenderBundleEncoder({
+  label: '\u0b96\u33d8\u5c62',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let sampler54 = device0.createSampler({
+  label: '\u0f55\u3465\u223c',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 93.79,
+  lodMaxClamp: 95.45,
+});
+try {
+computePassEncoder44.end();
+} catch {}
+try {
+renderBundleEncoder46.setPipeline(pipeline38);
+} catch {}
+try {
+commandEncoder85.copyBufferToBuffer(buffer12, 1484, buffer26, 4196, 2204);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+commandEncoder83.copyBufferToTexture({
+  /* bytesInLastRow: 4832 widthInBlocks: 604 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 10848 */
+  offset: 10848,
+  buffer: buffer12,
+}, {
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 604, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 12260, new Float32Array(42562), 20528);
+} catch {}
+let pipeline67 = await promise21;
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+offscreenCanvas10.height = 64;
+let imageBitmap29 = await createImageBitmap(video6);
+let img14 = await imageWithData(158, 100, '#69d19ec8', '#abe6fd1d');
+let bindGroupLayout24 = device0.createBindGroupLayout({
+  label: '\u5c15\u9a90\u077d\u{1fa97}\u0a79\u{1fbdd}\u07c1\u37b8',
+  entries: [
+    {
+      binding: 5117,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {binding: 2121, visibility: 0, sampler: { type: 'non-filtering' }},
+    {binding: 2070, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'non-filtering' }},
+  ],
+});
+let bindGroup34 = device0.createBindGroup({
+  label: '\u{1fbd3}\u{1f7ec}\u83d9\uab53\u03c1\u{1f68e}\ubbe7\u0460\u0008\u0c59\u{1f7da}',
+  layout: bindGroupLayout10,
+  entries: [],
+});
+let commandEncoder106 = device0.createCommandEncoder();
+let texture77 = device0.createTexture({
+  label: '\u8a3a\udb4b\u039e\u{1f820}\u{1ff56}',
+  size: [480, 240, 1],
+  mipLevelCount: 8,
+  format: 'etc2-rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView124 = texture51.createView({label: '\u3273\u0a39\u0d34', dimension: '1d', aspect: 'all'});
+try {
+renderBundleEncoder46.draw(121, 328, 1_253_765_677);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexedIndirect(buffer26, 10672);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer11, 'uint16', 20228, 172);
+} catch {}
+let arrayBuffer10 = buffer17.getMappedRange(13112, 404);
+try {
+commandEncoder0.copyBufferToTexture({
+  /* bytesInLastRow: 776 widthInBlocks: 97 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2280 */
+  offset: 2280,
+  bytesPerRow: 1024,
+  buffer: buffer21,
+}, {
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 97, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer21);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(new ArrayBuffer(24)), /* required buffer size: 584 */
+{offset: 584}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+let shaderModule21 = device0.createShaderModule({
+  code: `@group(3) @binding(1456)
+var<storage, read_write> type9: array<u32>;
+@group(8) @binding(1456)
+var<storage, read_write> n11: array<u32>;
+@group(0) @binding(3074)
+var<storage, read_write> parameter9: array<u32>;
+@group(2) @binding(3074)
+var<storage, read_write> local12: array<u32>;
+@group(7) @binding(3074)
+var<storage, read_write> parameter10: array<u32>;
+
+@compute @workgroup_size(4, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec2<u32>,
+  @location(3) f1: vec4<u32>,
+  @location(6) f2: vec4<u32>,
+  @location(0) f3: vec4<u32>,
+  @location(1) f4: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(sample_mask) a1: u32, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S14 {
+  @location(10) f0: vec4<f16>,
+  @location(5) f1: f32,
+  @location(13) f2: vec4<u32>,
+  @location(7) f3: f16,
+  @location(19) f4: u32,
+  @location(8) f5: f16,
+  @location(20) f6: vec3<u32>,
+  @location(9) f7: f16,
+  @location(14) f8: i32,
+  @location(16) f9: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(12) a0: vec2<f16>, @location(11) a1: vec3<i32>, @location(3) a2: vec4<f16>, @location(6) a3: f32, a4: S14, @location(17) a5: u32, @location(4) a6: vec3<i32>, @location(15) a7: vec2<i32>, @location(18) a8: f16, @location(2) a9: vec4<u32>, @location(0) a10: vec2<i32>, @location(1) a11: vec2<f32>, @builtin(vertex_index) a12: u32, @builtin(instance_index) a13: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let bindGroup35 = device0.createBindGroup({layout: bindGroupLayout13, entries: []});
+let commandEncoder107 = device0.createCommandEncoder({label: '\uf5ad\u{1fb4d}\u1f63\u{1ffc5}\u{1f8a4}\ub17f\ubd84\u0b0a\u3df5'});
+let textureView125 = texture13.createView({
+  label: '\u0973\u0430\u0a5e\ua79b\u27ed\u2b13\uf412\ue969\u{1fea3}',
+  dimension: '2d-array',
+  mipLevelCount: 3,
+});
+try {
+renderBundleEncoder40.drawIndirect(buffer26, 2884);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(7282, undefined, 0, 4185660048);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder85.copyTextureToBuffer({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 58, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 170 widthInBlocks: 85 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 216 */
+  offset: 46,
+  buffer: buffer22,
+}, {width: 85, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer22);
+} catch {}
+try {
+commandEncoder106.clearBuffer(buffer26, 17300, 8604);
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline68 = device0.createComputePipeline({
+  label: '\u82e3\u0ebf\ubd58\u{1fcea}\u{1f81e}\ubcae\u2d20',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule19, entryPoint: 'compute0', constants: {}},
+});
+let pipeline69 = await device0.createRenderPipelineAsync({
+  label: '\u5f75\u{1f840}\ufa00\u050c\u{1fac6}\ub3cc\ud02b\ub505',
+  layout: pipelineLayout9,
+  multisample: {count: 4, mask: 0xef9d945f},
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 9952, attributes: [{format: 'sint32x4', offset: 324, shaderLocation: 5}]},
+      {
+        arrayStride: 11932,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x4', offset: 1836, shaderLocation: 0}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'back'},
+});
+let commandEncoder108 = device0.createCommandEncoder();
+let commandBuffer24 = commandEncoder72.finish({label: '\u64ce\u7ade\u055c\u{1f758}\u{1fff6}\u8649\ud633\u{1fc69}\u{1f618}\u{1fc2c}\ufe60'});
+let externalTexture56 = device0.importExternalTexture({label: '\udf54\u682c\u7611\u9b5e', source: videoFrame13, colorSpace: 'display-p3'});
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder107.copyTextureToTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 162, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 3,
+  origin: {x: 36, y: 0, z: 8},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder63.resolveQuerySet(querySet56, 185, 443, buffer30, 350208);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0, commandBuffer13]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer22, 6920, new Int16Array(58447), 52406, 0);
+} catch {}
+let promise34 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 156, height: 1, depthOrArrayLayers: 25}
+*/
+{
+  source: offscreenCanvas7,
+  origin: { x: 15, y: 1 },
+  flipY: true,
+}, {
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline70 = await device0.createComputePipelineAsync({
+  label: '\u0c01\ue955\u5cb6\u3fe1',
+  layout: pipelineLayout9,
+  compute: {module: shaderModule13, entryPoint: 'compute0', constants: {}},
+});
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+offscreenCanvas0.height = 232;
+let bindGroupLayout25 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 2423,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 928,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let buffer36 = device0.createBuffer({label: '\u0940\u502d\u3619', size: 512462, usage: GPUBufferUsage.COPY_DST});
+let commandEncoder109 = device0.createCommandEncoder({});
+let commandBuffer25 = commandEncoder94.finish({label: '\uba3e\u8a71\u06f5\ue7cd\u88d5\u{1f9e1}\u15fa\ue66d\u2383'});
+let texture78 = device0.createTexture({
+  label: '\u{1fabc}\uf12d\u3fea\u0fa7\ud4fe\uba31',
+  size: [312, 1, 1491],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r16uint', 'r16uint'],
+});
+let textureView126 = texture60.createView({label: '\udeb8\ue3da\u{1fe18}'});
+let renderBundle73 = renderBundleEncoder10.finish();
+try {
+renderBundleEncoder51.drawIndirect(buffer26, 756);
+} catch {}
+try {
+commandEncoder99.copyBufferToTexture({
+  /* bytesInLastRow: 424 widthInBlocks: 106 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 9380 */
+  offset: 8956,
+  buffer: buffer15,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 106, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder60.copyTextureToTexture({
+  texture: texture40,
+  mipLevel: 1,
+  origin: {x: 11, y: 0, z: 183},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 225},
+  aspect: 'all',
+},
+{width: 71, height: 0, depthOrArrayLayers: 545});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 30},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 924 */
+{offset: 924}, {width: 48, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let promise35 = device0.createRenderPipelineAsync({
+  label: '\u4858\u7aee\udce1\u{1f7b7}',
+  layout: pipelineLayout9,
+  multisample: {mask: 0xe3792fe4},
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: GPUColorWrite.BLUE}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA}],
+},
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 1952, attributes: [{format: 'uint8x2', offset: 272, shaderLocation: 20}]},
+      {arrayStride: 0, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x4', offset: 8176, shaderLocation: 3}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front'},
+});
+let img15 = await imageWithData(40, 189, '#7baca81b', '#628fbecc');
+try {
+adapter0.label = '\ucf46\u0614\ud9b7';
+} catch {}
+let bindGroup36 = device0.createBindGroup({
+  label: '\ueb77\u0660\u4b1e\u{1fec5}\ubb49\u{1fdc0}\u0dd9\u0a43',
+  layout: bindGroupLayout9,
+  entries: [],
+});
+let textureView127 = texture58.createView({label: '\u0ae6\u47ac\u0921\u0292\u004a\ue417\ued0a\uaaeb\u0718\u9317\u{1fc71}', baseMipLevel: 0});
+let computePassEncoder52 = commandEncoder51.beginComputePass({label: '\u905a\u212e\u2037\u0e08\uadb1'});
+let externalTexture57 = device0.importExternalTexture({source: video8});
+try {
+renderBundleEncoder40.draw(62);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder105.copyBufferToBuffer(buffer17, 42704, buffer22, 1120, 19340);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer22);
+} catch {}
+try {
+device0.queue.submit([commandBuffer24, commandBuffer25]);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder110 = device0.createCommandEncoder();
+let texture79 = device0.createTexture({
+  label: '\uc9bf\u00d0\u0b9f\u001f\u00aa',
+  size: {width: 624},
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView128 = texture78.createView({label: '\u{1fdb4}\u4005\u{1f8c2}\uca38', baseMipLevel: 2});
+let sampler55 = device0.createSampler({
+  label: '\u{1f6df}\u0b1e\u39aa\u04d4',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 34.78,
+  lodMaxClamp: 57.24,
+  compare: 'equal',
+});
+let externalTexture58 = device0.importExternalTexture({label: '\ua2e4\ucdd7\u{1fa30}\u4442', source: video12, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder51.draw(0, 261, 453_031_875);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(39, 255, 560_735_917, 161_125_965);
+} catch {}
+try {
+renderBundleEncoder48.setPipeline(pipeline38);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(6073, undefined, 0, 1706300679);
+} catch {}
+let pipeline71 = await device0.createComputePipelineAsync({layout: pipelineLayout12, compute: {module: shaderModule7, entryPoint: 'compute0', constants: {}}});
+let canvas17 = document.createElement('canvas');
+try {
+window.someLabel = externalTexture11.label;
+} catch {}
+let imageBitmap30 = await createImageBitmap(imageBitmap17);
+let commandEncoder111 = device1.createCommandEncoder({label: '\ufa5b\u0b94\ucd14\u09cd\uc54f\u0dec\u{1fabb}\uc9d9'});
+let texture80 = device1.createTexture({
+  label: '\u3d76\u8f0a\u{1feb3}\u4ac3\u5287\u9d70\uae59\u0205\u335b\u05a0',
+  size: [1920],
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm'],
+});
+let computePassEncoder53 = commandEncoder96.beginComputePass({label: '\u911b\ucfb7\uc58a\u{1f98e}\u8e57'});
+let renderPassEncoder22 = commandEncoder73.beginRenderPass({
+  label: '\u556e\u{1f854}',
+  colorAttachments: [{view: textureView68, depthSlice: 706, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 1002267933,
+});
+let renderBundleEncoder62 = device1.createRenderBundleEncoder({label: '\u0aa7\u0a7a', colorFormats: ['bgra8unorm'], sampleCount: 1});
+let renderBundle74 = renderBundleEncoder41.finish({label: '\uebf1\uf1f1\u0d9e\uab41\u{1f772}\u03fe\u04b0\u5a80'});
+let sampler56 = device1.createSampler({
+  label: '\u0365\u{1f786}\u2a65\u2512\u{1f8f1}\u670a',
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 61.29,
+  compare: 'always',
+  maxAnisotropy: 11,
+});
+try {
+renderPassEncoder16.setStencilReference(1061);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(1, buffer33);
+} catch {}
+try {
+renderBundleEncoder47.drawIndexed(184);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexedIndirect(buffer8, 30288);
+} catch {}
+try {
+commandEncoder101.copyBufferToBuffer(buffer18, 259764, buffer2, 14576, 4832);
+dissociateBuffer(device1, buffer18);
+dissociateBuffer(device1, buffer2);
+} catch {}
+try {
+commandEncoder95.copyTextureToTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 8},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder14.insertDebugMarker('\u3822');
+} catch {}
+let pipeline72 = await promise28;
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+pipeline18.label = '\ua388\uf5dd';
+} catch {}
+let video16 = await videoWithData();
+let buffer37 = device1.createBuffer({
+  label: '\u05da\u02a7\u7050\u0b61\u0fc3\u0a15\ub65c\u993f\ua8ef\u015b',
+  size: 859116,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let textureView129 = texture55.createView({label: '\u{1fc56}\ubc86\u05a7\u9df2\u0fe3\uf1e2\u{1fec4}', baseMipLevel: 1, mipLevelCount: 1});
+let renderPassEncoder23 = commandEncoder95.beginRenderPass({
+  label: '\u85ea\u{1fc2a}\ue971\u23f8\u5ad4\u77d2\ue95d\uaf8f\u{1fa21}\u{1fb33}\u539c',
+  colorAttachments: [{
+  view: textureView88,
+  depthSlice: 0,
+  clearValue: { r: 255.8, g: 103.6, b: -907.8, a: 933.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet54,
+  maxDrawCount: 1220254693,
+});
+let sampler57 = device1.createSampler({
+  label: '\u9849\u161b\u7dd3\ud9df\uf30c\u3880\u180d\uad05\u1c76\uab8e',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMinClamp: 13.44,
+  lodMaxClamp: 29.98,
+});
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder13.setScissorRect(124, 0, 22, 0);
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(3104);
+} catch {}
+try {
+renderPassEncoder14.setViewport(109.2, 0.3571, 8.912, 0.05675, 0.8702, 0.9254);
+} catch {}
+try {
+renderBundleEncoder47.draw(131, 34, 398_544_799, 35_308_954);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(4, buffer33, 0, 9793);
+} catch {}
+try {
+commandEncoder101.copyBufferToTexture({
+  /* bytesInLastRow: 356 widthInBlocks: 89 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3544 */
+  offset: 3544,
+  buffer: buffer8,
+}, {
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 89, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer8);
+} catch {}
+try {
+commandEncoder111.copyTextureToBuffer({
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 3096 widthInBlocks: 774 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 34768 */
+  offset: 34768,
+  buffer: buffer3,
+}, {width: 774, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer3);
+} catch {}
+try {
+commandEncoder111.resolveQuerySet(querySet24, 1451, 1099, buffer3, 17920);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 60, height: 1, depthOrArrayLayers: 29}
+*/
+{
+  source: img7,
+  origin: { x: 4, y: 2 },
+  flipY: true,
+}, {
+  texture: texture17,
+  mipLevel: 5,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let adapter5 = await promise26;
+try {
+canvas17.getContext('webgl');
+} catch {}
+document.body.prepend(img14);
+let offscreenCanvas13 = new OffscreenCanvas(150, 927);
+let textureView130 = texture54.createView({});
+let externalTexture59 = device0.importExternalTexture({label: '\ua95a\u{1fc8c}\u99a3', source: videoFrame9, colorSpace: 'display-p3'});
+try {
+computePassEncoder52.end();
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(71, 164, 789_302_958, 515_035_268, 452_733_585);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexedIndirect(buffer26, 5036);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 20672, new Float32Array(28151), 1735);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 156, height: 1, depthOrArrayLayers: 25}
+*/
+{
+  source: offscreenCanvas9,
+  origin: { x: 55, y: 17 },
+  flipY: false,
+}, {
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 42, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline73 = device0.createComputePipeline({
+  label: '\u010d\udd0c\u0df5\u098b\u636f\ub561\u8208\u0fe4\u656d',
+  layout: pipelineLayout8,
+  compute: {module: shaderModule9, entryPoint: 'compute0'},
+});
+let texture81 = device1.createTexture({
+  size: [960, 6, 1089],
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb'],
+});
+let computePassEncoder54 = commandEncoder101.beginComputePass({label: '\u{1f895}\ueb9e\u0f57\u{1ff47}\u068f\u965e\u{1fd30}\ucec9\ua1aa\u3e82'});
+let externalTexture60 = device1.importExternalTexture({
+  label: '\u{1f7cf}\u{1f957}\u0199\ua131\uc98c\uef4e\u0e0b\u210e\u4bb7\u9154',
+  source: video3,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder35.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder1.draw(166, 401);
+} catch {}
+try {
+renderBundleEncoder47.drawIndexedIndirect(buffer33, 3672);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(4, buffer33, 0, 12739);
+} catch {}
+let promise36 = device1.popErrorScope();
+try {
+commandEncoder111.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5880 */
+  offset: 5880,
+  bytesPerRow: 0,
+  rowsPerImage: 280,
+  buffer: buffer18,
+}, {
+  texture: texture25,
+  mipLevel: 9,
+  origin: {x: 0, y: 0, z: 15},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 124});
+dissociateBuffer(device1, buffer18);
+} catch {}
+try {
+adapter2.label = '\u0db7\ue3ea\u33ba\u0c27\u048c';
+} catch {}
+let commandEncoder112 = device0.createCommandEncoder({});
+try {
+computePassEncoder45.end();
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(6, bindGroup31, []);
+} catch {}
+try {
+renderBundleEncoder51.drawIndexedIndirect(buffer26, 6752);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(1580, undefined, 0, 2546317479);
+} catch {}
+try {
+commandEncoder104.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 2,
+  origin: {x: 24, y: 0, z: 41},
+  aspect: 'all',
+},
+{width: 17, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let video17 = await videoWithData();
+let querySet57 = device0.createQuerySet({type: 'occlusion', count: 488});
+let textureView131 = texture13.createView({aspect: 'all', baseMipLevel: 3});
+try {
+computePassEncoder46.end();
+} catch {}
+try {
+renderBundleEncoder51.drawIndexedIndirect(buffer26, 1248);
+} catch {}
+try {
+renderBundleEncoder48.setPipeline(pipeline38);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+commandEncoder30.copyBufferToBuffer(buffer12, 1644, buffer31, 30764, 7252);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer31);
+} catch {}
+try {
+commandEncoder105.copyTextureToBuffer({
+  texture: texture50,
+  mipLevel: 0,
+  origin: {x: 4, y: 1, z: 264},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 448 widthInBlocks: 112 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 132744 */
+  offset: 2248,
+  bytesPerRow: 512,
+  rowsPerImage: 207,
+  buffer: buffer36,
+}, {width: 112, height: 48, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+commandEncoder71.resolveQuerySet(querySet42, 214, 916, buffer1, 110336);
+} catch {}
+try {
+device0.queue.submit([commandBuffer9]);
+} catch {}
+let gpuCanvasContext14 = offscreenCanvas13.getContext('webgpu');
+let bindGroupLayout26 = device1.createBindGroupLayout({
+  label: '\ua91b\u{1f808}\u4275\u{1fe4f}\ua104',
+  entries: [
+    {
+      binding: 605,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 490,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '2d' },
+    },
+    {binding: 560, visibility: 0, sampler: { type: 'non-filtering' }},
+  ],
+});
+let sampler58 = device1.createSampler({
+  label: '\u528e\u7ad9\ue7a4\u04de',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 51.69,
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder31.end();
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(123, 40, 873_477_846, 123_228_400, 125_098_119);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(2, buffer33, 0, 19312);
+} catch {}
+try {
+renderBundleEncoder27.drawIndirect(buffer35, 34060);
+} catch {}
+let promise37 = device1.popErrorScope();
+try {
+commandEncoder111.clearBuffer(buffer5, 54468, 101952);
+dissociateBuffer(device1, buffer5);
+} catch {}
+let pipeline74 = device1.createComputePipeline({
+  label: '\u853c\ub135\u088d',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule11, entryPoint: 'compute0', constants: {}},
+});
+canvas9.width = 343;
+let textureView132 = texture19.createView({aspect: 'all'});
+let renderPassEncoder24 = commandEncoder14.beginRenderPass({
+  colorAttachments: [{
+  view: textureView82,
+  depthSlice: 102,
+  clearValue: { r: 564.7, g: -150.4, b: -387.7, a: -506.7, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 43692487,
+});
+try {
+renderPassEncoder12.setScissorRect(3, 0, 0, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer20, 289_540_797);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(7, buffer27, 31148, 5162);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexedIndirect(buffer35, 20532);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(3, buffer33, 0, 14678);
+} catch {}
+try {
+commandEncoder111.copyBufferToBuffer(buffer18, 225072, buffer2, 17784, 852);
+dissociateBuffer(device1, buffer18);
+dissociateBuffer(device1, buffer2);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 240, height: 1, depthOrArrayLayers: 209}
+*/
+{
+  source: imageBitmap25,
+  origin: { x: 24, y: 3 },
+  flipY: false,
+}, {
+  texture: texture25,
+  mipLevel: 3,
+  origin: {x: 5, y: 0, z: 14},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(video8);
+try {
+adapter4.label = '\u{1ffca}\u{1f741}';
+} catch {}
+let bindGroupLayout27 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 3227,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 848,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 240148629, hasDynamicOffset: true },
+    },
+    {
+      binding: 4428,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let commandEncoder113 = device0.createCommandEncoder({label: '\u4c51\ud4df\u{1fcc4}\u4945\uf7b3\ud19a\ud9fb'});
+let texture82 = device0.createTexture({
+  label: '\u1b5e\ub699',
+  size: {width: 156, height: 1, depthOrArrayLayers: 114},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView133 = texture20.createView({label: '\u6d5c\ubd3f\u{1ff41}\u8196\ub8e9\u{1f9c0}\ub834\u17dd', baseMipLevel: 7});
+let sampler59 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 11.67,
+  lodMaxClamp: 74.40,
+});
+try {
+renderBundleEncoder60.setPipeline(pipeline38);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+renderPassEncoder18.beginOcclusionQuery(828);
+} catch {}
+try {
+renderBundleEncoder47.drawIndexed(259);
+} catch {}
+try {
+renderBundleEncoder47.drawIndexedIndirect(buffer35, 118244);
+} catch {}
+let pipeline75 = device1.createComputePipeline({
+  label: '\u2736\u0b90\u44b2\u3c71\u0dc9\u{1f798}\u58a9',
+  layout: pipelineLayout14,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let buffer38 = device0.createBuffer({
+  label: '\u0837\u0c53\u0b98\u0f17\u7a74\u0d4d\u5cd9\u016b',
+  size: 198796,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let commandEncoder114 = device0.createCommandEncoder({label: '\u0ded\u345a\u7708\ub5d4\ua5e0\u0df3\u6fe7'});
+let textureView134 = texture61.createView({
+  label: '\ud49b\u126f\u9c99\u87a7\u{1ff63}\u{1f645}\u545b\u{1f8f5}\u0e60',
+  aspect: 'all',
+  arrayLayerCount: 1,
+});
+let computePassEncoder55 = commandEncoder112.beginComputePass();
+let sampler60 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.03,
+  maxAnisotropy: 20,
+});
+let externalTexture61 = device0.importExternalTexture({
+  label: '\u2e72\u07a1\ueaf3\u757f\u89cb\uf3f4\u3d57\u{1fd12}\u{1fad4}\uf94b\u40f5',
+  source: videoFrame5,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder33.setPipeline(pipeline73);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(273, 49, 1_773_780_548, 111_676_691, 26_682_657);
+} catch {}
+try {
+commandEncoder106.copyTextureToBuffer({
+  texture: texture36,
+  mipLevel: 4,
+  origin: {x: 2, y: 0, z: 25},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 456808 */
+  offset: 12384,
+  bytesPerRow: 256,
+  rowsPerImage: 124,
+  buffer: buffer36,
+}, {width: 2, height: 1, depthOrArrayLayers: 15});
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+commandEncoder110.resolveQuerySet(querySet36, 184, 938, buffer30, 350208);
+} catch {}
+try {
+renderBundleEncoder52.insertDebugMarker('\u{1fb5a}');
+} catch {}
+try {
+gpuCanvasContext6.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 23024, new DataView(new ArrayBuffer(56698)), 35985, 1464);
+} catch {}
+let pipeline76 = device0.createComputePipeline({layout: pipelineLayout10, compute: {module: shaderModule9, entryPoint: 'compute0'}});
+let buffer39 = device0.createBuffer({
+  label: '\u{1fce7}\u0846\u3cb4\u502f',
+  size: 50891,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let querySet58 = device0.createQuerySet({label: '\u{1fc93}\u0b60\ud114\ude2e\u{1f637}\u0228\ud6eb', type: 'occlusion', count: 3400});
+let texture83 = device0.createTexture({
+  size: [156, 1, 98],
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint'],
+});
+let textureView135 = texture44.createView({baseMipLevel: 0});
+let externalTexture62 = device0.importExternalTexture({label: '\u06fa\u228f\u1129\u0227\u96d4\u83ba\u0f05\ufa17', source: videoFrame2});
+try {
+computePassEncoder11.setPipeline(pipeline46);
+} catch {}
+try {
+commandEncoder30.copyTextureToTexture({
+  texture: texture83,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder48.pushDebugGroup('\uba5d');
+} catch {}
+let pipeline77 = device0.createComputePipeline({
+  label: '\u{1f7e9}\u414b\u0190\u1839\u28b9\u7eb3\uc2f7\u703b',
+  layout: pipelineLayout12,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise37;
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let canvas18 = document.createElement('canvas');
+try {
+canvas18.getContext('2d');
+} catch {}
+let pipelineLayout18 = device1.createPipelineLayout({
+  label: '\ua2ed\u1921\u5f57\u{1f75f}\u9fa6\u030a\ua838\u7091',
+  bindGroupLayouts: [bindGroupLayout22, bindGroupLayout23, bindGroupLayout22],
+});
+let commandEncoder115 = device1.createCommandEncoder();
+let textureView136 = texture41.createView({label: '\uefa9\u{1f914}', dimension: '2d-array'});
+let renderPassEncoder25 = commandEncoder115.beginRenderPass({
+  label: '\u0f50\u{1fec1}\u0397\ue9b5\u079b\u786d\uf1a0',
+  colorAttachments: [{
+  view: textureView88,
+  depthSlice: 0,
+  clearValue: { r: -782.5, g: 826.3, b: -777.3, a: 275.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet43,
+  maxDrawCount: 166784154,
+});
+let sampler61 = device1.createSampler({
+  label: '\ud49c\u2a8e\u103f\u78bc\u{1fbd9}\u{1ffa1}\uaa1f\u9952',
+  addressModeU: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 78.37,
+  lodMaxClamp: 91.33,
+});
+try {
+renderPassEncoder1.drawIndexed(62);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer28, 2_119_622_402);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(0, bindGroup14);
+} catch {}
+try {
+renderBundleEncoder62.setBindGroup(2, bindGroup22, new Uint32Array(425), 403, 0);
+} catch {}
+try {
+renderBundleEncoder38.drawIndexed(39, 422, 965_621_945, -2_077_753_811);
+} catch {}
+try {
+renderBundleEncoder38.drawIndexedIndirect(buffer33, 13752);
+} catch {}
+try {
+renderBundleEncoder27.drawIndirect(buffer8, 288420);
+} catch {}
+try {
+renderBundleEncoder62.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(3, buffer33, 4104, 8806);
+} catch {}
+try {
+device1.addEventListener('uncapturederror', e => { log('device1.uncapturederror'); log(e); e.label = device1.label; });
+} catch {}
+try {
+commandEncoder111.copyBufferToBuffer(buffer18, 82876, buffer28, 53460, 9008);
+dissociateBuffer(device1, buffer18);
+dissociateBuffer(device1, buffer28);
+} catch {}
+try {
+device1.queue.submit([commandBuffer21, commandBuffer15]);
+} catch {}
+try {
+  await promise34;
+} catch {}
+let imageBitmap31 = await createImageBitmap(imageBitmap21);
+try {
+gpuCanvasContext10.unconfigure();
+} catch {}
+gc();
+let videoFrame16 = new VideoFrame(img2, {timestamp: 0});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+gc();
+let buffer40 = device1.createBuffer({
+  label: '\u0042\u0bd4\ufd38\u7051\u372e\u2b5c',
+  size: 21729,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let computePassEncoder56 = commandEncoder111.beginComputePass({label: '\ue5b6\u{1fbfd}\u8950\u1eda\u766f\u04fe\ud02a'});
+try {
+computePassEncoder39.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: 584.1, g: 382.9, b: 998.3, a: 342.3, });
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer3, 831_236_968);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer23, 2_129_529_931);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline53);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(2, buffer27, 0);
+} catch {}
+try {
+renderBundleEncoder57.setBindGroup(2, bindGroup27);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexedIndirect(buffer33, 380);
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(4, buffer27, 5888, 29839);
+} catch {}
+let texture84 = device1.createTexture({
+  size: [480, 3, 235],
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler62 = device1.createSampler({
+  label: '\u07ce\u0d41\u03f2\u0046\u0da2',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 24.23,
+  lodMaxClamp: 35.29,
+});
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder9.setBlendConstant({ r: 547.1, g: 614.8, b: -785.0, a: -462.9, });
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(3136);
+} catch {}
+try {
+renderPassEncoder1.draw(706, 28, 1_388_160_482);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(20, 238, 204_361_776);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(4, buffer33, 11096, 2579);
+} catch {}
+try {
+renderBundleEncoder62.drawIndexedIndirect(buffer8, 170396);
+} catch {}
+try {
+renderBundleEncoder42.setPipeline(pipeline45);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 60, height: 1, depthOrArrayLayers: 469}
+*/
+{
+  source: imageBitmap11,
+  origin: { x: 1, y: 15 },
+  flipY: false,
+}, {
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 143},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise38 = device1.createRenderPipelineAsync({
+  label: '\u01b6\uad3e\ud0f4\u8fb4\u{1f8f5}',
+  layout: pipelineLayout11,
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'bgra8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {
+      compare: 'not-equal',
+      failOp: 'decrement-wrap',
+      depthFailOp: 'decrement-wrap',
+      passOp: 'increment-clamp',
+    },
+    stencilBack: {failOp: 'decrement-wrap', depthFailOp: 'keep', passOp: 'increment-clamp'},
+    stencilReadMask: 4252869990,
+    stencilWriteMask: 1753772978,
+    depthBiasSlopeScale: 753.899186559732,
+    depthBiasClamp: 863.6392038344964,
+  },
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 132,
+        attributes: [
+          {format: 'uint32x2', offset: 24, shaderLocation: 15},
+          {format: 'uint32x3', offset: 4, shaderLocation: 10},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 7},
+          {format: 'unorm16x2', offset: 0, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 20, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 356, shaderLocation: 2}],
+      },
+      {
+        arrayStride: 156,
+        attributes: [
+          {format: 'float32x3', offset: 44, shaderLocation: 4},
+          {format: 'sint32x4', offset: 4, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 44, attributes: []},
+      {arrayStride: 44, attributes: [{format: 'unorm8x4', offset: 0, shaderLocation: 0}]},
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let canvas19 = document.createElement('canvas');
+let offscreenCanvas14 = new OffscreenCanvas(569, 216);
+let imageData26 = new ImageData(204, 64);
+let shaderModule22 = device1.createShaderModule({
+  label: '\u00ca\u008b\u0a23\u0429\u57e1\u0c11\u0119\u5007\u02ef\u{1fb10}\u0e02',
+  code: `@group(1) @binding(710)
+var<storage, read_write> parameter11: array<u32>;
+@group(2) @binding(551)
+var<storage, read_write> function5: array<u32>;
+
+@compute @workgroup_size(4, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(1) a0: vec4<f16>, @location(10) a1: vec2<f32>, @builtin(sample_index) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S15 {
+  @location(9) f0: f32,
+  @builtin(instance_index) f1: u32,
+  @location(15) f2: f16,
+  @location(0) f3: vec3<u32>,
+  @location(6) f4: vec4<f32>,
+  @location(2) f5: f32
+}
+struct VertexOutput0 {
+  @location(14) f110: vec4<f32>,
+  @builtin(position) f111: vec4<f32>,
+  @location(10) f112: vec2<f32>,
+  @location(1) f113: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(4) a0: vec4<i32>, a1: S15, @location(14) a2: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+});
+let texture85 = device1.createTexture({
+  label: '\u6570\ud051\u{1f9e6}',
+  size: {width: 480},
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm-srgb'],
+});
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+renderPassEncoder7.setViewport(9.333, 0.2848, 158.8, 0.5379, 0.5215, 0.6917);
+} catch {}
+try {
+renderPassEncoder8.draw(366, 26, 35_840_101, 1_746_551_052);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(57, 53);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer25, 224_659_416);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder62.drawIndirect(buffer35, 115292);
+} catch {}
+try {
+renderBundleEncoder38.setPipeline(pipeline45);
+} catch {}
+try {
+renderBundleEncoder56.setVertexBuffer(7, buffer33, 0);
+} catch {}
+let promise39 = buffer32.mapAsync(GPUMapMode.READ, 87664, 172);
+try {
+gpuCanvasContext14.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device1.queue.writeBuffer(buffer29, 5364, new Int16Array(16601), 7190, 3212);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 1920, height: 12, depthOrArrayLayers: 1207}
+*/
+{
+  source: offscreenCanvas8,
+  origin: { x: 2, y: 220 },
+  flipY: false,
+}, {
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 13, y: 2, z: 37},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline78 = device1.createComputePipeline({
+  label: '\u03c8\u4dbb\u0cc6\u{1f6a0}\u0963\u7632\uc979\uc990',
+  layout: pipelineLayout15,
+  compute: {module: shaderModule8, entryPoint: 'compute0', constants: {}},
+});
+let textureView137 = texture67.createView({label: '\u8085\u0053\u925b', aspect: 'all'});
+let renderBundleEncoder63 = device1.createRenderBundleEncoder({label: '\u{1ff1e}\u{1fcae}', colorFormats: ['bgra8unorm'], sampleCount: 1, depthReadOnly: true});
+try {
+renderPassEncoder8.draw(65, 203, 703_089_980, 901_074_645);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(10, 264, 1_030_073_497, 645_366_779);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer28, 995_137_626);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+renderBundleEncoder47.draw(255);
+} catch {}
+try {
+renderBundleEncoder62.setVertexBuffer(3, buffer27, 0, 527);
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm', 'rgba8unorm-srgb'],
+  alphaMode: 'opaque',
+});
+} catch {}
+let textureView138 = texture81.createView({label: '\u{1f682}\u22fb\u063d\u3500\uca99\u9af1\u8a90\u0a60', dimension: '3d', baseMipLevel: 0});
+let renderBundle75 = renderBundleEncoder53.finish({});
+let externalTexture63 = device1.importExternalTexture({label: '\ud85f\u96b1\u0082\u0044\u911d\u04a4\uc486', source: video13, colorSpace: 'srgb'});
+try {
+computePassEncoder32.setBindGroup(3, bindGroup0, new Uint32Array(4095), 3269, 0);
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline19);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(5);
+} catch {}
+try {
+renderPassEncoder11.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.setViewport(238.5, 0.07631, 0.2656, 0.2612, 0.2424, 0.3969);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer37, 1_653_467_180);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer27);
+} catch {}
+try {
+renderBundleEncoder27.setBindGroup(0, bindGroup17, new Uint32Array(6506), 5979, 0);
+} catch {}
+try {
+renderBundleEncoder62.drawIndexedIndirect(buffer33, 2876);
+} catch {}
+try {
+renderPassEncoder21.insertDebugMarker('\uead9');
+} catch {}
+let pipeline79 = device1.createComputePipeline({
+  label: '\u92b8\u2f21\u{1fae4}\u99d2\u105f\u{1fe9b}\u09fd\u016a',
+  layout: pipelineLayout16,
+  compute: {module: shaderModule8, entryPoint: 'compute0'},
+});
+let pipeline80 = device1.createRenderPipeline({
+  layout: pipelineLayout15,
+  multisample: {count: 4, mask: 0xcf989fd9},
+  fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'src-alpha', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'always', depthFailOp: 'zero', passOp: 'increment-wrap'},
+    stencilBack: {failOp: 'zero', depthFailOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilReadMask: 1144972166,
+    stencilWriteMask: 1408164410,
+    depthBias: 1871365023,
+    depthBiasSlopeScale: 690.6800046781076,
+  },
+  vertex: {
+    module: shaderModule12,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 196,
+        attributes: [
+          {format: 'sint32x4', offset: 80, shaderLocation: 10},
+          {format: 'uint32', offset: 76, shaderLocation: 6},
+          {format: 'sint32x3', offset: 32, shaderLocation: 7},
+          {format: 'uint32x3', offset: 68, shaderLocation: 1},
+          {format: 'float32x3', offset: 0, shaderLocation: 9},
+          {format: 'sint32x4', offset: 12, shaderLocation: 3},
+          {format: 'sint16x4', offset: 72, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 104,
+        attributes: [
+          {format: 'sint32', offset: 4, shaderLocation: 14},
+          {format: 'sint32x3', offset: 16, shaderLocation: 11},
+          {format: 'uint32x2', offset: 12, shaderLocation: 0},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 4},
+          {format: 'float32x3', offset: 32, shaderLocation: 13},
+          {format: 'sint32x2', offset: 32, shaderLocation: 2},
+          {format: 'uint32x2', offset: 4, shaderLocation: 5},
+          {format: 'sint16x2', offset: 0, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 232,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x4', offset: 24, shaderLocation: 8}],
+      },
+    ],
+  },
+});
+try {
+offscreenCanvas14.getContext('2d');
+} catch {}
+let commandEncoder116 = device1.createCommandEncoder({label: '\u49b9\u0fa4\u8f9a\ud808\u7406\u0782\u{1f9dd}\ud59d'});
+let querySet59 = device1.createQuerySet({label: '\u03e9\u0320\u171e', type: 'occlusion', count: 1800});
+let texture86 = device1.createTexture({
+  label: '\u9839\ufc3d',
+  size: {width: 960, height: 6, depthOrArrayLayers: 209},
+  mipLevelCount: 9,
+  sampleCount: 1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['bgra8unorm'],
+});
+let textureView139 = texture28.createView({label: '\u5f55\u551a', dimension: '2d', format: 'astc-10x6-unorm-srgb', baseArrayLayer: 138});
+let externalTexture64 = device1.importExternalTexture({label: '\uac55\u0210\u2761\u4daa\u{1fd84}', source: videoFrame14, colorSpace: 'srgb'});
+try {
+computePassEncoder35.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(119, 712, 1_545_339_566, 1_056_302_714, 174_327_057);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer5, 227_350_529);
+} catch {}
+try {
+renderBundleEncoder47.drawIndexed(38, 54, 273_731_550, 523_836_128);
+} catch {}
+try {
+renderBundleEncoder27.drawIndirect(buffer33, 396);
+} catch {}
+try {
+renderBundleEncoder38.setPipeline(pipeline10);
+} catch {}
+let arrayBuffer11 = buffer37.getMappedRange();
+try {
+commandEncoder116.copyBufferToBuffer(buffer4, 15592, buffer10, 14088, 15020);
+dissociateBuffer(device1, buffer4);
+dissociateBuffer(device1, buffer10);
+} catch {}
+try {
+renderPassEncoder5.insertDebugMarker('\ucb4b');
+} catch {}
+try {
+device1.queue.submit([commandBuffer20]);
+} catch {}
+let img16 = await imageWithData(234, 280, '#4195a33c', '#3aaa8996');
+let imageData27 = new ImageData(188, 216);
+let pipelineLayout19 = device0.createPipelineLayout({
+  bindGroupLayouts: [bindGroupLayout18, bindGroupLayout10, bindGroupLayout17, bindGroupLayout10, bindGroupLayout10, bindGroupLayout17, bindGroupLayout13, bindGroupLayout16, bindGroupLayout9, bindGroupLayout21, bindGroupLayout15],
+});
+let buffer41 = device0.createBuffer({
+  label: '\u{1f761}\u{1fb10}\u9915',
+  size: 7057,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let commandEncoder117 = device0.createCommandEncoder({});
+try {
+renderBundleEncoder51.drawIndexed(187, 472, 1_300_717_657, 273_565_950);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder99.copyTextureToTexture({
+  texture: texture77,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture77,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer36, 32256, new DataView(new ArrayBuffer(4532)), 2066, 428);
+} catch {}
+let pipeline81 = device0.createRenderPipeline({
+  layout: pipelineLayout9,
+  multisample: {mask: 0x39762535},
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.GREEN}, {format: 'rgba8uint', writeMask: 0}, {format: 'r16uint', writeMask: 0}, {format: 'rgb10a2uint'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater-equal', failOp: 'decrement-clamp', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilBack: {compare: 'never', failOp: 'zero', depthFailOp: 'increment-clamp', passOp: 'increment-wrap'},
+    stencilReadMask: 3235719746,
+    stencilWriteMask: 2673565737,
+    depthBias: 1606906518,
+    depthBiasClamp: 849.7602336526378,
+  },
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 6512,
+        attributes: [
+          {format: 'uint32x2', offset: 348, shaderLocation: 20},
+          {format: 'float32x3', offset: 3124, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', unclippedDepth: true},
+});
+offscreenCanvas14.width = 173;
+try {
+canvas19.getContext('webgpu');
+} catch {}
+try {
+  await promise36;
+} catch {}
+canvas0.height = 260;
+let texture87 = device1.createTexture({
+  label: '\uf560\u81d6\u0b30\u0f79\ue347\u{1ff6c}\u{1fed8}\u0d80\u{1fcee}',
+  size: [240, 1, 81],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm', 'bgra8unorm-srgb', 'bgra8unorm-srgb'],
+});
+let renderPassEncoder26 = commandEncoder116.beginRenderPass({
+  colorAttachments: [{view: textureView88, depthSlice: 0, loadOp: 'load', storeOp: 'store'}],
+  occlusionQuerySet: querySet6,
+  maxDrawCount: 369179419,
+});
+let renderBundleEncoder64 = device1.createRenderBundleEncoder({
+  label: '\u04b6\u{1fedd}\u{1fb4b}\ue350\u0720',
+  colorFormats: ['bgra8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderPassEncoder6.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder15.setViewport(226.9, 0.5744, 8.744, 0.1840, 0.3226, 0.3831);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(576, 111, 512_885_210, -1_940_182_698, 443_898_375);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer29, 671_151_920);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline45);
+} catch {}
+try {
+renderBundleEncoder63.setPipeline(pipeline45);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer29, 9180, new Float32Array(5277), 1921, 1260);
+} catch {}
+document.body.prepend(canvas11);
+let imageBitmap32 = await createImageBitmap(imageBitmap19);
+let bindGroupLayout28 = device0.createBindGroupLayout({
+  label: '\u05d6\u42f9\u{1f7a7}\u6f87\u0895\u{1fbcd}\ufdb8\u1d42\u0590',
+  entries: [
+    {
+      binding: 593,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d-array', sampleType: 'float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder118 = device0.createCommandEncoder({});
+let renderBundle76 = renderBundleEncoder17.finish({label: '\u{1ff46}\u8c59'});
+try {
+renderBundleEncoder61.setBindGroup(8, bindGroup8, new Uint32Array(7135), 4734, 0);
+} catch {}
+try {
+renderBundleEncoder54.setVertexBuffer(6786, undefined, 0, 2819784932);
+} catch {}
+try {
+  await buffer31.mapAsync(GPUMapMode.READ, 80344);
+} catch {}
+try {
+commandEncoder57.clearBuffer(buffer22, 15424, 1172);
+dissociateBuffer(device0, buffer22);
+} catch {}
+try {
+commandEncoder59.resolveQuerySet(querySet48, 812, 66, buffer30, 117760);
+} catch {}
+try {
+  await promise39;
+} catch {}
+let textureView140 = texture72.createView({label: '\u{1fb2c}\u{1fcd9}\u0c6d', baseMipLevel: 2, mipLevelCount: 1});
+let renderBundleEncoder65 = device1.createRenderBundleEncoder({label: '\uaeca\u5c39', colorFormats: ['bgra8unorm'], depthReadOnly: true, stencilReadOnly: true});
+let sampler63 = device1.createSampler({
+  label: '\u{1fc7d}\ud8c5\u0bba\u34f2\u00cb\u{1fae2}\u092b\u83cb\ue391\u01f7',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 10.37,
+  lodMaxClamp: 73.46,
+});
+try {
+renderPassEncoder1.setBlendConstant({ r: -913.3, g: -773.6, b: -83.69, a: 711.6, });
+} catch {}
+try {
+renderPassEncoder2.setViewport(25.45, 0.9984, 46.08, 0.00109, 0.5267, 0.6593);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(357);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer23, 408_448_540);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer4, 456_703_939);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexedIndirect(buffer8, 58468);
+} catch {}
+try {
+renderBundleEncoder47.drawIndirect(buffer35, 66944);
+} catch {}
+try {
+renderBundleEncoder63.setVertexBuffer(0, buffer27);
+} catch {}
+canvas16.height = 763;
+let video18 = await videoWithData();
+try {
+computePassEncoder10.setPipeline(pipeline32);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder48.drawIndexedIndirect(buffer26, 1820);
+} catch {}
+try {
+commandEncoder105.copyTextureToBuffer({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10160 */
+  offset: 10160,
+  buffer: buffer26,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 2},
+  aspect: 'all',
+}, new ArrayBuffer(113_154), /* required buffer size: 113_154 */
+{offset: 822, bytesPerRow: 234, rowsPerImage: 240}, {width: 3, height: 1, depthOrArrayLayers: 3});
+} catch {}
+let pipeline82 = await promise35;
+canvas5.height = 1222;
+let commandEncoder119 = device1.createCommandEncoder({label: '\uab3d\u236b\u7f9f\uf677\u{1f86d}\u{1f6d0}\u07d5'});
+let texture88 = device1.createTexture({
+  label: '\u{1fac5}\u{1f616}\u3e66',
+  size: [480, 3, 171],
+  mipLevelCount: 7,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder1.drawIndexed(123, 140, 1_196_589_629);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer37, 154_061_180);
+} catch {}
+try {
+renderBundleEncoder64.setBindGroup(1, bindGroup20, new Uint32Array(501), 467, 0);
+} catch {}
+try {
+renderBundleEncoder27.draw(260, 244, 2_018_562_190);
+} catch {}
+try {
+renderBundleEncoder42.setVertexBuffer(1, buffer27, 15452, 9190);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+try {
+commandEncoder119.copyTextureToTexture({
+  texture: texture88,
+  mipLevel: 1,
+  origin: {x: 18, y: 0, z: 10},
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+},
+{width: 18, height: 0, depthOrArrayLayers: 12});
+} catch {}
+try {
+commandEncoder119.clearBuffer(buffer5, 2724, 121476);
+dissociateBuffer(device1, buffer5);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer40, 1736, new DataView(new ArrayBuffer(8443)), 5718, 160);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 615 */
+{offset: 615}, {width: 79, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder120 = device0.createCommandEncoder({label: '\ucf64\uea42\ue33c\u1148\u27d7\ue30e\u0385'});
+try {
+renderBundleEncoder48.draw(96, 220);
+} catch {}
+try {
+renderBundleEncoder51.drawIndexed(445, 499, 335_216_004, 560_968_591, 206_973_679);
+} catch {}
+try {
+renderBundleEncoder60.drawIndirect(buffer26, 7912);
+} catch {}
+try {
+renderBundleEncoder48.setIndexBuffer(buffer26, 'uint16', 11780, 14789);
+} catch {}
+try {
+renderBundleEncoder48.setPipeline(pipeline38);
+} catch {}
+try {
+commandEncoder60.copyBufferToTexture({
+  /* bytesInLastRow: 60 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 40472 */
+  offset: 40472,
+  buffer: buffer15,
+}, {
+  texture: texture52,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 15, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandBuffer26 = commandEncoder119.finish({label: '\u0ab6\u{1fc0a}\u0b20\u8765\u9ed4\u{1f96e}\ub229\u0933\u{1f92f}\u0d20'});
+let sampler64 = device1.createSampler({
+  label: '\u23b2\ueb73\ub5f0',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 71.74,
+  lodMaxClamp: 78.44,
+  compare: 'not-equal',
+});
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer8, 2_039_110_400);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(9833, undefined, 0);
+} catch {}
+try {
+renderBundleEncoder58.setBindGroup(2, bindGroup11, new Uint32Array(6390), 3593, 0);
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device1,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline83 = await promise38;
+let imageData28 = new ImageData(20, 120);
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let commandEncoder121 = device0.createCommandEncoder();
+try {
+computePassEncoder12.setBindGroup(5, bindGroup7, new Uint32Array(5892), 3848, 0);
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline73);
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(8, bindGroup2, new Uint32Array(5090), 3031, 0);
+} catch {}
+try {
+renderBundleEncoder48.drawIndirect(buffer26, 11108);
+} catch {}
+try {
+commandEncoder121.copyBufferToBuffer(buffer15, 359808, buffer16, 120816, 19860);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder71.copyBufferToTexture({
+  /* bytesInLastRow: 216 widthInBlocks: 54 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3980 */
+  offset: 3980,
+  buffer: buffer12,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 86, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 54, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder59.copyTextureToTexture({
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 84, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 48, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline84 = device0.createRenderPipeline({
+  label: '\u44d8\u46b9\u61c0',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule10,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.GREEN}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {
+  format: 'r16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgb10a2uint'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'less-equal', failOp: 'decrement-wrap', depthFailOp: 'decrement-wrap', passOp: 'invert'},
+    stencilBack: {compare: 'equal', failOp: 'increment-clamp', depthFailOp: 'increment-wrap', passOp: 'keep'},
+    stencilReadMask: 3417273229,
+    depthBiasSlopeScale: -56.39626402150854,
+    depthBiasClamp: 330.84449820851535,
+  },
+  vertex: {
+    module: shaderModule10,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 25592,
+        attributes: [
+          {format: 'snorm16x4', offset: 4580, shaderLocation: 3},
+          {format: 'uint32x2', offset: 10856, shaderLocation: 20},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: true},
+});
+let img17 = await imageWithData(36, 273, '#b190bb12', '#840397d9');
+try {
+window.someLabel = textureView71.label;
+} catch {}
+let bindGroup37 = device1.createBindGroup({label: '\u6293\u{1fb69}\u00b4\u{1fcb3}\u{1f667}\uda1c', layout: bindGroupLayout3, entries: []});
+let textureView141 = texture85.createView({
+  label: '\u5628\u17f5\u879e',
+  dimension: '1d',
+  aspect: 'all',
+  format: 'bgra8unorm-srgb',
+  arrayLayerCount: 1,
+});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup20);
+} catch {}
+try {
+renderPassEncoder21.beginOcclusionQuery(1816);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(2542);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline10);
+} catch {}
+try {
+renderBundleEncoder47.drawIndirect(buffer8, 93148);
+} catch {}
+let pipeline85 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout13,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'bgra8unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1880,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint8x2', offset: 248, shaderLocation: 11},
+          {format: 'float32x2', offset: 0, shaderLocation: 0},
+          {format: 'snorm16x2', offset: 428, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 516,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 16, shaderLocation: 14},
+          {format: 'uint32', offset: 192, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', unclippedDepth: true},
+});
+let adapter6 = await promise12;
+let offscreenCanvas15 = new OffscreenCanvas(795, 632);
+try {
+gpuCanvasContext14.unconfigure();
+} catch {}
+let querySet60 = device0.createQuerySet({label: '\u{1f767}\u39e5\u01fa\u3039', type: 'occlusion', count: 3956});
+let textureView142 = texture32.createView({});
+let renderBundle77 = renderBundleEncoder16.finish({});
+try {
+renderBundleEncoder46.draw(88, 73, 207_146_445, 501_337_531);
+} catch {}
+try {
+renderBundleEncoder46.drawIndirect(buffer26, 1068);
+} catch {}
+try {
+commandEncoder121.resolveQuerySet(querySet42, 2932, 153, buffer30, 279296);
+} catch {}
+let promise40 = device0.queue.onSubmittedWorkDone();
+canvas2.height = 791;
+let videoFrame17 = new VideoFrame(img17, {timestamp: 0});
+let bindGroup38 = device0.createBindGroup({label: '\u301c\uecda\u05cb', layout: bindGroupLayout14, entries: [{binding: 224, resource: sampler8}]});
+let commandEncoder122 = device0.createCommandEncoder({label: '\ud49b\ufcd1\u14fb\ubcbe\u59fb\u0f67\u0125\u81c8'});
+let externalTexture65 = device0.importExternalTexture({
+  label: '\uc4e0\u5774\u86ac\ud2d4\u0050\ubb75\u0688\u9ba6\u{1fef6}',
+  source: video5,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder46.draw(1, 55, 1_465_240_034);
+} catch {}
+try {
+renderBundleEncoder60.drawIndexed(474, 27, 1_386_702_429, -1_880_570_513);
+} catch {}
+try {
+commandEncoder87.copyBufferToBuffer(buffer12, 15512, buffer31, 30040, 1468);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer31);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img9,
+  origin: { x: 0, y: 11 },
+  flipY: false,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline86 = await device0.createRenderPipelineAsync({
+  label: '\u0c46\u9224\u037c\uee38\u0721\u092a\u0fe9\u76b0\u080e',
+  layout: pipelineLayout8,
+  multisample: {count: 4, mask: 0x5df4c9f1},
+  fragment: {
+  module: shaderModule17,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint'}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule17,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 8328,
+        attributes: [
+          {format: 'sint32x2', offset: 1756, shaderLocation: 10},
+          {format: 'uint16x2', offset: 48, shaderLocation: 3},
+          {format: 'sint8x4', offset: 1180, shaderLocation: 13},
+          {format: 'uint32', offset: 1108, shaderLocation: 8},
+          {format: 'sint32', offset: 232, shaderLocation: 12},
+          {format: 'uint8x2', offset: 696, shaderLocation: 2},
+          {format: 'sint8x2', offset: 420, shaderLocation: 20},
+          {format: 'unorm16x2', offset: 256, shaderLocation: 0},
+          {format: 'float32', offset: 1760, shaderLocation: 9},
+          {format: 'unorm8x2', offset: 3380, shaderLocation: 19},
+          {format: 'sint32x2', offset: 3800, shaderLocation: 5},
+          {format: 'unorm8x2', offset: 1074, shaderLocation: 1},
+          {format: 'unorm16x4', offset: 1488, shaderLocation: 15},
+        ],
+      },
+      {arrayStride: 9164, attributes: []},
+      {
+        arrayStride: 856,
+        stepMode: 'vertex',
+        attributes: [{format: 'sint16x4', offset: 72, shaderLocation: 14}],
+      },
+    ],
+  },
+  primitive: {cullMode: 'back', unclippedDepth: true},
+});
+let videoFrame18 = new VideoFrame(videoFrame5, {timestamp: 0});
+let bindGroupLayout29 = device0.createBindGroupLayout({
+  label: '\u9e16\u0e65\u0f82\u{1f85c}',
+  entries: [{binding: 2234, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'comparison' }}],
+});
+let commandBuffer27 = commandEncoder89.finish({label: '\u0415\u08ae\u8af9\u370e\uec4e\u064a\ubb3f\u9c7d'});
+let renderBundle78 = renderBundleEncoder21.finish({label: '\u072d\ua327\u5245\u{1f935}\u015c'});
+try {
+computePassEncoder10.setBindGroup(5, bindGroup21, new Uint32Array(5920), 2718, 0);
+} catch {}
+try {
+renderBundleEncoder50.setBindGroup(10, bindGroup19);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexedIndirect(buffer26, 11248);
+} catch {}
+let arrayBuffer12 = buffer17.getMappedRange(13520, 72);
+try {
+commandEncoder120.insertDebugMarker('\u0d62');
+} catch {}
+try {
+gpuCanvasContext12.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline87 = device0.createRenderPipeline({
+  label: '\u{1f8c1}\u041f\uae6d\u35fd\u{1fac8}\uae15\u038e\u{1fb70}\u4f4c',
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule18,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: 0}, {format: 'rgba8uint', writeMask: GPUColorWrite.BLUE}, {format: 'r16uint', writeMask: GPUColorWrite.RED}, {format: 'rgb10a2uint'}],
+},
+  vertex: {
+    module: shaderModule18,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 12692, attributes: []},
+      {arrayStride: 1332, attributes: [{format: 'uint16x2', offset: 324, shaderLocation: 19}]},
+      {
+        arrayStride: 172,
+        attributes: [
+          {format: 'sint32x2', offset: 0, shaderLocation: 20},
+          {format: 'snorm16x2', offset: 0, shaderLocation: 7},
+          {format: 'sint32', offset: 12, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 6548,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 80, shaderLocation: 5},
+          {format: 'unorm16x4', offset: 812, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 20, shaderLocation: 17},
+          {format: 'sint8x4', offset: 128, shaderLocation: 14},
+          {format: 'sint8x4', offset: 252, shaderLocation: 8},
+          {format: 'float16x4', offset: 1640, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 3816,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x2', offset: 264, shaderLocation: 0}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back'},
+});
+try {
+offscreenCanvas15.getContext('webgl2');
+} catch {}
+let commandEncoder123 = device0.createCommandEncoder({label: '\u3a53\ue516\u887d\u{1fa42}\u4861\u0b22\uca5d\u{1fb67}'});
+let textureView143 = texture6.createView({
+  label: '\u0809\u4a14\u{1fd6c}\u09eb\u018b\u0b79\ud827\u0738\uf299\u0319\u3c96',
+  baseMipLevel: 7,
+  mipLevelCount: 1,
+});
+let computePassEncoder57 = commandEncoder118.beginComputePass({label: '\u019e\ud4f9\uf381\u4a64\u3516\u{1fa04}\uc20f\u{1f693}\u{1fa77}\u03a6'});
+try {
+renderBundleEncoder46.drawIndirect(buffer26, 6032);
+} catch {}
+try {
+commandEncoder102.copyBufferToTexture({
+  /* bytesInLastRow: 76 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 78704 */
+  offset: 50212,
+  bytesPerRow: 256,
+  rowsPerImage: 98,
+  buffer: buffer15,
+}, {
+  texture: texture4,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 19, height: 14, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder107.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 437, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 14, y: 0, z: 14},
+  aspect: 'all',
+},
+{width: 55, height: 1, depthOrArrayLayers: 41});
+} catch {}
+try {
+commandEncoder123.resolveQuerySet(querySet42, 115, 2100, buffer1, 130560);
+} catch {}
+let pipeline88 = await promise19;
+let offscreenCanvas16 = new OffscreenCanvas(824, 363);
+let bindGroup39 = device0.createBindGroup({layout: bindGroupLayout7, entries: [{binding: 1456, resource: sampler8}]});
+let texture89 = gpuCanvasContext8.getCurrentTexture();
+let textureView144 = texture38.createView({label: '\ucb6e\u155f\u{1f769}\u8987\u{1fd60}'});
+let computePassEncoder58 = commandEncoder30.beginComputePass();
+let externalTexture66 = device0.importExternalTexture({label: '\u{1fab9}\u7eec\u81cd', source: video11, colorSpace: 'srgb'});
+try {
+renderBundleEncoder60.draw(39, 78, 299_340_783, 105_345_952);
+} catch {}
+try {
+renderBundleEncoder51.drawIndirect(buffer26, 6668);
+} catch {}
+try {
+renderBundleEncoder51.setIndexBuffer(buffer11, 'uint32', 19332, 289);
+} catch {}
+try {
+renderBundleEncoder49.setVertexBuffer(1894, undefined, 0, 403157044);
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+commandEncoder59.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 26662 */
+  offset: 15652,
+  bytesPerRow: 256,
+  buffer: buffer21,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 44, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer21);
+} catch {}
+try {
+commandEncoder106.copyTextureToBuffer({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 7376 */
+  offset: 7376,
+  buffer: buffer39,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer39);
+} catch {}
+try {
+commandEncoder122.resolveQuerySet(querySet20, 102, 140, buffer30, 288768);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData8,
+  origin: { x: 18, y: 9 },
+  flipY: false,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let gpuCanvasContext15 = offscreenCanvas16.getContext('webgpu');
+let video19 = document.createElement('video');
+let commandEncoder124 = device1.createCommandEncoder({label: '\ufe6b\ue658'});
+let textureView145 = texture42.createView({label: '\u0509\u4e7c\u017f\uec11\u0207\uee6d', dimension: '2d-array'});
+let renderPassEncoder27 = commandEncoder124.beginRenderPass({
+  label: '\u0ba6\uedb7\ub083\u1757\u{1ff1f}\u{1f69e}\u{1fef0}\u05ce\udd90\u8984',
+  colorAttachments: [{
+  view: textureView82,
+  depthSlice: 97,
+  clearValue: { r: -329.2, g: -944.8, b: 760.8, a: 216.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 154255359,
+});
+let renderBundleEncoder66 = device1.createRenderBundleEncoder({
+  label: '\u{1faa4}\u9916\u1a8e\u0a20\u2288\u{1f795}\u6984\u0876\u066f',
+  colorFormats: ['bgra8unorm'],
+  depthReadOnly: true,
+});
+let renderBundle79 = renderBundleEncoder47.finish({label: '\ud108\ufd48\u4f57\u{1f608}\u2b45\u167c\u4ec3\u{1fc75}\u30f4'});
+let externalTexture67 = device1.importExternalTexture({source: video10});
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(97);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(82, 291);
+} catch {}
+try {
+renderBundleEncoder27.draw(88, 72);
+} catch {}
+try {
+renderBundleEncoder62.drawIndirect(buffer8, 67068);
+} catch {}
+try {
+computePassEncoder34.pushDebugGroup('\u805a');
+} catch {}
+let promise41 = device1.queue.onSubmittedWorkDone();
+let pipeline89 = await device1.createRenderPipelineAsync({
+  layout: pipelineLayout15,
+  fragment: {module: shaderModule8, entryPoint: 'fragment0', targets: [{format: 'bgra8unorm'}]},
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 148, stepMode: 'instance', attributes: []},
+      {arrayStride: 1308, attributes: []},
+      {
+        arrayStride: 96,
+        attributes: [
+          {format: 'float32x2', offset: 24, shaderLocation: 8},
+          {format: 'snorm16x4', offset: 24, shaderLocation: 11},
+          {format: 'unorm10-10-10-2', offset: 0, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 52,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 0, shaderLocation: 5},
+          {format: 'float32x4', offset: 4, shaderLocation: 2},
+          {format: 'sint32x2', offset: 16, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'ccw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let videoFrame19 = new VideoFrame(imageBitmap18, {timestamp: 0});
+let commandEncoder125 = device0.createCommandEncoder({label: '\uc483\u041f\uf790\u0d90'});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup39);
+} catch {}
+try {
+renderBundleEncoder46.setBindGroup(4, bindGroup31);
+} catch {}
+try {
+buffer30.unmap();
+} catch {}
+try {
+commandEncoder85.resolveQuerySet(querySet36, 926, 853, buffer1, 165632);
+} catch {}
+try {
+computePassEncoder48.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer12), /* required buffer size: 860 */
+{offset: 860}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData29 = new ImageData(228, 180);
+let querySet61 = device1.createQuerySet({label: '\ucad5\uc46e\u0e95\u6cdf\u51c7', type: 'occlusion', count: 2739});
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer25, 647_414_019);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline45);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 30, height: 1, depthOrArrayLayers: 18}
+*/
+{
+  source: imageBitmap4,
+  origin: { x: 3, y: 111 },
+  flipY: true,
+}, {
+  texture: texture43,
+  mipLevel: 6,
+  origin: {x: 6, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline90 = device1.createComputePipeline({
+  label: '\ua06b\u01b9\u{1f923}\uded7\udbfc\u0c49\u{1fa21}',
+  layout: pipelineLayout18,
+  compute: {module: shaderModule12, entryPoint: 'compute0', constants: {}},
+});
+let renderBundleEncoder67 = device1.createRenderBundleEncoder({colorFormats: ['bgra8unorm'], stencilReadOnly: true});
+try {
+computePassEncoder21.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(187);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer25, 40_770_896);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer10, 312_158_758);
+} catch {}
+try {
+renderBundleEncoder27.draw(297, 33, 472_603_591, 648_013_081);
+} catch {}
+try {
+renderBundleEncoder62.drawIndirect(buffer35, 91972);
+} catch {}
+try {
+  await promise40;
+} catch {}
+let img18 = await imageWithData(199, 178, '#7eb97e04', '#4d2d6dad');
+let bindGroup40 = device1.createBindGroup({
+  label: '\u363f\u{1faff}\u{1fcbe}\u94f1\u0a59\u{1ffa3}',
+  layout: bindGroupLayout2,
+  entries: [{binding: 644, resource: externalTexture27}],
+});
+let commandEncoder126 = device1.createCommandEncoder({label: '\u9cb5\ud5b8\u45f9\ue708\u{1fbe6}\u834e\u{1f645}'});
+let computePassEncoder59 = commandEncoder126.beginComputePass({label: '\uda4d\ubba0\u56e7\u1210\udb55\u{1fb90}\u05e2\ud808\u0497\u002b'});
+try {
+renderPassEncoder5.draw(99, 223, 113_748_925, 888_013_679);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer3, 36_527_451);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer32, 463_067_090);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(1, buffer33, 0, 6963);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(0, bindGroup5, new Uint32Array(223), 158, 0);
+} catch {}
+try {
+renderBundleEncoder62.drawIndexedIndirect(buffer8, 345572);
+} catch {}
+try {
+renderBundleEncoder27.drawIndirect(buffer8, 134332);
+} catch {}
+try {
+renderBundleEncoder42.setPipeline(pipeline89);
+} catch {}
+try {
+computePassEncoder34.popDebugGroup();
+} catch {}
+try {
+computePassEncoder42.insertDebugMarker('\u03df');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer40, 11372, new Float32Array(50979), 27437, 1248);
+} catch {}
+let img19 = await imageWithData(246, 98, '#74f0ff02', '#8d44e44f');
+let renderBundleEncoder68 = device1.createRenderBundleEncoder({
+  label: '\u08da\u{1f7e2}\uda01\u{1fa6f}\u4c95\u0234',
+  colorFormats: ['bgra8unorm'],
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder27.setPipeline(pipeline75);
+} catch {}
+try {
+renderPassEncoder8.draw(29, 117);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(194, 33, 10_146_539);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer33, 520_894_609);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer40, 2_458_466_042);
+} catch {}
+try {
+renderBundleEncoder57.setVertexBuffer(6, buffer33, 0, 8629);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer29, 784, new Float32Array(59159), 41037, 204);
+} catch {}
+try {
+commandEncoder126.label = '\u34e7\u{1fd59}\u8de4\u{1fef8}\u{1f8c7}\u73c8\u9bd2\u{1fdee}';
+} catch {}
+let texture90 = device1.createTexture({
+  size: [480],
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+});
+let textureView146 = texture33.createView({label: '\u8dc9\u0249\u0119\u{1ff76}\u6a98\u074b\u{1fcca}', dimension: '1d', mipLevelCount: 1});
+try {
+computePassEncoder43.setPipeline(pipeline48);
+} catch {}
+try {
+renderPassEncoder9.beginOcclusionQuery(1948);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(6, buffer33, 0, 5271);
+} catch {}
+try {
+renderBundleEncoder63.setBindGroup(1, bindGroup28, new Uint32Array(2900), 67, 0);
+} catch {}
+try {
+renderBundleEncoder62.drawIndexedIndirect(buffer8, 69484);
+} catch {}
+try {
+renderBundleEncoder27.setPipeline(pipeline10);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer5, 61440, new DataView(new ArrayBuffer(64261)), 43255, 16636);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 803 */
+{offset: 799}, {width: 1, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder127 = device1.createCommandEncoder({label: '\u0dbf\u{1fa0a}\u0e29\u1e3d\u{1f78f}\u{1fd96}\u9ad5\u{1fdaa}\u2c0f'});
+let commandBuffer28 = commandEncoder127.finish({});
+let textureView147 = texture90.createView({label: '\u1581\u{1f991}\u08c6\u0f01\u340d'});
+let renderBundle80 = renderBundleEncoder15.finish({label: '\u7d97\u6881\uf926\u1922'});
+let sampler65 = device1.createSampler({
+  label: '\u{1fa1b}\u7da9',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 39.64,
+  maxAnisotropy: 19,
+});
+try {
+renderPassEncoder22.setStencilReference(2011);
+} catch {}
+try {
+renderBundleEncoder62.drawIndexed(278, 85, 1_165_880_891);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let pipeline91 = await device1.createComputePipelineAsync({
+  label: '\ue068\u8f26\u0934\u4022\u{1fa08}\u00b6',
+  layout: pipelineLayout17,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let bindGroup41 = device1.createBindGroup({
+  label: '\u01b6\ua920\u{1facf}',
+  layout: bindGroupLayout23,
+  entries: [{binding: 710, resource: sampler12}],
+});
+let querySet62 = device1.createQuerySet({
+  label: '\u{1fc4e}\uc99f\u8647\u0013\u08ab\u{1f7b9}\u1457\u75ce\u{1fbb1}\u0d7b',
+  type: 'occlusion',
+  count: 1632,
+});
+let texture91 = device1.createTexture({
+  label: '\u6f34\u{1fc5c}\ub60f\u004a\u6318\u0400\u{1fda9}\u13e3\u{1fd9d}',
+  size: [1920, 12, 209],
+  mipLevelCount: 7,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView148 = texture39.createView({label: '\u0024\u0a54\u0ae4', format: 'bgra8unorm-srgb', baseMipLevel: 3, baseArrayLayer: 0});
+let renderBundle81 = renderBundleEncoder7.finish({label: '\u5cf6\u81f0\u{1fbb6}\u0a89\u2e30\u6099\ub09e\uc560\ub254\u{1fcf9}'});
+try {
+computePassEncoder21.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(167, 0, 51, 0);
+} catch {}
+try {
+renderPassEncoder8.draw(398, 161);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer24, 330_232_417);
+} catch {}
+try {
+renderBundleEncoder64.setBindGroup(3, bindGroup40);
+} catch {}
+try {
+renderBundleEncoder68.setVertexBuffer(3, buffer27, 0, 13483);
+} catch {}
+offscreenCanvas1.height = 462;
+let commandBuffer29 = commandEncoder69.finish({label: '\u7b14\uf746\u023d'});
+let renderBundle82 = renderBundleEncoder59.finish({label: '\u08cc\ud3c8\u01a1\u049d\u0dc6\u9944\u0b62\u07e4\u{1f90d}'});
+let offscreenCanvas17 = new OffscreenCanvas(688, 593);
+let texture92 = device1.createTexture({
+  label: '\u8933\u0d0a\u62cc\u30b6\u5086\ud5b3\u62da\u55fb\ucd39',
+  size: [240],
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['bgra8unorm', 'bgra8unorm', 'bgra8unorm-srgb'],
+});
+let renderBundle83 = renderBundleEncoder22.finish({});
+try {
+renderPassEncoder21.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.executeBundles([]);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder62.drawIndexed(113);
+} catch {}
+try {
+renderBundleEncoder62.drawIndexedIndirect(buffer33, 10928);
+} catch {}
+try {
+renderBundleEncoder65.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(0, buffer27, 100);
+} catch {}
+try {
+  await buffer40.mapAsync(GPUMapMode.READ, 0, 3232);
+} catch {}
+let gpuCanvasContext16 = offscreenCanvas17.getContext('webgpu');
+try {
+  await promise41;
+} catch {}
+let textureView149 = texture0.createView({dimension: '2d', baseMipLevel: 1, mipLevelCount: 3, baseArrayLayer: 527});
+let renderBundle84 = renderBundleEncoder37.finish({label: '\uf1cb\u5072\u034e\u1d57\u4b71\u015f\u{1f811}\u04ec\u{1f8d1}\uef78\u1a8f'});
+try {
+computePassEncoder13.setPipeline(pipeline88);
+} catch {}
+try {
+renderBundleEncoder49.setBindGroup(3, bindGroup33);
+} catch {}
+try {
+renderBundleEncoder60.setBindGroup(5, bindGroup32, new Uint32Array(7761), 3685, 0);
+} catch {}
+try {
+renderBundleEncoder48.draw(184, 399, 866_807_855, 4_186_672_532);
+} catch {}
+try {
+renderBundleEncoder40.drawIndexed(179, 61);
+} catch {}
+try {
+renderBundleEncoder60.drawIndexedIndirect(buffer26, 5532);
+} catch {}
+try {
+commandEncoder57.resolveQuerySet(querySet32, 1392, 1024, buffer30, 225536);
+} catch {}
+let promise42 = device0.queue.onSubmittedWorkDone();
+let commandEncoder128 = device0.createCommandEncoder();
+let texture93 = device0.createTexture({
+  label: '\u{1fa6a}\u05cd\u{1ff86}',
+  size: {width: 312, height: 1, depthOrArrayLayers: 131},
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+let textureView150 = texture89.createView({
+  label: '\uf783\u34a6\u{1f9c2}\u{1f667}\u0076\u8a69\u0bf9\ud352\u{1fb57}\u07a9\u{1fd85}',
+  dimension: '2d-array',
+  baseArrayLayer: 0,
+});
+let renderBundle85 = renderBundleEncoder14.finish({label: '\u{1fe85}\u242a\u2dd0'});
+try {
+renderBundleEncoder50.setBindGroup(7, bindGroup34);
+} catch {}
+try {
+renderBundleEncoder60.drawIndexed(430, 457, 453_437_613, 107_820_015);
+} catch {}
+try {
+commandEncoder106.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 18932 */
+  offset: 18932,
+  bytesPerRow: 0,
+  buffer: buffer16,
+}, {width: 0, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer16);
+} catch {}
+let offscreenCanvas18 = new OffscreenCanvas(401, 541);
+try {
+window.someLabel = texture37.label;
+} catch {}
+let bindGroup42 = device0.createBindGroup({
+  label: '\u91cb\u656c\u0f13\u7361',
+  layout: bindGroupLayout28,
+  entries: [{binding: 593, resource: textureView66}],
+});
+let querySet63 = device0.createQuerySet({
+  label: '\u8dbf\ud4c0\u6609\u{1f8ff}\u39f1\u0961\u{1f681}\u2093\u1a84\u0aed\ubd84',
+  type: 'occlusion',
+  count: 2505,
+});
+let textureView151 = texture73.createView({label: '\u{1f9d1}\u01e6', baseMipLevel: 3, mipLevelCount: 2});
+let renderBundleEncoder69 = device0.createRenderBundleEncoder({
+  label: '\uc2fe\ubae5\uc34f\u0a1c\u521f\u{1f9b9}\u962a\u{1fcd9}\u12b3\u84b6',
+  colorFormats: ['r16float', 'rg8sint', 'r32uint', 'r16float', 'r16sint', 'rgb10a2unorm', 'rg16uint'],
+  stencilReadOnly: true,
+});
+let renderBundle86 = renderBundleEncoder8.finish({label: '\u84fc\u083e\u4560\u{1f8a8}'});
+let sampler66 = device0.createSampler({
+  label: '\ue155\u0ca1\u{1fee3}\u0e42\u0560\u{1f6ff}\ue5bc\u82da\u0201\u264b',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 94.27,
+  lodMaxClamp: 98.57,
+  maxAnisotropy: 17,
+});
+try {
+renderBundleEncoder60.draw(543, 503, 5_319_410, 394_865_979);
+} catch {}
+try {
+renderBundleEncoder51.drawIndexed(2, 129, 2_154_237_730, -2_137_483_558, 3_220_779_576);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline87);
+} catch {}
+try {
+commandEncoder113.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 12816 */
+  offset: 12816,
+  bytesPerRow: 0,
+  rowsPerImage: 140,
+  buffer: buffer26,
+}, {
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 12});
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+commandEncoder87.copyTextureToTexture({
+  texture: texture93,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 27},
+  aspect: 'all',
+},
+{
+  texture: texture73,
+  mipLevel: 3,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 10380, new Float32Array(45749), 42886, 96);
+} catch {}
+try {
+  await promise42;
+} catch {}
+let renderBundleEncoder70 = device0.createRenderBundleEncoder({
+  label: '\u5141\u{1f79b}\u{1ffb1}\u83ac\u7dc9\u0aa3',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  stencilReadOnly: true,
+});
+let renderBundle87 = renderBundleEncoder17.finish({label: '\u4361\u6f41\u{1fb5b}\u1f6b\u9a23\u704b\u74d7\u28bf\ue637\u0f48\u4c03'});
+try {
+renderBundleEncoder70.setBindGroup(8, bindGroup34, new Uint32Array(352), 110, 0);
+} catch {}
+try {
+renderBundleEncoder51.drawIndirect(buffer26, 2268);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let gpuCanvasContext17 = offscreenCanvas18.getContext('webgpu');
+let texture94 = device1.createTexture({
+  label: '\ud0a1\u{1ff4e}\u0ecc\u3028\u087a\u01f5\u{1fe3e}\u033b\u8dc3\u0f06\u2440',
+  size: {width: 1920},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView152 = texture34.createView({label: '\ub374\u57e3\u1fb6\u{1f924}\u{1fde8}\ub32f\u003a\u0180\ued2b', dimension: '1d'});
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup27, new Uint32Array(9536), 5845, 0);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(497, 103, 231_185_687);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer23, 439_467_762);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline21);
+} catch {}
+try {
+renderBundleEncoder65.drawIndirect(buffer8, 385940);
+} catch {}
+try {
+renderBundleEncoder64.setPipeline(pipeline12);
+} catch {}
+let imageBitmap33 = await createImageBitmap(img3);
+let shaderModule23 = device1.createShaderModule({
+  label: '\u0733\u2178\u0494\u0ca0\u7f08\uee20\u{1fd07}\u{1f853}\u0830\uac80\uefd1',
+  code: `@group(1) @binding(575)
+var<storage, read_write> local13: array<u32>;
+@group(2) @binding(644)
+var<storage, read_write> global7: array<u32>;
+
+@compute @workgroup_size(4, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S16 {
+  @location(14) f0: vec3<u32>,
+  @location(1) f1: vec3<i32>,
+  @builtin(position) f2: vec4<f32>
+}
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(2) a0: vec3<i32>, a1: S16, @location(10) a2: vec2<f16>, @location(4) a3: vec2<f32>, @location(13) a4: vec3<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(0) f114: vec3<f32>,
+  @builtin(position) f115: vec4<f32>,
+  @location(10) f116: vec2<f16>,
+  @location(2) f117: vec3<i32>,
+  @location(1) f118: vec3<i32>,
+  @location(11) f119: vec2<i32>,
+  @location(4) f120: vec2<f32>,
+  @location(13) f121: vec3<f32>,
+  @location(15) f122: vec3<f16>,
+  @location(7) f123: vec3<f16>,
+  @location(14) f124: vec3<u32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec3<u32>, @location(13) a1: vec4<i32>, @location(2) a2: u32, @location(5) a3: vec4<i32>, @location(1) a4: vec3<u32>, @location(6) a5: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder129 = device1.createCommandEncoder({label: '\u{1fe83}\u07c9\ufde8'});
+let textureView153 = texture11.createView({label: '\u0603\u{1facd}\u2a44', baseMipLevel: 1, mipLevelCount: 1});
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup37, new Uint32Array(9950), 2327, 0);
+} catch {}
+try {
+renderBundleEncoder64.drawIndexedIndirect(buffer8, 308100);
+} catch {}
+try {
+renderBundleEncoder65.drawIndirect(buffer35, 24240);
+} catch {}
+try {
+commandEncoder129.clearBuffer(buffer37);
+dissociateBuffer(device1, buffer37);
+} catch {}
+let pipeline92 = await device1.createComputePipelineAsync({
+  label: '\ud751\u020b\u{1feee}\u7d4a\ue349\u583a',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule12, entryPoint: 'compute0'},
+});
+offscreenCanvas2.width = 493;
+let videoFrame20 = new VideoFrame(offscreenCanvas13, {timestamp: 0});
+let shaderModule24 = device1.createShaderModule({
+  code: `@group(0) @binding(575)
+var<storage, read_write> field8: array<u32>;
+@group(0) @binding(568)
+var<storage, read_write> global8: array<u32>;
+@group(1) @binding(575)
+var<storage, read_write> parameter12: array<u32>;
+@group(1) @binding(568)
+var<storage, read_write> global9: array<u32>;
+
+@compute @workgroup_size(4, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(6) f0: vec3<f32>,
+  @builtin(sample_mask) f1: u32,
+  @location(0) f2: vec4<f32>,
+  @location(3) f3: vec3<i32>,
+  @location(2) f4: i32
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S17 {
+  @location(9) f0: vec4<f16>,
+  @location(2) f1: vec4<i32>,
+  @location(12) f2: vec3<f16>,
+  @location(0) f3: vec4<i32>,
+  @location(10) f4: i32,
+  @location(5) f5: vec3<u32>,
+  @location(1) f6: i32
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec3<i32>, @location(3) a1: vec4<f32>, @location(6) a2: u32, @location(4) a3: vec3<f16>, @location(13) a4: vec3<u32>, @location(15) a5: vec3<u32>, a6: S17, @location(11) a7: vec4<f32>, @location(14) a8: vec3<f32>, @location(7) a9: vec3<u32>, @builtin(instance_index) a10: u32, @builtin(vertex_index) a11: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let bindGroupLayout30 = device1.createBindGroupLayout({label: '\u41b1\u1d27\u0249\u0171\u{1fe0f}\u{1f781}\u8d25\u5e24\u099d\u237e\ua9cf', entries: []});
+let renderPassEncoder28 = commandEncoder129.beginRenderPass({
+  label: '\ue7d4\uefba\u9e87\u{1fc46}\u04a7\u6fce',
+  colorAttachments: [{
+  view: textureView145,
+  clearValue: { r: 184.9, g: 857.8, b: -134.3, a: 427.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet34,
+  maxDrawCount: 674661614,
+});
+let renderBundle88 = renderBundleEncoder62.finish({});
+let sampler67 = device1.createSampler({
+  label: '\ubd96\u{1fbc0}\u520b\u884c',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 11.82,
+  lodMaxClamp: 58.42,
+  maxAnisotropy: 11,
+});
+try {
+renderPassEncoder3.setScissorRect(198, 1, 41, 0);
+} catch {}
+try {
+renderPassEncoder5.draw(33, 257, 1_322_605_239, 139_804_348);
+} catch {}
+try {
+renderPassEncoder26.drawIndexedIndirect(buffer20, 344_365_023);
+} catch {}
+try {
+renderBundleEncoder65.drawIndexedIndirect(buffer35, 19892);
+} catch {}
+try {
+renderBundleEncoder65.drawIndirect(buffer8, 6192);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder130 = device0.createCommandEncoder({label: '\u055c\u3ad9\u0c8a\ub01b\ufccc\u055c\u56ad\u02bf\u{1fdb7}\u8c3e'});
+try {
+computePassEncoder10.setBindGroup(8, bindGroup33);
+} catch {}
+try {
+renderBundleEncoder48.setPipeline(pipeline82);
+} catch {}
+try {
+commandEncoder82.copyBufferToBuffer(buffer26, 30508, buffer22, 7028, 2192);
+dissociateBuffer(device0, buffer26);
+dissociateBuffer(device0, buffer22);
+} catch {}
+try {
+commandEncoder103.copyTextureToBuffer({
+  texture: texture83,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 8 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 87156 */
+  offset: 2676,
+  bytesPerRow: 256,
+  rowsPerImage: 165,
+  buffer: buffer16,
+}, {width: 2, height: 0, depthOrArrayLayers: 3});
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer41, 1172, new Int16Array(35669), 16081, 828);
+} catch {}
+let shaderModule25 = device1.createShaderModule({
+  label: '\u0490\u0aa3\ueca7\ufa79\u{1fa20}\u1ff1\u{1fb83}\udabc',
+  code: `@group(0) @binding(644)
+var<storage, read_write> global10: array<u32>;
+@group(3) @binding(320)
+var<storage, read_write> local14: array<u32>;
+@group(3) @binding(148)
+var<storage, read_write> function6: array<u32>;
+@group(2) @binding(568)
+var<storage, read_write> parameter13: array<u32>;
+@group(2) @binding(575)
+var<storage, read_write> local15: array<u32>;
+@group(1) @binding(575)
+var<storage, read_write> local16: array<u32>;
+@group(1) @binding(568)
+var<storage, read_write> local17: array<u32>;
+
+@compute @workgroup_size(7, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(5) f0: f32,
+  @location(0) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(13) a0: f32, @location(5) a1: vec4<u32>, @location(9) a2: vec3<f32>, @location(6) a3: vec3<i32>, @builtin(vertex_index) a4: u32, @location(11) a5: u32, @location(8) a6: vec4<i32>, @location(2) a7: vec2<f32>, @location(10) a8: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let sampler68 = device1.createSampler({
+  label: '\u{1f807}\ufe65\u0e03\u7852\u0fe9\u711a\uf4c9\u{1fa25}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 29.77,
+  lodMaxClamp: 61.60,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder27.dispatchWorkgroups(1, 3, 1);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline20);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle74, renderBundle49, renderBundle17, renderBundle10, renderBundle37, renderBundle64, renderBundle22, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant({ r: 120.4, g: -161.5, b: -548.9, a: 934.1, });
+} catch {}
+try {
+renderPassEncoder3.setScissorRect(29, 0, 185, 1);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(86);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder58.setBindGroup(1, bindGroup37);
+} catch {}
+try {
+renderBundleEncoder65.draw(9, 122, 581_567_272, 542_120_224);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexedIndirect(buffer8, 220968);
+} catch {}
+let promise43 = device1.createRenderPipelineAsync({
+  label: '\u1944\u{1f638}',
+  layout: pipelineLayout15,
+  fragment: {module: shaderModule22, entryPoint: 'fragment0', constants: {}, targets: [{format: 'bgra8unorm'}]},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'equal', failOp: 'invert', depthFailOp: 'zero'},
+    stencilBack: {compare: 'greater-equal', failOp: 'replace', passOp: 'zero'},
+    stencilReadMask: 1105017571,
+    stencilWriteMask: 3389714390,
+    depthBias: 716347149,
+    depthBiasClamp: 953.0563962486235,
+  },
+  vertex: {
+    module: shaderModule22,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 792,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 80, shaderLocation: 2},
+          {format: 'unorm16x4', offset: 4, shaderLocation: 6},
+          {format: 'uint32x2', offset: 60, shaderLocation: 14},
+          {format: 'uint32', offset: 480, shaderLocation: 0},
+          {format: 'snorm8x2', offset: 142, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 24, shaderLocation: 9},
+          {format: 'sint32', offset: 84, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+let bindGroupLayout31 = pipeline9.getBindGroupLayout(1);
+let querySet64 = device1.createQuerySet({
+  label: '\u172d\u035e\u0b93\u{1fcdf}\u962e\u4f95\u689a\u8eaa\uce21\ua1ca',
+  type: 'occlusion',
+  count: 335,
+});
+try {
+renderPassEncoder19.draw(271, 284);
+} catch {}
+try {
+renderPassEncoder5.drawIndexedIndirect(buffer28, 578_823_636);
+} catch {}
+try {
+renderBundleEncoder64.setVertexBuffer(1, buffer27, 0, 11174);
+} catch {}
+let offscreenCanvas19 = new OffscreenCanvas(817, 711);
+let querySet65 = device1.createQuerySet({type: 'occlusion', count: 290});
+let externalTexture68 = device1.importExternalTexture({source: videoFrame8, colorSpace: 'display-p3'});
+try {
+renderPassEncoder22.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle57, renderBundle11, renderBundle49, renderBundle17, renderBundle74, renderBundle21]);
+} catch {}
+try {
+renderPassEncoder21.setScissorRect(82, 0, 153, 0);
+} catch {}
+try {
+renderPassEncoder19.draw(13);
+} catch {}
+try {
+renderPassEncoder26.drawIndexedIndirect(buffer25, 878_347_653);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer3, 2_085_718_407);
+} catch {}
+try {
+renderBundleEncoder42.setPipeline(pipeline53);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer3, 756, new BigUint64Array(63502), 22292, 2636);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer11, /* required buffer size: 593 */
+{offset: 593}, {width: 348, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let canvas20 = document.createElement('canvas');
+try {
+canvas20.getContext('2d');
+} catch {}
+let bindGroupLayout32 = device0.createBindGroupLayout({
+  label: '\uc884\ucd91\u0467\ue607\u6d88\u1921\u0b00\u07b6',
+  entries: [
+    {
+      binding: 6791,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 5448,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 5251, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let texture95 = device0.createTexture({
+  label: '\u0552\u976b\u{1fb45}\u2fa6\u{1f740}\uc993\u078d\u0229\u0937\ue097',
+  size: [624],
+  dimension: '1d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint'],
+});
+let renderBundleEncoder71 = device0.createRenderBundleEncoder({
+  label: '\ua70e\u{1ff2d}\ud437\u0475\u02d9\u01c5',
+  colorFormats: ['r16float', 'rg8sint', 'r32uint', 'r16float', 'r16sint', 'rgb10a2unorm', 'rg16uint'],
+  depthReadOnly: true,
+});
+let sampler69 = device0.createSampler({
+  label: '\u0a9c\u0e43\u{1fc8b}',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 60.58,
+  lodMaxClamp: 78.67,
+});
+try {
+renderBundleEncoder52.setPipeline(pipeline35);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(4677, undefined, 0);
+} catch {}
+try {
+commandEncoder128.copyBufferToTexture({
+  /* bytesInLastRow: 1808 widthInBlocks: 452 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10076 */
+  offset: 8268,
+  buffer: buffer15,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 452, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer15);
+} catch {}
+let imageBitmap34 = await createImageBitmap(imageData6);
+let commandEncoder131 = device0.createCommandEncoder({label: '\ue92c\ud8a1\u0d68\uedf0\u{1fec2}\u2607\u5edc\u0806\u{1fa20}\u3d59'});
+let sampler70 = device0.createSampler({
+  label: '\u7dad\u94cf\u168d',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 51.80,
+  lodMaxClamp: 52.80,
+  maxAnisotropy: 17,
+});
+try {
+renderBundleEncoder51.drawIndexed(106, 94, 920_911_304, -2_010_700_863, 303_800_409);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(7632, undefined);
+} catch {}
+try {
+commandEncoder104.copyBufferToTexture({
+  /* bytesInLastRow: 96 widthInBlocks: 48 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 305454 */
+  offset: 3278,
+  bytesPerRow: 512,
+  rowsPerImage: 57,
+  buffer: buffer15,
+}, {
+  texture: texture29,
+  mipLevel: 2,
+  origin: {x: 1, y: 3, z: 0},
+  aspect: 'all',
+}, {width: 48, height: 21, depthOrArrayLayers: 11});
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let shaderModule26 = device0.createShaderModule({
+  label: '\u{1f9c2}\u3f19\u335d\u55a0',
+  code: `@group(3) @binding(1456)
+var<storage, read_write> type10: array<u32>;
+
+@compute @workgroup_size(4, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec2<i32>,
+  @location(0) f1: vec3<f32>,
+  @location(1) f2: vec2<i32>,
+  @location(3) f3: vec3<f32>,
+  @location(5) f4: vec4<f32>,
+  @location(6) f5: vec3<u32>,
+  @location(2) f6: u32
+}
+
+@fragment
+fn fragment0(@location(27) a0: vec2<f16>, @location(12) a1: f32, @location(9) a2: vec2<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S18 {
+  @location(0) f0: vec4<i32>,
+  @location(9) f1: vec2<f32>,
+  @builtin(instance_index) f2: u32,
+  @location(3) f3: i32,
+  @location(16) f4: vec2<f16>,
+  @builtin(vertex_index) f5: u32,
+  @location(10) f6: vec4<i32>,
+  @location(11) f7: vec4<f32>,
+  @location(18) f8: u32
+}
+struct VertexOutput0 {
+  @location(12) f125: f32,
+  @location(7) f126: vec4<f16>,
+  @location(5) f127: vec3<f16>,
+  @location(26) f128: f32,
+  @location(20) f129: f32,
+  @location(31) f130: vec4<i32>,
+  @location(19) f131: vec4<f16>,
+  @location(0) f132: vec3<f32>,
+  @location(18) f133: vec3<u32>,
+  @location(22) f134: vec4<f16>,
+  @location(2) f135: u32,
+  @location(3) f136: vec4<f32>,
+  @builtin(position) f137: vec4<f32>,
+  @location(33) f138: vec2<f16>,
+  @location(25) f139: vec4<i32>,
+  @location(27) f140: vec2<f16>,
+  @location(15) f141: f16,
+  @location(21) f142: i32,
+  @location(17) f143: vec3<f32>,
+  @location(36) f144: vec3<u32>,
+  @location(9) f145: vec2<f32>
+}
+
+@vertex
+fn vertex0(@location(7) a0: f16, @location(5) a1: vec2<i32>, @location(8) a2: vec3<f16>, @location(17) a3: vec3<f32>, a4: S18, @location(4) a5: f32, @location(6) a6: vec3<i32>, @location(12) a7: vec2<f16>, @location(20) a8: i32, @location(19) a9: vec4<u32>, @location(14) a10: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture96 = device0.createTexture({
+  size: {width: 240},
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint', 'rgba8uint'],
+});
+try {
+computePassEncoder48.setPipeline(pipeline32);
+} catch {}
+try {
+renderBundleEncoder46.drawIndirect(buffer26, 7116);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder71.copyTextureToBuffer({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5028 */
+  offset: 5028,
+  buffer: buffer39,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer39);
+} catch {}
+try {
+commandEncoder57.copyTextureToTexture({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder104.clearBuffer(buffer6, 80060, 1856);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder130.resolveQuerySet(querySet33, 1495, 96, buffer30, 292864);
+} catch {}
+try {
+gpuCanvasContext13.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer41, 52, new DataView(new ArrayBuffer(63617)), 37400, 1040);
+} catch {}
+let pipeline93 = device0.createRenderPipeline({
+  label: '\u{1f9e1}\u35e6\u{1ff22}\u0e97\u0002\u7e27\ub9e6',
+  layout: 'auto',
+  multisample: {mask: 0x87689521},
+  fragment: {
+  module: shaderModule18,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint'}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA}],
+},
+  vertex: {
+    module: shaderModule18,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3548,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint16x4', offset: 52, shaderLocation: 19}],
+      },
+      {
+        arrayStride: 15164,
+        attributes: [
+          {format: 'sint32x2', offset: 5932, shaderLocation: 5},
+          {format: 'sint32x3', offset: 212, shaderLocation: 13},
+          {format: 'sint8x4', offset: 2768, shaderLocation: 8},
+          {format: 'sint16x2', offset: 4128, shaderLocation: 14},
+          {format: 'sint8x2', offset: 2038, shaderLocation: 20},
+          {format: 'float32x3', offset: 1732, shaderLocation: 17},
+          {format: 'float32x2', offset: 4700, shaderLocation: 7},
+          {format: 'snorm8x2', offset: 812, shaderLocation: 9},
+          {format: 'uint8x4', offset: 472, shaderLocation: 0},
+          {format: 'unorm16x2', offset: 3784, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+let offscreenCanvas20 = new OffscreenCanvas(674, 385);
+try {
+if (!arrayBuffer9.detached) { new Uint8Array(arrayBuffer9).fill(0x55) };
+} catch {}
+let shaderModule27 = device0.createShaderModule({
+  label: '\u03ce\u8b7b\u9eea\uc190\u7a77\u05fe\u8d34\u{1f7f3}\u001e\uc305\u{1f8ef}',
+  code: `@group(3) @binding(1456)
+var<storage, read_write> local18: array<u32>;
+
+@compute @workgroup_size(7, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(4) f0: vec4<i32>,
+  @location(2) f1: vec3<u32>,
+  @location(7) f2: vec2<i32>,
+  @location(5) f3: vec4<f32>,
+  @location(3) f4: vec3<f32>,
+  @location(6) f5: vec4<u32>,
+  @location(1) f6: vec4<i32>,
+  @location(0) f7: vec3<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(front_facing) a2: bool, @builtin(sample_mask) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(1) a0: vec3<f16>, @location(5) a1: vec2<u32>, @location(15) a2: vec3<f16>, @location(2) a3: vec3<f32>, @location(12) a4: vec2<f32>, @location(9) a5: i32, @location(3) a6: vec2<f32>, @location(8) a7: vec4<f32>, @location(11) a8: u32, @location(7) a9: vec2<f16>, @location(13) a10: vec2<f16>, @location(4) a11: i32, @location(19) a12: vec2<u32>, @location(6) a13: f16, @builtin(vertex_index) a14: u32, @location(17) a15: vec3<f32>, @location(18) a16: vec4<i32>, @location(16) a17: vec3<u32>, @location(10) a18: vec3<i32>, @location(0) a19: f16, @location(14) a20: i32, @location(20) a21: vec3<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder132 = device0.createCommandEncoder({label: '\u0c65\uf00a\u051d\u0de7\u{1f81e}\ue1a4\ueddd'});
+let textureView154 = texture0.createView({
+  label: '\ub28e\u4938\ud7c5\u0672\uf1c0\u{1fa1f}',
+  dimension: '2d',
+  baseMipLevel: 4,
+  baseArrayLayer: 133,
+});
+let externalTexture69 = device0.importExternalTexture({label: '\uc027\ucf6f\u4a52\u{1fc9f}\u{1fcf9}\u{1fa38}', source: videoFrame7, colorSpace: 'display-p3'});
+try {
+computePassEncoder13.setBindGroup(10, bindGroup39);
+} catch {}
+try {
+renderBundleEncoder46.drawIndirect(buffer26, 2656);
+} catch {}
+try {
+querySet0.destroy();
+} catch {}
+try {
+commandEncoder103.copyTextureToBuffer({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 208},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2336 widthInBlocks: 584 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 355064 */
+  offset: 45528,
+  bytesPerRow: 2560,
+  buffer: buffer36,
+}, {width: 584, height: 121, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+commandEncoder106.clearBuffer(buffer41, 720, 1700);
+dissociateBuffer(device0, buffer41);
+} catch {}
+try {
+commandEncoder113.insertDebugMarker('\u41ab');
+} catch {}
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+try {
+offscreenCanvas19.getContext('bitmaprenderer');
+} catch {}
+let querySet66 = device2.createQuerySet({
+  label: '\u{1f981}\ucef7\udba8\u0b9d\u69a2\u065e\uc5d9\ubc30\u00d1\ue954\ub513',
+  type: 'occlusion',
+  count: 2079,
+});
+let textureView155 = texture47.createView({
+  label: '\u8f92\u00de\u305e\u{1fa75}\u46da',
+  baseMipLevel: 1,
+  baseArrayLayer: 491,
+  arrayLayerCount: 1256,
+});
+let renderBundleEncoder72 = device2.createRenderBundleEncoder({
+  label: '\u{1f984}\u91ef\u0a21\u1612\u09a0\uca29\u2ccd',
+  colorFormats: ['rgb10a2uint', 'rgba8sint', 'bgra8unorm-srgb', 'rg16sint', 'r8unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle89 = renderBundleEncoder32.finish({label: '\u002f\u0832\uf5e4\uaae0\u0f7c\u08ab\u6dd6\uc1a6\u{1fbfc}\uef13\u0ca2'});
+try {
+commandEncoder100.resolveQuerySet(querySet52, 1338, 34, buffer34, 397824);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture68,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer1), /* required buffer size: 234 */
+{offset: 234}, {width: 14, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline94 = device2.createRenderPipeline({
+  label: '\u{1f7f9}\u{1f958}\u2594\u{1fa2d}\u0f8a\uf4d2\u1e0e\u0d8f\u{1fa3a}\u1821',
+  layout: pipelineLayout6,
+  multisample: {count: 4, mask: 0xed51c03d},
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.GREEN}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg16sint', writeMask: 0}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'src'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'equal', failOp: 'replace', depthFailOp: 'decrement-wrap'},
+    stencilBack: {compare: 'less', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilReadMask: 3265700401,
+    stencilWriteMask: 3108635631,
+    depthBiasSlopeScale: 0.0,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 5080,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x4', offset: 232, shaderLocation: 2},
+          {format: 'float32x4', offset: 296, shaderLocation: 0},
+          {format: 'float16x4', offset: 504, shaderLocation: 12},
+          {format: 'float32', offset: 300, shaderLocation: 11},
+          {format: 'uint8x2', offset: 540, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw'},
+});
+let commandBuffer30 = commandEncoder125.finish();
+let textureView156 = texture37.createView({label: '\u7a37\u{1f7c9}', dimension: '2d', baseMipLevel: 2, baseArrayLayer: 430});
+let externalTexture70 = device0.importExternalTexture({label: '\u0bf9\ubff6\ub67f\u{1fb1a}\u63c2', source: videoFrame0, colorSpace: 'display-p3'});
+try {
+computePassEncoder8.setBindGroup(6, bindGroup42, new Uint32Array(6579), 4203, 0);
+} catch {}
+try {
+renderBundleEncoder51.draw(286, 113, 195_903_478, 349_638_168);
+} catch {}
+try {
+renderBundleEncoder60.drawIndirect(buffer26, 5896);
+} catch {}
+try {
+commandEncoder59.copyBufferToBuffer(buffer21, 57652, buffer26, 32792, 192);
+dissociateBuffer(device0, buffer21);
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+commandEncoder113.clearBuffer(buffer41, 3756, 1612);
+dissociateBuffer(device0, buffer41);
+} catch {}
+try {
+commandEncoder132.resolveQuerySet(querySet57, 360, 32, buffer30, 305920);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 59, y: 20 },
+  flipY: true,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext18 = offscreenCanvas20.getContext('webgpu');
+try {
+window.someLabel = querySet14.label;
+} catch {}
+video7.height = 168;
+let commandEncoder133 = device0.createCommandEncoder({label: '\u02a3\u281d\u08ed'});
+let querySet67 = device0.createQuerySet({label: '\u{1fa11}\ud44a\u8094\u051e\ufe92', type: 'occlusion', count: 3307});
+let renderBundleEncoder73 = device0.createRenderBundleEncoder({
+  label: '\u995d\u{1fbb9}\u086b\uae10\u5b41\u{1f80b}\u1d05\u6ad1',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  depthReadOnly: false,
+  stencilReadOnly: false,
+});
+try {
+computePassEncoder38.setPipeline(pipeline43);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexed(0);
+} catch {}
+try {
+renderBundleEncoder30.setIndexBuffer(buffer11, 'uint16');
+} catch {}
+try {
+commandEncoder104.copyTextureToTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 117, y: 0, z: 212},
+  aspect: 'all',
+},
+{width: 4, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder120.clearBuffer(buffer36, 6188, 154636);
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 68, y: 0, z: 0},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer7), /* required buffer size: 159 */
+{offset: 159}, {width: 75, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let texture97 = device0.createTexture({
+  label: '\uf02f\u1bfd\u0c5b\u97c8\u0814\u{1ff7b}\u0a0a\u0afd\u04a8',
+  size: {width: 480, height: 240, depthOrArrayLayers: 118},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView157 = texture65.createView({label: '\ufddc\ua82f\u4d9c\u0353', dimension: '2d-array'});
+try {
+commandEncoder117.copyBufferToBuffer(buffer21, 44472, buffer36, 133304, 5328);
+dissociateBuffer(device0, buffer21);
+dissociateBuffer(device0, buffer36);
+} catch {}
+canvas17.width = 580;
+let commandEncoder134 = device1.createCommandEncoder({label: '\u{1fc59}\u1dbb\ua2a4\ua71e\u{1f72c}\u{1ff8c}\uf29c\u73d3\u360e'});
+let textureView158 = texture74.createView({label: '\u{1fc6d}\u059d\u6917\ue0d7\u{1f61a}\ue10b\u02ea\u6daf\u0283'});
+try {
+computePassEncoder41.setBindGroup(1, bindGroup11, new Uint32Array(4559), 1307, 0);
+} catch {}
+try {
+computePassEncoder27.dispatchWorkgroups(2);
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder64.drawIndexed(379, 164, 364_304_486, -2_105_097_441, 1_752_575_764);
+} catch {}
+try {
+renderBundleEncoder58.setPipeline(pipeline89);
+} catch {}
+try {
+renderBundleEncoder68.setVertexBuffer(0, buffer33);
+} catch {}
+try {
+commandEncoder134.copyTextureToTexture({
+  texture: texture91,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 23},
+  aspect: 'all',
+},
+{
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 546, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 72, height: 4, depthOrArrayLayers: 1});
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 60, height: 1, depthOrArrayLayers: 469}
+*/
+{
+  source: img5,
+  origin: { x: 19, y: 16 },
+  flipY: false,
+}, {
+  texture: texture7,
+  mipLevel: 2,
+  origin: {x: 6, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise44 = device1.createComputePipelineAsync({
+  label: '\u0a0c\u8d5c\u68ae',
+  layout: pipelineLayout14,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let imageData30 = new ImageData(148, 32);
+let bindGroupLayout33 = device1.createBindGroupLayout({
+  label: '\u0706\uf3d7\uff2a\u48eb\ub863\u0b31\u6051\u6a1a\u1814\u13e0\u6a45',
+  entries: [{binding: 336, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' }}],
+});
+let bindGroup43 = device1.createBindGroup({
+  label: '\u704f\ud5c9\u737e\u055b',
+  layout: bindGroupLayout23,
+  entries: [{binding: 710, resource: sampler10}],
+});
+let renderPassEncoder29 = commandEncoder134.beginRenderPass({
+  colorAttachments: [{
+  view: textureView88,
+  depthSlice: 1,
+  clearValue: { r: 512.8, g: 510.3, b: 730.0, a: -307.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 904216366,
+});
+try {
+renderPassEncoder14.beginOcclusionQuery(25);
+} catch {}
+try {
+renderPassEncoder18.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.draw(338, 14);
+} catch {}
+try {
+renderPassEncoder19.drawIndexed(475, 752);
+} catch {}
+try {
+renderPassEncoder5.drawIndirect(buffer8, 1_135_116_958);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline89);
+} catch {}
+try {
+renderBundleEncoder65.drawIndexedIndirect(buffer33, 1160);
+} catch {}
+try {
+gpuCanvasContext7.configure({
+  device: device1,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb'],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let shaderModule28 = device1.createShaderModule({
+  label: '\ue8b8\u042d\u4b78\u60d7\u0ef8\u23b1\u0b4f\ue51c\u{1f7f5}',
+  code: `@group(0) @binding(644)
+var<storage, read_write> field9: array<u32>;
+
+@compute @workgroup_size(4, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S19 {
+  @builtin(front_facing) f0: bool
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>
+}
+
+@fragment
+fn fragment0(a0: S19, @builtin(position) a1: vec4<f32>, @builtin(sample_mask) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(3) a0: vec2<f16>, @builtin(vertex_index) a1: u32, @location(11) a2: vec2<i32>, @location(12) a3: vec3<u32>, @location(2) a4: vec3<i32>, @location(8) a5: vec4<f32>, @location(1) a6: f32, @location(9) a7: vec4<u32>, @builtin(instance_index) a8: u32, @location(14) a9: vec4<f16>, @location(6) a10: vec4<i32>, @location(4) a11: vec3<u32>, @location(0) a12: vec2<f32>, @location(10) a13: vec3<f32>, @location(15) a14: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let bindGroupLayout34 = device1.createBindGroupLayout({entries: []});
+try {
+computePassEncoder56.setPipeline(pipeline39);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup37);
+} catch {}
+try {
+renderBundleEncoder67.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder27.draw(84, 14, 367_807_989, 417_154_109);
+} catch {}
+try {
+renderBundleEncoder65.drawIndirect(buffer35, 44748);
+} catch {}
+try {
+renderBundleEncoder64.setPipeline(pipeline10);
+} catch {}
+let arrayBuffer13 = buffer25.getMappedRange(0, 828);
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 120, height: 1, depthOrArrayLayers: 59}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture17,
+  mipLevel: 4,
+  origin: {x: 13, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline95 = await device1.createRenderPipelineAsync({
+  label: '\u0a6f\ud199\u04fe',
+  layout: pipelineLayout16,
+  multisample: {count: 4, mask: 0x7b1b4bd7},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'invert', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'less-equal', failOp: 'increment-wrap', depthFailOp: 'decrement-wrap', passOp: 'zero'},
+    stencilReadMask: 3116028090,
+    stencilWriteMask: 3364313626,
+    depthBias: -1422664695,
+    depthBiasClamp: 901.9307440323178,
+  },
+  vertex: {
+    module: shaderModule22,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 176, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 84,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 0, shaderLocation: 9},
+          {format: 'uint32x3', offset: 4, shaderLocation: 14},
+          {format: 'unorm16x4', offset: 16, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 72,
+        attributes: [
+          {format: 'float16x2', offset: 28, shaderLocation: 2},
+          {format: 'uint32x4', offset: 12, shaderLocation: 0},
+          {format: 'sint16x2', offset: 36, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 24, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', unclippedDepth: true},
+});
+let buffer42 = device1.createBuffer({
+  label: '\udeb9\uaeb3\u{1f7f1}\u3094\u{1f9e5}\u{1feb9}',
+  size: 99906,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: false,
+});
+let commandEncoder135 = device1.createCommandEncoder({label: '\uf82e\u228e\u0b66'});
+let externalTexture71 = device1.importExternalTexture({source: video1, colorSpace: 'display-p3'});
+try {
+computePassEncoder54.dispatchWorkgroupsIndirect(buffer35, 103536);
+} catch {}
+try {
+renderPassEncoder11.setScissorRect(1, 0, 2, 0);
+} catch {}
+try {
+renderPassEncoder19.setViewport(1.352, 0.06897, 1.541, 0.6167, 0.3779, 0.5415);
+} catch {}
+try {
+renderBundleEncoder56.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 4,
+  origin: {x: 3, y: 0, z: 1},
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 21_833_164 */
+{offset: 574, bytesPerRow: 442, rowsPerImage: 267}, {width: 76, height: 0, depthOrArrayLayers: 186});
+} catch {}
+gc();
+let imageBitmap35 = await createImageBitmap(imageBitmap24);
+let shaderModule29 = device2.createShaderModule({
+  label: '\u0569\u0898',
+  code: `@group(0) @binding(1173)
+var<storage, read_write> field10: array<u32>;
+@group(0) @binding(2764)
+var<storage, read_write> n12: array<u32>;
+
+@compute @workgroup_size(5, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec4<f32>,
+  @location(4) f1: vec2<f32>,
+  @location(0) f2: vec4<u32>,
+  @location(3) f3: vec4<i32>,
+  @location(1) f4: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S20 {
+  @location(8) f0: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec3<f16>, @location(2) a1: vec2<i32>, @location(14) a2: f16, a3: S20, @location(13) a4: vec2<i32>, @location(11) a5: f32, @location(1) a6: f16, @location(7) a7: vec4<f16>, @location(5) a8: vec4<i32>, @location(3) a9: vec3<i32>, @location(4) a10: i32, @location(16) a11: vec2<i32>, @location(17) a12: vec3<f16>, @location(10) a13: vec2<u32>, @location(12) a14: u32, @location(0) a15: vec4<f32>, @location(6) a16: vec4<f32>, @location(15) a17: vec4<f32>, @builtin(vertex_index) a18: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder136 = device2.createCommandEncoder({label: '\u090d\u{1f8de}\u0872'});
+try {
+commandEncoder20.copyBufferToBuffer(buffer14, 28640, buffer13, 37408, 19608);
+dissociateBuffer(device2, buffer14);
+dissociateBuffer(device2, buffer13);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer13, 26860, new Int16Array(38083), 26840, 1840);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture26,
+  mipLevel: 1,
+  origin: {x: 44, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint16Array(new ArrayBuffer(64)), /* required buffer size: 1_956_074 */
+{offset: 746, bytesPerRow: 2144, rowsPerImage: 76}, {width: 1048, height: 0, depthOrArrayLayers: 13});
+} catch {}
+video18.width = 146;
+let videoFrame21 = new VideoFrame(img16, {timestamp: 0});
+let videoFrame22 = new VideoFrame(videoFrame11, {timestamp: 0});
+document.body.prepend(img19);
+let textureView159 = texture49.createView({label: '\u20b3\u98ed\ua623\u05a0\u{1f761}\u{1fb0d}', dimension: '1d'});
+let renderBundle90 = renderBundleEncoder71.finish({});
+let externalTexture72 = device0.importExternalTexture({source: videoFrame22, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder60.draw(0);
+} catch {}
+try {
+commandEncoder131.copyBufferToBuffer(buffer15, 177688, buffer39, 44772, 5984);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer39);
+} catch {}
+let pipeline96 = await device0.createRenderPipelineAsync({
+  label: '\u{1f9de}\u814d\u{1f96e}\u{1fb2e}',
+  layout: pipelineLayout19,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgb10a2uint'}, {format: 'rgba8uint'}, {format: 'r16uint', writeMask: 0}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 9376,
+        attributes: [
+          {format: 'sint16x4', offset: 388, shaderLocation: 12},
+          {format: 'float32x2', offset: 4256, shaderLocation: 2},
+          {format: 'float32', offset: 4220, shaderLocation: 19},
+          {format: 'unorm16x2', offset: 3500, shaderLocation: 3},
+          {format: 'unorm16x2', offset: 800, shaderLocation: 6},
+          {format: 'sint32x3', offset: 1692, shaderLocation: 14},
+          {format: 'snorm8x4', offset: 492, shaderLocation: 4},
+          {format: 'sint8x4', offset: 1116, shaderLocation: 17},
+          {format: 'unorm10-10-10-2', offset: 380, shaderLocation: 20},
+          {format: 'float32', offset: 2292, shaderLocation: 16},
+          {format: 'snorm16x2', offset: 700, shaderLocation: 1},
+          {format: 'uint8x4', offset: 1292, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 5264,
+        attributes: [
+          {format: 'unorm8x2', offset: 1014, shaderLocation: 11},
+          {format: 'unorm10-10-10-2', offset: 232, shaderLocation: 10},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32'},
+});
+let img20 = await imageWithData(129, 36, '#3537294b', '#cceb7cc0');
+let videoFrame23 = new VideoFrame(video15, {timestamp: 0});
+let commandEncoder137 = device0.createCommandEncoder({label: '\ubdf9\u5bc7\u040e\u{1fc73}\u{1ffab}\udf9c\u3fec\u{1fb17}'});
+let renderBundle91 = renderBundleEncoder1.finish();
+try {
+renderBundleEncoder46.drawIndexed(539);
+} catch {}
+try {
+renderBundleEncoder60.drawIndexedIndirect(buffer26, 12944);
+} catch {}
+try {
+commandEncoder122.copyBufferToTexture({
+  /* bytesInLastRow: 74 widthInBlocks: 37 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 191592 */
+  offset: 15646,
+  bytesPerRow: 256,
+  rowsPerImage: 165,
+  buffer: buffer15,
+}, {
+  texture: texture29,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 37, height: 28, depthOrArrayLayers: 5});
+dissociateBuffer(device0, buffer15);
+} catch {}
+try {
+commandEncoder71.copyTextureToTexture({
+  texture: texture64,
+  mipLevel: 0,
+  origin: {x: 14, y: 31, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 73, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder132.resolveQuerySet(querySet15, 559, 522, buffer1, 185856);
+} catch {}
+try {
+device0.queue.submit([commandBuffer30]);
+} catch {}
+gc();
+let videoFrame24 = new VideoFrame(imageBitmap1, {timestamp: 0});
+let sampler71 = device1.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 95.81,
+  lodMaxClamp: 96.87,
+  maxAnisotropy: 4,
+});
+let externalTexture73 = device1.importExternalTexture({label: '\u0963\u0753\u{1ff88}', source: videoFrame22});
+try {
+computePassEncoder51.setBindGroup(2, bindGroup40);
+} catch {}
+try {
+renderPassEncoder21.beginOcclusionQuery(2301);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle56]);
+} catch {}
+try {
+renderPassEncoder22.setViewport(200.8, 0.2310, 26.09, 0.01683, 0.9356, 0.9710);
+} catch {}
+try {
+renderPassEncoder26.drawIndirect(buffer33, 741_683_994);
+} catch {}
+try {
+renderBundleEncoder65.setBindGroup(1, bindGroup37);
+} catch {}
+try {
+renderBundleEncoder65.draw(135);
+} catch {}
+try {
+renderBundleEncoder65.drawIndexedIndirect(buffer33, 1492);
+} catch {}
+try {
+commandEncoder135.copyTextureToTexture({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture88,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder138 = device0.createCommandEncoder({label: '\u96b5\u0b7c\u61b4\u2c72\u4e51\u09bf\u{1f623}\ud83f\u0e3e\u8538'});
+let textureView160 = texture65.createView({format: 'bgra8unorm'});
+let sampler72 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.10,
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder49.setBindGroup(3, bindGroup26);
+} catch {}
+try {
+computePassEncoder48.setBindGroup(0, bindGroup9, new Uint32Array(6007), 3146, 0);
+} catch {}
+try {
+renderBundleEncoder60.draw(969);
+} catch {}
+try {
+renderBundleEncoder60.drawIndexed(1, 69, 1_259_413_848, 369_982_968, 375_770_476);
+} catch {}
+try {
+renderBundleEncoder60.setPipeline(pipeline82);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder85.clearBuffer(buffer22, 15424, 6924);
+dissociateBuffer(device0, buffer22);
+} catch {}
+try {
+commandEncoder57.resolveQuerySet(querySet33, 504, 304, buffer1, 130048);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture82,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 13},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer12), /* required buffer size: 1_988_399 */
+{offset: 613, bytesPerRow: 411, rowsPerImage: 186}, {width: 95, height: 1, depthOrArrayLayers: 27});
+} catch {}
+let pipeline97 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout5,
+  multisample: {mask: 0xb1d6a4c2},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: GPUColorWrite.RED}, {format: 'r16uint', writeMask: 0}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 20452,
+        attributes: [
+          {format: 'uint32x2', offset: 2036, shaderLocation: 9},
+          {format: 'sint16x2', offset: 6000, shaderLocation: 14},
+          {format: 'unorm10-10-10-2', offset: 3772, shaderLocation: 3},
+          {format: 'unorm8x4', offset: 5952, shaderLocation: 11},
+          {format: 'float16x2', offset: 5088, shaderLocation: 6},
+          {format: 'unorm8x2', offset: 1900, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 1124, shaderLocation: 1},
+          {format: 'unorm16x4', offset: 7216, shaderLocation: 16},
+          {format: 'unorm8x4', offset: 1068, shaderLocation: 2},
+          {format: 'sint8x2', offset: 126, shaderLocation: 17},
+          {format: 'snorm8x2', offset: 3102, shaderLocation: 19},
+          {format: 'sint32x4', offset: 3308, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 5224,
+        attributes: [
+          {format: 'float16x2', offset: 964, shaderLocation: 10},
+          {format: 'snorm16x4', offset: 84, shaderLocation: 20},
+        ],
+      },
+    ],
+  },
+});
+let bindGroup44 = device0.createBindGroup({label: '\uef7a\uccd2\u2310\uee97', layout: bindGroupLayout9, entries: []});
+let texture98 = device0.createTexture({
+  label: '\u{1ff77}\u3da8\u041a\uaa7c\u{1fe3e}\ufcf1',
+  size: [1248, 1, 494],
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r16sint', 'r16sint'],
+});
+let textureView161 = texture51.createView({label: '\u01d8\u965d\u4b3e'});
+let computePassEncoder60 = commandEncoder0.beginComputePass();
+let renderBundle92 = renderBundleEncoder10.finish();
+let externalTexture74 = device0.importExternalTexture({label: '\u93f5\u{1fc95}\ub438\u0aff\u{1f810}\u63c1', source: videoFrame12, colorSpace: 'srgb'});
+try {
+renderBundleEncoder40.setBindGroup(4, bindGroup2, []);
+} catch {}
+try {
+renderBundleEncoder51.drawIndirect(buffer26, 4664);
+} catch {}
+try {
+renderBundleEncoder46.setIndexBuffer(buffer26, 'uint32', 9328, 15069);
+} catch {}
+try {
+  await buffer15.mapAsync(GPUMapMode.WRITE, 0, 144728);
+} catch {}
+let imageData31 = new ImageData(108, 136);
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+let commandBuffer31 = commandEncoder135.finish({label: '\u0b77\u{1f815}\u00eb\u{1ff23}\u0235\u0162\u0e22\u{1ff54}\u2cb8\u9d4e\u{1ff34}'});
+let texture99 = device1.createTexture({
+  label: '\u2456\u2d4e',
+  size: {width: 960, height: 6, depthOrArrayLayers: 694},
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let textureView162 = texture55.createView({label: '\uc02d\u15a7\u0ea3', baseMipLevel: 3});
+try {
+renderPassEncoder3.setBlendConstant({ r: -406.5, g: 421.8, b: 661.2, a: 982.3, });
+} catch {}
+try {
+renderPassEncoder2.setScissorRect(193, 0, 24, 0);
+} catch {}
+try {
+renderPassEncoder19.drawIndexed(25, 65, 210_743_234, 124_958_913);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(4, buffer33, 0);
+} catch {}
+try {
+renderBundleEncoder66.setBindGroup(3, bindGroup30, new Uint32Array(5004), 380, 0);
+} catch {}
+try {
+renderBundleEncoder65.drawIndexedIndirect(buffer33, 1552);
+} catch {}
+try {
+renderBundleEncoder65.setPipeline(pipeline53);
+} catch {}
+try {
+renderBundleEncoder43.setVertexBuffer(2, buffer27, 17180, 9728);
+} catch {}
+let querySet68 = device1.createQuerySet({
+  label: '\u{1fbb8}\u01dd\u73d7\u0d79\u227e\ubcfa\u03aa\ubc42\uc32c\u1cec',
+  type: 'occlusion',
+  count: 2946,
+});
+let textureView163 = texture94.createView({});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline49);
+} catch {}
+try {
+renderPassEncoder11.beginOcclusionQuery(737);
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(0, 1, 1, 0);
+} catch {}
+try {
+renderPassEncoder19.draw(386, 218, 151_829_797, 1_666_499_339);
+} catch {}
+try {
+renderPassEncoder5.drawIndexed(251, 78, 324_847_540, 137_881_417);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer20, 382_278_648);
+} catch {}
+try {
+renderBundleEncoder42.setBindGroup(3, bindGroup17, new Uint32Array(7588), 3638, 0);
+} catch {}
+try {
+renderBundleEncoder27.draw(311, 53, 146_029_137, 831_458_401);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device1.destroy();
+} catch {}
+let img21 = await imageWithData(255, 236, '#60b06e11', '#734674fb');
+let video20 = await videoWithData();
+let textureView164 = texture15.createView({label: '\u{1f8f0}\u{1fa4a}'});
+let renderBundle93 = renderBundleEncoder73.finish({label: '\u9d00\u01ec\u{1feb8}\u{1ffbd}\u0b5f\u0ba3\u8a77\u{1ffb7}\u0b87\u0ea7'});
+try {
+computePassEncoder12.setBindGroup(9, bindGroup13, new Uint32Array(8941), 8261, 0);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline27);
+} catch {}
+try {
+renderBundleEncoder51.draw(37, 120, 172_071_849, 349_763_294);
+} catch {}
+try {
+renderBundleEncoder51.drawIndexedIndirect(buffer26, 13100);
+} catch {}
+try {
+renderBundleEncoder51.drawIndirect(buffer26, 6512);
+} catch {}
+try {
+renderBundleEncoder51.setPipeline(pipeline96);
+} catch {}
+try {
+renderBundleEncoder52.setVertexBuffer(9521, undefined, 2872864081, 278690202);
+} catch {}
+try {
+commandEncoder63.copyBufferToTexture({
+  /* bytesInLastRow: 36 widthInBlocks: 18 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 28724 */
+  offset: 16656,
+  bytesPerRow: 256,
+  rowsPerImage: 38,
+  buffer: buffer26,
+}, {
+  texture: texture29,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 18, height: 10, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+commandEncoder138.clearBuffer(buffer31);
+dissociateBuffer(device0, buffer31);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 16},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 2_964_631 */
+{offset: 147, bytesPerRow: 76, rowsPerImage: 66}, {width: 7, height: 1, depthOrArrayLayers: 592});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img5,
+  origin: { x: 31, y: 24 },
+  flipY: true,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline98 = await device0.createRenderPipelineAsync({
+  label: '\u{1f8f6}\u903e\u{1f978}\u02ef\u8d51\u260d\u0819\u{1fe50}\u023f\ude93',
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule4,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'not-equal', failOp: 'increment-clamp', passOp: 'invert'},
+    stencilBack: {compare: 'never', failOp: 'invert', passOp: 'decrement-wrap'},
+    stencilWriteMask: 3278189348,
+    depthBiasClamp: 777.5424572963218,
+  },
+  vertex: {module: shaderModule4, entryPoint: 'vertex0', buffers: []},
+  primitive: {unclippedDepth: true},
+});
+let promise45 = navigator.gpu.requestAdapter();
+let video21 = await videoWithData();
+let buffer43 = device2.createBuffer({
+  size: 163604,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let textureView165 = texture47.createView({
+  label: '\uaf4e\u0f49\u{1f64b}\ua94f\ubbcf\u8cea\u1aa4\ufa01\u70ad\u13eb',
+  baseMipLevel: 1,
+  baseArrayLayer: 481,
+  arrayLayerCount: 1071,
+});
+try {
+commandEncoder136.copyBufferToBuffer(buffer43, 71516, buffer13, 36276, 24716);
+dissociateBuffer(device2, buffer43);
+dissociateBuffer(device2, buffer13);
+} catch {}
+try {
+commandEncoder22.clearBuffer(buffer13, 82040, 2244);
+dissociateBuffer(device2, buffer13);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup45 = device0.createBindGroup({
+  label: '\u09d6\u4674\u6de4\uc8a5\u0821\u57c4\u8ea9\u79ab\u{1f84b}\u0d74\u7a3d',
+  layout: bindGroupLayout10,
+  entries: [],
+});
+let commandEncoder139 = device0.createCommandEncoder({label: '\uff5e\u0e5e\u570f\u{1fa85}\u{1ff9d}\u{1f6c4}'});
+let computePassEncoder61 = commandEncoder132.beginComputePass({});
+let sampler73 = device0.createSampler({
+  label: '\u1d02\u68bc\u5fa5\ueca7\u00ac',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 75.16,
+  lodMaxClamp: 86.02,
+  compare: 'greater',
+});
+try {
+renderBundleEncoder46.draw(261, 238);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexed(27, 182);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexedIndirect(buffer26, 16976);
+} catch {}
+try {
+renderBundleEncoder46.drawIndirect(buffer26, 152);
+} catch {}
+try {
+commandEncoder103.copyBufferToTexture({
+  /* bytesInLastRow: 8 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 37232 */
+  offset: 37232,
+  bytesPerRow: 512,
+  buffer: buffer21,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer21);
+} catch {}
+try {
+computePassEncoder12.insertDebugMarker('\ue3c4');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 85328, new Float32Array(63911), 16862);
+} catch {}
+let bindGroup46 = device0.createBindGroup({
+  label: '\u247f\uc0a4\u3d13\u6264\u5f6e\u71b7',
+  layout: bindGroupLayout32,
+  entries: [
+    {binding: 5448, resource: externalTexture70},
+    {binding: 6791, resource: {buffer: buffer0, offset: 55552, size: 39808}},
+    {binding: 5251, resource: externalTexture59},
+  ],
+});
+let commandEncoder140 = device0.createCommandEncoder({label: '\ucf70\u{1f83c}'});
+let textureView166 = texture95.createView({});
+let renderBundle94 = renderBundleEncoder52.finish({label: '\u087e\u91a3\u9021\u3e02\ub5d9\u94c1\u2e6d'});
+let sampler74 = device0.createSampler({
+  label: '\u{1f89e}\u0a3c\u{1ffab}\u42c1',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 94.79,
+  lodMaxClamp: 95.48,
+  compare: 'greater',
+  maxAnisotropy: 1,
+});
+let externalTexture75 = device0.importExternalTexture({
+  label: '\u011d\u0caf\udc21\u{1fd42}\u{1f9e0}\u06b5\u06ee\u0844\u0721\u00bc\uf0b6',
+  source: videoFrame1,
+  colorSpace: 'display-p3',
+});
+try {
+commandEncoder71.copyBufferToTexture({
+  /* bytesInLastRow: 600 widthInBlocks: 150 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 16340 */
+  offset: 16340,
+  buffer: buffer26,
+}, {
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 150, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+commandEncoder128.resolveQuerySet(querySet27, 1729, 219, buffer30, 376320);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(arrayBuffer7), /* required buffer size: 1_296 */
+{offset: 432, rowsPerImage: 138}, {width: 108, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+offscreenCanvas15.width = 26;
+let video22 = await videoWithData();
+let commandEncoder141 = device0.createCommandEncoder({label: '\uc628\u5eff\u02d4\u{1fe99}'});
+let renderBundleEncoder74 = device0.createRenderBundleEncoder({
+  label: '\ufee2\u350a\u7d91\u0788\u52c3\u02e9\u0640\u0004\u8e46',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder57.setPipeline(pipeline77);
+} catch {}
+try {
+renderBundleEncoder46.draw(50, 90, 54_303_192, 575_944_160);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexed(63, 264, 522_769_535, 2_287_060, 25_450_176);
+} catch {}
+try {
+buffer0.destroy();
+} catch {}
+try {
+commandEncoder120.copyTextureToTexture({
+  texture: texture50,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 184},
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 2,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 52});
+} catch {}
+try {
+commandEncoder114.clearBuffer(buffer16);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 9},
+  aspect: 'all',
+}, arrayBuffer7, /* required buffer size: 17_445_282 */
+{offset: 582, bytesPerRow: 252, rowsPerImage: 195}, {width: 1, height: 0, depthOrArrayLayers: 356});
+} catch {}
+let pipeline99 = device0.createRenderPipeline({
+  layout: pipelineLayout7,
+  multisample: {count: 1, mask: 0x605a75ad},
+  fragment: {
+  module: shaderModule15,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {failOp: 'decrement-clamp', depthFailOp: 'invert', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'less', failOp: 'zero', depthFailOp: 'replace', passOp: 'decrement-wrap'},
+    stencilReadMask: 2597346185,
+    stencilWriteMask: 88083697,
+    depthBias: 1191091058,
+    depthBiasSlopeScale: 316.08564480343506,
+    depthBiasClamp: 666.1820194113726,
+  },
+  vertex: {
+    module: shaderModule15,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3444,
+        attributes: [
+          {format: 'uint16x4', offset: 664, shaderLocation: 19},
+          {format: 'sint16x2', offset: 1012, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 2556, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 884,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 88, shaderLocation: 12},
+          {format: 'uint32x4', offset: 56, shaderLocation: 9},
+          {format: 'snorm16x4', offset: 676, shaderLocation: 6},
+          {format: 'unorm8x2', offset: 188, shaderLocation: 1},
+          {format: 'float16x4', offset: 88, shaderLocation: 2},
+          {format: 'float32x2', offset: 72, shaderLocation: 3},
+          {format: 'sint16x4', offset: 424, shaderLocation: 16},
+          {format: 'sint8x4', offset: 836, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 372,
+        attributes: [
+          {format: 'uint32x2', offset: 56, shaderLocation: 4},
+          {format: 'uint16x2', offset: 68, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm10-10-10-2', offset: 4568, shaderLocation: 7}],
+      },
+      {arrayStride: 18180, attributes: []},
+      {
+        arrayStride: 5264,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 860, shaderLocation: 18},
+          {format: 'unorm16x4', offset: 760, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 4572, attributes: []},
+      {
+        arrayStride: 1636,
+        stepMode: 'vertex',
+        attributes: [{format: 'uint16x2', offset: 12, shaderLocation: 20}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', unclippedDepth: true},
+});
+let imageBitmap36 = await createImageBitmap(videoFrame16);
+let offscreenCanvas21 = new OffscreenCanvas(370, 753);
+let imageBitmap37 = await createImageBitmap(offscreenCanvas17);
+try {
+offscreenCanvas21.getContext('webgl2');
+} catch {}
+let commandEncoder142 = device0.createCommandEncoder({label: '\ub7b1\u6775\ufcbe\ucec3\ub8e1'});
+let textureView167 = texture57.createView({label: '\u{1fae6}\uc66a'});
+let renderBundleEncoder75 = device0.createRenderBundleEncoder({
+  label: '\u5a0e\u4d08\u32f3\u4e18\u3d24',
+  colorFormats: ['r16float', 'rg8sint', 'r32uint', 'r16float', 'r16sint', 'rgb10a2unorm', 'rg16uint'],
+});
+try {
+renderBundleEncoder46.drawIndirect(buffer26, 712);
+} catch {}
+try {
+commandEncoder85.clearBuffer(buffer16);
+dissociateBuffer(device0, buffer16);
+} catch {}
+let img22 = await imageWithData(10, 66, '#a1377e6c', '#c5086578');
+let bindGroup47 = device0.createBindGroup({
+  label: '\u{1fb3c}\u{1f9cf}\u01fd\u{1fac0}\u86a9\u{1f765}',
+  layout: bindGroupLayout11,
+  entries: [{binding: 3074, resource: externalTexture23}],
+});
+let texture100 = device0.createTexture({
+  size: {width: 240, height: 120, depthOrArrayLayers: 59},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r32uint', 'r32uint'],
+});
+let computePassEncoder62 = commandEncoder71.beginComputePass({label: '\u{1f604}\u2de8\u{1f98c}\uc0a2\ub4f3\u512c\u092d\ub7a1'});
+try {
+computePassEncoder9.setPipeline(pipeline88);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexed(233, 13, 1_331_028_333, 170_483_281, 3_883_280_184);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexedIndirect(buffer26, 11996);
+} catch {}
+try {
+renderBundleEncoder48.setPipeline(pipeline93);
+} catch {}
+try {
+commandEncoder85.copyTextureToTexture({
+  texture: texture40,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 51},
+  aspect: 'all',
+},
+{
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 124, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 184, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture100,
+  mipLevel: 0,
+  origin: {x: 5, y: 5, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(64), /* required buffer size: 187_816 */
+{offset: 876, bytesPerRow: 324, rowsPerImage: 131}, {width: 79, height: 53, depthOrArrayLayers: 5});
+} catch {}
+offscreenCanvas13.height = 1;
+let canvas21 = document.createElement('canvas');
+let video23 = await videoWithData();
+let img23 = await imageWithData(213, 125, '#707e0ef3', '#e266a585');
+let imageData32 = new ImageData(160, 8);
+try {
+window.someLabel = shaderModule11.label;
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let textureView168 = texture4.createView({baseMipLevel: 2, arrayLayerCount: 1});
+let renderBundle95 = renderBundleEncoder73.finish({label: '\ua901\u009e\u6fe5\u0993\u1ca1\u0a69\u052f\u1038\u389e\u0c48'});
+try {
+renderBundleEncoder60.setPipeline(pipeline35);
+} catch {}
+try {
+renderBundleEncoder40.setVertexBuffer(4158, undefined, 378089581, 3320037378);
+} catch {}
+try {
+commandEncoder123.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 11318 */
+  offset: 11318,
+  bytesPerRow: 0,
+  buffer: buffer12,
+}, {
+  texture: texture73,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder141.clearBuffer(buffer36, 293416, 22676);
+dissociateBuffer(device0, buffer36);
+} catch {}
+let canvas22 = document.createElement('canvas');
+let imageData33 = new ImageData(92, 192);
+try {
+bindGroup24.label = '\u0ae9\ua58e\u5e71\u5891\u{1fb04}\ufea4\u78d1\u{1fdae}';
+} catch {}
+let commandEncoder143 = device0.createCommandEncoder({label: '\u0e1e\u6452\u{1f6d5}\u2bc8\u884b\u5a80\ubcbe\u1dee\u431b\u{1fcb7}\ua20a'});
+let textureView169 = texture79.createView({label: '\u{1fed5}\u0f6c\u0f21\u{1f734}\u02f6\u{1fcd6}'});
+try {
+renderBundleEncoder46.draw(382, 58, 188_169_820, 655_304_087);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexedIndirect(buffer26, 2432);
+} catch {}
+try {
+commandEncoder107.copyBufferToBuffer(buffer17, 54944, buffer31, 13276, 5500);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer31);
+} catch {}
+try {
+commandEncoder51.resolveQuerySet(querySet35, 2537, 84, buffer1, 91904);
+} catch {}
+let pipeline100 = device0.createComputePipeline({
+  label: '\ubd57\u00c8\u0464',
+  layout: pipelineLayout9,
+  compute: {module: shaderModule17, entryPoint: 'compute0', constants: {}},
+});
+let canvas23 = document.createElement('canvas');
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+canvas0.height = 1129;
+let bindGroupLayout35 = device0.createBindGroupLayout({
+  label: '\u36fb\uc3fc',
+  entries: [{binding: 1904, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }}],
+});
+let commandEncoder144 = device0.createCommandEncoder({label: '\udcb8\u07e2'});
+let querySet69 = device0.createQuerySet({label: '\u1f67\ue815\u{1f972}\uf4ae\u{1f9d5}\u{1f704}', type: 'occlusion', count: 1761});
+let commandBuffer32 = commandEncoder142.finish({label: '\u69ea\u329c\u35fd\u0aab\u451f\uea70\u{1ff77}\u1587\ua0a8'});
+let texture101 = device0.createTexture({
+  label: '\u{1fc6a}\uae91\udd61\u083e\u60ce',
+  size: [120, 60, 1],
+  mipLevelCount: 5,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle96 = renderBundleEncoder6.finish();
+let sampler75 = device0.createSampler({
+  label: '\ufa85\u084d\u9912',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 75.98,
+  lodMaxClamp: 99.45,
+});
+try {
+computePassEncoder49.setPipeline(pipeline43);
+} catch {}
+try {
+renderBundleEncoder48.setBindGroup(10, bindGroup24);
+} catch {}
+try {
+renderBundleEncoder46.draw(41, 164, 315_285_401, 887_857_089);
+} catch {}
+try {
+commandEncoder60.copyTextureToBuffer({
+  texture: texture95,
+  mipLevel: 0,
+  origin: {x: 78, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 92 widthInBlocks: 23 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 27900 */
+  offset: 27900,
+  buffer: buffer36,
+}, {width: 23, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture31,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 360},
+  aspect: 'all',
+}, new ArrayBuffer(16_767_968), /* required buffer size: 16_767_968 */
+{offset: 728, bytesPerRow: 853, rowsPerImage: 252}, {width: 168, height: 1, depthOrArrayLayers: 79});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData12,
+  origin: { x: 102, y: 1 },
+  flipY: true,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter2.label = '\u6623\u08eb\u{1f84b}\u9e45\u0b29\u0697\u6722';
+} catch {}
+let commandEncoder145 = device0.createCommandEncoder();
+let querySet70 = device0.createQuerySet({type: 'occlusion', count: 1950});
+let commandBuffer33 = commandEncoder109.finish({label: '\u{1f722}\u{1fb4b}\uf0f3\u86c7\u1d97\u{1f797}\ucafb\uc54c\ua718\u9895\u800d'});
+try {
+renderBundleEncoder51.setBindGroup(7, bindGroup45, []);
+} catch {}
+try {
+renderBundleEncoder46.drawIndirect(buffer26, 13684);
+} catch {}
+try {
+commandEncoder122.copyBufferToBuffer(buffer38, 135628, buffer26, 272, 17652);
+dissociateBuffer(device0, buffer38);
+dissociateBuffer(device0, buffer26);
+} catch {}
+let canvas24 = document.createElement('canvas');
+let img24 = await imageWithData(251, 265, '#3e351921', '#98c3f47a');
+try {
+window.someLabel = textureView152.label;
+} catch {}
+document.body.prepend(img0);
+video17.height = 130;
+try {
+adapter1.label = '\u95fa\u032c\u18f8\u{1fb85}\u{1ffed}';
+} catch {}
+let textureView170 = texture8.createView({label: '\u66e8\u{1faa8}', dimension: '3d', mipLevelCount: 4, arrayLayerCount: 1});
+let renderBundle97 = renderBundleEncoder71.finish({label: '\u304f\u310b\u5f32\u5a9b\u19bf\u5100\u{1fe01}\u06dd\ue400\u0fda'});
+try {
+renderBundleEncoder40.setBindGroup(7, bindGroup24);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexed(150, 199, 126_559_679, 655_300_072, 60_096_791);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexedIndirect(buffer26, 4864);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame15,
+  origin: { x: 34, y: 82 },
+  flipY: false,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline101 = await device0.createComputePipelineAsync({
+  label: '\u{1f795}\u82ad\u{1ff7d}\u{1fa00}\ud05e\u0b91\u{1fcb1}',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule14, entryPoint: 'compute0', constants: {}},
+});
+let pipeline102 = device0.createRenderPipeline({
+  layout: pipelineLayout10,
+  vertex: {
+    module: shaderModule26,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 6368,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 2984, shaderLocation: 14},
+          {format: 'unorm10-10-10-2', offset: 20, shaderLocation: 12},
+          {format: 'sint8x2', offset: 320, shaderLocation: 6},
+          {format: 'snorm8x4', offset: 140, shaderLocation: 16},
+          {format: 'unorm8x4', offset: 1620, shaderLocation: 8},
+          {format: 'sint8x2', offset: 306, shaderLocation: 0},
+          {format: 'snorm16x4', offset: 1600, shaderLocation: 9},
+          {format: 'float32x2', offset: 212, shaderLocation: 17},
+          {format: 'uint32x2', offset: 944, shaderLocation: 18},
+          {format: 'sint8x2', offset: 1606, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 14360,
+        attributes: [
+          {format: 'sint32x3', offset: 3968, shaderLocation: 3},
+          {format: 'float16x2', offset: 1124, shaderLocation: 11},
+          {format: 'sint32x3', offset: 508, shaderLocation: 20},
+          {format: 'unorm8x2', offset: 2132, shaderLocation: 4},
+          {format: 'sint8x2', offset: 950, shaderLocation: 5},
+          {format: 'uint8x2', offset: 4370, shaderLocation: 19},
+          {format: 'snorm8x2', offset: 3354, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'none'},
+});
+let gpuCanvasContext19 = canvas23.getContext('webgpu');
+let videoFrame25 = new VideoFrame(offscreenCanvas10, {timestamp: 0});
+document.body.prepend(canvas13);
+let imageBitmap38 = await createImageBitmap(imageBitmap31);
+let shaderModule30 = device0.createShaderModule({
+  label: '\u181e\u9046\ud000\u{1ffe6}\u0c60\u{1f7df}\u282c\u188a\u7cb0\u086d',
+  code: `@group(2) @binding(3465)
+var<storage, read_write> type11: array<u32>;
+@group(1) @binding(1456)
+var<storage, read_write> local19: array<u32>;
+@group(2) @binding(5002)
+var<storage, read_write> n13: array<u32>;
+@group(2) @binding(4645)
+var<storage, read_write> type12: array<u32>;
+
+@compute @workgroup_size(8, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec4<u32>,
+  @location(2) f1: vec3<u32>,
+  @location(0) f2: vec4<u32>,
+  @location(5) f3: i32,
+  @location(3) f4: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(27) a0: i32, @location(10) a1: f16) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S21 {
+  @location(4) f0: vec3<i32>,
+  @location(5) f1: vec4<f32>,
+  @location(16) f2: vec3<i32>,
+  @builtin(vertex_index) f3: u32,
+  @location(0) f4: vec2<i32>,
+  @location(11) f5: vec2<f16>,
+  @builtin(instance_index) f6: u32,
+  @location(2) f7: u32,
+  @location(6) f8: vec4<u32>,
+  @location(15) f9: f16,
+  @location(18) f10: vec4<u32>,
+  @location(1) f11: u32,
+  @location(19) f12: vec2<f16>,
+  @location(12) f13: vec3<f32>,
+  @location(8) f14: vec4<f16>,
+  @location(7) f15: vec2<f16>,
+  @location(9) f16: u32,
+  @location(14) f17: vec4<i32>
+}
+struct VertexOutput0 {
+  @location(10) f146: f16,
+  @builtin(position) f147: vec4<f32>,
+  @location(22) f148: vec3<u32>,
+  @location(6) f149: f32,
+  @location(11) f150: vec4<u32>,
+  @location(1) f151: vec2<u32>,
+  @location(27) f152: i32,
+  @location(15) f153: i32
+}
+
+@vertex
+fn vertex0(@location(17) a0: f32, @location(10) a1: vec3<f32>, @location(20) a2: vec4<u32>, @location(13) a3: vec3<u32>, @location(3) a4: vec2<f32>, a5: S21) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup48 = device0.createBindGroup({
+  label: '\u0f58\u4c28\u0b10\u61d9\u5f86\u050c\u{1fbf5}\u8f50\u{1f8a6}\u000f',
+  layout: bindGroupLayout32,
+  entries: [
+    {binding: 5448, resource: externalTexture0},
+    {binding: 5251, resource: externalTexture62},
+    {binding: 6791, resource: {buffer: buffer0, offset: 91776, size: 13372}},
+  ],
+});
+let commandEncoder146 = device0.createCommandEncoder({label: '\u58b6\u0331\u83a8\u{1ffc8}\u{1fa09}\u082a'});
+let textureView171 = texture93.createView({baseMipLevel: 0});
+try {
+commandEncoder139.copyTextureToBuffer({
+  texture: texture13,
+  mipLevel: 3,
+  origin: {x: 0, y: 1, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 120 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 38172 */
+  offset: 38172,
+  bytesPerRow: 256,
+  buffer: buffer16,
+}, {width: 30, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder110.clearBuffer(buffer36, 16552, 185324);
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer39, 20588, new DataView(new ArrayBuffer(23504)), 4977, 2736);
+} catch {}
+let img25 = await imageWithData(122, 5, '#0604d8c2', '#939a34b9');
+let externalTexture76 = device0.importExternalTexture({label: '\u{1f8f2}\u85b4', source: videoFrame24, colorSpace: 'srgb'});
+try {
+computePassEncoder57.setBindGroup(7, bindGroup45, new Uint32Array(5354), 5202, 0);
+} catch {}
+try {
+renderBundleEncoder46.draw(68, 77, 4_294_967_295, 156_763_674);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexedIndirect(buffer26, 3864);
+} catch {}
+try {
+renderBundleEncoder46.drawIndirect(buffer26, 2472);
+} catch {}
+try {
+renderBundleEncoder51.setPipeline(pipeline35);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, new Int8Array(new ArrayBuffer(8)), /* required buffer size: 1_718 */
+{offset: 938}, {width: 195, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext20 = canvas22.getContext('webgpu');
+try {
+adapter6.label = '\u834f\u{1f8f1}';
+} catch {}
+let bindGroupLayout36 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 4476,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 1600,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let commandEncoder147 = device0.createCommandEncoder({label: '\uef27\u2f86\u9c3e\u08e2\ue40d\u6303\u0162'});
+let textureView172 = texture27.createView({dimension: '2d-array', arrayLayerCount: 1});
+let renderBundle98 = renderBundleEncoder30.finish({});
+try {
+renderBundleEncoder46.setBindGroup(3, bindGroup7, []);
+} catch {}
+try {
+commandEncoder107.copyTextureToTexture({
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 60, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture50,
+  mipLevel: 1,
+  origin: {x: 1, y: 16, z: 0},
+  aspect: 'all',
+},
+{width: 38, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline103 = device0.createRenderPipeline({
+  label: '\u612a\uf51d\u0eaf\u0486\u4ee3\u1e61\u{1ffdb}\uf7a9\u55a5',
+  layout: pipelineLayout9,
+  fragment: {
+  module: shaderModule18,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8uint'}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgb10a2uint'}],
+},
+  vertex: {
+    module: shaderModule18,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 3272, attributes: [{format: 'float32x3', offset: 188, shaderLocation: 1}]},
+      {
+        arrayStride: 6068,
+        attributes: [
+          {format: 'unorm8x2', offset: 214, shaderLocation: 9},
+          {format: 'sint8x4', offset: 1644, shaderLocation: 14},
+          {format: 'sint8x4', offset: 548, shaderLocation: 5},
+          {format: 'uint8x2', offset: 762, shaderLocation: 19},
+          {format: 'snorm16x4', offset: 284, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 7928,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 1616, shaderLocation: 0},
+          {format: 'float32x4', offset: 632, shaderLocation: 17},
+          {format: 'sint32x4', offset: 1220, shaderLocation: 20},
+          {format: 'sint32', offset: 364, shaderLocation: 8},
+          {format: 'sint16x4', offset: 760, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', unclippedDepth: true},
+});
+let video24 = await videoWithData();
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let videoFrame26 = new VideoFrame(img3, {timestamp: 0});
+let commandEncoder148 = device0.createCommandEncoder({label: '\u0941\uf7f8\u1c57\u0c42\u0a7a'});
+let textureView173 = texture62.createView({label: '\u{1fe88}\u05b7\u{1ff0b}\u40ea\ud09b', baseArrayLayer: 494, arrayLayerCount: 96});
+let sampler76 = device0.createSampler({
+  label: '\u{1fce3}\u0dfa\u9041\u{1f6ce}\u7b2b',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 51.96,
+  lodMaxClamp: 61.13,
+});
+try {
+computePassEncoder60.setPipeline(pipeline43);
+} catch {}
+try {
+renderBundleEncoder70.setPipeline(pipeline82);
+} catch {}
+try {
+commandEncoder108.clearBuffer(buffer26, 29500, 312);
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+commandEncoder138.resolveQuerySet(querySet9, 1135, 77, buffer30, 177152);
+} catch {}
+let pipeline104 = await device0.createRenderPipelineAsync({
+  label: '\uab04\u2bdf\u0a74\u0b1b\u{1f719}\u076f\u65f1\u0fb5\u75ae\u90b5',
+  layout: pipelineLayout12,
+  multisample: {count: 1, mask: 0xf49be585},
+  fragment: {
+  module: shaderModule17,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgb10a2uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.RED}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilFront: {compare: 'greater', failOp: 'decrement-clamp', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilBack: {failOp: 'increment-wrap', depthFailOp: 'invert'},
+    stencilReadMask: 1522163215,
+    stencilWriteMask: 3567351004,
+    depthBias: -1765533486,
+  },
+  vertex: {
+    module: shaderModule17,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 4336, shaderLocation: 10},
+          {format: 'sint8x4', offset: 5992, shaderLocation: 20},
+          {format: 'sint32x2', offset: 4552, shaderLocation: 12},
+          {format: 'unorm16x2', offset: 10620, shaderLocation: 15},
+          {format: 'sint32x3', offset: 18048, shaderLocation: 5},
+          {format: 'float32x4', offset: 5552, shaderLocation: 1},
+          {format: 'sint32x4', offset: 3240, shaderLocation: 14},
+          {format: 'sint32x3', offset: 12608, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 1624,
+        attributes: [
+          {format: 'uint32x2', offset: 444, shaderLocation: 8},
+          {format: 'uint32', offset: 20, shaderLocation: 2},
+          {format: 'float16x4', offset: 168, shaderLocation: 9},
+          {format: 'float32x3', offset: 1016, shaderLocation: 19},
+          {format: 'float32x4', offset: 544, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 7712, stepMode: 'instance', attributes: []},
+      {arrayStride: 4032, stepMode: 'vertex', attributes: []},
+      {arrayStride: 26552, attributes: []},
+      {arrayStride: 8088, attributes: [{format: 'uint8x2', offset: 568, shaderLocation: 3}]},
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: false,
+},
+});
+let video25 = await videoWithData();
+let bindGroup49 = device0.createBindGroup({
+  label: '\ud7ca\u{1ffda}\u{1ff8f}\u{1f641}\u5289\u{1f7b9}\u41bf\u0371',
+  layout: bindGroupLayout29,
+  entries: [{binding: 2234, resource: sampler73}],
+});
+let commandEncoder149 = device0.createCommandEncoder({label: '\u{1fa8c}\u{1fdf8}\u97f6\u{1fed3}\u0b5c\u01ea'});
+try {
+renderBundleEncoder60.setPipeline(pipeline97);
+} catch {}
+document.body.prepend(canvas3);
+try {
+canvas24.getContext('bitmaprenderer');
+} catch {}
+let bindGroupLayout37 = device0.createBindGroupLayout({
+  label: '\u04aa\u2169\u0db2\u9c8a\u{1fa6d}',
+  entries: [
+    {
+      binding: 4644,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let commandEncoder150 = device0.createCommandEncoder({label: '\ufbfd\u036e\u62ae\u0dee'});
+let texture102 = device0.createTexture({
+  label: '\u{1fd07}\u{1fef3}\u0278\u08e8\u0be3\u{1ff80}',
+  size: [1248, 1, 1],
+  mipLevelCount: 11,
+  sampleCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['r16sint', 'r16sint', 'r16sint'],
+});
+let textureView174 = texture82.createView({label: '\u52a1\u{1f83c}\ua06c\u01f1\u9e1d\u000a\ue165\u08e7\u0ba2\u249a\u{1f6a3}', baseMipLevel: 2});
+let sampler77 = device0.createSampler({
+  label: '\u{1ff02}\u3d85\ub64e\u0b0e\u147d\u{1fc8f}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 48.68,
+  lodMaxClamp: 98.19,
+  compare: 'equal',
+});
+let externalTexture77 = device0.importExternalTexture({label: '\u77c1\u{1fe00}\u84bc', source: video1});
+try {
+computePassEncoder12.setPipeline(pipeline43);
+} catch {}
+try {
+renderBundleEncoder46.draw(96);
+} catch {}
+try {
+commandEncoder105.clearBuffer(buffer6, 67272, 19252);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture93,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 2},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 7_772_964 */
+{offset: 436, bytesPerRow: 670, rowsPerImage: 100}, {width: 264, height: 1, depthOrArrayLayers: 117});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap29,
+  origin: { x: 1, y: 0 },
+  flipY: true,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle99 = renderBundleEncoder74.finish({label: '\u4ded\u0894\ube1f\ubb62\u7499\u062c\u{1fbdf}\u0977'});
+try {
+renderBundleEncoder46.draw(335, 127, 2_011_642_220, 2_148_827_301);
+} catch {}
+try {
+renderBundleEncoder51.setPipeline(pipeline38);
+} catch {}
+try {
+renderBundleEncoder51.setVertexBuffer(530, undefined, 0, 1083736521);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder131.insertDebugMarker('\u064b');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer41, 1184, new Float32Array(6129), 592, 420);
+} catch {}
+let promise46 = device0.queue.onSubmittedWorkDone();
+let pipeline105 = device0.createComputePipeline({
+  label: '\u6f98\u815b\u5ef1\ufb1c\u0de8\u0f1e\u046a\u2bc5\u0d70\u0b34\u{1fe54}',
+  layout: pipelineLayout9,
+  compute: {module: shaderModule26, entryPoint: 'compute0', constants: {}},
+});
+try {
+canvas21.getContext('2d');
+} catch {}
+let bindGroupLayout38 = device0.createBindGroupLayout({
+  label: '\uaf3a\u09c0\uefac\u{1fe42}\u0e78\u4ab3\ua89a',
+  entries: [
+    {
+      binding: 3655,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'filtering' },
+    },
+    {binding: 1580, visibility: 0, buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true }},
+    {binding: 1512, visibility: 0, externalTexture: {}},
+  ],
+});
+let pipelineLayout20 = device0.createPipelineLayout({
+  label: '\u0993\ucf7f\udfe5\uddac\u0b56\ua3df\u{1fd70}\u{1f7c3}\u{1f653}',
+  bindGroupLayouts: [bindGroupLayout38, bindGroupLayout35],
+});
+let buffer44 = device0.createBuffer({
+  label: '\u4cf6\u066d\u0077\u52bd\u{1f942}\u317d\u{1fe45}\u{1f9f0}',
+  size: 77213,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX,
+});
+let textureView175 = texture60.createView({
+  label: '\u5c90\u02c6\ub142\u002c\u2a39\u{1f950}\u8145\u{1f963}\u0de2\uc1f3\u9c65',
+  format: 'rgb10a2uint',
+});
+try {
+renderBundleEncoder51.drawIndexed(85);
+} catch {}
+try {
+renderBundleEncoder51.drawIndirect(buffer26, 1120);
+} catch {}
+try {
+renderBundleEncoder61.setPipeline(pipeline35);
+} catch {}
+try {
+commandEncoder82.copyBufferToTexture({
+  /* bytesInLastRow: 224 widthInBlocks: 112 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 15208 */
+  offset: 15208,
+  rowsPerImage: 101,
+  buffer: buffer21,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 44, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 112, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer21);
+} catch {}
+try {
+gpuCanvasContext16.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 37032, new DataView(new ArrayBuffer(15680)));
+} catch {}
+let adapter7 = await promise45;
+let commandEncoder151 = device0.createCommandEncoder({label: '\u95f3\uc15c\u0372\u{1f650}\ub1d2\u{1ff76}\u{1fbe4}\u8513\u08cc\u0ab9'});
+let commandBuffer34 = commandEncoder137.finish();
+let textureView176 = texture77.createView({
+  label: '\u97b5\u49ba\u0870\u{1fc1e}\u24db\ubba0\u{1fde9}\ub4e2\u034f\u638f\uddce',
+  dimension: '2d-array',
+  aspect: 'all',
+  format: 'etc2-rgba8unorm',
+  baseMipLevel: 7,
+});
+let computePassEncoder63 = commandEncoder104.beginComputePass();
+try {
+renderBundleEncoder46.drawIndexed(615, 209, 236_779_026, 368_230_804, 582_671_342);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexedIndirect(buffer26, 224);
+} catch {}
+try {
+renderBundleEncoder60.setPipeline(pipeline97);
+} catch {}
+try {
+commandEncoder131.clearBuffer(buffer22, 12232, 3492);
+dissociateBuffer(device0, buffer22);
+} catch {}
+try {
+commandEncoder130.resolveQuerySet(querySet31, 993, 847, buffer1, 84480);
+} catch {}
+try {
+renderBundleEncoder51.insertDebugMarker('\u3327');
+} catch {}
+try {
+  await promise46;
+} catch {}
+let adapter8 = await navigator.gpu.requestAdapter({});
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+try {
+device2.label = '\u{1f9f8}\uab78\u{1fb75}';
+} catch {}
+canvas13.width = 1232;
+try {
+window.someLabel = externalTexture12.label;
+} catch {}
+try {
+window.someLabel = commandEncoder46.label;
+} catch {}
+let promise47 = adapter8.requestDevice({
+  label: '\u0c15\u9c97\u0fe9\u378d',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxColorAttachmentBytesPerSample: 56,
+    maxVertexAttributes: 26,
+    maxVertexBufferArrayStride: 30841,
+    maxStorageTexturesPerShaderStage: 26,
+    maxStorageBuffersPerShaderStage: 9,
+    maxDynamicStorageBuffersPerPipelineLayout: 6128,
+    maxDynamicUniformBuffersPerPipelineLayout: 21569,
+    maxBindingsPerBindGroup: 5602,
+    maxTextureArrayLayers: 657,
+    maxTextureDimension1D: 8290,
+    maxTextureDimension2D: 15870,
+    maxVertexBuffers: 11,
+    maxBindGroupsPlusVertexBuffers: 30,
+    minStorageBufferOffsetAlignment: 32,
+    minUniformBufferOffsetAlignment: 64,
+    maxUniformBufferBindingSize: 260165348,
+    maxStorageBufferBindingSize: 241267388,
+    maxUniformBuffersPerShaderStage: 36,
+    maxSampledTexturesPerShaderStage: 33,
+    maxInterStageShaderVariables: 18,
+    maxInterStageShaderComponents: 124,
+    maxSamplersPerShaderStage: 18,
+  },
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let canvas25 = document.createElement('canvas');
+try {
+canvas25.getContext('webgl');
+} catch {}
+let textureView177 = texture56.createView({label: '\u0cb7\u4e64\ubf23\ubda2\u9d94\u0c86\u2cf0\u{1fe7b}\u0ff3\u035a', mipLevelCount: 1});
+let computePassEncoder64 = commandEncoder122.beginComputePass({label: '\u8e83\u09ac\u{1f7bb}\u0ba0\u0bfb\u0af4'});
+let renderBundleEncoder76 = device0.createRenderBundleEncoder({
+  label: '\u{1f845}\u9052',
+  colorFormats: ['rgba8unorm-srgb', 'r8uint', 'r16uint', 'rgb10a2uint', 'r16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder51.draw(394, 142, 1_248_274_922, 986_648_578);
+} catch {}
+try {
+commandEncoder123.resolveQuerySet(querySet29, 805, 587, buffer30, 350208);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageBitmap39 = await createImageBitmap(videoFrame19);
+let texture103 = device0.createTexture({
+  label: '\u0210\u{1fa89}\u053b\ud02c\uf40f\u5915\u502a\u75e8',
+  size: {width: 1248},
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder77 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint']});
+try {
+computePassEncoder57.setBindGroup(7, bindGroup13, new Uint32Array(7051), 1361, 0);
+} catch {}
+try {
+renderBundleEncoder51.drawIndexedIndirect(buffer26, 1556);
+} catch {}
+try {
+renderBundleEncoder75.setIndexBuffer(buffer11, 'uint32');
+} catch {}
+try {
+commandEncoder83.copyBufferToTexture({
+  /* bytesInLastRow: 254 widthInBlocks: 127 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 6462 */
+  offset: 6462,
+  buffer: buffer12,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 127, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder57.copyTextureToTexture({
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 59, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture50,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder149.resolveQuerySet(querySet63, 157, 601, buffer30, 68352);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer39, 5484, new Int16Array(44374), 16969, 5400);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 1,
+  origin: {x: 5, y: 5, z: 2},
+  aspect: 'all',
+}, new Int32Array(new ArrayBuffer(32)), /* required buffer size: 95_608 */
+{offset: 515, bytesPerRow: 253, rowsPerImage: 42}, {width: 109, height: 40, depthOrArrayLayers: 9});
+} catch {}
+let pipeline106 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule26,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'src', dstFactor: 'zero'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'dst'},
+  },
+  writeMask: GPUColorWrite.RED,
+}, {format: 'rg8sint'}, {format: 'r32uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'r16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'one'},
+  },
+}, {format: 'r16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'src-alpha-saturated'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-constant', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rg16uint', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'equal', failOp: 'decrement-wrap', depthFailOp: 'increment-wrap', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'always', failOp: 'increment-wrap', depthFailOp: 'zero', passOp: 'decrement-clamp'},
+    stencilReadMask: 863759542,
+    stencilWriteMask: 1427553006,
+    depthBiasClamp: 536.3836349034891,
+  },
+  vertex: {
+    module: shaderModule26,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 5500,
+        attributes: [
+          {format: 'sint32x4', offset: 1152, shaderLocation: 10},
+          {format: 'sint8x2', offset: 1084, shaderLocation: 6},
+          {format: 'sint32x3', offset: 412, shaderLocation: 3},
+          {format: 'unorm8x2', offset: 56, shaderLocation: 9},
+          {format: 'uint32', offset: 892, shaderLocation: 18},
+          {format: 'unorm16x4', offset: 3144, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 1196, shaderLocation: 11},
+          {format: 'uint16x4', offset: 1404, shaderLocation: 14},
+          {format: 'sint8x4', offset: 260, shaderLocation: 0},
+          {format: 'unorm8x2', offset: 588, shaderLocation: 17},
+          {format: 'sint8x4', offset: 432, shaderLocation: 5},
+          {format: 'uint16x4', offset: 1376, shaderLocation: 19},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 212, shaderLocation: 16},
+          {format: 'sint8x4', offset: 5656, shaderLocation: 20},
+          {format: 'float32x3', offset: 4128, shaderLocation: 7},
+          {format: 'snorm8x4', offset: 6660, shaderLocation: 8},
+          {format: 'float32', offset: 10696, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+offscreenCanvas11.height = 199;
+let imageBitmap40 = await createImageBitmap(videoFrame17);
+let video26 = await videoWithData();
+let imageBitmap41 = await createImageBitmap(offscreenCanvas16);
+try {
+externalTexture22.label = '\u0470\ud1ed\ub6b2\u0554\u27e3\u42e5\uc53d';
+} catch {}
+let querySet71 = device0.createQuerySet({type: 'occlusion', count: 2876});
+let renderBundleEncoder78 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16float', 'rg8sint', 'r32uint', 'r16float', 'r16sint', 'rgb10a2unorm', 'rg16uint'],
+  depthReadOnly: true,
+});
+let sampler78 = device0.createSampler({
+  label: '\u9f52\ua428\ub70f\u10df',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 79.19,
+  lodMaxClamp: 94.54,
+});
+try {
+computePassEncoder48.setBindGroup(5, bindGroup26, new Uint32Array(5301), 3324, 0);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexed(347, 28);
+} catch {}
+try {
+renderBundleEncoder51.drawIndirect(buffer26, 14740);
+} catch {}
+try {
+commandEncoder138.copyBufferToBuffer(buffer26, 30856, buffer31, 4468, 1212);
+dissociateBuffer(device0, buffer26);
+dissociateBuffer(device0, buffer31);
+} catch {}
+try {
+renderBundleEncoder76.pushDebugGroup('\u8a0b');
+} catch {}
+let canvas26 = document.createElement('canvas');
+let img26 = await imageWithData(184, 266, '#d9960ed7', '#646dad30');
+let computePassEncoder65 = commandEncoder60.beginComputePass({label: '\u31b0\u{1f6c3}\u{1fe0b}\u0f8d\u01f3\u{1f60e}\u247c\u1bfc\u{1fb6f}'});
+let renderBundleEncoder79 = device0.createRenderBundleEncoder({
+  label: '\u9dc1\u007e\u0971\u3c3c\u{1fb6a}\u04e1\ud72e\u06e3\u57a9',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  depthReadOnly: true,
+  stencilReadOnly: false,
+});
+let renderBundle100 = renderBundleEncoder35.finish({label: '\u{1fc8b}\u{1fe88}\u{1ff3b}\u8a5c\ubfaa\u08cc\u7902\uc22c'});
+let sampler79 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 9.201,
+  lodMaxClamp: 88.98,
+});
+try {
+renderBundleEncoder75.setBindGroup(7, bindGroup44, []);
+} catch {}
+try {
+renderBundleEncoder75.setBindGroup(6, bindGroup39, new Uint32Array(1050), 716, 0);
+} catch {}
+try {
+renderBundleEncoder75.setIndexBuffer(buffer44, 'uint32', 22300, 22649);
+} catch {}
+try {
+commandEncoder151.copyTextureToBuffer({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8072 */
+  offset: 8072,
+  buffer: buffer22,
+}, {width: 1, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer22);
+} catch {}
+try {
+commandEncoder133.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 131, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder59.clearBuffer(buffer36, 82780, 109532);
+dissociateBuffer(device0, buffer36);
+} catch {}
+gc();
+let canvas27 = document.createElement('canvas');
+try {
+canvas27.getContext('bitmaprenderer');
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let commandEncoder152 = device0.createCommandEncoder({label: '\u66ce\u{1f8ee}\u212f\ud85b\u2fc5\uf71b\u0bf1\u086b'});
+let textureView178 = texture58.createView({label: '\u{1faf0}\uca63\uf072\u{1fcfd}\u070a\ue846', format: 'r16uint'});
+let renderBundleEncoder80 = device0.createRenderBundleEncoder({colorFormats: ['r16float', 'rg8sint', 'r32uint', 'r16float', 'r16sint', 'rgb10a2unorm', 'rg16uint']});
+try {
+renderBundleEncoder51.setBindGroup(2, bindGroup44);
+} catch {}
+try {
+commandEncoder131.resolveQuerySet(querySet11, 91, 1864, buffer1, 152320);
+} catch {}
+let promise48 = device0.queue.onSubmittedWorkDone();
+let imageBitmap42 = await createImageBitmap(imageData25);
+let gpuCanvasContext21 = canvas26.getContext('webgpu');
+try {
+adapter3.label = '\ua6d5\u{1fcbd}\ud387\uc08f\ue916\uce73\u{1f94f}\u0311\u078e\u6f6b';
+} catch {}
+try {
+if (!arrayBuffer10.detached) { new Uint8Array(arrayBuffer10).fill(0x55) };
+} catch {}
+try {
+texture22.label = '\u7d78\u066b\u03be\uf9af\u0c65\ua531';
+} catch {}
+let imageBitmap43 = await createImageBitmap(imageData13);
+document.body.prepend(canvas6);
+let offscreenCanvas22 = new OffscreenCanvas(762, 116);
+let imageBitmap44 = await createImageBitmap(imageBitmap19);
+let videoFrame27 = new VideoFrame(img18, {timestamp: 0});
+let promise49 = adapter8.requestAdapterInfo();
+try {
+offscreenCanvas22.getContext('bitmaprenderer');
+} catch {}
+try {
+gpuCanvasContext20.unconfigure();
+} catch {}
+let imageData34 = new ImageData(100, 108);
+let commandEncoder153 = device0.createCommandEncoder({label: '\u007f\u4bf1\u0244\u0767\u6365\ue875\u{1face}\u1eb9\u{1fcad}'});
+let querySet72 = device0.createQuerySet({label: '\u{1f894}\uf4df\u0539\u0801\u0929', type: 'occlusion', count: 372});
+let texture104 = device0.createTexture({
+  label: '\u02ca\uc887\ufc2d\u{1f807}\u4cc7\u{1f8a3}\u6a18',
+  size: {width: 240, height: 120, depthOrArrayLayers: 59},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint'],
+});
+let textureView179 = texture13.createView({label: '\uf720\u6fb0\u01de\u73a6\u9db4\u055f\u0aac\u{1f6b1}', format: 'rgb10a2uint', baseMipLevel: 4});
+let computePassEncoder66 = commandEncoder102.beginComputePass({label: '\u{1fa8f}\u{1feed}'});
+let renderBundle101 = renderBundleEncoder70.finish({});
+try {
+computePassEncoder62.end();
+} catch {}
+try {
+renderBundleEncoder49.setBindGroup(9, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexedIndirect(buffer26, 6912);
+} catch {}
+try {
+renderBundleEncoder46.drawIndirect(buffer26, 2220);
+} catch {}
+try {
+renderBundleEncoder50.setPipeline(pipeline87);
+} catch {}
+try {
+renderBundleEncoder76.popDebugGroup();
+} catch {}
+let videoFrame28 = new VideoFrame(videoFrame21, {timestamp: 0});
+let texture105 = device0.createTexture({
+  label: '\u5a42\u{1ff7c}\uf742\u9775\u{1f65b}\u009b\u0c25\u0134',
+  size: {width: 480, height: 240, depthOrArrayLayers: 1261},
+  mipLevelCount: 6,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+});
+let renderBundleEncoder81 = device0.createRenderBundleEncoder({
+  label: '\ub205\uceb7\u0df1\u22ec\u62ed\u{1f7f8}\u3ed0\ub6fe',
+  colorFormats: ['rgba8unorm-srgb', 'r8uint', 'r16uint', 'rgb10a2uint', 'r16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture78 = device0.importExternalTexture({source: video7});
+try {
+renderBundleEncoder51.draw(312);
+} catch {}
+try {
+renderBundleEncoder46.drawIndexedIndirect(buffer26, 3180);
+} catch {}
+try {
+renderBundleEncoder49.setPipeline(pipeline93);
+} catch {}
+try {
+commandEncoder121.copyTextureToBuffer({
+  texture: texture93,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 2},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 448 widthInBlocks: 224 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 194404 */
+  offset: 12708,
+  bytesPerRow: 512,
+  rowsPerImage: 118,
+  buffer: buffer36,
+}, {width: 224, height: 1, depthOrArrayLayers: 4});
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+commandEncoder108.clearBuffer(buffer44, 47192, 14068);
+dissociateBuffer(device0, buffer44);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture98,
+  mipLevel: 6,
+  origin: {x: 1, y: 0, z: 2},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer10), /* required buffer size: 431 */
+{offset: 431}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+let video27 = await videoWithData();
+let textureView180 = texture60.createView({label: '\u0608\u{1fe45}\u0821\u8d70\u0ad3\ub939\u{1fdba}', dimension: '1d', format: 'rgb10a2uint'});
+let renderBundleEncoder82 = device0.createRenderBundleEncoder({
+  label: '\u58c2\u{1fe77}\u{1fd00}',
+  colorFormats: ['r16float', 'rg8sint', 'r32uint', 'r16float', 'r16sint', 'rgb10a2unorm', 'rg16uint'],
+  depthReadOnly: true,
+});
+let sampler80 = device0.createSampler({
+  label: '\u3f25\ud3ca\u{1f7b6}\u{1f85e}\u0e4f\ue1eb\u9811',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.78,
+  maxAnisotropy: 19,
+});
+try {
+computePassEncoder40.setPipeline(pipeline88);
+} catch {}
+try {
+renderBundleEncoder46.drawIndirect(buffer26, 4148);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+try {
+  await promise48;
+} catch {}
+let imageData35 = new ImageData(80, 108);
+gc();
+let img27 = await imageWithData(117, 193, '#c82bc25b', '#fedeaf53');
+gc();
+let buffer45 = device0.createBuffer({
+  label: '\u{1fde5}\u0047\u1397\u{1f96f}\u8e0f\u0f05\u4470\u10c1\uc86a\u8931',
+  size: 49035,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let computePassEncoder67 = commandEncoder140.beginComputePass();
+let renderBundleEncoder83 = device0.createRenderBundleEncoder({
+  label: '\u{1ff1a}\u{1ff8c}\u0769\u{1f712}\u0bd0\uc972',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  stencilReadOnly: true,
+});
+let renderBundle102 = renderBundleEncoder33.finish({label: '\ud73a\u1cfb\u1f5b\u0232\u6a64'});
+let sampler81 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 41.89,
+  lodMaxClamp: 83.43,
+  compare: 'less-equal',
+});
+try {
+renderBundleEncoder69.setBindGroup(7, bindGroup34, new Uint32Array(2235), 785, 0);
+} catch {}
+try {
+renderBundleEncoder51.drawIndirect(buffer26, 5068);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.prepend(canvas13);
+video7.height = 277;
+gc();
+let offscreenCanvas23 = new OffscreenCanvas(37, 326);
+try {
+  await promise49;
+} catch {}
+let videoFrame29 = new VideoFrame(img24, {timestamp: 0});
+let commandEncoder154 = device0.createCommandEncoder({});
+let texture106 = device0.createTexture({
+  label: '\u3c0d\u9815\uea63\u{1f810}\u264c',
+  size: {width: 1248, height: 1, depthOrArrayLayers: 1176},
+  mipLevelCount: 11,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let computePassEncoder68 = commandEncoder83.beginComputePass({});
+let renderBundle103 = renderBundleEncoder9.finish({});
+let sampler82 = device0.createSampler({
+  label: '\ucffc\u{1fb98}\u21d8\uaec0\u1719\u1ada',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 88.71,
+  lodMaxClamp: 92.43,
+});
+try {
+renderBundleEncoder46.drawIndexed(463, 32, 835_594_865, 59_451_906, 1_224_876_173);
+} catch {}
+try {
+renderBundleEncoder46.drawIndirect(buffer26, 3240);
+} catch {}
+try {
+renderBundleEncoder60.setPipeline(pipeline93);
+} catch {}
+try {
+buffer45.unmap();
+} catch {}
+try {
+commandEncoder141.clearBuffer(buffer22, 2760, 12696);
+dissociateBuffer(device0, buffer22);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer41, 2940, new Float32Array(33520), 32887, 56);
+} catch {}
+let pipeline107 = device0.createRenderPipeline({
+  label: '\u07a0\u{1f9ab}',
+  layout: pipelineLayout9,
+  multisample: {count: 4, mask: 0x93e059ad},
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgb10a2uint', writeMask: 0}, {format: 'rgba8uint', writeMask: 0}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule7,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 10984,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 112, shaderLocation: 5},
+          {format: 'unorm16x2', offset: 5392, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', unclippedDepth: true},
+});
+let querySet73 = device0.createQuerySet({
+  label: '\u770a\u56d7\u76af\udf58\u{1fe9c}\u2364\u{1f8c6}\u0041\u61bd\u27cd\uce03',
+  type: 'occlusion',
+  count: 3701,
+});
+let textureView181 = texture96.createView({format: 'rgba8uint'});
+let sampler83 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 26.31,
+  lodMaxClamp: 91.86,
+  maxAnisotropy: 9,
+});
+try {
+device0.queue.writeBuffer(buffer39, 2972, new BigUint64Array(16379), 14023, 400);
+} catch {}
+let offscreenCanvas24 = new OffscreenCanvas(407, 236);
+let video28 = await videoWithData();
+let imageData36 = new ImageData(204, 80);
+document.body.prepend(video8);
+let videoFrame30 = videoFrame21.clone();
+try {
+  await adapter5.requestAdapterInfo();
+} catch {}
+gc();
+let shaderModule31 = device0.createShaderModule({
+  label: '\u63cc\u7a40\u3e91\u0a9c\u08b9\u1d9d\ubd7c\ud2e6\u{1f61e}\u{1f680}\uc97a',
+  code: `@group(8) @binding(1456)
+var<storage, read_write> function7: array<u32>;
+@group(5) @binding(5002)
+var<storage, read_write> n14: array<u32>;
+@group(7) @binding(4645)
+var<storage, read_write> local20: array<u32>;
+@group(3) @binding(3074)
+var<storage, read_write> global11: array<u32>;
+@group(7) @binding(3465)
+var<storage, read_write> global12: array<u32>;
+@group(7) @binding(5002)
+var<storage, read_write> type13: array<u32>;
+@group(6) @binding(1456)
+var<storage, read_write> field11: array<u32>;
+@group(5) @binding(4645)
+var<storage, read_write> parameter14: array<u32>;
+
+@compute @workgroup_size(7, 1, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(5) f0: vec4<f32>,
+  @location(3) f1: f32,
+  @location(1) f2: vec4<i32>,
+  @location(6) f3: vec3<u32>,
+  @location(2) f4: vec2<u32>,
+  @location(0) f5: f32,
+  @location(4) f6: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(front_facing) a0: bool, @builtin(sample_mask) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S22 {
+  @location(10) f0: vec2<f32>,
+  @location(13) f1: u32,
+  @location(17) f2: vec3<f32>,
+  @location(8) f3: vec2<u32>,
+  @location(15) f4: f16,
+  @location(14) f5: vec4<f16>,
+  @location(20) f6: vec3<f32>,
+  @location(1) f7: f16,
+  @location(0) f8: vec4<i32>
+}
+
+@vertex
+fn vertex0(@location(6) a0: vec4<f16>, @builtin(instance_index) a1: u32, @location(16) a2: vec2<i32>, @location(12) a3: vec4<f32>, @builtin(vertex_index) a4: u32, @location(19) a5: vec3<f32>, @location(7) a6: vec3<u32>, @location(18) a7: f32, @location(5) a8: vec4<i32>, @location(11) a9: vec4<i32>, @location(2) a10: vec2<f32>, @location(9) a11: vec4<f32>, a12: S22, @location(4) a13: vec4<u32>, @location(3) a14: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let commandEncoder155 = device0.createCommandEncoder({});
+let commandBuffer35 = commandEncoder130.finish({label: '\u079e\u098a\u038f\u06c8\u{1fe67}\ua8a5\u99de\u03aa\uabc9\u9477'});
+let textureView182 = texture44.createView({label: '\u{1fecd}\uf9a0\u09bc\u0624\u0c79\ud1b7', baseMipLevel: 3, arrayLayerCount: 1});
+try {
+computePassEncoder40.setBindGroup(8, bindGroup13);
+} catch {}
+try {
+renderBundleEncoder61.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder76.setIndexBuffer(buffer26, 'uint32', 32132, 41);
+} catch {}
+try {
+renderBundleEncoder46.setPipeline(pipeline103);
+} catch {}
+try {
+device0.queue.submit([commandBuffer12, commandBuffer27, commandBuffer19, commandBuffer35]);
+} catch {}
+canvas10.height = 575;
+let canvas28 = document.createElement('canvas');
+let imageBitmap45 = await createImageBitmap(videoFrame17);
+try {
+canvas28.getContext('webgl2');
+} catch {}
+let bindGroup50 = device0.createBindGroup({
+  label: '\u0aea\u67d1\ua38f\u0c7b\u02b8\ua824\ub810\u8245\u50b0',
+  layout: bindGroupLayout13,
+  entries: [],
+});
+let commandEncoder156 = device0.createCommandEncoder();
+let renderBundleEncoder84 = device0.createRenderBundleEncoder({
+  label: '\u0af5\u0c25\u49ef',
+  colorFormats: ['rgba8unorm-srgb', 'r8uint', 'r16uint', 'rgb10a2uint', 'r16sint'],
+});
+let sampler84 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'clamp-to-edge', lodMinClamp: 82.84, lodMaxClamp: 90.10});
+try {
+computePassEncoder9.setBindGroup(8, bindGroup49);
+} catch {}
+try {
+renderBundleEncoder51.draw(21);
+} catch {}
+try {
+renderBundleEncoder51.drawIndexedIndirect(buffer26, 3216);
+} catch {}
+try {
+renderBundleEncoder50.setIndexBuffer(buffer44, 'uint32', 22800, 43239);
+} catch {}
+try {
+commandEncoder63.copyBufferToBuffer(buffer21, 58084, buffer36, 476580, 672);
+dissociateBuffer(device0, buffer21);
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+commandEncoder63.resolveQuerySet(querySet73, 145, 614, buffer45, 3072);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer16, 51596, new Float32Array(27128));
+} catch {}
+let pipeline108 = await device0.createRenderPipelineAsync({
+  label: '\u5456\u{1f8eb}\u01e4\u{1fe6a}\u2a38\u0694',
+  layout: pipelineLayout9,
+  fragment: {
+  module: shaderModule15,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgb10a2uint', writeMask: 0}, {
+  format: 'rgba8uint',
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'less', failOp: 'decrement-clamp', depthFailOp: 'decrement-wrap', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'equal', depthFailOp: 'replace'},
+    stencilReadMask: 3221695811,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule15,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 6976,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x2', offset: 100, shaderLocation: 5},
+          {format: 'sint32x4', offset: 3924, shaderLocation: 11},
+          {format: 'uint8x4', offset: 1392, shaderLocation: 9},
+          {format: 'uint32x2', offset: 1620, shaderLocation: 0},
+          {format: 'snorm16x4', offset: 680, shaderLocation: 1},
+          {format: 'float16x2', offset: 44, shaderLocation: 3},
+          {format: 'float16x2', offset: 144, shaderLocation: 18},
+          {format: 'snorm8x2', offset: 374, shaderLocation: 12},
+          {format: 'sint32x2', offset: 496, shaderLocation: 16},
+        ],
+      },
+      {
+        arrayStride: 15936,
+        attributes: [
+          {format: 'snorm8x2', offset: 2458, shaderLocation: 6},
+          {format: 'unorm16x2', offset: 1196, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 4812, shaderLocation: 15},
+          {format: 'uint32x2', offset: 2748, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 4076,
+        attributes: [
+          {format: 'float16x2', offset: 64, shaderLocation: 2},
+          {format: 'unorm16x2', offset: 680, shaderLocation: 7},
+          {format: 'uint32x2', offset: 396, shaderLocation: 19},
+          {format: 'uint8x4', offset: 544, shaderLocation: 20},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'back'},
+});
+let commandEncoder157 = device0.createCommandEncoder({label: '\ua95a\u5841\u0dfa\u0fa8\ua50d\u03d5\u4b0b\u0ad8\u{1fa30}\u6b41\u0e94'});
+let textureView183 = texture23.createView({
+  label: '\u46e5\u5ace\u{1fc3b}',
+  dimension: '2d',
+  aspect: 'all',
+  baseMipLevel: 1,
+  mipLevelCount: 3,
+  baseArrayLayer: 91,
+});
+let computePassEncoder69 = commandEncoder146.beginComputePass();
+let sampler85 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 10.56,
+  lodMaxClamp: 78.51,
+});
+try {
+computePassEncoder65.setBindGroup(3, bindGroup8, new Uint32Array(3288), 1914, 0);
+} catch {}
+try {
+renderBundleEncoder51.draw(44);
+} catch {}
+try {
+renderBundleEncoder51.drawIndexed(107, 190, 1_133_946_736, 260_402_420, 35_467_494);
+} catch {}
+try {
+renderBundleEncoder51.drawIndexedIndirect(buffer26, 1588);
+} catch {}
+try {
+renderBundleEncoder51.drawIndirect(buffer26, 8560);
+} catch {}
+try {
+commandEncoder57.copyBufferToBuffer(buffer9, 8200, buffer26, 960, 1020);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+commandEncoder57.copyTextureToBuffer({
+  texture: texture23,
+  mipLevel: 1,
+  origin: {x: 3, y: 20, z: 38},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 848 widthInBlocks: 212 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 211268 */
+  offset: 15860,
+  bytesPerRow: 1024,
+  buffer: buffer36,
+}, {width: 212, height: 191, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+commandEncoder57.resolveQuerySet(querySet29, 80, 1188, buffer45, 33024);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer11), /* required buffer size: 846 */
+{offset: 846}, {width: 9, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let imageBitmap46 = await createImageBitmap(imageData31);
+let imageData37 = new ImageData(200, 8);
+let bindGroupLayout39 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 947,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 4735,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let querySet74 = device0.createQuerySet({
+  label: '\u2743\u0368\u3ff4\u235b\u0b97\u{1fd2f}\u0eb5\u00f8\uaf9a\u8055\u0c47',
+  type: 'occlusion',
+  count: 3482,
+});
+let commandBuffer36 = commandEncoder131.finish({label: '\u{1f8da}\ueb7c\u03b2\u{1f713}\u0f74\u6a67\u{1f6e7}\uc750\u185c\u0938'});
+let renderBundle104 = renderBundleEncoder34.finish({label: '\ud3b2\u1285\ue5ce\u0fe6\u67bb'});
+let externalTexture79 = device0.importExternalTexture({source: videoFrame14});
+try {
+renderBundleEncoder79.setPipeline(pipeline96);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+commandEncoder150.copyTextureToBuffer({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1178 widthInBlocks: 589 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 18402 */
+  offset: 17224,
+  rowsPerImage: 169,
+  buffer: buffer45,
+}, {width: 589, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer45);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer22, 408, new Float32Array(8488), 6888, 620);
+} catch {}
+let device3 = await promise47;
+let buffer46 = device0.createBuffer({size: 69902, usage: GPUBufferUsage.INDIRECT});
+let commandEncoder158 = device0.createCommandEncoder({label: '\u8795\u0430\u0ad1\u02bf\ue9dc\u{1fc6b}\u00d1\u01be'});
+let textureView184 = texture56.createView({label: '\u08d2\u00bb\u0635\u2cda\u0fdd\u7e22\u7625\u6dbb', baseMipLevel: 1});
+let renderBundleEncoder85 = device0.createRenderBundleEncoder({
+  label: '\u{1f626}\u0da8\u4c19\u1632\u00a5\u0e0b\uc015',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+  stencilReadOnly: true,
+});
+let externalTexture80 = device0.importExternalTexture({label: '\uadad\u{1fc94}\uc4bd\u0dd6\u6c0a\u05ec\u0950\u{1fe79}', source: video15, colorSpace: 'srgb'});
+try {
+renderBundleEncoder51.setBindGroup(8, bindGroup38, new Uint32Array(4353), 3989, 0);
+} catch {}
+try {
+renderBundleEncoder51.draw(109, 63, 36_362_753, 173_884_531);
+} catch {}
+try {
+renderBundleEncoder51.drawIndirect(buffer26, 1996);
+} catch {}
+try {
+renderBundleEncoder49.setPipeline(pipeline38);
+} catch {}
+let promise50 = device0.queue.onSubmittedWorkDone();
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 30, height: 15, depthOrArrayLayers: 1261}
+*/
+{
+  source: canvas8,
+  origin: { x: 25, y: 637 },
+  flipY: true,
+}, {
+  texture: texture105,
+  mipLevel: 4,
+  origin: {x: 6, y: 1, z: 254},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 8, height: 5, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame31 = videoFrame5.clone();
+let commandEncoder159 = device0.createCommandEncoder({});
+let textureView185 = texture45.createView({label: '\uef03\u8b6b\uae18\u{1f981}\u{1f808}\u08bd\u5cfe\uf60e\u{1fca2}\u09dd', arrayLayerCount: 1});
+let renderBundle105 = renderBundleEncoder34.finish({label: '\u{1fd9f}\u6a4e\u0dc2'});
+try {
+renderBundleEncoder75.setBindGroup(4, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder51.drawIndexedIndirect(buffer46, 9572);
+} catch {}
+try {
+renderBundleEncoder77.setIndexBuffer(buffer26, 'uint32', 21004);
+} catch {}
+try {
+renderBundleEncoder48.setVertexBuffer(9393, undefined);
+} catch {}
+let buffer47 = device0.createBuffer({
+  label: '\u5e6b\u8706\ua415\ubcd6\u1955\u00c3',
+  size: 89564,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder160 = device0.createCommandEncoder();
+let computePassEncoder70 = commandEncoder160.beginComputePass({label: '\ubaf9\u08f8\u06e2\u5c70\u04e3\u3292\u5e56\uaa17\u096c\u0172\u6bc8'});
+try {
+commandEncoder108.clearBuffer(buffer45, 6196, 15072);
+dissociateBuffer(device0, buffer45);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer45, 7128, new BigUint64Array(14960), 11492, 780);
+} catch {}
+let pipeline109 = await device0.createComputePipelineAsync({
+  label: '\u{1fa5f}\u09cd\u{1f749}\u0efd\u4bf9\u0656',
+  layout: pipelineLayout20,
+  compute: {module: shaderModule13, entryPoint: 'compute0', constants: {}},
+});
+let pipeline110 = device0.createRenderPipeline({
+  label: '\u{1fcbd}\u2be2\uab01\ufab0',
+  layout: pipelineLayout5,
+  multisample: {count: 4, mask: 0xbbc00157},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint'}, {format: 'rgba8uint', writeMask: GPUColorWrite.BLUE}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rgb10a2uint'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater', failOp: 'invert', depthFailOp: 'decrement-wrap', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'less', failOp: 'increment-wrap', depthFailOp: 'decrement-wrap', passOp: 'decrement-wrap'},
+    stencilReadMask: 3887234248,
+    stencilWriteMask: 3570065809,
+    depthBiasSlopeScale: -12.321298782569485,
+    depthBiasClamp: 267.4380603176317,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 8832,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 644, shaderLocation: 16},
+          {format: 'float16x4', offset: 432, shaderLocation: 8},
+          {format: 'snorm8x4', offset: 472, shaderLocation: 14},
+          {format: 'snorm8x2', offset: 1282, shaderLocation: 15},
+          {format: 'snorm8x4', offset: 728, shaderLocation: 12},
+          {format: 'uint32x2', offset: 224, shaderLocation: 3},
+          {format: 'sint16x2', offset: 892, shaderLocation: 0},
+          {format: 'uint32x2', offset: 3432, shaderLocation: 19},
+          {format: 'sint16x2', offset: 368, shaderLocation: 6},
+          {format: 'float32x4', offset: 804, shaderLocation: 18},
+          {format: 'uint32x4', offset: 188, shaderLocation: 7},
+          {format: 'float32x3', offset: 4128, shaderLocation: 11},
+          {format: 'uint32x4', offset: 532, shaderLocation: 4},
+          {format: 'unorm16x2', offset: 448, shaderLocation: 10},
+          {format: 'uint8x4', offset: 1272, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 10020,
+        attributes: [
+          {format: 'uint8x2', offset: 1196, shaderLocation: 1},
+          {format: 'sint8x4', offset: 736, shaderLocation: 17},
+        ],
+      },
+      {
+        arrayStride: 39436,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x4', offset: 408, shaderLocation: 9},
+          {format: 'float32x3', offset: 2728, shaderLocation: 20},
+          {format: 'float32', offset: 4108, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 19192,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x2', offset: 2972, shaderLocation: 13}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+document.body.prepend(canvas11);
+let promise51 = adapter6.requestAdapterInfo();
+let querySet75 = device1.createQuerySet({label: '\u6494\ufd47\u0b3c\u060d\u{1ffd5}', type: 'occlusion', count: 3225});
+let textureView186 = texture90.createView({label: '\u{1fda9}\ud66c\u0998\u6328\uf510\u09dc'});
+let sampler86 = device1.createSampler({
+  label: '\ucc1c\ud17e\u0a7a\u089b\u6cd5\u0d6d\u{1ff48}\u995a\u86e9\u0d23\u338f',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.08,
+  maxAnisotropy: 3,
+});
+try {
+renderPassEncoder23.beginOcclusionQuery(176);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle56, renderBundle20, renderBundle67, renderBundle11, renderBundle74, renderBundle49, renderBundle72, renderBundle72]);
+} catch {}
+try {
+renderBundleEncoder56.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder43.setBindGroup(0, bindGroup37, new Uint32Array(333), 317, 0);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexed(13, 72, 155_035_994, -2_119_317_102, 888_256_704);
+} catch {}
+try {
+renderBundleEncoder67.setVertexBuffer(1, buffer33, 3032, 2048);
+} catch {}
+try {
+device1.queue.copyExternalImageToTexture(/*
+{width: 120, height: 1, depthOrArrayLayers: 58}
+*/
+{
+  source: canvas23,
+  origin: { x: 32, y: 4 },
+  flipY: true,
+}, {
+  texture: texture84,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 15},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = externalTexture44.label;
+} catch {}
+let bindGroup51 = device0.createBindGroup({
+  label: '\u{1fb5e}\u{1fdfd}',
+  layout: bindGroupLayout37,
+  entries: [{binding: 4644, resource: {buffer: buffer0, offset: 42496, size: 20856}}],
+});
+let texture107 = device0.createTexture({
+  label: '\u4bf4\ud06c\u0dac\u{1fe31}\ue817\u434d\u{1fa72}\u{1f9b9}\u0ce1',
+  size: [1248, 1, 238],
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView187 = texture73.createView({
+  label: '\u48bb\u0580\u8276\u414b\ub6eb\ucb9e\ue05b\ub1d7\u{1fc27}\uebd1',
+  baseMipLevel: 1,
+  mipLevelCount: 2,
+  baseArrayLayer: 0,
+});
+let computePassEncoder71 = commandEncoder141.beginComputePass({label: '\u04a5\u{1f8dd}\u0dcb\u5ec7\u0a2b\ube71\u0291\u0784\uae48'});
+try {
+renderBundleEncoder51.drawIndirect(buffer26, 13024);
+} catch {}
+try {
+renderBundleEncoder48.insertDebugMarker('\u137d');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 156, height: 1, depthOrArrayLayers: 25}
+*/
+{
+  source: canvas10,
+  origin: { x: 43, y: 7 },
+  flipY: true,
+}, {
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup52 = device0.createBindGroup({
+  label: '\ud9e8\u084f\uaf8a\u08f7\u7821\uc57d\u2214\uc36f\u9e27',
+  layout: bindGroupLayout11,
+  entries: [{binding: 3074, resource: externalTexture41}],
+});
+let commandEncoder161 = device0.createCommandEncoder();
+try {
+renderBundleEncoder51.drawIndexedIndirect(buffer46, 2060);
+} catch {}
+try {
+offscreenCanvas24.getContext('2d');
+} catch {}
+canvas9.width = 429;
+let renderBundleEncoder86 = device0.createRenderBundleEncoder({
+  label: '\u1b05\u0965\u0d4e\u{1f64c}\u4691\u6497\uabf9',
+  colorFormats: ['r16float', 'rg8sint', 'r32uint', 'r16float', 'r16sint', 'rgb10a2unorm', 'rg16uint'],
+  stencilReadOnly: true,
+});
+let sampler87 = device0.createSampler({
+  label: '\ud638\u0839\u{1f824}',
+  addressModeU: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 65.40,
+  lodMaxClamp: 87.95,
+});
+try {
+commandEncoder99.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3464 */
+  offset: 3460,
+  bytesPerRow: 256,
+  buffer: buffer47,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer47);
+} catch {}
+try {
+renderBundleEncoder82.insertDebugMarker('\ub7fd');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 156, height: 1, depthOrArrayLayers: 25}
+*/
+{
+  source: imageData29,
+  origin: { x: 9, y: 55 },
+  flipY: true,
+}, {
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 75, y: 0, z: 7},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup53 = device0.createBindGroup({
+  label: '\uadca\u0117\u{1fe80}\u58c5\u5a73\u46c1\ub042\u028a\u0fb5',
+  layout: bindGroupLayout19,
+  entries: [{binding: 662, resource: sampler82}],
+});
+let commandEncoder162 = device0.createCommandEncoder({label: '\u4fd2\u{1fc04}\u{1fdeb}\u{1f773}\u081b\u{1f6bc}\u{1facb}\u5b70\u{1fc1d}\ue044\u9e0a'});
+let querySet76 = device0.createQuerySet({
+  label: '\u{1fda8}\u003e\u5ef0\u{1f71f}\u0ebc\u03ed\ud676\u4c38\ube75\u1b51',
+  type: 'occlusion',
+  count: 3332,
+});
+let renderBundleEncoder87 = device0.createRenderBundleEncoder({
+  label: '\uf9f3\u2326\uf8a8\ufd93',
+  colorFormats: ['rgba8unorm-srgb', 'r8uint', 'r16uint', 'rgb10a2uint', 'r16sint'],
+});
+try {
+device0.queue.writeTexture({
+  texture: texture50,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 35},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 2_193_587 */
+{offset: 405, bytesPerRow: 95, rowsPerImage: 119}, {width: 3, height: 1, depthOrArrayLayers: 195});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 15, height: 7, depthOrArrayLayers: 1261}
+*/
+{
+  source: imageData11,
+  origin: { x: 31, y: 13 },
+  flipY: false,
+}, {
+  texture: texture105,
+  mipLevel: 5,
+  origin: {x: 4, y: 0, z: 108},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 3, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let pipeline111 = device0.createRenderPipeline({
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: 0}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {
+  format: 'rgb10a2uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3352,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 160, shaderLocation: 14},
+          {format: 'sint16x2', offset: 48, shaderLocation: 17},
+          {format: 'snorm16x2', offset: 216, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 4772,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x4', offset: 0, shaderLocation: 2},
+          {format: 'float16x4', offset: 356, shaderLocation: 4},
+          {format: 'unorm16x2', offset: 116, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 808, shaderLocation: 16},
+          {format: 'unorm10-10-10-2', offset: 576, shaderLocation: 11},
+          {format: 'snorm16x2', offset: 88, shaderLocation: 3},
+          {format: 'float32x2', offset: 1020, shaderLocation: 1},
+          {format: 'uint8x4', offset: 228, shaderLocation: 9},
+          {format: 'unorm8x4', offset: 1288, shaderLocation: 19},
+        ],
+      },
+      {
+        arrayStride: 2648,
+        attributes: [
+          {format: 'sint16x2', offset: 1204, shaderLocation: 12},
+          {format: 'unorm8x4', offset: 1024, shaderLocation: 20},
+        ],
+      },
+    ],
+  },
+});
+let imageBitmap47 = await createImageBitmap(img27);
+let offscreenCanvas25 = new OffscreenCanvas(243, 638);
+let textureView188 = texture98.createView({label: '\u52de\u00fc\u{1ffa3}', baseMipLevel: 5});
+let renderBundle106 = renderBundleEncoder80.finish({label: '\u2c56\u0239\u87e6\ub0cb\u5f2f\u7c63\ud3c6\u2a37\u01d6\u18d4\u2b07'});
+let sampler88 = device0.createSampler({addressModeU: 'repeat', magFilter: 'nearest', mipmapFilter: 'nearest', lodMaxClamp: 72.60});
+try {
+renderBundleEncoder76.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderBundleEncoder51.drawIndirect(buffer46, 4336);
+} catch {}
+try {
+renderBundleEncoder46.setPipeline(pipeline87);
+} catch {}
+try {
+  await buffer39.mapAsync(GPUMapMode.READ, 38728, 10020);
+} catch {}
+try {
+commandEncoder151.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder154.resolveQuerySet(querySet37, 1590, 405, buffer45, 22272);
+} catch {}
+try {
+device0.queue.submit([commandBuffer34, commandBuffer33]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img25,
+  origin: { x: 17, y: 0 },
+  flipY: true,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+offscreenCanvas25.getContext('2d');
+} catch {}
+document.body.prepend(video13);
+let commandEncoder163 = device3.createCommandEncoder({});
+let texture108 = device3.createTexture({
+  label: '\ufa03\ud406\u0544\ud864\u0969\u98af\u0122\u7dd6\u{1f8c7}\u{1fe30}\uf980',
+  size: [1872, 128, 77],
+  mipLevelCount: 8,
+  format: 'astc-8x8-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['astc-8x8-unorm-srgb'],
+});
+let renderBundleEncoder88 = device3.createRenderBundleEncoder({
+  label: '\u0526\u8577\ufd4c\uf454\ud53d\u74cc\ud647\ube21\u0bd4\u{1fc35}',
+  colorFormats: ['r32float', 'rgba8unorm'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let img28 = await imageWithData(205, 112, '#490255bf', '#1d53b396');
+try {
+  await promise51;
+} catch {}
+offscreenCanvas19.width = 369;
+let imageData38 = new ImageData(68, 24);
+try {
+  await promise50;
+} catch {}
+let renderBundle107 = renderBundleEncoder88.finish({label: '\ue088\u0181\ue2c9\u0029\u0609\ua5f3'});
+let gpuCanvasContext22 = offscreenCanvas23.getContext('webgpu');
+let video29 = await videoWithData();
+let videoFrame32 = new VideoFrame(canvas18, {timestamp: 0});
+let querySet77 = device3.createQuerySet({label: '\u30f1\u02cd\u0d27', type: 'occlusion', count: 942});
+let texture109 = gpuCanvasContext13.getCurrentTexture();
+let textureView189 = texture109.createView({dimension: '2d-array'});
+let renderBundle108 = renderBundleEncoder88.finish({label: '\u{1fec9}\ufd34\u901c\ue941\ue936\uacc8\u0f49\u82c5\u0238\u{1fa3f}'});
+try {
+commandEncoder163.copyTextureToTexture({
+  texture: texture108,
+  mipLevel: 4,
+  origin: {x: 16, y: 0, z: 12},
+  aspect: 'all',
+},
+{
+  texture: texture108,
+  mipLevel: 4,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 32, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder164 = device3.createCommandEncoder();
+let textureView190 = texture108.createView({
+  label: '\u03de\u72cf\u9fac\u80d1\u5c3c\u{1f9fa}\uabe6',
+  dimension: '2d-array',
+  format: 'astc-8x8-unorm-srgb',
+  baseMipLevel: 3,
+  mipLevelCount: 4,
+  baseArrayLayer: 18,
+  arrayLayerCount: 44,
+});
+let renderBundleEncoder89 = device3.createRenderBundleEncoder({colorFormats: ['r32float', 'rgba8unorm'], depthReadOnly: true});
+let externalTexture81 = device3.importExternalTexture({source: videoFrame13});
+try {
+renderBundleEncoder89.setVertexBuffer(313, undefined, 3983998668);
+} catch {}
+document.body.prepend(img21);
+let bindGroup54 = device0.createBindGroup({
+  label: '\uc9d1\u025b\u68eb',
+  layout: bindGroupLayout35,
+  entries: [{binding: 1904, resource: sampler29}],
+});
+let buffer48 = device0.createBuffer({size: 671, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder165 = device0.createCommandEncoder({label: '\u6717\u{1f958}\u0aa2\u5cdd\u047d\uef9b\u2942\u057d\u9160\ucee1\ua255'});
+let textureView191 = texture60.createView({label: '\u1e7a\u{1f68b}\u771d\u0308', baseArrayLayer: 0});
+try {
+computePassEncoder65.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder51.drawIndexedIndirect(buffer26, 6072);
+} catch {}
+try {
+renderBundleEncoder81.setVertexBuffer(672, undefined, 0, 2128410939);
+} catch {}
+try {
+commandEncoder57.copyTextureToTexture({
+  texture: texture83,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder165.clearBuffer(buffer31, 3564);
+dissociateBuffer(device0, buffer31);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 11},
+  aspect: 'all',
+}, new DataView(arrayBuffer4), /* required buffer size: 11_208_284 */
+{offset: 736, bytesPerRow: 654, rowsPerImage: 42}, {width: 151, height: 1, depthOrArrayLayers: 409});
+} catch {}
+let pipeline112 = await device0.createComputePipelineAsync({
+  label: '\u{1fb35}\uc9fe\u737b\u{1f706}\u2e7b\u4f19',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule9, entryPoint: 'compute0'},
+});
+let bindGroupLayout40 = device0.createBindGroupLayout({
+  label: '\u{1fd1f}\u{1fa1c}\u952b\u04e1\u068f\ue1e5\u0288',
+  entries: [
+    {
+      binding: 1900,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let commandEncoder166 = device0.createCommandEncoder({label: '\u{1f611}\u{1fa6f}'});
+try {
+computePassEncoder12.setPipeline(pipeline70);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let offscreenCanvas26 = new OffscreenCanvas(464, 440);
+let video30 = await videoWithData();
+let shaderModule32 = device0.createShaderModule({
+  label: '\u5b6d\u{1fc26}\ua6a9\u{1fe16}\u{1fef3}\u{1f967}\ue734\u{1f6ae}',
+  code: `@group(1) @binding(1904)
+var<storage, read_write> local21: array<u32>;
+@group(0) @binding(3655)
+var<storage, read_write> local22: array<u32>;
+@group(0) @binding(1512)
+var<storage, read_write> local23: array<u32>;
+@group(0) @binding(1580)
+var<storage, read_write> field12: array<u32>;
+
+@compute @workgroup_size(4, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<u32>,
+  @location(1) f1: vec4<u32>,
+  @location(0) f2: vec4<u32>,
+  @location(2) f3: vec3<u32>
+}
+
+@fragment
+fn fragment0(@location(2) a0: vec3<i32>, @location(25) a1: vec2<i32>, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S23 {
+  @location(18) f0: i32,
+  @location(13) f1: u32,
+  @location(6) f2: vec4<f32>
+}
+struct VertexOutput0 {
+  @location(13) f154: u32,
+  @builtin(position) f155: vec4<f32>,
+  @location(3) f156: i32,
+  @location(4) f157: vec2<i32>,
+  @location(18) f158: vec2<i32>,
+  @location(33) f159: f32,
+  @location(26) f160: vec4<f16>,
+  @location(2) f161: vec3<i32>,
+  @location(25) f162: vec2<i32>,
+  @location(21) f163: vec2<i32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(2) a1: vec2<u32>, @location(19) a2: vec4<f16>, @location(3) a3: vec4<u32>, @location(10) a4: i32, @location(5) a5: f32, @location(17) a6: vec3<i32>, @location(14) a7: vec3<u32>, @location(16) a8: f32, @location(20) a9: vec4<i32>, @location(8) a10: vec3<i32>, @location(11) a11: vec2<f16>, @location(7) a12: f16, a13: S23, @location(1) a14: vec4<f16>, @location(0) a15: f16) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup55 = device0.createBindGroup({layout: bindGroupLayout20, entries: [{binding: 1456, resource: sampler79}]});
+let commandEncoder167 = device0.createCommandEncoder();
+let texture110 = device0.createTexture({
+  label: '\u0386\u29aa\u{1fa69}\uaa5a\ub09f\u{1f65f}',
+  size: [624, 1, 637],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderBundleEncoder75.setBindGroup(3, bindGroup26, new Uint32Array(4917), 4186, 0);
+} catch {}
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+let textureView192 = texture108.createView({
+  label: '\u{1f787}\ud93a\u{1f909}\uea85\u09ce\u{1fc45}\u4af0\u881b\u729f',
+  dimension: '2d',
+  format: 'astc-8x8-unorm-srgb',
+  baseMipLevel: 7,
+  baseArrayLayer: 5,
+});
+let computePassEncoder72 = commandEncoder164.beginComputePass({label: '\u9e40\ua0a3\u8137\u{1f848}'});
+let externalTexture82 = device3.importExternalTexture({label: '\u{1fd27}\uceef\u0464\u0237\u0c97\u{1fb28}', source: videoFrame32, colorSpace: 'srgb'});
+try {
+renderBundleEncoder89.setVertexBuffer(3981, undefined, 694027739);
+} catch {}
+let video31 = await videoWithData();
+let texture111 = device0.createTexture({
+  label: '\uec21\u00ce\ucaf8',
+  size: [240, 120, 59],
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView193 = texture20.createView({
+  label: '\ud1f1\u{1f92c}\ud39c\u2f72\u{1fdec}\uee8a\u08d9\u1810',
+  format: 'r16uint',
+  baseMipLevel: 3,
+  mipLevelCount: 2,
+});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup36, new Uint32Array(6858), 787, 0);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline68);
+} catch {}
+try {
+renderBundleEncoder49.draw(215, 151);
+} catch {}
+try {
+renderBundleEncoder51.drawIndexed(51, 59, 333_727_961, 144_619_504, 3_236_354_993);
+} catch {}
+try {
+commandEncoder128.copyTextureToBuffer({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 31144 */
+  offset: 31144,
+  rowsPerImage: 9,
+  buffer: buffer16,
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 13320, new Float32Array(62479), 47657, 56);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 107},
+  aspect: 'all',
+}, new Float32Array(new ArrayBuffer(0)), /* required buffer size: 18_247_567 */
+{offset: 847, bytesPerRow: 480, rowsPerImage: 229}, {width: 82, height: 0, depthOrArrayLayers: 167});
+} catch {}
+let commandBuffer37 = commandEncoder163.finish({});
+let texture112 = device3.createTexture({
+  label: '\u0d5f\u{1fc64}',
+  size: {width: 257},
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView194 = texture109.createView({
+  label: '\u3b25\u01ba\u0012\u046c\u39de\u591a\u331a\u2d47',
+  dimension: '2d-array',
+  format: 'rgba8unorm-srgb',
+  mipLevelCount: 1,
+});
+let sampler89 = device3.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 50.47,
+  lodMaxClamp: 75.30,
+  maxAnisotropy: 15,
+});
+try {
+device3.queue.submit([commandBuffer37]);
+} catch {}
+try {
+offscreenCanvas26.getContext('2d');
+} catch {}
+let commandEncoder168 = device0.createCommandEncoder({label: '\u0d0b\u{1fc9c}\u{1f887}\u{1f962}\u76bb\u{1f8fe}'});
+let textureView195 = texture104.createView({label: '\udb98\u86d0', aspect: 'all', mipLevelCount: 3});
+try {
+computePassEncoder55.setBindGroup(0, bindGroup52, new Uint32Array(6999), 3423, 0);
+} catch {}
+try {
+renderBundleEncoder49.drawIndirect(buffer46, 3184);
+} catch {}
+try {
+commandEncoder82.copyBufferToBuffer(buffer47, 33148, buffer31, 60312, 10148);
+dissociateBuffer(device0, buffer47);
+dissociateBuffer(device0, buffer31);
+} catch {}
+try {
+commandEncoder117.clearBuffer(buffer26, 2548, 11852);
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 119, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(new ArrayBuffer(24)), /* required buffer size: 152 */
+{offset: 152, rowsPerImage: 65}, {width: 75, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline113 = device0.createComputePipeline({
+  label: '\u{1f70e}\u{1f73b}\ue2f8\u0fc8\u99fe\u0343\u7231\u{1fd18}\u02f2',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule31, entryPoint: 'compute0', constants: {}},
+});
+let img29 = await imageWithData(25, 112, '#8b3160e7', '#b64504e8');
+let commandEncoder169 = device0.createCommandEncoder();
+let texture113 = device0.createTexture({
+  label: '\ud4df\ufd87\u9186',
+  size: {width: 156, height: 1, depthOrArrayLayers: 332},
+  sampleCount: 1,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2uint', 'rgb10a2uint'],
+});
+let externalTexture83 = device0.importExternalTexture({label: '\u16ee\u066d', source: videoFrame13, colorSpace: 'display-p3'});
+try {
+computePassEncoder65.setBindGroup(4, bindGroup7, new Uint32Array(3107), 916, 0);
+} catch {}
+try {
+renderBundleEncoder51.draw(52, 297, 110_536_533);
+} catch {}
+try {
+renderBundleEncoder51.drawIndexedIndirect(buffer46, 64);
+} catch {}
+let arrayBuffer14 = buffer15.getMappedRange(0, 86000);
+try {
+commandEncoder71.copyBufferToBuffer(buffer12, 14856, buffer26, 32996, 160);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+commandEncoder106.clearBuffer(buffer26, 17604, 1044);
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+commandEncoder155.resolveQuerySet(querySet72, 109, 200, buffer1, 81664);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer45, 13976, new BigUint64Array(58718), 41083, 1408);
+} catch {}
+let canvas29 = document.createElement('canvas');
+let textureView196 = texture108.createView({
+  label: '\u3a8c\u7dc5\u{1fc93}',
+  format: 'astc-8x8-unorm-srgb',
+  baseMipLevel: 7,
+  baseArrayLayer: 71,
+  arrayLayerCount: 2,
+});
+let renderBundle109 = renderBundleEncoder88.finish({label: '\u{1f73c}\u05e0\u{1fdd1}\u04ed\u4686'});
+let imageBitmap48 = await createImageBitmap(videoFrame30);
+try {
+canvas29.getContext('webgl2');
+} catch {}
+let imageData39 = new ImageData(188, 176);
+let bindGroup56 = device0.createBindGroup({label: '\uf2c2\u3b18\u39aa\u0b6a\uf014\u0926\u0e53', layout: bindGroupLayout9, entries: []});
+let textureView197 = texture37.createView({
+  label: '\u{1f8c3}\u025c\ude45\u0d67\u{1fb56}\u{1fcd1}\u03c5\u{1fc5e}',
+  dimension: '2d',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  baseArrayLayer: 517,
+});
+let renderBundleEncoder90 = device0.createRenderBundleEncoder({
+  label: '\u{1fb54}\u362b\uef75\u01a8\u2465\u2066\ubaea\u3a59\ue907\uf4a4',
+  colorFormats: ['rgba8unorm-srgb', 'r8uint', 'r16uint', 'rgb10a2uint', 'r16sint'],
+});
+let renderBundle110 = renderBundleEncoder81.finish({label: '\u5f8b\u02f4\u3bc5\u{1f8b9}\uce0a\u0f88\u0226'});
+gc();
+try {
+buffer14.label = '\u{1f746}\u3812\u{1fd45}\u0f71\u9335\u50f0\u5f05\u095c\u0083\uc905\u6d46';
+} catch {}
+let video32 = await videoWithData();
+let textureView198 = texture108.createView({
+  label: '\u17ab\u291f\u{1fedc}\ub168\u0b1b\u0889\u0e95\u088a\u{1f92f}\u0d88',
+  dimension: '2d',
+  aspect: 'all',
+  format: 'astc-8x8-unorm-srgb',
+  baseMipLevel: 7,
+  baseArrayLayer: 60,
+});
+try {
+gpuCanvasContext0.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+let canvas30 = document.createElement('canvas');
+let textureView199 = texture109.createView({label: '\u{1f6fa}\u8140\u910d\u45f2\u{1ff31}'});
+try {
+renderBundleEncoder89.insertDebugMarker('\uf45e');
+} catch {}
+let imageBitmap49 = await createImageBitmap(canvas18);
+let querySet78 = device2.createQuerySet({
+  label: '\u9041\ued5d\uc3ac\u6584\u{1f6d5}\u{1f879}\ua1b2\u060b\u0e26\u0a32\u6bc9',
+  type: 'occlusion',
+  count: 1329,
+});
+try {
+buffer13.unmap();
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(55), /* required buffer size: 55 */
+{offset: 55}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let video33 = await videoWithData();
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let video34 = await videoWithData();
+let texture114 = device3.createTexture({
+  label: '\uc8c8\u2663\u{1f938}\u3ba1\u5e91\u92d6\u940f\u0ae2\uc40d\u{1f68a}\u0db0',
+  size: {width: 1165, height: 4, depthOrArrayLayers: 332},
+  mipLevelCount: 2,
+  format: 'astc-5x4-unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView200 = texture112.createView({label: '\u0fe4\u0565\uc5ae\u4eba\uf500\u{1fa64}\u{1f84c}'});
+try {
+renderBundleEncoder89.insertDebugMarker('\u037d');
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let gpuCanvasContext23 = canvas30.getContext('webgpu');
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+offscreenCanvas24.width = 1134;
+let imageBitmap50 = await createImageBitmap(imageBitmap1);
+try {
+window.someLabel = externalTexture16.label;
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+canvas23.height = 8;
+let imageBitmap51 = await createImageBitmap(img2);
+let commandEncoder170 = device0.createCommandEncoder({});
+let commandBuffer38 = commandEncoder170.finish({label: '\u8392\u73b8'});
+let texture115 = device0.createTexture({
+  label: '\u226b\u08cc\u7a85\u029c',
+  size: [156, 1, 89],
+  mipLevelCount: 8,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint', 'r16uint', 'r16uint'],
+});
+let externalTexture84 = device0.importExternalTexture({
+  label: '\u824a\uc9f0\u5c13\u{1fe86}\u{1fdc2}\u{1fe90}\u{1fc0b}\u{1f857}',
+  source: videoFrame32,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder11.setBindGroup(7, bindGroup33);
+} catch {}
+try {
+computePassEncoder55.setPipeline(pipeline58);
+} catch {}
+try {
+renderBundleEncoder83.setBindGroup(8, bindGroup29, new Uint32Array(6428), 2582, 0);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+commandEncoder162.insertDebugMarker('\u6e9b');
+} catch {}
+try {
+gpuCanvasContext10.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let canvas31 = document.createElement('canvas');
+let video35 = await videoWithData();
+let renderBundle111 = renderBundleEncoder88.finish({label: '\u08aa\u3ef6'});
+let externalTexture85 = device3.importExternalTexture({source: videoFrame31, colorSpace: 'srgb'});
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas0,
+  origin: { x: 58, y: 309 },
+  flipY: false,
+}, {
+  texture: texture109,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup57 = device0.createBindGroup({layout: bindGroupLayout18, entries: [{binding: 3128, resource: externalTexture49}]});
+let commandBuffer39 = commandEncoder156.finish({label: '\u55a6\u607c\u{1f701}\u5c47'});
+let texture116 = device0.createTexture({
+  label: '\u0591\u{1f9bc}\u03ff\u{1fae2}',
+  size: {width: 312, height: 1, depthOrArrayLayers: 1334},
+  dimension: '2d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder73 = commandEncoder166.beginComputePass({label: '\u2ee0\ud259\u967a\u07c1'});
+try {
+commandEncoder148.resolveQuerySet(querySet15, 1445, 79, buffer45, 29440);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 156, height: 1, depthOrArrayLayers: 25}
+*/
+{
+  source: canvas28,
+  origin: { x: 44, y: 18 },
+  flipY: false,
+}, {
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 9},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder171 = device3.createCommandEncoder();
+let texture117 = device3.createTexture({
+  label: '\u5c4c\ufea2\u3437\u0d57\uac38\u{1f77c}',
+  size: {width: 1872},
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView201 = texture109.createView({label: '\u{1fca1}\u1ab0\u3aaf\uc62a\u06b0\ue5ea\u0aab\uc906', baseArrayLayer: 0});
+let externalTexture86 = device3.importExternalTexture({source: videoFrame19});
+try {
+computePassEncoder72.end();
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+gc();
+let offscreenCanvas27 = new OffscreenCanvas(57, 519);
+let commandEncoder172 = device0.createCommandEncoder({label: '\u4fec\u0366\u057b\u0d6a\u{1fa09}\u{1fd50}\u9271\u59d8'});
+let commandBuffer40 = commandEncoder71.finish({label: '\u021a\u6af0\uadf7\uce70\u{1fe8e}\u0f49\u{1ffb5}'});
+let texture118 = device0.createTexture({
+  label: '\u2f32\ueb41\u{1f731}\u{1fb63}\u{1fc24}',
+  size: [156, 1, 168],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder70.setBindGroup(1, bindGroup6, new Uint32Array(1449), 775, 0);
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(0, bindGroup38, new Uint32Array(8971), 528, 0);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(262, 422, 1_303_799_555, 56_814_833, 427_022_604);
+} catch {}
+try {
+renderBundleEncoder51.drawIndexedIndirect(buffer26, 10696);
+} catch {}
+try {
+buffer46.unmap();
+} catch {}
+try {
+commandEncoder143.copyTextureToTexture({
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 1,
+  origin: {x: 11, y: 0, z: 17},
+  aspect: 'all',
+},
+{width: 121, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder151.clearBuffer(buffer41, 2492, 1964);
+dissociateBuffer(device0, buffer41);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 156, height: 1, depthOrArrayLayers: 25}
+*/
+{
+  source: imageData12,
+  origin: { x: 12, y: 2 },
+  flipY: true,
+}, {
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+canvas31.getContext('webgl2');
+} catch {}
+let commandEncoder173 = device0.createCommandEncoder({label: '\uab3d\ufbbc\ub061\u0201\u94ff\u36aa\ua60f'});
+let querySet79 = device0.createQuerySet({label: '\u4059\u900f\u059e\u01a0\u08dd\ufd34\u7d46\u0c8a\u08c5\u0293', type: 'occlusion', count: 2237});
+let texture119 = device0.createTexture({
+  label: '\u0b2d\u6d55\u3c15',
+  size: [312, 1, 1],
+  mipLevelCount: 4,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView202 = texture79.createView({label: '\uda8d\u{1fef9}\uea8e\u795c\u0a87\u{1f7b4}\ud433\u0859\u{1f97d}\u{1fb92}'});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup53, []);
+} catch {}
+try {
+computePassEncoder66.setPipeline(pipeline100);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer26, 952);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 10564, new Float32Array(47754), 20784, 76);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 60, height: 30, depthOrArrayLayers: 1261}
+*/
+{
+  source: imageData25,
+  origin: { x: 24, y: 0 },
+  flipY: false,
+}, {
+  texture: texture105,
+  mipLevel: 3,
+  origin: {x: 3, y: 0, z: 37},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 4, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture120 = device0.createTexture({
+  label: '\u05e3\u{1f7b0}\uf99b\u080d\uca08\uab8e\u018b\u08bf',
+  size: {width: 624},
+  dimension: '1d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView203 = texture4.createView({
+  label: '\u8fd5\ubc89\u1f6e\u0d37\u0303\u156d\u0804\u{1fa92}',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let externalTexture87 = device0.importExternalTexture({label: '\ucf44\u0f50', source: video9, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder51.draw(37, 33, 870_187_159, 1_288_281_550);
+} catch {}
+try {
+commandEncoder59.resolveQuerySet(querySet19, 418, 302, buffer30, 211456);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint32Array(new ArrayBuffer(56)), /* required buffer size: 10_253_696 */
+{offset: 510, bytesPerRow: 797, rowsPerImage: 201}, {width: 289, height: 1, depthOrArrayLayers: 65});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 156, height: 1, depthOrArrayLayers: 25}
+*/
+{
+  source: canvas18,
+  origin: { x: 7, y: 3 },
+  flipY: true,
+}, {
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext24 = offscreenCanvas27.getContext('webgpu');
+document.body.prepend(video17);
+let buffer49 = device0.createBuffer({
+  label: '\u13f1\u07e0\u020c\u0923\uc7bd\u5d1e\u6c53\u{1fad3}\u0b35\u{1fe15}',
+  size: 94739,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let querySet80 = device0.createQuerySet({label: '\u0ff1\ud363\u{1f9a2}\ubc7e\u01b9\u08ad\u2c3a\u{1f632}\u3499', type: 'occlusion', count: 2700});
+let textureView204 = texture120.createView({label: '\u12fd\u2178\ua04d\u4dce\u9380\u0794\u54d5'});
+let renderBundleEncoder91 = device0.createRenderBundleEncoder({colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'], stencilReadOnly: true});
+let externalTexture88 = device0.importExternalTexture({
+  label: '\u{1ff75}\u043c\u8ad7\uc7cb\u18fa\u{1f9c3}\u04f4\ua017\ua696',
+  source: video30,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder57.setPipeline(pipeline62);
+} catch {}
+try {
+renderBundleEncoder91.setBindGroup(3, bindGroup47, new Uint32Array(4), 4, 0);
+} catch {}
+try {
+  await buffer47.mapAsync(GPUMapMode.WRITE);
+} catch {}
+try {
+commandEncoder105.resolveQuerySet(querySet71, 2525, 13, buffer45, 41728);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 5732, new Float32Array(26135), 2103, 3316);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap37,
+  origin: { x: 42, y: 51 },
+  flipY: true,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline114 = await promise23;
+let offscreenCanvas28 = new OffscreenCanvas(761, 238);
+let imageBitmap52 = await createImageBitmap(videoFrame25);
+try {
+computePassEncoder33.end();
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline59);
+} catch {}
+try {
+renderBundleEncoder87.setIndexBuffer(buffer26, 'uint16', 31992);
+} catch {}
+try {
+renderBundleEncoder51.setPipeline(pipeline97);
+} catch {}
+try {
+commandEncoder155.resolveQuerySet(querySet12, 1097, 46, buffer45, 11264);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer45, 992, new DataView(new ArrayBuffer(31149)), 25788, 944);
+} catch {}
+let pipeline115 = device0.createComputePipeline({layout: pipelineLayout12, compute: {module: shaderModule31, entryPoint: 'compute0', constants: {}}});
+let img30 = await imageWithData(41, 4, '#f5b59e03', '#a44a5fd3');
+let textureView205 = texture35.createView({label: '\u04b0\u9bb1\u8c1c\u007d\uda80\u107b'});
+try {
+computePassEncoder38.setBindGroup(7, bindGroup24, new Uint32Array(5411), 4278, 0);
+} catch {}
+try {
+commandEncoder59.copyBufferToBuffer(buffer9, 2840, buffer49, 52220, 17196);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer49);
+} catch {}
+try {
+commandEncoder110.clearBuffer(buffer41, 2852, 1068);
+dissociateBuffer(device0, buffer41);
+} catch {}
+try {
+commandEncoder138.resolveQuerySet(querySet3, 502, 225, buffer45, 3840);
+} catch {}
+let pipeline116 = device0.createComputePipeline({
+  label: '\u73ad\u2de8\u0666\u{1fbb6}\u028c\u08dc\u8d34',
+  layout: pipelineLayout20,
+  compute: {module: shaderModule4, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext25 = offscreenCanvas28.getContext('webgpu');
+let videoFrame33 = new VideoFrame(offscreenCanvas5, {timestamp: 0});
+let querySet81 = device3.createQuerySet({label: '\u675d\u0a72\u{1f6c3}\u60a4\u0af5\u{1fdbe}', type: 'occlusion', count: 4065});
+try {
+  await device3.popErrorScope();
+} catch {}
+let imageData40 = new ImageData(188, 180);
+let bindGroupLayout41 = pipeline25.getBindGroupLayout(5);
+let textureView206 = texture52.createView({label: '\udcc9\u61e3\u42d7\ubc8a\ue149\u5c93\u0383\uae0b\u064d', aspect: 'all'});
+let externalTexture89 = device0.importExternalTexture({source: videoFrame3});
+try {
+renderBundleEncoder49.draw(10, 118, 855_466_924);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer46, 2420);
+} catch {}
+try {
+renderBundleEncoder49.drawIndirect(buffer26, 344);
+} catch {}
+try {
+commandEncoder87.copyTextureToTexture({
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 46, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline117 = await device0.createRenderPipelineAsync({
+  label: '\ub26e\u{1f8a1}\u02a8\u46c6\u{1fac1}\u2167\u3f4b\u69be\u{1ffd4}',
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule27,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'r16float',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'src', dstFactor: 'dst'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-dst', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: 0,
+}, {format: 'rg8sint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r32uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one', dstFactor: 'one-minus-dst'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'rg16uint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule27,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 39564,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 5100, shaderLocation: 0},
+          {format: 'snorm8x2', offset: 1778, shaderLocation: 15},
+          {format: 'unorm8x2', offset: 5650, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 3684, shaderLocation: 20},
+          {format: 'sint32x3', offset: 8096, shaderLocation: 18},
+          {format: 'float32x3', offset: 6832, shaderLocation: 3},
+          {format: 'uint8x4', offset: 6596, shaderLocation: 16},
+          {format: 'unorm8x4', offset: 19316, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 1040, shaderLocation: 2},
+          {format: 'uint32x2', offset: 6132, shaderLocation: 11},
+          {format: 'float16x4', offset: 3624, shaderLocation: 17},
+          {format: 'snorm8x2', offset: 6920, shaderLocation: 1},
+          {format: 'unorm16x2', offset: 3756, shaderLocation: 7},
+          {format: 'sint16x2', offset: 2544, shaderLocation: 9},
+          {format: 'uint8x2', offset: 7638, shaderLocation: 5},
+          {format: 'float32x4', offset: 1304, shaderLocation: 6},
+          {format: 'float32x4', offset: 152, shaderLocation: 13},
+          {format: 'sint16x4', offset: 9304, shaderLocation: 14},
+          {format: 'uint16x4', offset: 432, shaderLocation: 19},
+        ],
+      },
+      {arrayStride: 3612, attributes: [{format: 'sint16x4', offset: 2072, shaderLocation: 4}]},
+      {
+        arrayStride: 4372,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32', offset: 172, shaderLocation: 10}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let bindGroup58 = device0.createBindGroup({
+  label: '\uc667\u{1fa3f}\u4915',
+  layout: bindGroupLayout37,
+  entries: [{binding: 4644, resource: {buffer: buffer0, offset: 92416, size: 14128}}],
+});
+try {
+computePassEncoder60.setBindGroup(8, bindGroup13, new Uint32Array(9910), 2203, 0);
+} catch {}
+try {
+renderBundleEncoder49.draw(189, 25, 186_818_335, 2_717_572_864);
+} catch {}
+try {
+renderBundleEncoder49.drawIndirect(buffer26, 808);
+} catch {}
+try {
+renderBundleEncoder40.setPipeline(pipeline97);
+} catch {}
+try {
+gpuCanvasContext14.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let img31 = await imageWithData(186, 253, '#0d25a057', '#24cdfe36');
+let renderBundle112 = renderBundleEncoder89.finish({label: '\u60d2\u0adb\ud2db\u92b6\u6ec6'});
+try {
+querySet77.destroy();
+} catch {}
+let video36 = await videoWithData();
+let commandEncoder174 = device0.createCommandEncoder();
+let textureView207 = texture13.createView({label: '\uc001\uf83a\ubb0b\uad23\u{1f995}\u4d70', dimension: '2d-array'});
+let computePassEncoder74 = commandEncoder50.beginComputePass({label: '\u141b\u{1f76b}'});
+let externalTexture90 = device0.importExternalTexture({
+  label: '\u224c\u389d\u8f95\u02f5\u0da8\ue2f1\u08b4\u0a26\u0b60\ua81b\u{1fed9}',
+  source: videoFrame0,
+  colorSpace: 'display-p3',
+});
+try {
+computePassEncoder73.setPipeline(pipeline77);
+} catch {}
+try {
+renderBundleEncoder83.setBindGroup(7, bindGroup42);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(431, 93);
+} catch {}
+try {
+renderBundleEncoder49.drawIndirect(buffer46, 700);
+} catch {}
+try {
+buffer26.unmap();
+} catch {}
+try {
+commandEncoder168.copyBufferToBuffer(buffer48, 144, buffer49, 73600, 408);
+dissociateBuffer(device0, buffer48);
+dissociateBuffer(device0, buffer49);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer49, 5956, new BigUint64Array(13373), 8637, 416);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 156, height: 1, depthOrArrayLayers: 25}
+*/
+{
+  source: videoFrame16,
+  origin: { x: 3, y: 82 },
+  flipY: true,
+}, {
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 58, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas18.width = 187;
+let bindGroupLayout42 = device3.createBindGroupLayout({
+  label: '\u0139\uee35\u{1fbde}\ua1e6\u044a\u8e4e\u{1f9be}\uba66\ue9ec\u650a\ufa47',
+  entries: [
+    {
+      binding: 3847,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 4012,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let querySet82 = device3.createQuerySet({label: '\ub91d\u{1f6e7}\uabc8', type: 'occlusion', count: 1014});
+let commandBuffer41 = commandEncoder164.finish();
+let textureView208 = texture117.createView({label: '\u0356\u2fd9', arrayLayerCount: 1});
+try {
+device3.queue.writeTexture({
+  texture: texture108,
+  mipLevel: 3,
+  origin: {x: 8, y: 0, z: 3},
+  aspect: 'all',
+}, arrayBuffer4, /* required buffer size: 3_771_685 */
+{offset: 717, bytesPerRow: 276, rowsPerImage: 297}, {width: 128, height: 8, depthOrArrayLayers: 47});
+} catch {}
+let videoFrame34 = new VideoFrame(img30, {timestamp: 0});
+let pipelineLayout21 = device3.createPipelineLayout({label: '\u5a8e\ubad7\u{1fd88}\u{1f99d}\u{1f7e8}\u{1f7ff}\u18b9', bindGroupLayouts: []});
+let commandEncoder175 = device3.createCommandEncoder({label: '\u5dd9\uc92f\uc9e4\ubce4\u{1fdfb}\u9e6e\ua1d4\u091d'});
+let textureView209 = texture114.createView({label: '\ub68f\u3064', baseMipLevel: 1, baseArrayLayer: 89, arrayLayerCount: 41});
+let computePassEncoder75 = commandEncoder171.beginComputePass({});
+let sampler90 = device3.createSampler({
+  label: '\u0df9\u051a\u{1fc4a}',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 57.97,
+  lodMaxClamp: 65.40,
+  maxAnisotropy: 15,
+});
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video16,
+  origin: { x: 4, y: 2 },
+  flipY: true,
+}, {
+  texture: texture109,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame35 = new VideoFrame(imageBitmap33, {timestamp: 0});
+let commandEncoder176 = device0.createCommandEncoder({});
+let textureView210 = texture29.createView({label: '\uda80\ua243', baseMipLevel: 1, mipLevelCount: 2});
+let renderBundle113 = renderBundleEncoder77.finish({label: '\uf474\u{1f6de}\u838e\u{1ffd4}\u{1f7f0}\ua5e8\uf565\ua1bd\u4dc7\u1b95\u1e1f'});
+try {
+renderBundleEncoder86.setBindGroup(8, bindGroup19, []);
+} catch {}
+try {
+renderBundleEncoder49.draw(158, 155, 356_442_259, 756_099_035);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(10, 85);
+} catch {}
+try {
+commandEncoder121.clearBuffer(buffer26, 1016, 776);
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 9776, new Int16Array(43539), 24638, 3168);
+} catch {}
+let pipeline118 = device0.createRenderPipeline({
+  label: '\u7bab\u{1fd42}\u{1fc8d}',
+  layout: pipelineLayout20,
+  fragment: {
+  module: shaderModule13,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgb10a2uint'}, {format: 'rgba8uint', writeMask: 0}, {format: 'r16uint'}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule13,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1152,
+        attributes: [
+          {format: 'sint32', offset: 272, shaderLocation: 19},
+          {format: 'uint8x4', offset: 40, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 2632,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm8x4', offset: 652, shaderLocation: 20},
+          {format: 'snorm16x2', offset: 872, shaderLocation: 10},
+          {format: 'float32x4', offset: 248, shaderLocation: 11},
+          {format: 'float32', offset: 188, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 1156,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x3', offset: 144, shaderLocation: 1}],
+      },
+      {
+        arrayStride: 3012,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32x4', offset: 280, shaderLocation: 8},
+          {format: 'uint8x2', offset: 450, shaderLocation: 13},
+          {format: 'float32x2', offset: 888, shaderLocation: 4},
+          {format: 'uint32x3', offset: 440, shaderLocation: 5},
+          {format: 'sint8x2', offset: 682, shaderLocation: 7},
+          {format: 'sint32x4', offset: 272, shaderLocation: 16},
+        ],
+      },
+      {arrayStride: 708, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'float32', offset: 628, shaderLocation: 6}],
+      },
+    ],
+  },
+  primitive: {unclippedDepth: true},
+});
+let commandEncoder177 = device0.createCommandEncoder({});
+try {
+renderBundleEncoder49.draw(323, 25, 290_748_066, 144_964_752);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer39.destroy();
+} catch {}
+try {
+commandEncoder59.resolveQuerySet(querySet2, 1863, 164, buffer30, 118784);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 123, y: 0, z: 33},
+  aspect: 'all',
+}, new ArrayBuffer(10_072_619), /* required buffer size: 10_072_619 */
+{offset: 371, bytesPerRow: 589, rowsPerImage: 100}, {width: 87, height: 1, depthOrArrayLayers: 172});
+} catch {}
+let bindGroup59 = device0.createBindGroup({
+  label: '\u1dc5\u68d2\uf8b9',
+  layout: bindGroupLayout14,
+  entries: [{binding: 224, resource: sampler30}],
+});
+let pipelineLayout22 = device0.createPipelineLayout({
+  label: '\u8ad6\u083b\u{1fb74}',
+  bindGroupLayouts: [bindGroupLayout27, bindGroupLayout11, bindGroupLayout12, bindGroupLayout38, bindGroupLayout9],
+});
+let commandBuffer42 = commandEncoder159.finish({label: '\u7391\u1578\u0eac\u4e6e\u0eb6\u0836\uc471\u593e'});
+let sampler91 = device0.createSampler({
+  label: '\u591d\u0a9d\u{1f8d3}\u5de6\u6681\u1e81\u061e\u7912\u{1fd11}\u{1fc25}\ue2b2',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  lodMinClamp: 80.57,
+  lodMaxClamp: 92.09,
+});
+try {
+computePassEncoder50.setBindGroup(0, bindGroup39, new Uint32Array(6590), 4322, 0);
+} catch {}
+try {
+renderBundleEncoder49.setBindGroup(6, bindGroup44);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer26, 9060);
+} catch {}
+try {
+renderBundleEncoder82.setPipeline(pipeline117);
+} catch {}
+try {
+renderBundleEncoder87.setVertexBuffer(3969, undefined, 2953376601);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 156, height: 1, depthOrArrayLayers: 25}
+*/
+{
+  source: imageData20,
+  origin: { x: 2, y: 31 },
+  flipY: false,
+}, {
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer50 = device3.createBuffer({
+  label: '\u{1f701}\u07f5\u{1ff0f}',
+  size: 108735,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView211 = texture108.createView({
+  aspect: 'all',
+  format: 'astc-8x8-unorm-srgb',
+  baseMipLevel: 5,
+  mipLevelCount: 2,
+  baseArrayLayer: 73,
+  arrayLayerCount: 2,
+});
+let renderBundle114 = renderBundleEncoder88.finish();
+try {
+commandEncoder175.resolveQuerySet(querySet81, 3891, 143, buffer50, 103936);
+} catch {}
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let imageBitmap53 = await createImageBitmap(imageBitmap35);
+let imageData41 = new ImageData(128, 200);
+let commandBuffer43 = commandEncoder175.finish({label: '\ub93e\uee38\u607f\ubf63'});
+let renderBundle115 = renderBundleEncoder89.finish({label: '\u0078\u7897\ub6fc\ub491\u{1ff31}\u5fbd\u3d5b'});
+let sampler92 = device3.createSampler({
+  label: '\udf57\u04ef\u06bc\u7e7a\u{1f6d4}\uc2dc\u{1f90c}\u3e4a',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 75.82,
+  lodMaxClamp: 82.93,
+});
+gc();
+let img32 = await imageWithData(231, 199, '#afea8290', '#fa9a385d');
+let videoFrame36 = videoFrame27.clone();
+document.body.prepend(img6);
+let canvas32 = document.createElement('canvas');
+let bindGroup60 = device0.createBindGroup({
+  label: '\u6fa5\u1ac3\ub7ea',
+  layout: bindGroupLayout19,
+  entries: [{binding: 662, resource: sampler76}],
+});
+let commandBuffer44 = commandEncoder161.finish({label: '\u2337\u7e20\u00bc\u0871'});
+let textureView212 = texture15.createView({label: '\u8d6e\u4f28\u0206\u8935\u1706\u824d'});
+let renderBundle116 = renderBundleEncoder79.finish({label: '\u0ce8\u04e1\ub78b\u02ad\u01ea\uaa35\u6e08\u{1f822}'});
+try {
+computePassEncoder38.setBindGroup(10, bindGroup7, new Uint32Array(9344), 1194, 0);
+} catch {}
+try {
+renderBundleEncoder61.setPipeline(pipeline35);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+  await buffer16.mapAsync(GPUMapMode.READ, 0, 106476);
+} catch {}
+try {
+commandEncoder59.copyBufferToBuffer(buffer9, 19884, buffer6, 41656, 888);
+dissociateBuffer(device0, buffer9);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder123.copyBufferToTexture({
+  /* bytesInLastRow: 400 widthInBlocks: 100 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 10032 */
+  offset: 10032,
+  bytesPerRow: 768,
+  buffer: buffer26,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 100, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 8348, new DataView(new ArrayBuffer(43275)), 9976, 1192);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas12,
+  origin: { x: 1, y: 368 },
+  flipY: false,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline119 = device0.createComputePipeline({
+  label: '\u0391\ua358\u47f9\u09b3',
+  layout: pipelineLayout19,
+  compute: {module: shaderModule32, entryPoint: 'compute0', constants: {}},
+});
+let textureView213 = texture109.createView({
+  label: '\u{1fab3}\u{1fc89}\u3c64\u0ab9\u03a0\ucfbe\u0eaa',
+  dimension: '2d-array',
+  format: 'rgba8unorm-srgb',
+});
+try {
+texture108.destroy();
+} catch {}
+try {
+buffer50.destroy();
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture109,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer10), /* required buffer size: 337 */
+{offset: 337}, {width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture121 = device0.createTexture({
+  label: '\ua6c2\u827a',
+  size: [480, 240, 1],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView214 = texture9.createView({label: '\u{1fb1a}\u9f67', mipLevelCount: 2});
+try {
+computePassEncoder11.setPipeline(pipeline70);
+} catch {}
+try {
+renderBundleEncoder51.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+renderBundleEncoder49.draw(269, 222, 578_195_579, 316_007_010);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(440, 20, 288_270_807, 86_992_043, 572_371_207);
+} catch {}
+try {
+commandEncoder168.clearBuffer(buffer39, 46244, 3484);
+dissociateBuffer(device0, buffer39);
+} catch {}
+video30.width = 154;
+let computePassEncoder76 = commandEncoder153.beginComputePass({label: '\u0fcb\u8c15\u0542\u4b96\u072d\u73a0\u0930\u048e\u3cb2\u0117\u0bec'});
+let externalTexture91 = device0.importExternalTexture({label: '\u01a7\u{1f9b1}\ue72e\ua05c\u40dd\u03f4', source: videoFrame27});
+try {
+renderBundleEncoder60.setBindGroup(8, bindGroup6, new Uint32Array(3447), 1663, 0);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(63, 42, 1_887_797_658, 98_132_993, 47_830_268);
+} catch {}
+try {
+commandEncoder107.resolveQuerySet(querySet56, 1086, 31, buffer30, 261376);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture106,
+  mipLevel: 10,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer13), /* required buffer size: 324 */
+{offset: 324, rowsPerImage: 224}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let imageBitmap54 = await createImageBitmap(img23);
+let querySet83 = device3.createQuerySet({label: '\u{1fea8}\u{1fe70}\ud55b\u0738\ud948', type: 'occlusion', count: 3683});
+let texture122 = device3.createTexture({
+  size: [300],
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rg16sint'],
+});
+let textureView215 = texture117.createView({});
+try {
+device3.queue.submit([commandBuffer41]);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture122,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new Int32Array(arrayBuffer8), /* required buffer size: 257 */
+{offset: 257}, {width: 209, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let imageBitmap55 = await createImageBitmap(imageBitmap26);
+let buffer51 = device3.createBuffer({
+  label: '\u08ec\ud60a\u0fba\uc911\u30ce\u093e',
+  size: 448972,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+try {
+computePassEncoder75.end();
+} catch {}
+document.body.prepend(canvas12);
+let bindGroup61 = device0.createBindGroup({label: '\u0b34\u{1fa23}\u8e94\u8b82\ue429\ud4b6\u0fd9\u0134', layout: bindGroupLayout41, entries: []});
+let texture123 = device0.createTexture({
+  label: '\ua8d6\udd6b\u{1fd75}',
+  size: [624, 1, 1],
+  mipLevelCount: 5,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView216 = texture32.createView({label: '\u7c67\u813b\u06c3\u020a\ua465', arrayLayerCount: 1});
+let renderBundle117 = renderBundleEncoder71.finish({label: '\u7e91\uadf5\u0e7c\ua363\u48fe\u{1f975}\u01c2\u0368\u2a3b\ud4b5\u003f'});
+try {
+computePassEncoder9.setBindGroup(6, bindGroup44, new Uint32Array(3452), 2153, 0);
+} catch {}
+try {
+renderBundleEncoder84.setBindGroup(7, bindGroup54, new Uint32Array(2723), 1863, 0);
+} catch {}
+try {
+renderBundleEncoder49.draw(521, 42, 606_246_760, 1_813_866_516);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(303, 266, 2_584_722, -2_002_933_500);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer26, 2216);
+} catch {}
+try {
+commandEncoder105.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4188 */
+  offset: 4188,
+  buffer: buffer21,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer21);
+} catch {}
+try {
+gpuCanvasContext20.unconfigure();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let texture124 = device3.createTexture({
+  label: '\u{1f86c}\u{1fd2d}\u0478\u{1fee0}\u540d\u{1f890}\ue659\u{1fb79}\u5dfe\ua81b',
+  size: [75, 1, 123],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let textureView217 = texture117.createView({baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder77 = commandEncoder171.beginComputePass();
+let sampler93 = device3.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 37.98,
+  lodMaxClamp: 54.59,
+  compare: 'always',
+});
+try {
+device3.queue.writeTexture({
+  texture: texture122,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 0},
+  aspect: 'all',
+}, new DataView(new ArrayBuffer(64)), /* required buffer size: 826 */
+{offset: 826}, {width: 236, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let commandEncoder178 = device3.createCommandEncoder({label: '\u09bf\u53f0\ue788\u0410\u{1f99a}'});
+let querySet84 = device3.createQuerySet({type: 'occlusion', count: 2125});
+let texture125 = device3.createTexture({
+  label: '\u00ec\ube84\u6f96\u730e\ue7a3\ud898\u05f5\u82bb\u1bff',
+  size: {width: 257},
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32float', 'r32float', 'r32float'],
+});
+try {
+device3.queue.writeTexture({
+  texture: texture109,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(new ArrayBuffer(24)), /* required buffer size: 261 */
+{offset: 261, bytesPerRow: 75}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let video37 = await videoWithData();
+gc();
+let textureView218 = texture114.createView({
+  label: '\ub004\u{1f993}\u436e\u{1faf1}\u0269\ueb22\u0e57\u0069',
+  dimension: '2d-array',
+  baseMipLevel: 0,
+  mipLevelCount: 1,
+  baseArrayLayer: 164,
+  arrayLayerCount: 90,
+});
+let computePassEncoder78 = commandEncoder178.beginComputePass({});
+let gpuCanvasContext26 = canvas32.getContext('webgpu');
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let textureView219 = texture24.createView({});
+let renderBundle118 = renderBundleEncoder87.finish({label: '\u22ea\u{1f70f}\u0f14\u0ed9\u2b65\u0ff6\u6a27\u5585\u04fd\u0444\u679d'});
+try {
+renderBundleEncoder49.drawIndirect(buffer46, 59344);
+} catch {}
+try {
+commandEncoder157.copyTextureToBuffer({
+  texture: texture96,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 940 widthInBlocks: 235 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2416 */
+  offset: 1476,
+  rowsPerImage: 37,
+  buffer: buffer39,
+}, {width: 235, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer39);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture102,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer3), /* required buffer size: 152 */
+{offset: 152}, {width: 20, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55) };
+} catch {}
+let shaderModule33 = device0.createShaderModule({
+  label: '\u0d90\u864a\u0304\u0ece\u13fb\u{1fe85}\u086d\u{1f607}\u{1fe44}',
+  code: `@group(3) @binding(1456)
+var<storage, read_write> n15: array<u32>;
+
+@compute @workgroup_size(4, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(3) f1: vec4<u32>,
+  @location(5) f2: vec4<f32>,
+  @location(2) f3: vec4<u32>,
+  @location(1) f4: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(20) a0: vec2<f32>, @location(15) a1: vec3<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S24 {
+  @location(7) f0: vec3<i32>,
+  @location(18) f1: vec3<u32>,
+  @location(12) f2: i32,
+  @location(1) f3: vec3<f16>,
+  @location(19) f4: vec2<f32>,
+  @location(16) f5: vec4<i32>,
+  @location(13) f6: i32,
+  @builtin(vertex_index) f7: u32,
+  @location(3) f8: u32
+}
+struct VertexOutput0 {
+  @location(8) f164: f16,
+  @location(11) f165: vec3<f16>,
+  @location(4) f166: vec2<i32>,
+  @builtin(position) f167: vec4<f32>,
+  @location(24) f168: vec4<f16>,
+  @location(36) f169: vec3<u32>,
+  @location(28) f170: vec2<f32>,
+  @location(20) f171: vec2<f32>,
+  @location(15) f172: vec3<f32>,
+  @location(3) f173: vec2<f32>,
+  @location(1) f174: vec4<f16>,
+  @location(2) f175: f16,
+  @location(26) f176: vec3<f16>,
+  @location(5) f177: vec2<f16>,
+  @location(30) f178: vec4<u32>,
+  @location(18) f179: u32,
+  @location(7) f180: vec4<u32>,
+  @location(29) f181: vec3<u32>,
+  @location(14) f182: vec2<f16>,
+  @location(31) f183: vec3<f32>,
+  @location(21) f184: vec2<u32>,
+  @location(35) f185: vec4<u32>,
+  @location(16) f186: vec3<f32>,
+  @location(22) f187: vec2<i32>,
+  @location(6) f188: f32
+}
+
+@vertex
+fn vertex0(@location(14) a0: i32, @location(6) a1: vec3<f32>, @location(5) a2: vec4<f32>, @location(11) a3: vec3<f32>, @location(15) a4: vec3<f16>, @location(9) a5: vec2<f32>, a6: S24, @location(4) a7: u32, @location(0) a8: vec2<i32>, @location(2) a9: vec4<f32>, @location(17) a10: vec3<f16>, @location(8) a11: f16, @location(20) a12: vec4<f16>, @location(10) a13: vec3<i32>, @builtin(instance_index) a14: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout43 = device0.createBindGroupLayout({
+  label: '\u8306\u0d92\u{1ff8b}\u{1fcd5}\u0d1d',
+  entries: [
+    {
+      binding: 3446,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let commandEncoder179 = device0.createCommandEncoder({label: '\u07dc\u442f\u0948'});
+let querySet85 = device0.createQuerySet({
+  label: '\ua8da\u000b\uaaf9\u{1fae1}\ufae0\u82fe\u8ac8\uae40\u3f5e\u0846',
+  type: 'occlusion',
+  count: 616,
+});
+try {
+renderBundleEncoder90.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(593, 72, 301_444_381, 104_974_039, 1_014_249_068);
+} catch {}
+try {
+buffer39.unmap();
+} catch {}
+try {
+commandEncoder158.copyBufferToBuffer(buffer12, 14644, buffer22, 21056, 1500);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer22);
+} catch {}
+try {
+device0.queue.submit([commandBuffer39, commandBuffer42, commandBuffer40]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 1,
+  origin: {x: 16, y: 0, z: 1},
+  aspect: 'all',
+}, new DataView(arrayBuffer11), /* required buffer size: 760_979 */
+{offset: 659, bytesPerRow: 660, rowsPerImage: 64}, {width: 241, height: 0, depthOrArrayLayers: 19});
+} catch {}
+let pipeline120 = device0.createRenderPipeline({
+  label: '\u{1f8cb}\u{1fbdf}\udb73\u{1fd02}',
+  layout: pipelineLayout22,
+  fragment: {
+  module: shaderModule33,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8uint'}, {format: 'r16uint', writeMask: GPUColorWrite.BLUE}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.BLUE}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'greater', failOp: 'increment-wrap', depthFailOp: 'replace', passOp: 'replace'},
+    stencilBack: {compare: 'greater-equal', failOp: 'zero', depthFailOp: 'increment-wrap', passOp: 'invert'},
+    stencilReadMask: 960652814,
+    stencilWriteMask: 4184923929,
+    depthBias: -1452010947,
+    depthBiasClamp: 188.3756937894408,
+  },
+  vertex: {
+    module: shaderModule33,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4700,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 360, shaderLocation: 14},
+          {format: 'snorm8x2', offset: 1498, shaderLocation: 19},
+          {format: 'float32', offset: 88, shaderLocation: 5},
+          {format: 'unorm10-10-10-2', offset: 1016, shaderLocation: 17},
+          {format: 'uint16x2', offset: 448, shaderLocation: 3},
+          {format: 'unorm8x2', offset: 2012, shaderLocation: 20},
+          {format: 'sint32x4', offset: 596, shaderLocation: 13},
+          {format: 'sint32x3', offset: 256, shaderLocation: 10},
+          {format: 'unorm8x4', offset: 60, shaderLocation: 9},
+          {format: 'float32', offset: 956, shaderLocation: 6},
+          {format: 'snorm16x2', offset: 348, shaderLocation: 11},
+          {format: 'uint16x4', offset: 2544, shaderLocation: 4},
+          {format: 'sint8x4', offset: 748, shaderLocation: 16},
+          {format: 'sint8x4', offset: 1640, shaderLocation: 7},
+          {format: 'uint16x4', offset: 620, shaderLocation: 18},
+        ],
+      },
+      {
+        arrayStride: 5272,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'snorm16x4', offset: 244, shaderLocation: 2},
+          {format: 'sint32', offset: 332, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 1828, shaderLocation: 15},
+          {format: 'float32x4', offset: 412, shaderLocation: 8},
+          {format: 'float16x4', offset: 1176, shaderLocation: 1},
+          {format: 'sint32x2', offset: 1256, shaderLocation: 0},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'cw', unclippedDepth: true},
+});
+try {
+adapter3.label = '\u60e0\u0baa\u0609\u7cb9\u{1fb00}\u1c60\u{1fd16}\u{1fac9}';
+} catch {}
+let sampler94 = device3.createSampler({
+  label: '\u1ce4\u0edd\ufbfa\u65b2\u{1f8c5}\uc931\ubeab\u44c5',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 58.84,
+  lodMaxClamp: 88.95,
+  compare: 'greater-equal',
+  maxAnisotropy: 10,
+});
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+let offscreenCanvas29 = new OffscreenCanvas(208, 889);
+let img33 = await imageWithData(179, 194, '#f53222ee', '#76433edf');
+let videoFrame37 = videoFrame14.clone();
+canvas0.width = 117;
+try {
+offscreenCanvas29.getContext('webgpu');
+} catch {}
+let bindGroupLayout44 = device3.createBindGroupLayout({label: '\u80d3\u2a28\u09ee\u0501\u6975\ucc04\u6511\u8518\u04f2', entries: []});
+let commandEncoder180 = device3.createCommandEncoder({label: '\u0722\u0d4e\uc6ff\ue6d0\ue434'});
+let texture126 = device3.createTexture({
+  label: '\u0f5f\ua34d',
+  size: {width: 234},
+  dimension: '1d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint', 'r32uint'],
+});
+let textureView220 = texture125.createView({label: '\u0078\u70cb\u{1f995}\u00ba\u{1f81c}\u{1fbfc}\ufd04\uef26\ua7ba\ue2aa', dimension: '1d'});
+let computePassEncoder79 = commandEncoder180.beginComputePass();
+let sampler95 = device3.createSampler({
+  label: '\u03fd\u{1fb4c}\ucb01\u71e0\u6116\u40b9\u5fa5\u0297\u{1faba}\uc5d4',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 88.54,
+  lodMaxClamp: 88.68,
+});
+try {
+computePassEncoder77.end();
+} catch {}
+try {
+commandEncoder171.resolveQuerySet(querySet81, 3578, 107, buffer50, 98816);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device3,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let shaderModule34 = device0.createShaderModule({
+  label: '\ue477\u{1ff7e}\u029f\u2e3e\u0f78\uef71',
+  code: `@group(3) @binding(1456)
+var<storage, read_write> local24: array<u32>;
+
+@compute @workgroup_size(3, 4, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(1) f1: vec4<u32>,
+  @location(3) f2: vec4<u32>,
+  @location(2) f3: vec2<u32>,
+  @location(7) f4: vec2<u32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(12) a0: vec4<f32>, @location(14) a1: vec4<f32>, @location(7) a2: vec2<f16>, @location(16) a3: vec3<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup62 = device0.createBindGroup({
+  label: '\u035d\u0b48\u0838\u{1fffb}\u{1fcae}\ud016\u037e\u2c81',
+  layout: bindGroupLayout32,
+  entries: [
+    {binding: 6791, resource: {buffer: buffer0, offset: 40704, size: 41864}},
+    {binding: 5448, resource: externalTexture83},
+    {binding: 5251, resource: externalTexture53},
+  ],
+});
+let pipelineLayout23 = device0.createPipelineLayout({
+  label: '\u5641\u03fc\ua6e1\u0ad7\ubc8b\u1d1d',
+  bindGroupLayouts: [bindGroupLayout43, bindGroupLayout12],
+});
+let textureView221 = texture23.createView({
+  label: '\ue98b\u0143',
+  dimension: '2d',
+  format: 'rgb10a2uint',
+  baseMipLevel: 4,
+  baseArrayLayer: 322,
+  arrayLayerCount: 1,
+});
+let computePassEncoder80 = commandEncoder174.beginComputePass({label: '\u585f\u0c40\u13d2\u0bd7\ufcfa\ue2c5\u0119\u0fa5\u0c24\uc090'});
+let renderBundle119 = renderBundleEncoder73.finish({});
+try {
+renderBundleEncoder12.setVertexBuffer(1875, undefined, 0, 1206013440);
+} catch {}
+try {
+commandEncoder143.copyBufferToTexture({
+  /* bytesInLastRow: 54 widthInBlocks: 27 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2376 */
+  offset: 72,
+  bytesPerRow: 256,
+  rowsPerImage: 9,
+  buffer: buffer12,
+}, {
+  texture: texture59,
+  mipLevel: 3,
+  origin: {x: 11, y: 0, z: 5},
+  aspect: 'all',
+}, {width: 27, height: 0, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture105,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 20},
+  aspect: 'all',
+}, new BigUint64Array(arrayBuffer3), /* required buffer size: 2_729_219 */
+{offset: 383, bytesPerRow: 280, rowsPerImage: 162}, {width: 59, height: 26, depthOrArrayLayers: 61});
+} catch {}
+document.body.prepend(canvas8);
+let offscreenCanvas30 = new OffscreenCanvas(559, 866);
+let querySet86 = device3.createQuerySet({label: '\ud99f\ua3da\u0259', type: 'occlusion', count: 3486});
+let texture127 = device3.createTexture({
+  label: '\u62f6\u0afa\u020d\u0723\u{1fdc9}\ubffe\u08de\u6d55\u2713',
+  size: {width: 582},
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let sampler96 = device3.createSampler({
+  label: '\u6540\u{1f96b}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  lodMinClamp: 92.77,
+  lodMaxClamp: 95.41,
+});
+try {
+commandEncoder171.copyTextureToTexture({
+  texture: texture112,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture127,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 212, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let img34 = await imageWithData(81, 23, '#21066dd8', '#7a236961');
+let commandEncoder181 = device0.createCommandEncoder({label: '\u{1fcf0}\u0cc6\u8467\u049b\u05aa\u067a\u{1fe8f}\u7215\u{1fed8}'});
+let querySet87 = device0.createQuerySet({type: 'occlusion', count: 3240});
+let textureView222 = texture21.createView({
+  label: '\ua65a\u{1f9ad}\u2e5b\ud415\uf258\u{1fab1}\u30bf\u{1ff6e}',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 1,
+  baseArrayLayer: 759,
+});
+let renderBundleEncoder92 = device0.createRenderBundleEncoder({
+  label: '\u1b4e\u6b9c\u{1ff36}\u47b4\u{1f9be}\u{1fed4}\ue343\u37ef\u067e\u1152',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+});
+let externalTexture92 = device0.importExternalTexture({label: '\uabec\u0c77', source: video15});
+try {
+renderBundleEncoder12.setVertexBuffer(2293, undefined, 91571585, 1091201140);
+} catch {}
+let arrayBuffer15 = buffer16.getMappedRange(0, 5728);
+try {
+commandEncoder87.copyTextureToBuffer({
+  texture: texture6,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 13972 */
+  offset: 13968,
+  rowsPerImage: 8,
+  buffer: buffer39,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer39);
+} catch {}
+try {
+commandEncoder145.clearBuffer(buffer31);
+dissociateBuffer(device0, buffer31);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer11, /* required buffer size: 841 */
+{offset: 841, bytesPerRow: 133}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline121 = device0.createComputePipeline({
+  label: '\uf4e3\u3110\u6ba2\u1a76\u1bd0\u{1fe66}\u9397\u0258\u{1f94e}',
+  layout: 'auto',
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+let bindGroupLayout45 = device3.createBindGroupLayout({
+  entries: [
+    {
+      binding: 3327,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16float', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 812,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder182 = device3.createCommandEncoder();
+let texture128 = device3.createTexture({
+  size: [515],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float'],
+});
+let renderBundleEncoder93 = device3.createRenderBundleEncoder({
+  label: '\ua565\u353f\u2d20\u0ba1\u6948\u64e5\u0f0f\u2571\u0c79',
+  colorFormats: ['rg16float', 'r32uint', 'rg16sint', 'r16uint', 'rgba16float'],
+});
+let renderBundle120 = renderBundleEncoder93.finish({label: '\u97d5\u5e2b\u063b\ub07d\u06da\u{1ff41}\ud8fb'});
+let sampler97 = device3.createSampler({
+  label: '\u3f13\ub1f7\uc1cf\u09ad\u2e80\u4632\u{1fa23}\u0ccf',
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 38.50,
+  lodMaxClamp: 97.37,
+  compare: 'less',
+  maxAnisotropy: 2,
+});
+try {
+buffer50.destroy();
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture114,
+  mipLevel: 1,
+  origin: {x: 55, y: 0, z: 38},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 8_789_292 */
+{offset: 900, bytesPerRow: 348, rowsPerImage: 138}, {width: 40, height: 0, depthOrArrayLayers: 184});
+} catch {}
+let videoFrame38 = new VideoFrame(imageBitmap7, {timestamp: 0});
+let bindGroup63 = device0.createBindGroup({
+  label: '\u0b9a\u7e51\u021f\u{1fa31}',
+  layout: bindGroupLayout28,
+  entries: [{binding: 593, resource: textureView66}],
+});
+let commandEncoder183 = device0.createCommandEncoder();
+let texture129 = device0.createTexture({
+  label: '\u03da\u7c7c\u2d62\u067d\u5371\u{1fc18}\u0e9b',
+  size: [1248, 1, 140],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint'],
+});
+let textureView223 = texture105.createView({
+  label: '\uacb5\u569c\uc53d\u5e68\uee95\uf7b3\u0af7\u{1f8fd}\u2af6\u{1fbfa}\u0e64',
+  dimension: '2d',
+  baseMipLevel: 5,
+  baseArrayLayer: 389,
+});
+let externalTexture93 = device0.importExternalTexture({label: '\u{1f8f2}\ufcf2\u7ee8', source: video25, colorSpace: 'display-p3'});
+try {
+device0.queue.writeTexture({
+  texture: texture102,
+  mipLevel: 10,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer9, /* required buffer size: 296 */
+{offset: 296}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: img17,
+  origin: { x: 11, y: 14 },
+  flipY: false,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let img35 = await imageWithData(223, 41, '#c9ab7755', '#9f626a89');
+let videoFrame39 = new VideoFrame(canvas12, {timestamp: 0});
+document.body.prepend(canvas11);
+let commandEncoder184 = device1.createCommandEncoder();
+let textureView224 = texture43.createView({aspect: 'all', format: 'bgra8unorm', mipLevelCount: 2, baseArrayLayer: 0});
+let sampler98 = device1.createSampler({
+  label: '\ua22f\u1a2c\u0785\ua30d\u{1fe43}\u0032\u0d0e\u1862\u{1f84c}\uc65c',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  lodMinClamp: 42.32,
+  lodMaxClamp: 87.37,
+});
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup20);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup23, new Uint32Array(5526), 1561, 0);
+} catch {}
+try {
+renderPassEncoder9.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder18.setBlendConstant({ r: 828.6, g: 620.5, b: 272.2, a: 595.4, });
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(37, 146);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(0, buffer33, 15384, 3223);
+} catch {}
+try {
+renderBundleEncoder68.setPipeline(pipeline53);
+} catch {}
+try {
+querySet25.destroy();
+} catch {}
+try {
+commandEncoder184.copyTextureToBuffer({
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 56, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1324 widthInBlocks: 331 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 9128 */
+  offset: 9128,
+  buffer: buffer29,
+}, {width: 331, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer29);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer5, 4876, new BigUint64Array(10865), 6870, 44);
+} catch {}
+let texture130 = device3.createTexture({
+  label: '\uf61d\u0332\u4e4a\u07c5',
+  size: {width: 75, height: 1, depthOrArrayLayers: 445},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8unorm'],
+});
+let texture131 = gpuCanvasContext10.getCurrentTexture();
+let renderBundleEncoder94 = device3.createRenderBundleEncoder({
+  label: '\u9bf6\u{1fa53}\u865e\u6c7d\u{1fb45}',
+  colorFormats: ['r32float', 'rgba8unorm'],
+  stencilReadOnly: true,
+});
+let renderBundle121 = renderBundleEncoder88.finish({label: '\u7c3d\u590e\u{1ff82}\u058a\u4f74\u{1f89f}\ub617\udf4b\u{1fe1b}'});
+try {
+commandEncoder171.copyTextureToTexture({
+  texture: texture117,
+  mipLevel: 0,
+  origin: {x: 180, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture126,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 117, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder171.resolveQuerySet(querySet81, 3849, 125, buffer50, 42496);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture124,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+}, new ArrayBuffer(16), /* required buffer size: 121_544 */
+{offset: 132, bytesPerRow: 85, rowsPerImage: 238}, {width: 4, height: 1, depthOrArrayLayers: 7});
+} catch {}
+let imageBitmap56 = await createImageBitmap(img30);
+let promise52 = navigator.gpu.requestAdapter({});
+let texture132 = device3.createTexture({
+  label: '\u{1fbcb}\ub9b0\u{1f7a4}\ucfd0\ud32b',
+  size: {width: 468, height: 32, depthOrArrayLayers: 173},
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let gpuCanvasContext27 = offscreenCanvas30.getContext('webgpu');
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55) };
+} catch {}
+let commandEncoder185 = device3.createCommandEncoder();
+let commandBuffer45 = commandEncoder182.finish({label: '\u2ef0\uc4fa\u03e4'});
+let textureView225 = texture126.createView({
+  label: '\u9992\ucced\u0073\u0278\ude6a\ucf08\u9368\u{1fb6a}\u06d7',
+  dimension: '1d',
+  format: 'r32uint',
+});
+let sampler99 = device3.createSampler({
+  label: '\u069f\u3245\u88a8\ua833\u0952\u4236\u06ba\u{1f8c5}\ue4dc\uf9fb',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 91.32,
+});
+try {
+renderBundleEncoder94.setVertexBuffer(1994, undefined);
+} catch {}
+try {
+device3.queue.submit([commandBuffer45]);
+} catch {}
+try {
+device3.destroy();
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let videoFrame40 = new VideoFrame(img5, {timestamp: 0});
+let canvas33 = document.createElement('canvas');
+try {
+window.someLabel = externalTexture81.label;
+} catch {}
+let commandEncoder186 = device2.createCommandEncoder({label: '\u1b77\ud88a\u00a4\uaa5d\u86d9\u0461\u6331\uc7a6\u6fd4\u{1ff8e}\u0302'});
+try {
+computePassEncoder16.setPipeline(pipeline26);
+} catch {}
+try {
+commandEncoder22.clearBuffer(buffer13, 26584, 22076);
+dissociateBuffer(device2, buffer13);
+} catch {}
+let gpuCanvasContext28 = canvas33.getContext('webgpu');
+let bindGroup64 = device0.createBindGroup({label: '\ub132\u0598\u1920\ua64f\u{1f895}\u0a34', layout: bindGroupLayout16, entries: []});
+let textureView226 = texture105.createView({baseMipLevel: 5, baseArrayLayer: 526, arrayLayerCount: 337});
+try {
+computePassEncoder60.setBindGroup(1, bindGroup59);
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline109);
+} catch {}
+try {
+renderBundleEncoder82.setBindGroup(3, bindGroup38, new Uint32Array(8871), 5470, 0);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer26, 18624);
+} catch {}
+try {
+renderBundleEncoder49.drawIndirect(buffer46, 2424);
+} catch {}
+try {
+renderBundleEncoder49.setPipeline(pipeline38);
+} catch {}
+try {
+commandEncoder157.copyTextureToBuffer({
+  texture: texture93,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 19},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 552 widthInBlocks: 276 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 348044 */
+  offset: 13412,
+  bytesPerRow: 768,
+  rowsPerImage: 5,
+  buffer: buffer36,
+}, {width: 276, height: 1, depthOrArrayLayers: 88});
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+commandEncoder85.resolveQuerySet(querySet60, 2264, 873, buffer45, 17408);
+} catch {}
+let promise53 = device0.queue.onSubmittedWorkDone();
+let video38 = await videoWithData();
+gc();
+let bindGroup65 = device0.createBindGroup({
+  label: '\u{1fc60}\uf5fe\u0c4b\u2a77\u8568\u{1fca5}',
+  layout: bindGroupLayout43,
+  entries: [{binding: 3446, resource: sampler81}],
+});
+let textureView227 = texture89.createView({
+  label: '\u{1fcb7}\u6e82\u24b6\u{1f768}\u09d2\u0ec7\u0338\u4be6\u{1fe9c}',
+  dimension: '2d-array',
+  format: 'bgra8unorm',
+  arrayLayerCount: 1,
+});
+try {
+renderBundleEncoder49.drawIndirect(buffer26, 5156);
+} catch {}
+try {
+commandEncoder107.copyBufferToBuffer(buffer47, 32600, buffer16, 215100, 8740);
+dissociateBuffer(device0, buffer47);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder138.copyTextureToTexture({
+  texture: texture6,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder152.clearBuffer(buffer39, 46308, 2688);
+dissociateBuffer(device0, buffer39);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let videoFrame41 = new VideoFrame(offscreenCanvas24, {timestamp: 0});
+gc();
+let commandBuffer46 = commandEncoder157.finish({label: '\u9246\u1f07\u{1fdb9}\u6f1e\u09b9\u8123\ud74e'});
+let sampler100 = device0.createSampler({
+  label: '\u8495\u172a\u{1fc55}\ufd1e\u{1fefd}\ua56a',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 3.148,
+  lodMaxClamp: 66.08,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder70.setBindGroup(1, bindGroup32);
+} catch {}
+try {
+computePassEncoder71.setBindGroup(0, bindGroup59, new Uint32Array(6395), 315, 0);
+} catch {}
+try {
+computePassEncoder73.setPipeline(pipeline105);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer46, 3016);
+} catch {}
+try {
+renderBundleEncoder49.drawIndirect(buffer46, 20024);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer44, 2072, new DataView(new ArrayBuffer(43267)), 16375, 1568);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 2,
+  origin: {x: 4, y: 0, z: 69},
+  aspect: 'all',
+}, new ArrayBuffer(3_324_761), /* required buffer size: 3_324_761 */
+{offset: 825, bytesPerRow: 71, rowsPerImage: 224}, {width: 5, height: 0, depthOrArrayLayers: 210});
+} catch {}
+let pipeline122 = device0.createRenderPipeline({
+  label: '\u{1f946}\u0318\u02ec',
+  layout: pipelineLayout8,
+  depthStencil: {
+    format: 'stencil8',
+    stencilFront: {compare: 'less', failOp: 'invert', depthFailOp: 'increment-wrap', passOp: 'invert'},
+    stencilBack: {compare: 'less-equal', failOp: 'decrement-wrap', passOp: 'keep'},
+    stencilReadMask: 510124010,
+    depthBiasClamp: 312.1388958486568,
+  },
+  vertex: {module: shaderModule4, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'ccw', unclippedDepth: true},
+});
+let offscreenCanvas31 = new OffscreenCanvas(253, 62);
+let commandEncoder187 = device0.createCommandEncoder({label: '\u85cb\u2b3d\u0ec1\u{1fe4a}\u{1fc76}\u{1f816}'});
+let querySet88 = device0.createQuerySet({
+  label: '\ub764\u{1fe02}\u0b74\u0837\u3ddf\u78cd\u{1f7c3}\uf4b2\uc0b3\u3f3a',
+  type: 'occlusion',
+  count: 2913,
+});
+let texture133 = device0.createTexture({
+  label: '\u1427\uc59c\u64e2\ua630\u02b3\u{1f7b4}\ub2e2\u8781\u076c',
+  size: {width: 624, height: 1, depthOrArrayLayers: 46},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba8unorm', 'rgba8unorm', 'rgba8unorm'],
+});
+let renderBundle122 = renderBundleEncoder17.finish({label: '\u{1f647}\u2a73\u0a92\u{1fee7}\u046a\u45aa\u25f9\u{1f809}'});
+let sampler101 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 41.15,
+  lodMaxClamp: 80.98,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder63.setBindGroup(6, bindGroup39, new Uint32Array(2153), 1423, 0);
+} catch {}
+try {
+renderBundleEncoder49.draw(55, 317, 392_707_951, 1_025_400_478);
+} catch {}
+try {
+pipeline46.label = '\u00b4\u5cce';
+} catch {}
+let shaderModule35 = device0.createShaderModule({
+  label: '\u{1fb91}\u{1f8c0}\u4f0e',
+  code: `@group(10) @binding(3066)
+var<storage, read_write> parameter15: array<u32>;
+@group(5) @binding(5631)
+var<storage, read_write> type14: array<u32>;
+@group(10) @binding(2915)
+var<storage, read_write> local25: array<u32>;
+@group(5) @binding(2105)
+var<storage, read_write> global13: array<u32>;
+@group(9) @binding(3562)
+var<storage, read_write> parameter16: array<u32>;
+@group(5) @binding(5146)
+var<storage, read_write> field13: array<u32>;
+@group(10) @binding(4687)
+var<storage, read_write> field14: array<u32>;
+@group(2) @binding(5146)
+var<storage, read_write> local26: array<u32>;
+
+@compute @workgroup_size(3, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(5) f1: vec2<i32>,
+  @location(2) f2: u32,
+  @location(1) f3: vec2<u32>,
+  @location(4) f4: vec2<i32>,
+  @location(3) f5: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(position) a1: vec4<f32>, @builtin(sample_index) a2: u32, @builtin(front_facing) a3: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S25 {
+  @location(7) f0: vec2<u32>,
+  @builtin(instance_index) f1: u32,
+  @location(13) f2: f16,
+  @location(6) f3: vec2<u32>,
+  @location(4) f4: vec4<i32>,
+  @location(18) f5: vec3<f16>,
+  @location(17) f6: f16,
+  @location(20) f7: vec2<f16>,
+  @location(3) f8: vec2<u32>,
+  @location(2) f9: vec4<f16>,
+  @location(12) f10: vec2<u32>,
+  @location(8) f11: vec3<u32>,
+  @builtin(vertex_index) f12: u32,
+  @location(10) f13: vec2<u32>,
+  @location(15) f14: vec4<i32>,
+  @location(1) f15: vec4<u32>,
+  @location(16) f16: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(0) a0: i32, a1: S25, @location(19) a2: vec4<u32>, @location(14) a3: f16, @location(5) a4: vec2<f32>, @location(9) a5: vec4<i32>, @location(11) a6: vec3<f16>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder188 = device0.createCommandEncoder({});
+let texture134 = device0.createTexture({
+  label: '\u{1fd9f}\u4247\uc245\u{1f74f}\u0aa7\ud38d\u0d1d\u010d',
+  size: {width: 120},
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+});
+let renderBundleEncoder95 = device0.createRenderBundleEncoder({
+  label: '\u0527\u{1fd84}\u53d4\u4d7a\u0f04',
+  colorFormats: ['r16float', 'rg8sint', 'r32uint', 'r16float', 'r16sint', 'rgb10a2unorm', 'rg16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture94 = device0.importExternalTexture({
+  label: '\u9f12\ue606\u2986\u2fc6\u0ea5\u5b42\u00c0\u0a5a\u{1fdad}\u3c48',
+  source: videoFrame28,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder49.draw(36, 8, 146_216_252);
+} catch {}
+try {
+commandEncoder144.copyBufferToTexture({
+  /* bytesInLastRow: 168 widthInBlocks: 42 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 11232 */
+  offset: 11232,
+  bytesPerRow: 256,
+  buffer: buffer21,
+}, {
+  texture: texture121,
+  mipLevel: 1,
+  origin: {x: 64, y: 18, z: 0},
+  aspect: 'all',
+}, {width: 42, height: 63, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer21);
+} catch {}
+try {
+commandEncoder57.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 3,
+  origin: {x: 3, y: 3, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 14, y: 14, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 3, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder148.resolveQuerySet(querySet31, 989, 963, buffer30, 140288);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer49, 2948, new DataView(new ArrayBuffer(5731)), 916, 620);
+} catch {}
+let pipeline123 = device0.createRenderPipeline({
+  label: '\u8ce6\uc830\u{1f695}\u52c5\u65b3\u9f5c\u0b77\u{1fa84}\u1bdb\u0093\u{1f80e}',
+  layout: 'auto',
+  multisample: {count: 4, mask: 0x10b115a4},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgb10a2uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba8uint'}, {format: 'r16uint'}, {
+  format: 'rgb10a2uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 21432,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 6044, shaderLocation: 2},
+          {format: 'sint16x4', offset: 6612, shaderLocation: 6},
+          {format: 'unorm8x2', offset: 2060, shaderLocation: 13},
+          {format: 'float16x2', offset: 1516, shaderLocation: 10},
+          {format: 'float32', offset: 1468, shaderLocation: 12},
+          {format: 'unorm8x2', offset: 144, shaderLocation: 11},
+          {format: 'uint32', offset: 3924, shaderLocation: 5},
+          {format: 'float16x2', offset: 4752, shaderLocation: 9},
+          {format: 'uint32x3', offset: 3096, shaderLocation: 4},
+          {format: 'float16x4', offset: 1340, shaderLocation: 8},
+          {format: 'uint32x4', offset: 1916, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 5514, shaderLocation: 14},
+          {format: 'snorm16x2', offset: 8212, shaderLocation: 20},
+          {format: 'uint32x3', offset: 664, shaderLocation: 16},
+          {format: 'uint32', offset: 1492, shaderLocation: 7},
+          {format: 'sint32x3', offset: 1016, shaderLocation: 17},
+        ],
+      },
+      {arrayStride: 29308, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 10076,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 124, shaderLocation: 3},
+          {format: 'uint16x4', offset: 3540, shaderLocation: 19},
+          {format: 'float32x4', offset: 1928, shaderLocation: 18},
+          {format: 'sint32x4', offset: 420, shaderLocation: 0},
+          {format: 'float32', offset: 92, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', unclippedDepth: true},
+});
+let offscreenCanvas32 = new OffscreenCanvas(943, 965);
+try {
+offscreenCanvas31.getContext('webgpu');
+} catch {}
+document.body.prepend(img35);
+let bindGroupLayout46 = device0.createBindGroupLayout({entries: []});
+let pipelineLayout24 = device0.createPipelineLayout({
+  label: '\u{1faba}\u{1f7ed}\u0b21\u07aa\ufc2e\u0b9e\uf2a5\u0d31\u0751',
+  bindGroupLayouts: [bindGroupLayout28, bindGroupLayout28, bindGroupLayout7, bindGroupLayout17, bindGroupLayout15],
+});
+let texture135 = device0.createTexture({
+  label: '\u6aa6\u8c2f\u266a',
+  size: [480, 240, 1],
+  mipLevelCount: 7,
+  dimension: '2d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView228 = texture110.createView({
+  label: '\u{1fd47}\u6182\ud7d6\u{1fa00}\u{1f719}\u0db1\uf42f\u{1f8d2}',
+  baseMipLevel: 1,
+  baseArrayLayer: 325,
+  arrayLayerCount: 67,
+});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup57);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(397, 36);
+} catch {}
+try {
+renderBundleEncoder50.setVertexBuffer(6726, undefined, 1890962869, 1858533132);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 4,
+  origin: {x: 4, y: 0, z: 1},
+  aspect: 'all',
+}, new BigInt64Array(new ArrayBuffer(64)), /* required buffer size: 39_500 */
+{offset: 791, bytesPerRow: 187, rowsPerImage: 23}, {width: 70, height: 0, depthOrArrayLayers: 10});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video18,
+  origin: { x: 2, y: 0 },
+  flipY: true,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise54 = device0.createComputePipelineAsync({
+  label: '\u24f3\u09a4',
+  layout: pipelineLayout22,
+  compute: {module: shaderModule19, entryPoint: 'compute0', constants: {}},
+});
+try {
+gpuCanvasContext23.unconfigure();
+} catch {}
+try {
+offscreenCanvas32.getContext('webgl2');
+} catch {}
+let offscreenCanvas33 = new OffscreenCanvas(311, 961);
+let imageBitmap57 = await createImageBitmap(offscreenCanvas8);
+try {
+offscreenCanvas33.getContext('webgl');
+} catch {}
+let texture136 = device0.createTexture({
+  label: '\u6a5f\u92f1\u3be7\ud713\u0f20\ub7ae\u79e3\ue4b5\u0f11\ubf84\u0465',
+  size: {width: 1248, height: 1, depthOrArrayLayers: 216},
+  mipLevelCount: 10,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16sint', 'r16sint'],
+});
+let computePassEncoder81 = commandEncoder144.beginComputePass({label: '\uf3a1\u03f3\u46cf\u{1f89d}'});
+try {
+renderBundleEncoder54.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(243);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer46, 564);
+} catch {}
+try {
+commandEncoder183.copyTextureToTexture({
+  texture: texture101,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas34 = new OffscreenCanvas(981, 799);
+let videoFrame42 = new VideoFrame(canvas16, {timestamp: 0});
+let videoFrame43 = new VideoFrame(videoFrame4, {timestamp: 0});
+let textureView229 = texture56.createView({label: '\u{1ffb5}\u0a5d\u04e1\ue558\uc49e\u{1fe3c}', baseMipLevel: 1});
+try {
+renderBundleEncoder49.draw(307, 229, 1_784_472_898, 442_249_138);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 240, height: 120, depthOrArrayLayers: 1261}
+*/
+{
+  source: video20,
+  origin: { x: 9, y: 2 },
+  flipY: false,
+}, {
+  texture: texture105,
+  mipLevel: 1,
+  origin: {x: 28, y: 24, z: 155},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let videoFrame44 = new VideoFrame(canvas23, {timestamp: 0});
+try {
+  await adapter8.requestAdapterInfo();
+} catch {}
+let gpuCanvasContext29 = offscreenCanvas34.getContext('webgpu');
+offscreenCanvas10.width = 237;
+let video39 = await videoWithData();
+let commandEncoder189 = device0.createCommandEncoder({label: '\ued5e\u3a76\u0375\uef41\u063f'});
+let querySet89 = device0.createQuerySet({type: 'occlusion', count: 589});
+let texture137 = device0.createTexture({
+  size: {width: 120},
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8uint', 'r8uint'],
+});
+let textureView230 = texture37.createView({
+  label: '\u0861\u2386\u5361\u{1fc01}\u{1f6e2}\u0bc6\u{1f9c9}',
+  baseMipLevel: 2,
+  baseArrayLayer: 85,
+  arrayLayerCount: 75,
+});
+let computePassEncoder82 = commandEncoder168.beginComputePass({label: '\uc48c\u7ba4\u{1fe09}\u03da\ub361\u75b5\u{1fa17}\ue76c\ucbd4\u{1fea3}'});
+let renderBundle123 = renderBundleEncoder71.finish({label: '\u{1fadf}\uce93\u{1f78a}\u{1fb75}'});
+let sampler102 = device0.createSampler({
+  label: '\u1c92\u1708\u{1ff8f}\ub919\uee39\u1a71\ubb0a\u09c6\u0d08\u{1fec7}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 14.17,
+  lodMaxClamp: 60.66,
+  compare: 'greater',
+  maxAnisotropy: 10,
+});
+try {
+computePassEncoder76.setPipeline(pipeline73);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer46, 2392);
+} catch {}
+try {
+renderBundleEncoder49.drawIndirect(buffer46, 5356);
+} catch {}
+try {
+commandEncoder82.copyTextureToBuffer({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 218 widthInBlocks: 109 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 12730 */
+  offset: 12730,
+  bytesPerRow: 256,
+  buffer: buffer45,
+}, {width: 109, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer45);
+} catch {}
+try {
+device0.queue.submit([commandBuffer36, commandBuffer46]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer45, 1332, new Int16Array(7517), 1164, 284);
+} catch {}
+let bindGroupLayout47 = device0.createBindGroupLayout({
+  label: '\u{1fa98}\u4951',
+  entries: [
+    {
+      binding: 3103,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba32sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {binding: 2934, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {
+      binding: 1865,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let commandBuffer47 = commandEncoder143.finish({label: '\uffaa\u945d\u{1f73f}\uad5d\uf7a4\u0518\ub6c3'});
+let texture138 = device0.createTexture({
+  label: '\u10af\u{1fdd0}\u{1faf7}\uc5c3\u361c',
+  size: {width: 960, height: 480, depthOrArrayLayers: 237},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView231 = texture59.createView({label: '\uf366\uf003\u761d\u0ae2\u0669\u063e\uef9f\u097f\u{1f7e3}', baseMipLevel: 4});
+let computePassEncoder83 = commandEncoder155.beginComputePass({label: '\u7428\u3c7f\ub551\u16ee\u0add\udaeb\u1c10\uc362\u{1fde8}\ue2be\u411c'});
+let sampler103 = device0.createSampler({
+  label: '\u{1f7c4}\ud013\u088c\ufcac\u27f7\u9d85\u{1f9f2}\u14be\u090a\u2800',
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 80.52,
+  lodMaxClamp: 86.92,
+});
+try {
+computePassEncoder13.setBindGroup(2, bindGroup60, new Uint32Array(3462), 1109, 0);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(175, 54, 471_005_730, 69_005_532);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer46, 48812);
+} catch {}
+try {
+buffer49.unmap();
+} catch {}
+try {
+commandEncoder150.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 41, y: 0, z: 7},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 2,
+  origin: {x: 23, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 33, height: 1, depthOrArrayLayers: 18});
+} catch {}
+try {
+commandEncoder138.resolveQuerySet(querySet73, 664, 1430, buffer45, 7168);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture59,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer3), /* required buffer size: 9_279_266 */
+{offset: 122, bytesPerRow: 513, rowsPerImage: 266}, {width: 110, height: 0, depthOrArrayLayers: 69});
+} catch {}
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+try {
+gpuCanvasContext24.unconfigure();
+} catch {}
+let videoFrame45 = new VideoFrame(offscreenCanvas14, {timestamp: 0});
+let bindGroupLayout48 = device0.createBindGroupLayout({
+  label: '\u065b\u12aa\u{1fc08}\uccf5\u6fd0',
+  entries: [
+    {
+      binding: 123,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: true },
+    },
+    {
+      binding: 3615,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup66 = device0.createBindGroup({
+  label: '\u{1f65f}\u056f\u{1f9aa}',
+  layout: bindGroupLayout20,
+  entries: [{binding: 1456, resource: sampler33}],
+});
+let commandEncoder190 = device0.createCommandEncoder({});
+let textureView232 = texture115.createView({label: '\uec90\u7453\u497e\u0205\u4936\u973f', baseMipLevel: 5, mipLevelCount: 1, arrayLayerCount: 1});
+let renderBundle124 = renderBundleEncoder75.finish({label: '\u{1fd52}\u0042\u081b\u1af7\u{1f932}\u25c8\u02a4'});
+try {
+renderBundleEncoder49.drawIndexed(185, 479, 311_692_369, -1_328_398_030);
+} catch {}
+try {
+renderBundleEncoder86.setPipeline(pipeline117);
+} catch {}
+let arrayBuffer16 = buffer47.getMappedRange(0, 8808);
+try {
+commandEncoder181.clearBuffer(buffer16);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData26,
+  origin: { x: 45, y: 2 },
+  flipY: true,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+canvas2.height = 2117;
+let img36 = await imageWithData(74, 183, '#de88cb79', '#cdfe0cf4');
+let imageBitmap58 = await createImageBitmap(imageBitmap24);
+let texture139 = device0.createTexture({
+  label: '\u0c64\ud49e\u0c56\uf7ef',
+  size: [1248, 1, 818],
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm'],
+});
+let textureView233 = texture121.createView({dimension: '2d-array', mipLevelCount: 1});
+let renderBundle125 = renderBundleEncoder50.finish();
+try {
+computePassEncoder64.setBindGroup(9, bindGroup24);
+} catch {}
+try {
+renderBundleEncoder92.setIndexBuffer(buffer44, 'uint32');
+} catch {}
+let shaderModule36 = device0.createShaderModule({
+  label: '\uf9bf\uc6a2\u{1feb0}\u0fa3\u71f4',
+  code: `@group(1) @binding(1456)
+var<storage, read_write> local27: array<u32>;
+@group(2) @binding(5002)
+var<storage, read_write> local28: array<u32>;
+@group(2) @binding(3465)
+var<storage, read_write> field15: array<u32>;
+
+@compute @workgroup_size(8, 1, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S26 {
+  @builtin(position) f0: vec4<f32>,
+  @builtin(front_facing) f1: bool
+}
+struct FragmentOutput0 {
+  @location(3) f0: vec2<f32>,
+  @location(5) f1: vec4<f32>,
+  @location(1) f2: vec2<i32>,
+  @location(6) f3: vec3<u32>,
+  @location(4) f4: vec2<i32>,
+  @location(2) f5: vec3<u32>,
+  @location(0) f6: vec4<f32>
+}
+
+@fragment
+fn fragment0(a0: S26, @builtin(sample_index) a1: u32, @builtin(sample_mask) a2: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(6) a0: vec4<u32>, @builtin(vertex_index) a1: u32, @location(16) a2: vec4<f16>, @location(13) a3: vec2<i32>, @location(12) a4: vec2<f16>, @location(19) a5: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder191 = device0.createCommandEncoder({label: '\u{1fc39}\u0a47\ubf62\u{1fbcf}\u{1fc0e}\u0a7c\u9d3e\u01eb\u{1f69d}\u071b'});
+let textureView234 = texture51.createView({label: '\u9505\u{1fab9}\u6685\u049d', mipLevelCount: 1});
+let renderBundleEncoder96 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8unorm-srgb', 'r8uint', 'r16uint', 'rgb10a2uint', 'r16sint'],
+  stencilReadOnly: true,
+});
+let sampler104 = device0.createSampler({
+  label: '\uf642\u0512\u{1f688}\u97ed\ubf46\u3f8f',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+});
+try {
+computePassEncoder57.setBindGroup(3, bindGroup35);
+} catch {}
+try {
+computePassEncoder67.setPipeline(pipeline67);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder176.resolveQuerySet(querySet37, 2433, 525, buffer30, 58624);
+} catch {}
+canvas31.width = 225;
+let bindGroup67 = device0.createBindGroup({
+  label: '\u0947\u7b63\u{1f9b8}\u0594\uc581\ubb3b\ud7f4\u{1fa80}\uc93e',
+  layout: bindGroupLayout43,
+  entries: [{binding: 3446, resource: sampler28}],
+});
+try {
+renderBundleEncoder82.setBindGroup(8, bindGroup45);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(565, 386, 1_450_587_989, 196_383_105);
+} catch {}
+try {
+renderBundleEncoder95.setIndexBuffer(buffer44, 'uint32');
+} catch {}
+try {
+renderBundleEncoder76.setVertexBuffer(9612, undefined, 0, 1765217828);
+} catch {}
+try {
+commandEncoder151.copyBufferToBuffer(buffer21, 25320, buffer49, 89468, 1552);
+dissociateBuffer(device0, buffer21);
+dissociateBuffer(device0, buffer49);
+} catch {}
+try {
+commandEncoder123.copyBufferToTexture({
+  /* bytesInLastRow: 466 widthInBlocks: 233 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 6946 */
+  offset: 6480,
+  buffer: buffer12,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 233, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer12);
+} catch {}
+try {
+commandEncoder99.clearBuffer(buffer39, 49164, 64);
+dissociateBuffer(device0, buffer39);
+} catch {}
+try {
+commandEncoder151.resolveQuerySet(querySet20, 185, 123, buffer45, 8192);
+} catch {}
+let pipeline124 = device0.createRenderPipeline({
+  layout: pipelineLayout12,
+  fragment: {
+  module: shaderModule17,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL}, {format: 'rgba8uint', writeMask: 0}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'always',
+    stencilFront: {compare: 'greater-equal', failOp: 'zero', depthFailOp: 'decrement-wrap', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'equal', passOp: 'invert'},
+    stencilReadMask: 1743315833,
+    stencilWriteMask: 3350390028,
+    depthBiasClamp: 641.6519634372199,
+  },
+  vertex: {
+    module: shaderModule17,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 840,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 128, shaderLocation: 19},
+          {format: 'snorm16x2', offset: 324, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 1268,
+        attributes: [
+          {format: 'sint32', offset: 56, shaderLocation: 10},
+          {format: 'sint32x4', offset: 324, shaderLocation: 5},
+          {format: 'sint16x2', offset: 56, shaderLocation: 13},
+          {format: 'float32', offset: 296, shaderLocation: 9},
+          {format: 'uint32x3', offset: 540, shaderLocation: 2},
+        ],
+      },
+      {
+        arrayStride: 2580,
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 300, shaderLocation: 1},
+          {format: 'float32x4', offset: 972, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 14532,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x4', offset: 4992, shaderLocation: 12}],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 10472,
+        attributes: [
+          {format: 'uint32x4', offset: 204, shaderLocation: 8},
+          {format: 'uint32x2', offset: 2812, shaderLocation: 3},
+          {format: 'sint16x2', offset: 3644, shaderLocation: 20},
+          {format: 'sint32x3', offset: 804, shaderLocation: 14},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let bindGroupLayout49 = device0.createBindGroupLayout({label: '\u0128\u9d1b\u{1f630}\u0ff9\uf518\ucdf3', entries: []});
+let pipelineLayout25 = device0.createPipelineLayout({label: '\u5594\u9219\u0801\u02e2', bindGroupLayouts: [bindGroupLayout38, bindGroupLayout10]});
+let renderBundle126 = renderBundleEncoder31.finish({});
+try {
+renderBundleEncoder49.drawIndexed(32, 21, 373_089_939, 63_955_211);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer46, 41404);
+} catch {}
+try {
+commandEncoder133.copyBufferToBuffer(buffer26, 24888, buffer16, 50596, 6892);
+dissociateBuffer(device0, buffer26);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 4844, new Float32Array(42905), 42799, 4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 1_308 */
+{offset: 65, bytesPerRow: 345}, {width: 104, height: 24, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 156, height: 1, depthOrArrayLayers: 25}
+*/
+{
+  source: video27,
+  origin: { x: 0, y: 2 },
+  flipY: false,
+}, {
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext22.unconfigure();
+} catch {}
+let imageData42 = new ImageData(36, 156);
+try {
+adapter4.label = '\ue8c3\u61dc\u19f0\u{1f6c3}\ua63b';
+} catch {}
+let img37 = await imageWithData(249, 216, '#57c824b4', '#1e58175f');
+let img38 = await imageWithData(20, 151, '#a8063e77', '#95b3c2da');
+try {
+window.someLabel = renderPassEncoder11.label;
+} catch {}
+video35.width = 36;
+let bindGroupLayout50 = device0.createBindGroupLayout({label: '\u21a9\u01ab\u8ac5', entries: []});
+let buffer52 = device0.createBuffer({
+  label: '\u9e5f\u2225\u{1f7f4}\u05ee\u492f\u0775\u1197\u01cb\u0949\udad8',
+  size: 168542,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE,
+});
+let computePassEncoder84 = commandEncoder154.beginComputePass({label: '\u0f98\u{1f61b}\u{1fd8d}\u{1fa9c}\u69e0\u4146\ub3f6\u2c92'});
+let renderBundle127 = renderBundleEncoder17.finish();
+let sampler105 = device0.createSampler({
+  label: '\u05fe\u02e8\u0204\ua8f9\u0c1c\uc646\u3377\u0e9c\u3c92\u040f\u0daf',
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 61.48,
+  lodMaxClamp: 99.73,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder73.setBindGroup(7, bindGroup29);
+} catch {}
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(16, 124, 3_733_138_602, 746_725_307, 1_271_286_031);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer46, 6384);
+} catch {}
+try {
+commandEncoder63.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 4,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture73,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 16},
+  aspect: 'all',
+},
+{width: 1, height: 3, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 3440, new Int16Array(25906), 15158, 1924);
+} catch {}
+offscreenCanvas0.width = 2408;
+gc();
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55) };
+} catch {}
+let video40 = await videoWithData();
+let shaderModule37 = device0.createShaderModule({
+  label: '\u1b3b\u{1f76d}\uf342\u03e5',
+  code: `@group(1) @binding(1456)
+var<storage, read_write> n16: array<u32>;
+@group(0) @binding(1456)
+var<storage, read_write> global14: array<u32>;
+
+@compute @workgroup_size(5, 4, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S28 {
+  @location(35) f0: vec4<f16>,
+  @location(3) f1: vec3<f16>,
+  @location(14) f2: vec4<f16>,
+  @builtin(position) f3: vec4<f32>,
+  @location(12) f4: vec3<f32>,
+  @location(0) f5: vec3<f16>,
+  @location(22) f6: vec3<f16>,
+  @location(25) f7: vec4<f32>,
+  @location(16) f8: f32
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec2<u32>,
+  @location(1) f1: vec4<u32>,
+  @location(3) f2: vec4<u32>,
+  @location(0) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(@location(4) a0: f16, @location(9) a1: vec3<u32>, @location(2) a2: f16, a3: S28, @location(29) a4: vec3<i32>, @builtin(sample_mask) a5: u32, @location(36) a6: vec3<f32>, @location(6) a7: vec3<i32>, @location(8) a8: u32, @location(19) a9: vec2<u32>, @location(10) a10: f16, @location(27) a11: vec2<f32>, @location(17) a12: vec3<u32>, @location(18) a13: vec4<i32>, @location(34) a14: f16, @location(24) a15: f32, @location(11) a16: vec2<f16>, @location(13) a17: vec4<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S27 {
+  @location(8) f0: vec4<f32>,
+  @location(16) f1: f32,
+  @builtin(instance_index) f2: u32,
+  @location(6) f3: vec3<u32>,
+  @location(7) f4: vec4<f32>,
+  @location(19) f5: vec3<i32>
+}
+struct VertexOutput0 {
+  @location(24) f189: f32,
+  @location(25) f190: vec4<f32>,
+  @location(10) f191: f16,
+  @location(8) f192: u32,
+  @location(2) f193: f16,
+  @location(36) f194: vec3<f32>,
+  @location(13) f195: vec4<i32>,
+  @location(16) f196: f32,
+  @location(22) f197: vec3<f16>,
+  @location(0) f198: vec3<f16>,
+  @location(19) f199: vec2<u32>,
+  @location(30) f200: vec4<f16>,
+  @location(27) f201: vec2<f32>,
+  @builtin(position) f202: vec4<f32>,
+  @location(34) f203: f16,
+  @location(3) f204: vec3<f16>,
+  @location(11) f205: vec2<f16>,
+  @location(28) f206: vec4<u32>,
+  @location(5) f207: vec4<i32>,
+  @location(6) f208: vec3<i32>,
+  @location(18) f209: vec4<i32>,
+  @location(4) f210: f16,
+  @location(14) f211: vec4<f16>,
+  @location(9) f212: vec3<u32>,
+  @location(12) f213: vec3<f32>,
+  @location(23) f214: vec3<f16>,
+  @location(17) f215: vec3<u32>,
+  @location(35) f216: vec4<f16>,
+  @location(29) f217: vec3<i32>
+}
+
+@vertex
+fn vertex0(@location(13) a0: vec4<i32>, @location(0) a1: vec2<f32>, @location(20) a2: vec3<u32>, @location(15) a3: vec2<u32>, @location(5) a4: f32, @location(3) a5: vec3<u32>, @location(18) a6: i32, @location(1) a7: vec2<u32>, @location(12) a8: vec3<u32>, @location(9) a9: vec4<f32>, @location(10) a10: f16, @location(11) a11: vec4<f16>, @location(4) a12: vec3<u32>, @location(2) a13: vec2<f32>, @location(14) a14: vec3<f16>, a15: S27, @location(17) a16: vec4<f16>, @builtin(vertex_index) a17: u32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet90 = device0.createQuerySet({
+  label: '\u0ec5\u{1f6e2}\u3eaa\u88ca\u{1f814}\u031f\u{1f74e}\ua273\u006c\u375a',
+  type: 'occlusion',
+  count: 2940,
+});
+let textureView235 = texture49.createView({label: '\u0823\u{1fe52}\u0647\ude96\ucc34', mipLevelCount: 1});
+let computePassEncoder85 = commandEncoder63.beginComputePass({label: '\uae60\u4b3b\u1ff1'});
+try {
+renderBundleEncoder76.setBindGroup(9, bindGroup61, new Uint32Array(6851), 3541, 0);
+} catch {}
+try {
+renderBundleEncoder49.draw(62, 170, 819_589_257, 324_017_239);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(49, 425, 1_089_530_382);
+} catch {}
+try {
+buffer36.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 156, height: 1, depthOrArrayLayers: 25}
+*/
+{
+  source: video5,
+  origin: { x: 4, y: 0 },
+  flipY: true,
+}, {
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData43 = new ImageData(136, 12);
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let buffer53 = device1.createBuffer({
+  label: '\u1d51\u3c90\u06ff\u0197\u0480\u{1f737}\u{1f64b}\u8c37',
+  size: 57720,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let commandEncoder192 = device1.createCommandEncoder({});
+let textureView236 = texture19.createView({label: '\uf4b1\u0991\u{1f746}\u{1fe4a}\u{1fea5}\u0072\u6e0b\u{1fd5c}\u23ae', dimension: '1d'});
+let renderPassEncoder30 = commandEncoder192.beginRenderPass({
+  label: '\u011c\u4edb\ud85a\ub3fb\uc84c\u{1ffb2}\uddb4\u0303\u0b19\u0c79\u{1fbc5}',
+  colorAttachments: [{
+  view: textureView68,
+  depthSlice: 1605,
+  clearValue: { r: 751.4, g: -738.6, b: -792.8, a: 291.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 680540945,
+});
+try {
+renderPassEncoder14.setStencilReference(4051);
+} catch {}
+try {
+renderPassEncoder26.draw(327, 184, 361_637_926, 232_667_928);
+} catch {}
+try {
+renderBundleEncoder27.draw(526, 117, 732_260_116, 651_293_027);
+} catch {}
+try {
+renderBundleEncoder27.drawIndexedIndirect(buffer33, 640);
+} catch {}
+try {
+renderBundleEncoder27.drawIndirect(buffer35, 27696);
+} catch {}
+try {
+renderBundleEncoder27.setVertexBuffer(1, buffer27, 0, 7066);
+} catch {}
+let pipeline125 = device1.createComputePipeline({
+  label: '\u1b51\u{1fcfb}\u{1ff67}\u369a\u{1fb39}\u0693\u0f33\u48bd\u0178\u{1fb8c}',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule6, entryPoint: 'compute0', constants: {}},
+});
+let bindGroupLayout51 = device0.createBindGroupLayout({
+  label: '\u0f26\u04b2\u2da6\u2af4\u036d\u08de',
+  entries: [
+    {
+      binding: 2189,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 68, visibility: GPUShaderStage.COMPUTE, sampler: { type: 'non-filtering' }},
+    {
+      binding: 3807,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let bindGroup68 = device0.createBindGroup({
+  label: '\u{1ff3d}\uf06b\u{1fa2d}\u0e40\ub8aa\u{1f9b4}\u{1fdb0}\u{1f7d3}\u{1f835}\u{1fbd0}',
+  layout: bindGroupLayout37,
+  entries: [{binding: 4644, resource: {buffer: buffer0, offset: 41856, size: 7292}}],
+});
+let texture140 = device0.createTexture({
+  label: '\udd3a\u{1f9ba}\ub7e4\u09ee',
+  size: [156, 1, 1706],
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint'],
+});
+let textureView237 = texture8.createView({baseMipLevel: 4, mipLevelCount: 1});
+let computePassEncoder86 = commandEncoder121.beginComputePass({label: '\u6ddf\u6b19\ud25a\u0125\u8af8\u7819\u{1fa11}\u0f97'});
+let renderBundleEncoder97 = device0.createRenderBundleEncoder({
+  label: '\u0949\u{1fbd4}\u{1fc47}\u047c',
+  colorFormats: ['r16float', 'rg8sint', 'r32uint', 'r16float', 'r16sint', 'rgb10a2unorm', 'rg16uint'],
+  depthReadOnly: true,
+});
+let externalTexture95 = device0.importExternalTexture({label: '\u0b69\u{1fa05}', source: videoFrame27, colorSpace: 'srgb'});
+try {
+renderBundleEncoder85.setBindGroup(7, bindGroup47, new Uint32Array(159), 13, 0);
+} catch {}
+try {
+renderBundleEncoder61.setIndexBuffer(buffer26, 'uint16', 22756, 687);
+} catch {}
+try {
+texture78.destroy();
+} catch {}
+try {
+commandEncoder189.copyBufferToBuffer(buffer17, 17892, buffer6, 4692, 44424);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder103.clearBuffer(buffer41, 3108, 1848);
+dissociateBuffer(device0, buffer41);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture116,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 786},
+  aspect: 'all',
+}, new ArrayBuffer(40), /* required buffer size: 15_467_023 */
+{offset: 397, bytesPerRow: 1186, rowsPerImage: 63}, {width: 267, height: 0, depthOrArrayLayers: 208});
+} catch {}
+let pipeline126 = device0.createRenderPipeline({
+  label: '\ua6ad\u06c5\u0d24\u{1fe16}\u{1fee3}\u82c5',
+  layout: pipelineLayout10,
+  fragment: {
+  module: shaderModule18,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r16uint', writeMask: GPUColorWrite.BLUE}, {format: 'rgb10a2uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'greater', failOp: 'invert', depthFailOp: 'replace', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'less', failOp: 'zero', depthFailOp: 'invert', passOp: 'replace'},
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule18,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x3', offset: 10484, shaderLocation: 5},
+          {format: 'sint32', offset: 7148, shaderLocation: 8},
+          {format: 'uint32x2', offset: 1416, shaderLocation: 19},
+          {format: 'unorm8x2', offset: 9464, shaderLocation: 17},
+          {format: 'float16x4', offset: 4060, shaderLocation: 7},
+          {format: 'sint32', offset: 11040, shaderLocation: 13},
+          {format: 'float32x3', offset: 2356, shaderLocation: 9},
+          {format: 'uint16x2', offset: 11668, shaderLocation: 0},
+          {format: 'float32', offset: 19644, shaderLocation: 1},
+          {format: 'sint32x3', offset: 9344, shaderLocation: 14},
+          {format: 'sint32', offset: 8656, shaderLocation: 20},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', cullMode: 'front', unclippedDepth: true},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let offscreenCanvas35 = new OffscreenCanvas(397, 92);
+let imageData44 = new ImageData(136, 112);
+let buffer54 = device0.createBuffer({label: '\u097b\u23e6\u8c92\u0fc8\u0117', size: 475416, usage: GPUBufferUsage.UNIFORM});
+let textureView238 = texture65.createView({label: '\uced8\u6c43\u6629', format: 'bgra8unorm'});
+let renderBundleEncoder98 = device0.createRenderBundleEncoder({
+  label: '\ua335\ue08f\u6e02\u918a\ufbd6\ud5d3\u7503\u700e',
+  colorFormats: ['rgba8unorm-srgb', 'r8uint', 'r16uint', 'rgb10a2uint', 'r16sint'],
+});
+try {
+computePassEncoder49.setBindGroup(3, bindGroup21, new Uint32Array(7440), 5201, 0);
+} catch {}
+try {
+computePassEncoder85.end();
+} catch {}
+try {
+computePassEncoder83.setPipeline(pipeline40);
+} catch {}
+try {
+renderBundleEncoder49.draw(307, 12, 230_303_117, 436_848_529);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer46, 12000);
+} catch {}
+try {
+commandEncoder191.copyBufferToBuffer(buffer21, 21036, buffer16, 21276, 11788);
+dissociateBuffer(device0, buffer21);
+dissociateBuffer(device0, buffer16);
+} catch {}
+try {
+commandEncoder188.copyBufferToTexture({
+  /* bytesInLastRow: 1144 widthInBlocks: 286 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 9548 */
+  offset: 8404,
+  buffer: buffer21,
+}, {
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 286, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer21);
+} catch {}
+try {
+commandEncoder2.copyTextureToBuffer({
+  texture: texture29,
+  mipLevel: 3,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 30 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 65178 */
+  offset: 2940,
+  bytesPerRow: 256,
+  rowsPerImage: 241,
+  buffer: buffer36,
+}, {width: 15, height: 3, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+commandEncoder162.insertDebugMarker('\u{1fe73}');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 156, height: 1, depthOrArrayLayers: 25}
+*/
+{
+  source: video13,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline127 = device0.createRenderPipeline({
+  label: '\ucb12\ub267\u097f\u65ed\u9cef\u097b\u154f\u3809\u4bc9',
+  layout: pipelineLayout19,
+  multisample: {mask: 0xc841a7ad},
+  fragment: {
+  module: shaderModule26,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r16float'}, {format: 'rg8sint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'r32uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'r16float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+}, {format: 'r16sint', writeMask: GPUColorWrite.ALPHA}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg16uint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule26,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 14736,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x2', offset: 7056, shaderLocation: 6},
+          {format: 'float32x3', offset: 1216, shaderLocation: 9},
+          {format: 'uint8x2', offset: 108, shaderLocation: 19},
+          {format: 'unorm10-10-10-2', offset: 112, shaderLocation: 16},
+          {format: 'float32x3', offset: 908, shaderLocation: 12},
+          {format: 'uint32', offset: 660, shaderLocation: 18},
+          {format: 'sint32x4', offset: 4248, shaderLocation: 0},
+          {format: 'sint32', offset: 10644, shaderLocation: 3},
+          {format: 'float32x3', offset: 6172, shaderLocation: 17},
+          {format: 'sint8x4', offset: 140, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 13480, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 48, shaderLocation: 4},
+          {format: 'float32x4', offset: 2784, shaderLocation: 7},
+          {format: 'uint32x2', offset: 1200, shaderLocation: 14},
+          {format: 'sint32x2', offset: 21016, shaderLocation: 5},
+          {format: 'float16x4', offset: 10168, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 16308, attributes: [{format: 'sint32x4', offset: 208, shaderLocation: 20}]},
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', unclippedDepth: true},
+});
+try {
+offscreenCanvas35.getContext('2d');
+} catch {}
+try {
+window.someLabel = commandEncoder77.label;
+} catch {}
+offscreenCanvas0.height = 56;
+let bindGroup69 = device0.createBindGroup({
+  label: '\uea39\u{1fbf0}\u{1fca5}\u5341\uba0c\u448e\u0672\u6ad1',
+  layout: bindGroupLayout13,
+  entries: [],
+});
+let pipelineLayout26 = device0.createPipelineLayout({bindGroupLayouts: []});
+let renderBundle128 = renderBundleEncoder29.finish();
+try {
+renderBundleEncoder49.drawIndirect(buffer26, 8376);
+} catch {}
+try {
+renderBundleEncoder96.setIndexBuffer(buffer11, 'uint32', 9120);
+} catch {}
+try {
+renderBundleEncoder54.setPipeline(pipeline38);
+} catch {}
+try {
+commandEncoder107.copyTextureToBuffer({
+  texture: texture137,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 46 widthInBlocks: 46 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 3994 */
+  offset: 3994,
+  buffer: buffer6,
+}, {width: 46, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder158.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 218, y: 0, z: 5},
+  aspect: 'all',
+},
+{
+  texture: texture57,
+  mipLevel: 0,
+  origin: {x: 31, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 103, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture107,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 14},
+  aspect: 'all',
+}, new ArrayBuffer(8), /* required buffer size: 18_240_179 */
+{offset: 843, bytesPerRow: 874, rowsPerImage: 188}, {width: 176, height: 1, depthOrArrayLayers: 112});
+} catch {}
+let pipeline128 = device0.createRenderPipeline({
+  layout: pipelineLayout12,
+  multisample: {},
+  fragment: {
+  module: shaderModule13,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgb10a2uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {
+  format: 'rgba8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {
+  format: 'rgb10a2uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule13,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 30768,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 1236, shaderLocation: 13},
+          {format: 'snorm16x2', offset: 2792, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 5288,
+        attributes: [
+          {format: 'sint32x2', offset: 492, shaderLocation: 19},
+          {format: 'uint32x3', offset: 436, shaderLocation: 2},
+          {format: 'unorm8x2', offset: 974, shaderLocation: 1},
+          {format: 'unorm8x2', offset: 1708, shaderLocation: 15},
+          {format: 'float32', offset: 1072, shaderLocation: 6},
+          {format: 'sint8x4', offset: 1968, shaderLocation: 16},
+          {format: 'uint32x2', offset: 1248, shaderLocation: 5},
+        ],
+      },
+      {arrayStride: 6152, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 792,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32', offset: 8, shaderLocation: 7}],
+      },
+      {
+        arrayStride: 624,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x4', offset: 20, shaderLocation: 11},
+          {format: 'unorm8x4', offset: 40, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 280, shaderLocation: 20},
+        ],
+      },
+      {arrayStride: 972, attributes: []},
+      {
+        arrayStride: 4812,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x4', offset: 388, shaderLocation: 10}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', cullMode: 'back', unclippedDepth: true},
+});
+try {
+  await promise53;
+} catch {}
+let img39 = await imageWithData(258, 283, '#cec47e48', '#b36baf43');
+try {
+  await adapter4.requestAdapterInfo();
+} catch {}
+let bindGroupLayout52 = device3.createBindGroupLayout({
+  label: '\u{1fd0c}\u178c\u02f6',
+  entries: [
+    {
+      binding: 4214,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let buffer55 = device3.createBuffer({
+  label: '\ue7ad\u{1f672}\u24a3\uf098\u2f84\uad34',
+  size: 152388,
+  usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: true,
+});
+let textureView239 = texture128.createView({label: '\u{1f626}\u{1f7a1}\u{1fef8}\u07d3\u{1f7dd}'});
+let renderBundle129 = renderBundleEncoder93.finish({});
+let externalTexture96 = device3.importExternalTexture({source: video29, colorSpace: 'srgb'});
+try {
+commandEncoder185.resolveQuerySet(querySet77, 265, 420, buffer51, 67840);
+} catch {}
+video27.width = 38;
+gc();
+try {
+window.someLabel = querySet68.label;
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+computePassEncoder69.end();
+} catch {}
+try {
+renderBundleEncoder49.draw(405);
+} catch {}
+try {
+device0.queue.submit([commandBuffer38]);
+} catch {}
+canvas4.width = 806;
+gc();
+let bindGroupLayout53 = device0.createBindGroupLayout({entries: []});
+let commandEncoder193 = device0.createCommandEncoder({label: '\u2276\udbe5\u{1fd85}'});
+let sampler106 = device0.createSampler({
+  label: '\u04d1\u03d6\uc384\u55b2\u3b8a\u{1f698}\u22cb\ud7ff\u339d\u04a6\ua971',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 76.42,
+  lodMaxClamp: 87.81,
+  maxAnisotropy: 3,
+});
+try {
+renderBundleEncoder54.drawIndirect(buffer52, 14464);
+} catch {}
+try {
+querySet80.destroy();
+} catch {}
+let arrayBuffer17 = buffer16.getMappedRange(5728, 2008);
+try {
+  await buffer49.mapAsync(GPUMapMode.READ, 27480, 59760);
+} catch {}
+try {
+commandEncoder120.copyTextureToTexture({
+  texture: texture10,
+  mipLevel: 1,
+  origin: {x: 96, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 36, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder179.clearBuffer(buffer45, 11608, 36864);
+dissociateBuffer(device0, buffer45);
+} catch {}
+try {
+device0.queue.submit([commandBuffer32]);
+} catch {}
+let pipeline129 = await device0.createComputePipelineAsync({
+  label: '\u5c72\ue680\ua078\u{1f893}\u2cc4\u{1fd76}\u2306\u7501',
+  layout: pipelineLayout26,
+  compute: {module: shaderModule31, entryPoint: 'compute0', constants: {}},
+});
+let pipeline130 = device0.createRenderPipeline({
+  label: '\u095d\u0ffb\ua008\u731b\uaebd\u86aa\ub415\ued01',
+  layout: pipelineLayout23,
+  fragment: {
+  module: shaderModule15,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgb10a2uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rgba8uint'}, {format: 'r16uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgb10a2uint'}],
+},
+  vertex: {
+    module: shaderModule15,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 16768,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 732, shaderLocation: 18},
+          {format: 'uint32', offset: 384, shaderLocation: 9},
+          {format: 'sint32x2', offset: 11488, shaderLocation: 5},
+          {format: 'float32', offset: 256, shaderLocation: 8},
+          {format: 'unorm8x4', offset: 104, shaderLocation: 15},
+          {format: 'unorm16x4', offset: 616, shaderLocation: 2},
+          {format: 'float32x4', offset: 164, shaderLocation: 7},
+          {format: 'uint8x2', offset: 5546, shaderLocation: 0},
+          {format: 'sint32', offset: 796, shaderLocation: 11},
+          {format: 'uint32', offset: 3500, shaderLocation: 20},
+          {format: 'float32', offset: 600, shaderLocation: 12},
+          {format: 'float32x2', offset: 184, shaderLocation: 6},
+        ],
+      },
+      {
+        arrayStride: 1204,
+        attributes: [
+          {format: 'uint16x4', offset: 380, shaderLocation: 19},
+          {format: 'uint32x2', offset: 260, shaderLocation: 4},
+          {format: 'snorm16x2', offset: 0, shaderLocation: 1},
+          {format: 'sint32', offset: 292, shaderLocation: 16},
+          {format: 'unorm8x2', offset: 112, shaderLocation: 3},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', unclippedDepth: true},
+});
+let img40 = await imageWithData(229, 82, '#9e49ddb6', '#e89acc56');
+document.body.prepend(canvas20);
+let textureView240 = texture69.createView({label: '\uf26a\u07fa\u00e3\u1690'});
+let computePassEncoder87 = commandEncoder120.beginComputePass({label: '\u4011\u0911\uecf1\u{1fe1f}\u0dbb\udeac'});
+let sampler107 = device0.createSampler({
+  label: '\uf40b\u04f7\ua8d7\ucca5',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 82.76,
+  lodMaxClamp: 93.33,
+  maxAnisotropy: 16,
+});
+try {
+renderBundleEncoder95.setBindGroup(10, bindGroup66);
+} catch {}
+try {
+renderBundleEncoder85.setPipeline(pipeline130);
+} catch {}
+try {
+commandEncoder183.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5616 */
+  offset: 5616,
+  bytesPerRow: 0,
+  rowsPerImage: 224,
+  buffer: buffer21,
+}, {
+  texture: texture106,
+  mipLevel: 9,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer21);
+} catch {}
+try {
+commandEncoder145.resolveQuerySet(querySet80, 433, 1034, buffer52, 154368);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer41, 1212, new DataView(new ArrayBuffer(10381)), 3615, 4128);
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+video35.height = 278;
+let buffer56 = device0.createBuffer({label: '\u001b\u197c', size: 5292, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let textureView241 = texture96.createView({label: '\u01be\u{1f881}\u960c'});
+let renderBundleEncoder99 = device0.createRenderBundleEncoder({
+  label: '\u0ee5\u{1fba7}\u0f14\u34bc\u{1fc23}',
+  colorFormats: ['r16float', 'rg8sint', 'r32uint', 'r16float', 'r16sint', 'rgb10a2unorm', 'rg16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder99.setBindGroup(5, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder49.draw(214, 550, 1_629_073_749, 151_368_342);
+} catch {}
+try {
+renderBundleEncoder54.drawIndexedIndirect(buffer52, 16796);
+} catch {}
+try {
+texture89.destroy();
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(querySet42, 166, 9, buffer56, 2048);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 156, height: 1, depthOrArrayLayers: 25}
+*/
+{
+  source: canvas6,
+  origin: { x: 30, y: 17 },
+  flipY: true,
+}, {
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer14.detached) { new Uint8Array(arrayBuffer14).fill(0x55) };
+} catch {}
+let adapter9 = await navigator.gpu.requestAdapter({});
+let canvas34 = document.createElement('canvas');
+let commandEncoder194 = device0.createCommandEncoder({label: '\udcf0\u0720\ue313\u51bd\u6265\ua172\u{1f8ac}\ufc7e\u86e7'});
+try {
+commandEncoder172.copyBufferToBuffer(buffer38, 19356, buffer26, 20552, 9736);
+dissociateBuffer(device0, buffer38);
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+commandEncoder147.copyTextureToTexture({
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 120, height: 60, depthOrArrayLayers: 1261}
+*/
+{
+  source: canvas14,
+  origin: { x: 151, y: 13 },
+  flipY: true,
+}, {
+  texture: texture105,
+  mipLevel: 2,
+  origin: {x: 0, y: 9, z: 505},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 27, height: 16, depthOrArrayLayers: 0});
+} catch {}
+let gpuCanvasContext30 = canvas34.getContext('webgpu');
+let img41 = await imageWithData(35, 21, '#c55c50e6', '#736d25dc');
+let shaderModule38 = device0.createShaderModule({
+  label: '\u0371\ue06f\ud2bb\uf839\u{1f8f5}\u65a4',
+  code: `@group(4) @binding(1456)
+var<storage, read_write> parameter17: array<u32>;
+@group(1) @binding(1456)
+var<storage, read_write> local29: array<u32>;
+@group(2) @binding(1456)
+var<storage, read_write> type15: array<u32>;
+
+@compute @workgroup_size(7, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S29 {
+  @builtin(sample_index) f0: u32,
+  @location(29) f1: vec2<i32>,
+  @location(24) f2: vec4<u32>,
+  @location(22) f3: f16,
+  @location(14) f4: vec3<f16>,
+  @location(26) f5: vec4<i32>,
+  @location(18) f6: f32,
+  @location(11) f7: vec4<i32>,
+  @location(2) f8: vec4<i32>,
+  @location(4) f9: vec3<i32>,
+  @location(17) f10: vec3<i32>,
+  @location(28) f11: vec4<i32>,
+  @location(12) f12: vec4<f32>,
+  @location(33) f13: vec4<f16>,
+  @location(5) f14: vec2<f16>,
+  @location(9) f15: vec2<f16>,
+  @builtin(position) f16: vec4<f32>,
+  @location(6) f17: f32,
+  @location(20) f18: f16,
+  @builtin(sample_mask) f19: u32,
+  @location(21) f20: u32,
+  @location(16) f21: vec2<u32>
+}
+struct FragmentOutput0 {
+  @location(2) f0: u32,
+  @location(4) f1: vec2<i32>,
+  @location(6) f2: vec4<u32>,
+  @location(5) f3: vec4<f32>,
+  @location(0) f4: vec3<f32>,
+  @location(3) f5: f32,
+  @location(1) f6: vec3<i32>
+}
+
+@fragment
+fn fragment0(@location(36) a0: vec4<u32>, a1: S29, @location(35) a2: vec3<f16>, @location(7) a3: vec2<f16>, @builtin(front_facing) a4: bool, @location(0) a5: vec2<i32>, @location(30) a6: vec4<f16>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f218: vec4<f32>,
+  @location(35) f219: vec3<f16>,
+  @location(30) f220: vec4<f16>,
+  @location(6) f221: f32,
+  @location(36) f222: vec4<u32>,
+  @location(7) f223: vec2<f16>,
+  @location(8) f224: f32,
+  @location(20) f225: f16,
+  @location(9) f226: vec2<f16>,
+  @location(22) f227: f16,
+  @location(21) f228: u32,
+  @location(26) f229: vec4<i32>,
+  @location(14) f230: vec3<f16>,
+  @location(18) f231: f32,
+  @location(25) f232: i32,
+  @location(15) f233: vec3<u32>,
+  @location(4) f234: vec3<i32>,
+  @location(28) f235: vec4<i32>,
+  @location(0) f236: vec2<i32>,
+  @location(10) f237: i32,
+  @location(12) f238: vec4<f32>,
+  @location(29) f239: vec2<i32>,
+  @location(11) f240: vec4<i32>,
+  @location(5) f241: vec2<f16>,
+  @location(17) f242: vec3<i32>,
+  @location(19) f243: vec4<f16>,
+  @location(24) f244: vec4<u32>,
+  @location(16) f245: vec2<u32>,
+  @location(2) f246: vec4<i32>,
+  @location(33) f247: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(3) a0: f32, @location(16) a1: vec3<u32>, @location(13) a2: vec4<f32>, @location(15) a3: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout54 = pipeline101.getBindGroupLayout(3);
+let texture141 = gpuCanvasContext1.getCurrentTexture();
+let externalTexture97 = device0.importExternalTexture({label: '\u0dbf\u88c9\u5496', source: video35, colorSpace: 'srgb'});
+try {
+renderBundleEncoder48.setBindGroup(5, bindGroup65, []);
+} catch {}
+try {
+renderBundleEncoder91.setBindGroup(2, bindGroup45, new Uint32Array(7843), 3391, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 156, height: 1, depthOrArrayLayers: 25}
+*/
+{
+  source: canvas15,
+  origin: { x: 103, y: 14 },
+  flipY: true,
+}, {
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 13},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 19, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let canvas35 = document.createElement('canvas');
+let bindGroupLayout55 = device0.createBindGroupLayout({
+  label: '\u8cd9\ud6b1\uab30\uabc5',
+  entries: [
+    {
+      binding: 3020,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let commandEncoder195 = device0.createCommandEncoder();
+let commandBuffer48 = commandEncoder105.finish({label: '\u13ff\u9013\u1fc7\ub028\u5fff\u2c88\u{1fb49}\uc61e\u0b78\u{1fdec}\u0e6c'});
+let texture142 = device0.createTexture({
+  size: [960, 480, 1370],
+  mipLevelCount: 4,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView242 = texture135.createView({label: '\u03ec\ud9d2\u{1f794}\u90cf\u0b21\uef8e\u0213\u0ba1\u4aaf', baseMipLevel: 5, mipLevelCount: 1});
+let computePassEncoder88 = commandEncoder190.beginComputePass({label: '\u0085\u5f04\uf47b\u4b8d\u9588\ucedd\ud240\u0f39\u88ca'});
+try {
+computePassEncoder80.end();
+} catch {}
+let gpuCanvasContext31 = canvas35.getContext('webgpu');
+video20.height = 12;
+try {
+gpuCanvasContext9.unconfigure();
+} catch {}
+video39.height = 288;
+let querySet91 = device3.createQuerySet({label: '\u{1fd6a}\u655d\ub7d6', type: 'occlusion', count: 4080});
+let textureView243 = texture130.createView({label: '\u49cb\ued8a\udd4b\u0225\u9e4a', baseMipLevel: 1});
+let computePassEncoder89 = commandEncoder185.beginComputePass();
+try {
+commandEncoder171.copyTextureToTexture({
+  texture: texture130,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 107},
+  aspect: 'all',
+},
+{
+  texture: texture109,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder171.resolveQuerySet(querySet77, 347, 269, buffer51, 436736);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture114,
+  mipLevel: 0,
+  origin: {x: 165, y: 0, z: 10},
+  aspect: 'all',
+}, new Uint8ClampedArray(arrayBuffer16), /* required buffer size: 1_399_558 */
+{offset: 94, bytesPerRow: 372, rowsPerImage: 19}, {width: 30, height: 0, depthOrArrayLayers: 199});
+} catch {}
+try {
+if (!arrayBuffer16.detached) { new Uint8Array(arrayBuffer16).fill(0x55) };
+} catch {}
+let imageData45 = new ImageData(48, 248);
+let bindGroupLayout56 = device0.createBindGroupLayout({entries: []});
+let renderBundle130 = renderBundleEncoder61.finish();
+let externalTexture98 = device0.importExternalTexture({
+  label: '\ud655\u0b64\u6c5e\ud789\u0d33\ubed2\u7544\udbd1\u0f90\ufc85',
+  source: video21,
+  colorSpace: 'srgb',
+});
+try {
+renderBundleEncoder49.drawIndexed(380, 86, 894_858_960, 70_291_841, 919_503_970);
+} catch {}
+try {
+renderBundleEncoder49.drawIndirect(buffer52, 31328);
+} catch {}
+try {
+renderBundleEncoder97.setPipeline(pipeline117);
+} catch {}
+try {
+commandEncoder138.copyBufferToBuffer(buffer17, 16424, buffer6, 12132, 10968);
+dissociateBuffer(device0, buffer17);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder110.copyTextureToTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 187, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 2, y: 2, z: 0},
+  aspect: 'all',
+},
+{width: 65, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let offscreenCanvas36 = new OffscreenCanvas(295, 193);
+let videoFrame46 = new VideoFrame(video19, {timestamp: 0});
+try {
+if (!arrayBuffer8.detached) { new Uint8Array(arrayBuffer8).fill(0x55) };
+} catch {}
+canvas15.height = 658;
+try {
+offscreenCanvas36.getContext('2d');
+} catch {}
+let imageBitmap59 = await createImageBitmap(canvas17);
+let videoFrame47 = new VideoFrame(videoFrame46, {timestamp: 0});
+let renderBundleEncoder100 = device0.createRenderBundleEncoder({
+  colorFormats: ['r16float', 'rg8sint', 'r32uint', 'r16float', 'r16sint', 'rgb10a2unorm', 'rg16uint'],
+  stencilReadOnly: true,
+});
+let externalTexture99 = device0.importExternalTexture({label: '\u86ea\u4573\u0c2f\u0a91\ud2c0\uef11', source: video17});
+try {
+computePassEncoder74.setPipeline(pipeline112);
+} catch {}
+try {
+commandEncoder173.copyTextureToTexture({
+  texture: texture134,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 2, y: 5, z: 0},
+  aspect: 'all',
+}, arrayBuffer11, /* required buffer size: 490 */
+{offset: 490, bytesPerRow: 362}, {width: 109, height: 33, depthOrArrayLayers: 0});
+} catch {}
+let pipeline131 = device0.createComputePipeline({layout: pipelineLayout7, compute: {module: shaderModule18, entryPoint: 'compute0', constants: {}}});
+canvas7.width = 389;
+let img42 = await imageWithData(17, 288, '#8679a4f7', '#4c18906d');
+let imageBitmap60 = await createImageBitmap(videoFrame20);
+let videoFrame48 = new VideoFrame(video38, {timestamp: 0});
+let adapter10 = await promise52;
+let imageBitmap61 = await createImageBitmap(canvas35);
+let buffer57 = device0.createBuffer({
+  label: '\u{1fba2}\u1e81\ufea1\u{1f6f2}\u5545',
+  size: 574922,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE,
+});
+let externalTexture100 = device0.importExternalTexture({label: '\u0606\u4a9c\u0b23\u9d71\u0019\u0ac5\u61cc', source: video27});
+try {
+renderBundleEncoder54.drawIndexed(218, 126, 776_771_806, 1_350_036_210);
+} catch {}
+try {
+renderBundleEncoder54.drawIndexedIndirect(buffer52, 5288);
+} catch {}
+let adapter11 = await navigator.gpu.requestAdapter();
+let imageBitmap62 = await createImageBitmap(canvas35);
+let bindGroupLayout57 = device0.createBindGroupLayout({
+  label: '\u{1fc54}\u4f32',
+  entries: [
+    {
+      binding: 1145,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 3365,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 291,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 157997089, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandBuffer49 = commandEncoder128.finish({label: '\u0854\u{1f720}'});
+let renderBundleEncoder101 = device0.createRenderBundleEncoder({
+  label: '\u{1fac9}\u062d\u9f89\u8ad4\u{1f77e}\u{1f6c4}\ud74d',
+  colorFormats: ['r16float', 'rg8sint', 'r32uint', 'r16float', 'r16sint', 'rgb10a2unorm', 'rg16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture101 = device0.importExternalTexture({label: '\ued53\u04d9\ubeb9\u{1f90b}\u6555\u0361', source: videoFrame31, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder54.draw(78, 23);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(236, 480, 93_829_064, 2_076_169_797, 1_485_391_444);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+commandEncoder138.copyBufferToBuffer(buffer12, 6424, buffer31, 8724, 864);
+dissociateBuffer(device0, buffer12);
+dissociateBuffer(device0, buffer31);
+} catch {}
+try {
+commandEncoder162.copyTextureToBuffer({
+  texture: texture10,
+  mipLevel: 2,
+  origin: {x: 71, y: 0, z: 5},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 112 widthInBlocks: 28 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 448440 */
+  offset: 18248,
+  bytesPerRow: 256,
+  rowsPerImage: 42,
+  buffer: buffer57,
+}, {width: 28, height: 1, depthOrArrayLayers: 41});
+dissociateBuffer(device0, buffer57);
+} catch {}
+try {
+commandEncoder85.copyTextureToTexture({
+  texture: texture140,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 24},
+  aspect: 'all',
+},
+{
+  texture: texture138,
+  mipLevel: 1,
+  origin: {x: 81, y: 45, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 117});
+} catch {}
+try {
+commandEncoder187.clearBuffer(buffer26, 18144, 4196);
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm'],
+  colorSpace: 'srgb',
+});
+} catch {}
+let pipeline132 = await promise54;
+let video41 = await videoWithData();
+let imageBitmap63 = await createImageBitmap(canvas11);
+let buffer58 = device0.createBuffer({
+  label: '\u0873\ud10c\u0682\ue294\u90b6\u0494',
+  size: 48212,
+  usage: GPUBufferUsage.COPY_DST,
+  mappedAtCreation: true,
+});
+let commandEncoder196 = device0.createCommandEncoder({});
+let querySet92 = device0.createQuerySet({label: '\u434e\u15d4\u{1f9d7}\uc1bb\ua528\uaef7\u7ee5\u0a74', type: 'occlusion', count: 2328});
+let externalTexture102 = device0.importExternalTexture({
+  label: '\u{1fda6}\u0f2a\ue8c7\u{1f6eb}\ucb72\u{1fb8c}\u3b6b\u{1f65d}\uab32',
+  source: videoFrame33,
+  colorSpace: 'srgb',
+});
+try {
+computePassEncoder49.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline46);
+} catch {}
+try {
+renderBundleEncoder54.draw(476, 131, 1_624_952_828);
+} catch {}
+try {
+renderBundleEncoder54.drawIndexed(180, 129, 811_318_362);
+} catch {}
+try {
+renderBundleEncoder54.drawIndexedIndirect(buffer26, 696);
+} catch {}
+try {
+commandEncoder145.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 15904 */
+  offset: 15904,
+  buffer: buffer26,
+}, {
+  texture: texture102,
+  mipLevel: 4,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer26);
+} catch {}
+let promise55 = device0.queue.onSubmittedWorkDone();
+let pipeline133 = await promise24;
+let imageBitmap64 = await createImageBitmap(offscreenCanvas11);
+try {
+if (!arrayBuffer12.detached) { new Uint8Array(arrayBuffer12).fill(0x55) };
+} catch {}
+let querySet93 = device0.createQuerySet({label: '\u87dc\u{1fef5}\u069b\ucf5d', type: 'occlusion', count: 1331});
+let texture143 = device0.createTexture({
+  label: '\u{1fadb}\u{1fa1c}\u05d7',
+  size: {width: 480, height: 240, depthOrArrayLayers: 118},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rg16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg16uint'],
+});
+let sampler108 = device0.createSampler({
+  label: '\u6656\u0fb6\u09b7\u{1f910}\u1ac4\u4087\u1957',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 19.29,
+  lodMaxClamp: 60.51,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder68.setPipeline(pipeline77);
+} catch {}
+try {
+renderBundleEncoder54.draw(90);
+} catch {}
+try {
+renderBundleEncoder54.drawIndirect(buffer26, 3896);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(4916, undefined, 0, 3179485918);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+commandEncoder139.copyTextureToTexture({
+  texture: texture113,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 41},
+  aspect: 'all',
+},
+{
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 122, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 97, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder151.clearBuffer(buffer45, 10300, 15416);
+dissociateBuffer(device0, buffer45);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer41, 188, new DataView(new ArrayBuffer(61642)), 48601, 1136);
+} catch {}
+let promise56 = device0.queue.onSubmittedWorkDone();
+let offscreenCanvas37 = new OffscreenCanvas(361, 3);
+let video42 = await videoWithData();
+let videoFrame49 = new VideoFrame(imageBitmap48, {timestamp: 0});
+let commandEncoder197 = device0.createCommandEncoder({label: '\u174d\ub0d7\u0154\u{1fcb7}\u2758\u0ee1\u{1f81a}'});
+let commandBuffer50 = commandEncoder110.finish();
+let textureView244 = texture136.createView({
+  label: '\u175b\u1de5\ud34b\u7468\u00b5\u0e05\ub56f\u7b73\u0489\u027f\ue6bb',
+  baseMipLevel: 6,
+  mipLevelCount: 1,
+});
+try {
+computePassEncoder67.setPipeline(pipeline46);
+} catch {}
+try {
+renderBundleEncoder49.draw(6, 37);
+} catch {}
+try {
+commandEncoder177.clearBuffer(buffer49, 67792, 24932);
+dissociateBuffer(device0, buffer49);
+} catch {}
+try {
+  await promise56;
+} catch {}
+gc();
+document.body.prepend(img16);
+try {
+  await adapter10.requestAdapterInfo();
+} catch {}
+try {
+offscreenCanvas37.getContext('webgl');
+} catch {}
+let imageBitmap65 = await createImageBitmap(videoFrame44);
+let renderBundle131 = renderBundleEncoder79.finish({label: '\u8c62\u{1f7a6}\u1ffd\ud2c9\ua946\u0db2\u2087\u7987\u10ea'});
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer46, 1652);
+} catch {}
+try {
+renderBundleEncoder54.drawIndirect(buffer52, 9932);
+} catch {}
+try {
+renderBundleEncoder96.setVertexBuffer(1600, undefined, 0, 3357355286);
+} catch {}
+try {
+commandEncoder114.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 1,
+  origin: {x: 32, y: 39, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture60,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 42, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder149.clearBuffer(buffer22, 4572, 11204);
+dissociateBuffer(device0, buffer22);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture102,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer8, /* required buffer size: 719 */
+{offset: 719, rowsPerImage: 188}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise55;
+} catch {}
+document.body.prepend(canvas28);
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+let bindGroup70 = device0.createBindGroup({layout: bindGroupLayout11, entries: [{binding: 3074, resource: externalTexture91}]});
+let buffer59 = device0.createBuffer({size: 242998, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView245 = texture139.createView({label: '\uddec\u2034\ue0b3\u023b', format: 'rgba8unorm', mipLevelCount: 5});
+try {
+renderBundleEncoder83.setPipeline(pipeline82);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer57, 44492, new Float32Array(31001), 4620, 2044);
+} catch {}
+let offscreenCanvas38 = new OffscreenCanvas(834, 414);
+let img43 = await imageWithData(194, 89, '#ba4869fc', '#91e8b6fd');
+let imageBitmap66 = await createImageBitmap(video8);
+let imageData46 = new ImageData(4, 156);
+let gpuCanvasContext32 = offscreenCanvas38.getContext('webgpu');
+canvas28.height = 244;
+let shaderModule39 = device0.createShaderModule({
+  label: '\uad5e\u{1ffe8}',
+  code: `@group(1) @binding(1456)
+var<storage, read_write> type16: array<u32>;
+@group(2) @binding(5002)
+var<storage, read_write> parameter18: array<u32>;
+@group(2) @binding(4645)
+var<storage, read_write> parameter19: array<u32>;
+
+@compute @workgroup_size(3, 2, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(3) f0: vec4<f32>,
+  @location(4) f1: vec3<i32>,
+  @location(1) f2: vec2<i32>,
+  @builtin(sample_mask) f3: u32,
+  @location(2) f4: vec3<u32>,
+  @location(0) f5: vec2<f32>,
+  @location(5) f6: vec4<f32>,
+  @location(6) f7: vec3<u32>
+}
+
+@fragment
+fn fragment0(@location(2) a0: vec2<u32>, @location(19) a1: vec3<i32>, @location(28) a2: vec3<u32>, @location(15) a3: vec3<i32>, @location(0) a4: vec2<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S30 {
+  @location(4) f0: vec4<i32>,
+  @location(18) f1: vec3<u32>,
+  @location(20) f2: vec2<f32>,
+  @location(19) f3: i32,
+  @location(9) f4: f16,
+  @location(8) f5: f16,
+  @location(3) f6: vec3<f16>,
+  @location(5) f7: vec2<u32>,
+  @location(2) f8: vec4<u32>,
+  @location(17) f9: vec3<i32>,
+  @location(0) f10: vec3<f16>,
+  @location(14) f11: vec3<f32>
+}
+struct VertexOutput0 {
+  @location(6) f248: vec4<i32>,
+  @location(23) f249: vec4<u32>,
+  @location(35) f250: vec3<i32>,
+  @location(29) f251: vec4<i32>,
+  @location(31) f252: vec2<f32>,
+  @location(18) f253: f16,
+  @location(5) f254: vec3<f16>,
+  @location(17) f255: u32,
+  @location(2) f256: vec2<u32>,
+  @location(36) f257: vec3<f32>,
+  @location(22) f258: vec4<f16>,
+  @location(15) f259: vec3<i32>,
+  @location(14) f260: vec4<i32>,
+  @builtin(position) f261: vec4<f32>,
+  @location(4) f262: vec4<u32>,
+  @location(0) f263: vec2<u32>,
+  @location(19) f264: vec3<i32>,
+  @location(28) f265: vec3<u32>,
+  @location(11) f266: vec4<u32>,
+  @location(34) f267: vec2<u32>,
+  @location(20) f268: vec4<f16>,
+  @location(33) f269: vec2<f16>,
+  @location(7) f270: vec2<f32>,
+  @location(27) f271: vec2<i32>
+}
+
+@vertex
+fn vertex0(@location(15) a0: vec3<f32>, @location(1) a1: i32, @builtin(instance_index) a2: u32, @location(16) a3: f32, @builtin(vertex_index) a4: u32, @location(7) a5: f32, a6: S30, @location(12) a7: i32, @location(11) a8: vec4<u32>, @location(10) a9: vec4<u32>, @location(13) a10: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let texture144 = device0.createTexture({
+  label: '\u79f6\u070e\ua54b\u70df\u{1fdbf}\u0f6b\u6537',
+  size: {width: 480},
+  dimension: '1d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder90 = commandEncoder177.beginComputePass();
+let renderBundle132 = renderBundleEncoder2.finish({label: '\u{1fec8}\u570b\u6028\uc509\u9121\ud43f\u3ee1\u0f1f\u92c8\u{1fa2c}'});
+try {
+renderBundleEncoder49.drawIndexedIndirect(buffer26, 19900);
+} catch {}
+try {
+commandEncoder150.copyBufferToTexture({
+  /* bytesInLastRow: 4024 widthInBlocks: 503 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 16712 */
+  offset: 16712,
+  buffer: buffer21,
+}, {
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 503, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer21);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(48), /* required buffer size: 213 */
+{offset: 213}, {width: 29, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise57 = device0.createComputePipelineAsync({
+  label: '\u063f\u2ef7\u{1fcf5}\u{1f6d2}\u171b\u{1f90f}\u0544',
+  layout: 'auto',
+  compute: {module: shaderModule26, entryPoint: 'compute0', constants: {}},
+});
+let canvas36 = document.createElement('canvas');
+let canvas37 = document.createElement('canvas');
+try {
+canvas36.getContext('webgl');
+} catch {}
+let bindGroup71 = device0.createBindGroup({
+  label: '\u06ba\u0403\u7242\ud7b0\u{1fbae}\u263b\u06eb\ud834\u4951\u{1fc9a}',
+  layout: bindGroupLayout41,
+  entries: [],
+});
+let buffer60 = device0.createBuffer({
+  label: '\u{1f9ce}\uf01f\ud0b5\u1d80\u{1f66e}\u0f21\u6358\ud579\u52db',
+  size: 57684,
+  usage: GPUBufferUsage.COPY_SRC,
+  mappedAtCreation: true,
+});
+let commandEncoder198 = device0.createCommandEncoder({label: '\u9370\u1875'});
+let textureView246 = texture106.createView({
+  label: '\u{1fa9a}\u0670\u862a\u{1f759}\u401f\u28a2\u240f\u8be8',
+  dimension: '3d',
+  baseMipLevel: 2,
+  mipLevelCount: 8,
+});
+try {
+computePassEncoder40.setPipeline(pipeline50);
+} catch {}
+try {
+renderBundleEncoder54.drawIndexed(114, 158);
+} catch {}
+try {
+renderBundleEncoder54.drawIndirect(buffer26, 656);
+} catch {}
+try {
+renderBundleEncoder60.setVertexBuffer(2517, undefined, 2422395596, 50289141);
+} catch {}
+try {
+commandEncoder133.resolveQuerySet(querySet58, 545, 152, buffer30, 336640);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 12252, new BigUint64Array(26177), 2972, 384);
+} catch {}
+let promise58 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext33 = canvas37.getContext('webgpu');
+document.body.prepend(img3);
+let img44 = await imageWithData(81, 140, '#cd28f917', '#7aa3f583');
+let promise59 = adapter0.requestAdapterInfo();
+let commandEncoder199 = device0.createCommandEncoder({label: '\u01c1\ub098\u0f2a\udb4e\u559f\uf87e'});
+let textureView247 = texture123.createView({dimension: '2d-array', aspect: 'all'});
+let renderBundleEncoder102 = device0.createRenderBundleEncoder({
+  label: '\u0340\u0e46\u0c0e\u6f8b\u0ac2\ufae5',
+  colorFormats: ['rgb10a2uint', 'rgba8uint', 'r16uint', 'rgb10a2uint'],
+});
+try {
+computePassEncoder49.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder54.setBindGroup(4, bindGroup33);
+} catch {}
+try {
+renderBundleEncoder49.draw(99, 347, 2_002_660_517, 1_362_114_201);
+} catch {}
+try {
+renderBundleEncoder54.drawIndexed(124);
+} catch {}
+try {
+renderBundleEncoder54.drawIndexedIndirect(buffer46, 1876);
+} catch {}
+try {
+renderBundleEncoder54.drawIndirect(buffer26, 220);
+} catch {}
+try {
+renderBundleEncoder92.setPipeline(pipeline82);
+} catch {}
+try {
+renderBundleEncoder86.setVertexBuffer(5864, undefined, 0, 1751505777);
+} catch {}
+try {
+commandEncoder179.copyTextureToBuffer({
+  texture: texture115,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2228 */
+  offset: 2228,
+  rowsPerImage: 288,
+  buffer: buffer36,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+commandEncoder172.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 4, y: 19, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 4,
+  origin: {x: 3, y: 0, z: 4},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas4,
+  origin: { x: 15, y: 54 },
+  flipY: false,
+}, {
+  texture: texture65,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame50 = new VideoFrame(videoFrame23, {timestamp: 0});
+let pipelineLayout27 = device0.createPipelineLayout({
+  label: '\u0e83\u3690\u099e\u050e\u44ac\ufc95',
+  bindGroupLayouts: [bindGroupLayout41, bindGroupLayout13, bindGroupLayout54, bindGroupLayout36, bindGroupLayout21, bindGroupLayout27, bindGroupLayout53, bindGroupLayout28],
+});
+let commandEncoder200 = device0.createCommandEncoder({label: '\u{1fbe8}\u{1fc88}\u060d\u03f6\u56c5\u7b65\u1e43'});
+let textureView248 = texture144.createView({});
+let renderBundle133 = renderBundleEncoder69.finish();
+let externalTexture103 = device0.importExternalTexture({label: '\uef01\u{1f9dc}\u0a0a\u{1ff6d}', source: video17, colorSpace: 'display-p3'});
+try {
+computePassEncoder76.setBindGroup(5, bindGroup61);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(101);
+} catch {}
+try {
+renderBundleEncoder54.drawIndexedIndirect(buffer26, 956);
+} catch {}
+try {
+renderBundleEncoder49.drawIndirect(buffer52, 35184);
+} catch {}
+try {
+renderBundleEncoder76.setIndexBuffer(buffer26, 'uint16', 19396, 2694);
+} catch {}
+try {
+buffer57.unmap();
+} catch {}
+try {
+commandEncoder82.clearBuffer(buffer41, 6848, 164);
+dissociateBuffer(device0, buffer41);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 156, height: 1, depthOrArrayLayers: 25}
+*/
+{
+  source: video42,
+  origin: { x: 0, y: 4 },
+  flipY: false,
+}, {
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder90.label = '\u2b5c\ud781\u0dc7\u5b5a\ud8a8\u0db6\ua172\u2d43\u0540\u6c90';
+} catch {}
+let bindGroup72 = device0.createBindGroup({layout: bindGroupLayout16, entries: []});
+let texture145 = device0.createTexture({
+  label: '\u0ae6\u{1ff27}\uf462\ue9fb\u0fb5\ud23e\u9d60\u497e\u2a1a\u1cc7\ua5ef',
+  size: [480, 240, 118],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r32uint'],
+});
+let sampler109 = device0.createSampler({
+  label: '\u{1ffbf}\u0775\u{1f924}\u2c21\u2e8e\u37c3\u04f5\u0983',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 71.36,
+  lodMaxClamp: 88.60,
+});
+try {
+renderBundleEncoder54.draw(90, 242, 425_374_638);
+} catch {}
+try {
+  await buffer12.mapAsync(GPUMapMode.WRITE, 1832, 1236);
+} catch {}
+try {
+commandEncoder51.clearBuffer(buffer45, 18280, 14800);
+dissociateBuffer(device0, buffer45);
+} catch {}
+let promise60 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext32.unconfigure();
+} catch {}
+document.body.prepend(video17);
+offscreenCanvas11.height = 406;
+let canvas38 = document.createElement('canvas');
+let bindGroup73 = device0.createBindGroup({label: '\u{1fe84}\u0cb2\u0024\ud4fb', layout: bindGroupLayout54, entries: []});
+let commandEncoder201 = device0.createCommandEncoder({});
+let textureView249 = texture58.createView({label: '\u85f6\u0054\u0c3b\u3c97\ucfd4\u{1f651}', aspect: 'all'});
+let renderBundle134 = renderBundleEncoder85.finish({label: '\u{1fc1d}\u4914\u62f0\u0088\u{1f8a4}\u{1fd12}\u{1fb9e}\u1119\u{1f9a4}'});
+try {
+renderBundleEncoder84.setBindGroup(6, bindGroup39);
+} catch {}
+try {
+commandEncoder179.copyBufferToBuffer(buffer15, 37600, buffer58, 1224, 37884);
+dissociateBuffer(device0, buffer15);
+dissociateBuffer(device0, buffer58);
+} catch {}
+try {
+commandEncoder63.copyBufferToTexture({
+  /* bytesInLastRow: 236 widthInBlocks: 59 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 28476 */
+  offset: 28476,
+  bytesPerRow: 256,
+  buffer: buffer26,
+}, {
+  texture: texture138,
+  mipLevel: 0,
+  origin: {x: 122, y: 20, z: 43},
+  aspect: 'all',
+}, {width: 59, height: 353, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer26);
+} catch {}
+try {
+commandEncoder176.copyTextureToBuffer({
+  texture: texture50,
+  mipLevel: 2,
+  origin: {x: 14, y: 0, z: 73},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 36 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 90484 */
+  offset: 15440,
+  bytesPerRow: 256,
+  rowsPerImage: 20,
+  buffer: buffer36,
+}, {width: 9, height: 14, depthOrArrayLayers: 15});
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture116,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 9_176_006 */
+{offset: 294, bytesPerRow: 959, rowsPerImage: 208}, {width: 197, height: 0, depthOrArrayLayers: 47});
+} catch {}
+let gpuCanvasContext34 = canvas38.getContext('webgpu');
+document.body.prepend(img35);
+let offscreenCanvas39 = new OffscreenCanvas(105, 386);
+try {
+adapter9.label = '\u{1fe99}\ude96\ucbc8\u7c15';
+} catch {}
+let commandBuffer51 = commandEncoder100.finish({});
+let renderBundleEncoder103 = device2.createRenderBundleEncoder({
+  label: '\u{1fd02}\u00bc\u3827\u{1fb50}\u{1ff62}',
+  colorFormats: ['rgb10a2uint', 'rgba8sint', 'bgra8unorm-srgb', 'rg16sint', 'r8unorm'],
+});
+let renderBundle135 = renderBundleEncoder103.finish();
+let sampler110 = device2.createSampler({
+  label: '\u1328\ub571\ucb3f\u9cd2\u0abc\u{1fa6b}\u0804\u6a9e\u89e7\u0a6a\u{1facc}',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 51.50,
+  lodMaxClamp: 85.32,
+});
+try {
+renderBundleEncoder25.setVertexBuffer(3, buffer43);
+} catch {}
+try {
+computePassEncoder16.popDebugGroup();
+} catch {}
+try {
+  await promise59;
+} catch {}
+let imageData47 = new ImageData(196, 228);
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let arrayBuffer18 = buffer15.getMappedRange(86000, 12292);
+try {
+device0.queue.submit([commandBuffer50, commandBuffer48]);
+} catch {}
+let img45 = await imageWithData(4, 101, '#2a1fe499', '#359d027b');
+let video43 = await videoWithData();
+try {
+renderBundleEncoder28.label = '\u0630\u09c3\u1637\ucdaa\u06b3';
+} catch {}
+document.body.prepend(img31);
+try {
+if (!arrayBuffer7.detached) { new Uint8Array(arrayBuffer7).fill(0x55) };
+} catch {}
+document.body.prepend(img16);
+let gpuCanvasContext35 = offscreenCanvas39.getContext('webgpu');
+try {
+  await promise58;
+} catch {}
+let imageBitmap67 = await createImageBitmap(imageBitmap50);
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+canvas22.width = 161;
+let videoFrame51 = new VideoFrame(videoFrame18, {timestamp: 0});
+let commandEncoder202 = device0.createCommandEncoder({label: '\u6ff9\u{1fe71}\udfaa\u0fcd'});
+let renderBundle136 = renderBundleEncoder82.finish({label: '\uc695\u{1f914}'});
+try {
+computePassEncoder70.setBindGroup(1, bindGroup42, []);
+} catch {}
+try {
+renderBundleEncoder86.setBindGroup(3, bindGroup57, new Uint32Array(8478), 7264, 0);
+} catch {}
+try {
+renderBundleEncoder54.draw(53, 58, 291_078_595);
+} catch {}
+try {
+renderBundleEncoder54.drawIndexed(354);
+} catch {}
+try {
+renderBundleEncoder92.setVertexBuffer(8026, undefined);
+} catch {}
+try {
+commandEncoder162.clearBuffer(buffer58);
+dissociateBuffer(device0, buffer58);
+} catch {}
+document.body.prepend(img6);
+video12.width = 106;
+try {
+  await promise60;
+} catch {}
+let commandEncoder203 = device0.createCommandEncoder();
+let computePassEncoder91 = commandEncoder202.beginComputePass({});
+let sampler111 = device0.createSampler({
+  label: '\u{1f91a}\uf63e\u45ab',
+  addressModeV: 'clamp-to-edge',
+  minFilter: 'nearest',
+  lodMinClamp: 90.97,
+  lodMaxClamp: 98.65,
+});
+try {
+computePassEncoder11.setPipeline(pipeline71);
+} catch {}
+try {
+renderBundleEncoder54.draw(14);
+} catch {}
+try {
+renderBundleEncoder96.setVertexBuffer(8908, undefined, 2808955858, 1372782568);
+} catch {}
+let arrayBuffer19 = buffer38.getMappedRange(0, 17624);
+try {
+commandEncoder133.copyTextureToTexture({
+  texture: texture134,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture105,
+  mipLevel: 2,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 92, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let promise61 = device0.createComputePipelineAsync({
+  label: '\u04f9\u{1fe70}\ubdd7\u20ae\u0b8d\u12f8\u{1fdfe}\u49d1\u{1f6b8}\u{1ff3e}\u9219',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule18, entryPoint: 'compute0'},
+});
+let imageBitmap68 = await createImageBitmap(video6);
+let bindGroupLayout58 = device1.createBindGroupLayout({entries: []});
+let bindGroup74 = device1.createBindGroup({
+  label: '\ua666\ud2b3\u3b6e\u{1f886}\u07cf\ub69d\u{1fe50}\u01fa\ucfbf\u7cc0',
+  layout: bindGroupLayout34,
+  entries: [],
+});
+let renderPassEncoder31 = commandEncoder184.beginRenderPass({
+  label: '\uc445\u9fbc',
+  colorAttachments: [{
+  view: textureView145,
+  clearValue: { r: 564.4, g: 889.6, b: -714.4, a: 257.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet5,
+  maxDrawCount: 339752087,
+});
+let renderBundle137 = renderBundleEncoder7.finish({label: '\u9167\u599c\u{1f907}\ufce4\u0709\u{1fea5}\u{1f608}'});
+try {
+computePassEncoder23.setBindGroup(1, bindGroup12, new Uint32Array(92), 58, 0);
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline61);
+} catch {}
+try {
+renderPassEncoder19.draw(75, 122, 222_196_232);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline53);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(1, buffer27, 12672, 6252);
+} catch {}
+try {
+renderBundleEncoder56.setBindGroup(0, bindGroup4, new Uint32Array(9364), 3282, 0);
+} catch {}
+try {
+renderBundleEncoder27.drawIndirect(buffer53, 27460);
+} catch {}
+try {
+renderBundleEncoder68.setVertexBuffer(1, buffer27, 0, 26206);
+} catch {}
+let pipeline134 = device1.createRenderPipeline({
+  label: '\u{1fb35}\u012d\uabde',
+  layout: pipelineLayout11,
+  multisample: {mask: 0x7c3d3626},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'bgra8unorm',
+  blend: {
+    color: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'src'},
+    alpha: {operation: 'subtract', srcFactor: 'src-alpha', dstFactor: 'src-alpha'},
+  },
+  writeMask: GPUColorWrite.BLUE,
+}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'vertex',
+        attributes: [{format: 'float16x4', offset: 60, shaderLocation: 2}],
+      },
+    ],
+  },
+});
+let img46 = await imageWithData(202, 248, '#c26e8c3f', '#e91860a0');
+let videoFrame52 = new VideoFrame(offscreenCanvas7, {timestamp: 0});
+let textureView250 = texture61.createView({label: '\u0a79\uca76\u0993\u38eb\u{1fea5}'});
+let renderBundleEncoder104 = device0.createRenderBundleEncoder({
+  label: '\u{1ffa7}\u{1fea3}\u6d72\u83d0',
+  colorFormats: ['rgba8unorm-srgb', 'r8uint', 'r16uint', 'rgb10a2uint', 'r16sint'],
+  depthReadOnly: true,
+});
+let sampler112 = device0.createSampler({
+  label: '\u303d\u9d6b\ufc69\u{1ff20}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 39.74,
+  lodMaxClamp: 98.08,
+  compare: 'less-equal',
+});
+try {
+renderBundleEncoder95.setBindGroup(0, bindGroup47);
+} catch {}
+try {
+renderBundleEncoder49.drawIndexed(104, 123, 205_238_645);
+} catch {}
+try {
+renderBundleEncoder102.setPipeline(pipeline103);
+} catch {}
+let arrayBuffer20 = buffer15.getMappedRange(98296, 19828);
+try {
+commandEncoder145.clearBuffer(buffer39, 4544, 34956);
+dissociateBuffer(device0, buffer39);
+} catch {}
+try {
+commandEncoder149.resolveQuerySet(querySet47, 1235, 481, buffer1, 82176);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer19, /* required buffer size: 171 */
+{offset: 171}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise62 = device0.queue.onSubmittedWorkDone();
+let offscreenCanvas40 = new OffscreenCanvas(916, 525);
+let gpuCanvasContext36 = offscreenCanvas40.getContext('webgpu');
+let shaderModule40 = device0.createShaderModule({
+  label: '\u9912\u00ed\u04c1\u{1f70c}\u0c6f\u{1f666}\u{1fd4c}\u8894\u{1f8f5}',
+  code: `@group(1) @binding(1456)
+var<storage, read_write> global15: array<u32>;
+@group(2) @binding(5002)
+var<storage, read_write> global16: array<u32>;
+@group(2) @binding(4645)
+var<storage, read_write> field16: array<u32>;
+
+@compute @workgroup_size(4, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(2) f1: vec2<u32>,
+  @location(1) f2: vec4<u32>,
+  @location(3) f3: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_mask) a1: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S31 {
+  @location(16) f0: f32,
+  @location(13) f1: vec2<f16>,
+  @location(1) f2: f16,
+  @location(5) f3: vec2<u32>,
+  @location(2) f4: u32,
+  @location(17) f5: vec3<u32>,
+  @location(6) f6: i32
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(14) a1: f32, @location(18) a2: u32, @location(10) a3: vec3<f32>, @location(15) a4: vec2<f16>, @location(19) a5: vec3<f16>, a6: S31, @location(9) a7: vec2<u32>, @location(8) a8: vec3<u32>, @location(7) a9: vec2<f32>, @location(12) a10: f32, @location(0) a11: vec2<i32>, @location(11) a12: f32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroup75 = device0.createBindGroup({
+  label: '\u8306\u4fdf\u0975\u{1fcc6}\u013d\u{1faa3}\u052f\u04e5\u{1f728}\u7b57',
+  layout: bindGroupLayout51,
+  entries: [
+    {binding: 2189, resource: {buffer: buffer0, offset: 48640, size: 21548}},
+    {binding: 3807, resource: externalTexture0},
+    {binding: 68, resource: sampler39},
+  ],
+});
+let commandEncoder204 = device0.createCommandEncoder();
+let textureView251 = texture144.createView({aspect: 'all', baseMipLevel: 0});
+let computePassEncoder92 = commandEncoder51.beginComputePass();
+let externalTexture104 = device0.importExternalTexture({label: '\u0c3e\u{1f6e9}\u1d22', source: videoFrame12, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder54.drawIndexedIndirect(buffer26, 1920);
+} catch {}
+try {
+renderBundleEncoder46.setVertexBuffer(1990, undefined, 4251339353, 31457738);
+} catch {}
+try {
+commandEncoder146.copyBufferToTexture({
+  /* bytesInLastRow: 1476 widthInBlocks: 369 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 57836 */
+  offset: 57836,
+  bytesPerRow: 1536,
+  buffer: buffer21,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 369, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer21);
+} catch {}
+try {
+commandEncoder152.clearBuffer(buffer36, 390804, 45848);
+dissociateBuffer(device0, buffer36);
+} catch {}
+try {
+commandEncoder194.resolveQuerySet(querySet7, 200, 413, buffer45, 30976);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 240, height: 120, depthOrArrayLayers: 1261}
+*/
+{
+  source: imageData22,
+  origin: { x: 2, y: 35 },
+  flipY: true,
+}, {
+  texture: texture105,
+  mipLevel: 1,
+  origin: {x: 143, y: 18, z: 38},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 14, height: 6, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas39.width = 1260;
+let img47 = await imageWithData(195, 199, '#61bd5937', '#e3a0316c');
+let adapter12 = await navigator.gpu.requestAdapter();
+let buffer61 = device0.createBuffer({size: 305186, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView252 = texture9.createView({label: '\uf7e7\u{1f933}\u{1f6fb}\u059e', baseMipLevel: 2});
+let renderBundleEncoder105 = device0.createRenderBundleEncoder({
+  label: '\u0398\u87ca\u5233\u0830\u080c\u{1fb2f}\ube82\ua505\u{1fda2}\u{1f6ce}',
+  colorFormats: ['r16float', 'rg8sint', 'r32uint', 'r16float', 'r16sint', 'rgb10a2unorm', 'rg16uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture105 = device0.importExternalTexture({label: '\u0fa9\u8537\u0a86\u02b1\u0a52\u0ac0\u6fd9\u908e', source: video13, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder95.setIndexBuffer(buffer44, 'uint16', 55062, 12609);
+} catch {}
+try {
+commandEncoder181.copyBufferToTexture({
+  /* bytesInLastRow: 688 widthInBlocks: 86 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 16768 */
+  offset: 16768,
+  buffer: buffer61,
+}, {
+  texture: texture38,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 86, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer61);
+} catch {}
+let pipeline135 = await promise57;
+let commandEncoder205 = device0.createCommandEncoder({label: '\u6d38\u0bcf\uf09d\u05d8\uad88\u0690\uc60d\u{1fc45}\u2bef\u025c\u0890'});
+let querySet94 = device0.createQuerySet({label: '\u819f\u{1ff1e}\u{1fb68}\u23d7\u022c', type: 'occlusion', count: 342});
+let externalTexture106 = device0.importExternalTexture({
+  label: '\u15f4\u{1f9d1}\ueffa\u0033\u46f7\u0ea3\u{1f948}\ufb25',
+  source: videoFrame35,
+  colorSpace: 'display-p3',
+});
+try {
+renderBundleEncoder49.draw(306, 45, 449_067_886, 857_097_048);
+} catch {}
+try {
+renderBundleEncoder49.drawIndirect(buffer46, 1888);
+} catch {}
+try {
+renderBundleEncoder95.setPipeline(pipeline127);
+} catch {}
+try {
+commandEncoder152.clearBuffer(buffer16);
+dissociateBuffer(device0, buffer16);
+} catch {}
+let imageData48 = new ImageData(132, 80);
+document.body.prepend(img12);
+let imageBitmap69 = await createImageBitmap(canvas8);
+let texture146 = device3.createTexture({
+  label: '\u0610\u6300\ubd50\u{1fa95}\u02a8\udff0\ua78e\u0d4a',
+  size: [468, 32, 476],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundle138 = renderBundleEncoder93.finish({});
+try {
+renderBundleEncoder94.setVertexBuffer(9, buffer55, 20984, 112580);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture109,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(new ArrayBuffer(48)), /* required buffer size: 482 */
+{offset: 482}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+gc();
+let offscreenCanvas41 = new OffscreenCanvas(275, 309);
+let video44 = await videoWithData();
+try {
+offscreenCanvas41.getContext('webgl');
+} catch {}
+try {
+  await promise62;
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+videoFrame29.close();
+videoFrame30.close();
+videoFrame31.close();
+videoFrame32.close();
+videoFrame33.close();
+videoFrame34.close();
+videoFrame35.close();
+videoFrame36.close();
+videoFrame37.close();
+videoFrame38.close();
+videoFrame39.close();
+videoFrame40.close();
+videoFrame41.close();
+videoFrame42.close();
+videoFrame43.close();
+videoFrame44.close();
+videoFrame45.close();
+videoFrame46.close();
+videoFrame47.close();
+videoFrame48.close();
+videoFrame49.close();
+videoFrame50.close();
+videoFrame51.close();
+videoFrame52.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -812,7 +812,7 @@ void RenderBundleEncoder::endCurrentICB()
 
 bool RenderBundleEncoder::validToEncodeCommand() const
 {
-    return !m_finished || m_renderPassEncoder;
+    return !m_finished || (m_renderPassEncoder && m_renderPassEncoder->renderCommandEncoder());
 }
 
 Ref<RenderBundle> RenderBundleEncoder::finish(const WGPURenderBundleDescriptor& descriptor)


### PR DESCRIPTION
#### 4a27526e8d2b542964725cf5bee0ed362c8fc0aa
<pre>
[WebGPU] RenderBundleEncoder attempts to add commands during iteration
<a href="https://bugs.webkit.org/show_bug.cgi?id=275232">https://bugs.webkit.org/show_bug.cgi?id=275232</a>
&lt;radar://129354644&gt;

Reviewed by Dan Glastonbury.

Command encoding is only valid during replay when there is not only
a RenderPassEncoder but one which has a valid MTLRenderCommandEncoder.

* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::validToEncodeCommand const):

Canonical link: <a href="https://commits.webkit.org/279803@main">https://commits.webkit.org/279803@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b756decbd7b13cbd31de80185d3f7de7937a82c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34025 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57887 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5340 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5343 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44227 "Passed tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/3596 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56701 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32170 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47294 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25353 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28966 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4624 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3480 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4840 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59477 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29840 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/4991 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51650 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/30989 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47380 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51027 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11945 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31968 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30777 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->