### PR TITLE
[Site Isolation] Do not create separate back forward items for embedded root child frames

### DIFF
--- a/Source/WebKit/Shared/WebBackForwardListItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListItem.cpp
@@ -29,6 +29,7 @@
 #include "SuspendedPageProxy.h"
 #include "WebBackForwardCache.h"
 #include "WebBackForwardCacheEntry.h"
+#include "WebFrameProxy.h"
 #include "WebProcessPool.h"
 #include "WebProcessProxy.h"
 #include <wtf/DebugUtilities.h>
@@ -183,6 +184,28 @@ void WebBackForwardListItem::setBackForwardCacheEntry(std::unique_ptr<WebBackFor
 SuspendedPageProxy* WebBackForwardListItem::suspendedPage() const
 {
     return m_backForwardCacheEntry ? m_backForwardCacheEntry->suspendedPage() : nullptr;
+}
+
+WebBackForwardListItem* WebBackForwardListItem::childItemForFrameID(WebCore::FrameIdentifier frameID) const
+{
+    auto* frame = WebFrameProxy::webFrame(frameID);
+    if (!frame)
+        return nullptr;
+    auto rootFrameID = frame->rootFrame().frameID();
+    for (auto& child : m_rootChildFrameItems) {
+        if (child->frameID() == rootFrameID)
+            return child.ptr();
+    }
+    return nullptr;
+}
+
+WebBackForwardListItem* WebBackForwardListItem::childItemForProcessID(WebCore::ProcessIdentifier processID) const
+{
+    for (auto& child : m_rootChildFrameItems) {
+        if (child->lastProcessIdentifier() == processID)
+            return child.ptr();
+    }
+    return nullptr;
 }
 
 #if !LOG_DISABLED

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -89,11 +89,15 @@ public:
     WebBackForwardCacheEntry* backForwardCacheEntry() const { return m_backForwardCacheEntry.get(); }
     SuspendedPageProxy* suspendedPage() const;
 
-    void setIsRootChildFrameItem(bool rootChildFrameItem) { m_isRootChildFrameItem = rootChildFrameItem; }
-    bool isRootChildFrameItem() const { return m_isRootChildFrameItem; }
-
     void setFrameID(WebCore::FrameIdentifier frameID) { m_frameID = frameID; }
     WebCore::FrameIdentifier frameID() const { return m_frameID; }
+
+    void addRootChildFrameItem(Ref<WebBackForwardListItem>&& item) { m_rootChildFrameItems.append(WTFMove(item)); }
+    WebBackForwardListItem* childItemForFrameID(WebCore::FrameIdentifier) const;
+    WebBackForwardListItem* childItemForProcessID(WebCore::ProcessIdentifier) const;
+
+    void setMainFrameItem(WebBackForwardListItem* item) { m_mainFrameItem = item; }
+    WebBackForwardListItem* mainFrameItem() { return m_mainFrameItem.get(); }
 
 #if !LOG_DISABLED
     String loggingString();
@@ -116,7 +120,8 @@ private:
     WebCore::ProcessIdentifier m_lastProcessIdentifier;
     WebCore::FrameIdentifier m_frameID;
     std::unique_ptr<WebBackForwardCacheEntry> m_backForwardCacheEntry;
-    bool m_isRootChildFrameItem { false };
+    WeakPtr<WebBackForwardListItem> m_mainFrameItem;
+    Vector<Ref<WebBackForwardListItem>> m_rootChildFrameItems;
 };
 
 typedef Vector<Ref<WebBackForwardListItem>> BackForwardListItemVector;

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -86,6 +86,8 @@ public:
     Vector<BackForwardListItemState> itemStates() const;
     Vector<BackForwardListItemState> filteredItemStates(Function<bool(WebBackForwardListItem&)>&&) const;
 
+    void addRootChildFrameItem(Ref<WebBackForwardListItem>&&) const;
+
 #if !LOG_DISABLED
     String loggingString();
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2702,7 +2702,7 @@ private:
     void backForwardAddItem(WebCore::FrameIdentifier, BackForwardListItemState&&);
     void backForwardGoToItem(const WebCore::BackForwardItemIdentifier&, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
     void backForwardListContainsItem(const WebCore::BackForwardItemIdentifier&, CompletionHandler<void(bool)>&&);
-    void backForwardItemAtIndex(int32_t index, CompletionHandler<void(std::optional<WebCore::BackForwardItemIdentifier>&&)>&&);
+    void backForwardItemAtIndex(IPC::Connection&, int32_t index, CompletionHandler<void(std::optional<WebCore::BackForwardItemIdentifier>&&)>&&);
     void backForwardListCounts(CompletionHandler<void(WebBackForwardListCounts&&)>&&);
     void backForwardClear();
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -3339,4 +3339,57 @@ TEST(SiteIsolation, ProtocolProcessSeparation)
     });
 }
 
