### PR TITLE
The URL for Chromium bugs has changed, stopping them from being added to See Also in Bugzilla

### DIFF
--- a/Websites/bugs.webkit.org/Bugzilla/BugUrl/Chromium.pm
+++ b/Websites/bugs.webkit.org/Bugzilla/BugUrl/Chromium.pm
@@ -22,7 +22,11 @@ use Bugzilla::Util;
 
 sub should_handle {
     my ($class, $uri) = @_;
-    return ($uri->authority =~ /^bugs.chromium.org$/i) ? 1 : 0;
+
+    # Chromium URLs have this form:
+    #   http(s)://issues.chromium.org/issues/1234
+    return (lc($uri->authority) eq 'issues.chromium.org'
+            and $uri->path =~ m|^/issues/\d+$|) ? 1 : 0;
 }
 
 sub _check_value {
@@ -30,20 +34,7 @@ sub _check_value {
 
     $uri = $class->SUPER::_check_value($uri);
 
-    my $value = $uri->as_string;
-    my $project_name;
-    if ($uri->path =~ m|^/p/([^/]+)/issues/detail$|) {
-        $project_name = $1;
-    } else {
-        ThrowUserError('bug_url_invalid', { url => $value });
-    }
-    my $bug_id = $uri->query_param('id');
-    detaint_natural($bug_id);
-    if (!$bug_id) {
-        ThrowUserError('bug_url_invalid', { url => $value, reason => 'id' });
-    }
-
-    return URI->new($value);
+    return $uri;
 }
 
 1;


### PR DESCRIPTION
#### 15c7ae209695cb3f28009100d3ed1824b63c3a46
<pre>
The URL for Chromium bugs has changed, stopping them from being added to See Also in Bugzilla
<a href="https://bugs.webkit.org/show_bug.cgi?id=275174">https://bugs.webkit.org/show_bug.cgi?id=275174</a>

Reviewed by Alexey Proskuryakov.

The new URL for Chromium bugs is http(s)://issues.chromium.org/issues/1234, and this checks the URI authority is issues.chromium.org and that the path matches the regex ^/issues/\d+$

* Websites/bugs.webkit.org/Bugzilla/BugUrl/Chromium.pm
Bugzilla::BugUrl::Chromium.should_handle and Bugzilla::BugUrl::Chromium._check_value: Change logic in should_handle to allow new Chromium URL format and remove now unnecessary checks in _check_value

Canonical link: <a href="https://commits.webkit.org/279863@main">https://commits.webkit.org/279863@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/187c287a6879d54f1b94adcec8e24b88f7cc3ebb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54691 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7267 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57970 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5423 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44303 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3662 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56786 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32251 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47366 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25419 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29046 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3563 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50780 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4913 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59560 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29932 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5066 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51719 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31077 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47451 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51112 "Found 3 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12031 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32070 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30863 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->