### PR TITLE
[visionOS] Only delegate Image Fullscreen to Quick Look if client has proper entitlements

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -57,6 +57,7 @@
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <pal/spi/cocoa/URLFormattingSPI.h>
 #import <wtf/SoftLinking.h>
+#import <wtf/cocoa/Entitlements.h>
 #import <wtf/cocoa/NSURLExtras.h>
 #import <wtf/spi/cocoa/SecuritySPI.h>
 
@@ -758,7 +759,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
     RetainPtr<WKFullScreenParentWindowState> _parentWindowState;
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     RetainPtr<WKSPreviewWindowController> _previewWindowController;
-    bool _isImageElement;
+    bool _isUsingQuickLook;
     CGSize _imageDimensions;
 #endif // QUICKLOOK_FULLSCREEN
 #endif
@@ -840,7 +841,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 #if ENABLE(QUICKLOOK_FULLSCREEN)
 - (BOOL)isUsingQuickLook
 {
-    return _isImageElement;
+    return _isUsingQuickLook;
 }
 
 - (CGSize)imageDimensions
@@ -881,7 +882,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
     _lastKnownParentWindow = [webView window];
     _parentWindowState = adoptNS([[WKFullScreenParentWindowState alloc] initWithWindow:_lastKnownParentWindow.get()]);
 #if ENABLE(QUICKLOOK_FULLSCREEN)
-    _isImageElement = manager->isImageElement();
+    _isUsingQuickLook = manager->isImageElement() && WTF::processHasEntitlement("com.apple.surfboard.chrome-customization"_s);
 #endif // QUICKLOOK_FULLSCREEN
 #endif
     _fullScreenState = WebKit::WaitingToEnterFullScreen;
@@ -954,7 +955,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 #endif // ENABLE(FULLSCREEN_DISMISSAL_GESTURES)
 
 #if ENABLE(QUICKLOOK_FULLSCREEN)
-    if (_isImageElement)
+    if (_isUsingQuickLook)
         _imageDimensions = mediaDimensions;
 #endif
 
@@ -1743,7 +1744,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 - (void)_configureSpatialFullScreenTransition
 {
 #if ENABLE(QUICKLOOK_FULLSCREEN)
-    if (_isImageElement)
+    if (_isUsingQuickLook)
         return;
 #endif // QUICKLOOK_FULLSCREEN
 
@@ -1824,7 +1825,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     auto* manager = self._manager;
-    if (manager && _isImageElement) {
+    if (manager && _isUsingQuickLook) {
         if (enter) {
             // The fullscreen window won't be displayed.
             [inWindow setHidden:YES];
@@ -1941,7 +1942,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 #if PLATFORM(VISION)
 
 #if ENABLE(QUICKLOOK_FULLSCREEN)
-    if (_isImageElement)
+    if (_isUsingQuickLook)
         return;
 #endif // QUICKLOOK_FULLSCREEN
 
@@ -1955,7 +1956,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
 #if PLATFORM(VISION)
 
 #if ENABLE(QUICKLOOK_FULLSCREEN)
-    if (_isImageElement)
+    if (_isUsingQuickLook)
         return;
 #endif // QUICKLOOK_FULLSCREEN
 


### PR DESCRIPTION
#### 6ac0f7beb9713b7e18c58f7cef3a35a57a0b2841
<pre>
[visionOS] Only delegate Image Fullscreen to Quick Look if client has proper entitlements
<a href="https://bugs.webkit.org/show_bug.cgi?id=275235">https://bugs.webkit.org/show_bug.cgi?id=275235</a>
&lt;<a href="https://rdar.apple.com/129366478">rdar://129366478</a>&gt;

Reviewed by Andy Estes.

When going into fullscreen, check that the client has the necessary
entitlements before marking it to be delegated to Quick Look.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController enterFullScreen:]):
Rename `_isImageElement` to `_isUsingQuickLook` to more accurately
reflect it&apos;s purpose, and perform the entitlement check.

Canonical link: <a href="https://commits.webkit.org/279824@main">https://commits.webkit.org/279824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fdb6939b4b6dc428a077eb8555854993a4aa6ffe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57926 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5379 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41607 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5387 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44265 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3630 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56741 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32209 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47333 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25390 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29005 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3519 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59516 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29884 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5025 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51689 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31029 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47419 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51081 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11977 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32016 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30816 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->