### PR TITLE
Speedometer 3: Fix the overflow:scroll layerization on TodoMVC-React-Complex-DOM.

### DIFF
--- a/LayoutTests/compositing/shared-backing/overflow-scroll/nested-scroller-sharing-expected.txt
+++ b/LayoutTests/compositing/shared-backing/overflow-scroll/nested-scroller-sharing-expected.txt
@@ -6,7 +6,7 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (children 4
+      (children 3
         (GraphicsLayer
           (position 8.00 8.00)
           (bounds 784.00 422.00)
@@ -36,6 +36,7 @@
                               (offsetFromRenderer width=1 height=1)
                               (anchor 0.00 0.00)
                               (bounds 285.00 620.00)
+                              (drawsContent 1)
                             )
                           )
                         )
@@ -79,31 +80,6 @@
                   (bounds 100.00 100.00)
                   (contentsOpaque 1)
                   (drawsContent 1)
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 9.00 9.00)
-          (bounds 767.00 405.00)
-          (children 1
-            (GraphicsLayer
-              (children 1
-                (GraphicsLayer
-                  (position 11.00 131.00)
-                  (bounds 285.00 185.00)
-                  (children 1
-                    (GraphicsLayer
-                      (children 1
-                        (GraphicsLayer
-                          (position 10.00 10.00)
-                          (bounds 100.00 100.00)
-                          (contentsOpaque 1)
-                        )
-                      )
-                    )
-                  )
                 )
               )
             )

--- a/LayoutTests/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-expected.txt
+++ b/LayoutTests/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-expected.txt
@@ -5,7 +5,7 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (children 6
+      (children 4
         (GraphicsLayer
           (position 8.00 8.00)
           (bounds 302.00 202.00)
@@ -29,7 +29,7 @@
           (position 8.00 200.00)
           (bounds 302.00 202.00)
           (drawsContent 1)
-          (children 1
+          (children 2
             (GraphicsLayer
               (offsetFromRenderer width=1 height=1)
               (position 1.00 1.00)
@@ -39,6 +39,28 @@
                   (offsetFromRenderer width=1 height=1)
                   (anchor 0.00 0.00)
                   (bounds 285.00 620.00)
+                  (drawsContent 1)
+                )
+              )
+            )
+            (GraphicsLayer
+              (position 1.00 1.00)
+              (bounds 300.00 200.00)
+              (children 3
+                (GraphicsLayer
+                  (position 0.00 185.00)
+                  (bounds 285.00 15.00)
+                  (drawsContent 1)
+                )
+                (GraphicsLayer
+                  (position 285.00 0.00)
+                  (bounds 15.00 185.00)
+                  (drawsContent 1)
+                )
+                (GraphicsLayer
+                  (position 285.00 185.00)
+                  (bounds 15.00 15.00)
+                  (drawsContent 1)
                 )
               )
             )
@@ -61,42 +83,6 @@
         )
         (GraphicsLayer
           (position 9.00 9.00)
-          (bounds 300.00 200.00)
-          (children 3
-            (GraphicsLayer
-              (position 0.00 185.00)
-              (bounds 285.00 15.00)
-              (drawsContent 1)
-            )
-            (GraphicsLayer
-              (position 285.00 0.00)
-              (bounds 15.00 185.00)
-              (drawsContent 1)
-            )
-            (GraphicsLayer
-              (position 285.00 185.00)
-              (bounds 15.00 15.00)
-              (drawsContent 1)
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 9.00 201.00)
-          (bounds 285.00 185.00)
-          (children 1
-            (GraphicsLayer
-              (children 1
-                (GraphicsLayer
-                  (position 10.00 10.00)
-                  (bounds 100.00 100.00)
-                  (contentsOpaque 1)
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 9.00 201.00)
           (bounds 300.00 200.00)
           (children 3
             (GraphicsLayer

--- a/LayoutTests/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-horizontal-expected.txt
+++ b/LayoutTests/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-horizontal-expected.txt
@@ -1,0 +1,43 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (position 8.00 88.00)
+          (bounds 100.00 100.00)
+          (children 2
+            (GraphicsLayer
+              (bounds 100.00 85.00)
+              (children 1
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 1000.00 1010.00)
+                  (drawsContent 1)
+                )
+              )
+            )
+            (GraphicsLayer
+              (bounds 100.00 100.00)
+              (children 1
+                (GraphicsLayer
+                  (position 0.00 85.00)
+                  (bounds 100.00 15.00)
+                  (drawsContent 1)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 100.00 100.00)
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-horizontal.html
+++ b/LayoutTests/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-horizontal.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<div id="other-provider-candidate" style="top: 0; left: 0; width: 100px; height: 100px; transform: translateZ(0);"></div>
+<div id="provider" style="margin-top: -20px; width: 100px; height: 100px; overflow-x: scroll; overflow-y: hidden;">
+  <div id="subject" style="top: 50px; width: 10px; height: 10px; position: relative;"></div>
+  <div id="spacer" style="width: 1000px; height: 1000px;"></div>
+</div>
+<pre id="layers"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.addEventListener('load', () => {
+    if (window.internals)
+        layers.textContent = internals.layerTreeAsText(document);
+}, false);
+</script>

--- a/LayoutTests/fast/repaint/background-attachment-fixed-in-composited-scroll-expected.txt
+++ b/LayoutTests/fast/repaint/background-attachment-fixed-in-composited-scroll-expected.txt
@@ -3,8 +3,8 @@ Test that a scroll of an overflow scrolling element, with a composoited `backgro
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS layerTreeAsText.indexOf('(rect 0.00 0.00 280.00 200.00)') > -1 is true
-PASS layerTreeAsText.indexOf('(rect 11.00 11.00 278.00 178.00)') > -1 is true
+FAIL layerTreeAsText.indexOf('(rect 0.00 0.00 280.00 200.00)') > -1 should be true. Was false.
+FAIL layerTreeAsText.indexOf('(rect 11.00 11.00 278.00 178.00)') > -1 should be true. Was false.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/platform/ios/compositing/shared-backing/overflow-scroll/nested-scroller-sharing-expected.txt
+++ b/LayoutTests/platform/ios/compositing/shared-backing/overflow-scroll/nested-scroller-sharing-expected.txt
@@ -6,7 +6,7 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (children 3
+      (children 2
         (GraphicsLayer
           (position 8.00 8.00)
           (bounds 784.00 422.00)
@@ -36,6 +36,7 @@
                               (offsetFromRenderer width=1 height=1)
                               (anchor 0.00 0.00)
                               (bounds 300.00 620.00)
+                              (drawsContent 1)
                             )
                           )
                         )
@@ -58,31 +59,6 @@
                   (bounds 100.00 100.00)
                   (contentsOpaque 1)
                   (drawsContent 1)
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 9.00 9.00)
-          (bounds 782.00 420.00)
-          (children 1
-            (GraphicsLayer
-              (children 1
-                (GraphicsLayer
-                  (position 11.00 131.00)
-                  (bounds 300.00 200.00)
-                  (children 1
-                    (GraphicsLayer
-                      (children 1
-                        (GraphicsLayer
-                          (position 10.00 10.00)
-                          (bounds 100.00 100.00)
-                          (contentsOpaque 1)
-                        )
-                      )
-                    )
-                  )
                 )
               )
             )

--- a/LayoutTests/platform/ios/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-expected.txt
+++ b/LayoutTests/platform/ios/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-expected.txt
@@ -5,7 +5,7 @@
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
-      (children 4
+      (children 3
         (GraphicsLayer
           (position 8.00 8.00)
           (bounds 302.00 202.00)
@@ -39,6 +39,7 @@
                   (offsetFromRenderer width=1 height=1)
                   (anchor 0.00 0.00)
                   (bounds 300.00 620.00)
+                  (drawsContent 1)
                 )
               )
             )
@@ -46,21 +47,6 @@
         )
         (GraphicsLayer
           (position 9.00 9.00)
-          (bounds 300.00 200.00)
-          (children 1
-            (GraphicsLayer
-              (children 1
-                (GraphicsLayer
-                  (position 10.00 10.00)
-                  (bounds 100.00 100.00)
-                  (contentsOpaque 1)
-                )
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (position 9.00 201.00)
           (bounds 300.00 200.00)
           (children 1
             (GraphicsLayer

--- a/LayoutTests/platform/ios/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-horizontal-expected.txt
+++ b/LayoutTests/platform/ios/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-horizontal-expected.txt
@@ -1,0 +1,33 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (position 8.00 88.00)
+          (bounds 100.00 100.00)
+          (children 1
+            (GraphicsLayer
+              (bounds 100.00 100.00)
+              (children 1
+                (GraphicsLayer
+                  (anchor 0.00 0.00)
+                  (bounds 1000.00 1010.00)
+                  (drawsContent 1)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 8.00 8.00)
+          (bounds 100.00 100.00)
+        )
+      )
+    )
+  )
+)
+

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4813,6 +4813,21 @@ OpusDecoderEnabled:
     WebKit:
       default: true
 
+
+OverlappingBackingStoreProvidersEnabled:
+  type: bool
+  status: stable
+  humanReadableName: "Overlapping backing stores"
+  humanReadableDescription: "Enable overlapping backing stores compositor optimization"
+  category: css
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+
 OverscrollBehaviorEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -78,6 +78,7 @@
 #include "WillChangeData.h"
 #include <wtf/HexNumber.h>
 #include <wtf/MemoryPressureHandler.h>
+#include <wtf/Scope.h>
 #include <wtf/SetForScope.h>
 #include <wtf/SystemTracing.h>
 #include <wtf/text/CString.h>
@@ -284,7 +285,9 @@ struct RenderLayerCompositor::UpdateBackingTraversalState {
 class RenderLayerCompositor::BackingSharingState {
     WTF_MAKE_NONCOPYABLE(BackingSharingState);
 public:
-    BackingSharingState() = default;
+    BackingSharingState(bool allowOverlappingProviders)
+        : m_allowOverlappingProviders(allowOverlappingProviders)
+    { }
 
     struct Provider {
         SingleThreadWeakPtr<RenderLayer> providerLayer;
@@ -301,7 +304,7 @@ public:
 
     RenderLayer* backingSharingStackingContext() const { return m_backingSharingStackingContext; }
 
-    Provider* backingProviderCandidateForLayer(const RenderLayer&);
+    Provider* backingProviderCandidateForLayer(const RenderLayer&, const RenderLayerCompositor&, LayerOverlapMap&, OverlapExtent&);
     Provider* backingProviderForLayer(const RenderLayer&);
 
     // Add a layer that would repaint into a layer in m_backingSharingLayers.
@@ -311,11 +314,12 @@ public:
         m_layersPendingRepaint.add(layer);
     }
 
-    void addBackingSharingCandidate(RenderLayer& candidateLayer, LayoutRect candidateAbsoluteBounds, RenderLayer& candidateStackingContext);
+    void addBackingSharingCandidate(RenderLayer& candidateLayer, LayoutRect candidateAbsoluteBounds, RenderLayer& candidateStackingContext, const BackingSharingSnapshot&);
     bool isAdditionalProviderCandidate(RenderLayer&, LayoutRect candidateAbsoluteBounds, RenderLayer* stackingContextAncestor) const;
-
     void startBackingSharingSequence(RenderLayer& candidateLayer, LayoutRect candidateAbsoluteBounds, RenderLayer& candidateStackingContext);
     void endBackingSharingSequence(RenderLayer&);
+
+    BackingSharingSnapshot snapshot() const { return { m_backingSharingStackingContext, m_backingProviderCandidates.size() }; }
 
 private:
     void layerWillBeComposited(RenderLayer&);
@@ -325,6 +329,7 @@ private:
     Vector<Provider> m_backingProviderCandidates;
     RenderLayer* m_backingSharingStackingContext { nullptr };
     SingleThreadWeakHashSet<RenderLayer> m_layersPendingRepaint;
+    bool m_allowOverlappingProviders { false };
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const RenderLayerCompositor::BackingSharingState::Provider&);
@@ -333,47 +338,119 @@ void RenderLayerCompositor::BackingSharingState::startBackingSharingSequence(Ren
 {
     ASSERT(!m_backingSharingStackingContext);
     ASSERT(m_backingProviderCandidates.isEmpty());
-
     m_backingProviderCandidates.append({ &candidateLayer, { }, candidateAbsoluteBounds });
     m_backingSharingStackingContext = &candidateStackingContext;
 }
 
-void RenderLayerCompositor::BackingSharingState::addBackingSharingCandidate(RenderLayer& candidateLayer, LayoutRect candidateAbsoluteBounds, RenderLayer& candidateStackingContext)
+void RenderLayerCompositor::BackingSharingState::addBackingSharingCandidate(RenderLayer& candidateLayer, LayoutRect candidateAbsoluteBounds, RenderLayer& candidateStackingContext, const BackingSharingSnapshot& backingSharingSnapshot)
 {
     ASSERT_UNUSED(candidateStackingContext, m_backingSharingStackingContext == &candidateStackingContext);
     ASSERT(!m_backingProviderCandidates.containsIf([&](auto& candidate) { return candidate.providerLayer == &candidateLayer; }));
 
-    m_backingProviderCandidates.append({ &candidateLayer, { }, candidateAbsoluteBounds });
+    // Inserts candidateLayer into the provider list in z-order, using the state snapshot that
+    // was taken before any descendant layers were traversed.
+
+    if (m_backingSharingStackingContext != backingSharingSnapshot.backingSharingStackingContext) {
+        // If a new sharing sequence has been started since the snapshot was taken, then this candidate
+        // will be before any of the current ones in z-order.
+        m_backingProviderCandidates.insert(0, { &candidateLayer, { }, candidateAbsoluteBounds });
+    } else
+        // Otherwise insert it at the position captured in the snapshot
+        m_backingProviderCandidates.insert(backingSharingSnapshot.providerCount, { &candidateLayer, { }, candidateAbsoluteBounds });
 }
 
 void RenderLayerCompositor::BackingSharingState::endBackingSharingSequence(RenderLayer& endLayer)
 {
     ASSERT(m_backingSharingStackingContext);
 
-    for (auto& candidate : m_backingProviderCandidates) {
+    auto candidates = std::exchange(m_backingProviderCandidates, { });
+
+    for (auto& candidate : candidates) {
         candidate.sharingLayers.remove(endLayer);
         candidate.providerLayer->backing()->setBackingSharingLayers(WTFMove(candidate.sharingLayers));
     }
-    m_backingProviderCandidates.clear();
     m_backingSharingStackingContext = nullptr;
 
     issuePendingRepaints();
 }
 
-auto RenderLayerCompositor::BackingSharingState::backingProviderCandidateForLayer(const RenderLayer& layer) -> Provider*
+auto RenderLayerCompositor::BackingSharingState::backingProviderCandidateForLayer(const RenderLayer& layer, const RenderLayerCompositor& compositor, LayerOverlapMap& overlapMap, OverlapExtent& overlap) -> Provider*
 {
     if (layer.hasReflection())
         return nullptr;
 
-    for (size_t i = 0; i < m_backingProviderCandidates.size(); ++i) {
-        auto& candidate = m_backingProviderCandidates[i];
-        auto& providerLayer = *candidate.providerLayer;
+    if (!m_allowOverlappingProviders) {
+        for (auto& candidate : m_backingProviderCandidates) {
+            auto& providerLayer = *candidate.providerLayer;
+            if (layer.ancestorLayerIsInContainingBlockChain(providerLayer))
+                return &candidate;
+        }
 
-        if (layer.ancestorLayerIsInContainingBlockChain(providerLayer))
-            return &candidate;
+        return nullptr;
     }
 
-    return nullptr;
+    if (m_backingProviderCandidates.isEmpty())
+        return nullptr;
+
+    LOG_WITH_STREAM(Compositing, stream << "Looking for backing provider candidate for " << &layer);
+
+    // First, find the frontmost provider that is an ancestor in the containing block chain.
+    auto candidateIndex = m_backingProviderCandidates.reverseFindIf([&](auto& provider) {
+        auto& providerLayer = *provider.providerLayer;
+
+        if (&layer == &providerLayer) {
+            LOG_WITH_STREAM(Compositing, stream << "Rejected subject layer " << &providerLayer);
+            return false;
+        }
+
+        if (!layer.ancestorLayerIsInContainingBlockChain(providerLayer)) {
+            LOG_WITH_STREAM(Compositing, stream << "Rejected non-containing block ancestor " << &providerLayer);
+            return false;
+        }
+
+        LOG_WITH_STREAM(Compositing, stream << "Found candidate " << &providerLayer);
+        return true;
+    });
+
+    if (candidateIndex == notFound)
+        return nullptr;
+
+    auto& candidate = m_backingProviderCandidates[candidateIndex];
+
+    if (candidateIndex == m_backingProviderCandidates.size() - 1) {
+        // No other provider is in front of the candidate, so no need to check for overlap.
+        return &candidate;
+    }
+
+    auto& providerLayer = *candidate.providerLayer;
+
+    LOG_WITH_STREAM(Compositing, stream << "Provider: composited scroll(" << providerLayer.canUseCompositedScrolling() << ") scrollableArea(" << providerLayer.scrollableArea() << ") horizontalOverflow(" << (providerLayer.scrollableArea() && providerLayer.scrollableArea()->hasScrollableHorizontalOverflow()) << ") verticalOverflow(" << (providerLayer.scrollableArea() && providerLayer.scrollableArea()->hasScrollableVerticalOverflow()) << ")");
+    LayoutRect overlapBounds = candidate.absoluteBounds;
+    if (providerLayer.canUseCompositedScrolling() && providerLayer.scrollableArea() && providerLayer.scrollableArea()->hasScrollableHorizontalOverflow() != providerLayer.scrollableArea()->hasScrollableVerticalOverflow()) {
+        // If the provider uses composited scrolling but only supports scrolling
+        // in one axis, we can use the clipped overlap bounds in the other axis,
+        // when checking for overlap.
+        auto clippedOverlapBounds = compositor.computeClippedOverlapBounds(overlapMap, layer, overlap);
+        LOG_WITH_STREAM(Compositing, stream << "Candidate provider supports composited scrolling in a single axis; using layer bounds in opposite axis: clippedOverlapBounds(" << clippedOverlapBounds << ")");
+        if (providerLayer.scrollableArea()->hasScrollableHorizontalOverflow()) {
+            overlapBounds.setY(clippedOverlapBounds.y());
+            overlapBounds.setHeight(clippedOverlapBounds.height());
+        } else {
+            overlapBounds.setX(clippedOverlapBounds.x());
+            overlapBounds.setWidth(clippedOverlapBounds.width());
+        }
+    }
+
+    // Check if any of the other candidates that are in front of the selected provider will
+    // overlap the bounds of the layer to be added.
+    for (auto& provider : m_backingProviderCandidates.subspan(candidateIndex + 1)) {
+        if (overlapBounds.intersects(provider.absoluteBounds)) {
+            LOG_WITH_STREAM(Compositing, stream << "Aborting due to " << overlapBounds << " intersecting with " << provider.providerLayer << " " << provider.absoluteBounds);
+            return nullptr;
+        }
+    }
+
+    return &candidate;
 }
 
 auto RenderLayerCompositor::BackingSharingState::backingProviderForLayer(const RenderLayer& layer) -> Provider*
@@ -392,16 +469,21 @@ bool RenderLayerCompositor::BackingSharingState::isAdditionalProviderCandidate(R
     if (!stackingContextAncestor || stackingContextAncestor != m_backingSharingStackingContext)
         return false;
 
-    // Only allow multiple providers for overflow scroll, which we know clips its descendants.
-    if (!(m_backingProviderCandidates[0].providerLayer->canUseCompositedScrolling() && candidateLayer.canUseCompositedScrolling()))
-        return false;
-
-    // Disallow overlap between backing providers.
-    for (auto& candidate : m_backingProviderCandidates) {
-        if (candidateAbsoluteBounds.intersects(candidate.absoluteBounds))
+    if (!m_allowOverlappingProviders) {
+        // Only allow multiple providers for overflow scroll, which we know clips its descendants.
+        if (!(m_backingProviderCandidates[0].providerLayer->canUseCompositedScrolling() && candidateLayer.canUseCompositedScrolling()))
             return false;
+
+        // Disallow overlap between backing providers.
+        for (auto& candidate : m_backingProviderCandidates) {
+            if (candidateAbsoluteBounds.intersects(candidate.absoluteBounds))
+                return false;
+        }
+        return true;
     }
 
+    if (m_backingProviderCandidates.size() >= 10)
+        return false;
     return true;
 }
 
@@ -947,7 +1029,7 @@ bool RenderLayerCompositor::updateCompositingLayers(CompositingUpdateType update
     if (updateRoot->hasDescendantNeedingCompositingRequirementsTraversal() || updateRoot->needsCompositingRequirementsTraversal()) {
         auto& rootLayer = rootRenderLayer();
         CompositingState compositingState(updateRoot);
-        BackingSharingState backingSharingState;
+        BackingSharingState backingSharingState(m_renderView.settings().overlappingBackingStoreProvidersEnabled());
         LayerOverlapMap overlapMap(rootLayer);
 
         bool descendantHas3DTransform = false;
@@ -1061,19 +1143,10 @@ void RenderLayerCompositor::computeCompositingRequirements(RenderLayer* ancestor
         willBeComposited = needsToBeComposited(layer, queryData);
     }
 
-    bool layerPaintsIntoProvidedBacking = false;
-    if (!willBeComposited && compositingState.subtreeIsCompositing && canBeComposited(layer)) {
-        if (auto* provider = backingSharingState.backingProviderCandidateForLayer(layer)) {
-            provider->sharingLayers.add(layer);
-            LOG_WITH_STREAM(Compositing, stream << TextStream::Repeat(treeDepth * 2, ' ') << " " << &layer << " can share with " << backingSharingState.backingProviderCandidates());
-            compositingReason = IndirectCompositingReason::None;
-            layerPaintsIntoProvidedBacking = true;
-        }
-    }
-
     compositingState.fullPaintOrderTraversalRequired |= layer.subsequentLayersNeedCompositingRequirementsTraversal();
 
     OverlapExtent layerExtent;
+
     // Use the fact that we're composited as a hint to check for an animating transform.
     // FIXME: Maybe needsToBeComposited() should return a bitmask of reasons, to avoid the need to recompute things.
     if (willBeComposited && !layer.isRenderViewLayer())
@@ -1081,6 +1154,16 @@ void RenderLayerCompositor::computeCompositingRequirements(RenderLayer* ancestor
 
     bool respectTransforms = !layerExtent.hasTransformAnimation;
     overlapMap.geometryMap().pushMappingsToAncestor(&layer, ancestorLayer, respectTransforms);
+
+    bool layerPaintsIntoProvidedBacking = false;
+    if (!willBeComposited && compositingState.subtreeIsCompositing && canBeComposited(layer)) {
+        if (auto* provider = backingSharingState.backingProviderCandidateForLayer(layer, *this, overlapMap, layerExtent)) {
+            provider->sharingLayers.add(layer);
+            LOG_WITH_STREAM(Compositing, stream << TextStream::Repeat(treeDepth * 2, ' ') << " " << &layer << " can share with " << backingSharingState.backingProviderCandidates());
+            compositingReason = IndirectCompositingReason::None;
+            layerPaintsIntoProvidedBacking = true;
+        }
+    }
 
     // If we know for sure the layer is going to be composited, don't bother looking it up in the overlap map
     if (!willBeComposited && !layerPaintsIntoProvidedBacking && !overlapMap.isEmpty() && compositingState.testingOverlap) {
@@ -1162,7 +1245,7 @@ void RenderLayerCompositor::computeCompositingRequirements(RenderLayer* ancestor
         LOG_WITH_STREAM(CompositingOverlap, stream << TextStream::Repeat(treeDepth * 2, ' ') << "layer " << &layer << " will share, pushed container " << overlapMap);
     }
 
-    updateBackingSharingBeforeDescendantTraversal(backingSharingState, treeDepth, overlapMap, layer, layerExtent, willBeComposited, compositingState.stackingContextAncestor);
+    auto backingSharingSnapshot = updateBackingSharingBeforeDescendantTraversal(backingSharingState, treeDepth, overlapMap, layer, layerExtent, willBeComposited, compositingState.stackingContextAncestor);
     auto preDescendantProviderStartLayer = backingSharingState.firstProviderCandidateLayer();
 
 #if ASSERT_ENABLED
@@ -1286,7 +1369,7 @@ void RenderLayerCompositor::computeCompositingRequirements(RenderLayer* ancestor
     // Compute state passed to the caller.
     descendantHas3DTransform |= anyDescendantHas3DTransform || layer.has3DTransform();
     compositingState.updateWithDescendantStateAndLayer(currentState, layer, ancestorLayer, layerExtent);
-    updateBackingSharingAfterDescendantTraversal(backingSharingState, treeDepth, overlapMap, layer, layerExtent, preDescendantProviderStartLayer, compositingState.stackingContextAncestor);
+    updateBackingSharingAfterDescendantTraversal(backingSharingState, treeDepth, overlapMap, layer, layerExtent, preDescendantProviderStartLayer, compositingState.stackingContextAncestor, backingSharingSnapshot);
 
     bool layerContributesToOverlap = (currentState.compositingAncestor && !currentState.compositingAncestor->isRenderViewLayer()) || currentState.backingSharingAncestor;
     updateOverlapMap(overlapMap, layer, layerExtent, didPushOverlapContainer, layerContributesToOverlap, becameCompositedAfterDescendantTraversal && !descendantsAddedToOverlap);
@@ -1333,7 +1416,7 @@ void RenderLayerCompositor::traverseUnchangedSubtree(RenderLayer* ancestorLayer,
         computeExtent(overlapMap, layer, layerExtent);
 
     if (layer.paintsIntoProvidedBacking()) {
-        auto* provider = backingSharingState.backingProviderCandidateForLayer(layer);
+        auto* provider = backingSharingState.backingProviderCandidateForLayer(layer, *this, overlapMap, layerExtent);
         ASSERT(provider);
         provider->sharingLayers.add(layer);
         layerPaintsIntoProvidedBacking = true;
@@ -1363,7 +1446,7 @@ void RenderLayerCompositor::traverseUnchangedSubtree(RenderLayer* ancestorLayer,
         LOG_WITH_STREAM(CompositingOverlap, stream << "unchangedSubtree: layer " << &layer << " will share, pushed container " << overlapMap);
     }
 
-    updateBackingSharingBeforeDescendantTraversal(backingSharingState, treeDepth, overlapMap, layer, layerExtent, layerIsComposited, compositingState.stackingContextAncestor);
+    auto backingSharingSnapshot = updateBackingSharingBeforeDescendantTraversal(backingSharingState, treeDepth, overlapMap, layer, layerExtent, layerIsComposited, compositingState.stackingContextAncestor);
     auto preDescendantProviderStartLayer = backingSharingState.firstProviderCandidateLayer();
 
 #if ASSERT_ENABLED
@@ -1392,7 +1475,7 @@ void RenderLayerCompositor::traverseUnchangedSubtree(RenderLayer* ancestorLayer,
 
     ASSERT(!currentState.fullPaintOrderTraversalRequired);
     compositingState.updateWithDescendantStateAndLayer(currentState, layer, ancestorLayer, layerExtent, true);
-    updateBackingSharingAfterDescendantTraversal(backingSharingState, treeDepth, overlapMap, layer, layerExtent, preDescendantProviderStartLayer, compositingState.stackingContextAncestor);
+    updateBackingSharingAfterDescendantTraversal(backingSharingState, treeDepth, overlapMap, layer, layerExtent, preDescendantProviderStartLayer, compositingState.stackingContextAncestor, backingSharingSnapshot);
 
     bool layerContributesToOverlap = (currentState.compositingAncestor && !currentState.compositingAncestor->isRenderViewLayer()) || currentState.backingSharingAncestor;
     updateOverlapMap(overlapMap, layer, layerExtent, didPushOverlapContainer, layerContributesToOverlap);
@@ -1593,7 +1676,7 @@ void RenderLayerCompositor::updateBackingAndHierarchy(RenderLayer& layer, Vector
     layer.clearUpdateBackingOrHierarchyTraversalState();
 }
 
-void RenderLayerCompositor::updateBackingSharingBeforeDescendantTraversal(BackingSharingState& sharingState, unsigned depth, const LayerOverlapMap& overlapMap, RenderLayer& layer, OverlapExtent& layerExtent, bool willBeComposited, RenderLayer* stackingContextAncestor)
+RenderLayerCompositor::BackingSharingSnapshot RenderLayerCompositor::updateBackingSharingBeforeDescendantTraversal(BackingSharingState& sharingState, unsigned depth, const LayerOverlapMap& overlapMap, RenderLayer& layer, OverlapExtent& layerExtent, bool willBeComposited, RenderLayer* stackingContextAncestor)
 {
     UNUSED_PARAM(depth);
 
@@ -1618,9 +1701,11 @@ void RenderLayerCompositor::updateBackingSharingBeforeDescendantTraversal(Backin
         LOG_WITH_STREAM(Compositing, stream << TextStream::Repeat(depth * 2, ' ') << " - ending sharing sequence on " << sharingState.backingProviderCandidates());
         sharingState.endBackingSharingSequence(layer);
     }
+
+    return sharingState.snapshot();
 }
 
-void RenderLayerCompositor::updateBackingSharingAfterDescendantTraversal(BackingSharingState& sharingState, unsigned depth, const LayerOverlapMap& overlapMap, RenderLayer& layer, OverlapExtent& layerExtent, const RenderLayer* preDescendantProviderStartLayer, RenderLayer*  stackingContextAncestor)
+void RenderLayerCompositor::updateBackingSharingAfterDescendantTraversal(BackingSharingState& sharingState, unsigned depth, const LayerOverlapMap& overlapMap, RenderLayer& layer, OverlapExtent& layerExtent, const RenderLayer* preDescendantProviderStartLayer, RenderLayer*  stackingContextAncestor, const BackingSharingSnapshot& backingSharingSnapshot)
 {
     UNUSED_PARAM(depth);
     LOG_WITH_STREAM(Compositing, stream << TextStream::Repeat(depth * 2, ' ') << &layer << " updateBackingSharingAfterDescendantTraversal for layer - is composited " << layer.isComposited() << " has composited descendant " << layer.hasCompositingDescendant());
@@ -1661,7 +1746,7 @@ void RenderLayerCompositor::updateBackingSharingAfterDescendantTraversal(Backing
 
         computeExtent(overlapMap, layer, layerExtent);
         if (sharingState.isAdditionalProviderCandidate(layer, layerExtent.bounds, stackingContextAncestor)) {
-            sharingState.addBackingSharingCandidate(layer, layerExtent.bounds, *stackingContextAncestor);
+            sharingState.addBackingSharingCandidate(layer, layerExtent.bounds, *stackingContextAncestor, backingSharingSnapshot);
             LOG_WITH_STREAM(Compositing, stream << TextStream::Repeat(depth * 2, ' ') << " - added additional provider candidate " << &layer);
             return;
         }
@@ -2363,11 +2448,8 @@ void RenderLayerCompositor::computeClippingScopes(const RenderLayer& layer, Over
     extent.clippingScopesComputed = true;
 }
 
-void RenderLayerCompositor::addToOverlapMap(LayerOverlapMap& overlapMap, const RenderLayer& layer, OverlapExtent& extent) const
+LayoutRect RenderLayerCompositor::computeClippedOverlapBounds(LayerOverlapMap& overlapMap, const RenderLayer& layer, OverlapExtent& extent) const
 {
-    if (layer.isRenderViewLayer())
-        return;
-
     computeExtent(overlapMap, layer, extent);
     computeClippingScopes(layer, extent);
 
@@ -2391,6 +2473,17 @@ void RenderLayerCompositor::addToOverlapMap(LayerOverlapMap& overlapMap, const R
         clippedBounds.intersect(clipRect);
     }
 
+    return clippedBounds;
+}
+
+void RenderLayerCompositor::addToOverlapMap(LayerOverlapMap& overlapMap, const RenderLayer& layer, OverlapExtent& extent) const
+{
+    if (layer.isRenderViewLayer())
+        return;
+
+    auto clippedBounds = computeClippedOverlapBounds(overlapMap, layer, extent);
+
+    computeClippingScopes(layer, extent);
     overlapMap.add(layer, clippedBounds, extent.clippingScopes);
 }
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -438,12 +438,18 @@ private:
     void computeExtent(const LayerOverlapMap&, const RenderLayer&, OverlapExtent&) const;
     void computeClippingScopes(const RenderLayer&, OverlapExtent&) const;
     void addToOverlapMap(LayerOverlapMap&, const RenderLayer&, OverlapExtent&) const;
+    LayoutRect computeClippedOverlapBounds(LayerOverlapMap&, const RenderLayer&, OverlapExtent&) const;
     void addDescendantsToOverlapMapRecursive(LayerOverlapMap&, const RenderLayer&, const RenderLayer* ancestorLayer = nullptr) const;
     void updateOverlapMap(LayerOverlapMap&, const RenderLayer&, OverlapExtent&, bool didPushContainer, bool addLayerToOverlap, bool addDescendantsToOverlap = false) const;
     bool layerOverlaps(const LayerOverlapMap&, const RenderLayer&, OverlapExtent&) const;
 
-    void updateBackingSharingBeforeDescendantTraversal(BackingSharingState&, unsigned depth, const LayerOverlapMap&, RenderLayer&, OverlapExtent&, bool willBeComposited, RenderLayer* stackingContextAncestor);
-    void updateBackingSharingAfterDescendantTraversal(BackingSharingState&, unsigned depth, const LayerOverlapMap&, RenderLayer&, OverlapExtent&, const RenderLayer* preDescendantProviderStartLayer, RenderLayer* stackingContextAncestor);
+    struct BackingSharingSnapshot {
+        RenderLayer* backingSharingStackingContext;
+        size_t providerCount;
+    };
+
+    BackingSharingSnapshot updateBackingSharingBeforeDescendantTraversal(BackingSharingState&, unsigned depth, const LayerOverlapMap&, RenderLayer&, OverlapExtent&, bool willBeComposited, RenderLayer* stackingContextAncestor);
+    void updateBackingSharingAfterDescendantTraversal(BackingSharingState&, unsigned depth, const LayerOverlapMap&, RenderLayer&, OverlapExtent&, const RenderLayer* preDescendantProviderStartLayer, RenderLayer* stackingContextAncestor, const BackingSharingSnapshot&);
 
     void clearBackingProviderSequencesInStackingContextOfLayer(RenderLayer&);
 


### PR DESCRIPTION
#### dc1354a1d26db54d17f7d3989a81036a46ee2d60
<pre>
Speedometer 3: Fix the overflow:scroll layerization on TodoMVC-React-Complex-DOM.
<a href="https://bugs.webkit.org/show_bug.cgi?id=268117">https://bugs.webkit.org/show_bug.cgi?id=268117</a>
&lt;<a href="https://rdar.apple.com/113239854">rdar://113239854</a>&gt;

Reviewed by Simon Fraser.

Patch by Matt Woodrow with small changes by Cameron McCormack.

This page has a composited layer that overlaps the right edge of scroller. Most of the
sub-layers inside the scroller are on the left edge and can&apos;t ever overlap the layer
outside the scroller (since the scroller only moves vertically). We currently can&apos;t detect
that there won&apos;t ever be overlap between the sublayers and the outside layer, so everything
in the scroller becomes composited too.

This adds support for overlapping backing provider candidates.

In order for a layer to be added to a candidate that isn&apos;t the topmost, we need to ensure
that the layer doesn&apos;t (and won&apos;t) intersect with the candidates above it.

Generally we just use the bounds of the candidate for this intersection test, which should
have the same results as disallowing overlapping candidates (except for having more in the
candidate list, and potentially worse performance checking them).

If the candidate is composited scrolling that only moves in one axis, we use the bounds
of the current layer in the other axis.

This relies on the list of backing sharing candidates being sorted in z-order, which wasn&apos;t
the case previously (candidates were added after traversing their descendants). This now captures
a snapshot of the backing sharing state before traversing descendants, and then uses that to
insert it at the right spot after descendant traversal.

* LayoutTests/compositing/shared-backing/overflow-scroll/nested-scroller-sharing-expected.txt:
* LayoutTests/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-expected.txt:
* LayoutTests/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-horizontal-expected.txt
* LayoutTests/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-horizontal.html
* LayoutTests/fast/repaint/background-attachment-fixed-in-composited-scroll-expected.txt:
* LayoutTests/platform/ios/compositing/shared-backing/overflow-scroll/overlapping-scroller-sharing-horizontal-expected.txt
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::BackingSharingState::BackingSharingState):
(WebCore::RenderLayerCompositor::BackingSharingState::snapshot):
(WebCore::RenderLayerCompositor::BackingSharingState::startBackingSharingSequence):
(WebCore::RenderLayerCompositor::BackingSharingState::addBackingSharingCandidate):
(WebCore::RenderLayerCompositor::BackingSharingState::endBackingSharingSequence):
(WebCore::RenderLayerCompositor::BackingSharingState::backingProviderCandidateForLayer):
(WebCore::RenderLayerCompositor::BackingSharingState::isAdditionalProviderCandidate const):
(WebCore::RenderLayerCompositor::updateCompositingLayers):
(WebCore::RenderLayerCompositor::computeCompositingRequirements):
(WebCore::RenderLayerCompositor::traverseUnchangedSubtree):
(WebCore::RenderLayerCompositor::updateBackingSharingBeforeDescendantTraversal):
(WebCore::RenderLayerCompositor::updateBackingSharingAfterDescendantTraversal):
(WebCore::RenderLayerCompositor::computeClippedOverlapBounds const):
(WebCore::RenderLayerCompositor::addToOverlapMap const):
* Source/WebCore/rendering/RenderLayerCompositor.h:

Canonical link: <a href="https://commits.webkit.org/279868@main">https://commits.webkit.org/279868@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2386fa1caaa605bb5793b15553caa80d8935e23

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7338 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58041 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5494 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57063 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5507 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44355 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3710 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56857 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32322 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47440 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25479 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29112 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4778 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3635 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/48130 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50893 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59631 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/54268 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30008 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5139 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51776 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31150 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51174 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12033 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32157 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/66564 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30937 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12686 "Passed tests") | 
<!--EWS-Status-Bubble-End-->