### PR TITLE
REGRESSION (iOS 17.2): Infinite recursion in -[WKContentView(WKInteraction) inputViewForWebView]

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -537,6 +537,7 @@ struct ImageAnalysisContextMenuActionData {
     BOOL _isHandlingActiveKeyEvent;
     BOOL _isHandlingActivePressesEvent;
     BOOL _isDeferringKeyEventsToInputMethod;
+    BOOL _isUpdatingAccessoryView;
 
     BOOL _focusRequiresStrongPasswordAssistance;
     BOOL _waitingForEditDragSnapshot;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -1404,6 +1404,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if USE(UICONTEXTMENU)
     _isDisplayingContextMenuWithAnimation = NO;
 #endif
+    _isUpdatingAccessoryView = NO;
 
 #if ENABLE(DATALIST_ELEMENT)
     _dataListTextSuggestionsInputView = nil;
@@ -5900,6 +5901,11 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 
 - (void)_updateAccessory
 {
+    if (_isUpdatingAccessoryView)
+        return;
+
+    SetForScope updateAccessoryScope { _isUpdatingAccessoryView, YES };
+
     auto* accessoryView = self.formAccessoryView; // Creates one, if needed.
 
     if ([accessoryView respondsToSelector:@selector(setNextPreviousItemsVisible:)])


### PR DESCRIPTION
#### 703a5b6bfcf1ff18afc3c0b46042d9ccee39371f
<pre>
REGRESSION (iOS 17.2): Infinite recursion in -[WKContentView(WKInteraction) inputViewForWebView]
<a href="https://bugs.webkit.org/show_bug.cgi?id=275171">https://bugs.webkit.org/show_bug.cgi?id=275171</a>
<a href="https://rdar.apple.com/127722998">rdar://127722998</a>

Reviewed by Richard Robinson.

The changes in <a href="https://rdar.apple.com/116751305&amp">rdar://116751305&amp</a>;104994662 seem to have made it possible for `-inputViewForWebView`
to trigger infinite recursion, due to a new `-[UITextInputAssistantItem leadingBarButtonGroups]`
KVO listener in UIKit. Underneath this new KVO logic, UIKit calls into some internal methods which
ultimately call back into `-[WKContentView inputViewForWebView]`. In order of stack depth (growing
downwards), the reentrant calls to update the input accessory view look like this:

```
-[WKContentView(WKInteraction) _updateAccessory]
-[WKContentView(WKInteraction) formAccessoryView]
-[WKFormAccessoryView _initForUniversalControlBar:] // &lt;--- Setting up WKFormAccessoryView

  … (KVO triggered by setting leading/trailing bar button groups)

-[UISystemInputAssistantViewController observeValueForKeyPath:ofObject:change:context:]
-[TUISystemInputAssistantView setInputAssistantItem:force:]

  … (UIKit internals)

-[UIKeyboardSceneDelegate expectedInputViewSetIsCustom]
-[WKContentView(WKInteraction) inputViewForWebView]
-[WKContentView(WKInteraction) _updateAccessory]
-[WKContentView(WKInteraction) formAccessoryView]
-[WKFormAccessoryView _initForUniversalControlBar:] // &lt;--- Setting up WKFormAccessoryView (reentrancy!)
```

While I wasn&apos;t able to reproduce the crash at all, we can at least harden against this scenario by
making `-_updateAccessory` robust against reentrancy. Achieve this by adding a new ivar that&apos;s only
set during the scope of `-_updateAccessory`, and return early if it&apos;s set.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView setUpInteraction]):
(-[WKContentView _updateAccessory]):

Canonical link: <a href="https://commits.webkit.org/279845@main">https://commits.webkit.org/279845@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e92d2e3b037be3046d7d2c4fc56551b4b0b018a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54714 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34140 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/57993 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5446 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41686 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5457 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44314 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3673 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32272 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47395 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25438 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29064 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3587 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59583 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/29957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/5091 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/51737 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/31101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47478 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51127 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/11994 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/32103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/30886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->