### PR TITLE
[JSC] Add fast path for `String#replaceAll`

### DIFF
--- a/JSTests/microbenchmarks/string-replaceall-benchmark.js
+++ b/JSTests/microbenchmarks/string-replaceall-benchmark.js
@@ -1,0 +1,21 @@
+function fill(template, title, completed, checked) {
+    return template.replaceAll("{{title}}", title)
+                   .replaceAll("{{completed}}", completed)
+                   .replaceAll("{{checked}}", checked);
+}
+noInline(fill);
+
+function test() {
+    for (var i = 55; i < 100; ++i) {
+        for (var j = 0; j < i; ++j) {
+            var template = `<li data-id="${j + 1}" class="{{completed}}"><div class="view"><input class="toggle" type="checkbox" {{checked}}><label>{{title}}</label><button class="destroy"></button></div></li>
+                            <li data-id="${j + 1}" class="{{completed}}"><div class="view"><input class="toggle" type="checkbox" {{checked}}><label>{{title}}</label><button class="destroy"></button></div></li>
+                            <li data-id="${j + 1}" class="{{completed}}"><div class="view"><input class="toggle" type="checkbox" {{checked}}><label>{{title}}</label><button class="destroy"></button></div></li>`;
+            fill(template, `Something to do ${j}`, "", "");
+        }
+    }
+}
+noInline(test);
+
+for (var i = 0; i < 100; ++i)
+    test();


### PR DESCRIPTION
#### 3e2d78bf8226127c6f7c9766579f95a5499814b5
<pre>
[JSC] Add fast path for `String#replaceAll`
<a href="https://bugs.webkit.org/show_bug.cgi?id=275310">https://bugs.webkit.org/show_bug.cgi?id=275310</a>

Reviewed by Yusuke Suzuki.

`String#replace(search, replace)` already has a fast path when `search` and `replace` are Strings,
but `String#replaceAll` does not.

This patch adds a fast path to `String#replaceAll` using almost the same algorithm as the fast path
for `String#replace`. A microbenchmark shows an improvement of about 1.3x ~ 1.4x:

                                     TipOfTree                  Patched

string-replaceall-benchmark      413.9061+-13.2920    ^    304.0226+-4.1146        ^ definitely 1.3614x faster

* JSTests/microbenchmarks/string-replaceall-benchmark.js: Added.
(fill):
(test.template.li.data.id.string_appeared_here.div.input):
(test.template.li.data.id.string_appeared_here.div):
(test.label.button.button.div.li.li.data.id.string_appeared_here.div.input):
(test.label.button.button.div.li.li.data.id.string_appeared_here.div):
(test.label.button):
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::stringReplaceAllStringString):
(JSC::replaceUsingStringSearch):

Canonical link: <a href="https://commits.webkit.org/280990@main">https://commits.webkit.org/280990@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83537804924be05a761467c7c5845cabe7633ad1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37559 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61856 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8676 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45195 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8870 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47193 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6201 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50349 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28027 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31975 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7646 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7680 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/51323 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53929 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7915 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63561 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57474 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2145 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7976 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54507 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2153 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50361 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54566 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1838 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/79234 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8691 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33388 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13171 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34474 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35558 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34219 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->