### PR TITLE
Add an entry about a space in empty braces, check-webkit-style checks.

### DIFF
--- a/Websites/webkit.org/code-style.md
+++ b/Websites/webkit.org/code-style.md
@@ -573,6 +573,34 @@ for ( ; current; current = current->next) { }
 for ( ; current; current = current->next);
 ```
 
+[](#empty-braces-space) Any empty braces should contain a space.
+
+###### Right:
+
+```cpp
+void f() { }
+struct Unit { };
+union Unit { };
+class Unit { };
+enum Unit { };
+int x { };
+auto a = [] { };
+while (true) { }
+```
+
+###### Wrong:
+
+```cpp
+void f() {}
+struct Unit {};
+union Unit {};
+class Unit {};
+enum Unit {};
+int x {};
+auto a = [] {};
+while (true) {}
+```
+
 ### Null, false and zero
 
 [](#zero-null) In C++, the null pointer value should be written as `nullptr`. In C, it should be written as `NULL`. In Objective-C and Objective-C++, follow the guideline for C or C++, respectively, but use `nil` to represent a null Objective-C object.


### PR DESCRIPTION
#### 528d5d1f396a00125c57890cd5c3d07dafa9730b
<pre>
Add an entry about a space in empty braces, check-webkit-style checks.
<a href="https://bugs.webkit.org/show_bug.cgi?id=275309">https://bugs.webkit.org/show_bug.cgi?id=275309</a>

Reviewed by Michael Catanzaro and Ryosuke Niwa.

Code style misses an entry about a space in empty braces, check-webkit-style checks
This patch adds that.

* Websites/webkit.org/code-style.md:

Canonical link: <a href="https://commits.webkit.org/280182@main">https://commits.webkit.org/280182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2b31ff19981a0acfdfdf644575a7493a55ba410

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7439 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58137 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5590 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5612 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44426 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3785 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56954 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32414 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47529 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25553 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29203 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3731 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51044 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5087 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59727 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30112 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5240 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51850 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31249 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47609 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51263 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12399 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32264 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31036 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->