### PR TITLE
[WebGPU] Crash running compute_pipeline overrides CTS

### DIFF
--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -142,11 +142,14 @@ std::variant<PrepareResult, Error> prepare(ShaderModule& ast, const String& entr
     return prepareImpl(ast, pipelineLayouts);
 }
 
-ConstantValue evaluate(const AST::Expression& expression, const HashMap<String, ConstantValue>& constants)
+std::optional<ConstantValue> evaluate(const AST::Expression& expression, const HashMap<String, ConstantValue>& constants)
 {
     if (auto constantValue = expression.constantValue())
         return *constantValue;
-    auto constantValue = constants.get(downcast<const AST::IdentifierExpression>(expression).identifier());
+    auto* maybeIdentifierExpression = dynamicDowncast<const AST::IdentifierExpression>(expression);
+    if (!maybeIdentifierExpression)
+        return std::nullopt;
+    auto constantValue = constants.get(maybeIdentifierExpression->identifier());
     const_cast<AST::Expression&>(expression).setConstantValue(constantValue);
     return constantValue;
 }

--- a/Source/WebGPU/WGSL/WGSL.h
+++ b/Source/WebGPU/WGSL/WGSL.h
@@ -234,6 +234,6 @@ std::variant<PrepareResult, Error> prepare(ShaderModule&, const String& entryPoi
 
 String generate(ShaderModule&, PrepareResult&, HashMap<String, ConstantValue>&);
 
-ConstantValue evaluate(const AST::Expression&, const HashMap<String, ConstantValue>&);
+std::optional<ConstantValue> evaluate(const AST::Expression&, const HashMap<String, ConstantValue>&);
 
 } // namespace WGSL

--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -73,7 +73,12 @@ std::optional<LibraryCreationResult> createLibrary(id<MTLDevice> device, const S
             continue;
 
         auto constantValue = WGSL::evaluate(*kvp.value.defaultValue, wgslConstantValues);
-        auto addResult = wgslConstantValues.add(kvp.key, constantValue);
+        if (!constantValue) {
+            if (error)
+                *error = [NSError errorWithDomain:@"WebGPU" code:1 userInfo:@{ NSLocalizedDescriptionKey: @"Failed to evaluate override value" }];
+            return std::nullopt;
+        }
+        auto addResult = wgslConstantValues.add(kvp.key, *constantValue);
         ASSERT_UNUSED(addResult, addResult.isNewEntry);
     }
 


### PR DESCRIPTION
#### 00f81bf9e46aa71cc2446565207025cbea0118ea
<pre>
[WebGPU] Crash running compute_pipeline overrides CTS
<a href="https://bugs.webkit.org/show_bug.cgi?id=275258">https://bugs.webkit.org/show_bug.cgi?id=275258</a>
&lt;radar://129404225&gt;

Reviewed by Tadeu Zagallo.

Workaround crash in <a href="https://gpuweb.github.io/cts/standalone/?q=webgpu">https://gpuweb.github.io/cts/standalone/?q=webgpu</a>:api,operation,compute_pipeline,overrides:computed:*
until <a href="https://bugs.webkit.org/show_bug.cgi?id=275010">https://bugs.webkit.org/show_bug.cgi?id=275010</a> is addressed.

* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::evaluate):
* Source/WebGPU/WGSL/WGSL.h:
* Source/WebGPU/WebGPU/ComputePipeline.mm:
(WebGPU::metalSize):
* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::createLibrary):

Canonical link: <a href="https://commits.webkit.org/279825@main">https://commits.webkit.org/279825@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4ec97872c70e3772a6e9b9f6ce5e161fa5ee744

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54653 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34075 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57933 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5386 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41614 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5394 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44270 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3634 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56748 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32219 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47338 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25394 "Found 1 new API test failure: /WPE/TestLoaderClient:/webkit/WebKitWebView/load-twice-and-reload (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29010 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3526 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59523 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29892 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5031 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Checked out pull request; Running run-layout-tests-in-stress-mode; 12 flakes 1 failures; Uploaded test results; 8 flakes 2 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51694 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31036 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47424 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51079 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11981 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32023 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30823 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->