### PR TITLE
[WPE][GTK] Un-deprecate webkit_back_forward_list_item_get_title()

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitBackForwardListItem.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitBackForwardListItem.cpp
@@ -119,16 +119,22 @@ const gchar* webkit_back_forward_list_item_get_uri(WebKitBackForwardListItem* li
  * webkit_back_forward_list_item_get_title:
  * @list_item: a #WebKitBackForwardListItem
  *
- * Since 2.44, page titles are no longer stored in history. This function now returns an empty string.
+ * Obtain the title of the item.
  *
- * Returns: an empty string
- *
- * Deprecated: 2.44
+ * Returns: the page title of @list_item or %NULL
+ *    when the title is empty.
  */
 const gchar* webkit_back_forward_list_item_get_title(WebKitBackForwardListItem* listItem)
 {
     g_return_val_if_fail(WEBKIT_IS_BACK_FORWARD_LIST_ITEM(listItem), 0);
-    return "";
+
+    WebKitBackForwardListItemPrivate* priv = listItem->priv;
+    String title = priv->webListItem->title();
+    if (title.isEmpty())
+        return 0;
+
+    priv->title = title.utf8();
+    return priv->title.data();
 }
 
 /**

--- a/Source/WebKit/UIProcess/API/glib/WebKitBackForwardListItem.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitBackForwardListItem.h.in
@@ -51,7 +51,7 @@ WEBKIT_DECLARE_FINAL_TYPE (WebKitBackForwardListItem, webkit_back_forward_list_i
 WEBKIT_API const gchar *
 webkit_back_forward_list_item_get_uri          (WebKitBackForwardListItem* list_item);
 
-WEBKIT_DEPRECATED const gchar *
+WEBKIT_API const gchar *
 webkit_back_forward_list_item_get_title        (WebKitBackForwardListItem* list_item);
 
 WEBKIT_API const gchar *

--- a/Tools/MiniBrowser/gtk/BrowserWindow.c
+++ b/Tools/MiniBrowser/gtk/BrowserWindow.c
@@ -228,7 +228,9 @@ static void browserWindowCreateBackForwardMenu(BrowserWindow *window, GList *lis
     GList *listItem;
     for (listItem = list; listItem; listItem = g_list_next(listItem)) {
         WebKitBackForwardListItem *item = (WebKitBackForwardListItem *)listItem->data;
-        const char *title = webkit_back_forward_list_item_get_uri(item);
+        const char *title = webkit_back_forward_list_item_get_title(item);
+        if (!title || !*title)
+            title = webkit_back_forward_list_item_get_uri(item);
 
         char *displayTitle;
 #define MAX_TITLE 100

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestBackForwardList.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestBackForwardList.cpp
@@ -69,10 +69,11 @@ public:
         RemovedItems = 1 << 2
     };
 
-    static void checkItem(WebKitBackForwardListItem* item, const char* uri, const char* originalURI)
+    static void checkItem(WebKitBackForwardListItem* item, const char* title, const char* uri, const char* originalURI)
     {
         g_assert_nonnull(item);
         g_assert_cmpstr(webkit_back_forward_list_item_get_uri(item), ==, uri);
+        g_assert_cmpstr(webkit_back_forward_list_item_get_title(item), == , title);
         g_assert_cmpstr(webkit_back_forward_list_item_get_original_uri(item), ==, originalURI);
     }
 
@@ -180,7 +181,7 @@ static void testBackForwardListNavigation(BackForwardListTest* test, gconstpoint
 
     g_assert_cmpuint(webkit_back_forward_list_get_length(test->m_list), ==, 1);
     WebKitBackForwardListItem* itemPage1 = webkit_back_forward_list_get_current_item(test->m_list);
-    BackForwardListTest::checkItem(itemPage1, uriPage1.data(), uriPage1.data());
+    BackForwardListTest::checkItem(itemPage1, "Page1", uriPage1.data(), uriPage1.data());
     g_assert_null(webkit_back_forward_list_get_back_item(test->m_list));
     g_assert_null(webkit_back_forward_list_get_forward_item(test->m_list));
     BackForwardListTest::checkItemIndex(test->m_list);
@@ -198,7 +199,7 @@ static void testBackForwardListNavigation(BackForwardListTest* test, gconstpoint
 
     g_assert_cmpuint(webkit_back_forward_list_get_length(test->m_list), ==, 2);
     WebKitBackForwardListItem* itemPage2 = webkit_back_forward_list_get_current_item(test->m_list);
-    BackForwardListTest::checkItem(itemPage2, uriPage2.data(), uriPage2.data());
+    BackForwardListTest::checkItem(itemPage2, "Page2", uriPage2.data(), uriPage2.data());
     g_assert_true(webkit_back_forward_list_get_back_item(test->m_list) == itemPage1);
     g_assert_null(webkit_back_forward_list_get_forward_item(test->m_list));
     BackForwardListTest::checkItemIndex(test->m_list);
@@ -215,7 +216,7 @@ static void testBackForwardListNavigation(BackForwardListTest* test, gconstpoint
 
     g_assert_cmpuint(webkit_back_forward_list_get_length(test->m_list), ==, 2);
     g_assert_true(itemPage1 == webkit_back_forward_list_get_current_item(test->m_list));
-    BackForwardListTest::checkItem(webkit_back_forward_list_get_current_item(test->m_list), uriPage1.data(), uriPage1.data());
+    BackForwardListTest::checkItem(webkit_back_forward_list_get_current_item(test->m_list), "Page1", uriPage1.data(), uriPage1.data());
     g_assert_null(webkit_back_forward_list_get_back_item(test->m_list));
     g_assert_true(webkit_back_forward_list_get_forward_item(test->m_list) == itemPage2);
     BackForwardListTest::checkItemIndex(test->m_list);
@@ -232,7 +233,7 @@ static void testBackForwardListNavigation(BackForwardListTest* test, gconstpoint
 
     g_assert_cmpuint(webkit_back_forward_list_get_length(test->m_list), ==, 2);
     g_assert_true(itemPage2 == webkit_back_forward_list_get_current_item(test->m_list));
-    BackForwardListTest::checkItem(webkit_back_forward_list_get_current_item(test->m_list), uriPage2.data(), uriPage2.data());
+    BackForwardListTest::checkItem(webkit_back_forward_list_get_current_item(test->m_list), "Page2", uriPage2.data(), uriPage2.data());
     g_assert_true(webkit_back_forward_list_get_back_item(test->m_list) == itemPage1);
     g_assert_null(webkit_back_forward_list_get_forward_item(test->m_list));
     BackForwardListTest::checkItemIndex(test->m_list);
@@ -314,9 +315,9 @@ static void testWebKitWebViewSessionState(BackForwardListTest* test, gconstpoint
     webkit_web_view_restore_session_state(view.get(), state);
     g_assert_cmpuint(webkit_back_forward_list_get_length(bfList), ==, 3);
 
-    BackForwardListTest::checkItem(webkit_back_forward_list_get_nth_item(bfList, -1), uriPage1.data(), uriPage1.data());
-    BackForwardListTest::checkItem(webkit_back_forward_list_get_current_item(bfList), uriPage2.data(), uriPage2.data());
-    BackForwardListTest::checkItem(webkit_back_forward_list_get_nth_item(bfList, 1), uriPage3.data(), uriPage3.data());
+    BackForwardListTest::checkItem(webkit_back_forward_list_get_nth_item(bfList, -1), "Page1", uriPage1.data(), uriPage1.data());
+    BackForwardListTest::checkItem(webkit_back_forward_list_get_current_item(bfList), "Page2", uriPage2.data(), uriPage2.data());
+    BackForwardListTest::checkItem(webkit_back_forward_list_get_nth_item(bfList, 1), "Page3", uriPage3.data(), uriPage3.data());
 
     data = adoptGRef(webkit_web_view_session_state_serialize(state));
     g_assert_nonnull(data);
@@ -331,9 +332,9 @@ static void testWebKitWebViewSessionState(BackForwardListTest* test, gconstpoint
     g_assert_cmpuint(webkit_back_forward_list_get_length(bfList), ==, 3);
     webkit_web_view_session_state_unref(state);
 
-    BackForwardListTest::checkItem(webkit_back_forward_list_get_nth_item(bfList, -1), uriPage1.data(), uriPage1.data());
-    BackForwardListTest::checkItem(webkit_back_forward_list_get_current_item(bfList), uriPage2.data(), uriPage2.data());
-    BackForwardListTest::checkItem(webkit_back_forward_list_get_nth_item(bfList, 1), uriPage3.data(), uriPage3.data());
+    BackForwardListTest::checkItem(webkit_back_forward_list_get_nth_item(bfList, -1), "Page1", uriPage1.data(), uriPage1.data());
+    BackForwardListTest::checkItem(webkit_back_forward_list_get_current_item(bfList), "Page2", uriPage2.data(), uriPage2.data());
+    BackForwardListTest::checkItem(webkit_back_forward_list_get_nth_item(bfList, 1), "Page3", uriPage3.data(), uriPage3.data());
 
     static const char* invalidSessionData = "invalid session data";
     data = adoptGRef(g_bytes_new_static(invalidSessionData, strlen(invalidSessionData)));


### PR DESCRIPTION
#### eef110a09e7b36a057ec4b06af82176f463dca1f
<pre>
[WPE][GTK] Un-deprecate webkit_back_forward_list_item_get_title()
<a href="https://bugs.webkit.org/show_bug.cgi?id=275298">https://bugs.webkit.org/show_bug.cgi?id=275298</a>

Reviewed by Adrian Perez de Castro.

We changed our minds and are bringing back the ability to set page
titles in the back/forward list. Apparently this functionality worked on
macOS.

It does *not* work for WPE/GTK. The page title is always equal to the
URL. I have not investigated to find out why. But we should still not
discourage applications from using this API if it might work in the
future.

* Source/WebKit/UIProcess/API/glib/WebKitBackForwardListItem.cpp:
(webkit_back_forward_list_item_get_title):
* Source/WebKit/UIProcess/API/glib/WebKitBackForwardListItem.h.in:
* Tools/MiniBrowser/gtk/BrowserWindow.c:
(browserWindowCreateBackForwardMenu):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestBackForwardList.cpp:
(testBackForwardListNavigation):
(testWebKitWebViewSessionState):

Canonical link: <a href="https://commits.webkit.org/279918@main">https://commits.webkit.org/279918@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7e5a02d4bf8b20dacdf19977d3a3224ffa05909

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7513 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58203 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5656 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57225 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5689 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44487 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3834 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32465 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47582 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25606 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29255 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4923 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3797 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5145 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59793 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30186 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5298 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51902 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31321 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47660 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51334 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12065 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32334 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31110 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->