### PR TITLE
Piecemeal adoption of std::ranges - adopt std::ranges for TransformOperations & FilterOperations

### DIFF
--- a/Source/WebCore/platform/graphics/filters/FilterOperations.h
+++ b/Source/WebCore/platform/graphics/filters/FilterOperations.h
@@ -27,6 +27,7 @@
 
 #include "CompositeOperation.h"
 #include "FilterOperation.h"
+#include <algorithm>
 #include <wtf/ArgumentCoder.h>
 #include <wtf/Ref.h>
 #include <wtf/Vector.h>
@@ -75,10 +76,7 @@ public:
     bool hasFilterThatShouldBeRestrictedBySecurityOrigin() const;
 
     template<FilterOperation::Type Type>
-    bool hasFilterOfType() const
-    {
-        return WTF::anyOf(m_operations, [](auto& op) { return op->type() == Type; });
-    }
+    bool hasFilterOfType() const;
 
     bool hasReferenceFilter() const;
     bool isReferenceFilter() const;
@@ -95,6 +93,11 @@ private:
 
     Vector<Ref<FilterOperation>> m_operations;
 };
+
+template<FilterOperation::Type type> bool FilterOperations::hasFilterOfType() const
+{
+    return std::ranges::any_of(m_operations, [](auto& op) { return op->type() == type; });
+}
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const FilterOperations&);
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -38,6 +38,7 @@
 #include "TextureMapperPlatformLayerProxyProvider.h"
 #include "TiledBackingStore.h"
 #include "TransformOperation.h"
+#include <algorithm>
 #ifndef NDEBUG
 #include <wtf/SetForScope.h>
 #endif
@@ -1371,7 +1372,7 @@ bool CoordinatedGraphicsLayer::shouldHaveBackingStore() const
     bool isInvisibleBecauseOpacityZero = !opacity() && !m_animations.hasActiveAnimationsOfType(AnimatedProperty::Opacity);
 
     // Check if there's a filter that sets the opacity to zero.
-    bool hasOpacityZeroFilter = WTF::anyOf(filters(), [](auto& operation) {
+    bool hasOpacityZeroFilter = std::ranges::any_of(filters(), [](auto& operation) {
         return operation->type() == FilterOperation::Type::Opacity && !downcast<BasicComponentTransferFilterOperation>(operation.get()).amount();
     });
 

--- a/Source/WebCore/platform/graphics/transforms/TransformOperations.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperations.cpp
@@ -25,6 +25,7 @@
 #include "AnimationUtilities.h"
 #include "Matrix3DTransformOperation.h"
 #include <algorithm>
+#include <ranges>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
@@ -41,16 +42,9 @@ TransformOperations::TransformOperations(Vector<Ref<TransformOperation>>&& opera
 
 bool TransformOperations::operator==(const TransformOperations& o) const
 {
-    if (m_operations.size() != o.m_operations.size())
-        return false;
+    static_assert(std::ranges::sized_range<decltype(m_operations)>);
 
-    unsigned size = m_operations.size();
-    for (unsigned i = 0; i < size; i++) {
-        if (m_operations[i].get() != o.m_operations[i].get())
-            return false;
-    }
-    
-    return true;
+    return std::ranges::equal(m_operations, o.m_operations, [](auto& a, auto& b) { return a.get() == b.get(); });
 }
 
 TransformOperations TransformOperations::clone() const
@@ -71,17 +65,17 @@ void TransformOperations::apply(TransformationMatrix& matrix, const FloatSize& s
 
 bool TransformOperations::has3DOperation() const
 {
-    return WTF::anyOf(m_operations, [](auto& op) { return op->is3DOperation(); });
+    return std::ranges::any_of(m_operations, [](auto& op) { return op->is3DOperation(); });
 }
 
 bool TransformOperations::isRepresentableIn2D() const
 {
-    return WTF::allOf(m_operations, [](auto& op) { return op->isRepresentableIn2D(); });
+    return std::ranges::all_of(m_operations, [](auto& op) { return op->isRepresentableIn2D(); });
 }
 
 bool TransformOperations::affectedByTransformOrigin() const
 {
-    return WTF::anyOf(m_operations, [](auto& op) { return op->isAffectedByTransformOrigin(); });
+    return std::ranges::any_of(m_operations, [](auto& op) { return op->isAffectedByTransformOrigin(); });
 }
 
 bool TransformOperations::isInvertible(const LayoutSize& size) const

--- a/Source/WebCore/platform/graphics/transforms/TransformOperations.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformOperations.h
@@ -25,6 +25,7 @@
 
 #include "LayoutSize.h"
 #include "TransformOperation.h"
+#include <algorithm>
 #include <wtf/ArgumentCoder.h>
 #include <wtf/Ref.h>
 #include <wtf/Vector.h>
@@ -91,7 +92,7 @@ private:
 template<TransformOperation::Type operationType>
 bool TransformOperations::hasTransformOfType() const
 {
-    return WTF::anyOf(m_operations, [](auto& op) { return op->type() == operationType; });
+    return std::ranges::any_of(m_operations, [](auto& op) { return op->type() == operationType; });
 }
 
 WTF::TextStream& operator<<(WTF::TextStream&, const TransformOperations&);


### PR DESCRIPTION
#### 139f357261e16b23b9e26171cdf88b2e5c5b2856
<pre>
Piecemeal adoption of std::ranges - adopt std::ranges for TransformOperations &amp; FilterOperations
<a href="https://bugs.webkit.org/show_bug.cgi?id=275254">https://bugs.webkit.org/show_bug.cgi?id=275254</a>

Reviewed by Darin Adler.

Use std::ranges::any_of/std::ranges::all_of/std::ranges::equal
in TransformOperations and FilterOperations.

* Source/WebCore/platform/graphics/filters/FilterOperations.cpp:
(WebCore::FilterOperations::operator== const):
(WebCore::FilterOperations::operationsMatch const):
(WebCore::FilterOperations::hasFilterThatAffectsOpacity const):
(WebCore::FilterOperations::hasFilterThatMovesPixels const):
(WebCore::FilterOperations::hasFilterThatShouldBeRestrictedBySecurityOrigin const):
* Source/WebCore/platform/graphics/filters/FilterOperations.h:
(WebCore::FilterOperations::hasFilterOfType const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp:
(WebCore::CoordinatedGraphicsLayer::shouldHaveBackingStore const):
* Source/WebCore/platform/graphics/transforms/TransformOperations.cpp:
(WebCore::TransformOperations::operator== const):
(WebCore::TransformOperations::has3DOperation const):
(WebCore::TransformOperations::isRepresentableIn2D const):
(WebCore::TransformOperations::affectedByTransformOrigin const):
* Source/WebCore/platform/graphics/transforms/TransformOperations.h:
(WebCore::TransformOperations::hasTransformOfType const):

Canonical link: <a href="https://commits.webkit.org/279945@main">https://commits.webkit.org/279945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1685e546fe4c56c51831fb0fddd88331e99b32f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54911 "10 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7498 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58189 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5642 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57211 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5670 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44470 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3825 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57006 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32457 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47574 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25597 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29247 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4915 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3783 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51098 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5137 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59779 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30169 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5288 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51893 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31305 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47652 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51320 "Found 3 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/select-all/editable, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12097 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32320 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31094 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->