### PR TITLE
REGRESSION (273650@main): Back forward list doesn’t have any webpage titles

### DIFF
--- a/LayoutTests/loader/stateobjects/pushstate-size-expected.txt
+++ b/LayoutTests/loader/stateobjects/pushstate-size-expected.txt
@@ -1,38 +1,4 @@
 Test should not crash.
 Click to test pushState through a user gesture
-Successfully added item: 1 times
-Successfully added item: 2 times
-Successfully added item: 3 times
-Successfully added item: 4 times
-Successfully added item: 5 times
-Successfully added item: 6 times
-Successfully added item: 7 times
-Successfully added item: 8 times
-Successfully added item: 9 times
-Successfully added item: 10 times
-Successfully added item: 11 times
-Successfully added item: 12 times
-Successfully added item: 13 times
-Successfully added item: 14 times
-Successfully added item: 15 times
-Successfully added item: 16 times
-Successfully added item: 17 times
-Successfully added item: 18 times
-Successfully added item: 19 times
-Successfully added item: 20 times
-Successfully added item: 21 times
-Successfully added item: 22 times
-Successfully added item: 23 times
-Successfully added item: 24 times
-Successfully added item: 25 times
-Successfully added item: 26 times
-Successfully added item: 27 times
-Successfully added item: 28 times
-Successfully added item: 29 times
-Successfully added item: 30 times
-Successfully added item: 31 times
-Successfully added item: 32 times
-Successfully added item: 33 times
-Successfully added item: 34 times
 User gesture: QuotaExceededError: Attempt to store more data than allowed using history.pushState()
 

--- a/LayoutTests/loader/stateobjects/pushstate-size-iframe-expected.txt
+++ b/LayoutTests/loader/stateobjects/pushstate-size-iframe-expected.txt
@@ -1,13 +1,5 @@
 Test should not crash.
 Test does pushState both from the main frame and from an iframe and makes sure they both count against the main frame document's size limit.
 Click to test pushState through a user gesture
-Parent frame successfully added item: 1 times
-Parent frame successfully added item: 2 times
-Parent frame successfully added item: 3 times
-Parent frame successfully added item: 4 times
-iFrame successfully added item: 1 times
-iFrame successfully added item: 2 times
-iFrame successfully added item: 3 times
-iFrame successfully added item: 4 times
 Expected exception: QuotaExceededError: Attempt to store more data than allowed using history.pushState()
 

--- a/LayoutTests/loader/stateobjects/pushstate-size-iframe.html
+++ b/LayoutTests/loader/stateobjects/pushstate-size-iframe.html
@@ -43,7 +43,6 @@ function clicked()
             testRunner.notifyDone();    
     }
 
-    log("Parent frame successfully added item: " + count + " times");
     ++count;
 
     if (count > 4) {

--- a/LayoutTests/loader/stateobjects/pushstate-size.html
+++ b/LayoutTests/loader/stateobjects/pushstate-size.html
@@ -35,7 +35,6 @@ function clicked()
             testRunner.notifyDone();    
     }
 
-    log("Successfully added item: " + count + " times");
     ++count;
 
     setTimeout(click, 0);

--- a/LayoutTests/loader/stateobjects/resources/pushstate-iframe.html
+++ b/LayoutTests/loader/stateobjects/resources/pushstate-iframe.html
@@ -12,7 +12,6 @@ function iframeClicked()
             testRunner.notifyDone();    
     }
 
-    top.log("iFrame successfully added item: " + count + " times");
     ++count;
 
     if (count > 50) {

--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -50,9 +50,11 @@ int64_t HistoryItem::generateSequenceNumber()
     return ++next;
 }
 
-HistoryItem::HistoryItem(Client& client, const String& urlString, std::optional<BackForwardItemIdentifier> identifier)
+HistoryItem::HistoryItem(Client& client, const String& urlString, const String& title, const String& alternateTitle, std::optional<BackForwardItemIdentifier> identifier)
     : m_urlString(urlString)
     , m_originalURLString(urlString)
