### PR TITLE
[SVG] Handle `repeatEvent` for svg animations

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/onrepeat-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/onrepeat-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT 'onrepeat' event handler content attribute Test timed out
+PASS 'onrepeat' event handler content attribute
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/repeat-event-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/repeat-event-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Animation triggers on 'repeatEvent' Test timed out
+PASS Animation triggers on 'repeatEvent'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt
@@ -1638,7 +1638,7 @@ PASS SVGAnimationElement interface: existence and properties of interface protot
 PASS SVGAnimationElement interface: attribute targetElement
 FAIL SVGAnimationElement interface: attribute onbegin assert_true: The prototype object must have a property "onbegin" expected true got false
 FAIL SVGAnimationElement interface: attribute onend assert_true: The prototype object must have a property "onend" expected true got false
-FAIL SVGAnimationElement interface: attribute onrepeat assert_true: The prototype object must have a property "onrepeat" expected true got false
+PASS SVGAnimationElement interface: attribute onrepeat
 PASS SVGAnimationElement interface: operation getStartTime()
 PASS SVGAnimationElement interface: operation getCurrentTime()
 PASS SVGAnimationElement interface: operation getSimpleDuration()
@@ -1659,7 +1659,7 @@ PASS Stringification of objects.animate
 PASS SVGAnimationElement interface: objects.animate must inherit property "targetElement" with the proper type
 FAIL SVGAnimationElement interface: objects.animate must inherit property "onbegin" with the proper type assert_inherits: property "onbegin" not found in prototype chain
 FAIL SVGAnimationElement interface: objects.animate must inherit property "onend" with the proper type assert_inherits: property "onend" not found in prototype chain
-FAIL SVGAnimationElement interface: objects.animate must inherit property "onrepeat" with the proper type assert_inherits: property "onrepeat" not found in prototype chain
+PASS SVGAnimationElement interface: objects.animate must inherit property "onrepeat" with the proper type
 PASS SVGAnimationElement interface: objects.animate must inherit property "getStartTime()" with the proper type
 PASS SVGAnimationElement interface: objects.animate must inherit property "getCurrentTime()" with the proper type
 PASS SVGAnimationElement interface: objects.animate must inherit property "getSimpleDuration()" with the proper type
@@ -1687,7 +1687,7 @@ PASS Stringification of objects.set
 PASS SVGAnimationElement interface: objects.set must inherit property "targetElement" with the proper type
 FAIL SVGAnimationElement interface: objects.set must inherit property "onbegin" with the proper type assert_inherits: property "onbegin" not found in prototype chain
 FAIL SVGAnimationElement interface: objects.set must inherit property "onend" with the proper type assert_inherits: property "onend" not found in prototype chain
-FAIL SVGAnimationElement interface: objects.set must inherit property "onrepeat" with the proper type assert_inherits: property "onrepeat" not found in prototype chain
+PASS SVGAnimationElement interface: objects.set must inherit property "onrepeat" with the proper type
 PASS SVGAnimationElement interface: objects.set must inherit property "getStartTime()" with the proper type
 PASS SVGAnimationElement interface: objects.set must inherit property "getCurrentTime()" with the proper type
 PASS SVGAnimationElement interface: objects.set must inherit property "getSimpleDuration()" with the proper type
@@ -1715,7 +1715,7 @@ PASS Stringification of objects.animateMotion
 PASS SVGAnimationElement interface: objects.animateMotion must inherit property "targetElement" with the proper type
 FAIL SVGAnimationElement interface: objects.animateMotion must inherit property "onbegin" with the proper type assert_inherits: property "onbegin" not found in prototype chain
 FAIL SVGAnimationElement interface: objects.animateMotion must inherit property "onend" with the proper type assert_inherits: property "onend" not found in prototype chain
-FAIL SVGAnimationElement interface: objects.animateMotion must inherit property "onrepeat" with the proper type assert_inherits: property "onrepeat" not found in prototype chain
+PASS SVGAnimationElement interface: objects.animateMotion must inherit property "onrepeat" with the proper type
 PASS SVGAnimationElement interface: objects.animateMotion must inherit property "getStartTime()" with the proper type
 PASS SVGAnimationElement interface: objects.animateMotion must inherit property "getCurrentTime()" with the proper type
 PASS SVGAnimationElement interface: objects.animateMotion must inherit property "getSimpleDuration()" with the proper type
@@ -1758,7 +1758,7 @@ PASS Stringification of objects.animateTransform
 PASS SVGAnimationElement interface: objects.animateTransform must inherit property "targetElement" with the proper type
 FAIL SVGAnimationElement interface: objects.animateTransform must inherit property "onbegin" with the proper type assert_inherits: property "onbegin" not found in prototype chain
 FAIL SVGAnimationElement interface: objects.animateTransform must inherit property "onend" with the proper type assert_inherits: property "onend" not found in prototype chain
-FAIL SVGAnimationElement interface: objects.animateTransform must inherit property "onrepeat" with the proper type assert_inherits: property "onrepeat" not found in prototype chain
+PASS SVGAnimationElement interface: objects.animateTransform must inherit property "onrepeat" with the proper type
 PASS SVGAnimationElement interface: objects.animateTransform must inherit property "getStartTime()" with the proper type
 PASS SVGAnimationElement interface: objects.animateTransform must inherit property "getCurrentTime()" with the proper type
 PASS SVGAnimationElement interface: objects.animateTransform must inherit property "getSimpleDuration()" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative-expected.txt
