### PR TITLE
[GTK][WPE] Undeprecate console message API and make it available in 2022 API

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -221,6 +221,7 @@ set(WebKitWebProcessExtension_INSTALLED_HEADERS
 )
 
 set(WebKitWebProcessExtension_HEADER_TEMPLATES
+    ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitConsoleMessage.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitFrame.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitScriptWorld.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitWebEditor.h.in

--- a/Source/WebKit/PlatformGTKDeprecated.cmake
+++ b/Source/WebKit/PlatformGTKDeprecated.cmake
@@ -13,10 +13,6 @@ list(APPEND WebKitGTK_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/gtk/WebKitPrintCustomWidget.h.in
 )
 
-list(APPEND WebKitWebProcessExtension_HEADER_TEMPLATES
-    ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitConsoleMessage.h.in
-)
-
 set(WebKitDOM_INSTALLED_HEADERS
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/gtk/DOM/webkitdomautocleanups.h
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/gtk/DOM/webkitdomdefines.h

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -236,6 +236,7 @@ set(WPE_WEB_PROCESS_EXTENSION_API_INSTALLED_HEADERS
 )
 
 set(WPE_WEB_PROCESS_EXTENSION_API_HEADER_TEMPLATES
+    ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitConsoleMessage.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitFrame.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitScriptWorld.h.in
     ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitWebEditor.h.in

--- a/Source/WebKit/PlatformWPEDeprecated.cmake
+++ b/Source/WebKit/PlatformWPEDeprecated.cmake
@@ -11,10 +11,6 @@ list(APPEND WPE_API_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitPlugin.h.in
 )
 
-list(APPEND WPE_WEB_PROCESS_EXTENSION_API_HEADER_TEMPLATES
-    ${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/WebKitConsoleMessage.h.in
-)
-
 list(APPEND WebKit_INCLUDE_DIRECTORIES
     "${FORWARDING_HEADERS_WPE_DOM_DIR}"
     "${WEBKIT_DIR}/WebProcess/InjectedBundle/API/glib/DOM"

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -297,6 +297,7 @@ WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp
 
 WebProcess/GPU/media/gstreamer/VideoLayerRemoteGStreamer.cpp
 
+WebProcess/InjectedBundle/API/glib/WebKitConsoleMessage.cpp @no-unify
 WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp @no-unify
 WebProcess/InjectedBundle/API/glib/WebKitScriptWorld.cpp @no-unify
 WebProcess/InjectedBundle/API/glib/WebKitWebEditor.cpp @no-unify

--- a/Source/WebKit/SourcesGTKDeprecated.txt
+++ b/Source/WebKit/SourcesGTKDeprecated.txt
@@ -27,8 +27,6 @@ UIProcess/API/glib/WebKitPlugin.cpp @no-unify
 
 UIProcess/API/gtk/WebKitPrintCustomWidget.cpp @no-unify
 
-WebProcess/InjectedBundle/API/glib/WebKitConsoleMessage.cpp @no-unify
-
 WebProcess/InjectedBundle/API/glib/DOM/DOMObjectCache.cpp @no-unify
 WebProcess/InjectedBundle/API/glib/DOM/WebKitDOMDocument.cpp @no-unify
 WebProcess/InjectedBundle/API/glib/DOM/WebKitDOMElement.cpp @no-unify

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -263,6 +263,7 @@ WebProcess/GPU/graphics/gbm/RemoteGraphicsContextGLProxyGBM.cpp
 
 WebProcess/GPU/media/gstreamer/VideoLayerRemoteGStreamer.cpp
 
+WebProcess/InjectedBundle/API/glib/WebKitConsoleMessage.cpp @no-unify
 WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp @no-unify
 WebProcess/InjectedBundle/API/glib/WebKitScriptWorld.cpp @no-unify
 WebProcess/InjectedBundle/API/glib/WebKitWebEditor.cpp @no-unify

--- a/Source/WebKit/SourcesWPEDeprecated.txt
+++ b/Source/WebKit/SourcesWPEDeprecated.txt
@@ -27,8 +27,6 @@ UIProcess/API/glib/WebKitJavascriptResult.cpp @no-unify
 UIProcess/API/glib/WebKitMimeInfo.cpp @no-unify
 UIProcess/API/glib/WebKitPlugin.cpp @no-unify
 
-WebProcess/InjectedBundle/API/glib/WebKitConsoleMessage.cpp @no-unify
-
 WebProcess/InjectedBundle/API/glib/DOM/DOMObjectCache.cpp @no-unify
 WebProcess/InjectedBundle/API/glib/DOM/WebKitDOMDocument.cpp @no-unify
 WebProcess/InjectedBundle/API/glib/DOM/WebKitDOMElement.cpp @no-unify

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitConsoleMessage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitConsoleMessage.cpp
@@ -22,9 +22,7 @@
 
 #include "WebKitConsoleMessagePrivate.h"
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 G_DEFINE_BOXED_TYPE(WebKitConsoleMessage, webkit_console_message, webkit_console_message_copy, webkit_console_message_free)
-ALLOW_DEPRECATED_DECLARATIONS_END
 
 /**
  * webkit_console_message_copy:
@@ -35,8 +33,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
  * Returns: (transfer full): A copy of passed in #WebKitConsoleMessage
  *
  * Since: 2.12
- *
- * Deprecated: 2.40
  */
 WebKitConsoleMessage* webkit_console_message_copy(WebKitConsoleMessage* consoleMessage)
 {
@@ -53,8 +49,6 @@ WebKitConsoleMessage* webkit_console_message_copy(WebKitConsoleMessage* consoleM
  * Free the #WebKitConsoleMessage
  *
  * Since: 2.12
- *
- * Deprecated: 2.40
  */
 void webkit_console_message_free(WebKitConsoleMessage* consoleMessage)
 {
@@ -72,8 +66,6 @@ void webkit_console_message_free(WebKitConsoleMessage* consoleMessage)
  * Returns: a #WebKitConsoleMessageSource indicating the source of @console_message
  *
  * Since: 2.12
- *
- * Deprecated: 2.40
  */
 WebKitConsoleMessageSource webkit_console_message_get_source(WebKitConsoleMessage* consoleMessage)
 {
@@ -104,8 +96,6 @@ WebKitConsoleMessageSource webkit_console_message_get_source(WebKitConsoleMessag
  * Returns: a #WebKitConsoleMessageLevel indicating the log level of @console_message
  *
  * Since: 2.12
- *
- * Deprecated: 2.40
  */
 WebKitConsoleMessageLevel webkit_console_message_get_level(WebKitConsoleMessage* consoleMessage)
 {
@@ -136,8 +126,6 @@ WebKitConsoleMessageLevel webkit_console_message_get_level(WebKitConsoleMessage*
  * Returns: the text message of @console_message
  *
  * Since: 2.12
- *
- * Deprecated: 2.40
  */
 const gchar* webkit_console_message_get_text(WebKitConsoleMessage* consoleMessage)
 {
@@ -154,8 +142,6 @@ const gchar* webkit_console_message_get_text(WebKitConsoleMessage* consoleMessag
  * Returns: the line number of @console_message
  *
  * Since: 2.12
- *
- * Deprecated: 2.40
  */
 guint webkit_console_message_get_line(WebKitConsoleMessage* consoleMessage)
 {
@@ -172,8 +158,6 @@ guint webkit_console_message_get_line(WebKitConsoleMessage* consoleMessage)
  * Returns: the source identifier of @console_message
  *
  * Since: 2.12
- *
- * Deprecated: 2.40
  */
 const gchar* webkit_console_message_get_source_id(WebKitConsoleMessage* consoleMessage)
 {

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitConsoleMessage.h.in
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitConsoleMessage.h.in
@@ -40,8 +40,6 @@ G_BEGIN_DECLS
  * Enum values used to denote the various sources of console messages.
  *
  * Since: 2.12
- *
- * Deprecated: 2.40
  */
 typedef enum {
     WEBKIT_CONSOLE_MESSAGE_SOURCE_JAVASCRIPT,
@@ -62,8 +60,6 @@ typedef enum {
  * Enum values used to denote the various levels of console messages.
  *
  * Since: 2.12
- *
- * Deprecated: 2.40
  */
 typedef enum {
     WEBKIT_CONSOLE_MESSAGE_LEVEL_INFO,
@@ -75,30 +71,30 @@ typedef enum {
 
 typedef struct _WebKitConsoleMessage WebKitConsoleMessage;
 
-WEBKIT_DEPRECATED GType
+WEBKIT_API GType
 webkit_console_message_get_type      (void);
 
-WEBKIT_DEPRECATED WebKitConsoleMessage *
+WEBKIT_API WebKitConsoleMessage *
 webkit_console_message_copy          (WebKitConsoleMessage *console_message);
 
-WEBKIT_DEPRECATED void
+WEBKIT_API void
 webkit_console_message_free          (WebKitConsoleMessage *console_message);
 
-WEBKIT_DEPRECATED WebKitConsoleMessageSource
+WEBKIT_API WebKitConsoleMessageSource
 webkit_console_message_get_source    (WebKitConsoleMessage *console_message);
 
-WEBKIT_DEPRECATED WebKitConsoleMessageLevel
+WEBKIT_API WebKitConsoleMessageLevel
 webkit_console_message_get_level     (WebKitConsoleMessage *console_message);
 
-WEBKIT_DEPRECATED const gchar *
+WEBKIT_API const gchar *
 webkit_console_message_get_text      (WebKitConsoleMessage *console_message);
 
-WEBKIT_DEPRECATED guint
+WEBKIT_API guint
 webkit_console_message_get_line      (WebKitConsoleMessage *console_message);
 
-WEBKIT_DEPRECATED const gchar *
+WEBKIT_API const gchar *
 webkit_console_message_get_source_id (WebKitConsoleMessage *console_message);
 
 G_END_DECLS
 
-#endif
+#endif /* WebKitConsoleMessage_h */

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitConsoleMessagePrivate.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitConsoleMessagePrivate.h
@@ -17,8 +17,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#ifndef WebKitConsoleMessagePrivate_h
-#define WebKitConsoleMessagePrivate_h
+#pragma once
 
 #include "WebKitConsoleMessage.h"
 #include <JavaScriptCore/ConsoleTypes.h>
@@ -50,5 +49,3 @@ struct _WebKitConsoleMessage {
     unsigned lineNumber;
     CString sourceID;
 };
-
-#endif // WebKitConsoleMessagePrivate_h

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/webkit-web-process-extension.h.in
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/webkit-web-process-extension.h.in
@@ -40,9 +40,7 @@
 
 #define __WEBKIT_WEB_PROCESS_EXTENSION_H_INSIDE__
 
-#if !ENABLE(2022_GLIB_API)
 #include <@API_INCLUDE_PREFIX@/WebKitConsoleMessage.h>
-#endif
 #include <@API_INCLUDE_PREFIX@/WebKitContextMenu.h>
 #include <@API_INCLUDE_PREFIX@/WebKitContextMenuActions.h>
 #include <@API_INCLUDE_PREFIX@/WebKitContextMenuItem.h>

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestConsoleMessage.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestConsoleMessage.cpp
@@ -78,7 +78,11 @@ public:
     ~ConsoleMessageTest()
     {
         g_signal_handlers_disconnect_matched(m_userContentManager.get(), G_SIGNAL_MATCH_DATA, 0, 0, nullptr, nullptr, this);
+#if !ENABLE(2022_GLIB_API)
         webkit_user_content_manager_unregister_script_message_handler(m_userContentManager.get(), "console");
+#else
+        webkit_user_content_manager_unregister_script_message_handler(m_userContentManager.get(), "console", nullptr);
+#endif
     }
 
     void waitUntilConsoleMessageReceived()

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/WebProcessExtensionTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/WebProcessExtensionTest.cpp
@@ -315,8 +315,6 @@ static gboolean contextMenuCallback(WebKitWebPage* page, WebKitContextMenu* menu
     return FALSE;
 }
 
-#if !ENABLE(2022_GLIB_API)
-G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
 static void consoleMessageSentCallback(WebKitWebPage* webPage, WebKitConsoleMessage* consoleMessage)
 {
     g_assert_nonnull(consoleMessage);
@@ -332,8 +330,6 @@ static void consoleMessageSentCallback(WebKitWebPage* webPage, WebKitConsoleMess
         g_assert_true(JSC_IS_VALUE(result.get()));
     }
 }
-G_GNUC_END_IGNORE_DEPRECATIONS;
-#endif
 
 static void emitFormControlsAssociated(GDBusConnection* connection, const char* formIds)
 {
@@ -555,8 +551,8 @@ static void pageCreatedCallback(WebKitWebProcessExtension* extension, WebKitWebP
 #if !ENABLE(2022_GLIB_API)
     g_signal_connect(webPage, "form-controls-associated-for-frame", G_CALLBACK(formControlsAssociatedForFrameCallback), extension);
     g_signal_connect(webPage, "will-submit-form", G_CALLBACK(willSubmitFormDeprecatedCallback), extension);
-    g_signal_connect(webPage, "console-message-sent", G_CALLBACK(consoleMessageSentCallback), nullptr);
 #endif
+    g_signal_connect(webPage, "console-message-sent", G_CALLBACK(consoleMessageSentCallback), nullptr);
     g_signal_connect(webPage, "user-message-received", G_CALLBACK(pageMessageReceivedCallback), extension);
 
     auto* formManager = webkit_web_page_get_form_manager(webPage, nullptr);

--- a/Tools/TestWebKitAPI/glib/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/glib/CMakeLists.txt
@@ -139,6 +139,7 @@ ADD_WK2_TEST_WEB_PROCESS_EXTENSION(WebProcessTest ${WebKitGLibAPIWebProcessTests
 ADD_WK2_TEST(TestAuthentication ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestAuthentication.cpp)
 ADD_WK2_TEST(TestAutomationSession ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestAutomationSession.cpp)
 ADD_WK2_TEST(TestBackForwardList ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestBackForwardList.cpp)
+ADD_WK2_TEST(TestConsoleMessage ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestConsoleMessage.cpp)
 ADD_WK2_TEST(TestCookieManager ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestCookieManager.cpp)
 ADD_WK2_TEST(TestDownloads ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestDownloads.cpp)
 ADD_WK2_TEST(TestWebKitFindController ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestWebKitFindController.cpp)
@@ -167,8 +168,6 @@ ADD_WK2_TEST(TestInputMethodContext ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/
 
 if (ENABLE_2022_GLIB_API)
     ADD_WK2_TEST(TestWebKitNetworkSession ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestWebKitNetworkSession.cpp)
-else ()
-    ADD_WK2_TEST(TestConsoleMessage ${TOOLS_DIR}/TestWebKitAPI/Tests/WebKitGLib/TestConsoleMessage.cpp)
 endif ()
 
 macro(ADD_WPE_QT_TEST test_name)


### PR DESCRIPTION
#### e41ec2c29b8e53c5a5548c720195a808ac40124e
<pre>
[GTK][WPE] Undeprecate console message API and make it available in 2022 API
<a href="https://bugs.webkit.org/show_bug.cgi?id=275311">https://bugs.webkit.org/show_bug.cgi?id=275311</a>

Reviewed by Adrian Perez de Castro.

People have complained about this since we removed it, as long as we have the
web process extensions API there&apos;s no reason to not have this too.

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/PlatformGTKDeprecated.cmake:
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/PlatformWPEDeprecated.cmake:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesGTKDeprecated.txt:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/SourcesWPEDeprecated.txt:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitConsoleMessage.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitConsoleMessage.h.in:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitConsoleMessagePrivate.h:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp:
(webkitWebPageDidSendConsoleMessage):
(webkit_web_page_class_init):
(webkitWebPageCreate):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/webkit-web-process-extension.h.in:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestConsoleMessage.cpp:
(ConsoleMessageTest::~ConsoleMessageTest):
* Tools/TestWebKitAPI/Tests/WebKitGLib/WebProcessExtensionTest.cpp:
(consoleMessageSentCallback):
(pageCreatedCallback):
* Tools/TestWebKitAPI/glib/CMakeLists.txt:

Canonical link: <a href="https://commits.webkit.org/279899@main">https://commits.webkit.org/279899@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9483f83f130f0fbb38f386305b8164ded2286ba2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58056 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5509 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57078 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5523 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44368 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3727 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56873 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47457 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25492 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29128 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4794 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3650 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50945 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59646 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30024 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5155 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51788 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47539 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51199 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32175 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8126 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30954 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->