### PR TITLE
FileSystemDirectoryHandle::getFileHandle should succeed even if 'this' is GCed

### DIFF
--- a/Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.cpp
@@ -55,12 +55,11 @@ void FileSystemDirectoryHandle::getFileHandle(const String& name, const FileSyst
     if (isClosed())
         return promise.reject(Exception { ExceptionCode::InvalidStateError, "Handle is closed"_s });
 
-    connection().getFileHandle(identifier(), name, options.create, [weakThis = ThreadSafeWeakPtr { *this }, connection = Ref { connection() }, name, promise = WTFMove(promise)](auto result) mutable {
+    connection().getFileHandle(identifier(), name, options.create, [weakContext = WeakPtr { *scriptExecutionContext() }, connection = Ref { connection() }, name, promise = WTFMove(promise)](auto result) mutable {
         if (result.hasException())
             return promise.reject(result.releaseException());
 
-        auto protectedThis = weakThis.get();
-        RefPtr context = protectedThis ? protectedThis->scriptExecutionContext() : nullptr;
+        RefPtr context = weakContext.get();
         if (!context)
             return promise.reject(Exception { ExceptionCode::InvalidStateError, "Context has stopped"_s });
 
@@ -75,12 +74,11 @@ void FileSystemDirectoryHandle::getDirectoryHandle(const String& name, const Fil
     if (isClosed())
         return promise.reject(Exception { ExceptionCode::InvalidStateError, "Handle is closed"_s });
 
-    connection().getDirectoryHandle(identifier(), name, options.create, [weakThis = ThreadSafeWeakPtr { *this }, connection = Ref { connection() }, name, promise = WTFMove(promise)](auto result) mutable {
+    connection().getDirectoryHandle(identifier(), name, options.create, [weakContext = WeakPtr { *scriptExecutionContext() }, connection = Ref { connection() }, name, promise = WTFMove(promise)](auto result) mutable {
         if (result.hasException())
             return promise.reject(result.releaseException());
 
-        auto protectedThis = weakThis.get();
-        RefPtr context = protectedThis ? protectedThis->scriptExecutionContext() : nullptr;
+        RefPtr context = weakContext.get();
         if (!context)
             return promise.reject(Exception { ExceptionCode::InvalidStateError, "Context has stopped"_s });
 
@@ -123,13 +121,12 @@ void FileSystemDirectoryHandle::getHandle(const String& name, CompletionHandler<
     if (isClosed())
         return completionHandler(Exception { ExceptionCode::InvalidStateError, "Handle is closed"_s });
 
-    connection().getHandle(identifier(), name, [weakThis = ThreadSafeWeakPtr { *this }, name, connection = Ref { connection() }, completionHandler = WTFMove(completionHandler)](auto result) mutable {
+    connection().getHandle(identifier(), name, [weakContext = WeakPtr { *scriptExecutionContext() }, name, connection = Ref { connection() }, completionHandler = WTFMove(completionHandler)](auto result) mutable {
         if (result.hasException())
             return completionHandler(result.releaseException());
 
         auto [identifier, isDirectory] = result.returnValue()->release();
-        auto protectedThis = weakThis.get();
-        RefPtr context = protectedThis ? protectedThis->scriptExecutionContext() : nullptr;
+        RefPtr context = weakContext.get();
         if (!context)
             return completionHandler(Exception { ExceptionCode::InvalidStateError, "Context has stopped"_s });
 

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemHandle.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemHandle.h
@@ -29,7 +29,7 @@
 #include "FileSystemHandleIdentifier.h"
 #include "IDLTypes.h"
 #include <wtf/IsoMalloc.h>
-#include <wtf/ThreadSafeWeakPtr.h>
+#include <wtf/RefCounted.h>
 
 namespace WebCore {
 
@@ -37,13 +37,13 @@ template<typename> class DOMPromiseDeferred;
 
 class FileSystemStorageConnection;
 
-class FileSystemHandle : public ActiveDOMObject, public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<FileSystemHandle> {
+class FileSystemHandle : public ActiveDOMObject, public RefCounted<FileSystemHandle> {
     WTF_MAKE_ISO_ALLOCATED(FileSystemHandle);
 public:
     virtual ~FileSystemHandle();
 
-    void ref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
-    void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     enum class Kind : uint8_t {
         File,


### PR DESCRIPTION
#### cf758a90a435b2e02b182c4b6444c4bfb590049e
<pre>
FileSystemDirectoryHandle::getFileHandle should succeed even if &apos;this&apos; is GCed
<a href="https://bugs.webkit.org/show_bug.cgi?id=275252">https://bugs.webkit.org/show_bug.cgi?id=275252</a>
<a href="https://rdar.apple.com/problem/129395480">rdar://problem/129395480</a>

Reviewed by Ben Nham.

Stop taking a weak pointer of FileSystemDirectoryHandle in FileSystemDirectoryHandle::getFileHandle and FileSystemDirectoryHandle::getDirectoryHandle.
Instead, we take a weak pointer of its context and return early if the context is gone.

This change will be covered by test added in <a href="https://github.com/WebKit/WebKit/pull/29615.">https://github.com/WebKit/WebKit/pull/29615.</a>

Since we do not need FileSystemHandle to be thread safe or weak pointer, we move it to a simple RefCounted object.

* Source/WebCore/Modules/filesystemaccess/FileSystemDirectoryHandle.cpp:
(WebCore::FileSystemDirectoryHandle::getFileHandle):
(WebCore::FileSystemDirectoryHandle::getDirectoryHandle):
(WebCore::FileSystemDirectoryHandle::getHandle):
* Source/WebCore/Modules/filesystemaccess/FileSystemHandle.h:

Canonical link: <a href="https://commits.webkit.org/279879@main">https://commits.webkit.org/279879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/089045d329cc0ae423ef089da75e560ed22e30a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57911 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5364 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56932 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5371 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44249 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3618 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56725 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32195 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47320 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25375 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/28992 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4654 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3504 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50739 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59501 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29867 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5011 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51674 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31014 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47406 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51058 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12044 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/31997 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30801 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->