### PR TITLE
Use "= default" for constructor and destructor in more JSC code

### DIFF
--- a/Source/JavaScriptCore/bytecode/DFGExitProfile.cpp
+++ b/Source/JavaScriptCore/bytecode/DFGExitProfile.cpp
@@ -101,8 +101,8 @@ bool ExitProfile::hasExitSite(const ConcurrentJSLocker&, const FrequentExitSite&
     return false;
 }
 
-QueryableExitProfile::QueryableExitProfile() { }
-QueryableExitProfile::~QueryableExitProfile() { }
+QueryableExitProfile::QueryableExitProfile() = default;
+QueryableExitProfile::~QueryableExitProfile() = default;
 
 void QueryableExitProfile::initialize(UnlinkedCodeBlock* unlinkedCodeBlock)
 {

--- a/Source/JavaScriptCore/dfg/DFGAtTailAbstractState.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAtTailAbstractState.cpp
@@ -47,7 +47,7 @@ AtTailAbstractState::AtTailAbstractState(Graph& graph)
     }
 }
 
-AtTailAbstractState::~AtTailAbstractState() { }
+AtTailAbstractState::~AtTailAbstractState() = default;
 
 void AtTailAbstractState::createValueForNode(NodeFlowProjection node)
 {

--- a/Source/JavaScriptCore/dfg/DFGBasicBlock.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBasicBlock.cpp
@@ -64,9 +64,7 @@ BasicBlock::BasicBlock(BytecodeIndex bytecodeBegin, unsigned numArguments, unsig
 {
 }
 
-BasicBlock::~BasicBlock()
-{
-}
+BasicBlock::~BasicBlock() = default;
 
 void BasicBlock::ensureLocals(unsigned newNumLocals)
 {

--- a/Source/JavaScriptCore/dfg/DFGBlockInsertionSet.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBlockInsertionSet.cpp
@@ -37,7 +37,7 @@ BlockInsertionSet::BlockInsertionSet(Graph& graph)
 {
 }
 
-BlockInsertionSet::~BlockInsertionSet() { }
+BlockInsertionSet::~BlockInsertionSet() = default;
 
 void BlockInsertionSet::insert(const BlockInsertion& insertion)
 {

--- a/Source/JavaScriptCore/dfg/DFGClobberSet.cpp
+++ b/Source/JavaScriptCore/dfg/DFGClobberSet.cpp
@@ -34,8 +34,8 @@
 
 namespace JSC { namespace DFG {
 
-ClobberSet::ClobberSet() { }
-ClobberSet::~ClobberSet() { }
+ClobberSet::ClobberSet() = default;
+ClobberSet::~ClobberSet() = default;
 
 void ClobberSet::add(AbstractHeap heap)
 {

--- a/Source/JavaScriptCore/dfg/DFGDesiredIdentifiers.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDesiredIdentifiers.cpp
@@ -46,9 +46,7 @@ DesiredIdentifiers::DesiredIdentifiers(CodeBlock* codeBlock)
 {
 }
 
-DesiredIdentifiers::~DesiredIdentifiers()
-{
-}
+DesiredIdentifiers::~DesiredIdentifiers() = default;
 
 unsigned DesiredIdentifiers::numberOfIdentifiers()
 {

--- a/Source/JavaScriptCore/dfg/DFGDesiredTransitions.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDesiredTransitions.cpp
@@ -58,9 +58,7 @@ DesiredTransitions::DesiredTransitions(CodeBlock* codeBlock)
 {
 }
 
-DesiredTransitions::~DesiredTransitions()
-{
-}
+DesiredTransitions::~DesiredTransitions() = default;
 
 void DesiredTransitions::addLazily(CodeBlock* codeOriginOwner, Structure* oldStructure, Structure* newStructure)
 {

--- a/Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.cpp
@@ -110,8 +110,8 @@ bool AdaptiveStructureWatchpointAdaptor::add(CodeBlock* codeBlock, const ObjectP
     return true;
 }
 
-DesiredWatchpoints::DesiredWatchpoints() { }
-DesiredWatchpoints::~DesiredWatchpoints() { }
+DesiredWatchpoints::DesiredWatchpoints() = default;
+DesiredWatchpoints::~DesiredWatchpoints() = default;
 
 void DesiredWatchpoints::addLazily(WatchpointSet& set)
 {

--- a/Source/JavaScriptCore/dfg/DFGFailedFinalizer.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFailedFinalizer.cpp
@@ -38,9 +38,7 @@ FailedFinalizer::FailedFinalizer(Plan& plan)
 {
 }
 
-FailedFinalizer::~FailedFinalizer()
-{
-}
+FailedFinalizer::~FailedFinalizer() = default;
 
 size_t FailedFinalizer::codeSize()
 {

--- a/Source/JavaScriptCore/dfg/DFGFlowIndexing.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFlowIndexing.cpp
@@ -42,9 +42,7 @@ FlowIndexing::FlowIndexing(Graph& graph)
     recompute();
 }
 
-FlowIndexing::~FlowIndexing()
-{
-}
+FlowIndexing::~FlowIndexing() = default;
 
 void FlowIndexing::recompute()
 {

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -94,9 +94,7 @@ Graph::Graph(VM& vm, Plan& plan)
     this->symbolStructure = registerStructure(vm.symbolStructure.get());
 }
 
-Graph::~Graph()
-{
-}
+Graph::~Graph() = default;
 
 ASCIILiteral Graph::opName(NodeType op)
 {

--- a/Source/JavaScriptCore/dfg/DFGGraphSafepoint.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraphSafepoint.cpp
@@ -40,7 +40,7 @@ GraphSafepoint::GraphSafepoint(Graph& graph, Safepoint::Result& result)
     m_safepoint.begin();
 }
 
-GraphSafepoint::~GraphSafepoint() { }
+GraphSafepoint::~GraphSafepoint() = default;
 
 } } // namespace JSC::DFG
 

--- a/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.cpp
+++ b/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.cpp
@@ -49,7 +49,7 @@ InPlaceAbstractState::InPlaceAbstractState(Graph& graph)
 {
 }
 
-InPlaceAbstractState::~InPlaceAbstractState() { }
+InPlaceAbstractState::~InPlaceAbstractState() = default;
 
 void InPlaceAbstractState::beginBasicBlock(BasicBlock* basicBlock)
 {

--- a/Source/JavaScriptCore/dfg/DFGJITCode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.cpp
@@ -187,9 +187,7 @@ JITCode::JITCode(bool isUnlinked)
 {
 }
 
-JITCode::~JITCode()
-{
-}
+JITCode::~JITCode() = default;
 
 CommonData* JITCode::dfgCommon()
 {

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
@@ -64,9 +64,7 @@ JITCompiler::JITCompiler(Graph& dfg)
 #endif
 }
 
-JITCompiler::~JITCompiler()
-{
-}
+JITCompiler::~JITCompiler() = default;
 
 void JITCompiler::linkOSRExits()
 {

--- a/Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp
@@ -46,9 +46,7 @@ JITFinalizer::JITFinalizer(Plan& plan, Ref<DFG::JITCode>&& jitCode, CodePtr<JSEn
 {
 }
 
-JITFinalizer::~JITFinalizer()
-{
-}
+JITFinalizer::~JITFinalizer() = default;
 
 size_t JITFinalizer::codeSize()
 {

--- a/Source/JavaScriptCore/dfg/DFGOSRAvailabilityAnalysisPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRAvailabilityAnalysisPhase.cpp
@@ -224,9 +224,7 @@ LocalOSRAvailabilityCalculator::LocalOSRAvailabilityCalculator(Graph& graph)
 {
 }
 
-LocalOSRAvailabilityCalculator::~LocalOSRAvailabilityCalculator()
-{
-}
+LocalOSRAvailabilityCalculator::~LocalOSRAvailabilityCalculator() = default;
 
 void LocalOSRAvailabilityCalculator::beginBlock(BasicBlock* block)
 {

--- a/Source/JavaScriptCore/dfg/DFGPhiChildren.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPhiChildren.cpp
@@ -36,9 +36,7 @@ namespace JSC { namespace DFG {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PhiChildren);
 
-PhiChildren::PhiChildren()
-{
-}
+PhiChildren::PhiChildren() = default;
 
 PhiChildren::PhiChildren(Graph& graph)
 {
@@ -52,9 +50,7 @@ PhiChildren::PhiChildren(Graph& graph)
     }
 }
 
-PhiChildren::~PhiChildren()
-{
-}
+PhiChildren::~PhiChildren() = default;
 
 const PhiChildren::List& PhiChildren::upsilonsOf(Node* node) const
 {

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -147,9 +147,7 @@ Plan::Plan(CodeBlock* passedCodeBlock, CodeBlock* profiledDFGCodeBlock,
     m_inlineCallFrames->disableThreadingChecks();
 }
 
-Plan::~Plan()
-{
-}
+Plan::~Plan() = default;
 
 size_t Plan::codeSize() const
 {

--- a/Source/JavaScriptCore/dfg/DFGSSACalculator.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSSACalculator.cpp
@@ -62,9 +62,7 @@ SSACalculator::SSACalculator(Graph& graph)
 {
 }
 
-SSACalculator::~SSACalculator()
-{
-}
+SSACalculator::~SSACalculator() = default;
 
 void SSACalculator::reset()
 {

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -115,9 +115,7 @@ SpeculativeJIT::SpeculativeJIT(Graph& dfg)
 {
 }
 
-SpeculativeJIT::~SpeculativeJIT()
-{
-}
+SpeculativeJIT::~SpeculativeJIT() = default;
 
 static void emitStackOverflowCheck(JITCompiler& jit, MacroAssembler::JumpList& stackOverflow)
 {
@@ -1886,7 +1884,7 @@ GPRTemporary::GPRTemporary(SpeculativeJIT* jit, ReuseTag, JSValueOperand& op1, W
 }
 #endif
 
-JSValueRegsTemporary::JSValueRegsTemporary() { }
+JSValueRegsTemporary::JSValueRegsTemporary() = default;
 
 JSValueRegsTemporary::JSValueRegsTemporary(SpeculativeJIT* jit)
 #if USE(JSVALUE64)
@@ -1926,7 +1924,7 @@ JSValueRegsTemporary::JSValueRegsTemporary(SpeculativeJIT* jit, ReuseTag, JSValu
 }
 #endif
 
-JSValueRegsTemporary::~JSValueRegsTemporary() { }
+JSValueRegsTemporary::~JSValueRegsTemporary() = default;
 
 JSValueRegs JSValueRegsTemporary::regs()
 {

--- a/Source/JavaScriptCore/dfg/DFGToFTLDeferredCompilationCallback.cpp
+++ b/Source/JavaScriptCore/dfg/DFGToFTLDeferredCompilationCallback.cpp
@@ -33,11 +33,9 @@
 
 namespace JSC { namespace DFG {
 
-ToFTLDeferredCompilationCallback::ToFTLDeferredCompilationCallback()
-{
-}
+ToFTLDeferredCompilationCallback::ToFTLDeferredCompilationCallback() = default;
 
-ToFTLDeferredCompilationCallback::~ToFTLDeferredCompilationCallback() { }
+ToFTLDeferredCompilationCallback::~ToFTLDeferredCompilationCallback() = default;
 
 Ref<ToFTLDeferredCompilationCallback> ToFTLDeferredCompilationCallback::create()
 {

--- a/Source/JavaScriptCore/dfg/DFGToFTLForOSREntryDeferredCompilationCallback.cpp
+++ b/Source/JavaScriptCore/dfg/DFGToFTLForOSREntryDeferredCompilationCallback.cpp
@@ -39,9 +39,7 @@ ToFTLForOSREntryDeferredCompilationCallback::ToFTLForOSREntryDeferredCompilation
 {
 }
 
-ToFTLForOSREntryDeferredCompilationCallback::~ToFTLForOSREntryDeferredCompilationCallback()
-{
-}
+ToFTLForOSREntryDeferredCompilationCallback::~ToFTLForOSREntryDeferredCompilationCallback() = default;
 
 Ref<ToFTLForOSREntryDeferredCompilationCallback>ToFTLForOSREntryDeferredCompilationCallback::create(JITCode::TriggerReason* forcedOSREntryTrigger)
 {

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeap.cpp
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeap.cpp
@@ -138,9 +138,7 @@ IndexedAbstractHeap::IndexedAbstractHeap(AbstractHeap* parent, const char* heapN
 {
 }
 
-IndexedAbstractHeap::~IndexedAbstractHeap()
-{
-}
+IndexedAbstractHeap::~IndexedAbstractHeap() = default;
 
 TypedPointer IndexedAbstractHeap::baseIndex(Output& out, LValue base, LValue index, JSValue indexAsConstant, ptrdiff_t offset, LValue mask)
 {
@@ -246,9 +244,7 @@ NumberedAbstractHeap::NumberedAbstractHeap(AbstractHeap* heap, const char* heapN
 {
 }
 
-NumberedAbstractHeap::~NumberedAbstractHeap()
-{
-}
+NumberedAbstractHeap::~NumberedAbstractHeap() = default;
 
 void NumberedAbstractHeap::dump(PrintStream& out)
 {
@@ -260,9 +256,7 @@ AbsoluteAbstractHeap::AbsoluteAbstractHeap(AbstractHeap* heap, const char* heapN
 {
 }
 
-AbsoluteAbstractHeap::~AbsoluteAbstractHeap()
-{
-}
+AbsoluteAbstractHeap::~AbsoluteAbstractHeap() = default;
 
 void AbsoluteAbstractHeap::dump(PrintStream& out)
 {

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.cpp
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.cpp
@@ -99,9 +99,7 @@ AbstractHeapRepository::AbstractHeapRepository()
     RELEASE_ASSERT(!JSCell_freeListNext.offset());
 }
 
-AbstractHeapRepository::~AbstractHeapRepository()
-{
-}
+AbstractHeapRepository::~AbstractHeapRepository() = default;
 
 void AbstractHeapRepository::decorateMemory(const AbstractHeap* heap, B3::Value* value)
 {

--- a/Source/JavaScriptCore/ftl/FTLExceptionTarget.cpp
+++ b/Source/JavaScriptCore/ftl/FTLExceptionTarget.cpp
@@ -32,9 +32,7 @@
 
 namespace JSC { namespace FTL {
 
-ExceptionTarget::~ExceptionTarget()
-{
-}
+ExceptionTarget::~ExceptionTarget() = default;
 
 CodeLocationLabel<ExceptionHandlerPtrTag> ExceptionTarget::label(LinkBuffer& linkBuffer)
 {

--- a/Source/JavaScriptCore/ftl/FTLExitTimeObjectMaterialization.cpp
+++ b/Source/JavaScriptCore/ftl/FTLExitTimeObjectMaterialization.cpp
@@ -40,9 +40,7 @@ ExitTimeObjectMaterialization::ExitTimeObjectMaterialization(NodeType type, Code
 {
 }
 
-ExitTimeObjectMaterialization::~ExitTimeObjectMaterialization()
-{
-}
+ExitTimeObjectMaterialization::~ExitTimeObjectMaterialization() = default;
 
 void ExitTimeObjectMaterialization::add(
     PromotedLocationDescriptor location, const ExitValue& value)

--- a/Source/JavaScriptCore/ftl/FTLForOSREntryJITCode.cpp
+++ b/Source/JavaScriptCore/ftl/FTLForOSREntryJITCode.cpp
@@ -35,9 +35,7 @@ ForOSREntryJITCode::ForOSREntryJITCode()
 {
 }
 
-ForOSREntryJITCode::~ForOSREntryJITCode()
-{
-}
+ForOSREntryJITCode::~ForOSREntryJITCode() = default;
 
 ForOSREntryJITCode* ForOSREntryJITCode::ftlForOSREntry()
 {

--- a/Source/JavaScriptCore/ftl/FTLJITFinalizer.cpp
+++ b/Source/JavaScriptCore/ftl/FTLJITFinalizer.cpp
@@ -44,9 +44,7 @@ JITFinalizer::JITFinalizer(DFG::Plan& plan)
 {
 }
 
-JITFinalizer::~JITFinalizer()
-{
-}
+JITFinalizer::~JITFinalizer() = default;
 
 size_t JITFinalizer::codeSize()
 {

--- a/Source/JavaScriptCore/ftl/FTLLazySlowPath.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLazySlowPath.cpp
@@ -35,9 +35,7 @@ namespace JSC { namespace FTL {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LazySlowPath);
 
-LazySlowPath::~LazySlowPath()
-{
-}
+LazySlowPath::~LazySlowPath() = default;
 
 void LazySlowPath::initialize(
     CodeLocationJump<JSInternalPtrTag> patchableJump, CodeLocationLabel<JSInternalPtrTag> done,

--- a/Source/JavaScriptCore/ftl/FTLOutput.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOutput.cpp
@@ -50,9 +50,7 @@ Output::Output(State& state)
 {
 }
 
-Output::~Output()
-{
-}
+Output::~Output() = default;
 
 void Output::initialize(AbstractHeapRepository& heaps)
 {

--- a/Source/JavaScriptCore/ftl/FTLPatchpointExceptionHandle.cpp
+++ b/Source/JavaScriptCore/ftl/FTLPatchpointExceptionHandle.cpp
@@ -54,9 +54,7 @@ RefPtr<PatchpointExceptionHandle> PatchpointExceptionHandle::defaultHandle(State
     return state.defaultExceptionHandle;
 }
 
-PatchpointExceptionHandle::~PatchpointExceptionHandle()
-{
-}
+PatchpointExceptionHandle::~PatchpointExceptionHandle() = default;
 
 RefPtr<ExceptionTarget> PatchpointExceptionHandle::scheduleExitCreation(
     const B3::StackmapGenerationParams& params)

--- a/Source/JavaScriptCore/ftl/FTLState.cpp
+++ b/Source/JavaScriptCore/ftl/FTLState.cpp
@@ -160,9 +160,7 @@ void State::dumpDisassembly(PrintStream& out, LinkBuffer& linkBuffer, const Scop
     linkBuffer.didAlreadyDisassemble();
 }
 
-State::~State()
-{
-}
+State::~State() = default;
 
 StructureStubInfo* State::addStructureStubInfo()
 {

--- a/Source/JavaScriptCore/heap/AlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/AlignedMemoryAllocator.cpp
@@ -32,13 +32,9 @@
 
 namespace JSC { 
 
-AlignedMemoryAllocator::AlignedMemoryAllocator()
-{
-}
+AlignedMemoryAllocator::AlignedMemoryAllocator() = default;
 
-AlignedMemoryAllocator::~AlignedMemoryAllocator()
-{
-}
+AlignedMemoryAllocator::~AlignedMemoryAllocator() = default;
 
 void AlignedMemoryAllocator::registerDirectory(JSC::Heap& heap, BlockDirectory* directory)
 {

--- a/Source/JavaScriptCore/heap/CodeBlockSet.cpp
+++ b/Source/JavaScriptCore/heap/CodeBlockSet.cpp
@@ -35,13 +35,9 @@ namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CodeBlockSet);
 
-CodeBlockSet::CodeBlockSet()
-{
-}
+CodeBlockSet::CodeBlockSet() = default;
 
-CodeBlockSet::~CodeBlockSet()
-{
-}
+CodeBlockSet::~CodeBlockSet() = default;
 
 bool CodeBlockSet::contains(const AbstractLocker&, void* candidateCodeBlock)
 {

--- a/Source/JavaScriptCore/heap/CompleteSubspace.cpp
+++ b/Source/JavaScriptCore/heap/CompleteSubspace.cpp
@@ -42,9 +42,7 @@ CompleteSubspace::CompleteSubspace(CString name, JSC::Heap& heap, const HeapCell
     initialize(heapCellType, alignedMemoryAllocator);
 }
 
-CompleteSubspace::~CompleteSubspace()
-{
-}
+CompleteSubspace::~CompleteSubspace() = default;
 
 Allocator CompleteSubspace::allocatorForNonInline(size_t size, AllocatorForMode mode)
 {

--- a/Source/JavaScriptCore/heap/FastMallocAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/FastMallocAlignedMemoryAllocator.cpp
@@ -37,9 +37,7 @@ FastMallocAlignedMemoryAllocator::FastMallocAlignedMemoryAllocator()
 {
 }
 
-FastMallocAlignedMemoryAllocator::~FastMallocAlignedMemoryAllocator()
-{
-}
+FastMallocAlignedMemoryAllocator::~FastMallocAlignedMemoryAllocator() = default;
 
 void* FastMallocAlignedMemoryAllocator::tryAllocateAlignedMemory(size_t alignment, size_t size)
 {

--- a/Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.cpp
@@ -36,9 +36,7 @@ GigacageAlignedMemoryAllocator::GigacageAlignedMemoryAllocator(Gigacage::Kind ki
 {
 }
 
-GigacageAlignedMemoryAllocator::~GigacageAlignedMemoryAllocator()
-{
-}
+GigacageAlignedMemoryAllocator::~GigacageAlignedMemoryAllocator() = default;
 
 void* GigacageAlignedMemoryAllocator::tryAllocateAlignedMemory(size_t alignment, size_t size)
 {

--- a/Source/JavaScriptCore/heap/HeapCellType.cpp
+++ b/Source/JavaScriptCore/heap/HeapCellType.cpp
@@ -52,9 +52,7 @@ HeapCellType::HeapCellType(CellAttributes attributes)
 {
 }
 
-HeapCellType::~HeapCellType()
-{
-}
+HeapCellType::~HeapCellType() = default;
 
 void HeapCellType::finishSweep(MarkedBlock::Handle& block, FreeList* freeList) const
 {

--- a/Source/JavaScriptCore/heap/HeapProfiler.cpp
+++ b/Source/JavaScriptCore/heap/HeapProfiler.cpp
@@ -39,9 +39,7 @@ HeapProfiler::HeapProfiler(VM& vm)
 {
 }
 
-HeapProfiler::~HeapProfiler()
-{
-}
+HeapProfiler::~HeapProfiler() = default;
 
 HeapSnapshot* HeapProfiler::mostRecentSnapshot()
 {

--- a/Source/JavaScriptCore/heap/HeapSnapshot.cpp
+++ b/Source/JavaScriptCore/heap/HeapSnapshot.cpp
@@ -38,9 +38,7 @@ HeapSnapshot::HeapSnapshot(HeapSnapshot* previousSnapshot)
 {
 }
 
-HeapSnapshot::~HeapSnapshot()
-{
-}
+HeapSnapshot::~HeapSnapshot() = default;
 
 void HeapSnapshot::appendNode(const HeapSnapshotNode& node)
 {

--- a/Source/JavaScriptCore/heap/IsoMemoryAllocatorBase.cpp
+++ b/Source/JavaScriptCore/heap/IsoMemoryAllocatorBase.cpp
@@ -35,9 +35,7 @@ IsoMemoryAllocatorBase::IsoMemoryAllocatorBase(CString name)
     UNUSED_PARAM(name);
 }
 
-IsoMemoryAllocatorBase::~IsoMemoryAllocatorBase()
-{
-}
+IsoMemoryAllocatorBase::~IsoMemoryAllocatorBase() = default;
 
 // We need to call this from the derived class's destructor because it's undefined behavior to call pure virtual methods from within a destructor.
 void IsoMemoryAllocatorBase::releaseMemoryFromSubclassDestructor()

--- a/Source/JavaScriptCore/heap/IsoSubspace.cpp
+++ b/Source/JavaScriptCore/heap/IsoSubspace.cpp
@@ -54,9 +54,7 @@ IsoSubspace::IsoSubspace(CString name, JSC::Heap& heap, const HeapCellType& heap
     m_firstDirectory = &m_directory;
 }
 
-IsoSubspace::~IsoSubspace()
-{
-}
+IsoSubspace::~IsoSubspace() = default;
 
 void IsoSubspace::didResizeBits(unsigned blockIndex)
 {

--- a/Source/JavaScriptCore/heap/JITStubRoutineSet.cpp
+++ b/Source/JavaScriptCore/heap/JITStubRoutineSet.cpp
@@ -36,7 +36,7 @@ namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(JITStubRoutineSet);
 
-JITStubRoutineSet::JITStubRoutineSet() { }
+JITStubRoutineSet::JITStubRoutineSet() = default;
 JITStubRoutineSet::~JITStubRoutineSet()
 {
     for (auto& entry : m_routines) {

--- a/Source/JavaScriptCore/heap/MarkStackMergingConstraint.cpp
+++ b/Source/JavaScriptCore/heap/MarkStackMergingConstraint.cpp
@@ -40,9 +40,7 @@ MarkStackMergingConstraint::MarkStackMergingConstraint(JSC::Heap& heap)
 {
 }
 
-MarkStackMergingConstraint::~MarkStackMergingConstraint()
-{
-}
+MarkStackMergingConstraint::~MarkStackMergingConstraint() = default;
 
 double MarkStackMergingConstraint::quickWorkEstimate(SlotVisitor&)
 {

--- a/Source/JavaScriptCore/heap/MarkedBlock.cpp
+++ b/Source/JavaScriptCore/heap/MarkedBlock.cpp
@@ -101,9 +101,7 @@ MarkedBlock::Header::Header(VM& vm, Handle& handle)
 {
 }
 
-MarkedBlock::Header::~Header()
-{
-}
+MarkedBlock::Header::~Header() = default;
 
 void MarkedBlock::Handle::unsweepWithNoNewlyAllocated()
 {

--- a/Source/JavaScriptCore/heap/MarkingConstraint.cpp
+++ b/Source/JavaScriptCore/heap/MarkingConstraint.cpp
@@ -45,9 +45,7 @@ MarkingConstraint::MarkingConstraint(CString abbreviatedName, CString name, Cons
 {
 }
 
-MarkingConstraint::~MarkingConstraint()
-{
-}
+MarkingConstraint::~MarkingConstraint() = default;
 
 void MarkingConstraint::resetStats()
 {

--- a/Source/JavaScriptCore/heap/MarkingConstraintSet.cpp
+++ b/Source/JavaScriptCore/heap/MarkingConstraintSet.cpp
@@ -42,9 +42,7 @@ MarkingConstraintSet::MarkingConstraintSet(JSC::Heap& heap)
 {
 }
 
-MarkingConstraintSet::~MarkingConstraintSet()
-{
-}
+MarkingConstraintSet::~MarkingConstraintSet() = default;
 
 void MarkingConstraintSet::didStartMarking()
 {

--- a/Source/JavaScriptCore/heap/MarkingConstraintSolver.cpp
+++ b/Source/JavaScriptCore/heap/MarkingConstraintSolver.cpp
@@ -42,9 +42,7 @@ MarkingConstraintSolver::MarkingConstraintSolver(MarkingConstraintSet& set)
         });
 }
 
-MarkingConstraintSolver::~MarkingConstraintSolver()
-{
-}
+MarkingConstraintSolver::~MarkingConstraintSolver() = default;
 
 bool MarkingConstraintSolver::didVisitSomething() const
 {

--- a/Source/JavaScriptCore/heap/MutatorScheduler.cpp
+++ b/Source/JavaScriptCore/heap/MutatorScheduler.cpp
@@ -33,13 +33,9 @@ namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MutatorScheduler);
 
-MutatorScheduler::MutatorScheduler()
-{
-}
+MutatorScheduler::MutatorScheduler() = default;
 
-MutatorScheduler::~MutatorScheduler()
-{
-}
+MutatorScheduler::~MutatorScheduler() = default;
 
 void MutatorScheduler::didStop()
 {

--- a/Source/JavaScriptCore/heap/SimpleMarkingConstraint.cpp
+++ b/Source/JavaScriptCore/heap/SimpleMarkingConstraint.cpp
@@ -41,9 +41,7 @@ SimpleMarkingConstraint::SimpleMarkingConstraint(
 {
 }
 
-SimpleMarkingConstraint::~SimpleMarkingConstraint()
-{
-}
+SimpleMarkingConstraint::~SimpleMarkingConstraint() = default;
 
 template<typename Visitor>
 void SimpleMarkingConstraint::executeImplImpl(Visitor& visitor)

--- a/Source/JavaScriptCore/heap/SpaceTimeMutatorScheduler.cpp
+++ b/Source/JavaScriptCore/heap/SpaceTimeMutatorScheduler.cpp
@@ -61,9 +61,7 @@ SpaceTimeMutatorScheduler::SpaceTimeMutatorScheduler(JSC::Heap& heap)
 {
 }
 
-SpaceTimeMutatorScheduler::~SpaceTimeMutatorScheduler()
-{
-}
+SpaceTimeMutatorScheduler::~SpaceTimeMutatorScheduler() = default;
 
 MutatorScheduler::State SpaceTimeMutatorScheduler::state() const
 {

--- a/Source/JavaScriptCore/heap/StochasticSpaceTimeMutatorScheduler.cpp
+++ b/Source/JavaScriptCore/heap/StochasticSpaceTimeMutatorScheduler.cpp
@@ -61,9 +61,7 @@ StochasticSpaceTimeMutatorScheduler::StochasticSpaceTimeMutatorScheduler(JSC::He
 {
 }
 
-StochasticSpaceTimeMutatorScheduler::~StochasticSpaceTimeMutatorScheduler()
-{
-}
+StochasticSpaceTimeMutatorScheduler::~StochasticSpaceTimeMutatorScheduler() = default;
 
 MutatorScheduler::State StochasticSpaceTimeMutatorScheduler::state() const
 {

--- a/Source/JavaScriptCore/heap/Subspace.cpp
+++ b/Source/JavaScriptCore/heap/Subspace.cpp
@@ -54,9 +54,7 @@ void Subspace::initialize(const HeapCellType& heapCellType, AlignedMemoryAllocat
     m_alignedMemoryAllocator->registerSubspace(this);
 }
 
-Subspace::~Subspace()
-{
-}
+Subspace::~Subspace() = default;
 
 void Subspace::finishSweep(MarkedBlock::Handle& block, FreeList* freeList)
 {

--- a/Source/JavaScriptCore/heap/SynchronousStopTheWorldMutatorScheduler.cpp
+++ b/Source/JavaScriptCore/heap/SynchronousStopTheWorldMutatorScheduler.cpp
@@ -32,13 +32,9 @@ namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SynchronousStopTheWorldMutatorScheduler);
 
-SynchronousStopTheWorldMutatorScheduler::SynchronousStopTheWorldMutatorScheduler()
-{
-}
+SynchronousStopTheWorldMutatorScheduler::SynchronousStopTheWorldMutatorScheduler() = default;
 
-SynchronousStopTheWorldMutatorScheduler::~SynchronousStopTheWorldMutatorScheduler()
-{
-}
+SynchronousStopTheWorldMutatorScheduler::~SynchronousStopTheWorldMutatorScheduler() = default;
 
 MutatorScheduler::State SynchronousStopTheWorldMutatorScheduler::state() const
 {

--- a/Source/JavaScriptCore/heap/WeakHandleOwner.cpp
+++ b/Source/JavaScriptCore/heap/WeakHandleOwner.cpp
@@ -31,9 +31,7 @@ namespace JSC {
 class SlotVisitor;
 template<typename T> class Handle;
 
-WeakHandleOwner::~WeakHandleOwner()
-{
-}
+WeakHandleOwner::~WeakHandleOwner() = default;
 
 bool WeakHandleOwner::isReachableFromOpaqueRoots(Handle<Unknown>, void*, AbstractSlotVisitor&, ASCIILiteral*)
 {

--- a/Source/JavaScriptCore/inspector/ConsoleMessage.cpp
+++ b/Source/JavaScriptCore/inspector/ConsoleMessage.cpp
@@ -160,9 +160,7 @@ ConsoleMessage::ConsoleMessage(MessageSource source, MessageType type, MessageLe
         m_message = m_jsonLogValues[0].value;
 }
 
-ConsoleMessage::~ConsoleMessage()
-{
-}
+ConsoleMessage::~ConsoleMessage() = default;
 
 void ConsoleMessage::autogenerateMetadata(JSC::JSGlobalObject* globalObject)
 {

--- a/Source/JavaScriptCore/inspector/InjectedScript.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScript.cpp
@@ -51,9 +51,7 @@ InjectedScript::InjectedScript(JSC::JSGlobalObject* globalObject, JSC::JSObject*
 {
 }
 
-InjectedScript::~InjectedScript()
-{
-}
+InjectedScript::~InjectedScript() = default;
 
 void InjectedScript::execute(Protocol::ErrorString& errorString, const String& functionString, ExecuteOptions&& options, RefPtr<Protocol::Runtime::RemoteObject>& result, std::optional<bool>& wasThrown, std::optional<int>& savedResultIndex)
 {

--- a/Source/JavaScriptCore/inspector/InjectedScriptBase.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptBase.cpp
@@ -117,9 +117,7 @@ InjectedScriptBase::InjectedScriptBase(const String& name, JSC::JSGlobalObject* 
 {
 }
 
-InjectedScriptBase::~InjectedScriptBase()
-{
-}
+InjectedScriptBase::~InjectedScriptBase() = default;
 
 bool InjectedScriptBase::hasAccessToInspectedScriptState() const
 {

--- a/Source/JavaScriptCore/inspector/InjectedScriptHost.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptHost.cpp
@@ -34,9 +34,7 @@ namespace Inspector {
 
 using namespace JSC;
 
-InjectedScriptHost::~InjectedScriptHost()
-{
-}
+InjectedScriptHost::~InjectedScriptHost() = default;
 
 JSValue InjectedScriptHost::wrapper(JSGlobalObject* globalObject)
 {

--- a/Source/JavaScriptCore/inspector/InjectedScriptManager.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptManager.cpp
@@ -53,9 +53,7 @@ InjectedScriptManager::InjectedScriptManager(InspectorEnvironment& environment, 
 {
 }
 
-InjectedScriptManager::~InjectedScriptManager()
-{
-}
+InjectedScriptManager::~InjectedScriptManager() = default;
 
 void InjectedScriptManager::connect()
 {

--- a/Source/JavaScriptCore/inspector/InjectedScriptModule.cpp
+++ b/Source/JavaScriptCore/inspector/InjectedScriptModule.cpp
@@ -43,9 +43,7 @@ InjectedScriptModule::InjectedScriptModule(const String& name)
 {
 }
 
-InjectedScriptModule::~InjectedScriptModule()
-{
-}
+InjectedScriptModule::~InjectedScriptModule() = default;
 
 void InjectedScriptModule::ensureInjected(InjectedScriptManager* injectedScriptManager, JSC::JSGlobalObject* globalObject)
 {

--- a/Source/JavaScriptCore/inspector/InspectorAgentRegistry.cpp
+++ b/Source/JavaScriptCore/inspector/InspectorAgentRegistry.cpp
@@ -31,9 +31,7 @@
 
 namespace Inspector {
 
-AgentRegistry::AgentRegistry()
-{
-}
+AgentRegistry::AgentRegistry() = default;
 
 AgentRegistry::~AgentRegistry()
 {

--- a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
+++ b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp
@@ -39,9 +39,7 @@ SupplementalBackendDispatcher::SupplementalBackendDispatcher(BackendDispatcher& 
 {
 }
 
-SupplementalBackendDispatcher::~SupplementalBackendDispatcher()
-{
-}
+SupplementalBackendDispatcher::~SupplementalBackendDispatcher() = default;
 
 BackendDispatcher::CallbackBase::CallbackBase(Ref<BackendDispatcher>&& backendDispatcher, long requestId)
     : m_backendDispatcher(WTFMove(backendDispatcher))

--- a/Source/JavaScriptCore/inspector/ScriptCallFrame.cpp
+++ b/Source/JavaScriptCore/inspector/ScriptCallFrame.cpp
@@ -51,9 +51,7 @@ ScriptCallFrame::ScriptCallFrame(const String& functionName, const String& scrip
 {
 }
 
-ScriptCallFrame::~ScriptCallFrame()
-{
-}
+ScriptCallFrame::~ScriptCallFrame() = default;
 
 bool ScriptCallFrame::isEqual(const ScriptCallFrame& o) const
 {

--- a/Source/JavaScriptCore/inspector/ScriptCallStack.cpp
+++ b/Source/JavaScriptCore/inspector/ScriptCallStack.cpp
@@ -44,9 +44,7 @@ Ref<ScriptCallStack> ScriptCallStack::create(Vector<ScriptCallFrame>&& frames, b
     return adoptRef(*new ScriptCallStack(WTFMove(frames), truncated, parentStackTrace));
 }
 
-ScriptCallStack::ScriptCallStack()
-{
-}
+ScriptCallStack::ScriptCallStack() = default;
 
 ScriptCallStack::ScriptCallStack(Vector<ScriptCallFrame>&& frames, bool truncated, AsyncStackTrace* parentStackTrace)
     : m_frames(WTFMove(frames))
@@ -56,9 +54,7 @@ ScriptCallStack::ScriptCallStack(Vector<ScriptCallFrame>&& frames, bool truncate
     ASSERT(m_frames.size() <= maxCallStackSizeToCapture);
 }
 
-ScriptCallStack::~ScriptCallStack()
-{
-}
+ScriptCallStack::~ScriptCallStack() = default;
 
 const ScriptCallFrame& ScriptCallStack::at(size_t index) const
 {

--- a/Source/JavaScriptCore/inspector/remote/RemoteAutomationTarget.cpp
+++ b/Source/JavaScriptCore/inspector/remote/RemoteAutomationTarget.cpp
@@ -32,9 +32,7 @@
 
 namespace Inspector {
 
-RemoteAutomationTarget::~RemoteAutomationTarget()
-{
-}
+RemoteAutomationTarget::~RemoteAutomationTarget() = default;
 
 void RemoteAutomationTarget::setIsPaired(bool paired)
 {

--- a/Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.cpp
+++ b/Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.cpp
@@ -40,9 +40,7 @@ RemoteConnectionToTarget::RemoteConnectionToTarget(RemoteControllableTarget& tar
 {
 }
 
-RemoteConnectionToTarget::~RemoteConnectionToTarget()
-{
-}
+RemoteConnectionToTarget::~RemoteConnectionToTarget() = default;
 
 bool RemoteConnectionToTarget::setup(bool isAutomaticInspection, bool automaticallyPause)
 {

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -379,9 +379,7 @@ Interpreter::Interpreter()
 #endif // ASSERT_ENABLED
 }
 
-Interpreter::~Interpreter()
-{
-}
+Interpreter::~Interpreter() = default;
 
 #if ENABLE(COMPUTED_GOTO_OPCODES)
 #if !ENABLE(LLINT_EMBEDDED_OPCODE_ID) || ASSERT_ENABLED

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -79,9 +79,7 @@ JIT::JIT(VM& vm, BaselineJITPlan& plan, CodeBlock* codeBlock)
 {
 }
 
-JIT::~JIT()
-{
-}
+JIT::~JIT() = default;
 
 JITConstantPool::Constant JIT::addToConstantPool(JITConstantPool::Type type, void* payload)
 {

--- a/Source/JavaScriptCore/jit/JITCode.cpp
+++ b/Source/JavaScriptCore/jit/JITCode.cpp
@@ -42,9 +42,7 @@ JITCode::JITCode(JITType jitType, CodePtr<JSEntryPtrTag> code, ShareAttribute sh
 {
 }
 
-JITCode::~JITCode()
-{
-}
+JITCode::~JITCode() = default;
 
 ASCIILiteral JITCode::typeName(JITType jitType)
 {
@@ -242,9 +240,7 @@ DirectJITCode::DirectJITCode(JITCode::CodeRef<JSEntryPtrTag> ref, CodePtr<JSEntr
     ASSERT(m_withArityCheck);
 }
 
-DirectJITCode::~DirectJITCode()
-{
-}
+DirectJITCode::~DirectJITCode() = default;
 
 void DirectJITCode::initializeCodeRefForDFG(JITCode::CodeRef<JSEntryPtrTag> ref, CodePtr<JSEntryPtrTag> withArityCheck)
 {
@@ -281,9 +277,7 @@ NativeJITCode::NativeJITCode(CodeRef<JSEntryPtrTag> ref, JITType jitType, Intrin
     m_intrinsic = intrinsic;
 }
 
-NativeJITCode::~NativeJITCode()
-{
-}
+NativeJITCode::~NativeJITCode() = default;
 
 CodePtr<JSEntryPtrTag> NativeJITCode::addressForCall(ArityCheckMode arity)
 {

--- a/Source/JavaScriptCore/jit/JITCompilation.cpp
+++ b/Source/JavaScriptCore/jit/JITCompilation.cpp
@@ -47,9 +47,7 @@ Compilation::Compilation(Compilation&& other)
 {
 }
 
-Compilation::~Compilation()
-{
-}
+Compilation::~Compilation() = default;
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/jit/JITDisassembler.cpp
+++ b/Source/JavaScriptCore/jit/JITDisassembler.cpp
@@ -48,9 +48,7 @@ JITDisassembler::JITDisassembler(CodeBlock *codeBlock)
 {
 }
 
-JITDisassembler::~JITDisassembler()
-{
-}
+JITDisassembler::~JITDisassembler() = default;
 
 void JITDisassembler::dump(PrintStream& out, LinkBuffer& linkBuffer)
 {

--- a/Source/JavaScriptCore/jit/JITOpaqueByproducts.cpp
+++ b/Source/JavaScriptCore/jit/JITOpaqueByproducts.cpp
@@ -35,13 +35,9 @@ namespace JSC {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(OpaqueByproduct);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(OpaqueByproducts);
 
-OpaqueByproducts::OpaqueByproducts()
-{
-}
+OpaqueByproducts::OpaqueByproducts() = default;
 
-OpaqueByproducts::~OpaqueByproducts()
-{
-}
+OpaqueByproducts::~OpaqueByproducts() = default;
 
 void OpaqueByproducts::add(std::unique_ptr<OpaqueByproduct> byproduct)
 {

--- a/Source/JavaScriptCore/jit/JITThunks.cpp
+++ b/Source/JavaScriptCore/jit/JITThunks.cpp
@@ -42,13 +42,9 @@ namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(JITThunks);
 
-JITThunks::JITThunks()
-{
-}
+JITThunks::JITThunks() = default;
 
-JITThunks::~JITThunks()
-{
-}
+JITThunks::~JITThunks() = default;
 
 void JITThunks::initialize(VM& vm)
 {

--- a/Source/JavaScriptCore/jit/JITToDFGDeferredCompilationCallback.cpp
+++ b/Source/JavaScriptCore/jit/JITToDFGDeferredCompilationCallback.cpp
@@ -32,8 +32,8 @@
 
 namespace JSC {
 
-JITToDFGDeferredCompilationCallback::JITToDFGDeferredCompilationCallback() { }
-JITToDFGDeferredCompilationCallback::~JITToDFGDeferredCompilationCallback() { }
+JITToDFGDeferredCompilationCallback::JITToDFGDeferredCompilationCallback() = default;
+JITToDFGDeferredCompilationCallback::~JITToDFGDeferredCompilationCallback() = default;
 
 Ref<JITToDFGDeferredCompilationCallback> JITToDFGDeferredCompilationCallback::create()
 {

--- a/Source/JavaScriptCore/jit/ScratchRegisterAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ScratchRegisterAllocator.cpp
@@ -40,7 +40,7 @@ ScratchRegisterAllocator::ScratchRegisterAllocator(const RegisterSet& usedRegist
 {
 }
 
-ScratchRegisterAllocator::~ScratchRegisterAllocator() { }
+ScratchRegisterAllocator::~ScratchRegisterAllocator() = default;
 
 void ScratchRegisterAllocator::lock(GPRReg reg)
 {

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -2309,9 +2309,7 @@ Message::Message(Content&& contents, int32_t index)
 {
 }
 
-Message::~Message()
-{
-}
+Message::~Message() = default;
 
 Worker::Worker(Workers& workers, bool isMain)
     : m_workers(workers)
@@ -2360,9 +2358,7 @@ ThreadSpecific<Worker*>& Worker::currentWorker()
     return *result;
 }
 
-Workers::Workers()
-{
-}
+Workers::Workers() = default;
 
 Workers::~Workers()
 {

--- a/Source/JavaScriptCore/parser/SourceProvider.cpp
+++ b/Source/JavaScriptCore/parser/SourceProvider.cpp
@@ -40,9 +40,7 @@ SourceProvider::SourceProvider(const SourceOrigin& sourceOrigin, String&& source
 {
 }
 
-SourceProvider::~SourceProvider()
-{
-}
+SourceProvider::~SourceProvider() = default;
 
 void SourceProvider::getID()
 {

--- a/Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.cpp
@@ -60,9 +60,7 @@ BytecodeSequence::BytecodeSequence(CodeBlock* codeBlock)
     }
 }
 
-BytecodeSequence::~BytecodeSequence()
-{
-}
+BytecodeSequence::~BytecodeSequence() = default;
 
 unsigned BytecodeSequence::indexForBytecodeIndex(unsigned bytecodeIndex) const
 {

--- a/Source/JavaScriptCore/profiler/ProfilerBytecodes.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecodes.cpp
@@ -45,7 +45,7 @@ Bytecodes::Bytecodes(size_t id, CodeBlock* codeBlock)
 {
 }
 
-Bytecodes::~Bytecodes() { }
+Bytecodes::~Bytecodes() = default;
 
 void Bytecodes::dump(PrintStream& out) const
 {

--- a/Source/JavaScriptCore/profiler/ProfilerCompilation.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerCompilation.cpp
@@ -45,7 +45,7 @@ Compilation::Compilation(Bytecodes* bytecodes, CompilationKind kind)
 {
 }
 
-Compilation::~Compilation() { }
+Compilation::~Compilation() = default;
 
 void Compilation::addProfiledBytecodes(Database& database, CodeBlock* profiledBlock)
 {

--- a/Source/JavaScriptCore/profiler/ProfilerCompiledBytecode.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerCompiledBytecode.cpp
@@ -38,9 +38,7 @@ CompiledBytecode::CompiledBytecode(const OriginStack& origin, const CString& des
 {
 }
 
-CompiledBytecode::~CompiledBytecode()
-{
-}
+CompiledBytecode::~CompiledBytecode() = default;
 
 Ref<JSON::Value> CompiledBytecode::toJSON(Dumper& dumper) const
 {

--- a/Source/JavaScriptCore/profiler/ProfilerOSRExit.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerOSRExit.cpp
@@ -41,9 +41,7 @@ OSRExit::OSRExit(unsigned id, const OriginStack& origin, ExitKind kind, bool isW
 {
 }
 
-OSRExit::~OSRExit()
-{
-}
+OSRExit::~OSRExit() = default;
 
 Ref<JSON::Value> OSRExit::toJSON(Dumper& dumper) const
 {

--- a/Source/JavaScriptCore/profiler/ProfilerOriginStack.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerOriginStack.cpp
@@ -56,7 +56,7 @@ OriginStack::OriginStack(Database& database, CodeBlock* codeBlock, const CodeOri
     }
 }
 
-OriginStack::~OriginStack() { }
+OriginStack::~OriginStack() = default;
 
 void OriginStack::append(const Origin& origin)
 {

--- a/Source/JavaScriptCore/profiler/ProfilerProfiledBytecodes.cpp
+++ b/Source/JavaScriptCore/profiler/ProfilerProfiledBytecodes.cpp
@@ -38,9 +38,7 @@ ProfiledBytecodes::ProfiledBytecodes(Bytecodes* bytecodes, CodeBlock* profiledBl
 {
 }
 
-ProfiledBytecodes::~ProfiledBytecodes()
-{
-}
+ProfiledBytecodes::~ProfiledBytecodes() = default;
 
 Ref<JSON::Value> ProfiledBytecodes::toJSON(Dumper& dumper) const
 {

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.cpp
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.cpp
@@ -51,9 +51,7 @@ CommonIdentifiers::CommonIdentifiers(VM& vm)
 {
 }
 
-CommonIdentifiers::~CommonIdentifiers()
-{
-}
+CommonIdentifiers::~CommonIdentifiers() = default;
 
 void CommonIdentifiers::appendExternalName(const Identifier& publicName, const Identifier& privateName)
 {

--- a/Source/JavaScriptCore/runtime/DumpContext.cpp
+++ b/Source/JavaScriptCore/runtime/DumpContext.cpp
@@ -33,7 +33,7 @@ DumpContext::DumpContext()
 {
 }
 
-DumpContext::~DumpContext() { }
+DumpContext::~DumpContext() = default;
 
 bool DumpContext::isEmpty() const
 {

--- a/Source/JavaScriptCore/runtime/FunctionRareData.cpp
+++ b/Source/JavaScriptCore/runtime/FunctionRareData.cpp
@@ -81,9 +81,7 @@ FunctionRareData::FunctionRareData(VM& vm, ExecutableBase* executable)
 {
 }
 
-FunctionRareData::~FunctionRareData()
-{
-}
+FunctionRareData::~FunctionRareData() = default;
 
 void FunctionRareData::initializeObjectAllocationProfile(VM& vm, JSGlobalObject* globalObject, JSObject* prototype, size_t inlineCapacity, JSFunction* constructor)
 {

--- a/Source/JavaScriptCore/runtime/FuzzerAgent.cpp
+++ b/Source/JavaScriptCore/runtime/FuzzerAgent.cpp
@@ -28,9 +28,7 @@
 
 namespace JSC {
 
-FuzzerAgent::~FuzzerAgent()
-{
-}
+FuzzerAgent::~FuzzerAgent() = default;
 
 SpeculatedType FuzzerAgent::getPrediction(CodeBlock*, const CodeOrigin&, SpeculatedType result)
 {

--- a/Source/JavaScriptCore/runtime/JSDestructibleObjectHeapCellType.cpp
+++ b/Source/JavaScriptCore/runtime/JSDestructibleObjectHeapCellType.cpp
@@ -49,9 +49,7 @@ JSDestructibleObjectHeapCellType::JSDestructibleObjectHeapCellType()
 {
 }
 
-JSDestructibleObjectHeapCellType::~JSDestructibleObjectHeapCellType()
-{
-}
+JSDestructibleObjectHeapCellType::~JSDestructibleObjectHeapCellType() = default;
 
 void JSDestructibleObjectHeapCellType::finishSweep(MarkedBlock::Handle& handle, FreeList* freeList) const
 {

--- a/Source/JavaScriptCore/runtime/JSLock.cpp
+++ b/Source/JavaScriptCore/runtime/JSLock.cpp
@@ -82,9 +82,7 @@ JSLock::JSLock(VM* vm)
 {
 }
 
-JSLock::~JSLock()
-{
-}
+JSLock::~JSLock() = default;
 
 void JSLock::willDestroyVM(VM* vm)
 {

--- a/Source/JavaScriptCore/runtime/JSRunLoopTimer.cpp
+++ b/Source/JavaScriptCore/runtime/JSRunLoopTimer.cpp
@@ -241,9 +241,7 @@ JSRunLoopTimer::JSRunLoopTimer(VM& vm)
 {
 }
 
-JSRunLoopTimer::~JSRunLoopTimer()
-{
-}
+JSRunLoopTimer::~JSRunLoopTimer() = default;
 
 std::optional<Seconds> JSRunLoopTimer::timeUntilFire()
 {

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -320,9 +320,7 @@ SamplingProfiler::SamplingProfiler(VM& vm, Ref<Stopwatch>&& stopwatch)
     vm.heap.objectSpace().enablePreciseAllocationTracking();
 }
 
-SamplingProfiler::~SamplingProfiler()
-{
-}
+SamplingProfiler::~SamplingProfiler() = default;
 
 void SamplingProfiler::createThreadIfNecessary()
 {

--- a/Source/JavaScriptCore/runtime/ScopedArgumentsTable.cpp
+++ b/Source/JavaScriptCore/runtime/ScopedArgumentsTable.cpp
@@ -41,9 +41,7 @@ ScopedArgumentsTable::ScopedArgumentsTable(VM& vm)
 {
 }
 
-ScopedArgumentsTable::~ScopedArgumentsTable()
-{
-}
+ScopedArgumentsTable::~ScopedArgumentsTable() = default;
 
 void ScopedArgumentsTable::destroy(JSCell* cell)
 {

--- a/Source/JavaScriptCore/runtime/SimpleTypedArrayController.cpp
+++ b/Source/JavaScriptCore/runtime/SimpleTypedArrayController.cpp
@@ -38,7 +38,7 @@ SimpleTypedArrayController::SimpleTypedArrayController(bool allowAtomicsWait)
 {
 }
 
-SimpleTypedArrayController::~SimpleTypedArrayController() { }
+SimpleTypedArrayController::~SimpleTypedArrayController() = default;
 
 JSArrayBuffer* SimpleTypedArrayController::toJS(JSGlobalObject* lexicalGlobalObject, JSGlobalObject* globalObject, ArrayBuffer* native)
 {

--- a/Source/JavaScriptCore/runtime/SmallStrings.cpp
+++ b/Source/JavaScriptCore/runtime/SmallStrings.cpp
@@ -110,9 +110,7 @@ void SmallStrings::visitStrongReferences(Visitor& visitor)
 template void SmallStrings::visitStrongReferences(AbstractSlotVisitor&);
 template void SmallStrings::visitStrongReferences(SlotVisitor&);
 
-SmallStrings::~SmallStrings()
-{
-}
+SmallStrings::~SmallStrings() = default;
 
 Ref<AtomStringImpl> SmallStrings::singleCharacterStringRep(unsigned char character)
 {

--- a/Source/JavaScriptCore/runtime/SymbolTable.cpp
+++ b/Source/JavaScriptCore/runtime/SymbolTable.cpp
@@ -88,7 +88,7 @@ SymbolTable::SymbolTable(VM& vm)
 {
 }
 
-SymbolTable::~SymbolTable() { }
+SymbolTable::~SymbolTable() = default;
 
 template<typename Visitor>
 void SymbolTable::visitChildrenImpl(JSCell* thisCell, Visitor& visitor)

--- a/Source/JavaScriptCore/runtime/TemplateObjectDescriptor.cpp
+++ b/Source/JavaScriptCore/runtime/TemplateObjectDescriptor.cpp
@@ -28,8 +28,6 @@
 
 namespace JSC {
 
-TemplateObjectDescriptor::~TemplateObjectDescriptor()
-{
-}
+TemplateObjectDescriptor::~TemplateObjectDescriptor() = default;
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/TypedArrayController.cpp
+++ b/Source/JavaScriptCore/runtime/TypedArrayController.cpp
@@ -28,8 +28,8 @@
 
 namespace JSC {
 
-TypedArrayController::TypedArrayController() { }
-TypedArrayController::~TypedArrayController() { }
+TypedArrayController::TypedArrayController() = default;
+TypedArrayController::~TypedArrayController() = default;
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -211,7 +211,7 @@ CalleeGroup::CalleeGroup(VM& vm, MemoryMode mode, ModuleInformation& moduleInfor
     worklist.enqueue(*m_plan.get());
 }
 
-CalleeGroup::~CalleeGroup() { }
+CalleeGroup::~CalleeGroup() = default;
 
 void CalleeGroup::waitUntilFinished()
 {

--- a/Source/JavaScriptCore/wasm/WasmModule.cpp
+++ b/Source/JavaScriptCore/wasm/WasmModule.cpp
@@ -51,7 +51,7 @@ Module::Module(IPIntPlan& plan)
 {
 }
 
-Module::~Module() { }
+Module::~Module() = default;
 
 Wasm::TypeIndex Module::typeIndexFromFunctionIndexSpace(unsigned functionIndexSpace) const
 {

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.cpp
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.cpp
@@ -37,7 +37,7 @@ ModuleInformation::ModuleInformation()
 {
 }
 
-ModuleInformation::~ModuleInformation() { }
+ModuleInformation::~ModuleInformation() = default;
 
 } } // namespace JSC::Wasm
 

--- a/Source/JavaScriptCore/wasm/WasmPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmPlan.cpp
@@ -123,7 +123,7 @@ void Plan::fail(String&& errorMessage)
     complete();
 }
 
-Plan::~Plan() { }
+Plan::~Plan() = default;
 
 } } // namespace JSC::Wasm
 

--- a/Source/JavaScriptCore/yarr/RegularExpression.cpp
+++ b/Source/JavaScriptCore/yarr/RegularExpression.cpp
@@ -85,9 +85,7 @@ RegularExpression::RegularExpression(const RegularExpression& re)
 {
 }
 
-RegularExpression::~RegularExpression()
-{
-}
+RegularExpression::~RegularExpression() = default;
 
 RegularExpression& RegularExpression::operator=(const RegularExpression& re)
 {

--- a/Source/JavaScriptCore/yarr/YarrDisassembler.cpp
+++ b/Source/JavaScriptCore/yarr/YarrDisassembler.cpp
@@ -55,9 +55,7 @@ YarrDisassembler::YarrDisassembler(YarrJITInfo* yarrJITInfo)
 {
 }
 
-YarrDisassembler::~YarrDisassembler()
-{
-}
+YarrDisassembler::~YarrDisassembler() = default;
 
 void YarrDisassembler::dump(PrintStream& out, LinkBuffer& linkBuffer)
 {

--- a/Source/bmalloc/bmalloc/FreeList.cpp
+++ b/Source/bmalloc/bmalloc/FreeList.cpp
@@ -31,13 +31,9 @@
 
 namespace bmalloc {
 
-FreeList::FreeList()
-{
-}
+FreeList::FreeList() = default;
 
-FreeList::~FreeList()
-{
-}
+FreeList::~FreeList() = default;
 
 void FreeList::clear()
 {


### PR DESCRIPTION
#### 0710c9fcecd0a9ec28c3614b6f563d269dbaba0e
<pre>
Use &quot;= default&quot; for constructor and destructor in more JSC code

<a href="https://bugs.webkit.org/show_bug.cgi?id=275238">https://bugs.webkit.org/show_bug.cgi?id=275238</a>

Reviewed by Darin Adler.

This extends our &quot;= default&quot; usage across constructor and destructor in JSC
and bmalloc code.

* Source/JavaScriptCore/bytecode/DFGExitProfile.cpp:
(JSC::DFG::QueryableExitProfile::QueryableExitProfile):
(JSC::DFG::QueryableExitProfile::~QueryableExitProfile):
* Source/JavaScriptCore/dfg/DFGAtTailAbstractState.cpp:
(JSC::DFG::AtTailAbstractState::~AtTailAbstractState):
* Source/JavaScriptCore/dfg/DFGBasicBlock.cpp:
(JSC::DFG::BasicBlock::~BasicBlock):
* Source/JavaScriptCore/dfg/DFGBlockInsertionSet.cpp:
(JSC::DFG::BlockInsertionSet::~BlockInsertionSet):
* Source/JavaScriptCore/dfg/DFGClobberSet.cpp:
(JSC::DFG::ClobberSet::ClobberSet):
(JSC::DFG::ClobberSet::~ClobberSet):
* Source/JavaScriptCore/dfg/DFGDesiredIdentifiers.cpp:
(JSC::DFG::DesiredIdentifiers::~DesiredIdentifiers):
* Source/JavaScriptCore/dfg/DFGDesiredTransitions.cpp:
(JSC::DFG::DesiredTransitions::~DesiredTransitions):
* Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.cpp:
(JSC::DFG::DesiredWatchpoints::DesiredWatchpoints):
(JSC::DFG::DesiredWatchpoints::~DesiredWatchpoints):
* Source/JavaScriptCore/dfg/DFGFailedFinalizer.cpp:
(JSC::DFG::FailedFinalizer::~FailedFinalizer):
* Source/JavaScriptCore/dfg/DFGFlowIndexing.cpp:
(JSC::DFG::FlowIndexing::~FlowIndexing):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::~Graph):
* Source/JavaScriptCore/dfg/DFGGraphSafepoint.cpp:
(JSC::DFG::GraphSafepoint::~GraphSafepoint):
* Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.cpp:
(JSC::DFG::InPlaceAbstractState::~InPlaceAbstractState):
* Source/JavaScriptCore/dfg/DFGJITCode.cpp:
(JSC::DFG::JITCode::~JITCode):
* Source/JavaScriptCore/dfg/DFGJITCompiler.cpp:
(JSC::DFG::JITCompiler::~JITCompiler):
* Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp:
(JSC::DFG::JITFinalizer::~JITFinalizer):
* Source/JavaScriptCore/dfg/DFGOSRAvailabilityAnalysisPhase.cpp:
(JSC::DFG::LocalOSRAvailabilityCalculator::~LocalOSRAvailabilityCalculator):
* Source/JavaScriptCore/dfg/DFGPhiChildren.cpp:
(JSC::DFG::PhiChildren::~PhiChildren):
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::~Plan):
* Source/JavaScriptCore/dfg/DFGSSACalculator.cpp:
(JSC::DFG::SSACalculator::~SSACalculator):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::~SpeculativeJIT):
(JSC::JSValueRegsTemporary::~JSValueRegsTemporary):
* Source/JavaScriptCore/dfg/DFGToFTLDeferredCompilationCallback.cpp:
(JSC::DFG::ToFTLDeferredCompilationCallback::ToFTLDeferredCompilationCallback):
(JSC::DFG::ToFTLDeferredCompilationCallback::~ToFTLDeferredCompilationCallback):
* Source/JavaScriptCore/dfg/DFGToFTLForOSREntryDeferredCompilationCallback.cpp:
(JSC::DFG::ToFTLForOSREntryDeferredCompilationCallback::~ToFTLForOSREntryDeferredCompilationCallback):
* Source/JavaScriptCore/ftl/FTLAbstractHeap.cpp:
(JSC::FTL::IndexedAbstractHeap::~IndexedAbstractHeap):
(JSC::FTL::NumberedAbstractHeap::~NumberedAbstractHeap):
(JSC::FTL::AbsoluteAbstractHeap::~AbsoluteAbstractHeap):
* Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.cpp:
(JSC::FTL::AbstractHeapRepository::~AbstractHeapRepository):
* Source/JavaScriptCore/ftl/FTLExceptionTarget.cpp:
(JSC::FTL::ExceptionTarget::~ExceptionTarget):
* Source/JavaScriptCore/ftl/FTLExitTimeObjectMaterialization.cpp:
(JSC::FTL::ExitTimeObjectMaterialization::~ExitTimeObjectMaterialization):
* Source/JavaScriptCore/ftl/FTLForOSREntryJITCode.cpp:
(JSC::FTL::ForOSREntryJITCode::~ForOSREntryJITCode):
* Source/JavaScriptCore/ftl/FTLJITFinalizer.cpp:
(JSC::FTL::JITFinalizer::~JITFinalizer):
* Source/JavaScriptCore/ftl/FTLLazySlowPath.cpp:
(JSC::FTL::LazySlowPath::~LazySlowPath):
* Source/JavaScriptCore/ftl/FTLOutput.cpp:
(JSC::FTL::Output::~Output):
* Source/JavaScriptCore/ftl/FTLPatchpointExceptionHandle.cpp:
(JSC::FTL::PatchpointExceptionHandle::~PatchpointExceptionHandle):
* Source/JavaScriptCore/ftl/FTLState.cpp:
(JSC::FTL::State::~State):
* Source/JavaScriptCore/heap/AlignedMemoryAllocator.cpp:
(JSC::AlignedMemoryAllocator::AlignedMemoryAllocator):
(JSC::AlignedMemoryAllocator::~AlignedMemoryAllocator):
* Source/JavaScriptCore/heap/CodeBlockSet.cpp:
(JSC::CodeBlockSet::CodeBlockSet):
(JSC::CodeBlockSet::~CodeBlockSet):
* Source/JavaScriptCore/heap/CompleteSubspace.cpp:
(JSC::CompleteSubspace::~CompleteSubspace):
* Source/JavaScriptCore/heap/FastMallocAlignedMemoryAllocator.cpp:
(JSC::FastMallocAlignedMemoryAllocator::~FastMallocAlignedMemoryAllocator):
* Source/JavaScriptCore/heap/GigacageAlignedMemoryAllocator.cpp:
(JSC::GigacageAlignedMemoryAllocator::~GigacageAlignedMemoryAllocator):
* Source/JavaScriptCore/heap/HeapCellType.cpp:
(JSC::HeapCellType::~HeapCellType):
* Source/JavaScriptCore/heap/HeapProfiler.cpp:
(JSC::HeapProfiler::~HeapProfiler):
* Source/JavaScriptCore/heap/HeapSnapshot.cpp:
(JSC::HeapSnapshot::~HeapSnapshot):
* Source/JavaScriptCore/heap/IsoMemoryAllocatorBase.cpp:
(JSC::IsoMemoryAllocatorBase::~IsoMemoryAllocatorBase):
* Source/JavaScriptCore/heap/IsoSubspace.cpp:
(JSC::IsoSubspace::~IsoSubspace):
* Source/JavaScriptCore/heap/JITStubRoutineSet.cpp:
(JSC::JITStubRoutineSet::JITStubRoutineSet):
* Source/JavaScriptCore/heap/MarkStackMergingConstraint.cpp:
(JSC::MarkStackMergingConstraint::~MarkStackMergingConstraint):
* Source/JavaScriptCore/heap/MarkedBlock.cpp:
(JSC::MarkedBlock::Header::~Header):
* Source/JavaScriptCore/heap/MarkingConstraint.cpp:
(JSC::MarkingConstraint::~MarkingConstraint):
* Source/JavaScriptCore/heap/MarkingConstraintSet.cpp:
(JSC::MarkingConstraintSet::~MarkingConstraintSet):
* Source/JavaScriptCore/heap/MarkingConstraintSolver.cpp:
(JSC::MarkingConstraintSolver::~MarkingConstraintSolver):
* Source/JavaScriptCore/heap/MutatorScheduler.cpp:
(JSC::MutatorScheduler::MutatorScheduler):
(JSC::MutatorScheduler::~MutatorScheduler):
* Source/JavaScriptCore/heap/SimpleMarkingConstraint.cpp:
(JSC::SimpleMarkingConstraint::~SimpleMarkingConstraint):
* Source/JavaScriptCore/heap/SpaceTimeMutatorScheduler.cpp:
(JSC::SpaceTimeMutatorScheduler::~SpaceTimeMutatorScheduler):
* Source/JavaScriptCore/heap/StochasticSpaceTimeMutatorScheduler.cpp:
(JSC::StochasticSpaceTimeMutatorScheduler::~StochasticSpaceTimeMutatorScheduler):
* Source/JavaScriptCore/heap/Subspace.cpp:
(JSC::Subspace::~Subspace):
* Source/JavaScriptCore/heap/SynchronousStopTheWorldMutatorScheduler.cpp:
(JSC::SynchronousStopTheWorldMutatorScheduler::SynchronousStopTheWorldMutatorScheduler):
(JSC::SynchronousStopTheWorldMutatorScheduler::~SynchronousStopTheWorldMutatorScheduler):
* Source/JavaScriptCore/heap/WeakHandleOwner.cpp:
(JSC::WeakHandleOwner::~WeakHandleOwner):
* Source/JavaScriptCore/inspector/ConsoleMessage.cpp:
(Inspector::ConsoleMessage::~ConsoleMessage):
* Source/JavaScriptCore/inspector/InjectedScript.cpp:
(Inspector::InjectedScript::~InjectedScript):
* Source/JavaScriptCore/inspector/InjectedScriptBase.cpp:
(Inspector::InjectedScriptBase::~InjectedScriptBase):
* Source/JavaScriptCore/inspector/InjectedScriptHost.cpp:
(Inspector::InjectedScriptHost::~InjectedScriptHost):
* Source/JavaScriptCore/inspector/InjectedScriptManager.cpp:
(Inspector::InjectedScriptManager::~InjectedScriptManager):
* Source/JavaScriptCore/inspector/InjectedScriptModule.cpp:
(Inspector::InjectedScriptModule::~InjectedScriptModule):
* Source/JavaScriptCore/inspector/InspectorAgentRegistry.cpp:
(Inspector::AgentRegistry::AgentRegistry):
* Source/JavaScriptCore/inspector/InspectorBackendDispatcher.cpp:
(Inspector::SupplementalBackendDispatcher::~SupplementalBackendDispatcher):
* Source/JavaScriptCore/inspector/ScriptCallFrame.cpp:
(Inspector::ScriptCallFrame::~ScriptCallFrame):
* Source/JavaScriptCore/inspector/ScriptCallStack.cpp:
(Inspector::ScriptCallStack::~ScriptCallStack):
* Source/JavaScriptCore/inspector/remote/RemoteAutomationTarget.cpp:
(Inspector::RemoteAutomationTarget::~RemoteAutomationTarget):
* Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.cpp:
(Inspector::RemoteConnectionToTarget::~RemoteConnectionToTarget):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::~Interpreter):
* Source/JavaScriptCore/jit/JIT.cpp:
(JSC::JIT::~JIT):
* Source/JavaScriptCore/jit/JITCode.cpp:
(JSC::JITCode::~JITCode):
(JSC::DirectJITCode::~DirectJITCode):
(JSC::NativeJITCode::~NativeJITCode):
* Source/JavaScriptCore/jit/JITCompilation.cpp:
(JSC::Compilation::~Compilation):
* Source/JavaScriptCore/jit/JITDisassembler.cpp:
(JSC::JITDisassembler::~JITDisassembler):
* Source/JavaScriptCore/jit/JITOpaqueByproducts.cpp:
(JSC::OpaqueByproducts::OpaqueByproducts):
(JSC::OpaqueByproducts::~OpaqueByproducts):
* Source/JavaScriptCore/jit/JITThunks.cpp:
(JSC::JITThunks::JITThunks):
(JSC::JITThunks::~JITThunks):
* Source/JavaScriptCore/jit/JITToDFGDeferredCompilationCallback.cpp:
(JSC::JITToDFGDeferredCompilationCallback::JITToDFGDeferredCompilationCallback):
(JSC::JITToDFGDeferredCompilationCallback::~JITToDFGDeferredCompilationCallback):
* Source/JavaScriptCore/jit/ScratchRegisterAllocator.cpp:
(JSC::ScratchRegisterAllocator::~ScratchRegisterAllocator):
* Source/JavaScriptCore/jsc.cpp:
(Message::~Message):
(Workers::Workers):
* Source/JavaScriptCore/parser/SourceProvider.cpp:
(JSC::SourceProvider::~SourceProvider):
* Source/JavaScriptCore/profiler/ProfilerBytecodeSequence.cpp:
(JSC::Profiler::BytecodeSequence::~BytecodeSequence):
* Source/JavaScriptCore/profiler/ProfilerBytecodes.cpp:
(JSC::Profiler::Bytecodes::~Bytecodes):
* Source/JavaScriptCore/profiler/ProfilerCompilation.cpp:
(JSC::Profiler::Compilation::~Compilation):
* Source/JavaScriptCore/profiler/ProfilerCompiledBytecode.cpp:
(JSC::Profiler::CompiledBytecode::~CompiledBytecode):
* Source/JavaScriptCore/profiler/ProfilerOSRExit.cpp:
(JSC::Profiler::OSRExit::~OSRExit):
* Source/JavaScriptCore/profiler/ProfilerOriginStack.cpp:
(JSC::Profiler::OriginStack::~OriginStack):
* Source/JavaScriptCore/profiler/ProfilerProfiledBytecodes.cpp:
(JSC::Profiler::ProfiledBytecodes::~ProfiledBytecodes):
* Source/JavaScriptCore/runtime/CommonIdentifiers.cpp:
(JSC::CommonIdentifiers::~CommonIdentifiers):
* Source/JavaScriptCore/runtime/DumpContext.cpp:
(JSC::DumpContext::~DumpContext):
* Source/JavaScriptCore/runtime/FunctionRareData.cpp:
(JSC::FunctionRareData::~FunctionRareData):
* Source/JavaScriptCore/runtime/FuzzerAgent.cpp:
(JSC::FuzzerAgent::~FuzzerAgent):
* Source/JavaScriptCore/runtime/JSDestructibleObjectHeapCellType.cpp:
(JSC::JSDestructibleObjectHeapCellType::~JSDestructibleObjectHeapCellType):
* Source/JavaScriptCore/runtime/JSLock.cpp:
(JSC::JSLock::~JSLock):
* Source/JavaScriptCore/runtime/JSRunLoopTimer.cpp:
(JSC::JSRunLoopTimer::~JSRunLoopTimer):
* Source/JavaScriptCore/runtime/SamplingProfiler.cpp:
(JSC::SamplingProfiler::~SamplingProfiler):
* Source/JavaScriptCore/runtime/ScopedArgumentsTable.cpp:
(JSC::ScopedArgumentsTable::~ScopedArgumentsTable):
* Source/JavaScriptCore/runtime/SimpleTypedArrayController.cpp:
(JSC::SimpleTypedArrayController::~SimpleTypedArrayController):
* Source/JavaScriptCore/runtime/SmallStrings.cpp:
(JSC::SmallStrings::~SmallStrings):
* Source/JavaScriptCore/runtime/SymbolTable.cpp:
(JSC::SymbolTable::~SymbolTable):
* Source/JavaScriptCore/runtime/TemplateObjectDescriptor.cpp:
(JSC::TemplateObjectDescriptor::~TemplateObjectDescriptor):
* Source/JavaScriptCore/runtime/TypedArrayController.cpp:
(JSC::TypedArrayController::TypedArrayController):
(JSC::TypedArrayController::~TypedArrayController):
* Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp:
(JSC::Wasm::CalleeGroup::~CalleeGroup):
* Source/JavaScriptCore/wasm/WasmModule.cpp:
(JSC::Wasm::Module::~Module):
* Source/JavaScriptCore/wasm/WasmModuleInformation.cpp:
(JSC::Wasm::ModuleInformation::~ModuleInformation):
* Source/JavaScriptCore/wasm/WasmPlan.cpp:
(JSC::Wasm::Plan::~Plan):
* Source/JavaScriptCore/yarr/RegularExpression.cpp:
(JSC::Yarr::RegularExpression::~RegularExpression):
* Source/JavaScriptCore/yarr/YarrDisassembler.cpp:
(JSC::Yarr::YarrDisassembler::~YarrDisassembler):
* Source/bmalloc/bmalloc/FreeList.cpp:
(bmalloc::FreeList::FreeList):
(bmalloc::FreeList::~FreeList):

Canonical link: <a href="https://commits.webkit.org/279826@main">https://commits.webkit.org/279826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a923ce3fdedbf9c41d41b9a7364bebbfc4910301

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57921 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5374 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5382 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44262 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3628 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56736 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32204 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25387 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29001 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4664 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3514 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/48005 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4878 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59511 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/54147 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29879 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5022 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51688 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31024 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47416 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51070 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11982 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32011 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/66444 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30811 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12665 "Passed tests") | 
<!--EWS-Status-Bubble-End-->