### PR TITLE
[visionOS] Unable to enter LinearMediaPlayer fullscreen when playing a WebM video

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -118,7 +118,6 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
     MediaTime currentTime() const override;
     bool timeIsProgressing() const final;
-    AVSampleBufferDisplayLayer *sampleBufferDisplayLayer() const { return m_sampleBufferDisplayLayer.get(); }
     WebCoreDecompressionSession *decompressionSession() const { return m_decompressionSession.get(); }
     WebSampleBufferVideoRendering *layerOrVideoRenderer() const;
 
@@ -290,6 +289,7 @@ private:
     void ensureVideoRenderer();
     void destroyVideoRenderer();
 
+    bool shouldEnsureLayerOrVideoRenderer() const;
     void ensureLayerOrVideoRenderer();
     void destroyLayerOrVideoRenderer();
     void configureLayerOrVideoRenderer(WebSampleBufferVideoRendering *);
@@ -311,8 +311,6 @@ private:
 
     void checkNewVideoFrameMetadata(CMTime);
     MediaTime clampTimeToSensicalValue(const MediaTime&) const;
-
-    bool shouldEnsureLayerOrVideoRenderer() const;
 
     void setShouldDisableHDR(bool) final;
     void playerContentBoxRectChanged(const LayoutRect&) final;

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -1808,10 +1808,10 @@ bool MediaPlayerPrivateRemote::supportsLinearMediaPlayer() const
     switch (m_remoteEngineIdentifier) {
     case MediaPlayerMediaEngineIdentifier::AVFoundation:
     case MediaPlayerMediaEngineIdentifier::AVFoundationMSE:
+    case MediaPlayerMediaEngineIdentifier::CocoaWebM:
         return true;
     case MediaPlayerMediaEngineIdentifier::AVFoundationMediaStream:
-    case MediaPlayerMediaEngineIdentifier::CocoaWebM:
-        // FIXME: MediaStream and WebM players don't support LinearMediaPlayer yet but should.
+        // FIXME: MediaStream doesn't support LinearMediaPlayer yet but should.
         return false;
     case MediaPlayerMediaEngineIdentifier::AVFoundationCF:
     case MediaPlayerMediaEngineIdentifier::GStreamer:


### PR DESCRIPTION
#### 869e39dfdda8b30eb808eb5b53bec83cdb6c3bd3
<pre>
[visionOS] Unable to enter LinearMediaPlayer fullscreen when playing a WebM video
<a href="https://bugs.webkit.org/show_bug.cgi?id=275253">https://bugs.webkit.org/show_bug.cgi?id=275253</a>
<a href="https://rdar.apple.com/125204360">rdar://125204360</a>

Reviewed by Jer Noble.

Original patch by Jean-Yves Avenard &lt;jya@apple.com&gt;.

Implemented support for rendering to an AVSampleBufferVideoRenderer backed by a FigVideoTargetRef by
copying MediaPlayerPrivateMediaSourceAVFObjC&apos;s implementation. While here, cherry-picked work
related to spatial tracking labels (274873@main) and aspect ratio preservation (270876@main).

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::sampleBufferDisplayLayer const): Deleted.
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
(WebCore::MediaPlayerPrivateWebM::decompressionSession const):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::MediaPlayerPrivateWebM):
(WebCore::MediaPlayerPrivateWebM::setPageIsVisible):
(WebCore::MediaPlayerPrivateWebM::shouldEnsureLayerOrVideoRenderer const):
(WebCore::MediaPlayerPrivateWebM::updateDisplayLayerAndDecompressionSession):
(WebCore::MediaPlayerPrivateWebM::reenqueSamples):
(WebCore::MediaPlayerPrivateWebM::reenqueueMediaForTime):
(WebCore::MediaPlayerPrivateWebM::ensureLayer):
(WebCore::MediaPlayerPrivateWebM::destroyLayer):
(WebCore::MediaPlayerPrivateWebM::ensureVideoRenderer):
(WebCore::MediaPlayerPrivateWebM::destroyVideoRenderer):
(WebCore::MediaPlayerPrivateWebM::hasSelectedVideo const):
(WebCore::MediaPlayerPrivateWebM::ensureLayerOrVideoRenderer):
(WebCore::MediaPlayerPrivateWebM::setShouldDisableHDR):
(WebCore::MediaPlayerPrivateWebM::playerContentBoxRectChanged):
(WebCore::MediaPlayerPrivateWebM::setShouldMaintainAspectRatio):
(WebCore::MediaPlayerPrivateWebM::defaultSpatialTrackingLabel const):
(WebCore::MediaPlayerPrivateWebM::setDefaultSpatialTrackingLabel):
(WebCore::MediaPlayerPrivateWebM::spatialTrackingLabel const):
(WebCore::MediaPlayerPrivateWebM::setSpatialTrackingLabel):
(WebCore::MediaPlayerPrivateWebM::updateSpatialTrackingLabel):
(WebCore::MediaPlayerPrivateWebM::destroyLayerOrVideoRenderer):
(WebCore::MediaPlayerPrivateWebM::configureLayerOrVideoRenderer):
(WebCore::MediaPlayerPrivateWebM::configureVideoRenderer):
(WebCore::MediaPlayerPrivateWebM::invalidateVideoRenderer):
(WebCore::MediaPlayerPrivateWebM::setVideoRenderer):
(WebCore::MediaPlayerPrivateWebM::stageVideoRenderer):
(WebCore::MediaPlayerPrivateWebM::acceleratedVideoMode const):
(WebCore::MediaPlayerPrivateWebM::layerOrVideoRenderer const):
(WebCore::MediaPlayerPrivateWebM::setVideoTarget):
(WebCore::MediaPlayerPrivateWebM::isInFullscreenOrPictureInPictureChanged):
(WebCore::MediaPlayerPrivateWebM::shouldEnsureLayer const): Deleted.
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::supportsLinearMediaPlayer const):

Canonical link: <a href="https://commits.webkit.org/280106@main">https://commits.webkit.org/280106@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47ed249021dc9c8b1818497147bfb186143abd47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55771 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35094 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8238 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58755 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6202 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57897 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6400 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44915 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4269 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57800 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32993 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26049 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29779 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5404 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4345 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5673 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60346 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5802 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52342 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48146 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51839 "Found 3 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12355 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30925 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32010 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33091 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31757 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->