### PR TITLE
`navigator.storage.getDirectory()` fails in service workers with an `NotSupportedError: The operation is not supported`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Call getFileHandle successfully
+PASS Call getDirectoryHandle successfully
+

--- a/LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.js
@@ -1,0 +1,12 @@
+// META: global=window,worker
+// META: script=resources/test-helpers.js
+
+promise_test(async t => {
+    const directory = await navigator.storage.getDirectory();
+    return directory.getFileHandle("testFile", { create: true });
+}, "Call getFileHandle successfully");
+
+promise_test(async t => {
+    const directory = await navigator.storage.getDirectory();
+    return directory.getDirectoryHandle("testDirectory", { create: true });
+}, "Call getDirectoryHandle successfully");

--- a/LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.serviceworker-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Call getFileHandle successfully
+PASS Call getDirectoryHandle successfully
+

--- a/LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.serviceworker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.serviceworker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.sharedworker-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Call getFileHandle successfully
+PASS Call getDirectoryHandle successfully
+

--- a/LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.sharedworker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.sharedworker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.worker-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Call getFileHandle successfully
+PASS Call getDirectoryHandle successfully
+

--- a/LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -55,6 +55,7 @@
 #include "WebSWServerToContextConnectionMessages.h"
 #include "WebServiceWorkerFetchTaskClient.h"
 #include "WebSocketProvider.h"
+#include "WebStorageProvider.h"
 #include "WebUserContentController.h"
 #include <WebCore/EditorClient.h>
 #include <WebCore/EmptyClients.h>
@@ -166,6 +167,8 @@ void WebSWContextManagerConnection::installServiceWorker(ServiceWorkerContextDat
 #if ENABLE(WEB_RTC)
         pageConfiguration.webRTCProvider = makeUniqueRef<RemoteWorkerLibWebRTCProvider>();
 #endif
+        pageConfiguration.storageProvider = makeUniqueRef<WebStorageProvider>(WebProcess::singleton().mediaKeysStorageDirectory(), WebProcess::singleton().mediaKeysStorageSalt());
+
         if (auto* serviceWorkerPage = m_serviceWorkerPageIdentifier ? Page::serviceWorkerPage(*m_serviceWorkerPageIdentifier) : nullptr)
             pageConfiguration.corsDisablingPatterns = serviceWorkerPage->corsDisablingPatterns();
 

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp
@@ -42,6 +42,7 @@
 #include "WebProcess.h"
 #include "WebSharedWorkerServerToContextConnectionMessages.h"
 #include "WebSocketProvider.h"
+#include "WebStorageProvider.h"
 #include "WebUserContentController.h"
 #include <WebCore/EmptyClients.h>
 #include <WebCore/Page.h>
@@ -107,6 +108,7 @@ void WebSharedWorkerContextManagerConnection::launchSharedWorker(WebCore::Client
 #if ENABLE(WEB_RTC)
     pageConfiguration.webRTCProvider = makeUniqueRef<RemoteWorkerLibWebRTCProvider>();
 #endif
+    pageConfiguration.storageProvider = makeUniqueRef<WebStorageProvider>(WebProcess::singleton().mediaKeysStorageDirectory(), WebProcess::singleton().mediaKeysStorageSalt());
 
     pageConfiguration.clientCreatorForMainFrame = CompletionHandler<UniqueRef<WebCore::LocalFrameLoaderClient>(WebCore::LocalFrame&)> { [client = makeUniqueRef<RemoteWorkerFrameLoaderClient>(m_webPageProxyID, m_pageID, m_userAgent)] (auto&) mutable {
         return WTFMove(client);


### PR DESCRIPTION
#### c47f4cabd53d3a7ac9b68677900bc678c11eeb33
<pre>
`navigator.storage.getDirectory()` fails in service workers with an `NotSupportedError: The operation is not supported`
<a href="https://bugs.webkit.org/show_bug.cgi?id=273906">https://bugs.webkit.org/show_bug.cgi?id=273906</a>
<a href="https://rdar.apple.com/127775672">rdar://127775672</a>

Reviewed by Ben Nham.

Add a storage provider to shared workers and service workers.
We reuse the one used for documents since shared workers and service workers use a WorkerStorageConnection which will use the document&apos;s one.

* LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.js: Added.
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.serviceworker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.serviceworker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.sharedworker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.sharedworker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.worker.html: Added.
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::installServiceWorker):
* Source/WebKit/WebProcess/Storage/WebSharedWorkerContextManagerConnection.cpp:
(WebKit::WebSharedWorkerContextManagerConnection::launchSharedWorker):

Canonical link: <a href="https://commits.webkit.org/279908@main">https://commits.webkit.org/279908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c75b23db67a72f132686eac2be52bc93b24ff7cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34356 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58180 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5633 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5665 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44465 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3819 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56997 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25592 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/29243 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4910 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3774 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5132 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59770 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30160 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/5278 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/51887 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47647 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51313 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12063 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32311 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31087 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->