### PR TITLE
Remove unused SVG attribute names from `svgattrs.in`

### DIFF
--- a/Source/WebCore/svg/svgattrs.in
+++ b/Source/WebCore/svg/svgattrs.in
@@ -2,11 +2,9 @@ namespace="SVG"
 namespaceURI="http://www.w3.org/2000/svg"
 attrsNullNamespace
 
-accent-height
 accumulate
 additive
 alignment-baseline
-alphabetic
 amplitude
 animate
 arabic-form
@@ -18,7 +16,6 @@ azimuth
 baseFrequency
 baseline-shift
 baseProfile
-bbox
 begin
 bias
 buffered-rendering
@@ -76,13 +73,11 @@ glyph-orientation-vertical
 glyphRef
 gradientTransform
 gradientUnits
-hanging
 height
 horiz-adv-x
 horiz-origin-x
 horiz-origin-y
 href
-ideographic
 image-rendering
 in
 in2
@@ -114,7 +109,6 @@ mask
 mask-type
 maskContentUnits
 maskUnits
-mathematical
 max
 media
 method
@@ -130,11 +124,8 @@ opacity
 operator
 order
 orient
-orientation
 origin
 overflow
-overline-position
-overline-thickness
 paint-order
 panose-1
 path
@@ -155,7 +146,6 @@ radius
 refX
 refY
 rel
-rendering-intent
 repeatCount
 repeatDur
 requiredExtensions
@@ -175,13 +165,9 @@ specularExponent
 spreadMethod
 startOffset
 stdDeviation
-stemh
-stemv
 stitchTiles
 stop-color
 stop-opacity
-strikethrough-position
-strikethrough-thickness
 stroke
 stroke-dasharray
 stroke-dashoffset
@@ -208,16 +194,9 @@ transform-origin
 type
 u1
 u2
-underline-position
-underline-thickness
 unicode
 unicode-bidi
-unicode-range
 units-per-em
-v-alphabetic
-v-hanging
-v-ideographic
-v-mathematical
 values
 vector-effect
 version
@@ -228,7 +207,6 @@ viewBox
 viewTarget
 visibility
 width
-widths
 word-spacing
 writing-mode
 x


### PR DESCRIPTION
#### 602836ee3e934096c4388617e77f46edeca0ed63
<pre>
Remove unused SVG attribute names from `svgattrs.in`

<a href="https://bugs.webkit.org/show_bug.cgi?id=275292">https://bugs.webkit.org/show_bug.cgi?id=275292</a>

Reviewed by Darin Adler.

Merge: <a href="https://github.com/chromium/chromium/commit/f0f63cf75081fe88ac8713ff32296bdc765bf836">https://github.com/chromium/chromium/commit/f0f63cf75081fe88ac8713ff32296bdc765bf836</a>

This patch remove unused attribute names, which were
never implemented and added back around 2005, during
the original import of KSVG2 import [1]:

[1] <a href="https://commits.webkit.org/8394@main">https://commits.webkit.org/8394@main</a>

* Source/WebCore/svg/svgattrs.in:

Canonical link: <a href="https://commits.webkit.org/279858@main">https://commits.webkit.org/279858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1359d8933a2df1537d1f5d3945df6f96e4be1d32

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58034 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5487 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57056 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41730 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5500 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44347 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3703 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56850 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32311 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47433 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25471 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29101 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4771 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3628 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50899 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/4988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59624 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30001 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5130 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51769 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31143 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51165 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32147 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8105 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30930 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->