### PR TITLE
Rename WebPageProxy::process to legacyMainFrameProcess

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -183,7 +183,7 @@ WKTypeID WKPageGetTypeID()
 
 WKContextRef WKPageGetContext(WKPageRef pageRef)
 {
-    return toAPI(&toImpl(pageRef)->process().processPool());
+    return toAPI(&toImpl(pageRef)->legacyMainFrameProcess().processPool());
 }
 
 WKPageGroupRef WKPageGetPageGroup(WKPageRef pageRef)
@@ -529,14 +529,14 @@ void WKPageSetCustomTextEncodingName(WKPageRef pageRef, WKStringRef encodingName
 void WKPageTerminate(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    Ref<WebProcessProxy> protectedProcessProxy(toImpl(pageRef)->process());
+    Ref<WebProcessProxy> protectedProcessProxy(toImpl(pageRef)->legacyMainFrameProcess());
     protectedProcessProxy->requestTermination(ProcessTerminationReason::RequestedByClient);
 }
 
 void WKPageResetProcessState(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    Ref<WebProcessProxy> protectedProcessProxy(toImpl(pageRef)->process());
+    Ref<WebProcessProxy> protectedProcessProxy(toImpl(pageRef)->legacyMainFrameProcess());
     protectedProcessProxy->resetState();
 }
 
@@ -2881,7 +2881,7 @@ WKArrayRef WKPageCopyRelatedPages(WKPageRef pageRef)
 {
     Vector<RefPtr<API::Object>> relatedPages;
 
-    for (Ref page : toImpl(pageRef)->process().pages()) {
+    for (Ref page : toImpl(pageRef)->legacyMainFrameProcess().pages()) {
         if (page.ptr() != toImpl(pageRef))
             relatedPages.append(WTFMove(page));
     }
@@ -3025,13 +3025,13 @@ void WKPageSetIgnoresViewportScaleLimits(WKPageRef pageRef, bool ignoresViewport
 
 ProcessID WKPageGetProcessIdentifier(WKPageRef page)
 {
-    return toImpl(page)->processID();
+    return toImpl(page)->legacyMainFrameProcessID();
 }
 
 ProcessID WKPageGetGPUProcessIdentifier(WKPageRef page)
 {
 #if ENABLE(GPU_PROCESS)
-    auto* gpuProcess = toImpl(page)->process().processPool().gpuProcess();
+    auto* gpuProcess = toImpl(page)->legacyMainFrameProcess().processPool().gpuProcess();
     if (!gpuProcess)
         return 0;
     return gpuProcess->processID();
@@ -3168,7 +3168,7 @@ void WKPageSetMockCaptureDevicesInterrupted(WKPageRef pageRef, bool isCameraInte
 {
     CRASH_IF_SUSPENDED;
 #if ENABLE(MEDIA_STREAM) && ENABLE(GPU_PROCESS)
-    auto& gpuProcess = toImpl(pageRef)->process().processPool().ensureGPUProcess();
+    auto& gpuProcess = toImpl(pageRef)->legacyMainFrameProcess().processPool().ensureGPUProcess();
     gpuProcess.setMockCaptureDevicesInterrupted(isCameraInterrupted, isMicrophoneInterrupted);
 #endif
 #if ENABLE(MEDIA_STREAM) && USE(GSTREAMER)
@@ -3183,7 +3183,7 @@ void WKPageTriggerMockCaptureConfigurationChange(WKPageRef pageRef, bool forMicr
     MockRealtimeMediaSourceCenter::singleton().triggerMockCaptureConfigurationChange(forMicrophone, forDisplay);
 
 #if ENABLE(GPU_PROCESS)
-    auto& gpuProcess = toImpl(pageRef)->process().processPool().ensureGPUProcess();
+    auto& gpuProcess = toImpl(pageRef)->legacyMainFrameProcess().processPool().ensureGPUProcess();
     gpuProcess.triggerMockCaptureConfigurationChange(forMicrophone, forDisplay);
 #endif // ENABLE(GPU_PROCESS)
 

--- a/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
+++ b/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
@@ -93,7 +93,7 @@
 
 - (BOOL)_webProcessIsResponsive
 {
-    return _page->process().isResponsive();
+    return _page->legacyMainFrameProcess().isResponsive();
 }
 
 - (double)estimatedProgress
@@ -131,7 +131,7 @@ bool WKPageIsURLKnownHSTSHost(WKPageRef page, WKURLRef url)
 {
     WebKit::WebPageProxy* webPageProxy = WebKit::toImpl(page);
 
-    return webPageProxy->process().processPool().isURLKnownHSTSHost(WebKit::toImpl(url)->string());
+    return webPageProxy->legacyMainFrameProcess().processPool().isURLKnownHSTSHost(WebKit::toImpl(url)->string());
 }
 
 WKNavigation *WKPageLoadURLRequestReturningNavigation(WKPageRef pageRef, WKURLRequestRef urlRequestRef)

--- a/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm
@@ -496,7 +496,7 @@ static NSMutableArray<NSURL *> *readOnlyAccessPaths()
 
         contentNavigation = loadWebContent(webView.get());
         if (!finished)
-            attributedStringActivity = Box<UniqueRef<WebKit::ProcessThrottler::Activity>>::create([webView _page]->protectedProcess()->throttler().foregroundActivity("NSAttributedString serialization"_s));
+            attributedStringActivity = Box<UniqueRef<WebKit::ProcessThrottler::Activity>>::create([webView _page]->protectedLegacyMainFrameProcess()->throttler().foregroundActivity("NSAttributedString serialization"_s));
 
         ASSERT(contentNavigation);
         ASSERT(webView.get().loading);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
@@ -743,12 +743,12 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (pid_t)processIdentifier
 {
-    return _page->processID();
+    return _page->legacyMainFrameProcessID();
 }
 
 - (BOOL)_webProcessIsResponsive
 {
-    return _page->process().isResponsive();
+    return _page->legacyMainFrameProcess().isResponsive();
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -649,7 +649,7 @@ static void hardwareKeyboardAvailabilityChangedCallback(CFNotificationCenterRef,
     [_contentView _webViewDestroyed];
 
     if (_page && _remoteObjectRegistry)
-        _page->process().processPool().removeMessageReceiver(Messages::RemoteObjectRegistry::messageReceiverName(), _page->identifier());
+        _page->legacyMainFrameProcess().processPool().removeMessageReceiver(Messages::RemoteObjectRegistry::messageReceiverName(), _page->identifier());
 #endif
 
     if (_page)
@@ -2558,7 +2558,7 @@ static RetainPtr<NSArray> wkTextManipulationErrors(NSArray<_WKTextManipulationIt
 #else
     if (!_remoteObjectRegistry) {
         _remoteObjectRegistry = adoptNS([[_WKRemoteObjectRegistry alloc] _initWithWebPageProxy:*_page]);
-        _page->process().processPool().addMessageReceiver(Messages::RemoteObjectRegistry::messageReceiverName(), _page->identifier(), [_remoteObjectRegistry remoteObjectRegistry]);
+        _page->legacyMainFrameProcess().processPool().addMessageReceiver(Messages::RemoteObjectRegistry::messageReceiverName(), _page->identifier(), [_remoteObjectRegistry remoteObjectRegistry]);
     }
 
     return _remoteObjectRegistry.get();
@@ -2596,7 +2596,7 @@ static RetainPtr<NSArray> wkTextManipulationErrors(NSArray<_WKTextManipulationIt
 
 - (BOOL)_isSuspended
 {
-    return _page->process().throttler().isSuspended();
+    return _page->legacyMainFrameProcess().throttler().isSuspended();
 }
 
 - (BOOL)_canTogglePictureInPicture
@@ -3097,7 +3097,7 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
     if (![self _isValid])
         return 0;
 
-    return _page->processID();
+    return _page->legacyMainFrameProcessID();
 }
 
 - (pid_t)_provisionalWebProcessIdentifier
@@ -3131,7 +3131,7 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 
 - (BOOL)_webProcessIsResponsive
 {
-    return _page->process().isResponsive();
+    return _page->legacyMainFrameProcess().isResponsive();
 }
 
 - (void)_killWebContentProcess
@@ -3140,7 +3140,7 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
     if (![self _isValid])
         return;
 
-    _page->process().terminate();
+    _page->legacyMainFrameProcess().terminate();
 }
 
 - (WKNavigation *)_reloadWithoutContentBlockers
@@ -3158,7 +3158,7 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 - (void)_killWebContentProcessAndResetState
 {
     THROW_IF_SUSPENDED;
-    Ref<WebKit::WebProcessProxy> protectedProcessProxy(_page->process());
+    Ref<WebKit::WebProcessProxy> protectedProcessProxy(_page->legacyMainFrameProcess());
     protectedProcessProxy->requestTermination(WebKit::ProcessTerminationReason::RequestedByClient);
 
     if (auto* provisionalPageProxy = _page->provisionalPageProxy()) {
@@ -3306,7 +3306,7 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 - (void)_clearBackForwardCache
 {
     THROW_IF_SUSPENDED;
-    _page->process().processPool().backForwardCache().removeEntriesForPage(*_page);
+    _page->legacyMainFrameProcess().processPool().backForwardCache().removeEntriesForPage(*_page);
 }
 
 + (BOOL)_handlesSafeBrowsing
@@ -3599,7 +3599,7 @@ static inline OptionSet<WebCore::LayoutMilestone> layoutMilestones(_WKRenderingP
 - (void)_getContentsAsStringWithCompletionHandlerKeepIPCConnectionAliveForTesting:(void (^)(NSString *, NSError *))completionHandler
 {
     THROW_IF_SUSPENDED;
-    _page->getContentsAsString(WebKit::ContentAsStringIncludesChildFrames::No, [handler = makeBlockPtr(completionHandler), connection = RefPtr { _page->process().connection() }](String string) {
+    _page->getContentsAsString(WebKit::ContentAsStringIncludesChildFrames::No, [handler = makeBlockPtr(completionHandler), connection = RefPtr { _page->legacyMainFrameProcess().connection() }](String string) {
         handler(string, nil);
     });
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -344,7 +344,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
         completionHandler();
         return;
     }
-    _page->process().sendPrepareToSuspend(WebKit::IsSuspensionImminent::No, 0.0, [completionHandler = makeBlockPtr(completionHandler)] {
+    _page->legacyMainFrameProcess().sendPrepareToSuspend(WebKit::IsSuspensionImminent::No, 0.0, [completionHandler = makeBlockPtr(completionHandler)] {
         completionHandler();
     });
 }
@@ -352,13 +352,13 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 - (void)_processWillSuspendImminentlyForTesting
 {
     if (_page)
-        _page->process().sendPrepareToSuspend(WebKit::IsSuspensionImminent::Yes, 0.0, [] { });
+        _page->legacyMainFrameProcess().sendPrepareToSuspend(WebKit::IsSuspensionImminent::Yes, 0.0, [] { });
 }
 
 - (void)_processDidResumeForTesting
 {
     if (_page)
-        _page->process().sendProcessDidResume(WebKit::AuxiliaryProcessProxy::ResumeReason::ForegroundActivity);
+        _page->legacyMainFrameProcess().sendProcessDidResume(WebKit::AuxiliaryProcessProxy::ResumeReason::ForegroundActivity);
 }
 
 - (void)_setThrottleStateForTesting:(int)value
@@ -366,17 +366,17 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     if (!_page)
         return;
 
-    _page->process().setThrottleStateForTesting(static_cast<WebKit::ProcessThrottleState>(value));
+    _page->legacyMainFrameProcess().setThrottleStateForTesting(static_cast<WebKit::ProcessThrottleState>(value));
 }
 
 - (BOOL)_hasServiceWorkerBackgroundActivityForTesting
 {
-    return _page ? _page->process().processPool().hasServiceWorkerBackgroundActivityForTesting() : false;
+    return _page ? _page->legacyMainFrameProcess().processPool().hasServiceWorkerBackgroundActivityForTesting() : false;
 }
 
 - (BOOL)_hasServiceWorkerForegroundActivityForTesting
 {
-    return _page ? _page->process().processPool().hasServiceWorkerForegroundActivityForTesting() : false;
+    return _page ? _page->legacyMainFrameProcess().processPool().hasServiceWorkerForegroundActivityForTesting() : false;
 }
 
 - (void)_denyNextUserMediaRequest
@@ -461,7 +461,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 - (WKWebViewAudioRoutingArbitrationStatus)_audioRoutingArbitrationStatus
 {
 #if ENABLE(ROUTING_ARBITRATION)
-    switch (_page->process().audioSessionRoutingArbitrator().arbitrationStatus()) {
+    switch (_page->legacyMainFrameProcess().audioSessionRoutingArbitrator().arbitrationStatus()) {
     case WebKit::AudioSessionRoutingArbitratorProxy::ArbitrationStatus::None: return WKWebViewAudioRoutingArbitrationStatusNone;
     case WebKit::AudioSessionRoutingArbitratorProxy::ArbitrationStatus::Pending: return WKWebViewAudioRoutingArbitrationStatusPending;
     case WebKit::AudioSessionRoutingArbitratorProxy::ArbitrationStatus::Active: return WKWebViewAudioRoutingArbitrationStatusActive;
@@ -475,7 +475,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 - (double)_audioRoutingArbitrationUpdateTime
 {
 #if ENABLE(ROUTING_ARBITRATION)
-    return _page->process().audioSessionRoutingArbitrator().arbitrationUpdateTime().secondsSinceEpoch().seconds();
+    return _page->legacyMainFrameProcess().audioSessionRoutingArbitrator().arbitrationUpdateTime().secondsSinceEpoch().seconds();
 #else
     return 0;
 #endif
@@ -612,7 +612,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
 - (void)_gpuToWebProcessConnectionCountForTesting:(void(^)(NSUInteger))completionHandler
 {
-    RefPtr gpuProcess = _page->process().processPool().gpuProcess();
+    RefPtr gpuProcess = _page->legacyMainFrameProcess().processPool().gpuProcess();
     if (!gpuProcess) {
         completionHandler(0);
         return;

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -20,6 +20,7 @@
 #include "config.h"
 #include "WebKitProtocolHandler.h"
 
+#include "APIPageConfiguration.h"
 #include "BuildRevision.h"
 #include "DMABufRendererBufferMode.h"
 #include "DisplayVBlankMonitor.h"
@@ -428,7 +429,7 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
 #endif
 
     if (displayID) {
-        if (auto* displayLink = page.process().processPool().displayLinks().existingDisplayLinkForDisplay(*displayID)) {
+        if (auto* displayLink = page.configuration().processPool().displayLinks().existingDisplayLinkForDisplay(*displayID)) {
             auto& vblankMonitor = displayLink->vblankMonitor();
             addTableRow(displayObject, "VBlank type"_s, vblankMonitor.type() == DisplayVBlankMonitor::Type::Timer ? "Timer"_s : "DRM"_s);
             addTableRow(displayObject, "VBlank refresh rate"_s, makeString(vblankMonitor.refreshRate(), "Hz"_s));

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -4887,7 +4887,7 @@ WebKitDownload* webkit_web_view_download_uri(WebKitWebView* webView, const char*
     g_return_val_if_fail(uri, nullptr);
 
     auto& page = getPage(webView);
-    auto downloadProxy = page.process().processPool().download(page.websiteDataStore(), &page, ResourceRequest { String::fromUTF8(uri) });
+    auto downloadProxy = page.configuration().processPool().download(page.websiteDataStore(), &page, ResourceRequest { String::fromUTF8(uri) });
     auto download = webkitDownloadCreate(downloadProxy, webView);
 #if ENABLE(2022_GLIB_API)
     downloadProxy->setDidStartCallback([session = GRefPtr<WebKitNetworkSession> { webView->priv->networkSession }, download = download.get()](auto* downloadProxy) {
@@ -5417,11 +5417,11 @@ void webkit_web_view_terminate_web_process(WebKitWebView* webView)
 
     auto& page = getPage(webView);
 
-    Ref<WebKit::WebProcessProxy> protectedProcessProxy(page.process());
+    Ref protectedProcessProxy(page.legacyMainFrameProcess());
     protectedProcessProxy->requestTermination(WebKit::ProcessTerminationReason::RequestedByClient);
 
     if (auto* provisionalPageProxy = page.provisionalPageProxy()) {
-        Ref<WebKit::WebProcessProxy> protectedProcessProxy(provisionalPageProxy->process());
+        Ref protectedProcessProxy(provisionalPageProxy->process());
         protectedProcessProxy->requestTermination(WebKit::ProcessTerminationReason::RequestedByClient);
     }
 }

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -1738,7 +1738,7 @@ static gboolean webkitWebViewBaseCrossingNotifyEvent(GtkWidget* widget, GdkEvent
     // Do not send mouse move events to the WebProcess for crossing events during testing.
     // WTR never generates crossing events and they can confuse tests.
     // https://bugs.webkit.org/show_bug.cgi?id=185072.
-    if (UNLIKELY(priv->pageProxy->process().processPool().configuration().fullySynchronousModeIsAllowedForTesting()))
+    if (UNLIKELY(priv->pageProxy->configuration().processPool().configuration().fullySynchronousModeIsAllowedForTesting()))
         return GDK_EVENT_PROPAGATE;
 #endif
 
@@ -1789,7 +1789,7 @@ static void webkitWebViewBaseEnter(WebKitWebViewBase* webViewBase, double x, dou
     // Do not send mouse move events to the WebProcess for crossing events during testing.
     // WTR never generates crossing events and they can confuse tests.
     // https://bugs.webkit.org/show_bug.cgi?id=185072.
-    if (UNLIKELY(priv->pageProxy->process().processPool().configuration().fullySynchronousModeIsAllowedForTesting()))
+    if (UNLIKELY(priv->pageProxy->configuration().processPool().configuration().fullySynchronousModeIsAllowedForTesting()))
         return;
 #endif
 
@@ -1829,7 +1829,7 @@ static void webkitWebViewBaseLeave(WebKitWebViewBase* webViewBase, GdkCrossingMo
     // Do not send mouse move events to the WebProcess for crossing events during testing.
     // WTR never generates crossing events and they can confuse tests.
     // https://bugs.webkit.org/show_bug.cgi?id=185072.
-    if (UNLIKELY(priv->pageProxy->process().processPool().configuration().fullySynchronousModeIsAllowedForTesting()))
+    if (UNLIKELY(priv->pageProxy->configuration().processPool().configuration().fullySynchronousModeIsAllowedForTesting()))
         return;
 #endif
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -853,7 +853,7 @@ static WebCore::Color scrollViewBackgroundColor(WKWebView *webView, AllowPageBac
 
 - (void)_didRelaunchProcess
 {
-    WKWEBVIEW_RELEASE_LOG("%p -[WKWebView _didRelaunchProcess] (pid=%d)", self, _page->processID());
+    WKWEBVIEW_RELEASE_LOG("%p -[WKWebView _didRelaunchProcess] (pid=%d)", self, _page->legacyMainFrameProcessID());
     _perProcessState.hasScheduledVisibleRectUpdate = NO;
     _viewStabilityWhenVisibleContentRectUpdateScheduled = { };
     if (_gestureController)

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -305,7 +305,7 @@ static void dumpUIView(TextStream& ts, UIView *view)
 
 - (NSDictionary *)_propertiesOfLayerWithID:(unsigned long long)layerID
 {
-    CALayer* layer = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(*_page->drawingArea()).layerWithIDForTesting({ ObjectIdentifier<WebCore::PlatformLayerIdentifierType>(layerID), _page->process().coreProcessIdentifier() });
+    CALayer* layer = downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(*_page->drawingArea()).layerWithIDForTesting({ ObjectIdentifier<WebCore::PlatformLayerIdentifierType>(layerID), _page->legacyMainFrameProcess().coreProcessIdentifier() });
     if (!layer)
         return nil;
 

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -972,7 +972,7 @@ void WebAutomationSession::evaluateJavaScriptFunction(const Inspector::Protocol:
     uint64_t callbackID = m_nextEvaluateJavaScriptCallbackID++;
     m_evaluateJavaScriptFunctionCallbacks.set(callbackID, WTFMove(callback));
 
-    page->process().send(Messages::WebAutomationSessionProxy::EvaluateJavaScriptFunction(page->webPageID(), frameID, function, argumentsVector, expectsImplicitCallbackArgument.value_or(false), WTFMove(callbackTimeout), callbackID), 0);
+    page->legacyMainFrameProcess().send(Messages::WebAutomationSessionProxy::EvaluateJavaScriptFunction(page->webPageID(), frameID, function, argumentsVector, expectsImplicitCallbackArgument.value_or(false), WTFMove(callbackTimeout), callbackID), 0);
 }
 
 void WebAutomationSession::didEvaluateJavaScriptFunction(uint64_t callbackID, const String& result, const String& errorType)
@@ -1011,17 +1011,17 @@ void WebAutomationSession::resolveChildFrameHandle(const Inspector::Protocol::Au
     };
 
     if (!!optionalNodeHandle) {
-        page->process().sendWithAsyncReply(Messages::WebAutomationSessionProxy::ResolveChildFrameWithNodeHandle(page->webPageID(), frameID, optionalNodeHandle), WTFMove(completionHandler));
+        page->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebAutomationSessionProxy::ResolveChildFrameWithNodeHandle(page->webPageID(), frameID, optionalNodeHandle), WTFMove(completionHandler));
         return;
     }
 
     if (!!optionalName) {
-        page->process().sendWithAsyncReply(Messages::WebAutomationSessionProxy::ResolveChildFrameWithName(page->webPageID(), frameID, optionalName), WTFMove(completionHandler));
+        page->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebAutomationSessionProxy::ResolveChildFrameWithName(page->webPageID(), frameID, optionalName), WTFMove(completionHandler));
         return;
     }
 
     if (optionalOrdinal) {
-        page->process().sendWithAsyncReply(Messages::WebAutomationSessionProxy::ResolveChildFrameWithOrdinal(page->webPageID(), frameID, *optionalOrdinal), WTFMove(completionHandler));
+        page->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebAutomationSessionProxy::ResolveChildFrameWithOrdinal(page->webPageID(), frameID, *optionalOrdinal), WTFMove(completionHandler));
         return;
     }
 
@@ -1048,7 +1048,7 @@ void WebAutomationSession::resolveParentFrameHandle(const Inspector::Protocol::A
         callback->sendSuccess(handleForWebFrameID(frameID));
     };
 
-    page->process().sendWithAsyncReply(Messages::WebAutomationSessionProxy::ResolveParentFrame(page->webPageID(), frameID), WTFMove(completionHandler));
+    page->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebAutomationSessionProxy::ResolveParentFrame(page->webPageID(), frameID), WTFMove(completionHandler));
 }
 
 static std::optional<CoordinateSystem> protocolStringToCoordinateSystem(Inspector::Protocol::Automation::CoordinateSystem coordinateSystem)
@@ -1116,7 +1116,7 @@ void WebAutomationSession::computeElementLayout(const Inspector::Protocol::Autom
     };
 
     bool scrollIntoViewIfNeeded = optionalScrollIntoViewIfNeeded ? *optionalScrollIntoViewIfNeeded : false;
-    page->process().sendWithAsyncReply(Messages::WebAutomationSessionProxy::ComputeElementLayout(page->webPageID(), frameID, nodeHandle, scrollIntoViewIfNeeded, coordinateSystem.value()), WTFMove(completionHandler));
+    page->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebAutomationSessionProxy::ComputeElementLayout(page->webPageID(), frameID, nodeHandle, scrollIntoViewIfNeeded, coordinateSystem.value()), WTFMove(completionHandler));
 }
 
 void WebAutomationSession::getComputedRole(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, const Inspector::Protocol::Automation::NodeHandle& nodeHandle, Ref<GetComputedRoleCallback>&& callback)
@@ -1139,7 +1139,7 @@ void WebAutomationSession::getComputedRole(const Inspector::Protocol::Automation
         callback->sendSuccess(*role);
     };
 
-    page->process().sendWithAsyncReply(Messages::WebAutomationSessionProxy::GetComputedRole(page->webPageID(), frameID, nodeHandle), WTFMove(completionHandler));
+    page->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebAutomationSessionProxy::GetComputedRole(page->webPageID(), frameID, nodeHandle), WTFMove(completionHandler));
 }
 
 void WebAutomationSession::getComputedLabel(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, const Inspector::Protocol::Automation::NodeHandle& nodeHandle, Ref<GetComputedLabelCallback>&& callback)
@@ -1162,7 +1162,7 @@ void WebAutomationSession::getComputedLabel(const Inspector::Protocol::Automatio
         callback->sendSuccess(*label);
     };
 
-    page->process().sendWithAsyncReply(Messages::WebAutomationSessionProxy::GetComputedLabel(page->webPageID(), frameID, nodeHandle), WTFMove(completionHandler));
+    page->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebAutomationSessionProxy::GetComputedLabel(page->webPageID(), frameID, nodeHandle), WTFMove(completionHandler));
 }
 
 void WebAutomationSession::selectOptionElement(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, const Inspector::Protocol::Automation::NodeHandle& nodeHandle, Ref<SelectOptionElementCallback>&& callback)
@@ -1185,7 +1185,7 @@ void WebAutomationSession::selectOptionElement(const Inspector::Protocol::Automa
         callback->sendSuccess();
     };
 
-    page->process().sendWithAsyncReply(Messages::WebAutomationSessionProxy::SelectOptionElement(page->webPageID(), frameID, nodeHandle), WTFMove(completionHandler));
+    page->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebAutomationSessionProxy::SelectOptionElement(page->webPageID(), frameID, nodeHandle), WTFMove(completionHandler));
 }
 
 Inspector::Protocol::ErrorStringOr<bool> WebAutomationSession::isShowingJavaScriptDialog(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle)
@@ -1353,7 +1353,7 @@ void WebAutomationSession::setFilesForInputFileUpload(const Inspector::Protocol:
         callback->sendSuccess();
     };
 
-    page->process().sendWithAsyncReply(Messages::WebAutomationSessionProxy::SetFilesForInputFileUpload(page->webPageID(), frameID, nodeHandle, WTFMove(newFileList)), WTFMove(completionHandler));
+    page->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebAutomationSessionProxy::SetFilesForInputFileUpload(page->webPageID(), frameID, nodeHandle, WTFMove(newFileList)), WTFMove(completionHandler));
 }
 
 static inline Inspector::Protocol::Automation::CookieSameSitePolicy toProtocolSameSitePolicy(WebCore::Cookie::SameSitePolicy policy)
@@ -1423,7 +1423,7 @@ void WebAutomationSession::getAllCookies(const Inspector::Protocol::Automation::
         callback->sendSuccess(buildArrayForCookies(cookies));
     };
 
-    page->process().sendWithAsyncReply(Messages::WebAutomationSessionProxy::GetCookiesForFrame(page->webPageID(), std::nullopt), WTFMove(completionHandler));
+    page->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebAutomationSessionProxy::GetCookiesForFrame(page->webPageID(), std::nullopt), WTFMove(completionHandler));
 }
 
 void WebAutomationSession::deleteSingleCookie(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const String& cookieName, Ref<DeleteSingleCookieCallback>&& callback)
@@ -1441,7 +1441,7 @@ void WebAutomationSession::deleteSingleCookie(const Inspector::Protocol::Automat
         callback->sendSuccess();
     };
 
-    page->process().sendWithAsyncReply(Messages::WebAutomationSessionProxy::DeleteCookie(page->webPageID(), std::nullopt, cookieName), WTFMove(completionHandler));
+    page->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebAutomationSessionProxy::DeleteCookie(page->webPageID(), std::nullopt, cookieName), WTFMove(completionHandler));
 }
 
 static String domainByAddingDotPrefixIfNeeded(String domain)
@@ -1748,7 +1748,7 @@ void WebAutomationSession::viewportInViewCenterPointOfElement(WebPageProxy& page
         completionHandler(inViewCenterPoint, std::nullopt);
     };
 
-    page.process().sendWithAsyncReply(Messages::WebAutomationSessionProxy::ComputeElementLayout(page.webPageID(), frameID, nodeHandle, false, CoordinateSystem::LayoutViewport), WTFMove(didComputeElementLayoutHandler));
+    page.legacyMainFrameProcess().sendWithAsyncReply(Messages::WebAutomationSessionProxy::ComputeElementLayout(page.webPageID(), frameID, nodeHandle, false, CoordinateSystem::LayoutViewport), WTFMove(didComputeElementLayoutHandler));
 }
 
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
@@ -2393,7 +2393,7 @@ void WebAutomationSession::takeScreenshot(const Inspector::Protocol::Automation:
         uint64_t callbackID = m_nextScreenshotCallbackID++;
         m_screenshotCallbacks.set(callbackID, WTFMove(callback));
 
-        page->process().send(Messages::WebAutomationSessionProxy::TakeScreenshot(page->webPageID(), frameID, nodeHandle, scrollIntoViewIfNeeded, clipToViewport, callbackID), 0);
+        page->legacyMainFrameProcess().send(Messages::WebAutomationSessionProxy::TakeScreenshot(page->webPageID(), frameID, nodeHandle, scrollIntoViewIfNeeded, clipToViewport, callbackID), 0);
         return;
     }
 #endif
@@ -2426,12 +2426,12 @@ void WebAutomationSession::takeScreenshot(const Inspector::Protocol::Automation:
         takeViewSnapsot(page.get(), WTFMove(rect), WTFMove(callback));
     };
 
-    page->process().sendWithAsyncReply(Messages::WebAutomationSessionProxy::SnapshotRectForScreenshot(page->webPageID(), frameID, nodeHandle, scrollIntoViewIfNeeded, clipToViewport), WTFMove(completionHandler));
+    page->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebAutomationSessionProxy::SnapshotRectForScreenshot(page->webPageID(), frameID, nodeHandle, scrollIntoViewIfNeeded, clipToViewport), WTFMove(completionHandler));
 #else
     uint64_t callbackID = m_nextScreenshotCallbackID++;
     m_screenshotCallbacks.set(callbackID, WTFMove(callback));
 
-    page->process().send(Messages::WebAutomationSessionProxy::TakeScreenshot(page->webPageID(), frameID, nodeHandle, scrollIntoViewIfNeeded, clipToViewport, callbackID), 0);
+    page->legacyMainFrameProcess().send(Messages::WebAutomationSessionProxy::TakeScreenshot(page->webPageID(), frameID, nodeHandle, scrollIntoViewIfNeeded, clipToViewport, callbackID), 0);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.cpp
@@ -62,7 +62,7 @@ Ref<FrameProcess> BrowsingContextGroup::ensureProcessForConnection(IPC::Connecti
                 return *process;
         }
     }
-    return FrameProcess::create(page.process(), *this, Site(URL(page.currentURL())), preferences);
+    return FrameProcess::create(page.legacyMainFrameProcess(), *this, Site(URL(page.currentURL())), preferences);
 }
 
 FrameProcess* BrowsingContextGroup::processForSite(const Site& site)
@@ -127,7 +127,7 @@ void BrowsingContextGroup::addPage(WebPageProxy& page)
             return true;
         }
 
-        if (process->process().coreProcessIdentifier() == page.process().coreProcessIdentifier())
+        if (process->process().coreProcessIdentifier() == page.legacyMainFrameProcess().coreProcessIdentifier())
             return false;
         auto newRemotePage = makeUnique<RemotePageProxy>(page, process->process(), site);
         newRemotePage->injectPageIntoNewProcess();
@@ -189,7 +189,7 @@ void BrowsingContextGroup::transitionPageToRemotePage(WebPageProxy& page, const 
         return HashSet<std::unique_ptr<RemotePageProxy>> { };
     }).iterator->value;
 
-    auto newRemotePage = makeUnique<RemotePageProxy>(page, page.process(), openerSite, &page.messageReceiverRegistration());
+    auto newRemotePage = makeUnique<RemotePageProxy>(page, page.legacyMainFrameProcess(), openerSite, &page.messageReceiverRegistration());
 #if ASSERT_ENABLED
     for (auto& existingPage : set) {
         ASSERT(existingPage->process().coreProcessIdentifier() != newRemotePage->process().coreProcessIdentifier() || existingPage->site() != newRemotePage->site());

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -1530,7 +1530,7 @@ void NavigationState::didChangeIsLoading()
         }
         if (!m_networkActivity) {
             RELEASE_LOG(ProcessSuspension, "%p - NavigationState is taking a process network assertion because a page load started", this);
-            m_networkActivity = webView->_page->process().throttler().backgroundActivity("Page Load"_s).moveToUniquePtr();
+            m_networkActivity = webView->_page->legacyMainFrameProcess().throttler().backgroundActivity("Page Load"_s).moveToUniquePtr();
         }
     } else if (m_networkActivity) {
         // The application is visible so we delay releasing the background activity for 3 seconds to give it a chance to start another navigation
@@ -1663,7 +1663,7 @@ void NavigationState::didSwapWebProcesses()
     // Transfer our background assertion from the old process to the new one.
     auto webView = this->webView();
     if (m_networkActivity && webView)
-        m_networkActivity = webView->_page->process().throttler().backgroundActivity("Page Load"_s).moveToUniquePtr();
+        m_networkActivity = webView->_page->legacyMainFrameProcess().throttler().backgroundActivity("Page Load"_s).moveToUniquePtr();
 #endif
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -472,7 +472,7 @@ PlaybackSessionManagerProxy::PlaybackSessionManagerProxy(WebPageProxy& page)
 #endif
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    m_page->process().addMessageReceiver(Messages::PlaybackSessionManagerProxy::messageReceiverName(), m_page->webPageID(), *this);
+    m_page->legacyMainFrameProcess().addMessageReceiver(Messages::PlaybackSessionManagerProxy::messageReceiverName(), m_page->webPageID(), *this);
 }
 
 PlaybackSessionManagerProxy::~PlaybackSessionManagerProxy()
@@ -486,7 +486,7 @@ PlaybackSessionManagerProxy::~PlaybackSessionManagerProxy()
 void PlaybackSessionManagerProxy::invalidate()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    m_page->process().removeMessageReceiver(Messages::PlaybackSessionManagerProxy::messageReceiverName(), m_page->webPageID());
+    m_page->legacyMainFrameProcess().removeMessageReceiver(Messages::PlaybackSessionManagerProxy::messageReceiverName(), m_page->webPageID());
     m_page = nullptr;
 
     auto contextMap = WTFMove(m_contextMap);
@@ -829,7 +829,7 @@ void PlaybackSessionManagerProxy::setVideoReceiverEndpoint(PlaybackSessionContex
     ALWAYS_LOG(LOGIDENTIFIER);
     WebCore::MediaPlayerIdentifier playerIdentifier = *interface->playerIdentifier();
 
-    Ref process = m_page->protectedProcess();
+    Ref process = m_page->protectedLegacyMainFrameProcess();
     WebCore::ProcessIdentifier processIdentifier = process->coreProcessIdentifier();
 
     Ref gpuProcess = process->processPool().ensureProtectedGPUProcess();
@@ -852,7 +852,7 @@ void PlaybackSessionManagerProxy::setVideoReceiverEndpoint(PlaybackSessionContex
 void PlaybackSessionManagerProxy::uncacheVideoReceiverEndpoint(PlaybackSessionContextIdentifier contextId)
 {
 #if ENABLE(LINEAR_MEDIA_PLAYER)
-    Ref process = m_page->protectedProcess();
+    Ref process = m_page->protectedLegacyMainFrameProcess();
     WebCore::ProcessIdentifier processIdentifier = process->coreProcessIdentifier();
 
     Ref gpuProcess = process->processPool().ensureProtectedGPUProcess();

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -565,7 +565,7 @@ void SystemPreviewController::takeActivityToken()
 #if USE(RUNNINGBOARD)
     RELEASE_LOG(ProcessSuspension, "%p - UIProcess is taking a background assertion because it is downloading a system preview", this);
     ASSERT(!m_activity);
-    m_activity = page().process().throttler().backgroundActivity("System preview download"_s).moveToUniquePtr();
+    m_activity = page().legacyMainFrameProcess().throttler().backgroundActivity("System preview download"_s).moveToUniquePtr();
 #endif
 }
 
@@ -600,7 +600,7 @@ void SystemPreviewController::triggerSystemPreviewActionWithTargetForTesting(uin
 
     m_systemPreviewInfo.isPreview = true;
     m_systemPreviewInfo.element.elementIdentifier = ObjectIdentifier<WebCore::ElementIdentifierType>(elementID);
-    m_systemPreviewInfo.element.documentIdentifier = { *uuid, m_webPageProxy.process().coreProcessIdentifier() };
+    m_systemPreviewInfo.element.documentIdentifier = { *uuid, m_webPageProxy.legacyMainFrameProcess().coreProcessIdentifier() };
     m_systemPreviewInfo.element.webPageIdentifier = ObjectIdentifier<WebCore::PageIdentifierType>(pageID);
     triggerSystemPreviewAction();
 }

--- a/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp
@@ -33,7 +33,7 @@ namespace WebKit {
 
 std::unique_ptr<ProcessThrottler::BackgroundActivity> UIRemoteObjectRegistry::backgroundActivity(ASCIILiteral name)
 {
-    return protectedPage()->process().throttler().backgroundActivity(name).moveToUniquePtr();
+    return protectedPage()->legacyMainFrameProcess().throttler().backgroundActivity(name).moveToUniquePtr();
 }
 
 UIRemoteObjectRegistry::UIRemoteObjectRegistry(_WKRemoteObjectRegistry *remoteObjectRegistry, WebPageProxy& page)

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -72,7 +72,7 @@
 #import <BrowserEngineKit/BELayerHierarchyHostingView.h>
 #endif
 
-#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, m_page->process().connection())
+#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, m_page->legacyMainFrameProcess().connection())
 
 @interface WKLayerHostView : PlatformView
 @property (nonatomic, assign) uint32_t contextID;
@@ -499,7 +499,7 @@ VideoPresentationManagerProxy::VideoPresentationManagerProxy(WebPageProxy& page,
     , m_playbackSessionManagerProxy(playbackSessionManagerProxy)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    m_page->process().addMessageReceiver(Messages::VideoPresentationManagerProxy::messageReceiverName(), m_page->webPageID(), *this);
+    m_page->legacyMainFrameProcess().addMessageReceiver(Messages::VideoPresentationManagerProxy::messageReceiverName(), m_page->webPageID(), *this);
 }
 
 VideoPresentationManagerProxy::~VideoPresentationManagerProxy()
@@ -514,7 +514,7 @@ void VideoPresentationManagerProxy::invalidate()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
     if (m_page) {
-        m_page->process().removeMessageReceiver(Messages::VideoPresentationManagerProxy::messageReceiverName(), m_page->webPageID());
+        m_page->legacyMainFrameProcess().removeMessageReceiver(Messages::VideoPresentationManagerProxy::messageReceiverName(), m_page->webPageID());
         m_page = nullptr;
     }
 
@@ -714,7 +714,7 @@ void VideoPresentationManagerProxy::requestBitmapImageForCurrentTime(PlaybackSes
         return;
     }
 
-    gpuProcess->requestBitmapImageForCurrentTime(m_page->process().coreProcessIdentifier(), playerIdentifier, WTFMove(completionHandler));
+    gpuProcess->requestBitmapImageForCurrentTime(m_page->legacyMainFrameProcess().coreProcessIdentifier(), playerIdentifier, WTFMove(completionHandler));
 }
 
 void VideoPresentationManagerProxy::addVideoInPictureInPictureDidChangeObserver(const VideoInPictureInPictureDidChangeObserver& observer)
@@ -798,7 +798,7 @@ RetainPtr<WKLayerHostView> VideoPresentationManagerProxy::createLayerHostViewWit
 
 #if USE(EXTENSIONKIT)
     RefPtr page = m_page.get();
-    if (RefPtr gpuProcess = page ? page->process().processPool().gpuProcess() : nullptr) {
+    if (RefPtr gpuProcess = page ? page->legacyMainFrameProcess().processPool().gpuProcess() : nullptr) {
         RetainPtr handle = LayerHostingContext::createHostingHandle(gpuProcess->processID(), videoLayerID);
         [view->_hostingView setHandle:handle.get()];
     } else

--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
@@ -139,7 +139,7 @@ void DrawingAreaProxyCoordinatedGraphics::incorporateUpdate(UpdateInfo&& updateI
 std::optional<WebCore::FramesPerSecond> DrawingAreaProxyCoordinatedGraphics::displayNominalFramesPerSecond()
 {
     if (auto displayId = m_webPageProxy->displayID())
-        return m_webPageProxy->process().nominalFramesPerSecondForDisplay(displayId.value());
+        return m_webPageProxy->legacyMainFrameProcess().nominalFramesPerSecondForDisplay(displayId.value());
     return std::nullopt;
 }
 #endif

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -3011,7 +3011,7 @@ void WebExtensionContext::addPopupPage(WebPageProxy& page, WebExtensionAction& a
     auto tabIdentifier = tab ? std::optional(tab->identifier()) : std::nullopt;
     auto windowIdentifier = window ? std::optional(window->identifier()) : std::nullopt;
 
-    page.process().send(Messages::WebExtensionContextProxy::AddPopupPageIdentifier(page.webPageID(), tabIdentifier, windowIdentifier), identifier());
+    page.legacyMainFrameProcess().send(Messages::WebExtensionContextProxy::AddPopupPageIdentifier(page.webPageID(), tabIdentifier, windowIdentifier), identifier());
 }
 
 void WebExtensionContext::addExtensionTabPage(WebPageProxy& page, WebExtensionTab& tab)
@@ -3021,7 +3021,7 @@ void WebExtensionContext::addExtensionTabPage(WebPageProxy& page, WebExtensionTa
     RefPtr window = tab.window();
     auto windowIdentifier = window ? std::optional(window->identifier()) : std::nullopt;
 
-    page.process().send(Messages::WebExtensionContextProxy::AddTabPageIdentifier(page.webPageID(), tab.identifier(), windowIdentifier), identifier());
+    page.legacyMainFrameProcess().send(Messages::WebExtensionContextProxy::AddTabPageIdentifier(page.webPageID(), tab.identifier(), windowIdentifier), identifier());
 }
 
 void WebExtensionContext::enumerateExtensionPages(Function<void(WebPageProxy&, bool&)>&& action)
@@ -3236,7 +3236,7 @@ void WebExtensionContext::loadBackgroundWebView()
 
     if (!extension().backgroundContentIsServiceWorker()) {
         auto backgroundPage = m_backgroundWebView.get()._page;
-        backgroundPage->process().send(Messages::WebExtensionContextProxy::SetBackgroundPageIdentifier(backgroundPage->webPageID()), identifier());
+        backgroundPage->legacyMainFrameProcess().send(Messages::WebExtensionContextProxy::SetBackgroundPageIdentifier(backgroundPage->webPageID()), identifier());
 
         [m_backgroundWebView loadRequest:[NSURLRequest requestWithURL:backgroundContentURL()]];
         return;
@@ -3679,7 +3679,7 @@ HashSet<Ref<WebProcessProxy>> WebExtensionContext::processes(const API::Inspecto
     auto [tabIdentifier, webView] = m_inspectorBackgroundPageMap.get(*inspectorProxy);
     ASSERT(webView);
 
-    result.add(webView->_page->process());
+    result.add(webView->_page->legacyMainFrameProcess());
 
     return result;
 }
@@ -3838,8 +3838,8 @@ void WebExtensionContext::loadInspectorBackgroundPage(WebInspectorUIProxy& inspe
 
         auto appearance = inspector->inspectorPage()->useDarkAppearance() ? Inspector::ExtensionAppearance::Dark : Inspector::ExtensionAppearance::Light;
 
-        Ref process = webView._page->process();
-        ASSERT(inspectorWebView._page->process() == process);
+        Ref process = webView._page->legacyMainFrameProcess();
+        ASSERT(inspectorWebView._page->legacyMainFrameProcess() == process);
         process->send(Messages::WebExtensionContextProxy::AddInspectorPageIdentifier(inspectorWebView._page->webPageID(), tab->identifier(), windowIdentifier), identifier());
         process->send(Messages::WebExtensionContextProxy::AddInspectorBackgroundPageIdentifier(webView._page->webPageID(), tab->identifier(), windowIdentifier), identifier());
         process->send(Messages::WebExtensionContextProxy::DispatchDevToolsPanelsThemeChangedEvent(appearance), identifier());

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -367,7 +367,7 @@ void WebExtensionController::addPage(WebPageProxy& page)
     for (auto& entry : m_registeredSchemeHandlers)
         page.setURLSchemeHandlerForScheme(entry.value.copyRef(), entry.key);
 
-    Ref pool = page.process().processPool();
+    Ref pool = page.legacyMainFrameProcess().processPool();
     addProcessPool(pool);
 
     Ref dataStore = page.websiteDataStore();
@@ -382,7 +382,7 @@ void WebExtensionController::removePage(WebPageProxy& page)
     ASSERT(m_pages.contains(page));
     m_pages.remove(page);
 
-    Ref pool = page.process().processPool();
+    Ref pool = page.legacyMainFrameProcess().processPool();
     removeProcessPool(pool);
 
     Ref dataStore = page.websiteDataStore();
@@ -416,7 +416,7 @@ void WebExtensionController::removeProcessPool(WebProcessPool& processPool)
 {
     // Only remove the message receiver and process pool if no other pages use the same process pool.
     for (Ref knownPage : m_pages) {
-        if (knownPage->process().processPool() == processPool)
+        if (knownPage->legacyMainFrameProcess().processPool() == processPool)
             return;
     }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -935,7 +935,7 @@ WebExtensionTab::WebProcessProxySet WebExtensionTab::processes(WebExtensionEvent
     if (!extensionContext()->pageListensForEvent(*webView._page, type, contentWorldType))
         return { };
 
-    Ref process = webView._page->process();
+    Ref process = webView._page->legacyMainFrameProcess();
     if (!process->canSendMessage())
         return { };
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -117,7 +117,7 @@ bool WebExtensionContext::pageListensForEvent(const WebPageProxy& page, WebExten
     if (!found)
         return false;
 
-    return page.process().canSendMessage();
+    return page.legacyMainFrameProcess().canSendMessage();
 }
 
 WebExtensionContext::WebProcessProxySet WebExtensionContext::processes(EventListenerTypeSet&& typeSet, ContentWorldTypeSet&& contentWorldTypeSet) const
@@ -145,7 +145,7 @@ WebExtensionContext::WebProcessProxySet WebExtensionContext::processes(EventList
                 if (!hasAccessInPrivateBrowsing() && entry.key.sessionID().isEphemeral())
                     continue;
 
-                Ref process = entry.key.process();
+                Ref process = entry.key.legacyMainFrameProcess();
                 if (process->canSendMessage())
                     result.add(WTFMove(process));
             }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -92,7 +92,7 @@ WebExtensionController::WebProcessProxySet WebExtensionController::allProcesses(
 {
     WebProcessProxySet processes;
     for (auto& page : m_pages)
-        processes.add(page.process());
+        processes.add(page.legacyMainFrameProcess());
     return processes;
 }
 

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
@@ -62,7 +62,7 @@ UIGamepadProvider::~UIGamepadProvider()
 void UIGamepadProvider::gamepadSyncTimerFired()
 {
     RefPtr webPageProxy = platformWebPageProxyForGamepadInput();
-    if (!webPageProxy || !m_processPoolsUsingGamepads.contains(webPageProxy->process().processPool()))
+    if (!webPageProxy || !m_processPoolsUsingGamepads.contains(webPageProxy->legacyMainFrameProcess().processPool()))
         return;
 
     webPageProxy->gamepadActivity(snapshotGamepads(), m_shouldMakeGamepadsVisibleOnSync ? EventMakesGamepadsVisible::Yes : EventMakesGamepadsVisible::No);
@@ -149,7 +149,7 @@ void UIGamepadProvider::processPoolStoppedUsingGamepads(WebProcessPool& pool)
 
 void UIGamepadProvider::viewBecameActive(WebPageProxy& page)
 {
-    if (!m_processPoolsUsingGamepads.contains(page.process().processPool()))
+    if (!m_processPoolsUsingGamepads.contains(page.legacyMainFrameProcess().processPool()))
         return;
 
     if (!m_isMonitoringGamepads)

--- a/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp
@@ -221,7 +221,7 @@ void RemoteWebInspectorUIProxy::createFrontendPageAndWindow()
 
     trackInspectorPage(inspectorPage.get(), nullptr);
 
-    inspectorPage->process().addMessageReceiver(Messages::RemoteWebInspectorUIProxy::messageReceiverName(), inspectorPage->webPageID(), *this);
+    inspectorPage->legacyMainFrameProcess().addMessageReceiver(Messages::RemoteWebInspectorUIProxy::messageReceiverName(), inspectorPage->webPageID(), *this);
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     m_extensionController = WebInspectorUIExtensionControllerProxy::create(*inspectorPage);
@@ -234,7 +234,7 @@ void RemoteWebInspectorUIProxy::closeFrontendPageAndWindow()
     if (!inspectorPage)
         return;
 
-    inspectorPage->process().removeMessageReceiver(Messages::RemoteWebInspectorUIProxy::messageReceiverName(), inspectorPage->webPageID());
+    inspectorPage->legacyMainFrameProcess().removeMessageReceiver(Messages::RemoteWebInspectorUIProxy::messageReceiverName(), inspectorPage->webPageID());
 
     untrackInspectorPage(inspectorPage.get());
 

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
@@ -42,7 +42,7 @@ namespace WebKit {
 WebInspectorUIExtensionControllerProxy::WebInspectorUIExtensionControllerProxy(WebPageProxy& inspectorPage)
     : m_inspectorPage(inspectorPage)
 {
-    m_inspectorPage->process().addMessageReceiver(Messages::WebInspectorUIExtensionControllerProxy::messageReceiverName(), m_inspectorPage->webPageID(), *this);
+    m_inspectorPage->legacyMainFrameProcess().addMessageReceiver(Messages::WebInspectorUIExtensionControllerProxy::messageReceiverName(), m_inspectorPage->webPageID(), *this);
 }
 
 WebInspectorUIExtensionControllerProxy::~WebInspectorUIExtensionControllerProxy()
@@ -86,7 +86,7 @@ void WebInspectorUIExtensionControllerProxy::inspectorFrontendWillClose()
     if (!m_inspectorPage)
         return;
 
-    m_inspectorPage->process().removeMessageReceiver(Messages::WebInspectorUIExtensionControllerProxy::messageReceiverName(), m_inspectorPage->webPageID());
+    m_inspectorPage->legacyMainFrameProcess().removeMessageReceiver(Messages::WebInspectorUIExtensionControllerProxy::messageReceiverName(), m_inspectorPage->webPageID());
     m_inspectorPage = nullptr;
 
     m_extensionAPIObjectMap.clear();

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
@@ -77,7 +77,7 @@ WebInspectorUIProxy::WebInspectorUIProxy(WebPageProxy& inspectedPage)
     , m_closeFrontendAfterInactivityTimer(RunLoop::main(), this, &WebInspectorUIProxy::closeFrontendAfterInactivityTimerFired)
 #endif
 {
-    m_inspectedPage->process().addMessageReceiver(Messages::WebInspectorUIProxy::messageReceiverName(), m_inspectedPage->webPageID(), *this);
+    m_inspectedPage->legacyMainFrameProcess().addMessageReceiver(Messages::WebInspectorUIProxy::messageReceiverName(), m_inspectedPage->webPageID(), *this);
 }
 
 WebInspectorUIProxy::~WebInspectorUIProxy()
@@ -221,7 +221,7 @@ void WebInspectorUIProxy::resetState()
 void WebInspectorUIProxy::reset()
 {
     if (m_inspectedPage) {
-        m_inspectedPage->process().removeMessageReceiver(Messages::WebInspectorUIProxy::messageReceiverName(), m_inspectedPage->webPageID());
+        m_inspectedPage->legacyMainFrameProcess().removeMessageReceiver(Messages::WebInspectorUIProxy::messageReceiverName(), m_inspectedPage->webPageID());
         m_inspectedPage = nullptr;
     }
 }
@@ -233,7 +233,7 @@ void WebInspectorUIProxy::updateForNewPageProcess(WebPageProxy& inspectedPage)
     m_inspectedPage = &inspectedPage;
     m_inspectedPageIdentifier = m_inspectedPage->identifier();
 
-    m_inspectedPage->process().addMessageReceiver(Messages::WebInspectorUIProxy::messageReceiverName(), m_inspectedPage->webPageID(), *this);
+    m_inspectedPage->legacyMainFrameProcess().addMessageReceiver(Messages::WebInspectorUIProxy::messageReceiverName(), m_inspectedPage->webPageID(), *this);
 
     if (m_inspectorPage)
         m_inspectorPage->send(Messages::WebInspectorUI::UpdateConnection());
@@ -427,7 +427,7 @@ void WebInspectorUIProxy::createFrontendPage()
     // Make sure the inspected page has a running WebProcess so we can inspect it.
     m_inspectedPage->launchInitialProcessIfNecessary();
 
-    m_inspectorPage->process().addMessageReceiver(Messages::WebInspectorUIProxy::messageReceiverName(), m_inspectedPageIdentifier, *this);
+    m_inspectorPage->legacyMainFrameProcess().addMessageReceiver(Messages::WebInspectorUIProxy::messageReceiverName(), m_inspectedPageIdentifier, *this);
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     m_extensionController = WebInspectorUIExtensionControllerProxy::create(*m_inspectorPage);
@@ -564,7 +564,7 @@ void WebInspectorUIProxy::closeFrontendPageAndWindow()
     untrackInspectorPage(inspectorPage.get());
 
     inspectorPage->send(Messages::WebInspectorUI::SetIsVisible(m_isVisible));
-    inspectorPage->process().removeMessageReceiver(Messages::WebInspectorUIProxy::messageReceiverName(), m_inspectedPageIdentifier);
+    inspectorPage->legacyMainFrameProcess().removeMessageReceiver(Messages::WebInspectorUIProxy::messageReceiverName(), m_inspectedPageIdentifier);
 
     if (auto inspectedPage = this->inspectedPage(); inspectedPage && m_isActiveFrontend)
         inspectedPage->inspectorController().disconnectFrontend(*this);
@@ -606,7 +606,7 @@ void WebInspectorUIProxy::frontendLoaded()
     if (!inspectedPage)
         return;
 
-    if (auto* automationSession = inspectedPage->process().processPool().automationSession())
+    if (auto* automationSession = inspectedPage->legacyMainFrameProcess().processPool().automationSession())
         automationSession->inspectorFrontendLoaded(*inspectedPage);
     
 #if ENABLE(INSPECTOR_EXTENSIONS)

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp
@@ -61,12 +61,12 @@ RemoteMediaSessionCoordinatorProxy::RemoteMediaSessionCoordinatorProxy(WebPagePr
 #endif
 {
     m_privateCoordinator->setClient(*this);
-    m_webPageProxy.process().addMessageReceiver(Messages::RemoteMediaSessionCoordinatorProxy::messageReceiverName(), m_webPageProxy.webPageID(), *this);
+    m_webPageProxy.legacyMainFrameProcess().addMessageReceiver(Messages::RemoteMediaSessionCoordinatorProxy::messageReceiverName(), m_webPageProxy.webPageID(), *this);
 }
 
 RemoteMediaSessionCoordinatorProxy::~RemoteMediaSessionCoordinatorProxy()
 {
-    m_webPageProxy.process().removeMessageReceiver(Messages::RemoteMediaSessionCoordinatorProxy::messageReceiverName(), m_webPageProxy.webPageID());
+    m_webPageProxy.legacyMainFrameProcess().removeMessageReceiver(Messages::RemoteMediaSessionCoordinatorProxy::messageReceiverName(), m_webPageProxy.webPageID());
 }
 
 void RemoteMediaSessionCoordinatorProxy::join(MediaSessionCommandCompletionHandler&& completionHandler)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -47,7 +47,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-#define MESSAGE_CHECK_WITH_RETURN_VALUE(assertion, returnValue) MESSAGE_CHECK_WITH_RETURN_VALUE_BASE(assertion, (webPageProxy().process().connection()), returnValue)
+#define MESSAGE_CHECK_WITH_RETURN_VALUE(assertion, returnValue) MESSAGE_CHECK_WITH_RETURN_VALUE_BASE(assertion, (webPageProxy().legacyMainFrameProcess().connection()), returnValue)
 
 RemoteScrollingCoordinatorProxy::RemoteScrollingCoordinatorProxy(WebPageProxy& webPageProxy)
     : m_webPageProxy(webPageProxy)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm
@@ -85,7 +85,7 @@ std::unique_ptr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteL
         }
 #endif
 
-        auto view = adoptNS([[WKUIRemoteView alloc] initWithFrame:CGRectZero pid:m_drawingArea->page().processID() contextID:properties.hostingContextID()]);
+        auto view = adoptNS([[WKUIRemoteView alloc] initWithFrame:CGRectZero pid:m_drawingArea->page().legacyMainFrameProcessID() contextID:properties.hostingContextID()]);
         return makeWithView(WTFMove(view));
     }
     case PlatformCALayer::LayerType::LayerTypeShapeLayer:

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -56,7 +56,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, webPageProxy().process().connection())
+#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, webPageProxy().legacyMainFrameProcess().connection())
 
 RemoteScrollingCoordinatorProxyIOS::RemoteScrollingCoordinatorProxyIOS(WebPageProxy& webPageProxy)
     : RemoteScrollingCoordinatorProxy(webPageProxy)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -113,14 +113,14 @@ DisplayLink* RemoteLayerTreeDrawingAreaProxyMac::existingDisplayLink()
     if (!m_displayID)
         return nullptr;
     
-    return m_webPageProxy->process().processPool().displayLinks().existingDisplayLinkForDisplay(*m_displayID);
+    return m_webPageProxy->legacyMainFrameProcess().processPool().displayLinks().existingDisplayLinkForDisplay(*m_displayID);
 }
 
 DisplayLink& RemoteLayerTreeDrawingAreaProxyMac::displayLink()
 {
     ASSERT(m_displayID);
 
-    auto& displayLinks = m_webPageProxy->process().processPool().displayLinks();
+    auto& displayLinks = m_webPageProxy->legacyMainFrameProcess().processPool().displayLinks();
     return displayLinks.displayLinkForDisplay(*m_displayID);
 }
 

--- a/Source/WebKit/UIProcess/UserMediaProcessManager.cpp
+++ b/Source/WebKit/UIProcess/UserMediaProcessManager.cpp
@@ -80,7 +80,7 @@ bool UserMediaProcessManager::willCreateMediaStream(UserMediaPermissionRequestMa
     ASSERT(request.hasAudioDevice() || request.hasVideoDevice());
 
 #if ENABLE(SANDBOX_EXTENSIONS) && USE(APPLE_INTERNAL_SDK)
-    Ref process = proxy.page().process();
+    Ref process = proxy.page().legacyMainFrameProcess();
     size_t extensionCount = 0;
 
     bool needsAudioSandboxExtension = request.hasAudioDevice() && !process->hasAudioCaptureExtension() && !proxy.page().preferences().captureAudioInUIProcessEnabled() && !proxy.page().preferences().captureAudioInGPUProcessEnabled();
@@ -189,7 +189,7 @@ void UserMediaProcessManager::revokeSandboxExtensionsIfNeeded(WebProcessProxy& p
     bool hasPendingCapture = false;
 
     UserMediaPermissionRequestManagerProxy::forEach([&hasAudioCapture, &hasVideoCapture, &hasPendingCapture, &process](auto& managerProxy) {
-        if (&process != &managerProxy.page().process())
+        if (&process != &managerProxy.page().legacyMainFrameProcess())
             return;
         hasAudioCapture |= managerProxy.page().isCapturingAudio();
         hasVideoCapture |= managerProxy.page().isCapturingVideo();

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -103,7 +103,7 @@ void ViewGestureController::disconnectFromProcess()
     if (!m_isConnectedToProcess)
         return;
 
-    m_webPageProxy.process().removeMessageReceiver(Messages::ViewGestureController::messageReceiverName(), m_webPageProxy.webPageID());
+    m_webPageProxy.legacyMainFrameProcess().removeMessageReceiver(Messages::ViewGestureController::messageReceiverName(), m_webPageProxy.webPageID());
     m_isConnectedToProcess = false;
 }
 
@@ -112,7 +112,7 @@ void ViewGestureController::connectToProcess()
     if (m_isConnectedToProcess)
         return;
 
-    m_webPageProxy.process().addMessageReceiver(Messages::ViewGestureController::messageReceiverName(), m_webPageProxy.webPageID(), *this);
+    m_webPageProxy.legacyMainFrameProcess().addMessageReceiver(Messages::ViewGestureController::messageReceiverName(), m_webPageProxy.webPageID(), *this);
     m_isConnectedToProcess = true;
 }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp
@@ -50,7 +50,7 @@ using namespace WebCore;
 WebAuthenticatorCoordinatorProxy::WebAuthenticatorCoordinatorProxy(WebPageProxy& webPageProxy)
     : m_webPageProxy(webPageProxy)
 {
-    m_webPageProxy.process().addMessageReceiver(Messages::WebAuthenticatorCoordinatorProxy::messageReceiverName(), m_webPageProxy.webPageID(), *this);
+    m_webPageProxy.legacyMainFrameProcess().addMessageReceiver(Messages::WebAuthenticatorCoordinatorProxy::messageReceiverName(), m_webPageProxy.webPageID(), *this);
 }
 
 WebAuthenticatorCoordinatorProxy::~WebAuthenticatorCoordinatorProxy()
@@ -58,7 +58,7 @@ WebAuthenticatorCoordinatorProxy::~WebAuthenticatorCoordinatorProxy()
 #if HAVE(UNIFIED_ASC_AUTH_UI)
     cancel([]() { });
 #endif // HAVE(UNIFIED_ASC_AUTH_UI)
-    m_webPageProxy.process().removeMessageReceiver(Messages::WebAuthenticatorCoordinatorProxy::messageReceiverName(), m_webPageProxy.webPageID());
+    m_webPageProxy.legacyMainFrameProcess().removeMessageReceiver(Messages::WebAuthenticatorCoordinatorProxy::messageReceiverName(), m_webPageProxy.webPageID());
 }
 
 void WebAuthenticatorCoordinatorProxy::makeCredential(FrameIdentifier frameId, FrameInfoData&& frameInfo, PublicKeyCredentialCreationOptions&& options, MediationRequirement mediation, RequestCompletionHandler&& handler)

--- a/Source/WebKit/UIProcess/WebContextMenuProxy.cpp
+++ b/Source/WebKit/UIProcess/WebContextMenuProxy.cpp
@@ -62,7 +62,7 @@ void WebContextMenuProxy::show()
 
     m_contextMenuListener = WebContextMenuListenerProxy::create(*this);
     page->contextMenuClient().getContextMenuFromProposedMenu(*page, proposedItems(), *m_contextMenuListener, m_context.webHitTestResultData().value(),
-        page->process().transformHandlesToObjects(m_userData.protectedObject().get()).get());
+        page->legacyMainFrameProcess().transformHandlesToObjects(m_userData.protectedObject().get()).get());
 }
 
 void WebContextMenuProxy::useContextMenuItems(Vector<Ref<WebContextMenuItem>>&& items)
@@ -74,7 +74,7 @@ void WebContextMenuProxy::useContextMenuItems(Vector<Ref<WebContextMenuItem>>&& 
         return;
 
     // Since showContextMenuWithItems can spin a nested run loop we need to turn off the responsiveness timer.
-    page->process().stopResponsivenessTimer();
+    page->legacyMainFrameProcess().stopResponsivenessTimer();
 
     // Protect |this| from being deallocated if WebPageProxy code is re-entered from the menu runloop or delegates.
     Ref protectedThis { *this };

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -60,12 +60,12 @@ WebFullScreenManagerProxy::WebFullScreenManagerProxy(WebPageProxy& page, WebFull
     , m_logIdentifier(page.logIdentifier())
 #endif
 {
-    m_page.process().addMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), m_page.webPageID(), *this);
+    m_page.legacyMainFrameProcess().addMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), m_page.webPageID(), *this);
 }
 
 WebFullScreenManagerProxy::~WebFullScreenManagerProxy()
 {
-    m_page.process().removeMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), m_page.webPageID());
+    m_page.legacyMainFrameProcess().removeMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), m_page.webPageID());
     m_client.closeFullScreenManager();
     callCloseCompletionHandlers();
 }
@@ -86,7 +86,7 @@ void WebFullScreenManagerProxy::didEnterFullScreen()
     m_page.send(Messages::WebFullScreenManager::DidEnterFullScreen());
 
     if (m_page.isControlledByAutomation()) {
-        if (WebAutomationSession* automationSession = m_page.process().processPool().automationSession())
+        if (WebAutomationSession* automationSession = m_page.legacyMainFrameProcess().processPool().automationSession())
             automationSession->didEnterFullScreenForPage(m_page);
     }
 }
@@ -120,7 +120,7 @@ void WebFullScreenManagerProxy::didExitFullScreen()
     m_page.send(Messages::WebFullScreenManager::DidExitFullScreen());
     
     if (m_page.isControlledByAutomation()) {
-        if (WebAutomationSession* automationSession = m_page.process().processPool().automationSession())
+        if (WebAutomationSession* automationSession = m_page.legacyMainFrameProcess().processPool().automationSession())
             automationSession->didExitFullScreenForPage(m_page);
     }
     callCloseCompletionHandlers();

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1548,9 +1548,9 @@ public:
 #endif
 
     WebProcessProxy& ensureRunningProcess();
-    WebProcessProxy& process() const { return m_process; }
-    Ref<WebProcessProxy> protectedProcess() const;
-    ProcessID processID() const;
+    WebProcessProxy& legacyMainFrameProcess() const { return m_legacyMainFrameProcess; }
+    Ref<WebProcessProxy> protectedLegacyMainFrameProcess() const;
+    ProcessID legacyMainFrameProcessID() const;
 
     ProcessID gpuProcessID() const;
     ProcessID modelProcessID() const;
@@ -3147,7 +3147,7 @@ private:
 #if PLATFORM(COCOA) && ENABLE(ASYNC_SCROLLING)
     std::unique_ptr<RemoteScrollingCoordinatorProxy> m_scrollingCoordinatorProxy;
 #endif
-    Ref<WebProcessProxy> m_process;
+    Ref<WebProcessProxy> m_legacyMainFrameProcess;
     Ref<WebPageGroup> m_pageGroup;
     Ref<WebPreferences> m_preferences;
 
@@ -3260,7 +3260,7 @@ private:
 #endif
     bool m_allowsMediaDocumentInlinePlayback { false };
 
-    ProcessActivityState m_processActivityState;
+    ProcessActivityState m_legacyMainFrameProcessActivityState;
 
     bool m_initialCapitalizationEnabled { false };
     std::optional<double> m_cpuLimit;

--- a/Source/WebKit/UIProcess/WebPreferences.cpp
+++ b/Source/WebKit/UIProcess/WebPreferences.cpp
@@ -190,7 +190,7 @@ void WebPreferences::updateBoolValueForKey(const String& key, bool value, bool e
     
     if (key == WebPreferencesKey::processSwapOnCrossSiteNavigationEnabledKey()) {
         for (auto& page : m_pages)
-            page.process().processPool().configuration().setProcessSwapsOnNavigation(value);
+            page.legacyMainFrameProcess().processPool().configuration().setProcessSwapsOnNavigation(value);
 
         return;
     }

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -242,7 +242,7 @@ Vector<std::pair<WebCore::ProcessIdentifier, WebCore::RegistrableDomain>> WebPro
 {
     Vector<std::pair<WebCore::ProcessIdentifier, WebCore::RegistrableDomain>> result;
     for (Ref page : globalPages())
-        result.append(std::make_pair(page->process().coreProcessIdentifier(), RegistrableDomain(URL(page->currentURL()))));
+        result.append(std::make_pair(page->legacyMainFrameProcess().coreProcessIdentifier(), RegistrableDomain(URL(page->currentURL()))));
     return result;
 }
 

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
@@ -42,14 +42,14 @@ WebScreenOrientationManagerProxy::WebScreenOrientationManagerProxy(WebPageProxy&
     : m_page(page)
     , m_currentOrientation(orientation)
 {
-    m_page.process().addMessageReceiver(Messages::WebScreenOrientationManagerProxy::messageReceiverName(), m_page.webPageID(), *this);
+    m_page.legacyMainFrameProcess().addMessageReceiver(Messages::WebScreenOrientationManagerProxy::messageReceiverName(), m_page.webPageID(), *this);
 }
 
 WebScreenOrientationManagerProxy::~WebScreenOrientationManagerProxy()
 {
     unlockIfNecessary();
 
-    m_page.process().removeMessageReceiver(Messages::WebScreenOrientationManagerProxy::messageReceiverName(), m_page.webPageID());
+    m_page.legacyMainFrameProcess().removeMessageReceiver(Messages::WebScreenOrientationManagerProxy::messageReceiverName(), m_page.webPageID());
 }
 
 void WebScreenOrientationManagerProxy::currentOrientation(CompletionHandler<void(WebCore::ScreenOrientationType)>&& completionHandler)

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
@@ -35,19 +35,19 @@
 #include "WebProcessProxy.h"
 #include <WebCore/SecurityOriginData.h>
 
-#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, m_page.process().connection())
+#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, m_page.legacyMainFrameProcess().connection())
 
 namespace WebKit {
 
 PlatformXRSystem::PlatformXRSystem(WebPageProxy& page)
     : m_page(page)
 {
-    m_page.process().addMessageReceiver(Messages::PlatformXRSystem::messageReceiverName(), m_page.webPageID(), *this);
+    m_page.legacyMainFrameProcess().addMessageReceiver(Messages::PlatformXRSystem::messageReceiverName(), m_page.webPageID(), *this);
 }
 
 PlatformXRSystem::~PlatformXRSystem()
 {
-    m_page.process().removeMessageReceiver(Messages::PlatformXRSystem::messageReceiverName(), m_page.webPageID());
+    m_page.legacyMainFrameProcess().removeMessageReceiver(Messages::PlatformXRSystem::messageReceiverName(), m_page.webPageID());
 }
 
 void PlatformXRSystem::invalidate()
@@ -70,7 +70,7 @@ void PlatformXRSystem::ensureImmersiveSessionActivity()
     if (m_immersiveSessionActivity && m_immersiveSessionActivity->isValid())
         return;
 
-    m_immersiveSessionActivity = m_page.process().throttler().foregroundActivity("XR immersive session"_s).moveToUniquePtr();
+    m_immersiveSessionActivity = m_page.legacyMainFrameProcess().throttler().foregroundActivity("XR immersive session"_s).moveToUniquePtr();
 }
 
 void PlatformXRSystem::enumerateImmersiveXRDevices(CompletionHandler<void(Vector<XRDeviceInfo>&&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/glib/UserMediaPermissionRequestManagerProxyGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/UserMediaPermissionRequestManagerProxyGLib.cpp
@@ -31,7 +31,7 @@ using namespace WebCore;
 
 void UserMediaPermissionRequestManagerProxy::platformValidateUserMediaRequestConstraints(RealtimeMediaSourceCenter::ValidConstraintsHandler&& validHandler, RealtimeMediaSourceCenter::InvalidConstraintsHandler&& invalidHandler, WebCore::MediaDeviceHashSalts&& deviceIDHashSalts)
 {
-    m_page->process().protectedConnection()->sendWithAsyncReply(Messages::UserMediaCaptureManager::ValidateUserMediaRequestConstraints(m_currentUserMediaRequest->userRequest(), WTFMove(deviceIDHashSalts)), [validHandler = WTFMove(validHandler), invalidHandler = WTFMove(invalidHandler)](std::optional<WebCore::MediaConstraintType> invalidConstraint, Vector<WebCore::CaptureDevice> audioDevices, Vector<WebCore::CaptureDevice> videoDevices) mutable {
+    m_page->legacyMainFrameProcess().protectedConnection()->sendWithAsyncReply(Messages::UserMediaCaptureManager::ValidateUserMediaRequestConstraints(m_currentUserMediaRequest->userRequest(), WTFMove(deviceIDHashSalts)), [validHandler = WTFMove(validHandler), invalidHandler = WTFMove(invalidHandler)](std::optional<WebCore::MediaConstraintType> invalidConstraint, Vector<WebCore::CaptureDevice> audioDevices, Vector<WebCore::CaptureDevice> videoDevices) mutable {
         if (invalidConstraint)
             invalidHandler(*invalidConstraint);
         else
@@ -41,7 +41,7 @@ void UserMediaPermissionRequestManagerProxy::platformValidateUserMediaRequestCon
 
 void UserMediaPermissionRequestManagerProxy::platformGetMediaStreamDevices(bool revealIdsAndLabels, CompletionHandler<void(Vector<CaptureDeviceWithCapabilities>&&)>&& completionHandler)
 {
-    m_page->process().protectedConnection()->sendWithAsyncReply(Messages::UserMediaCaptureManager::GetMediaStreamDevices(revealIdsAndLabels), WTFMove(completionHandler));
+    m_page->legacyMainFrameProcess().protectedConnection()->sendWithAsyncReply(Messages::UserMediaCaptureManager::GetMediaStreamDevices(revealIdsAndLabels), WTFMove(completionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
@@ -149,7 +149,7 @@ AcceleratedBackingStoreDMABuf::AcceleratedBackingStoreDMABuf(WebPageProxy& webPa
 AcceleratedBackingStoreDMABuf::~AcceleratedBackingStoreDMABuf()
 {
     if (m_surfaceID)
-        m_webPage.process().removeMessageReceiver(Messages::AcceleratedBackingStoreDMABuf::messageReceiverName(), m_surfaceID);
+        m_webPage.legacyMainFrameProcess().removeMessageReceiver(Messages::AcceleratedBackingStoreDMABuf::messageReceiverName(), m_surfaceID);
 
     if (m_gdkGLContext) {
         gdk_gl_context_make_current(m_gdkGLContext.get());
@@ -556,7 +556,7 @@ void AcceleratedBackingStoreDMABuf::frame(uint64_t bufferID)
 
 void AcceleratedBackingStoreDMABuf::frameDone()
 {
-    m_webPage.process().send(Messages::AcceleratedSurfaceDMABuf::FrameDone(), m_surfaceID);
+    m_webPage.legacyMainFrameProcess().send(Messages::AcceleratedSurfaceDMABuf::FrameDone(), m_surfaceID);
 }
 
 void AcceleratedBackingStoreDMABuf::unrealize()
@@ -603,12 +603,12 @@ void AcceleratedBackingStoreDMABuf::update(const LayerTreeContext& context)
         // avoid flickering.
         m_committedBuffer = nullptr;
         m_buffers.clear();
-        m_webPage.process().removeMessageReceiver(Messages::AcceleratedBackingStoreDMABuf::messageReceiverName(), m_surfaceID);
+        m_webPage.legacyMainFrameProcess().removeMessageReceiver(Messages::AcceleratedBackingStoreDMABuf::messageReceiverName(), m_surfaceID);
     }
 
     m_surfaceID = context.contextID;
     if (m_surfaceID)
-        m_webPage.process().addMessageReceiver(Messages::AcceleratedBackingStoreDMABuf::messageReceiverName(), m_surfaceID, *this);
+        m_webPage.legacyMainFrameProcess().addMessageReceiver(Messages::AcceleratedBackingStoreDMABuf::messageReceiverName(), m_surfaceID, *this);
 }
 
 bool AcceleratedBackingStoreDMABuf::prepareForRendering()
@@ -618,7 +618,7 @@ bool AcceleratedBackingStoreDMABuf::prepareForRendering()
 
     if (m_pendingBuffer) {
         if (m_committedBuffer)
-            m_webPage.process().send(Messages::AcceleratedSurfaceDMABuf::ReleaseBuffer(m_committedBuffer->id()), m_surfaceID);
+            m_webPage.legacyMainFrameProcess().send(Messages::AcceleratedSurfaceDMABuf::ReleaseBuffer(m_committedBuffer->id()), m_surfaceID);
         m_committedBuffer = WTFMove(m_pendingBuffer);
     }
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -79,7 +79,7 @@
 
 #define MESSAGE_CHECK(assertion) do { \
     if (auto webView = this->webView()) { \
-        MESSAGE_CHECK_BASE(assertion, webView->_page->process().connection()); \
+        MESSAGE_CHECK_BASE(assertion, webView->_page->legacyMainFrameProcess().connection()); \
     } else { \
         ASSERT_NOT_REACHED(); \
     } \
@@ -298,7 +298,7 @@ void PageClientImpl::didCompleteSyntheticClick()
 void PageClientImpl::decidePolicyForGeolocationPermissionRequest(WebFrameProxy& frame, const FrameInfoData& frameInfo, Function<void(bool)>& completionHandler)
 {
     if (auto webView = this->webView()) {
-        auto* geolocationProvider = [wrapper(webView->_page->process().processPool()) _geolocationProvider];
+        auto* geolocationProvider = [wrapper(webView->_page->legacyMainFrameProcess().processPool()) _geolocationProvider];
         [geolocationProvider decidePolicyForGeolocationRequestFromOrigin:FrameInfoData { frameInfo } completionHandler:std::exchange(completionHandler, nullptr) view:webView.get()];
     }
 }

--- a/Source/WebKit/UIProcess/ios/SmartMagnificationController.mm
+++ b/Source/WebKit/UIProcess/ios/SmartMagnificationController.mm
@@ -54,12 +54,12 @@ SmartMagnificationController::SmartMagnificationController(WKContentView *conten
     : m_webPageProxy(*contentView.page)
     , m_contentView(contentView)
 {
-    m_webPageProxy.process().addMessageReceiver(Messages::SmartMagnificationController::messageReceiverName(), m_webPageProxy.webPageID(), *this);
+    m_webPageProxy.legacyMainFrameProcess().addMessageReceiver(Messages::SmartMagnificationController::messageReceiverName(), m_webPageProxy.webPageID(), *this);
 }
 
 SmartMagnificationController::~SmartMagnificationController()
 {
-    m_webPageProxy.process().removeMessageReceiver(Messages::SmartMagnificationController::messageReceiverName(), m_webPageProxy.webPageID());
+    m_webPageProxy.legacyMainFrameProcess().removeMessageReceiver(Messages::SmartMagnificationController::messageReceiverName(), m_webPageProxy.webPageID());
 }
 
 void SmartMagnificationController::handleSmartMagnificationGesture(FloatPoint origin)

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -316,10 +316,10 @@ static NSArray *keyCommandsPlaceholderHackForEvernote(id self, SEL _cmd)
 
 #if USE(EXTENSIONKIT)
     for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
-        [visibilityPropagationView propagateVisibilityToProcess:_page->process()];
+        [visibilityPropagationView propagateVisibilityToProcess:_page->legacyMainFrameProcess()];
 #else
 
-    auto processID = _page->process().processID();
+    auto processID = _page->legacyMainFrameProcess().processID();
     auto contextID = _page->contextIDForVisibilityPropagationInWebProcess();
 #if HAVE(NON_HOSTING_VISIBILITY_PROPAGATION_VIEW)
     if (!processID)
@@ -331,7 +331,7 @@ static NSArray *keyCommandsPlaceholderHackForEvernote(id self, SEL _cmd)
     ASSERT(!_visibilityPropagationViewForWebProcess);
     // Propagate the view's visibility state to the WebContent process so that it is marked as "Foreground Running" when necessary.
 #if HAVE(NON_HOSTING_VISIBILITY_PROPAGATION_VIEW)
-    auto environmentIdentifier = _page->process().environmentIdentifier();
+    auto environmentIdentifier = _page->legacyMainFrameProcess().environmentIdentifier();
     _visibilityPropagationViewForWebProcess = adoptNS([[_UINonHostingVisibilityPropagationView alloc] initWithFrame:CGRectZero pid:processID environmentIdentifier:environmentIdentifier]);
 #else
     _visibilityPropagationViewForWebProcess = adoptNS([[_UILayerHostView alloc] initWithFrame:CGRectZero pid:processID contextID:contextID]);
@@ -344,7 +344,7 @@ static NSArray *keyCommandsPlaceholderHackForEvernote(id self, SEL _cmd)
 #if ENABLE(GPU_PROCESS)
 - (void)_setupVisibilityPropagationForGPUProcess
 {
-    auto* gpuProcess = _page->process().processPool().gpuProcess();
+    auto* gpuProcess = _page->legacyMainFrameProcess().processPool().gpuProcess();
     if (!gpuProcess)
         return;
 
@@ -371,7 +371,7 @@ static NSArray *keyCommandsPlaceholderHackForEvernote(id self, SEL _cmd)
 #if ENABLE(MODEL_PROCESS)
 - (void)_setupVisibilityPropagationForModelProcess
 {
-    auto* modelProcess = _page->process().processPool().modelProcess();
+    auto* modelProcess = _page->legacyMainFrameProcess().processPool().modelProcess();
     if (!modelProcess)
         return;
     auto processIdentifier = modelProcess->processID();
@@ -394,7 +394,7 @@ static NSArray *keyCommandsPlaceholderHackForEvernote(id self, SEL _cmd)
 #if USE(EXTENSIONKIT)
     if (auto page = _page.get()) {
         for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
-            [visibilityPropagationView stopPropagatingVisibilityToProcess:page->process()];
+            [visibilityPropagationView stopPropagatingVisibilityToProcess:page->legacyMainFrameProcess()];
     }
 #endif
 
@@ -410,7 +410,7 @@ static NSArray *keyCommandsPlaceholderHackForEvernote(id self, SEL _cmd)
 {
 #if USE(EXTENSIONKIT)
     auto page = _page.get();
-    if (auto gpuProcess = page ? page->process().processPool().gpuProcess() : nullptr) {
+    if (auto gpuProcess = page ? page->legacyMainFrameProcess().processPool().gpuProcess() : nullptr) {
         for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
             [visibilityPropagationView stopPropagatingVisibilityToProcess:*gpuProcess];
     }
@@ -804,7 +804,7 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
 #if PLATFORM(MACCATALYST)
     pid_t pid = 0;
     if (registerProcess)
-        pid = _page->process().processID();
+        pid = _page->legacyMainFrameProcess().processID();
     else
         pid = [objc_getAssociatedObject(self, (void*)[@"ax-pid" hash]) intValue];
     if (!pid)
@@ -823,9 +823,9 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
     NSData *remoteElementToken = WebKit::newAccessibilityRemoteToken(uuid);
 
     // Store information about the WebProcess that can later be retrieved by the iOS Accessibility runtime.
-    if (_page->process().state() == WebKit::WebProcessProxy::State::Running) {
+    if (_page->legacyMainFrameProcess().state() == WebKit::WebProcessProxy::State::Running) {
         [self _updateRemoteAccessibilityRegistration:YES];
-        storeAccessibilityRemoteConnectionInformation(self, _page->process().processID(), uuid);
+        storeAccessibilityRemoteConnectionInformation(self, _page->legacyMainFrameProcess().processID(), uuid);
 
         auto elementToken = span(remoteElementToken);
         _page->registerUIProcessAccessibilityTokens(elementToken, elementToken);
@@ -1265,7 +1265,7 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
         if (!callbackID)
             return;
 
-        _page->process().connection()->waitForAsyncReplyAndDispatchImmediately<Messages::WebPage::DrawToPDFiOS>(callbackID, Seconds::infinity());
+        _page->legacyMainFrameProcess().connection()->waitForAsyncReplyAndDispatchImmediately<Messages::WebPage::DrawToPDFiOS>(callbackID, Seconds::infinity());
         return;
     }
 
@@ -1309,7 +1309,7 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
         if (!callbackID)
             return;
 
-        _page->process().connection()->waitForAsyncReplyAndDispatchImmediately<Messages::WebPage::DrawRectToImage>(callbackID, Seconds::infinity());
+        _page->legacyMainFrameProcess().connection()->waitForAsyncReplyAndDispatchImmediately<Messages::WebPage::DrawRectToImage>(callbackID, Seconds::infinity());
         return;
     }
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -1416,7 +1416,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     _autocorrectionContextNeedsUpdate = YES;
 
-    _page->process().updateTextCheckerState();
+    _page->legacyMainFrameProcess().updateTextCheckerState();
     _page->setScreenIsBeingCaptured([self screenIsBeingCaptured]);
 
 #if ENABLE(IMAGE_ANALYSIS)
@@ -3091,7 +3091,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!_page->hasRunningProcess())
         return NO;
 
-    auto* connection = _page->process().connection();
+    auto* connection = _page->legacyMainFrameProcess().connection();
     if (!connection)
         return NO;
 
@@ -5675,7 +5675,7 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
     _pendingAutocorrectionContextHandler = WTFMove(completionHandler);
     _page->requestAutocorrectionContext();
 
-    if (_page->process().connection()->waitForAndDispatchImmediately<Messages::WebPageProxy::HandleAutocorrectionContext>(_page->webPageID(), 1_s, IPC::WaitForOption::DispatchIncomingSyncMessagesWhileWaiting) != IPC::Error::NoError)
+    if (_page->legacyMainFrameProcess().connection()->waitForAndDispatchImmediately<Messages::WebPageProxy::HandleAutocorrectionContext>(_page->webPageID(), 1_s, IPC::WaitForOption::DispatchIncomingSyncMessagesWhileWaiting) != IPC::Error::NoError)
         RELEASE_LOG(TextInput, "Timed out while waiting for autocorrection context.");
 
     if (_autocorrectionContextNeedsUpdate)
@@ -8408,7 +8408,7 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
 #endif // HAVE(QUICKBOARD_CONTROLLER)
 
     // Presenting a fullscreen input view controller fully obscures the web view. Without taking this token, the web content process will get backgrounded.
-    _page->process().startBackgroundActivityForFullscreenInput();
+    _page->legacyMainFrameProcess().startBackgroundActivityForFullscreenInput();
 
     // FIXME: PUICQuickboardController does not present its view controller immediately, since it asynchronously
     // establishes a connection to QuickboardViewService before presenting the remote view controller.
@@ -8478,7 +8478,7 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
             [self becomeFirstResponder];
     }
 
-    _page->process().endBackgroundActivityForFullscreenInput();
+    _page->legacyMainFrameProcess().endBackgroundActivityForFullscreenInput();
 }
 
 - (void)focusedFormControlViewDidSubmit:(WKFocusedFormControlView *)view
@@ -11270,7 +11270,7 @@ static WebKit::DocumentEditingContextRequest toWebRequest(id request)
 - (void)setContinuousSpellCheckingEnabled:(BOOL)enabled
 {
     if (WebKit::TextChecker::setContinuousSpellCheckingEnabled(enabled))
-        _page->process().updateTextCheckerState();
+        _page->legacyMainFrameProcess().updateTextCheckerState();
 }
 
 - (void)setGrammarCheckingEnabled:(BOOL)enabled
@@ -11279,7 +11279,7 @@ static WebKit::DocumentEditingContextRequest toWebRequest(id request)
         return;
 
     WebKit::TextChecker::setGrammarCheckingEnabled(enabled);
-    _page->process().updateTextCheckerState();
+    _page->legacyMainFrameProcess().updateTextCheckerState();
 }
 
 #if HAVE(UIKIT_WITH_MOUSE_SUPPORT)

--- a/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm
+++ b/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm
@@ -40,12 +40,12 @@ namespace WebKit {
 WebDeviceOrientationUpdateProviderProxy::WebDeviceOrientationUpdateProviderProxy(WebPageProxy& page)
     : m_page(page)
 {
-    m_page.process().addMessageReceiver(Messages::WebDeviceOrientationUpdateProviderProxy::messageReceiverName(), m_page.webPageID(), *this);
+    m_page.legacyMainFrameProcess().addMessageReceiver(Messages::WebDeviceOrientationUpdateProviderProxy::messageReceiverName(), m_page.webPageID(), *this);
 }
 
 WebDeviceOrientationUpdateProviderProxy::~WebDeviceOrientationUpdateProviderProxy()
 {
-    m_page.process().removeMessageReceiver(Messages::WebDeviceOrientationUpdateProviderProxy::messageReceiverName(), m_page.webPageID());
+    m_page.legacyMainFrameProcess().removeMessageReceiver(Messages::WebDeviceOrientationUpdateProviderProxy::messageReceiverName(), m_page.webPageID());
 }
 
 void WebDeviceOrientationUpdateProviderProxy::startUpdatingDeviceOrientation()

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -88,9 +88,9 @@
 #import <wtf/text/WTFString.h>
 #endif
 
-#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, process().connection())
+#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, legacyMainFrameProcess().connection())
 
-#define WEBPAGEPROXY_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [pageProxyID=%llu, webPageID=%llu, PID=%i] WebPageProxy::" fmt, this, identifier().toUInt64(), webPageID().toUInt64(), m_process->processID(), ##__VA_ARGS__)
+#define WEBPAGEPROXY_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [pageProxyID=%llu, webPageID=%llu, PID=%i] WebPageProxy::" fmt, this, identifier().toUInt64(), webPageID().toUInt64(), m_legacyMainFrameProcess->processID(), ##__VA_ARGS__)
 
 #if PLATFORM(VISION)
 static constexpr CGFloat kTargetFullscreenAspectRatio = 1.7778;
@@ -186,12 +186,12 @@ void WebPageProxy::updateVisibleContentRects(const VisibleContentRectUpdateInfo&
     if (!hasRunningProcess())
         return;
 
-    m_process->send(Messages::ViewUpdateDispatcher::VisibleContentRectUpdate(webPageID(), visibleContentRectUpdate), 0);
+    m_legacyMainFrameProcess->send(Messages::ViewUpdateDispatcher::VisibleContentRectUpdate(webPageID(), visibleContentRectUpdate), 0);
 }
 
 void WebPageProxy::resendLastVisibleContentRects()
 {
-    m_process->send(Messages::ViewUpdateDispatcher::VisibleContentRectUpdate(webPageID(), internals().lastVisibleContentRectUpdate), 0);
+    m_legacyMainFrameProcess->send(Messages::ViewUpdateDispatcher::VisibleContentRectUpdate(webPageID(), internals().lastVisibleContentRectUpdate), 0);
 }
 
 void WebPageProxy::updateStringForFind(const String& string)
@@ -278,7 +278,7 @@ void WebPageProxy::dynamicViewportSizeUpdate(const DynamicViewportSizeUpdate& ta
     internals().defaultUnobscuredSize = target.maximumUnobscuredSize;
     internals().minimumUnobscuredSize = target.minimumUnobscuredSize;
     internals().maximumUnobscuredSize = target.maximumUnobscuredSize;
-    m_process->send(Messages::WebPage::DynamicViewportSizeUpdate(target), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::DynamicViewportSizeUpdate(target), webPageID());
     setDeviceOrientation(target.deviceOrientation);
 }
 
@@ -291,13 +291,13 @@ void WebPageProxy::setViewportConfigurationViewLayoutSize(const WebCore::FloatSi
     if (m_provisionalPage)
         m_provisionalPage->send(Messages::WebPage::SetViewportConfigurationViewLayoutSize(size, layoutSizeScaleFactorFromClient, minimumEffectiveDeviceWidth));
     if (hasRunningProcess())
-        m_process->send(Messages::WebPage::SetViewportConfigurationViewLayoutSize(size, layoutSizeScaleFactorFromClient, minimumEffectiveDeviceWidth), webPageID());
+        m_legacyMainFrameProcess->send(Messages::WebPage::SetViewportConfigurationViewLayoutSize(size, layoutSizeScaleFactorFromClient, minimumEffectiveDeviceWidth), webPageID());
 }
 
 void WebPageProxy::setSceneIdentifier(String&& sceneIdentifier)
 {
     if (hasRunningProcess())
-        m_process->send(Messages::WebPage::SetSceneIdentifier(WTFMove(sceneIdentifier)), webPageID());
+        m_legacyMainFrameProcess->send(Messages::WebPage::SetSceneIdentifier(WTFMove(sceneIdentifier)), webPageID());
 }
 
 void WebPageProxy::setForceAlwaysUserScalable(bool userScalable)
@@ -307,7 +307,7 @@ void WebPageProxy::setForceAlwaysUserScalable(bool userScalable)
     m_forceAlwaysUserScalable = userScalable;
 
     if (hasRunningProcess())
-        m_process->send(Messages::WebPage::SetForceAlwaysUserScalable(userScalable), webPageID());
+        m_legacyMainFrameProcess->send(Messages::WebPage::SetForceAlwaysUserScalable(userScalable), webPageID());
 }
 
 WebCore::ScreenOrientationType WebPageProxy::toScreenOrientationType(IntDegrees angle)
@@ -329,7 +329,7 @@ void WebPageProxy::setDeviceOrientation(IntDegrees deviceOrientation)
     if (deviceOrientation != m_deviceOrientation) {
         m_deviceOrientation = deviceOrientation;
         if (hasRunningProcess())
-            m_process->send(Messages::WebPage::SetDeviceOrientation(deviceOrientation), webPageID());
+            m_legacyMainFrameProcess->send(Messages::WebPage::SetDeviceOrientation(deviceOrientation), webPageID());
     }
 }
 
@@ -339,7 +339,7 @@ void WebPageProxy::setOverrideViewportArguments(const std::optional<ViewportArgu
         return;
     internals().overrideViewportArguments = viewportArguments;
     if (hasRunningProcess())
-        m_process->send(Messages::WebPage::SetOverrideViewportArguments(viewportArguments), webPageID());
+        m_legacyMainFrameProcess->send(Messages::WebPage::SetOverrideViewportArguments(viewportArguments), webPageID());
 }
 
 bool WebPageProxy::updateLayoutViewportParameters(const RemoteLayerTreeTransaction& layerTreeTransaction)
@@ -373,22 +373,22 @@ void WebPageProxy::updateSelectionWithTouches(IntPoint point, SelectionTouch tou
 
 void WebPageProxy::willInsertFinalDictationResult()
 {
-    m_process->send(Messages::WebPage::WillInsertFinalDictationResult(), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::WillInsertFinalDictationResult(), webPageID());
 }
 
 void WebPageProxy::didInsertFinalDictationResult()
 {
-    m_process->send(Messages::WebPage::DidInsertFinalDictationResult(), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::DidInsertFinalDictationResult(), webPageID());
 }
 
 void WebPageProxy::replaceDictatedText(const String& oldText, const String& newText)
 {
-    m_process->send(Messages::WebPage::ReplaceDictatedText(oldText, newText), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::ReplaceDictatedText(oldText, newText), webPageID());
 }
 
 void WebPageProxy::replaceSelectedText(const String& oldText, const String& newText)
 {
-    m_process->send(Messages::WebPage::ReplaceSelectedText(oldText, newText), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::ReplaceSelectedText(oldText, newText), webPageID());
 }
 
 void WebPageProxy::requestAutocorrectionData(const String& textForAutocorrection, CompletionHandler<void(WebAutocorrectionData)>&& callback)
@@ -407,7 +407,7 @@ void WebPageProxy::applyAutocorrection(const String& correction, const String& o
 
 bool WebPageProxy::applyAutocorrection(const String& correction, const String& originalText, bool isCandidate)
 {
-    auto sendSync = m_process->sendSync(Messages::WebPage::SyncApplyAutocorrection(correction, originalText, isCandidate), webPageID());
+    auto sendSync = m_legacyMainFrameProcess->sendSync(Messages::WebPage::SyncApplyAutocorrection(correction, originalText, isCandidate), webPageID());
     auto [autocorrectionApplied] = sendSync.takeReplyOr(false);
     return autocorrectionApplied;
 }
@@ -419,7 +419,7 @@ void WebPageProxy::selectTextWithGranularityAtPoint(const WebCore::IntPoint poin
         return;
     }
 
-    sendWithAsyncReply(Messages::WebPage::SelectTextWithGranularityAtPoint(point, granularity, isInteractingWithFocusedElement), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_process->throttler().backgroundActivity("WebPageProxy::selectTextWithGranularityAtPoint"_s)] () mutable {
+    sendWithAsyncReply(Messages::WebPage::SelectTextWithGranularityAtPoint(point, granularity, isInteractingWithFocusedElement), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->throttler().backgroundActivity("WebPageProxy::selectTextWithGranularityAtPoint"_s)] () mutable {
         callbackFunction();
     });
 }
@@ -431,7 +431,7 @@ void WebPageProxy::selectPositionAtBoundaryWithDirection(const WebCore::IntPoint
         return;
     }
 
-    sendWithAsyncReply(Messages::WebPage::SelectPositionAtBoundaryWithDirection(point, granularity, direction, isInteractingWithFocusedElement), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_process->throttler().backgroundActivity("WebPageProxy::selectPositionAtBoundaryWithDirection"_s)] () mutable {
+    sendWithAsyncReply(Messages::WebPage::SelectPositionAtBoundaryWithDirection(point, granularity, direction, isInteractingWithFocusedElement), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->throttler().backgroundActivity("WebPageProxy::selectPositionAtBoundaryWithDirection"_s)] () mutable {
         callbackFunction();
     });
 }
@@ -443,7 +443,7 @@ void WebPageProxy::moveSelectionAtBoundaryWithDirection(WebCore::TextGranularity
         return;
     }
 
-    sendWithAsyncReply(Messages::WebPage::MoveSelectionAtBoundaryWithDirection(granularity, direction), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_process->throttler().backgroundActivity("WebPageProxy::moveSelectionAtBoundaryWithDirection"_s)] () mutable {
+    sendWithAsyncReply(Messages::WebPage::MoveSelectionAtBoundaryWithDirection(granularity, direction), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->throttler().backgroundActivity("WebPageProxy::moveSelectionAtBoundaryWithDirection"_s)] () mutable {
         callbackFunction();
     });
 }
@@ -455,7 +455,7 @@ void WebPageProxy::selectPositionAtPoint(const WebCore::IntPoint point, bool isI
         return;
     }
 
-    sendWithAsyncReply(Messages::WebPage::SelectPositionAtPoint(point, isInteractingWithFocusedElement), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_process->throttler().backgroundActivity("WebPageProxy::selectPositionAtPoint"_s)] () mutable {
+    sendWithAsyncReply(Messages::WebPage::SelectPositionAtPoint(point, isInteractingWithFocusedElement), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->throttler().backgroundActivity("WebPageProxy::selectPositionAtPoint"_s)] () mutable {
         callbackFunction();
     });
 }
@@ -502,7 +502,7 @@ void WebPageProxy::prepareSelectionForContextMenuWithLocationInView(IntPoint poi
 
 void WebPageProxy::requestAutocorrectionContext()
 {
-    m_process->send(Messages::WebPage::HandleAutocorrectionContextRequest(), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::HandleAutocorrectionContextRequest(), webPageID());
 }
 
 void WebPageProxy::handleAutocorrectionContext(const WebAutocorrectionContext& context)
@@ -537,17 +537,17 @@ void WebPageProxy::didReceivePositionInformation(const InteractionInformationAtP
 
 void WebPageProxy::requestPositionInformation(const InteractionInformationRequest& request)
 {
-    m_process->send(Messages::WebPage::RequestPositionInformation(request), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::RequestPositionInformation(request), webPageID());
 }
 
 void WebPageProxy::startInteractionWithPositionInformation(const InteractionInformationAtPosition& positionInformation)
 {
-    m_process->send(Messages::WebPage::StartInteractionWithElementContextOrPosition(positionInformation.elementContext, positionInformation.request.point), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::StartInteractionWithElementContextOrPosition(positionInformation.elementContext, positionInformation.request.point), webPageID());
 }
 
 void WebPageProxy::stopInteraction()
 {
-    m_process->send(Messages::WebPage::StopInteraction(), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::StopInteraction(), webPageID());
 }
 
 bool WebPageProxy::isValidPerformActionOnElementAuthorizationToken(const String& authorizationToken) const
@@ -572,7 +572,7 @@ void WebPageProxy::performActionOnElement(uint32_t action)
 
 void WebPageProxy::performActionOnElements(uint32_t action, Vector<WebCore::ElementContext>&& elements)
 {
-    m_process->send(Messages::WebPage::PerformActionOnElements(action, elements), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::PerformActionOnElements(action, elements), webPageID());
 }
 
 void WebPageProxy::saveImageToLibrary(SharedMemory::Handle&& imageHandle, const String& authorizationToken)
@@ -603,7 +603,7 @@ void WebPageProxy::applicationDidEnterBackground()
             navigationState->releaseNetworkActivity(NavigationState::NetworkActivityReleaseReason::ScreenLocked);
     }
 #endif
-    m_process->send(Messages::WebPage::ApplicationDidEnterBackground(isSuspendedUnderLock), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::ApplicationDidEnterBackground(isSuspendedUnderLock), webPageID());
 }
 
 void WebPageProxy::applicationDidFinishSnapshottingAfterEnteringBackground()
@@ -612,7 +612,7 @@ void WebPageProxy::applicationDidFinishSnapshottingAfterEnteringBackground()
         m_drawingArea->prepareForAppSuspension();
         m_drawingArea->hideContentUntilPendingUpdate();
     }
-    m_process->send(Messages::WebPage::ApplicationDidFinishSnapshottingAfterEnteringBackground(), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::ApplicationDidFinishSnapshottingAfterEnteringBackground(), webPageID());
 }
 
 void WebPageProxy::applicationWillEnterForeground()
@@ -622,14 +622,14 @@ void WebPageProxy::applicationWillEnterForeground()
     bool isSuspendedUnderLock = UIApplication.sharedApplication.isSuspendedUnderLock;
     WEBPAGEPROXY_RELEASE_LOG(ViewState, "applicationWillEnterForeground: isSuspendedUnderLock? %d", isSuspendedUnderLock);
 
-    m_process->send(Messages::WebPage::ApplicationWillEnterForeground(isSuspendedUnderLock), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::ApplicationWillEnterForeground(isSuspendedUnderLock), webPageID());
 
     hardwareKeyboardAvailabilityChanged();
 }
 
 void WebPageProxy::applicationWillResignActive()
 {
-    m_process->send(Messages::WebPage::ApplicationWillResignActive(), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::ApplicationWillResignActive(), webPageID());
 }
 
 void WebPageProxy::applicationDidEnterBackgroundForMedia()
@@ -637,7 +637,7 @@ void WebPageProxy::applicationDidEnterBackgroundForMedia()
     bool isSuspendedUnderLock = UIApplication.sharedApplication.isSuspendedUnderLock;
     WEBPAGEPROXY_RELEASE_LOG(ViewState, "applicationWillEnterForegroundForMedia: isSuspendedUnderLock? %d", isSuspendedUnderLock);
 
-    m_process->send(Messages::WebPage::ApplicationDidEnterBackgroundForMedia(isSuspendedUnderLock), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::ApplicationDidEnterBackgroundForMedia(isSuspendedUnderLock), webPageID());
 }
 
 void WebPageProxy::applicationWillEnterForegroundForMedia()
@@ -645,7 +645,7 @@ void WebPageProxy::applicationWillEnterForegroundForMedia()
     bool isSuspendedUnderLock = UIApplication.sharedApplication.isSuspendedUnderLock;
     WEBPAGEPROXY_RELEASE_LOG(ViewState, "applicationWillEnterForegroundForMedia: isSuspendedUnderLock? %d", isSuspendedUnderLock);
 
-    m_process->send(Messages::WebPage::ApplicationWillEnterForegroundForMedia(isSuspendedUnderLock), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::ApplicationWillEnterForegroundForMedia(isSuspendedUnderLock), webPageID());
 }
 
 void WebPageProxy::applicationDidBecomeActive()
@@ -654,7 +654,7 @@ void WebPageProxy::applicationDidBecomeActive()
     if (m_videoPresentationManager)
         m_videoPresentationManager->applicationDidBecomeActive();
 #endif
-    m_process->send(Messages::WebPage::ApplicationDidBecomeActive(), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::ApplicationDidBecomeActive(), webPageID());
 }
 
 void WebPageProxy::extendSelection(WebCore::TextGranularity granularity, CompletionHandler<void()>&& completionHandler)
@@ -667,7 +667,7 @@ void WebPageProxy::extendSelection(WebCore::TextGranularity granularity, Complet
 
 void WebPageProxy::selectWordBackward()
 {
-    m_process->send(Messages::WebPage::SelectWordBackward(), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::SelectWordBackward(), webPageID());
 }
 
 void WebPageProxy::extendSelectionForReplacement(CompletionHandler<void()>&& completion)
@@ -693,17 +693,17 @@ void WebPageProxy::requestRectsAtSelectionOffsetWithText(int32_t offset, const S
 
 void WebPageProxy::storeSelectionForAccessibility(bool shouldStore)
 {
-    m_process->send(Messages::WebPage::StoreSelectionForAccessibility(shouldStore), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::StoreSelectionForAccessibility(shouldStore), webPageID());
 }
 
 void WebPageProxy::startAutoscrollAtPosition(const WebCore::FloatPoint& positionInWindow)
 {
-    m_process->send(Messages::WebPage::StartAutoscrollAtPosition(positionInWindow), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::StartAutoscrollAtPosition(positionInWindow), webPageID());
 }
 
 void WebPageProxy::cancelAutoscroll()
 {
-    m_process->send(Messages::WebPage::CancelAutoscroll(), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::CancelAutoscroll(), webPageID());
 }
 
 void WebPageProxy::moveSelectionByOffset(int32_t offset, CompletionHandler<void()>&& callbackFunction)
@@ -713,7 +713,7 @@ void WebPageProxy::moveSelectionByOffset(int32_t offset, CompletionHandler<void(
         return;
     }
     
-    sendWithAsyncReply(Messages::WebPage::MoveSelectionByOffset(offset), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_process->throttler().backgroundActivity("WebPageProxy::moveSelectionByOffset"_s)] () mutable {
+    sendWithAsyncReply(Messages::WebPage::MoveSelectionByOffset(offset), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->throttler().backgroundActivity("WebPageProxy::moveSelectionByOffset"_s)] () mutable {
         callbackFunction();
     });
 }
@@ -910,7 +910,7 @@ void WebPageProxy::elementDidFocus(const FocusedElementInformation& information,
 {
     m_pendingInputModeChange = std::nullopt;
 
-    API::Object* userDataObject = process().transformHandlesToObjects(userData.object()).get();
+    API::Object* userDataObject = legacyMainFrameProcess().transformHandlesToObjects(userData.object()).get();
     protectedPageClient()->elementDidFocus(information, userIsInteracting, blurPreviousNode, activityStateChanges, userDataObject);
 }
 
@@ -948,7 +948,7 @@ void WebPageProxy::didReleaseAllTouchPoints()
 
 void WebPageProxy::autofillLoginCredentials(const String& username, const String& password)
 {
-    m_process->send(Messages::WebPage::AutofillLoginCredentials(username, password), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::AutofillLoginCredentials(username, password), webPageID());
 }
 
 void WebPageProxy::showInspectorHighlight(const WebCore::InspectorOverlay::Highlight& highlight)
@@ -988,7 +988,7 @@ void WebPageProxy::focusNextFocusedElement(bool isForward, CompletionHandler<voi
         return;
     }
     
-    sendWithAsyncReply(Messages::WebPage::FocusNextFocusedElement(isForward), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_process->throttler().backgroundActivity("WebPageProxy::focusNextFocusedElement"_s)] () mutable {
+    sendWithAsyncReply(Messages::WebPage::FocusNextFocusedElement(isForward), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->throttler().backgroundActivity("WebPageProxy::focusNextFocusedElement"_s)] () mutable {
         callbackFunction();
     });
 }
@@ -1157,7 +1157,7 @@ void WebPageProxy::hardwareKeyboardAvailabilityChanged()
     protectedPageClient()->hardwareKeyboardAvailabilityChanged();
 
     updateCurrentModifierState();
-    m_process->send(Messages::WebPage::HardwareKeyboardAvailabilityChanged(hardwareKeyboardState), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::HardwareKeyboardAvailabilityChanged(hardwareKeyboardState), webPageID());
 }
 
 void WebPageProxy::requestEvasionRectsAboveSelection(CompletionHandler<void(const Vector<WebCore::FloatRect>&)>&& callback)
@@ -1224,13 +1224,13 @@ void WebPageProxy::didHandleAdditionalDragItemsRequest(bool added)
 void WebPageProxy::requestDragStart(const WebCore::IntPoint& clientPosition, const WebCore::IntPoint& globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask)
 {
     if (hasRunningProcess())
-        m_process->send(Messages::WebPage::RequestDragStart(clientPosition, globalPosition, allowedActionsMask), webPageID());
+        m_legacyMainFrameProcess->send(Messages::WebPage::RequestDragStart(clientPosition, globalPosition, allowedActionsMask), webPageID());
 }
 
 void WebPageProxy::requestAdditionalItemsForDragSession(const IntPoint& clientPosition, const IntPoint& globalPosition, OptionSet<WebCore::DragSourceAction> allowedActionsMask)
 {
     if (hasRunningProcess())
-        m_process->send(Messages::WebPage::RequestAdditionalItemsForDragSession(clientPosition, globalPosition, allowedActionsMask), webPageID());
+        m_legacyMainFrameProcess->send(Messages::WebPage::RequestAdditionalItemsForDragSession(clientPosition, globalPosition, allowedActionsMask), webPageID());
 }
 
 void WebPageProxy::insertDroppedImagePlaceholders(const Vector<IntSize>& imageSizes, CompletionHandler<void(const Vector<IntRect>&, std::optional<WebCore::TextIndicatorData>)>&& completionHandler)
@@ -1253,7 +1253,7 @@ void WebPageProxy::didReceiveEditDragSnapshot(std::optional<TextIndicatorData> d
 
 void WebPageProxy::didConcludeDrop()
 {
-    m_process->send(Messages::WebPage::DidConcludeDrop(), webPageID());
+    m_legacyMainFrameProcess->send(Messages::WebPage::DidConcludeDrop(), webPageID());
 }
 
 #endif
@@ -1504,17 +1504,17 @@ void WebPageProxy::setScreenIsBeingCaptured(bool captured)
 
 void WebPageProxy::willOpenAppLink()
 {
-    if (m_processActivityState.hasValidOpeningAppLinkActivity())
+    if (m_legacyMainFrameProcessActivityState.hasValidOpeningAppLinkActivity())
         return;
 
     // We take a background activity for 25 seconds when switching to another app via an app link in case the WebPage
     // needs to run script to pass information to the native app.
     // We chose 25 seconds because the system only gives us 30 seconds and we don't want to get too close to that limit
     // to avoid assertion invalidation (or even termination).
-    m_processActivityState.takeOpeningAppLinkActivity();
+    m_legacyMainFrameProcessActivityState.takeOpeningAppLinkActivity();
     WorkQueue::main().dispatchAfter(25_s, [weakThis = WeakPtr { *this }] {
         if (weakThis)
-            weakThis->m_processActivityState.dropOpeningAppLinkActivity();
+            weakThis->m_legacyMainFrameProcessActivityState.dropOpeningAppLinkActivity();
     });
 }
 

--- a/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
+++ b/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
@@ -214,7 +214,7 @@ void DisplayCaptureSessionManager::promptForGetDisplayMedia(UserMediaPermissionR
             return;
         }
 
-        Ref gpuProcess = page.process().processPool().ensureGPUProcess();
+        Ref gpuProcess = page.legacyMainFrameProcess().processPool().ensureGPUProcess();
         gpuProcess->updateSandboxAccess(false, false, true);
         gpuProcess->promptForGetDisplayMedia(toScreenCaptureKitPromptType(promptType), WTFMove(completionHandler));
         return;
@@ -263,7 +263,7 @@ void DisplayCaptureSessionManager::cancelGetDisplayMediaPrompt(WebPageProxy& pag
         return;
     }
 
-    auto gpuProcess = page.process().processPool().gpuProcess();
+    auto gpuProcess = page.legacyMainFrameProcess().processPool().gpuProcess();
     if (!gpuProcess)
         return;
 

--- a/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
+++ b/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
@@ -195,7 +195,7 @@
     // FIXME: We need to be able to cancel this if the gesture recognizer is cancelled.
     // FIXME: Connection can be null if the process is closed; we should clean up better in that case.
     if (_state == WebKit::ImmediateActionState::Pending) {
-        if (auto* connection = RefPtr { _page.get() }->process().connection()) {
+        if (auto* connection = RefPtr { _page.get() }->legacyMainFrameProcess().connection()) {
             bool receivedReply = connection->waitForAndDispatchImmediately<Messages::WebPageProxy::DidPerformImmediateActionHitTest>(RefPtr { _page.get() }->webPageID(), 500_ms) == IPC::Error::NoError;
             if (!receivedReply)
                 _state = WebKit::ImmediateActionState::TimedOut;

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -71,8 +71,8 @@
 #import <wtf/ProcessPrivilege.h>
 #import <wtf/text/StringConcatenate.h>
 
-#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, process().connection())
-#define MESSAGE_CHECK_URL(url) MESSAGE_CHECK_BASE(checkURLReceivedFromCurrentOrPreviousWebProcess(m_process, url), m_process->connection())
+#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, legacyMainFrameProcess().connection())
+#define MESSAGE_CHECK_URL(url) MESSAGE_CHECK_BASE(checkURLReceivedFromCurrentOrPreviousWebProcess(m_legacyMainFrameProcess, url), m_legacyMainFrameProcess->connection())
 #define MESSAGE_CHECK_WITH_RETURN_VALUE(assertion, returnValue) MESSAGE_CHECK_WITH_RETURN_VALUE_BASE(assertion, process().connection(), returnValue)
 
 @interface NSApplication ()
@@ -353,7 +353,7 @@ void WebPageProxy::executeSavedCommandBySelector(const String& selector, Complet
 
 bool WebPageProxy::shouldDelayWindowOrderingForEvent(const WebKit::WebMouseEvent& event)
 {
-    if (process().state() != WebProcessProxy::State::Running)
+    if (legacyMainFrameProcess().state() != WebProcessProxy::State::Running)
         return false;
 
     const Seconds messageTimeout(3);
@@ -367,14 +367,14 @@ bool WebPageProxy::acceptsFirstMouse(int eventNumber, const WebKit::WebMouseEven
     if (!hasRunningProcess())
         return false;
 
-    if (!m_process->hasConnection())
+    if (!m_legacyMainFrameProcess->hasConnection())
         return false;
 
     if (shouldAvoidSynchronouslyWaitingToPreventDeadlock())
         return false;
 
     send(Messages::WebPage::RequestAcceptsFirstMouse(eventNumber, event), IPC::SendOption::DispatchMessageEvenWhenWaitingForUnboundedSyncReply);
-    bool receivedReply = m_process->connection()->waitForAndDispatchImmediately<Messages::WebPageProxy::HandleAcceptsFirstMouse>(webPageID(), 3_s, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives) == IPC::Error::NoError;
+    bool receivedReply = m_legacyMainFrameProcess->connection()->waitForAndDispatchImmediately<Messages::WebPageProxy::HandleAcceptsFirstMouse>(webPageID(), 3_s, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives) == IPC::Error::NoError;
 
     if (!receivedReply)
         return false;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1330,7 +1330,7 @@ WebViewImpl::WebViewImpl(NSView <WebViewImplDelegate> *view, WKWebView *outerWeb
 WebViewImpl::~WebViewImpl()
 {
     if (m_remoteObjectRegistry) {
-        m_page->process().processPool().removeMessageReceiver(Messages::RemoteObjectRegistry::messageReceiverName(), m_page->identifier());
+        m_page->legacyMainFrameProcess().processPool().removeMessageReceiver(Messages::RemoteObjectRegistry::messageReceiverName(), m_page->identifier());
         [m_remoteObjectRegistry _invalidate];
         m_remoteObjectRegistry = nil;
     }
@@ -2142,7 +2142,7 @@ void WebViewImpl::windowDidChangeOcclusionState()
 
 void WebViewImpl::screenDidChangeColorSpace()
 {
-    m_page->process().processPool().screenPropertiesChanged();
+    m_page->legacyMainFrameProcess().processPool().screenPropertiesChanged();
 }
 
 bool WebViewImpl::mightBeginDragWhileInactive()
@@ -3083,7 +3083,7 @@ void WebViewImpl::setContinuousSpellCheckingEnabled(bool enabled)
         return;
 
     TextChecker::setContinuousSpellCheckingEnabled(enabled);
-    m_page->process().updateTextCheckerState();
+    m_page->legacyMainFrameProcess().updateTextCheckerState();
 }
 
 void WebViewImpl::toggleContinuousSpellChecking()
@@ -3091,7 +3091,7 @@ void WebViewImpl::toggleContinuousSpellChecking()
     bool spellCheckingEnabled = !TextChecker::state().isContinuousSpellCheckingEnabled;
     TextChecker::setContinuousSpellCheckingEnabled(spellCheckingEnabled);
 
-    m_page->process().updateTextCheckerState();
+    m_page->legacyMainFrameProcess().updateTextCheckerState();
 }
 
 bool WebViewImpl::isGrammarCheckingEnabled()
@@ -3105,7 +3105,7 @@ void WebViewImpl::setGrammarCheckingEnabled(bool flag)
         return;
 
     TextChecker::setGrammarCheckingEnabled(flag);
-    m_page->process().updateTextCheckerState();
+    m_page->legacyMainFrameProcess().updateTextCheckerState();
 }
 
 void WebViewImpl::toggleGrammarChecking()
@@ -3113,14 +3113,14 @@ void WebViewImpl::toggleGrammarChecking()
     bool grammarCheckingEnabled = !TextChecker::state().isGrammarCheckingEnabled;
     TextChecker::setGrammarCheckingEnabled(grammarCheckingEnabled);
 
-    m_page->process().updateTextCheckerState();
+    m_page->legacyMainFrameProcess().updateTextCheckerState();
 }
 
 void WebViewImpl::toggleAutomaticSpellingCorrection()
 {
     TextChecker::setAutomaticSpellingCorrectionEnabled(!TextChecker::state().isAutomaticSpellingCorrectionEnabled);
 
-    m_page->process().updateTextCheckerState();
+    m_page->legacyMainFrameProcess().updateTextCheckerState();
 }
 
 void WebViewImpl::orderFrontSubstitutionsPanel(id sender)
@@ -3155,13 +3155,13 @@ void WebViewImpl::setAutomaticQuoteSubstitutionEnabled(bool flag)
         return;
 
     TextChecker::setAutomaticQuoteSubstitutionEnabled(flag);
-    m_page->process().updateTextCheckerState();
+    m_page->legacyMainFrameProcess().updateTextCheckerState();
 }
 
 void WebViewImpl::toggleAutomaticQuoteSubstitution()
 {
     TextChecker::setAutomaticQuoteSubstitutionEnabled(!TextChecker::state().isAutomaticQuoteSubstitutionEnabled);
-    m_page->process().updateTextCheckerState();
+    m_page->legacyMainFrameProcess().updateTextCheckerState();
 }
 
 bool WebViewImpl::isAutomaticDashSubstitutionEnabled()
@@ -3175,13 +3175,13 @@ void WebViewImpl::setAutomaticDashSubstitutionEnabled(bool flag)
         return;
 
     TextChecker::setAutomaticDashSubstitutionEnabled(flag);
-    m_page->process().updateTextCheckerState();
+    m_page->legacyMainFrameProcess().updateTextCheckerState();
 }
 
 void WebViewImpl::toggleAutomaticDashSubstitution()
 {
     TextChecker::setAutomaticDashSubstitutionEnabled(!TextChecker::state().isAutomaticDashSubstitutionEnabled);
-    m_page->process().updateTextCheckerState();
+    m_page->legacyMainFrameProcess().updateTextCheckerState();
 }
 
 bool WebViewImpl::isAutomaticLinkDetectionEnabled()
@@ -3195,13 +3195,13 @@ void WebViewImpl::setAutomaticLinkDetectionEnabled(bool flag)
         return;
 
     TextChecker::setAutomaticLinkDetectionEnabled(flag);
-    m_page->process().updateTextCheckerState();
+    m_page->legacyMainFrameProcess().updateTextCheckerState();
 }
 
 void WebViewImpl::toggleAutomaticLinkDetection()
 {
     TextChecker::setAutomaticLinkDetectionEnabled(!TextChecker::state().isAutomaticLinkDetectionEnabled);
-    m_page->process().updateTextCheckerState();
+    m_page->legacyMainFrameProcess().updateTextCheckerState();
 }
 
 bool WebViewImpl::isAutomaticTextReplacementEnabled()
@@ -3215,13 +3215,13 @@ void WebViewImpl::setAutomaticTextReplacementEnabled(bool flag)
         return;
 
     TextChecker::setAutomaticTextReplacementEnabled(flag);
-    m_page->process().updateTextCheckerState();
+    m_page->legacyMainFrameProcess().updateTextCheckerState();
 }
 
 void WebViewImpl::toggleAutomaticTextReplacement()
 {
     TextChecker::setAutomaticTextReplacementEnabled(!TextChecker::state().isAutomaticTextReplacementEnabled);
-    m_page->process().updateTextCheckerState();
+    m_page->legacyMainFrameProcess().updateTextCheckerState();
 }
 
 void WebViewImpl::uppercaseWord()
@@ -3604,7 +3604,7 @@ void WebViewImpl::setIgnoresMouseDraggedEvents(bool ignoresMouseDraggedEvents)
 
 void WebViewImpl::setAccessibilityWebProcessToken(NSData *data, WebCore::FrameIdentifier frameID, pid_t pid)
 {
-    if (pid == m_page->process().processID()) {
+    if (pid == m_page->legacyMainFrameProcess().processID()) {
         m_remoteAccessibilityChild = data.length ? adoptNS([[NSAccessibilityRemoteUIElement alloc] initWithRemoteToken:data]) : nil;
         updateRemoteAccessibilityRegistration(true);
     }
@@ -3617,7 +3617,7 @@ void WebViewImpl::updateRemoteAccessibilityRegistration(bool registerProcess)
     // away, that information is not present in WebProcess
     pid_t pid = 0;
     if (registerProcess)
-        pid = m_page->process().processID();
+        pid = m_page->legacyMainFrameProcess().processID();
     else if (!registerProcess) {
         pid = [m_remoteAccessibilityChild processIdentifier];
         m_remoteAccessibilityChild = nil;
@@ -3959,7 +3959,7 @@ _WKRemoteObjectRegistry *WebViewImpl::remoteObjectRegistry()
 {
     if (!m_remoteObjectRegistry) {
         m_remoteObjectRegistry = adoptNS([[_WKRemoteObjectRegistry alloc] _initWithWebPageProxy:m_page.get()]);
-        m_page->process().processPool().addMessageReceiver(Messages::RemoteObjectRegistry::messageReceiverName(), m_page->identifier(), [m_remoteObjectRegistry remoteObjectRegistry]);
+        m_page->legacyMainFrameProcess().processPool().addMessageReceiver(Messages::RemoteObjectRegistry::messageReceiverName(), m_page->identifier(), [m_remoteObjectRegistry remoteObjectRegistry]);
     }
 
     return m_remoteObjectRegistry.get();

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp
@@ -78,12 +78,12 @@ void AcceleratedBackingStoreDMABuf::updateSurfaceID(uint64_t surfaceID)
         }
         m_buffers.clear();
         m_bufferIDs.clear();
-        m_webPage.process().removeMessageReceiver(Messages::AcceleratedBackingStoreDMABuf::messageReceiverName(), m_surfaceID);
+        m_webPage.legacyMainFrameProcess().removeMessageReceiver(Messages::AcceleratedBackingStoreDMABuf::messageReceiverName(), m_surfaceID);
     }
 
     m_surfaceID = surfaceID;
     if (m_surfaceID)
-        m_webPage.process().addMessageReceiver(Messages::AcceleratedBackingStoreDMABuf::messageReceiverName(), m_surfaceID, *this);
+        m_webPage.legacyMainFrameProcess().addMessageReceiver(Messages::AcceleratedBackingStoreDMABuf::messageReceiverName(), m_surfaceID, *this);
 
 }
 
@@ -143,7 +143,7 @@ void AcceleratedBackingStoreDMABuf::frame(uint64_t bufferID)
 
 void AcceleratedBackingStoreDMABuf::frameDone()
 {
-    m_webPage.process().send(Messages::AcceleratedSurfaceDMABuf::FrameDone(), m_surfaceID);
+    m_webPage.legacyMainFrameProcess().send(Messages::AcceleratedSurfaceDMABuf::FrameDone(), m_surfaceID);
 }
 
 void AcceleratedBackingStoreDMABuf::bufferRendered()
@@ -155,7 +155,7 @@ void AcceleratedBackingStoreDMABuf::bufferRendered()
 void AcceleratedBackingStoreDMABuf::bufferReleased(WPEBuffer* buffer)
 {
     if (auto id = m_bufferIDs.get(buffer))
-        m_webPage.process().send(Messages::AcceleratedSurfaceDMABuf::ReleaseBuffer(id), m_surfaceID);
+        m_webPage.legacyMainFrameProcess().send(Messages::AcceleratedSurfaceDMABuf::ReleaseBuffer(id), m_surfaceID);
 }
 
 RendererBufferFormat AcceleratedBackingStoreDMABuf::bufferFormat() const


### PR DESCRIPTION
#### d32262e9ca14909fe195b1cd329dd37f04f35125
<pre>
Rename WebPageProxy::process to legacyMainFrameProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=275270">https://bugs.webkit.org/show_bug.cgi?id=275270</a>
<a href="https://rdar.apple.com/129414565">rdar://129414565</a>

Reviewed by Timothy Hatcher and Charlie Wolfe.

Thinking of a WebPageProxy as having a process is how things were before site isolation.
All these uses need to be audited, and future uses need to think about which web content
process they want to use.

* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageGetContext):
(WKPageTerminate):
(WKPageResetProcessState):
(WKPageCopyRelatedPages):
(WKPageGetProcessIdentifier):
(WKPageGetGPUProcessIdentifier):
(WKPageSetMockCaptureDevicesInterrupted):
(WKPageTriggerMockCaptureConfigurationChange):
* Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm:
(-[WKObservablePageState _webProcessIsResponsive]):
(WKPageIsURLKnownHSTSHost):
* Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm:
(+[NSAttributedString _loadFromHTMLWithOptions:contentLoader:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm:
(-[WKBrowsingContextController processIdentifier]):
(-[WKBrowsingContextController _webProcessIsResponsive]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView dealloc]):
(-[WKWebView _remoteObjectRegistry]):
(-[WKWebView _isSuspended]):
(-[WKWebView _webProcessIdentifier]):
(-[WKWebView _webProcessIsResponsive]):
(-[WKWebView _killWebContentProcess]):
(-[WKWebView _killWebContentProcessAndResetState]):
(-[WKWebView _clearBackForwardCache]):
(-[WKWebView _getContentsAsStringWithCompletionHandlerKeepIPCConnectionAliveForTesting:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _processWillSuspendForTesting:]):
(-[WKWebView _processWillSuspendImminentlyForTesting]):
(-[WKWebView _processDidResumeForTesting]):
(-[WKWebView _setThrottleStateForTesting:]):
(-[WKWebView _hasServiceWorkerBackgroundActivityForTesting]):
(-[WKWebView _hasServiceWorkerForegroundActivityForTesting]):
(-[WKWebView _audioRoutingArbitrationStatus]):
(-[WKWebView _audioRoutingArbitrationUpdateTime]):
(-[WKWebView _gpuToWebProcessConnectionCountForTesting:]):
* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(-[WKWebView _propertiesOfLayerWithID:]):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::evaluateJavaScriptFunction):
(WebKit::WebAutomationSession::resolveChildFrameHandle):
(WebKit::WebAutomationSession::resolveParentFrameHandle):
(WebKit::WebAutomationSession::computeElementLayout):
(WebKit::WebAutomationSession::getComputedRole):
(WebKit::WebAutomationSession::getComputedLabel):
(WebKit::WebAutomationSession::selectOptionElement):
(WebKit::WebAutomationSession::setFilesForInputFileUpload):
(WebKit::WebAutomationSession::getAllCookies):
(WebKit::WebAutomationSession::deleteSingleCookie):
(WebKit::WebAutomationSession::viewportInViewCenterPointOfElement):
(WebKit::WebAutomationSession::takeScreenshot):
* Source/WebKit/UIProcess/BrowsingContextGroup.cpp:
(WebKit::BrowsingContextGroup::ensureProcessForConnection):
(WebKit::BrowsingContextGroup::addPage):
(WebKit::BrowsingContextGroup::transitionPageToRemotePage):
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::didChangeIsLoading):
(WebKit::NavigationState::didSwapWebProcesses):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionManagerProxy::PlaybackSessionManagerProxy):
(WebKit::PlaybackSessionManagerProxy::invalidate):
* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
* Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp:
(WebKit::UIRemoteObjectRegistry::backgroundActivity):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::VideoPresentationManagerProxy):
(WebKit::VideoPresentationManagerProxy::invalidate):
(WebKit::VideoPresentationManagerProxy::requestBitmapImageForCurrentTime):
(WebKit::VideoPresentationManagerProxy::createLayerHostViewWithID):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::grantAccessToCurrentPasteboardData):
(WebKit::WebPageProxy::contentFilterDidBlockLoadForFrame):
(WebKit::WebPageProxy::createSandboxExtensionsIfNeeded):
(WebKit::WebPageProxy::Internals::paymentCoordinatorAddMessageReceiver):
(WebKit::WebPageProxy::Internals::paymentCoordinatorRemoveMessageReceiver):
(WebKit::WebPageProxy::grantAccessToAssetServices):
(WebKit::WebPageProxy::revokeAccessToAssetServices):
(WebKit::WebPageProxy::disableURLSchemeCheckInDataDetectors const):
(WebKit::WebPageProxy::switchFromStaticFontRegistryToUserFontRegistry):
(WebKit::WebPageProxy::deactivateMediaCapability):
(WebKit::WebPageProxy::updateMediaCapability):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::addPopupPage):
(WebKit::WebExtensionContext::addExtensionTabPage):
(WebKit::WebExtensionContext::loadBackgroundWebView):
(WebKit::WebExtensionContext::processes const):
(WebKit::WebExtensionContext::loadInspectorBackgroundPage):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::addPage):
(WebKit::WebExtensionController::removePage):
(WebKit::WebExtensionController::removeProcessPool):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::processes const):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
(WebKit::WebExtensionContext::pageListensForEvent const):
(WebKit::WebExtensionContext::processes const):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
(WebKit::WebExtensionController::allProcesses const):
* Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp:
(WebKit::UIGamepadProvider::gamepadSyncTimerFired):
(WebKit::UIGamepadProvider::viewBecameActive):
* Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp:
(WebKit::RemoteWebInspectorUIProxy::createFrontendPageAndWindow):
(WebKit::RemoteWebInspectorUIProxy::closeFrontendPageAndWindow):
* Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp:
(WebKit::WebInspectorUIExtensionControllerProxy::WebInspectorUIExtensionControllerProxy):
(WebKit::WebInspectorUIExtensionControllerProxy::inspectorFrontendWillClose):
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp:
(WebKit::WebInspectorUIProxy::WebInspectorUIProxy):
(WebKit::WebInspectorUIProxy::reset):
(WebKit::WebInspectorUIProxy::updateForNewPageProcess):
(WebKit::WebInspectorUIProxy::createFrontendPage):
(WebKit::WebInspectorUIProxy::closeFrontendPageAndWindow):
(WebKit::WebInspectorUIProxy::frontendLoaded):
* Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp:
(WebKit::RemoteMediaSessionCoordinatorProxy::RemoteMediaSessionCoordinatorProxy):
(WebKit::RemoteMediaSessionCoordinatorProxy::~RemoteMediaSessionCoordinatorProxy):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::existingDisplayLink):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::displayLink):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::~UserMediaPermissionRequestManagerProxy):
(WebKit::UserMediaPermissionRequestManagerProxy::finishGrantingRequest):
(WebKit::UserMediaPermissionRequestManagerProxy::processUserMediaPermissionValidRequest):
(WebKit::UserMediaPermissionRequestManagerProxy::syncWithWebCorePrefs const):
(WebKit::UserMediaPermissionRequestManagerProxy::captureStateChanged):
* Source/WebKit/UIProcess/UserMediaProcessManager.cpp:
(WebKit::UserMediaProcessManager::willCreateMediaStream):
(WebKit::UserMediaProcessManager::revokeSandboxExtensionsIfNeeded):
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::disconnectFromProcess):
(WebKit::ViewGestureController::connectToProcess):
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp:
(WebKit::WebAuthenticatorCoordinatorProxy::WebAuthenticatorCoordinatorProxy):
(WebKit::WebAuthenticatorCoordinatorProxy::~WebAuthenticatorCoordinatorProxy):
* Source/WebKit/UIProcess/WebContextMenuProxy.cpp:
(WebKit::WebContextMenuProxy::show):
(WebKit::WebContextMenuProxy::useContextMenuItems):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::WebFullScreenManagerProxy):
(WebKit::WebFullScreenManagerProxy::~WebFullScreenManagerProxy):
(WebKit::WebFullScreenManagerProxy::didEnterFullScreen):
(WebKit::WebFullScreenManagerProxy::didExitFullScreen):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::ProcessActivityState::takeVisibleActivity):
(WebKit::WebPageProxy::ProcessActivityState::takeAudibleActivity):
(WebKit::WebPageProxy::ProcessActivityState::takeCapturingActivity):
(WebKit::WebPageProxy::ProcessActivityState::dropVisibleActivity):
(WebKit::WebPageProxy::ProcessActivityState::takeOpeningAppLinkActivity):
(WebKit::WebPageProxy::WebPageProxy):
(WebKit::WebPageProxy::~WebPageProxy):
(WebKit::WebPageProxy::addAllMessageReceivers):
(WebKit::WebPageProxy::removeAllMessageReceivers):
(WebKit::WebPageProxy::gpuProcessID const):
(WebKit::WebPageProxy::protectedLegacyMainFrameProcess const):
(WebKit::WebPageProxy::modelProcessID const):
(WebKit::WebPageProxy::legacyMainFrameProcessID const):
(WebKit::WebPageProxy::notifyProcessPoolToPrewarm):
(WebKit::WebPageProxy::handleMessage):
(WebKit::WebPageProxy::handleSynchronousMessage):
(WebKit::WebPageProxy::launchProcess):
(WebKit::WebPageProxy::suspendCurrentPageIfPossible):
(WebKit::WebPageProxy::backForwardCache const):
(WebKit::WebPageProxy::swapToProvisionalPage):
(WebKit::WebPageProxy::finishAttachingToWebProcess):
(WebKit::WebPageProxy::launchProcessForReload):
(WebKit::WebPageProxy::setDrawingArea):
(WebKit::WebPageProxy::initializeWebPage):
(WebKit::WebPageProxy::close):
(WebKit::WebPageProxy::tryClose):
(WebKit::WebPageProxy::ensureRunningProcess):
(WebKit::WebPageProxy::loadRequest):
(WebKit::WebPageProxy::loadFile):
(WebKit::WebPageProxy::loadData):
(WebKit::WebPageProxy::loadSimulatedRequest):
(WebKit::WebPageProxy::loadAlternateHTML):
(WebKit::WebPageProxy::navigateToPDFLinkWithSimulatedClick):
(WebKit::WebPageProxy::stopLoading):
(WebKit::WebPageProxy::reload):
(WebKit::WebPageProxy::goToBackForwardItem):
(WebKit::WebPageProxy::createInspectorTarget):
(WebKit::WebPageProxy::destroyInspectorTarget):
(WebKit::WebPageProxy::dispatchActivityStateChange):
(WebKit::WebPageProxy::updateThrottleState):
(WebKit::WebPageProxy::clearAudibleActivity):
(WebKit::WebPageProxy::hasValidAudibleActivity const):
(WebKit::WebPageProxy::updateHiddenPageThrottlingAutoIncreases):
(WebKit::WebPageProxy::waitForDidUpdateActivityState):
(WebKit::WebPageProxy::setInitialFocus):
(WebKit::WebPageProxy::executeEditCommand):
(WebKit::WebPageProxy::isConnectedToHardwareConsoleDidChange):
(WebKit::WebPageProxy::isAllowedToChangeMuteState const):
(WebKit::WebPageProxy::dragEntered):
(WebKit::WebPageProxy::dragUpdated):
(WebKit::WebPageProxy::performDragControllerAction):
(WebKit::WebPageProxy::sendMouseEvent):
(WebKit::WebPageProxy::processNextQueuedMouseEvent):
(WebKit::WebPageProxy::sendWheelEvent):
(WebKit::WebPageProxy::handleWheelEventReply):
(WebKit::WebPageProxy::wheelEventHandlingCompleted):
(WebKit::WebPageProxy::updateDisplayLinkFrequency):
(WebKit::WebPageProxy::sendKeyEvent):
(WebKit::WebPageProxy::handleKeyboardEvent):
(WebKit::WebPageProxy::handleGestureEvent):
(WebKit::WebPageProxy::touchEventHandlingCompleted):
(WebKit::WebPageProxy::handleTouchEvent):
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::receivedPolicyDecision):
(WebKit::WebPageProxy::receivedNavigationResponsePolicyDecision):
(WebKit::WebPageProxy::commitProvisionalPage):
(WebKit::WebPageProxy::shouldClosePreviousPage):
(WebKit::WebPageProxy::setUserAgent):
(WebKit::WebPageProxy::windowScreenDidChange):
(WebKit::WebPageProxy::accessibilitySettingsDidChange):
(WebKit::WebPageProxy::pageScaleFactorDidChange):
(WebKit::WebPageProxy::pluginScaleFactorDidChange):
(WebKit::WebPageProxy::pluginZoomFactorDidChange):
(WebKit::WebPageProxy::launchInitialProcessIfNecessary):
(WebKit::WebPageProxy::runJavaScriptInFrameInScriptWorld):
(WebKit::WebPageProxy::getContentsAsAttributedString):
(WebKit::WebPageProxy::didCreateMainFrame):
(WebKit::WebPageProxy::didCreateSubframe):
(WebKit::WebPageProxy::didDestroyFrame):
(WebKit::WebPageProxy::didDestroyNavigation):
(WebKit::WebPageProxy::didStartProvisionalLoadForFrame):
(WebKit::WebPageProxy::didExplicitOpenForFrame):
(WebKit::WebPageProxy::didReceiveServerRedirectForProvisionalLoadForFrame):
(WebKit::WebPageProxy::willPerformClientRedirectForFrame):
(WebKit::WebPageProxy::didCancelClientRedirectForFrame):
(WebKit::WebPageProxy::didChangeProvisionalURLForFrame):
(WebKit::WebPageProxy::didFailProvisionalLoadForFrame):
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::didFinishDocumentLoadForFrame):
(WebKit::WebPageProxy::forEachWebContentProcess):
(WebKit::WebPageProxy::didFinishLoadForFrame):
(WebKit::WebPageProxy::didFailLoadForFrame):
(WebKit::WebPageProxy::didSameDocumentNavigationForFrame):
(WebKit::WebPageProxy::didSameDocumentNavigationForFrameViaJSHistoryAPI):
(WebKit::WebPageProxy::didChangeMainDocument):
(WebKit::WebPageProxy::viewIsBecomingVisible):
(WebKit::WebPageProxy::didReceiveTitleForFrame):
(WebKit::WebPageProxy::didFirstVisuallyNonEmptyLayoutForFrame):
(WebKit::WebPageProxy::didDisplayInsecureContentForFrame):
(WebKit::WebPageProxy::didRunInsecureContentForFrame):
(WebKit::WebPageProxy::decidePolicyForNavigationActionAsync):
(WebKit::WebPageProxy::decidePolicyForNavigationActionSync):
(WebKit::WebPageProxy::decidePolicyForNewWindowAction):
(WebKit::WebPageProxy::decidePolicyForResponseShared):
(WebKit::WebPageProxy::triggerBrowsingContextGroupSwitchForNavigation):
(WebKit::WebPageProxy::willSubmitForm):
(WebKit::WebPageProxy::didNavigateWithNavigationData):
(WebKit::WebPageProxy::didPerformClientRedirect):
(WebKit::WebPageProxy::didPerformServerRedirect):
(WebKit::WebPageProxy::didUpdateHistoryTitle):
(WebKit::WebPageProxy::createNewPage):
(WebKit::WebPageProxy::runJavaScriptAlert):
(WebKit::WebPageProxy::runJavaScriptConfirm):
(WebKit::WebPageProxy::runJavaScriptPrompt):
(WebKit::WebPageProxy::mouseDidMoveOverElement):
(WebKit::WebPageProxy::runBeforeUnloadConfirmPanel):
(WebKit::WebPageProxy::runOpenPanel):
(WebKit::WebPageProxy::showShareSheet):
(WebKit::WebPageProxy::showContactPicker):
(WebKit::WebPageProxy::printFrame):
(WebKit::WebPageProxy::setMuted):
(WebKit::WebPageProxy::resumeDownload):
(WebKit::WebPageProxy::downloadRequest):
(WebKit::WebPageProxy::requestDOMPasteAccess):
(WebKit::WebPageProxy::backForwardAddItem):
(WebKit::WebPageProxy::backForwardGoToItemShared):
(WebKit::WebPageProxy::sendMessage):
(WebKit::WebPageProxy::sendMessageWithAsyncReply):
(WebKit::WebPageProxy::messageSenderConnection const):
(WebKit::WebPageProxy::postMessageToInjectedBundle):
(WebKit::WebPageProxy::showPopupMenu):
(WebKit::WebPageProxy::showContextMenu):
(WebKit::WebPageProxy::contextMenuItemSelected):
(WebKit::WebPageProxy::registerEditCommand):
(WebKit::WebPageProxy::learnWord):
(WebKit::WebPageProxy::ignoreWord):
(WebKit::WebPageProxy::mouseEventHandlingCompleted):
(WebKit::WebPageProxy::keyEventHandlingCompleted):
(WebKit::WebPageProxy::didReceiveEvent):
(WebKit::WebPageProxy::logDiagnosticMessageFromWebProcess):
(WebKit::WebPageProxy::logDiagnosticMessageWithResultFromWebProcess):
(WebKit::WebPageProxy::logDiagnosticMessageWithValueFromWebProcess):
(WebKit::WebPageProxy::logDiagnosticMessageWithEnhancedPrivacyFromWebProcess):
(WebKit::WebPageProxy::logDiagnosticMessageWithValueDictionaryFromWebProcess):
(WebKit::WebPageProxy::logDiagnosticMessageWithDomainFromWebProcess):
(WebKit::WebPageProxy::focusedFrameChanged):
(WebKit::WebPageProxy::resetStateAfterProcessTermination):
(WebKit::WebPageProxy::resetStateAfterProcessExited):
(WebKit::WebPageProxy::creationParameters):
(WebKit::WebPageProxy::makeStorageSpaceRequest):
(WebKit::WebPageProxy::requestGeolocationPermissionForFrame):
(WebKit::WebPageProxy::willStartCapture):
(WebKit::WebPageProxy::requestUserMediaPermissionForFrame):
(WebKit::WebPageProxy::enumerateMediaDevicesForFrame):
(WebKit::WebPageProxy::requestMediaKeySystemPermissionForFrame):
(WebKit::WebPageProxy::shouldAllowDeviceOrientationAndMotionAccess):
(WebKit::WebPageProxy::pageWillLikelyUseNotifications):
(WebKit::WebPageProxy::showNotification):
(WebKit::WebPageProxy::cancelNotification):
(WebKit::WebPageProxy::clearNotifications):
(WebKit::WebPageProxy::didDestroyNotification):
(WebKit::WebPageProxy::runModal):
(WebKit::WebPageProxy::updateBackingStoreDiscardableState):
(WebKit::WebPageProxy::isPlayingMediaDidChange):
(WebKit::WebPageProxy::updatePlayingMediaDidChange):
(WebKit::WebPageProxy::didPerformImmediateActionHitTest):
(WebKit::WebPageProxy::handleAutoFillButtonClick):
(WebKit::WebPageProxy::didResignInputElementStrongPasswordAppearance):
(WebKit::WebPageProxy::startURLSchemeTask):
(WebKit::WebPageProxy::startURLSchemeTaskShared):
(WebKit::WebPageProxy::stopURLSchemeTask):
(WebKit::WebPageProxy::loadSynchronousURLSchemeTask):
(WebKit::WebPageProxy::writePromisedAttachmentToPasteboard):
(WebKit::WebPageProxy::requestAttachmentIcon):
(WebKit::WebPageProxy::registerAttachmentIdentifierFromData):
(WebKit::WebPageProxy::registerAttachmentIdentifierFromFilePath):
(WebKit::WebPageProxy::registerAttachmentIdentifier):
(WebKit::WebPageProxy::registerAttachmentsFromSerializedData):
(WebKit::WebPageProxy::cloneAttachmentData):
(WebKit::WebPageProxy::serializedAttachmentDataForIdentifiers):
(WebKit::WebPageProxy::didInsertAttachmentWithIdentifier):
(WebKit::WebPageProxy::didRemoveAttachmentWithIdentifier):
(WebKit::WebPageProxy::setOrientationForMediaCapture):
(WebKit::WebPageProxy::gpuProcessExited):
(WebKit::WebPageProxy::createRealtimeMediaSourceForSpeechRecognition):
(WebKit::WebPageProxy::beginTextRecognitionForVideoInElementFullScreen):
(WebKit::WebPageProxy::didCreateSleepDisabler):
(WebKit::WebPageProxy::didAccessWindowProxyPropertyViaOpenerForFrame):
(WebKit::WebPageProxy::protectedProcess const): Deleted.
(WebKit::WebPageProxy::processID const): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPreferences.cpp:
(WebKit::WebPreferences::updateBoolValueForKey):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::allowedFirstPartiesForCookies):
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp:
(WebKit::WebScreenOrientationManagerProxy::WebScreenOrientationManagerProxy):
(WebKit::WebScreenOrientationManagerProxy::~WebScreenOrientationManagerProxy):
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::PlatformXRSystem):
(WebKit::PlatformXRSystem::~PlatformXRSystem):
(WebKit::PlatformXRSystem::ensureImmersiveSessionActivity):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::decidePolicyForGeolocationPermissionRequest):
* Source/WebKit/UIProcess/ios/SmartMagnificationController.mm:
(WebKit::SmartMagnificationController::SmartMagnificationController):
(WebKit::SmartMagnificationController::~SmartMagnificationController):
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _setupVisibilityPropagationForWebProcess]):
(-[WKContentView _setupVisibilityPropagationForGPUProcess]):
(-[WKContentView _setupVisibilityPropagationForModelProcess]):
(-[WKContentView _removeVisibilityPropagationViewForWebProcess]):
(-[WKContentView _removeVisibilityPropagationViewForGPUProcess]):
(-[WKContentView _updateRemoteAccessibilityRegistration:]):
(-[WKContentView _accessibilityRegisterUIProcessTokens]):
(-[WKContentView _waitForDrawToPDFCallbackForPrintFormatterIfNeeded:]):
(-[WKContentView _waitForDrawToImageCallbackForPrintFormatterIfNeeded:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView setUpInteraction]):
(-[WKContentView ensurePositionInformationIsUpToDate:]):
(-[WKContentView _internalRequestAutocorrectionContextWithCompletionHandler:]):
(-[WKContentView presentViewControllerForCurrentFocusedElement]):
(-[WKContentView dismissAllInputViewControllers:]):
(-[WKContentView setContinuousSpellCheckingEnabled:]):
(-[WKContentView setGrammarCheckingEnabled:]):
* Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm:
(WebKit::WebDeviceOrientationUpdateProviderProxy::WebDeviceOrientationUpdateProviderProxy):
(WebKit::WebDeviceOrientationUpdateProviderProxy::~WebDeviceOrientationUpdateProviderProxy):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::updateVisibleContentRects):
(WebKit::WebPageProxy::resendLastVisibleContentRects):
(WebKit::WebPageProxy::dynamicViewportSizeUpdate):
(WebKit::WebPageProxy::setViewportConfigurationViewLayoutSize):
(WebKit::WebPageProxy::setSceneIdentifier):
(WebKit::WebPageProxy::setForceAlwaysUserScalable):
(WebKit::WebPageProxy::setDeviceOrientation):
(WebKit::WebPageProxy::setOverrideViewportArguments):
(WebKit::WebPageProxy::willInsertFinalDictationResult):
(WebKit::WebPageProxy::didInsertFinalDictationResult):
(WebKit::WebPageProxy::replaceDictatedText):
(WebKit::WebPageProxy::replaceSelectedText):
(WebKit::WebPageProxy::applyAutocorrection):
(WebKit::WebPageProxy::selectTextWithGranularityAtPoint):
(WebKit::WebPageProxy::selectPositionAtBoundaryWithDirection):
(WebKit::WebPageProxy::moveSelectionAtBoundaryWithDirection):
(WebKit::WebPageProxy::selectPositionAtPoint):
(WebKit::WebPageProxy::requestAutocorrectionContext):
(WebKit::WebPageProxy::requestPositionInformation):
(WebKit::WebPageProxy::startInteractionWithPositionInformation):
(WebKit::WebPageProxy::stopInteraction):
(WebKit::WebPageProxy::performActionOnElements):
(WebKit::WebPageProxy::applicationDidEnterBackground):
(WebKit::WebPageProxy::applicationDidFinishSnapshottingAfterEnteringBackground):
(WebKit::WebPageProxy::applicationWillEnterForeground):
(WebKit::WebPageProxy::applicationWillResignActive):
(WebKit::WebPageProxy::applicationDidEnterBackgroundForMedia):
(WebKit::WebPageProxy::applicationWillEnterForegroundForMedia):
(WebKit::WebPageProxy::applicationDidBecomeActive):
(WebKit::WebPageProxy::selectWordBackward):
(WebKit::WebPageProxy::storeSelectionForAccessibility):
(WebKit::WebPageProxy::startAutoscrollAtPosition):
(WebKit::WebPageProxy::cancelAutoscroll):
(WebKit::WebPageProxy::moveSelectionByOffset):
(WebKit::WebPageProxy::autofillLoginCredentials):
(WebKit::WebPageProxy::focusNextFocusedElement):
(WebKit::WebPageProxy::hardwareKeyboardAvailabilityChanged):
(WebKit::WebPageProxy::requestDragStart):
(WebKit::WebPageProxy::requestAdditionalItemsForDragSession):
(WebKit::WebPageProxy::didConcludeDrop):
(WebKit::WebPageProxy::willOpenAppLink):
* Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm:
(WebKit::DisplayCaptureSessionManager::promptForGetDisplayMedia):
(WebKit::DisplayCaptureSessionManager::cancelGetDisplayMediaPrompt):
* Source/WebKit/UIProcess/mac/WKImmediateActionController.mm:
(-[WKImmediateActionController immediateActionRecognizerWillBeginAnimation:]):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::shouldDelayWindowOrderingForEvent):
(WebKit::WebPageProxy::acceptsFirstMouse):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::~WebViewImpl):
(WebKit::WebViewImpl::screenDidChangeColorSpace):
(WebKit::WebViewImpl::setContinuousSpellCheckingEnabled):
(WebKit::WebViewImpl::toggleContinuousSpellChecking):
(WebKit::WebViewImpl::setGrammarCheckingEnabled):
(WebKit::WebViewImpl::toggleGrammarChecking):
(WebKit::WebViewImpl::toggleAutomaticSpellingCorrection):
(WebKit::WebViewImpl::setAutomaticQuoteSubstitutionEnabled):
(WebKit::WebViewImpl::toggleAutomaticQuoteSubstitution):
(WebKit::WebViewImpl::setAutomaticDashSubstitutionEnabled):
(WebKit::WebViewImpl::toggleAutomaticDashSubstitution):
(WebKit::WebViewImpl::setAutomaticLinkDetectionEnabled):
(WebKit::WebViewImpl::toggleAutomaticLinkDetection):
(WebKit::WebViewImpl::setAutomaticTextReplacementEnabled):
(WebKit::WebViewImpl::toggleAutomaticTextReplacement):
(WebKit::WebViewImpl::setAccessibilityWebProcessToken):
(WebKit::WebViewImpl::updateRemoteAccessibilityRegistration):
(WebKit::WebViewImpl::remoteObjectRegistry):

Canonical link: <a href="https://commits.webkit.org/279841@main">https://commits.webkit.org/279841@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/376b924e55a7a0cf91d971e0977ebb0d160cc3b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57989 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/5442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5452 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44310 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/5442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56805 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/32266 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/47393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25434 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/29059 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3583 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/4941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59579 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/29953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/5088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/51733 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/31096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47475 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/32096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8096 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/30882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->