@@ -89,4 +89,5 @@ PASS getAttributeType("dummy", "onunhandledrejection", "dummyNs", attrNs)
 PASS getAttributeType("dummy", "onunload", "dummyNs", attrNs)
 PASS getAttributeType("dummy", "onencrypted", "dummyNs", attrNs)
 PASS getAttributeType("dummy", "onwaitingforkey", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onrepeat", "dummyNs", attrNs)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative-expected.txt
@@ -499,6 +499,8 @@ PASS AUDIO.setAttribute(onwaitingforkey, "unsafe_handler()") calls default polic
 PASS AUDIO.setAttributeNS(onwaitingforkey, "unsafe_handler()") calls default policy
 PASS VIDEO.setAttribute(onwaitingforkey, "unsafe_handler()") calls default policy
 PASS VIDEO.setAttributeNS(onwaitingforkey, "unsafe_handler()") calls default policy
+PASS animation.setAttribute(onrepeat, "unsafe_handler()") calls default policy
+PASS animation.setAttributeNS(onrepeat, "unsafe_handler()") calls default policy
 PASS DIV.setAttribute("onafterprint", "unsafe_handler()") calls default policy
 PASS DIV.setAttribute("onwaitingforkey", "unsafe_handler()") calls default policy
 FAIL DIV.setAttribute("onbegin", "unsafe_handler()") calls default policy assert_equals: expected (string) "Element onbegin" but got (undefined) undefined

--- a/LayoutTests/platform/win/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative-expected.txt
+++ b/LayoutTests/platform/win/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative-expected.txt
@@ -80,4 +80,7 @@ PASS getAttributeType("dummy", "onrejectionhandled", "dummyNs", attrNs)
 PASS getAttributeType("dummy", "onstorage", "dummyNs", attrNs)
 PASS getAttributeType("dummy", "onunhandledrejection", "dummyNs", attrNs)
 PASS getAttributeType("dummy", "onunload", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onencrypted", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onwaitingforkey", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onrepeat", "dummyNs", attrNs)
 

--- a/Source/WebCore/dom/EventNames.json
+++ b/Source/WebCore/dom/EventNames.json
@@ -214,6 +214,8 @@
     "removesourcebuffer": { },
     "removestream": { },
     "removetrack": { },
+    "repeat": { },
+    "repeatEvent": { },
     "reset": { },
     "resize": { },
     "resourcetimingbufferfull": { },

--- a/Source/WebCore/svg/SVGAnimationElement.idl
+++ b/Source/WebCore/svg/SVGAnimationElement.idl
@@ -39,6 +39,8 @@
     undefined beginElementAt(float offset);
     undefined endElement();
     undefined endElementAt(float offset);
+
+    attribute EventHandler onrepeat;
 };
 
 SVGAnimationElement includes SVGTests;

--- a/Source/WebCore/svg/svgattrs.in
+++ b/Source/WebCore/svg/svgattrs.in
@@ -119,6 +119,7 @@ numOctaves
 offset
 onbegin
 onend
+onrepeat
 onzoom
 opacity
 operator
@@ -146,6 +147,7 @@ radius
 refX
 refY
 rel
+repeat
 repeatCount
 repeatDur
 requiredExtensions


### PR DESCRIPTION
#### d7366f00065ab8ce5d0fd04f946c4225a5470149
<pre>
[SVG] Handle `repeatEvent` for svg animations
<a href="https://bugs.webkit.org/show_bug.cgi?id=275293">https://bugs.webkit.org/show_bug.cgi?id=275293</a>
<a href="https://rdar.apple.com/problem/129919749">rdar://problem/129919749</a>

Reviewed by Darin Adler.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/f7d3a4aaa8598d79b137dde63e9b401ea351e1e9">https://chromium.googlesource.com/chromium/blink/+/f7d3a4aaa8598d79b137dde63e9b401ea351e1e9</a>

This implements &apos;repeatEvent&apos; as per web specification [1]:

[1] <a href="https://www.w3.org/TR/SMIL3/smil-timing.html#q135">https://www.w3.org/TR/SMIL3/smil-timing.html#q135</a>

* Source/WebCore/dom/EventNames.json:
* Source/WebCore/svg/SVGAnimationElement.idl:
* Source/WebCore/svg/svgattrs.in:
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::attributeChanged):
(WebCore::SVGSMILElement::progress):
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/repeat-event-expected.txt: Progressions
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/onrepeat-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt: Ditto
* LayoutTests/platform/win/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative-expected.txt:

Canonical link: <a href="https://commits.webkit.org/298715@main">https://commits.webkit.org/298715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16bd56817be33bc165988c7226d20419ff57215d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/115634 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/35297 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/25820 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/121681 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/66150 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/c6f3490d-7098-481c-a138-131daee6880e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/117523 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/35978 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/43880 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/87839 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/42469 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/ece37666-4b00-4cba-97c5-f79a4c7f8f05) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/118582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/28701 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/103777 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/68239 "Passed tests") | | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/27838 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/21893 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/65359 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/98078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/22014 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/124830 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/42529 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/31885 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/96596 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/42896 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/99967 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/96384 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/24664 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/41638 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/19496 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/38404 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/42420 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/47992 "Built successfully") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/41893 "Built successfully") | | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/45224 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/43601 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->