### PR TITLE
AppCache removal: remove applicationCache property

### DIFF
--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -529,7 +529,6 @@ namespace WebCore {
     macro(abortSteps) \
     macro(addAbortAlgorithmToSignal) \
     macro(appendFromJS) \
-    macro(applicationCache) \
     macro(associatedReadableByteStreamController) \
     macro(autoAllocateChunkSize) \
     macro(backingMap) \

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -415,14 +415,6 @@ ExceptionOr<Navigator&> DOMWindow::navigator()
     return localThis->navigator();
 }
 
-ExceptionOr<DOMApplicationCache&> DOMWindow::applicationCache()
-{
-    auto* localThis = dynamicDowncast<LocalDOMWindow>(*this);
-    if (!localThis)
-        return Exception { ExceptionCode::SecurityError };
-    return localThis->applicationCache();
-}
-
 ExceptionOr<bool> DOMWindow::offscreenBuffering() const
 {
     auto* localThis = dynamicDowncast<LocalDOMWindow>(*this);

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -41,7 +41,6 @@ class CSSStyleDeclaration;
 class CookieStore;
 class Crypto;
 class CustomElementRegistry;
-class DOMApplicationCache;
 class DOMSelection;
 class DOMWrapperWorld;
 class Document;
@@ -157,7 +156,6 @@ public:
     ExceptionOr<int> scrollY() const;
     ExceptionOr<HTMLFrameOwnerElement*> frameElement() const;
     ExceptionOr<Navigator&> navigator();
-    ExceptionOr<DOMApplicationCache&> applicationCache();
     ExceptionOr<bool> offscreenBuffering() const;
     ExceptionOr<CookieStore&> cookieStore();
     ExceptionOr<Screen&> screen();

--- a/Source/WebCore/page/DOMWindow.idl
+++ b/Source/WebCore/page/DOMWindow.idl
@@ -84,8 +84,6 @@
     // the user agent
     readonly attribute Navigator navigator;
     [Replaceable, ImplementedAs=navigator] readonly attribute Navigator clientInformation;
-    // FIXME: This is specified to be [SecureContext]
-    [EnabledByQuirk=shouldEnableApplicationCache] readonly attribute DOMApplicationCache applicationCache;
 
     // user prompts
     undefined alert();

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -43,7 +43,6 @@
 #include "CrossOriginOpenerPolicy.h"
 #include "Crypto.h"
 #include "CustomElementRegistry.h"
-#include "DOMApplicationCache.h"
 #include "DOMSelection.h"
 #include "DOMStringList.h"
 #include "DOMTimer.h"
@@ -752,13 +751,6 @@ BarProp& LocalDOMWindow::toolbar()
     if (!m_toolbar)
         m_toolbar = BarProp::create(*this, BarProp::Toolbar);
     return *m_toolbar;
-}
-
-DOMApplicationCache& LocalDOMWindow::applicationCache()
-{
-    if (!m_applicationCache)
-        m_applicationCache = DOMApplicationCache::create(*this);
-    return *m_applicationCache;
 }
 
 Navigator& LocalDOMWindow::navigator()

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -280,9 +280,6 @@ public:
     Storage* optionalSessionStorage() const { return m_sessionStorage.get(); }
     Storage* optionalLocalStorage() const { return m_localStorage.get(); }
 
-    DOMApplicationCache& applicationCache();
-    DOMApplicationCache* optionalApplicationCache() const { return m_applicationCache.get(); }
-
     CustomElementRegistry* customElementRegistry() { return m_customElementRegistry.get(); }
     CustomElementRegistry& ensureCustomElementRegistry();
 
@@ -432,7 +429,6 @@ private:
 
     mutable RefPtr<Storage> m_sessionStorage;
     mutable RefPtr<Storage> m_localStorage;
-    mutable RefPtr<DOMApplicationCache> m_applicationCache;
 
     RefPtr<CustomElementRegistry> m_customElementRegistry;
 

--- a/Source/WebKitLegacy/mac/WebKit.exp
+++ b/Source/WebKitLegacy/mac/WebKit.exp
@@ -205,7 +205,6 @@ _WebFrameCanSuspendActiveDOMObjects
 _WebFrameHasPlugins
 _WebFrameHasUnloadListener
 _WebFrameMainDocumentError
-_WebFrameUsesApplicationCache
 _WebFrameUsesDatabases
 _WebFrameUsesGeolocation
 _WebHistoryAllItemsRemovedNotification

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -191,7 +191,6 @@ NSString *WebFrameHasPlugins = @"WebFrameHasPluginsKey";
 NSString *WebFrameHasUnloadListener = @"WebFrameHasUnloadListenerKey";
 NSString *WebFrameUsesDatabases = @"WebFrameUsesDatabasesKey";
 NSString *WebFrameUsesGeolocation = @"WebFrameUsesGeolocationKey";
-NSString *WebFrameUsesApplicationCache = @"WebFrameUsesApplicationCacheKey";
 NSString *WebFrameCanSuspendActiveDOMObjects = @"WebFrameCanSuspendActiveDOMObjectsKey";
 
 // FIXME: Remove when this key becomes publicly defined
@@ -2040,8 +2039,6 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
     if (auto* domWindow = _private->coreFrame->document()->domWindow()) {
         if (domWindow->hasEventListeners(WebCore::eventNames().unloadEvent))
             [result setObject:@YES forKey:WebFrameHasUnloadListener];
-        if (domWindow->optionalApplicationCache())
-            [result setObject:@YES forKey:WebFrameUsesApplicationCache];
     }
     
     if (auto* document = _private->coreFrame->document()) {

--- a/Source/WebKitLegacy/mac/WebView/WebFramePrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebFramePrivate.h
@@ -56,7 +56,6 @@ extern NSString *WebFrameHasPlugins;
 extern NSString *WebFrameHasUnloadListener;
 extern NSString *WebFrameUsesDatabases;
 extern NSString *WebFrameUsesGeolocation;
-extern NSString *WebFrameUsesApplicationCache;
 extern NSString *WebFrameCanSuspendActiveDOMObjects;
 
 typedef enum {


### PR DESCRIPTION
#### 0f1d0a1df59cae58c89e3644433ccedc61659974
<pre>
AppCache removal: remove applicationCache property
<a href="https://bugs.webkit.org/show_bug.cgi?id=275312">https://bugs.webkit.org/show_bug.cgi?id=275312</a>

Reviewed by Youenn Fablet.

Follows 279811@main as another small incremental step towards fully
removing AppCache.

* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/page/DOMWindow.cpp:
* Source/WebCore/page/DOMWindow.h:
* Source/WebCore/page/DOMWindow.idl:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::applicationCache): Deleted.
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebKitLegacy/mac/WebKit.exp:
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _cacheabilityDictionary]):
* Source/WebKitLegacy/mac/WebView/WebFramePrivate.h:

Canonical link: <a href="https://commits.webkit.org/279873@main">https://commits.webkit.org/279873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d62719176f98fc9c6fa7dc3d6d684d7f45e55148

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58060 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5513 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57082 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5527 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44369 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3728 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56877 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32343 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47460 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25493 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29133 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4797 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3654 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50951 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5014 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59650 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30028 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5160 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51792 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31170 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47542 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51197 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12040 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32179 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30958 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->