+    , m_title(title)
+    , m_displayTitle(alternateTitle)
     , m_pruningReason(PruningReason::None)
     , m_identifier(identifier ? *identifier : BackForwardItemIdentifier::generate())
     , m_uuidIdentifier(WTF::UUID::createVersion4Weak())
@@ -73,6 +75,8 @@ HistoryItem::HistoryItem(const HistoryItem& item)
     , m_referrer(item.m_referrer)
     , m_target(item.m_target)
     , m_frameID(item.m_frameID)
+    , m_title(item.m_title)
+    , m_displayTitle(item.m_displayTitle)
     , m_scrollPosition(item.m_scrollPosition)
     , m_pageScaleFactor(item.m_pageScaleFactor)
     , m_children(item.m_children.map([](auto& child) { return child->copy(); }))
@@ -106,6 +110,8 @@ void HistoryItem::reset()
     m_referrer = String();
     m_target = nullAtom();
     m_frameID = std::nullopt;
+    m_title = String();
+    m_displayTitle = String();
 
     m_lastVisitWasFailure = false;
     m_isTargetItem = false;
@@ -132,6 +138,16 @@ const String& HistoryItem::urlString() const
 const String& HistoryItem::originalURLString() const
 {
     return m_originalURLString;
+}
+
+const String& HistoryItem::title() const
+{
+    return m_title;
+}
+
+const String& HistoryItem::alternateTitle() const
+{
+    return m_displayTitle;
 }
 
 bool HistoryItem::hasCachedPageExpired() const
@@ -175,6 +191,12 @@ const AtomString& HistoryItem::target() const
     return m_target;
 }
 