+TEST(SiteIsolation, GoBackToPageWithIframe)
+{
+    HTTPServer server({
+        { "/a"_s, { "<iframe src='https://frame.com/frame'></iframe>"_s } },
+        { "/b"_s, { ""_s } },
+        { "/frame"_s, { ""_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://b.com/b"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+    checkFrameTreesInProcesses(webView.get(), {
+        { "https://a.com"_s,
+            { { RemoteFrame } }
+        }, { RemoteFrame,
+            { { "https://frame.com"_s } }
+        },
+    });
+}
+
+TEST(SiteIsolation, NavigateNestedIframeSameOriginBackForward)
+{
+    HTTPServer server({
+        { "/example"_s, { "<iframe src='https://a.com/nest'></iframe>"_s } },
+        { "/nest"_s, { "<iframe src='https://a.com/a'></iframe>"_s } },
+        { "/a"_s, { "<script> alert('a'); </script>"_s } },
+        { "/b"_s, { "<script> alert('b'); </script>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "a");
+
+    __block RetainPtr<WKFrameInfo> childFrameInfo;
+    [webView _frames:^(_WKFrameTreeNode *mainFrame) {
+        childFrameInfo = mainFrame.childFrames.firstObject.childFrames.firstObject.info;
+    }];
+    while (!childFrameInfo)
+        Util::spinRunLoop();
+
+    [webView evaluateJavaScript:@"location.href = 'https://a.com/b'" inFrame:childFrameInfo.get() inContentWorld:WKContentWorld.pageWorld completionHandler:nil];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "b");
+    [webView goBack];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "a");
+    [webView goForward];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "b");
+}
+
 }


### PR DESCRIPTION
#### 3d354010882cd25a00e72caadf532f31f0d1d341
<pre>
[Site Isolation] Do not create separate back forward items for embedded root child frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=275250">https://bugs.webkit.org/show_bug.cgi?id=275250</a>
<a href="https://rdar.apple.com/129391516">rdar://129391516</a>

Reviewed by Alex Christensen.

Before this change, we would add a separate item to the back forward list each time an out-of-process
iframe was embedded. Then, we would try to skip over these items when moving the main frame or its local
children back or forward. This did not work in certain cases, like when navigating nested iframes or when
navigating back to a page that contained iframes. This patch changes this so that instead, when a root
child frame is embedded, we attach the created back forward items to the item that corresponds to the
page it was embedded in. Then, when moving back, we reference the frame that was most recently navigated
to associate it with an out-of-process iframe that may have existed on a previous back forward item.

* Source/WebKit/Shared/WebBackForwardListItem.cpp:
(WebKit::WebBackForwardListItem::childItemForFrameID const):
(WebKit::WebBackForwardListItem::childItemForProcessID const):
* Source/WebKit/Shared/WebBackForwardListItem.h:
(WebKit::WebBackForwardListItem::addRootChildFrameItem):
(WebKit::WebBackForwardListItem::setMainFrameItem):
(WebKit::WebBackForwardListItem::mainFrameItem):
(WebKit::WebBackForwardListItem::setIsRootChildFrameItem): Deleted.
(WebKit::WebBackForwardListItem::isRootChildFrameItem const): Deleted.
(): Deleted.
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::addRootChildFrameItem const):
(WebKit::WebBackForwardList::goToItem):
When a web process sends a message indicating it has navigated to a root child frame item, we need to
update the back forward list with it’s main frame item, since the root child frame does not exist in
the back forward list.

(WebKit::itemSkippingBackForwardItemsAddedByJSWithoutUserGesture):
* Source/WebKit/UIProcess/WebBackForwardList.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::goBack):
(WebKit::WebPageProxy::didChangeBackForwardList):
(WebKit::WebPageProxy::backForwardAddItemShared):
(WebKit::WebPageProxy::backForwardItemAtIndex):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, GoBackToPageWithIframe)):
(TestWebKitAPI::TEST(SiteIsolation, NavigateNestedIframeSameOriginBackForward)):

Canonical link: <a href="https://commits.webkit.org/279823@main">https://commits.webkit.org/279823@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce29908cd5e86f8c432a0181ba51aeec99199a25

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57947 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/5400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56968 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5409 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/5400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56762 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/32233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/47351 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25406 "Found 1 new API test failure: /WPE/TestMultiprocess:/webkit/WebKitWebView/multiprocess-create-ready-close (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/29029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4685 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3540 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4899 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59537 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/29907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/5048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/51704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31052 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47437 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/11978 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/32041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8084 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/30838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->