### PR TITLE
Tidy up instance time handling in SVGSMILElement

### DIFF
--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -247,31 +247,17 @@ ExceptionOr<float> SVGAnimationElement::getSimpleDuration() const
         return Exception { ExceptionCode::NotSupportedError, "The simple duration is not determined on the given element."_s };
     return narrowPrecisionToFloat(simpleDuration.value());
 }    
-    
-void SVGAnimationElement::beginElement()
-{
-    beginElementAt(0);
-}
 
 void SVGAnimationElement::beginElementAt(float offset)
 {
-    if (!std::isfinite(offset))
-        return;
-    SMILTime elapsed = this->elapsed();
-    addBeginTime(elapsed, elapsed + offset, SMILTimeWithOrigin::ScriptOrigin);
-}
-
-void SVGAnimationElement::endElement()
-{
-    endElementAt(0);
+    ASSERT(std::isfinite(offset));
+    addInstanceTime(Begin, elapsed() + offset, SMILTimeWithOrigin::ScriptOrigin);
 }
 
 void SVGAnimationElement::endElementAt(float offset)
 {
-    if (!std::isfinite(offset))
-        return;
-    SMILTime elapsed = this->elapsed();
-    addEndTime(elapsed, elapsed + offset, SMILTimeWithOrigin::ScriptOrigin);
+    ASSERT(std::isfinite(offset));
+    addInstanceTime(End, elapsed() + offset, SMILTimeWithOrigin::ScriptOrigin);
 }
 
 void SVGAnimationElement::updateAnimationMode()

--- a/Source/WebCore/svg/SVGAnimationElement.h
+++ b/Source/WebCore/svg/SVGAnimationElement.h
@@ -44,9 +44,9 @@ public:
     float getCurrentTime() const;
     ExceptionOr<float> getSimpleDuration() const;
 
-    void beginElement();
+    void beginElement() { beginElementAt(0); }
     void beginElementAt(float offset);
-    void endElement();
+    void endElement() { endElementAt(0); }
     void endElementAt(float offset);
 
     static bool isTargetAttributeCSSProperty(SVGElement*, const QualifiedName&);

--- a/Source/WebCore/svg/animation/SVGSMILElement.h
+++ b/Source/WebCore/svg/animation/SVGSMILElement.h
@@ -109,9 +109,6 @@ public:
     void dispatchPendingEvent(SMILEventSender*, const AtomString& eventType);
 
 protected:
-    void addBeginTime(SMILTime eventTime, SMILTime endTime, SMILTimeWithOrigin::Origin = SMILTimeWithOrigin::ParserOrigin);
-    void addEndTime(SMILTime eventTime, SMILTime endTime, SMILTimeWithOrigin::Origin = SMILTimeWithOrigin::ParserOrigin);
-
     void setInactive() { m_activeState = Inactive; }
 
     bool rendererIsNeeded(const RenderStyle&) override { return false; }
@@ -121,6 +118,10 @@ protected:
     virtual void setAttributeName(const QualifiedName&);
 
     void didFinishInsertingNode() override;
+
+    enum BeginOrEnd { Begin, End };
+
+    void addInstanceTime(BeginOrEnd, SMILTime, SMILTimeWithOrigin::Origin = SMILTimeWithOrigin::ParserOrigin);
 
 private:
     void buildPendingResource() override;
@@ -136,7 +137,6 @@ private:
     QualifiedName constructAttributeName() const;
     void updateAttributeName();
 
-    enum BeginOrEnd { Begin, End };
     SMILTime findInstanceTime(BeginOrEnd, SMILTime minimumTime, bool equalsMinimumOK) const;
     void resolveFirstInterval();
     bool resolveNextInterval();
@@ -166,9 +166,6 @@ private:
     RefPtr<Element> eventBaseFor(const Condition&);
 
     void disconnectConditions();
-
-    // Event base timing
-    void handleConditionEvent(Condition*);
 
     // Syncbase timing
     enum NewOrExistingInterval { NewInterval, ExistingInterval };


### PR DESCRIPTION
#### 1465a7975860d39d4b6e1a2f8d2dd4e6a77a3e92
<pre>
Tidy up instance time handling in SVGSMILElement

<a href="https://bugs.webkit.org/show_bug.cgi?id=275296">https://bugs.webkit.org/show_bug.cgi?id=275296</a>

Reviewed by Darin Adler.

Merge: <a href="https://github.com/chromium/chromium/commit/901d1e45d6a0a49407a7e8936f6edf9b6124c260">https://github.com/chromium/chromium/commit/901d1e45d6a0a49407a7e8936f6edf9b6124c260</a>

Merge the addBeginTime and addEndTime methods into a single method
addInstanceTime (that takes a BeginOrEnd argument.) Migrate callers to
the new method, getting rid of SVGSMILElement::handleConditionEvent in
the process.

Also inline some trivial functions in SVGAnimationElement.

* Source/WebCore/svg/SVGAnimationElement.cpp:
(WebCore::SVGAnimationElement::getSimpleDuration const):
(WebCore::SVGAnimationElement::beginElementAt):
(WebCore::SVGAnimationElement::endElementAt):
(WebCore::SVGAnimationElement::beginElement): Deleted.
(WebCore::SVGAnimationElement::endElement): Deleted.
* Source/WebCore/svg/SVGAnimationElement.h:
(WebCore::SVGAnimationElement::beginElement):
(WebCore::SVGAnimationElement::endElement):
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::ConditionEventListener::handleEvent):
(WebCore::SVGSMILElement::addInstanceTime):
(WebCore::SVGSMILElement::createInstanceTimesFromSyncbase):
(WebCore::SVGSMILElement::removeTimeDependent):
(WebCore::SVGSMILElement::beginByLinkActivation):
(WebCore::SVGSMILElement::addBeginTime): Deleted.
(WebCore::SVGSMILElement::addEndTime): Deleted.
(WebCore::SVGSMILElement::handleConditionEvent): Deleted.
* Source/WebCore/svg/animation/SVGSMILElement.h:

Canonical link: <a href="https://commits.webkit.org/279971@main">https://commits.webkit.org/279971@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55a14aeac70bcb36689231445845e4bbfb6b9eb7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58321 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5771 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57339 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5807 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44562 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3937 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57134 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32580 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47693 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25686 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29366 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5038 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3915 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59911 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30314 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5417 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51993 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31441 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47762 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51447 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12108 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32468 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31232 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->