+void HistoryItem::setAlternateTitle(const String& alternateTitle)
+{
+    m_displayTitle = alternateTitle;
+    notifyChanged();
+}
+
 void HistoryItem::setURLString(const String& urlString)
 {
     m_urlString = urlString;
@@ -197,6 +219,12 @@ void HistoryItem::setOriginalURLString(const String& urlString)
 void HistoryItem::setReferrer(const String& referrer)
 {
     m_referrer = referrer;
+    notifyChanged();
+}
+
+void HistoryItem::setTitle(const String& title)
+{
+    m_title = title;
     notifyChanged();
 }
 

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -74,9 +74,9 @@ class HistoryItem : public RefCounted<HistoryItem>, public CanMakeWeakPtr<Histor
 
 public:
     using Client = HistoryItemClient;
-    static Ref<HistoryItem> create(Client& client, const String& urlString = { }, std::optional<BackForwardItemIdentifier> identifier = { })
+    static Ref<HistoryItem> create(Client& client, const String& urlString = { }, const String& title = { }, const String& alternateTitle = { }, std::optional<BackForwardItemIdentifier> identifier = { })
     {
-        return adoptRef(*new HistoryItem(client, urlString, identifier));
+        return adoptRef(*new HistoryItem(client, urlString, title, alternateTitle, identifier));
     }
     
     WEBCORE_EXPORT ~HistoryItem();
@@ -93,10 +93,13 @@ public:
 
     WEBCORE_EXPORT const String& originalURLString() const;
     WEBCORE_EXPORT const String& urlString() const;
+    WEBCORE_EXPORT const String& title() const;
     
     bool isInBackForwardCache() const { return m_cachedPage.get(); }
     WEBCORE_EXPORT bool hasCachedPageExpired() const;
 
+    WEBCORE_EXPORT void setAlternateTitle(const String&);
+    WEBCORE_EXPORT const String& alternateTitle() const;
     
     WEBCORE_EXPORT URL url() const;
     WEBCORE_EXPORT URL originalURL() const;
@@ -133,6 +136,7 @@ public:
     WEBCORE_EXPORT void setReferrer(const String&);
     WEBCORE_EXPORT void setTarget(const AtomString&);
     void setFrameID(std::optional<FrameIdentifier> frameID) { m_frameID = frameID; }
+    WEBCORE_EXPORT void setTitle(const String&);
     WEBCORE_EXPORT void setIsTargetItem(bool);
     
     WEBCORE_EXPORT void setStateObject(RefPtr<SerializedScriptValue>&&);
@@ -220,7 +224,7 @@ public:
     void setPolicyContainer(const PolicyContainer& policyContainer) { m_policyContainer = policyContainer; }
 
 private:
-    WEBCORE_EXPORT HistoryItem(Client&, const String& urlString, std::optional<BackForwardItemIdentifier>);
+    WEBCORE_EXPORT HistoryItem(Client&, const String& urlString, const String& title, const String& alternateTitle, std::optional<BackForwardItemIdentifier>);
 
     void setCachedPage(std::unique_ptr<CachedPage>&&);
     std::unique_ptr<CachedPage> takeCachedPage();
@@ -236,7 +240,9 @@ private:
     String m_referrer;
     AtomString m_target;
     std::optional<FrameIdentifier> m_frameID;
-    
+    String m_title;
+    String m_displayTitle;
+
     IntPoint m_scrollPosition;
     float m_pageScaleFactor { 0 }; // 0 indicates "unset".
     Vector<AtomString> m_documentState;

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4468,6 +4468,8 @@ void FrameLoader::didChangeTitle(DocumentLoader* loader)
     m_client->didChangeTitle(loader);
 
     if (loader == m_documentLoader) {
+        // Must update the entries in the back-forward list too.
+        m_frame->history().setCurrentItemTitle(loader->title());
         // This must go through the WebFrame because it has the right notion of the current b/f item.
         m_client->setTitle(loader->title(), loader->urlForHistory());
         m_client->setMainFrameDocumentReady(true); // update observers with new DOMDocument

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -659,6 +659,13 @@ void HistoryController::setCurrentItem(Ref<HistoryItem>&& item)
     m_previousItem = std::exchange(m_currentItem, WTFMove(item));
 }
 
+void HistoryController::setCurrentItemTitle(const StringWithDirection& title)
+{
+    // FIXME: This ignores the title's direction.
+    if (RefPtr currentItem = m_currentItem)
+        currentItem->setTitle(title.string);
+}
+
 bool HistoryController::currentItemShouldBeReplaced() const
 {
     // From the HTML5 spec for location.assign():
@@ -713,9 +720,13 @@ void HistoryController::initializeItem(HistoryItem& item)
     if (originalURL.isEmpty())
         originalURL = aboutBlankURL();
     
+    StringWithDirection title = documentLoader->title();
+
     item.setURL(url);
     item.setTarget(frame->tree().uniqueName());
     item.setFrameID(frame->frameID());
+    // FIXME: Should store the title direction as well.
+    item.setTitle(title.string);
     item.setOriginalURLString(originalURL.string());
 
     if (!unreachableURL.isEmpty() || documentLoader->response().httpStatusCode() >= 400)

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -77,6 +77,7 @@ public:
     HistoryItem* currentItem() const { return m_currentItem.get(); }
     RefPtr<HistoryItem> protectedCurrentItem() const;
     WEBCORE_EXPORT void setCurrentItem(Ref<HistoryItem>&&);
+    void setCurrentItemTitle(const StringWithDirection&);
     bool currentItemShouldBeReplaced() const;
     WEBCORE_EXPORT void replaceCurrentItem(RefPtr<HistoryItem>&&);
 

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -69,6 +69,7 @@ public:
 
     const String& originalURL() const { return m_itemState.pageState.mainFrameState.originalURLString; }
     const String& url() const { return m_itemState.pageState.mainFrameState.urlString; }
+    const String& title() const { return m_itemState.pageState.title; }
     bool wasCreatedByJSWithoutUserInteraction() const { return m_itemState.pageState.wasCreatedByJSWithoutUserInteraction; }
 
     const URL& resourceDirectoryURL() const { return m_resourceDirectoryURL; }

--- a/Source/WebKit/UIProcess/API/C/WKBackForwardListItemRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKBackForwardListItemRef.cpp
@@ -27,7 +27,6 @@
 #include "WKBackForwardListItemRef.h"
 
 #include "WKAPICast.h"
-#include "WKString.h"
 #include "WebBackForwardListItem.h"
 
 using namespace WebKit;
@@ -44,7 +43,7 @@ WKURLRef WKBackForwardListItemCopyURL(WKBackForwardListItemRef itemRef)
 
 WKStringRef WKBackForwardListItemCopyTitle(WKBackForwardListItemRef itemRef)
 {
-    return WKStringCreateWithUTF8CString("");
+    return WebKit::toCopiedAPI(toImpl(itemRef)->title());
 }
 
 WKURLRef WKBackForwardListItemCopyOriginalURL(WKBackForwardListItemRef itemRef)

--- a/Source/WebKit/UIProcess/API/C/WKBackForwardListItemRef.h
+++ b/Source/WebKit/UIProcess/API/C/WKBackForwardListItemRef.h
@@ -27,7 +27,6 @@
 #define WKBackForwardListItemRef_h
 
 #include <WebKit/WKBase.h>
-#include <WebKit/WKDeprecated.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,7 +35,7 @@ extern "C" {
 WK_EXPORT WKTypeID WKBackForwardListItemGetTypeID(void);
 
 WK_EXPORT WKURLRef WKBackForwardListItemCopyURL(WKBackForwardListItemRef item);
-WK_EXPORT WKStringRef WKBackForwardListItemCopyTitle(WKBackForwardListItemRef item) WK_C_API_DEPRECATED;
+WK_EXPORT WKStringRef WKBackForwardListItemCopyTitle(WKBackForwardListItemRef item);
 WK_EXPORT WKURLRef WKBackForwardListItemCopyOriginalURL(WKBackForwardListItemRef item);
 
 #ifdef __cplusplus

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.h
@@ -41,9 +41,9 @@ WK_CLASS_AVAILABLE(macos(10.10), ios(8.0))
  */
 @property (readonly, copy) NSURL *URL;
 
-/*! @abstract Deprecated. Always returns nil.
+/*! @abstract The title of the webpage represented by this item.
  */
-@property (nullable, readonly, copy) NSString *title WK_API_DEPRECATED("No longer supported", macos(10.10, WK_MAC_TBA), ios(8.0, WK_IOS_TBA), visionos(1.0, WK_XROS_TBA));
+@property (nullable, readonly, copy) NSString *title;
 
 /*! @abstract The URL of the initial request that created this item.
  */

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm
@@ -52,7 +52,10 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (NSString *)title
 {
-    return nil;
+    if (!_item->title())
+        return nil;
+
+    return _item->title();
 }
 
 - (NSURL *)initialURL

--- a/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp
@@ -110,8 +110,11 @@ static FrameState toFrameState(const HistoryItem& historyItem)
 
 BackForwardListItemState toBackForwardListItemState(const WebCore::HistoryItem& historyItem)
 {
+    static constexpr unsigned maxTitleLength = 1000; // Closest power of 10 above the W3C recommendation for Title length.
+
     BackForwardListItemState state;
     state.identifier = historyItem.identifier();
+    state.pageState.title = historyItem.title().left(maxTitleLength);
     state.pageState.mainFrameState = toFrameState(historyItem);
     state.pageState.shouldOpenExternalURLsPolicy = historyItem.shouldOpenExternalURLsPolicy();
     state.pageState.sessionStateObject = historyItem.stateObject();
@@ -175,7 +178,7 @@ static void applyFrameState(WebCore::HistoryItemClient& client, HistoryItem& his
 #endif
 
     for (const auto& childFrameState : frameState.children) {
-        Ref<HistoryItem> childHistoryItem = HistoryItem::create(client, childFrameState.urlString, { });
+        Ref<HistoryItem> childHistoryItem = HistoryItem::create(client, childFrameState.urlString, { }, { });
         applyFrameState(client, childHistoryItem, childFrameState);
 
         historyItem.addChildItem(WTFMove(childHistoryItem));
@@ -184,7 +187,7 @@ static void applyFrameState(WebCore::HistoryItemClient& client, HistoryItem& his
 
 Ref<HistoryItem> toHistoryItem(WebCore::HistoryItemClient& client, const BackForwardListItemState& itemState)
 {
-    Ref<HistoryItem> historyItem = HistoryItem::create(client, itemState.pageState.mainFrameState.urlString, itemState.identifier);
+    Ref<HistoryItem> historyItem = HistoryItem::create(client, itemState.pageState.mainFrameState.urlString, itemState.pageState.title, { }, itemState.identifier);
     historyItem->setShouldOpenExternalURLsPolicy(itemState.pageState.shouldOpenExternalURLsPolicy);
     historyItem->setStateObject(itemState.pageState.sessionStateObject.get());
     applyFrameState(client, historyItem, itemState.pageState.mainFrameState);

--- a/Source/WebKitLegacy/mac/History/HistoryPropertyList.mm
+++ b/Source/WebKitLegacy/mac/History/HistoryPropertyList.mm
@@ -86,11 +86,17 @@ void HistoryPropertyListWriter::writeHistoryItem(BinaryPropertyListObjectStream&
 
     size_t itemDictionaryStart = stream.writeDictionaryStart();
 
+    const String& title = item->title();
+    const String& displayTitle = item->alternateTitle();
     double lastVisitedDate = webHistoryItem->_private->_lastVisitedTime;
     Vector<String>* redirectURLs = webHistoryItem->_private->_redirectURLs.get();
 
     // keys
     stream.writeString(m_urlKey);
+    if (!title.isEmpty())
+        stream.writeString(m_titleKey);
+    if (!displayTitle.isEmpty())
+        stream.writeString(m_displayTitleKey);
     if (lastVisitedDate)
         stream.writeString(m_lastVisitedDateKey);
     if (item->lastVisitWasFailure())
@@ -100,6 +106,10 @@ void HistoryPropertyListWriter::writeHistoryItem(BinaryPropertyListObjectStream&
 
     // values
     stream.writeUniqueString(item->urlString());
+    if (!title.isEmpty())
+        stream.writeString(title);
+    if (!displayTitle.isEmpty())
+        stream.writeString(displayTitle);
     if (lastVisitedDate) {
         char buffer[32];
         snprintf(buffer, sizeof(buffer), "%.1lf", lastVisitedDate);

--- a/Source/WebKitLegacy/mac/History/WebHistory.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistory.mm
@@ -291,8 +291,8 @@ static inline WebHistoryDateKey dateKey(NSTimeInterval date)
         // as seen in <rdar://problem/6570573>.
         BOOL itemWasInDateCaches = [self removeItemFromDateCaches:entry.get()];
         ASSERT_UNUSED(itemWasInDateCaches, itemWasInDateCaches);
-        [entry _visited];
 
+        [entry _visitedWithTitle:title];
     } else {
         LOG(History, "Adding new global history entry for %@", url);
         entry = adoptNS([[WebHistoryItem alloc] initWithURLString:URLString title:title lastVisitedTimeInterval:[NSDate timeIntervalSinceReferenceDate]]);

--- a/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
@@ -141,7 +141,7 @@ void WKNotifyHistoryItemChanged()
 {
     WebCoreThreadViolationCheckRoundOne();
 
-    WebHistoryItem *item = [self initWithWebCoreHistoryItem:HistoryItem::create(LegacyHistoryItemClient::singleton(), URLString)];
+    WebHistoryItem *item = [self initWithWebCoreHistoryItem:HistoryItem::create(LegacyHistoryItemClient::singleton(), URLString, title)];
     item->_private->_lastVisitedTime = time;
 
     return item;
@@ -181,6 +181,21 @@ void WKNotifyHistoryItemChanged()
 - (NSString *)originalURLString
 {
     return nsStringNilIfEmpty(core(_private)->originalURLString());
+}
+
+- (NSString *)title
+{
+    return nsStringNilIfEmpty(core(_private)->title());
+}
+
+- (void)setAlternateTitle:(NSString *)alternateTitle
+{
+    core(_private)->setAlternateTitle(alternateTitle);
+}
+
+- (NSString *)alternateTitle
+{
+    return nsStringNilIfEmpty(core(_private)->alternateTitle());
 }
 
 #if !PLATFORM(IOS_FAMILY)
@@ -266,7 +281,7 @@ WebHistoryItem *kit(HistoryItem* item)
 
 - (id)initWithURLString:(NSString *)URLString title:(NSString *)title displayTitle:(NSString *)displayTitle lastVisitedTimeInterval:(NSTimeInterval)time
 {
-    auto item = [self initWithWebCoreHistoryItem:HistoryItem::create(LegacyHistoryItemClient::singleton(), URLString)];
+    auto item = [self initWithWebCoreHistoryItem:HistoryItem::create(LegacyHistoryItemClient::singleton(), URLString, title, displayTitle)];
     if (!item)
         return nil;
     item->_private->_lastVisitedTime = time;
@@ -286,6 +301,11 @@ WebHistoryItem *kit(HistoryItem* item)
     ASSERT(!historyItemWrappers().get(*core(_private)));
     historyItemWrappers().set(*core(_private), self);
     return self;
+}
+
+- (void)setTitle:(NSString *)title
+{
+    core(_private)->setTitle(title);
 }
 
 - (void)setViewState:(id)statePList
@@ -349,8 +369,9 @@ WebHistoryItem *kit(HistoryItem* item)
     return core(_private)->scrollPosition();
 }
 
-- (void)_visited
+- (void)_visitedWithTitle:(NSString *)title
 {
+    core(_private)->setTitle(title);
     _private->_lastVisitedTime = [NSDate timeIntervalSinceReferenceDate];
 }
 
@@ -381,6 +402,10 @@ WebHistoryItem *kit(HistoryItem* item)
     
     if (!coreItem->urlString().isEmpty())
         [dict setObject:(NSString*)coreItem->urlString() forKey:@""];
+    if (!coreItem->title().isEmpty())
+        [dict setObject:(NSString*)coreItem->title() forKey:titleKey];
+    if (!coreItem->alternateTitle().isEmpty())
+        [dict setObject:(NSString*)coreItem->alternateTitle() forKey:displayTitleKey];
     if (_private->_lastVisitedTime) {
         // Store as a string to maintain backward compatibility. (See 3245793)
         [dict setObject:[NSString stringWithFormat:@"%.1lf", _private->_lastVisitedTime]

--- a/Source/WebKitLegacy/mac/History/WebHistoryItemInternal.h
+++ b/Source/WebKitLegacy/mac/History/WebHistoryItemInternal.h
@@ -48,7 +48,9 @@ extern void WKNotifyHistoryItemChanged();
 - (id)initWithURLString:(NSString *)URLString title:(NSString *)title displayTitle:(NSString *)displayTitle lastVisitedTimeInterval:(NSTimeInterval)time;
 - (id)initFromDictionaryRepresentation:(NSDictionary *)dict;
 - (id)initWithWebCoreHistoryItem:(Ref<WebCore::HistoryItem>&&)item;
-- (void)_visited;
+
+- (void)setTitle:(NSString *)title;
+- (void)_visitedWithTitle:(NSString *)title;
 
 @end
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -1343,6 +1343,7 @@ void WebFrameLoaderClient::setTitle(const WebCore::StringWithDirection& title, c
     if ([[nsURL absoluteString] isEqualToString:@"about:blank"])
         return;
 #endif
+    [[[WebHistory optionalSharedHistory] itemForURL:nsURL] setTitle:title.string];
 }
 
 void WebFrameLoaderClient::savePlatformDataToCachedFrame(WebCore::CachedFrame* cachedFrame)


### PR DESCRIPTION
#### 443a65a4c3a25485b3083c8a92f3be46e71102f2
<pre>
REGRESSION (273650@main): Back forward list doesn’t have any webpage titles
<a href="https://rdar.apple.com/128448221">rdar://128448221</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=275280">https://bugs.webkit.org/show_bug.cgi?id=275280</a>

Reviewed by Alex Christensen.

273650@main was an update to the web APIs &quot;pushState&quot; and &quot;replaceState&quot; to remove their
ability to change the title on a back/forward list item.

That ability had left the other browsers and left the spec, so it was a fine removal to make.
Unfortunately that change incorrectly assumed that no back/forward list item ever has a title.

They do have titles - populated by WebKit itself from document titles - and they do show up
in both the native WebKit API and inside WebKit based browsers.

document.title population of the back/forward list entries happens in other browsers, as well.

This change is a partial revert of 273650@main, leaving the web API changes in tact but
restoring the WKBackForwardListItem.title functionality.

* LayoutTests/loader/stateobjects/pushstate-size-expected.txt:
* LayoutTests/loader/stateobjects/pushstate-size-iframe-expected.txt:
* LayoutTests/loader/stateobjects/pushstate-size-iframe.html:
* LayoutTests/loader/stateobjects/pushstate-size.html:
* LayoutTests/loader/stateobjects/resources/pushstate-iframe.html:
* Source/WebCore/history/HistoryItem.cpp:
(WebCore::HistoryItem::HistoryItem):
(WebCore::HistoryItem::reset):
(WebCore::HistoryItem::title const):
(WebCore::HistoryItem::alternateTitle const):
(WebCore::HistoryItem::setAlternateTitle):
(WebCore::HistoryItem::setTitle):
* Source/WebCore/history/HistoryItem.h:
(WebCore::HistoryItem::create):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::didChangeTitle):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::setCurrentItemTitle):
(WebCore::HistoryController::initializeItem):
* Source/WebCore/loader/HistoryController.h:
* Source/WebKit/Shared/WebBackForwardListItem.h:
(WebKit::WebBackForwardListItem::title const):
* Source/WebKit/UIProcess/API/C/WKBackForwardListItemRef.cpp:
(WKBackForwardListItemCopyTitle):
* Source/WebKit/UIProcess/API/C/WKBackForwardListItemRef.h:
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.h:
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm:
(-[WKBackForwardListItem title]):
* Source/WebKit/WebProcess/WebCoreSupport/SessionStateConversion.cpp:
(WebKit::toBackForwardListItemState):
(WebKit::applyFrameState):
(WebKit::toHistoryItem):
* Source/WebKitLegacy/mac/History/HistoryPropertyList.mm:
(HistoryPropertyListWriter::writeHistoryItem):
* Source/WebKitLegacy/mac/History/WebHistory.mm:
(-[WebHistoryPrivate visitedURL:withTitle:]):
* Source/WebKitLegacy/mac/History/WebHistoryItem.mm:
(-[WebHistoryItem initWithURLString:title:lastVisitedTimeInterval:]):
(-[WebHistoryItem title]):
(-[WebHistoryItem setAlternateTitle:]):
(-[WebHistoryItem alternateTitle]):
(-[WebHistoryItem initWithURLString:title:displayTitle:lastVisitedTimeInterval:]):
(-[WebHistoryItem setTitle:]):
(-[WebHistoryItem _visitedWithTitle:]):
(-[WebHistoryItem _visited]): Deleted.
* Source/WebKitLegacy/mac/History/WebHistoryItemInternal.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::setTitle):
* Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm:
(TEST(WKBackForwardList, SessionStateTitleTruncation)):

Canonical link: <a href="https://commits.webkit.org/279844@main">https://commits.webkit.org/279844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/810c29a1a6aae12d84e1bcc7458e9d226f85f54a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7284 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57987 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5440 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5450 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44307 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3670 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56803 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32263 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47385 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25431 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29056 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4721 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3581 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4934 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59577 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/29951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5083 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51730 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/31094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47470 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51120 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11993 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/32087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/30880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->