### PR TITLE
[JSC] Update links in test262 runner README

### DIFF
--- a/Tools/Scripts/test262/README.md
+++ b/Tools/Scripts/test262/README.md
@@ -12,7 +12,7 @@ To execute the Test262 Runner script, just call it through your shell.
 
 If you need to customize the execution, check out `runner.pl --help` for extra commands.
 
-### test262-config.yaml
+### [JSTests/test262/config.yaml](https://github.com/WebKit/WebKit/blob/main/JSTests/test262/config.yaml)
 
 This yaml file can be used to skip tests. An example file:
 ```
@@ -28,7 +28,7 @@ skip:
     - test/built-ins/Array/prototype/unshift/length-near-integer-limit.js
 ```
 
-### test262-expectation.yaml
+### [JSTets/test262/expectations.yaml](https://github.com/WebKit/WebKit/blob/main/JSTests/test262/expectations.yaml)
 
 This file contains all exected failures. If JSC or Test262 is updated, this file should be updated with the new set of expected tests in order for developers to only see errors they introduce.
 
@@ -37,7 +37,7 @@ To update this file, run:
 runner.pl --save-expectations
 ```
 
-### test262-results.yaml
+### test262-results/results.yaml
 
 This file contains results for all tests. It is updated on every run.
 


### PR DESCRIPTION
#### d9dd91259b077da95038e8897626eb515fef5955
<pre>
[JSC] Update links in test262 runner README
<a href="https://bugs.webkit.org/show_bug.cgi?id=275300">https://bugs.webkit.org/show_bug.cgi?id=275300</a>

Reviewed by Keith Miller.

`test262-expectation.yaml` and `test262-config.yaml` in `/Tools/Scripts/test262` was moved to
`JSTests/test262` by <a href="https://commits.webkit.org/200895@main.">https://commits.webkit.org/200895@main.</a> But, README is not updated.

This patch updates the README.

* Tools/Scripts/test262/README.md:

Canonical link: <a href="https://commits.webkit.org/279864@main">https://commits.webkit.org/279864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/156bbb6837c988a252f480f037c3e65f35952ed3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58047 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5500 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57069 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5514 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44359 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3716 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56863 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32330 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47446 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25483 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29120 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4784 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3641 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50905 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5001 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59637 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30014 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5147 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/51782 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31156 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47529 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51185 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32165 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8106 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30943 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->