### PR TITLE
AppCache removal: remove manifest attribute

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1325,11 +1325,6 @@ DOMImplementation& Document::implementation()
     return *m_implementation;
 }
 
-bool Document::hasManifest() const
-{
-    return documentElement() && documentElement()->hasTagName(htmlTag) && documentElement()->hasAttributeWithoutSynchronization(manifestAttr);
-}
-
 DocumentType* Document::doctype() const
 {
     for (Node* node = firstChild(); node; node = node->nextSibling()) {

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -502,8 +502,6 @@ public:
     WEBCORE_EXPORT bool hasFocus() const;
     void whenVisible(Function<void()>&&);
 
-    bool hasManifest() const;
-    
     WEBCORE_EXPORT ExceptionOr<Ref<Element>> createElementForBindings(const AtomString& tagName);
     WEBCORE_EXPORT Ref<DocumentFragment> createDocumentFragment();
     WEBCORE_EXPORT Ref<Text> createTextNode(String&& data);

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -182,7 +182,6 @@ loopend
 loopstart
 low
 lowsrc
-manifest
 marginheight
 marginwidth
 max

--- a/Source/WebCore/html/HTMLHtmlElement.cpp
+++ b/Source/WebCore/html/HTMLHtmlElement.cpp
@@ -24,7 +24,6 @@
 #include "config.h"
 #include "HTMLHtmlElement.h"
 
-#include "ApplicationCacheHost.h"
 #include "Document.h"
 #include "DocumentLoader.h"
 #include "DocumentParser.h"
@@ -58,32 +57,4 @@ Ref<HTMLHtmlElement> HTMLHtmlElement::create(const QualifiedName& tagName, Docum
     return adoptRef(*new HTMLHtmlElement(tagName, document));
 }
 
-bool HTMLHtmlElement::isURLAttribute(const Attribute& attribute) const
-{
-    return attribute.name() == manifestAttr || HTMLElement::isURLAttribute(attribute);
-}
-
-void HTMLHtmlElement::insertedByParser()
-{
-    // When parsing a fragment, its dummy document has a null parser.
-    if (!document().parser() || !document().parser()->documentWasLoadedAsPartOfNavigation())
-        return;
-
-    if (!document().frame())
-        return;
-
-    RefPtr documentLoader = document().frame()->loader().documentLoader();
-    if (!documentLoader)
-        return;
-
-    auto& manifest = attributeWithoutSynchronization(manifestAttr);
-    if (manifest.isEmpty())
-        documentLoader->applicationCacheHost().selectCacheWithoutManifest();
-    else {
-        RELEASE_LOG_FAULT(Storage, "HTMLHtmlElement::insertedByParser: ApplicationCache is deprecated.");
-        document().addConsoleMessage(MessageSource::AppCache, MessageLevel::Warning, "ApplicationCache is deprecated. Please use ServiceWorkers instead."_s);
-        documentLoader->applicationCacheHost().selectCacheWithManifest(document().completeURL(manifest));
-    }
-}
-
-}
+} // namespace WebCore

--- a/Source/WebCore/html/HTMLHtmlElement.h
+++ b/Source/WebCore/html/HTMLHtmlElement.h
@@ -33,12 +33,8 @@ public:
     WEBCORE_EXPORT static Ref<HTMLHtmlElement> create(Document&);
     static Ref<HTMLHtmlElement> create(const QualifiedName&, Document&);
 
-    void insertedByParser();
-
 private:
     HTMLHtmlElement(const QualifiedName&, Document&);
