### PR TITLE
[JSC] Iterator should throw a TypeError when it is String/BigInt/Symbol in Baseline JIT

### DIFF
--- a/JSTests/stress/iterator-open-throw-for-non-objects.js
+++ b/JSTests/stress/iterator-open-throw-for-non-objects.js
@@ -1,0 +1,91 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+const runs = 1e5;
+
+let count = 0;
+for (let i = 0; i < runs; i++) {
+    try {
+        const arr = [101, 101];
+        arr[Symbol.iterator] = function () { return 3; };
+        [] = arr;
+    } catch (e) {
+        count++;
+    }
+}
+shouldBe(count, runs);
+count = 0;
+
+for (let i = 0; i < runs; i++) {
+    try {
+        const arr = [101, 101];
+        arr[Symbol.iterator] = function () { return "foo"; };
+        [] = arr;
+    } catch (e) {
+        count++;
+    }
+}
+shouldBe(count, runs);
+count = 0;
+
+for (let i = 0; i < runs; i++) {
+    try {
+        const arr = [101, 101];
+        arr[Symbol.iterator] = function () { return true; };
+        [] = arr;
+    } catch (e) {
+        count++;
+    }
+}
+shouldBe(count, runs);
+count = 0;
+
+for (let i = 0; i < runs; i++) {
+    try {
+        const arr = [101, 101];
+        arr[Symbol.iterator] = function () { return null; };
+        [] = arr;
+    } catch (e) {
+        count++;
+    }
+}
+shouldBe(count, runs);
+count = 0;
+
+for (let i = 0; i < runs; i++) {
+    try {
+        const arr = [101, 101];
+        arr[Symbol.iterator] = function () { return undefined; };
+        [] = arr;
+    } catch (e) {
+        count++;
+    }
+}
+shouldBe(count, runs);
+count = 0;
+
+for (let i = 0; i < runs; i++) {
+    try {
+        const arr = [101, 101];
+        arr[Symbol.iterator] = function () { return Symbol("foo"); };
+        [] = arr;
+    } catch (e) {
+        count++;
+    }
+}
+shouldBe(count, runs);
+count = 0;
+
+for (let i = 0; i < runs; i++) {
+    try {
+        const arr = [101, 101];
+        arr[Symbol.iterator] = function () { return 3n; };
+        [] = arr;
+    } catch (e) {
+        count++;
+    }
+}
+shouldBe(count, runs);
+count = 0;

--- a/Source/JavaScriptCore/jit/JITCall.cpp
+++ b/Source/JavaScriptCore/jit/JITCall.cpp
@@ -398,6 +398,8 @@ void JIT::emit_op_iterator_open(const JSInstruction* instruction)
 
     emitJumpSlowCaseIfNotJSCell(baseJSR);
 
+    addSlowCase(branchIfNotObject(baseJSR.payloadGPR()));
+
     static_assert(noOverlap(returnValueJSR, stubInfoGPR));
 
     const Identifier* ident = &vm().propertyNames->next;


### PR DESCRIPTION
#### 54e08075c3f02b6442e12934f6d02a02265b808c
<pre>
[JSC] Iterator should throw a TypeError when it is String/BigInt/Symbol in Baseline JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=256437">https://bugs.webkit.org/show_bug.cgi?id=256437</a>

Reviewed by Yusuke Suzuki.

According to the spec[1], when opening an iterator, a TypeError should be thrown if `Symbol.iterator`
returns a non-object value. However, the current Baseline JIT in JSC does not throw a TypeError when
`Symbol.iterator` returns a BigInt, Symbol, or String.

This patch modifies `emit_op_iterator_open` to check if the iterator is an object, and if not, it
falls back to the slow path.

[1]: <a href="https://tc39.es/ecma262/multipage/abstract-operations.html#sec-getiteratorfrommethod">https://tc39.es/ecma262/multipage/abstract-operations.html#sec-getiteratorfrommethod</a>

* JSTests/stress/iterator-open-throw-for-non-objects.js: Added.
(shouldBe):
(i.try.arr.Symbol.iterator):
(i.catch):
* Source/JavaScriptCore/jit/JITCall.cpp:
(JSC::JIT::emit_op_iterator_open):

Canonical link: <a href="https://commits.webkit.org/288071@main">https://commits.webkit.org/288071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b03ce0c0f7723e231e5207ef5dee5a10344ebb6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/81807 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/1333 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/35761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/86354 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/32803 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/1366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/9154 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/63800 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/21527 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/84877 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/996 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/74445 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/44086 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/895 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/28620 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/31256 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/74787 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/72271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/29226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/87790 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/80861 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/9047 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/6423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/72146 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/9232 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/70266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/71378 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/17784 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/15473 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/14396 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/103273 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/8998 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/14530 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/25074 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/8839 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/12362 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/10647 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->