### PR TITLE
visualViewport.scale() should be 1 at the default scale when using automatic view scale adjustment

### DIFF
--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -657,6 +657,8 @@ public:
     virtual void gamepadsRecentlyAccessed() { }
 #endif
 
+    virtual double baseViewportLayoutSizeScaleFactor() const { return 1; }
+
     WEBCORE_EXPORT virtual ~ChromeClient();
 
 protected:

--- a/Source/WebCore/page/VisualViewport.cpp
+++ b/Source/WebCore/page/VisualViewport.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "VisualViewport.h"
 
+#include "Chrome.h"
+#include "ChromeClient.h"
 #include "ContextDestructionObserver.h"
 #include "Document.h"
 #include "Event.h"
@@ -161,8 +163,8 @@ void VisualViewport::update()
             width = visualViewportRect.width() / pageZoomFactor;
             height = visualViewportRect.height() / pageZoomFactor;
         }
-        if (auto* page = frame->page())
-            scale = page->pageScaleFactor();
+        if (RefPtr page = frame->page())
+            scale = page->pageScaleFactor() / page->chrome().client().baseViewportLayoutSizeScaleFactor();
     }
 
     RefPtr<Document> document = frame ? frame->document() : nullptr;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -101,6 +101,7 @@
 #include <WebCore/Settings.h>
 #include <WebCore/TextIndicator.h>
 #include <WebCore/TextRecognitionOptions.h>
+#include <WebCore/ViewportConfiguration.h>
 #include <WebCore/WindowFeatures.h>
 
 #if HAVE(WEBGPU_IMPLEMENTATION)
@@ -1734,6 +1735,15 @@ URL WebChromeClient::allowedQueryParametersForAdvancedPrivacyProtections(const U
 void WebChromeClient::textAutosizingUsesIdempotentModeChanged()
 {
     protectedPage()->textAutosizingUsesIdempotentModeChanged();
+}
+
+#endif
+
+#if ENABLE(META_VIEWPORT)
+
+double WebChromeClient::baseViewportLayoutSizeScaleFactor() const
+{
+    return protectedPage()->baseViewportLayoutSizeScaleFactor();
 }
 
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -467,6 +467,10 @@ private:
     void textAutosizingUsesIdempotentModeChanged() final;
 #endif
 
+#if ENABLE(META_VIEWPORT)
+    double baseViewportLayoutSizeScaleFactor() const final;
+#endif
+
     std::pair<URL, WebCore::DidFilterLinkDecoration> applyLinkDecorationFilteringWithResult(const URL&, WebCore::LinkDecorationFilteringTrigger) const final;
     URL allowedQueryParametersForAdvancedPrivacyProtections(const URL&) const final;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1671,6 +1671,10 @@ public:
     void textAutosizingUsesIdempotentModeChanged();
 #endif
 
+#if ENABLE(META_VIEWPORT)
+    double baseViewportLayoutSizeScaleFactor() const { return m_baseViewportLayoutSizeScaleFactor; }
+#endif
+
 #if ENABLE(WEBXR) && !USE(OPENXR)
     PlatformXRSystemProxy& xrSystemProxy();
 #endif
@@ -2586,6 +2590,7 @@ private:
 
 #if ENABLE(META_VIEWPORT)
     WebCore::ViewportConfiguration m_viewportConfiguration;
+    double m_baseViewportLayoutSizeScaleFactor { 1 };
     bool m_useTestingViewportConfiguration { false };
     bool m_forceAlwaysUserScalable { false };
 #endif

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3883,10 +3883,20 @@ void WebPage::setViewportConfigurationViewLayoutSize(const FloatSize& size, doub
     if (!m_viewportConfiguration.isKnownToLayOutWiderThanViewport())
         m_viewportConfiguration.setMinimumEffectiveDeviceWidthForShrinkToFit(0);
 
-    double layoutSizeScaleFactor = layoutSizeScaleFactorFromClient;
+    m_baseViewportLayoutSizeScaleFactor = [&] {
+        if (!m_page->settings().automaticallyAdjustsViewScaleUsingMinimumEffectiveDeviceWidth())
+            return 1.0;
 
-    if (m_page->settings().automaticallyAdjustsViewScaleUsingMinimumEffectiveDeviceWidth() && minimumEffectiveDeviceWidth && minimumEffectiveDeviceWidth < size.width())
-        layoutSizeScaleFactor = layoutSizeScaleFactorFromClient * size.width() / minimumEffectiveDeviceWidth;
+        if (!minimumEffectiveDeviceWidth)
+            return 1.0;
+
+        if (minimumEffectiveDeviceWidth >= size.width())
+            return 1.0;
+
+        return size.width() / minimumEffectiveDeviceWidth;
+    }();
+
+    double layoutSizeScaleFactor = layoutSizeScaleFactorFromClient * m_baseViewportLayoutSizeScaleFactor;
 
     auto previousLayoutSizeScaleFactor = m_viewportConfiguration.layoutSizeScaleFactor();
     if (!m_viewportConfiguration.setViewLayoutSize(size, layoutSizeScaleFactor, minimumEffectiveDeviceWidth))


### PR DESCRIPTION
#### d4fa89ab44bce81fa25269d46b955777dd1804fb
<pre>
visualViewport.scale() should be 1 at the default scale when using automatic view scale adjustment
<a href="https://bugs.webkit.org/show_bug.cgi?id=275260">https://bugs.webkit.org/show_bug.cgi?id=275260</a>

Reviewed by Aditya Keerthi.

Report a `visualViewport.scale()` of 1 at the default scale (i.e. without any explicit user scaling)
when automatic view scale adjustments are enabled.

For context, the idea of applying a layout size scale factor is that WebKit can take the normal
minimum layout size it would&apos;ve used, scale those dimensions by an arbitrary amount, perform layout
using those scaled dimensions, and finally scale down (or up) to fit the real view dimensions when
computing initial scale.

Without this change, `scale()` reports the actual page scale factor, which may not be equal to 1 (by
default) when `automaticallyAdjustsViewScaleUsingMinimumEffectiveDeviceWidth` is enabled. This
causes the entire page to be clipped on certain websites, where the result of
`(visualViewport.width * visualViewport.scale)` is used to compute an &quot;effective layout width which
is used to size the rest of the webpage.

Mitigate this by pretending to be `scale=1` in this case, such that the result of `width * scale`
can no longer be used to infer the real size of the web view, and we can properly scale up to fit
the webpage to the view without clipping the page.

* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::baseViewportLayoutSizeScaleFactor const):

Add a chrome client hook to ask for the current base layout size scale factor, so that we can adjust
the scale factor reported by `visualViewport.scale()` by this amount. See above.

* Source/WebCore/page/VisualViewport.cpp:
(WebCore::VisualViewport::update):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::baseViewportLayoutSizeScaleFactor const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
(WebKit::WebPage::baseViewportLayoutSizeScaleFactor const):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::setViewportConfigurationViewLayoutSize):

Canonical link: <a href="https://commits.webkit.org/279829@main">https://commits.webkit.org/279829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b53c29d3d8c52a48b93aff1b9444b19b1164ac80

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54659 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34081 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7235 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57939 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5392 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/56960 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5401 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44277 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3643 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56754 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32222 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47347 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25402 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29016 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4681 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3532 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4895 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59529 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/29898 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5039 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51700 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31043 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51087 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11983 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32031 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30829 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->