-
-    bool isURLAttribute(const Attribute&) const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -230,7 +230,6 @@ void ImageDocument::createDocumentStructure()
 {
     auto rootElement = HTMLHtmlElement::create(*this);
     appendChild(rootElement);
-    rootElement->insertedByParser();
     rootElement->setInlineStyleProperty(CSSPropertyHeight, 100, CSSUnitType::CSS_PERCENTAGE);
 
     if (RefPtr localFrame = frame())

--- a/Source/WebCore/html/MediaDocument.cpp
+++ b/Source/WebCore/html/MediaDocument.cpp
@@ -88,7 +88,6 @@ void MediaDocumentParser::createDocumentStructure()
     Ref rootElement = HTMLHtmlElement::create(document);
     document->appendChild(rootElement);
     document->setCSSTarget(rootElement.ptr());
-    rootElement->insertedByParser();
 
     if (RefPtr frame = document->frame())
         frame->injectUserScripts(UserScriptInjectionTime::DocumentStart);

--- a/Source/WebCore/html/ModelDocument.cpp
+++ b/Source/WebCore/html/ModelDocument.cpp
@@ -82,7 +82,6 @@ void ModelDocumentParser::createDocumentStructure()
     auto rootElement = HTMLHtmlElement::create(document);
     document.appendChild(rootElement);
     document.setCSSTarget(rootElement.ptr());
-    rootElement->insertedByParser();
 
     if (document.frame())
         document.frame()->injectUserScripts(UserScriptInjectionTime::DocumentStart);

--- a/Source/WebCore/html/PDFDocument.cpp
+++ b/Source/WebCore/html/PDFDocument.cpp
@@ -149,7 +149,6 @@ void PDFDocument::createDocumentStructure()
     auto viewerURL = "webkit-pdfjs-viewer://pdfjs/web/viewer.html?file="_s;
     auto rootElement = HTMLHtmlElement::create(*this);
     appendChild(rootElement);
-    rootElement->insertedByParser();
 
     frame()->injectUserScripts(UserScriptInjectionTime::DocumentStart);
 

--- a/Source/WebCore/html/PluginDocument.cpp
+++ b/Source/WebCore/html/PluginDocument.cpp
@@ -93,7 +93,6 @@ void PluginDocumentParser::createDocumentStructure()
 
     auto rootElement = HTMLHtmlElement::create(document);
     document.appendChild(rootElement);
-    rootElement->insertedByParser();
 
     auto headElement = HTMLHeadElement::create(document);
     auto styleElement = createStyleElement(document);

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -319,7 +319,6 @@ void HTMLConstructionSite::insertHTMLHtmlStartTagBeforeHTML(AtomHTMLToken&& toke
     m_openElements.pushHTMLHtmlElement(HTMLStackItem(element.copyRef(), WTFMove(token)));
 
     executeQueuedTasks();
-    element->insertedByParser();
     dispatchDocumentElementAvailableIfNeeded();
 }
 

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -511,12 +511,6 @@ void DocumentLoader::finishedLoading()
     if (!frameLoader()->stateMachine().creatingInitialEmptyDocument())
         frameLoader()->checkLoadComplete();
 
-    // If the document specified an application cache manifest, it violates the author's intent if we store it in the memory cache
-    // and deny the appcache the chance to intercept it in the future, so remove from the memory cache.
-    if (m_frame) {
-        if (m_mainResource && m_frame->document()->hasManifest())
-            MemoryCache::singleton().remove(*m_mainResource);
-    }
     m_applicationCacheHost->finishedLoadingMainResource();
 }
 

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -851,9 +851,6 @@ void XMLDocumentParser::startElementNs(const xmlChar* xmlLocalName, const xmlCha
     else
         pushCurrentNode(newElement.ptr());
 
-    if (is<HTMLHtmlElement>(newElement))
-        downcast<HTMLHtmlElement>(newElement.get()).insertedByParser();
-
     if (!m_parsingFragment && isFirstElement && document()->frame())
         document()->frame()->injectUserScripts(UserScriptInjectionTime::DocumentStart);
 }

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLHtmlElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLHtmlElement.mm
@@ -53,14 +53,11 @@
 
 - (NSString *)manifest
 {
-    WebCore::JSMainThreadNullState state;
-    return IMPL->getURLAttribute(WebCore::HTMLNames::manifestAttr).string();
+    return nullString();
 }
 
 - (void)setManifest:(NSString *)newManifest
 {
-    WebCore::JSMainThreadNullState state;
-    IMPL->setAttributeWithoutSynchronization(WebCore::HTMLNames::manifestAttr, newManifest);
 }
 
 @end


### PR DESCRIPTION
#### f5bdfbfc1c90bdfb897d9d1d03827854ec3128bf
<pre>
AppCache removal: remove manifest attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=275251">https://bugs.webkit.org/show_bug.cgi?id=275251</a>

Reviewed by Youenn Fablet.

As AppCache has been fully disabled it&apos;s time to remove the code.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::hasManifest const): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/html/HTMLAttributeNames.in:
* Source/WebCore/html/HTMLHtmlElement.cpp:
(WebCore::HTMLHtmlElement::isURLAttribute const): Deleted.
(WebCore::HTMLHtmlElement::insertedByParser): Deleted.
* Source/WebCore/html/HTMLHtmlElement.h:
* Source/WebCore/html/ImageDocument.cpp:
(WebCore::ImageDocument::createDocumentStructure):
* Source/WebCore/html/MediaDocument.cpp:
(WebCore::MediaDocumentParser::createDocumentStructure):
* Source/WebCore/html/ModelDocument.cpp:
(WebCore::ModelDocumentParser::createDocumentStructure):
* Source/WebCore/html/PDFDocument.cpp:
(WebCore::PDFDocument::createDocumentStructure):
* Source/WebCore/html/PluginDocument.cpp:
(WebCore::PluginDocumentParser::createDocumentStructure):
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::insertHTMLHtmlStartTagBeforeHTML):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::finishedLoading):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::startElementNs):
* Source/WebKitLegacy/mac/DOM/DOMHTMLHtmlElement.mm:
(-[DOMHTMLHtmlElement manifest]):
(-[DOMHTMLHtmlElement setManifest:]):

Canonical link: <a href="https://commits.webkit.org/279811@main">https://commits.webkit.org/279811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80e041d89b2b49ab10f2dd6248dc8c404dbc493d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7203 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57908 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5361 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56929 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5366 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44252 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3617 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32192 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47316 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25378 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28989 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4650 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3501 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59498 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29864 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5006 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/51671 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31010 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47402 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51055 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31994 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8078 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30798 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->