### PR TITLE
[JSC] Add Concurrent Sweeping Locking

### DIFF
--- a/Source/JavaScriptCore/heap/BlockDirectory.cpp
+++ b/Source/JavaScriptCore/heap/BlockDirectory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 
 #include "BlockDirectoryInlines.h"
 #include "Heap.h"
+#include "MarkedSpaceInlines.h"
 #include "SubspaceInlines.h"
 #include "SuperSampler.h"
 
@@ -37,7 +38,12 @@
 
 namespace JSC {
 
+namespace BlockDirectoryInternal {
+static constexpr bool verbose = false;
+}
+
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(BlockDirectory);
+
 
 BlockDirectory::BlockDirectory(size_t cellSize)
     : m_cellSize(static_cast<unsigned>(cellSize))
@@ -92,30 +98,34 @@ void BlockDirectory::updatePercentageOfPagedOutPages(SimpleStats& stats)
 
 MarkedBlock::Handle* BlockDirectory::findEmptyBlockToSteal()
 {
-    m_emptyCursor = m_bits.empty().findBit(m_emptyCursor, true);
+    Locker locker(bitvectorLock());
+    m_emptyCursor = (emptyBits() & ~inUseBits()).findBit(m_emptyCursor, true);
     if (m_emptyCursor >= m_blocks.size())
         return nullptr;
+    dataLogLnIf(BlockDirectoryInternal::verbose, "Setting block ", m_emptyCursor, " in use (findEmptyBlockToSteal) for ", *this);
+    setIsInUse(m_emptyCursor, true);
     return m_blocks[m_emptyCursor];
 }
 
 MarkedBlock::Handle* BlockDirectory::findBlockForAllocation(LocalAllocator& allocator)
 {
+    Locker locker(bitvectorLock());
     for (;;) {
-        allocator.m_allocationCursor = (m_bits.canAllocateButNotEmpty() | m_bits.empty()).findBit(allocator.m_allocationCursor, true);
+        allocator.m_allocationCursor = ((canAllocateButNotEmptyBits() | emptyBits()) & ~inUseBits()).findBit(allocator.m_allocationCursor, true);
         if (allocator.m_allocationCursor >= m_blocks.size())
             return nullptr;
         
         unsigned blockIndex = allocator.m_allocationCursor++;
         MarkedBlock::Handle* result = m_blocks[blockIndex];
-        setIsCanAllocateButNotEmpty(NoLockingNecessary, blockIndex, false);
+        setIsCanAllocateButNotEmpty(blockIndex, false);
+        dataLogLnIf(BlockDirectoryInternal::verbose, "Setting block ", blockIndex, " in use (findBlockForAllocation) for ", *this);
+        setIsInUse(blockIndex, true);
         return result;
     }
 }
 
 MarkedBlock::Handle* BlockDirectory::tryAllocateBlock(JSC::Heap& heap)
 {
-    SuperSamplerScope superSamplerScope(false);
-    
     MarkedBlock::Handle* handle = MarkedBlock::tryCreate(heap, subspace()->alignedMemoryAllocator());
     if (!handle)
         return nullptr;
@@ -127,6 +137,7 @@ MarkedBlock::Handle* BlockDirectory::tryAllocateBlock(JSC::Heap& heap)
 
 void BlockDirectory::addBlock(MarkedBlock::Handle* block)
 {
+    Locker locker { m_bitvectorLock };
     unsigned index;
     if (m_freeBlockIndices.isEmpty()) {
         index = m_blocks.size();
@@ -137,7 +148,6 @@ void BlockDirectory::addBlock(MarkedBlock::Handle* block)
             ASSERT(m_bits.numBits() == oldCapacity);
             ASSERT(m_blocks.capacity() > oldCapacity);
             
-            Locker locker { m_bitvectorLock };
             subspace()->didResizeBits(m_blocks.capacity());
             m_bits.resize(m_blocks.capacity());
         }
@@ -148,7 +158,6 @@ void BlockDirectory::addBlock(MarkedBlock::Handle* block)
     }
     
     forEachBitVector(
-        NoLockingNecessary,
         [&](auto vectorRef) {
             ASSERT_UNUSED(vectorRef, !vectorRef[index]);
         });
@@ -156,22 +165,27 @@ void BlockDirectory::addBlock(MarkedBlock::Handle* block)
     // This is the point at which the block learns of its cellSize() and attributes().
     block->didAddToDirectory(this, index);
     
-    setIsLive(NoLockingNecessary, index, true);
-    setIsEmpty(NoLockingNecessary, index, true);
+    setIsLive(index, true);
+    setIsEmpty(index, true);
+    dataLogLnIf(BlockDirectoryInternal::verbose, "Setting block ", index, " in use (addBlock) for ", *this);
+    setIsInUse(index, true);
 }
 
 void BlockDirectory::removeBlock(MarkedBlock::Handle* block, WillDeleteBlock willDelete)
 {
+    assertIsMutatorOrMutatorIsStopped();
     ASSERT(block->directory() == this);
     ASSERT(m_blocks[block->index()] == block);
+    ASSERT(isInUse(block));
     
     subspace()->didRemoveBlock(block->index());
     
     m_blocks[block->index()] = nullptr;
     m_freeBlockIndices.append(block->index());
     
+    releaseAssertAcquiredBitVectorLock();
+    Locker locker(bitvectorLock());
     forEachBitVector(
-        Locker { m_bitvectorLock },
         [&](auto vectorRef) {
             vectorRef[block->index()] = false;
         });
@@ -182,12 +196,21 @@ void BlockDirectory::removeBlock(MarkedBlock::Handle* block, WillDeleteBlock wil
 
 void BlockDirectory::stopAllocating()
 {
-    if (false)
-        dataLog(RawPointer(this), ": BlockDirectory::stopAllocating!\n");
+    dataLogLnIf(BlockDirectoryInternal::verbose, RawPointer(this), ": BlockDirectory::stopAllocating!");
     m_localAllocators.forEach(
         [&] (LocalAllocator* allocator) {
             allocator->stopAllocating();
         });
+
+#if ASSERT_ENABLED
+    assertIsMutatorOrMutatorIsStopped();
+    if (UNLIKELY(!inUseBitsView().isEmpty())) {
+        dataLogLn("Not all inUse bits are clear at stopAllocating");
+        dataLogLn(*this);
+        dumpBits();
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+#endif
 }
 
 void BlockDirectory::prepareForAllocation()
@@ -200,7 +223,8 @@ void BlockDirectory::prepareForAllocation()
     m_unsweptCursor = 0;
     m_emptyCursor = 0;
     
-    m_bits.eden().clearAll();
+    assertSweeperIsSuspended();
+    edenBits().clearAll();
 
     if (UNLIKELY(Options::useImmortalObjects())) {
         // FIXME: Make this work again.
@@ -211,8 +235,7 @@ void BlockDirectory::prepareForAllocation()
 
 void BlockDirectory::stopAllocatingForGood()
 {
-    if (false)
-        dataLog(RawPointer(this), ": BlockDirectory::stopAllocatingForGood!\n");
+    dataLogLnIf(BlockDirectoryInternal::verbose, RawPointer(this), ": BlockDirectory::stopAllocatingForGood!");
     
     m_localAllocators.forEach(
         [&] (LocalAllocator* allocator) {
@@ -234,6 +257,7 @@ void BlockDirectory::lastChanceToFinalize()
 
 void BlockDirectory::resumeAllocating()
 {
+    dataLogLnIf(BlockDirectoryInternal::verbose, RawPointer(this), ": BlockDirectory::resumeAllocating!");
     m_localAllocators.forEach(
         [&] (LocalAllocator* allocator) {
             allocator->resumeAllocating();
@@ -242,23 +266,37 @@ void BlockDirectory::resumeAllocating()
 
 void BlockDirectory::beginMarkingForFullCollection()
 {
+    assertSweeperIsSuspended();
+
     // Mark bits are sticky and so is our summary of mark bits. We only clear these during full
     // collections, so if you survived the last collection you will survive the next one so long
     // as the next one is eden.
-    m_bits.markingNotEmpty().clearAll();
-    m_bits.markingRetired().clearAll();
+    markingNotEmptyBits().clearAll();
+    markingRetiredBits().clearAll();
 }
 
 void BlockDirectory::endMarking()
 {
-    m_bits.allocated().clearAll();
+    assertSweeperIsSuspended();
+
+    allocatedBits().clearAll();
     
+#if ASSERT_ENABLED
+    if (UNLIKELY(!inUseBitsView().isEmpty())) {
+        dataLogLn("Block is inUse at end marking.");
+        dataLogLn(*this);
+        dumpBits();
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+#endif
+
     // It's surprising and frustrating to comprehend, but the end-of-marking flip does not need to
     // know what kind of collection it is. That knowledge is already encoded in the m_markingXYZ
     // vectors.
     
-    m_bits.empty() = m_bits.live() & ~m_bits.markingNotEmpty();
-    m_bits.canAllocateButNotEmpty() = m_bits.live() & m_bits.markingNotEmpty() & ~m_bits.markingRetired();
+    // Sweeper is suspended so we don't need the lock here.
+    emptyBits() = liveBits() & ~markingNotEmptyBits();
+    canAllocateButNotEmptyBits() = liveBits() & markingNotEmptyBits() & ~markingRetiredBits();
 
     if (needsDestruction()) {
         // There are some blocks that we didn't allocate out of in the last cycle, but we swept them. This
@@ -266,61 +304,121 @@ void BlockDirectory::endMarking()
         // destructors again. That's fine because of zapping. The only time when we cannot forget is when
         // we just allocate a block or when we move a block from one size class to another. That doesn't
         // happen here.
-        m_bits.destructible() = m_bits.live();
+        destructibleBits() = liveBits();
     }
     
-    if (false) {
-        dataLog("Bits for ", m_cellSize, ", ", m_attributes, " after endMarking:\n");
+    if (BlockDirectoryInternal::verbose) {
+        dataLogLn("Bits for ", m_cellSize, ", ", m_attributes, " after endMarking:");
         dumpBits(WTF::dataFile());
     }
 }
 
 void BlockDirectory::snapshotUnsweptForEdenCollection()
 {
-    m_bits.unswept() |= m_bits.eden();
+    assertSweeperIsSuspended();
+    unsweptBits() |= edenBits();
 }
 
 void BlockDirectory::snapshotUnsweptForFullCollection()
 {
-    m_bits.unswept() = m_bits.live();
+    assertSweeperIsSuspended();
+    unsweptBits() = liveBits();
 }
 
-MarkedBlock::Handle* BlockDirectory::findBlockToSweep()
+MarkedBlock::Handle* BlockDirectory::findBlockToSweep(unsigned& unsweptCursor)
 {
-    m_unsweptCursor = m_bits.unswept().findBit(m_unsweptCursor, true);
-    if (m_unsweptCursor >= m_blocks.size())
+    Locker locker(bitvectorLock());
+    unsweptCursor = (unsweptBits() & ~inUseBits()).findBit(unsweptCursor, true);
+    if (unsweptCursor >= m_blocks.size())
         return nullptr;
-    return m_blocks[m_unsweptCursor];
+    dataLogLnIf(BlockDirectoryInternal::verbose, "Setting block ", unsweptCursor, " in use (findBlockToSweep) for ", *this);
+    setIsInUse(unsweptCursor, true);
+    return m_blocks[unsweptCursor];
 }
 
 void BlockDirectory::sweep()
 {
-    m_bits.unswept().forEachSetBit(
-        [&] (size_t index) {
-            MarkedBlock::Handle* block = m_blocks[index];
+    // We need to be careful of a weird race where while we are sweeping a block
+    // the concurrent sweeper comes along and takes the inUse bit for a block
+    // in the same bit vector word as we're currently scanning. If we did't
+    // refresh our view into the word we could see stale data and try to scan
+    // a block already in use.
+
+    Locker locker(bitvectorLock());
+    for (size_t index = 0; index < m_blocks.size(); ++index) {
+        index = (unsweptBits() & ~inUseBits()).findBit(index, true);
+        if (index >= m_blocks.size())
+            break;
+
+        MarkedBlock::Handle* block = m_blocks[index];
+        ASSERT(!isInUse(index));
+        dataLogLnIf(BlockDirectoryInternal::verbose, "Setting block ", index, " in use (sweep) for ", *this);
+        setIsInUse(index, true);
+        {
+            DropLockForScope scope(locker);
             block->sweep(nullptr);
-        });
+        }
+        ASSERT(!isUnswept(index));
+        setIsInUse(index, false);
+    }
 }
 
 void BlockDirectory::shrink()
 {
-    (m_bits.empty() & ~m_bits.destructible()).forEachSetBit(
-        [&] (size_t index) {
+    // We need to be careful of a weird race where while we are sweeping a block
+    // the concurrent sweeper comes along and takes the inUse bit for a block
+    // in the same bit vector word as we're currently scanning. If we did't
+    // refresh our view into the word we could see stale data and try to scan
+    // a block already in use.
+
+    Locker locker(bitvectorLock());
+    for (size_t index = 0; index < m_blocks.size(); ++index) {
+        index = (emptyBits() & ~destructibleBits() & ~inUseBits()).findBit(index, true);
+        if (index >= m_blocks.size())
+            break;
+
+        ASSERT(!isInUse(index));
+        dataLogLnIf(BlockDirectoryInternal::verbose, "Setting block ", index, " in use (shrink) for ", *this);
+        setIsInUse(index, true);
+        {
+            DropLockForScope scope(locker);
             markedSpace().freeBlock(m_blocks[index]);
-        });
+        }
+        setIsInUse(index, false);
+    }
 }
 
 void BlockDirectory::assertNoUnswept()
 {
     if (!ASSERT_ENABLED)
         return;
-    
-    if (m_bits.unswept().isEmpty())
+
+    assertIsMutatorOrMutatorIsStopped();
+
+    if (unsweptBitsView().isEmpty())
         return;
     
     dataLog("Assertion failed: unswept not empty in ", *this, ".\n");
     dumpBits();
     ASSERT_NOT_REACHED();
+}
+
+void BlockDirectory::didFinishUsingBlock(MarkedBlock::Handle* handle)
+{
+    Locker locker(bitvectorLock());
+    didFinishUsingBlock(locker, handle);
+}
+
+void BlockDirectory::didFinishUsingBlock(AbstractLocker&, MarkedBlock::Handle* handle)
+{
+    if (UNLIKELY(!isInUse(handle))) {
+        dataLogLn("Finish using on a block that's not in use: ", handle->index());
+        dumpBits();
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    dataLogLnIf(BlockDirectoryInternal::verbose, "Setting block ", handle->index(), " not in use (didFinishUsingBlock) for ", *this);
+    setIsInUse(handle, false);
 }
 
 RefPtr<SharedTask<MarkedBlock::Handle*()>> BlockDirectory::parallelNotEmptyBlockSource()
@@ -337,6 +435,7 @@ RefPtr<SharedTask<MarkedBlock::Handle*()>> BlockDirectory::parallelNotEmptyBlock
             if (m_done)
                 return nullptr;
             Locker locker { m_lock };
+            m_directory.assertIsMutatorOrMutatorIsStopped();
             m_index = m_directory.m_bits.markingNotEmpty().findBit(m_index, true);
             if (m_index >= m_directory.m_blocks.size()) {
                 m_done = true;
@@ -364,7 +463,6 @@ void BlockDirectory::dumpBits(PrintStream& out)
 {
     unsigned maxNameLength = 0;
     forEachBitVectorWithName(
-        NoLockingNecessary,
         [&](auto vectorRef, const char* name) {
             UNUSED_PARAM(vectorRef);
             unsigned length = strlen(name);
@@ -372,7 +470,6 @@ void BlockDirectory::dumpBits(PrintStream& out)
         });
     
     forEachBitVectorWithName(
-        NoLockingNecessary,
         [&](auto vectorRef, const char* name) {
             out.print("    ", name, ": ");
             for (unsigned i = maxNameLength - strlen(name); i--;)
@@ -396,5 +493,24 @@ bool BlockDirectory::isFreeListedCell(const void* target)
     return result;
 }
 
+#if ASSERT_ENABLED
+void BlockDirectory::assertIsMutatorOrMutatorIsStopped() const
+{
+    auto& heap = markedSpace().heap();
+    if (!heap.worldIsStopped()) {
+        if (auto owner = heap.vm().apiLock().ownerThread())
+            ASSERT(owner->get() == &Thread::current());
+        else {
+            // FIXME: It feels like heap access should be tied to holding the API lock.
+            ASSERT(heap.hasAccess());
+        }
+    }
+}
+
+void BlockDirectory::assertSweeperIsSuspended() const
+{
+    assertIsMutatorOrMutatorIsStopped();
+}
+#endif
 } // namespace JSC
 

--- a/Source/JavaScriptCore/heap/BlockDirectory.h
+++ b/Source/JavaScriptCore/heap/BlockDirectory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -81,8 +81,8 @@ public:
 
     bool isFreeListedCell(const void* target);
 
-    template<typename Functor> void forEachBlock(const Functor&);
-    template<typename Functor> void forEachNotEmptyBlock(const Functor&);
+    inline void forEachBlock(const std::invocable<MarkedBlock::Handle*> auto&);
+    inline void forEachNotEmptyBlock(const std::invocable<MarkedBlock::Handle*> auto&);
     
     RefPtr<SharedTask<MarkedBlock::Handle*()>> parallelNotEmptyBlockSource();
     
@@ -93,18 +93,33 @@ public:
 
     void updatePercentageOfPagedOutPages(WTF::SimpleStats&);
     
+#if ASSERT_ENABLED
+    void assertIsMutatorOrMutatorIsStopped() const WTF_ASSERTS_ACQUIRED_SHARED_LOCK(m_bitvectorLock);
+    void assertSweeperIsSuspended() const WTF_ASSERTS_ACQUIRED_LOCK(m_bitvectorLock);
+#else
+    ALWAYS_INLINE void assertIsMutatorOrMutatorIsStopped() const WTF_ASSERTS_ACQUIRED_SHARED_LOCK(m_bitvectorLock) { }
+    ALWAYS_INLINE void assertSweeperIsSuspended() const WTF_ASSERTS_ACQUIRED_LOCK(m_bitvectorLock) { }
+#endif
+    // This feels like it shouldn't be needed to go from assertIsMutatorOrMutatorIsStopped -> Locker but Clang's seems to think it is necessary
+    // to release the capability.
+    ALWAYS_INLINE void releaseAssertAcquiredBitVectorLock() const WTF_RELEASES_SHARED_CAPABILITY(m_bitvectorLock) WTF_IGNORES_THREAD_SAFETY_ANALYSIS { }
+
     Lock& bitvectorLock() WTF_RETURNS_LOCK(m_bitvectorLock) { return m_bitvectorLock; }
 
 #define BLOCK_DIRECTORY_BIT_ACCESSORS(lowerBitName, capitalBitName)     \
-    bool is ## capitalBitName(const AbstractLocker&, size_t index) const { return m_bits.is ## capitalBitName(index); } \
-    bool is ## capitalBitName(const AbstractLocker& locker, MarkedBlock::Handle* block) const { return is ## capitalBitName(locker, block->index()); } \
-    void setIs ## capitalBitName(const AbstractLocker&, size_t index, bool value) { m_bits.setIs ## capitalBitName(index, value); } \
-    void setIs ## capitalBitName(const AbstractLocker& locker, MarkedBlock::Handle* block, bool value) { setIs ## capitalBitName(locker, block->index(), value); }
+    bool is ## capitalBitName(size_t index) const WTF_REQUIRES_SHARED_LOCK(m_bitvectorLock) { return m_bits.is ## capitalBitName(index); } \
+    bool is ## capitalBitName(MarkedBlock::Handle* block) const WTF_REQUIRES_SHARED_LOCK(m_bitvectorLock) { return is ## capitalBitName(block->index()); } \
+    BlockDirectoryBits::BlockDirectoryBitVectorView<BlockDirectoryBits::Kind::capitalBitName> lowerBitName ## BitsView() const WTF_REQUIRES_SHARED_LOCK(m_bitvectorLock) { return m_bits.lowerBitName(); } \
+    \
+    void setIs ## capitalBitName(size_t index, bool value) WTF_REQUIRES_LOCK(m_bitvectorLock) { m_bits.setIs ## capitalBitName(index, value); } \
+    void setIs ## capitalBitName(MarkedBlock::Handle* block, bool value) WTF_REQUIRES_LOCK(m_bitvectorLock) { setIs ## capitalBitName(block->index(), value); } \
+    BlockDirectoryBits::BlockDirectoryBitVectorRef<BlockDirectoryBits::Kind::capitalBitName> lowerBitName ## Bits() WTF_REQUIRES_LOCK(m_bitvectorLock) { return m_bits.lowerBitName(); }
+
     FOR_EACH_BLOCK_DIRECTORY_BIT(BLOCK_DIRECTORY_BIT_ACCESSORS)
 #undef BLOCK_DIRECTORY_BIT_ACCESSORS
 
     template<typename Func>
-    void forEachBitVector(const AbstractLocker&, const Func& func)
+    void forEachBitVector(const Func& func) WTF_REQUIRES_LOCK(m_bitvectorLock)
     {
 #define BLOCK_DIRECTORY_BIT_CALLBACK(lowerBitName, capitalBitName) \
         func(m_bits.lowerBitName());
@@ -113,7 +128,7 @@ public:
     }
     
     template<typename Func>
-    void forEachBitVectorWithName(const AbstractLocker&, const Func& func)
+    void forEachBitVectorWithName(const Func& func) const WTF_REQUIRES_SHARED_LOCK(m_bitvectorLock)
     {
 #define BLOCK_DIRECTORY_BIT_CALLBACK(lowerBitName, capitalBitName) \
         func(m_bits.lowerBitName(), #capitalBitName);
@@ -131,14 +146,18 @@ public:
     
     MarkedBlock::Handle* findEmptyBlockToSteal();
     
-    MarkedBlock::Handle* findBlockToSweep();
+    MarkedBlock::Handle* findBlockToSweep() { return findBlockToSweep(m_unsweptCursor); }
+    MarkedBlock::Handle* findBlockToSweep(unsigned& unsweptCursor);
     
+    void didFinishUsingBlock(MarkedBlock::Handle*);
+    void didFinishUsingBlock(AbstractLocker&, MarkedBlock::Handle*) WTF_REQUIRES_LOCK(m_bitvectorLock);
+
     Subspace* subspace() const { return m_subspace; }
     MarkedSpace& markedSpace() const;
     
     void dump(PrintStream&) const;
-    void dumpBits(PrintStream& = WTF::dataFile());
-    
+    void dumpBits(PrintStream& = WTF::dataFile()) WTF_REQUIRES_SHARED_LOCK(m_bitvectorLock);
+
 private:
     friend class IsoCellSet;
     friend class LocalAllocator;
@@ -154,7 +173,7 @@ private:
 
     // Mutator uses this to guard resizing the bitvectors. Those things in the GC that may run
     // concurrently to the mutator must lock this when accessing the bitvectors.
-    BlockDirectoryBits m_bits;
+    BlockDirectoryBits m_bits WTF_GUARDED_BY_LOCK(m_bitvectorLock); // Don't access this directly use one of the accessors above.
     Lock m_bitvectorLock;
     Lock m_localAllocatorsLock;
     CellAttributes m_attributes;

--- a/Source/JavaScriptCore/heap/BlockDirectoryBits.h
+++ b/Source/JavaScriptCore/heap/BlockDirectoryBits.h
@@ -34,12 +34,13 @@ namespace JSC {
 
 #define FOR_EACH_BLOCK_DIRECTORY_BIT(macro) \
     macro(live, Live) /* The set of block indices that have actual blocks. */\
-    macro(empty, Empty) /* The set of all blocks that have no live objects. */ \
+    macro(empty, Empty) /* The set of all blocks that have no live objects and are not free listed. */ \
     macro(allocated, Allocated) /* The set of all blocks that are full of live objects. */\
     macro(canAllocateButNotEmpty, CanAllocateButNotEmpty) /* The set of all blocks are neither empty nor retired (i.e. are more than minMarkedBlockUtilization full). */ \
     macro(destructible, Destructible) /* The set of all blocks that may have destructors to run. */\
     macro(eden, Eden) /* The set of all blocks that have new objects since the last GC. */\
     macro(unswept, Unswept) /* The set of all blocks that could be swept by the incremental sweeper. */\
+    macro(inUse, InUse) /* This tells us if a block is currently being allocated from or swept. This acts like a lock bit. */\
     \
     /* These are computed during marking. */\
     macro(markingNotEmpty, MarkingNotEmpty) /* The set of all blocks that are not empty. */ \

--- a/Source/JavaScriptCore/heap/BlockDirectoryInlines.h
+++ b/Source/JavaScriptCore/heap/BlockDirectoryInlines.h
@@ -31,17 +31,19 @@
 
 namespace JSC {
 
-template <typename Functor> inline void BlockDirectory::forEachBlock(const Functor& functor)
+inline void BlockDirectory::forEachBlock(const std::invocable<MarkedBlock::Handle*> auto& functor)
 {
-    m_bits.live().forEachSetBit(
+    assertIsMutatorOrMutatorIsStopped();
+    liveBitsView().forEachSetBit(
         [&] (size_t index) {
             functor(m_blocks[index]);
         });
 }
 
-template <typename Functor> inline void BlockDirectory::forEachNotEmptyBlock(const Functor& functor)
+inline void BlockDirectory::forEachNotEmptyBlock(const std::invocable<MarkedBlock::Handle*> auto& functor)
 {
-    m_bits.markingNotEmpty().forEachSetBit(
+    assertIsMutatorOrMutatorIsStopped();
+    markingNotEmptyBitsView().forEachSetBit(
         [&] (size_t index) {
             functor(m_blocks[index]);
         });

--- a/Source/JavaScriptCore/heap/HeapIterationScope.h
+++ b/Source/JavaScriptCore/heap/HeapIterationScope.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,6 +43,10 @@ private:
 inline HeapIterationScope::HeapIterationScope(JSC::Heap& heap)
     : m_heap(heap)
 {
+    // FIXME: It would be nice to assert we're holding the API lock when iterating the heap so we know no other thread is mutating the heap
+    // but adding `ASSERT_WITH_MESSAGE(heap.vm().currentThreadIsHoldingAPILock(), "Trying to iterate the JS heap without the API lock");`
+    // causes spurious crashes since the only thing technically needed is just heap.hasAccess() but that doesn't verify this thread is
+    // the one with access only that *some* thread has access.
     m_heap.willStartIterating();
 }
 

--- a/Source/JavaScriptCore/heap/IsoCellSet.cpp
+++ b/Source/JavaScriptCore/heap/IsoCellSet.cpp
@@ -59,8 +59,9 @@ Ref<SharedTask<MarkedBlock::Handle*()>> IsoCellSet::parallelNotEmptyMarkedBlockS
         {
             if (m_done)
                 return nullptr;
+            m_directory.assertIsMutatorOrMutatorIsStopped();
             Locker locker { m_lock };
-            auto bits = m_directory.m_bits.markingNotEmpty() & m_set.m_blocksWithBits;
+            auto bits = m_directory.markingNotEmptyBitsView() & m_set.m_blocksWithBits;
             m_index = bits.findBit(m_index, true);
             if (m_index >= m_directory.m_blocks.size()) {
                 m_done = true;

--- a/Source/JavaScriptCore/heap/IsoCellSetInlines.h
+++ b/Source/JavaScriptCore/heap/IsoCellSetInlines.h
@@ -78,7 +78,8 @@ template<typename Func>
 void IsoCellSet::forEachMarkedCell(const Func& func)
 {
     BlockDirectory& directory = m_subspace.m_directory;
-    (directory.m_bits.markingNotEmpty() & m_blocksWithBits).forEachSetBit(
+    directory.assertIsMutatorOrMutatorIsStopped();
+    (directory.markingNotEmptyBitsView() & m_blocksWithBits).forEachSetBit(
         [&] (unsigned blockIndex) {
             MarkedBlock::Handle* block = directory.m_blocks[blockIndex];
 

--- a/Source/JavaScriptCore/heap/MarkedBlock.cpp
+++ b/Source/JavaScriptCore/heap/MarkedBlock.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -107,6 +107,7 @@ void MarkedBlock::Handle::unsweepWithNoNewlyAllocated()
 {
     RELEASE_ASSERT(m_isFreeListed);
     m_isFreeListed = false;
+    m_directory->didFinishUsingBlock(this);
 }
 
 void MarkedBlock::Handle::stopAllocating(const FreeList& freeList)
@@ -115,7 +116,8 @@ void MarkedBlock::Handle::stopAllocating(const FreeList& freeList)
     
     if (MarkedBlockInternal::verbose)
         dataLog(RawPointer(this), ": MarkedBlock::Handle::stopAllocating!\n");
-    ASSERT(!directory()->isAllocated(NoLockingNecessary, this));
+    m_directory->assertIsMutatorOrMutatorIsStopped();
+    ASSERT(!m_directory->isAllocated(this));
 
     if (!isFreeListed()) {
         if (MarkedBlockInternal::verbose)
@@ -152,29 +154,37 @@ void MarkedBlock::Handle::stopAllocating(const FreeList& freeList)
         });
     
     m_isFreeListed = false;
+    directory()->didFinishUsingBlock(this);
 }
 
 void MarkedBlock::Handle::lastChanceToFinalize()
 {
-    directory()->setIsAllocated(NoLockingNecessary, this, false);
-    directory()->setIsDestructible(NoLockingNecessary, this, true);
+    // Concurrent sweeper is shut down at this point.
+    m_directory->assertSweeperIsSuspended();
+    m_directory->setIsAllocated(this, false);
+    m_directory->setIsDestructible(this, true);
     blockHeader().m_marks.clearAll();
     block().clearHasAnyMarked();
     blockHeader().m_markingVersion = heap()->objectSpace().markingVersion();
     m_weakSet.lastChanceToFinalize();
     blockHeader().m_newlyAllocated.clearAll();
     blockHeader().m_newlyAllocatedVersion = heap()->objectSpace().newlyAllocatedVersion();
+    m_directory->setIsInUse(this, true);
     sweep(nullptr);
 }
 
 void MarkedBlock::Handle::resumeAllocating(FreeList& freeList)
 {
+    BlockDirectory* directory = this->directory();
+    directory->assertSweeperIsSuspended();
     {
         Locker locker { blockHeader().m_lock };
         
         if (MarkedBlockInternal::verbose)
             dataLog(RawPointer(this), ": MarkedBlock::Handle::resumeAllocating!\n");
-        ASSERT(!directory()->isAllocated(NoLockingNecessary, this));
+
+
+        ASSERT(!directory->isAllocated(this));
         ASSERT(!isFreeListed());
         
         if (!block().hasAnyNewlyAllocated()) {
@@ -185,6 +195,8 @@ void MarkedBlock::Handle::resumeAllocating(FreeList& freeList)
             return;
         }
     }
+
+    directory->setIsInUse(this, true);
 
     // Re-create our free list from before stopping allocation. Note that this may return an empty
     // freelist, in which case the block will still be Marked!
@@ -200,9 +212,13 @@ void MarkedBlock::aboutToMarkSlow(HeapVersion markingVersion)
         return;
     
     BlockDirectory* directory = handle().directory();
+    bool isAllocated;
+    {
+        Locker bitLocker { directory->bitvectorLock() };
+        isAllocated = directory->isAllocated(&handle());
+    }
 
-    if (handle().directory()->isAllocated(Locker { directory->bitvectorLock() }, &handle())
-        || !marksConveyLivenessDuringMarking(markingVersion)) {
+    if (isAllocated || !marksConveyLivenessDuringMarking(markingVersion)) {
         if (MarkedBlockInternal::verbose)
             dataLog(RawPointer(this), ": Clearing marks without doing anything else.\n");
         // We already know that the block is full and is already recognized as such, or that the
@@ -241,7 +257,8 @@ void MarkedBlock::aboutToMarkSlow(HeapVersion markingVersion)
 #pragma clang diagnostic ignored "-Wthread-safety-analysis"
 #endif
     // This means we're the first ones to mark any object in this block.
-    directory->setIsMarkingNotEmpty(Locker { directory->bitvectorLock() }, &handle(), true);
+    Locker bitLocker { directory->bitvectorLock() };
+    directory->setIsMarkingNotEmpty(&handle(), true);
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif
@@ -295,7 +312,9 @@ void MarkedBlock::Handle::didConsumeFreeList()
         dataLog(RawPointer(this), ": MarkedBlock::Handle::didConsumeFreeList!\n");
     ASSERT(isFreeListed());
     m_isFreeListed = false;
-    directory()->setIsAllocated(NoLockingNecessary, this, true);
+    Locker bitLocker(m_directory->bitvectorLock());
+    m_directory->setIsAllocated(this, true);
+    m_directory->didFinishUsingBlock(bitLocker, this);
 }
 
 size_t MarkedBlock::markCount()
@@ -311,7 +330,8 @@ void MarkedBlock::clearHasAnyMarked()
 void MarkedBlock::noteMarkedSlow()
 {
     BlockDirectory* directory = handle().directory();
-    directory->setIsMarkingRetired(Locker { directory->bitvectorLock() }, &handle(), true);
+    Locker locker { directory->bitvectorLock() };
+    directory->setIsMarkingRetired(&handle(), true);
 }
 
 void MarkedBlock::Handle::removeFromDirectory()
@@ -380,8 +400,8 @@ void MarkedBlock::assertValidCell(VM& vm, HeapCell* cell) const
 void MarkedBlock::Handle::dumpState(PrintStream& out)
 {
     CommaPrinter comma;
+    Locker locker { directory()->bitvectorLock() };
     directory()->forEachBitVectorWithName(
-        Locker { directory()->bitvectorLock() },
         [&](auto vectorRef, const char* name) {
             out.print(comma, name, ":"_s, vectorRef[index()] ? "YES"_s : "no"_s);
         });
@@ -395,18 +415,23 @@ Subspace* MarkedBlock::Handle::subspace() const
 void MarkedBlock::Handle::sweep(FreeList* freeList)
 {
     SweepingScope sweepingScope(*heap());
-    
-    SweepMode sweepMode = freeList ? SweepToFreeList : SweepOnly;
-    
-    m_directory->setIsUnswept(NoLockingNecessary, this, false);
-    
-    m_weakSet.sweep();
-    
-    bool needsDestruction = m_attributes.destruction == NeedsDestruction
-        && m_directory->isDestructible(NoLockingNecessary, this);
+    m_directory->assertIsMutatorOrMutatorIsStopped();
+    ASSERT(m_directory->isInUse(this));
 
-    if (sweepMode == SweepOnly && !needsDestruction)
+    SweepMode sweepMode = freeList ? SweepToFreeList : SweepOnly;
+    bool needsDestruction = m_attributes.destruction == NeedsDestruction
+        && m_directory->isDestructible(this);
+
+    m_weakSet.sweep();
+
+    // If we don't "release" our read access without locking then the ThreadSafetyAnalysis code gets upset with the locker below.
+    m_directory->releaseAssertAcquiredBitVectorLock();
+
+    if (sweepMode == SweepOnly && !needsDestruction) {
+        Locker locker(m_directory->bitvectorLock());
+        m_directory->setIsUnswept(this, false);
         return;
+    }
 
     if (m_isFreeListed) {
         dataLog("FATAL: ", RawPointer(this), "->sweep: block is free-listed.\n");

--- a/Source/JavaScriptCore/heap/MarkedBlock.h
+++ b/Source/JavaScriptCore/heap/MarkedBlock.h
@@ -231,8 +231,6 @@ public:
         template<bool, EmptyMode, SweepMode, SweepDestructionMode, ScribbleMode, NewlyAllocatedMode, MarksMode, typename DestroyFunc>
         void specializedSweep(FreeList*, EmptyMode, SweepMode, SweepDestructionMode, ScribbleMode, NewlyAllocatedMode, MarksMode, const DestroyFunc&);
         
-        void setIsFreeListed();
-        
         unsigned m_atomsPerCell { std::numeric_limits<unsigned>::max() };
         unsigned m_startAtom { std::numeric_limits<unsigned>::max() }; // Exact location of the first allocatable atom.
             

--- a/Source/JavaScriptCore/heap/MarkedBlockInlines.h
+++ b/Source/JavaScriptCore/heap/MarkedBlockInlines.h
@@ -93,12 +93,14 @@ inline bool MarkedBlock::marksConveyLivenessDuringMarking(HeapVersion myMarkingV
 
 inline bool MarkedBlock::Handle::isAllocated()
 {
-    return m_directory->isAllocated(NoLockingNecessary, this);
+    m_directory->assertIsMutatorOrMutatorIsStopped();
+    return m_directory->isAllocated(this);
 }
 
 ALWAYS_INLINE bool MarkedBlock::Handle::isLive(HeapVersion markingVersion, HeapVersion newlyAllocatedVersion, bool isMarking, const HeapCell* cell)
 {
-    if (directory()->isAllocated(NoLockingNecessary, this))
+    m_directory->assertIsMutatorOrMutatorIsStopped();
+    if (m_directory->isAllocated(this))
         return true;
 
     // We need to do this while holding the lock because marks might be stale. In that case, newly
@@ -284,7 +286,17 @@ void MarkedBlock::Handle::specializedSweep(FreeList* freeList, MarkedBlock::Hand
         }
     };
 
-    m_directory->setIsDestructible(NoLockingNecessary, this, false);
+    auto setBits = [&] (bool isEmpty) ALWAYS_INLINE_LAMBDA {
+        Locker locker { m_directory->bitvectorLock() };
+        m_directory->setIsUnswept(this, false);
+        m_directory->setIsDestructible(this, false);
+        m_directory->setIsEmpty(this, false);
+        if (sweepMode == SweepToFreeList)
+            m_isFreeListed = true;
+        else if (isEmpty)
+            m_directory->setIsEmpty(this, true);
+    };
+    UNUSED_PARAM(setBits);
 
     if (Options::useBumpAllocator()
         && emptyMode == IsEmpty
@@ -306,8 +318,7 @@ void MarkedBlock::Handle::specializedSweep(FreeList* freeList, MarkedBlock::Hand
         char* payloadBegin = bitwise_cast<char*>(block.atoms() + m_startAtom);
         RELEASE_ASSERT(static_cast<size_t>(payloadEnd - payloadBegin) <= payloadSize, payloadBegin, payloadEnd, &block, cellSize, m_startAtom);
 
-        if (sweepMode == SweepToFreeList)
-            setIsFreeListed();
+        setBits(true);
         if (space()->isMarking())
             header.m_lock.unlock();
         if (destructionMode != BlockHasNoDestructors) {
@@ -417,11 +428,10 @@ void MarkedBlock::Handle::specializedSweep(FreeList* freeList, MarkedBlock::Hand
         checkForFinalInterval();
     }
 
-    if (sweepMode == SweepToFreeList) {
+    if (sweepMode == SweepToFreeList)
         freeList->initialize(head, secret, freedBytes);
-        setIsFreeListed();
-    } else if (isEmpty)
-        m_directory->setIsEmpty(NoLockingNecessary, this, true);
+    setBits(isEmpty);
+
     if (false)
         dataLog("Slowly swept block ", RawPointer(&block), " with cell size ", cellSize, " and attributes ", m_attributes, ": ", pointerDump(freeList), "\n");
 }
@@ -514,7 +524,8 @@ inline MarkedBlock::Handle::SweepDestructionMode MarkedBlock::Handle::sweepDestr
 
 inline bool MarkedBlock::Handle::isEmpty()
 {
-    return m_directory->isEmpty(NoLockingNecessary, this);
+    m_directory->assertIsMutatorOrMutatorIsStopped();
+    return m_directory->isEmpty(this);
 }
 
 inline MarkedBlock::Handle::EmptyMode MarkedBlock::Handle::emptyMode()
@@ -544,12 +555,6 @@ inline MarkedBlock::Handle::MarksMode MarkedBlock::Handle::marksMode()
     if (space()->isMarking())
         marksAreUseful |= block().marksConveyLivenessDuringMarking(markingVersion);
     return marksAreUseful ? MarksNotStale : MarksStale;
-}
-
-inline void MarkedBlock::Handle::setIsFreeListed()
-{
-    m_directory->setIsEmpty(NoLockingNecessary, this, false);
-    m_isFreeListed = true;
 }
 
 template <typename Functor>

--- a/Source/JavaScriptCore/heap/MarkedSpace.cpp
+++ b/Source/JavaScriptCore/heap/MarkedSpace.cpp
@@ -559,6 +559,7 @@ void MarkedSpace::dumpBits(PrintStream& out)
 {
     forEachDirectory(
         [&] (BlockDirectory& directory) -> IterationStatus {
+            directory.assertIsMutatorOrMutatorIsStopped();
             out.print("Bits for ", directory, ":\n");
             directory.dumpBits(out);
             return IterationStatus::Continue;


### PR DESCRIPTION
#### 58b937859832c12a4df62a2486ee23ccca6a5cb6
<pre>
[JSC] Add Concurrent Sweeping Locking
<a href="https://bugs.webkit.org/show_bug.cgi?id=275085">https://bugs.webkit.org/show_bug.cgi?id=275085</a>
<a href="https://rdar.apple.com/problem/129194601">rdar://problem/129194601</a>

Reviewed by Yusuke Suzuki.

This patch updates the various parts needed for BlockDirectory to work with
concurrent sweeping.

To make sure the future sweeper thread and the mutator don&apos;t clobber each other this patch
adds a new bit to BlockDirectory that tracks when a MarkedBlock is &quot;in use&quot;. Being in
use means that the MarkedBlock is actively being swept or allocated out of. Additionally,
we need to make sure that we don&apos;t see a tear when updating the BlockDirectory bits. This is done by
holding the BlockDirectory&apos;s bit vector lock when reading/writing the following bit fields:

1) empty
2) destructable
3) unswept
4) inUse

To help make the locking mechanism for BlockDirectoryBits more clear this patch adds support for
Clang&apos;s thread safety analysis tooling with some special tricks for reading/writing. Specifically,
this patch adds assertIsMutatorOrMutatorIsStopped that tells the thread safety analysis m_bitvectorLock
is acquired in as a shared lock (despite m_bitvectorLock being an exclusive lock) when reading from m_bits is
race-safe. The read-only accessors for m_bits take the &quot;shared&quot; lock so Clang is happy. For cases where
writing is race-free there is assertSweeperIsSuspended which &quot;assert acquires&quot; m_bitvectorLock and allows
access to the mutating accessors of m_bits.

Note, the concurrent sweeper doesn&apos;t sweep weak blocks because it&apos;s not thread safe to do so.
This is ok though because when the main thread goes to allocate out of a marked block it always does
another sweep to build the free list, which will clear these weak impls.

Lastly, this patch adds an assertion to HeapIterationScope that the current thread is holding the API
lock. It&apos;s expected the JS isn&apos;t running concurrently to HeapIterationScope so this shouldn&apos;t be an
issue.

* Source/JavaScriptCore/heap/BlockDirectory.cpp:
(JSC::BlockDirectory::findEmptyBlockToSteal):
(JSC::BlockDirectory::findBlockForAllocation):
(JSC::BlockDirectory::tryAllocateBlock):
(JSC::BlockDirectory::addBlock):
(JSC::BlockDirectory::removeBlock):
(JSC::BlockDirectory::stopAllocating):
(JSC::BlockDirectory::prepareForAllocation):
(JSC::BlockDirectory::stopAllocatingForGood):
(JSC::BlockDirectory::resumeAllocating):
(JSC::BlockDirectory::beginMarkingForFullCollection):
(JSC::BlockDirectory::endMarking):
(JSC::BlockDirectory::snapshotUnsweptForEdenCollection):
(JSC::BlockDirectory::snapshotUnsweptForFullCollection):
(JSC::BlockDirectory::findBlockToSweep):
(JSC::BlockDirectory::sweep):
(JSC::BlockDirectory::shrink):
(JSC::BlockDirectory::assertNoUnswept):
(JSC::BlockDirectory::didFinishUsingBlock):
(JSC::BlockDirectory::parallelNotEmptyBlockSource):
(JSC::BlockDirectory::dumpBits):
(JSC::BlockDirectory::assertIsMutatorOrMutatorIsStopped const):
(JSC::BlockDirectory::assertSweeperIsSuspended const):
* Source/JavaScriptCore/heap/BlockDirectory.h:
(JSC::BlockDirectory::WTF_ASSERTS_ACQUIRED_SHARED_LOCK):
(JSC::BlockDirectory::WTF_ASSERTS_ACQUIRED_LOCK):
(JSC::BlockDirectory::WTF_REQUIRES_LOCK):
(JSC::BlockDirectory::WTF_REQUIRES_SHARED_LOCK):
(JSC::BlockDirectory::findBlockToSweep):
(JSC::BlockDirectory::forEachBitVector): Deleted.
(JSC::BlockDirectory::forEachBitVectorWithName): Deleted.
* Source/JavaScriptCore/heap/BlockDirectoryBits.h:
* Source/JavaScriptCore/heap/BlockDirectoryInlines.h:
(JSC::BlockDirectory::forEachBlock):
(JSC::BlockDirectory::forEachNotEmptyBlock):
* Source/JavaScriptCore/heap/HeapIterationScope.h:
(JSC::HeapIterationScope::HeapIterationScope):
* Source/JavaScriptCore/heap/IncrementalSweeper.cpp:
(JSC::IncrementalSweeper::sweepNextBlock):
* Source/JavaScriptCore/heap/IsoCellSet.cpp:
(JSC::IsoCellSet::parallelNotEmptyMarkedBlockSource):
* Source/JavaScriptCore/heap/IsoCellSetInlines.h:
(JSC::IsoCellSet::forEachMarkedCell):
* Source/JavaScriptCore/heap/LocalAllocator.cpp:
(JSC::LocalAllocator::tryAllocateIn):
* Source/JavaScriptCore/heap/MarkedBlock.cpp:
(JSC::MarkedBlock::Handle::unsweepWithNoNewlyAllocated):
(JSC::MarkedBlock::Handle::stopAllocating):
(JSC::MarkedBlock::Handle::lastChanceToFinalize):
(JSC::MarkedBlock::Handle::resumeAllocating):
(JSC::MarkedBlock::aboutToMarkSlow):
(JSC::MarkedBlock::Handle::didConsumeFreeList):
(JSC::MarkedBlock::noteMarkedSlow):
(JSC::MarkedBlock::Handle::dumpState):
(JSC::MarkedBlock::Handle::sweep):
* Source/JavaScriptCore/heap/MarkedBlock.h:
* Source/JavaScriptCore/heap/MarkedBlockInlines.h:
(JSC::MarkedBlock::Handle::isAllocated):
(JSC::MarkedBlock::Handle::isLive):
(JSC::MarkedBlock::Handle::specializedSweep):
(JSC::MarkedBlock::Handle::isEmpty):
(JSC::MarkedBlock::Handle::setIsFreeListed): Deleted.
* Source/JavaScriptCore/heap/MarkedSpace.cpp:
(JSC::MarkedSpace::dumpBits):
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp:
(Inspector::InspectorDebuggerAgent::addSymbolicBreakpoint):
* Source/JavaScriptCore/llint/LLIntOffsetsExtractor.cpp:
* Source/WebCore/page/PerformanceLogging.cpp:

Canonical link: <a href="https://commits.webkit.org/279861@main">https://commits.webkit.org/279861@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4820847feed88c051005756f79eba356476d9b2b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58044 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5497 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5510 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44357 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3713 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56860 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32327 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47443 "Found 1 new API test failure: TestWebKitAPI.GPUProcess.ExitsUnderMemoryPressureCanvasCase (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25481 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29117 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4781 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3638 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/48133 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50901 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4998 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59634 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/54271 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30011 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5143 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51779 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31153 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47526 "Build is in progress. Recent messages:OS: Ventura (13.6.6), Xcode: 14.3; Running apply-patch; Checked out pull request; Skipped layout-tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51182 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12028 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32160 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/66567 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30940 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12687 "Passed tests") | 
<!--EWS-Status-Bubble-End-->