### PR TITLE
[MSE][GStreamer] allow fallback to seeked position on seek finish

### DIFF
--- a/LayoutTests/media/media-source/media-source-seek-back-after-ended-expected.txt
+++ b/LayoutTests/media/media-source/media-source-seek-back-after-ended-expected.txt
@@ -1,0 +1,21 @@
+This tests that a SourceBuffer can accept an initialization segment and a media segment and fire "update" events, the element can play and seek back properly when it's ended.
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(source.duration = loader.duration())
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(source.endOfStream())
+RUN(await video.play())
+EXPECTED (video.paused == 'false') OK
+EVENT(ended)
+RUN(video.currentTime = 0)
+EVENT(seeked)
+RUN(await video.play())
+EXPECTED (video.paused == 'false') OK
+EXPECTED (video.currentTime > '1') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-seek-back-after-ended.html
+++ b/LayoutTests/media/media-source/media-source-seek-back-after-ended.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-seek-back-after-ended</title>
+    <script src="media-source-loader.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    var loader;
+    var source;
+    var sourceBuffer;
+
+    function loaderPromise(loader) {
+        return new Promise((resolve, reject) => {
+            loader.onload = resolve;
+            loader.onerror = reject;
+        });
+    }
+
+    function timeUpdatePromise(video) {
+        return new Promise(resolve => {
+            video.addEventListener('timeupdate', event => {
+                if (!video.paused && video.currentTime > 1) {
+                    testExpected("video.paused", false);
+                    testExpected("video.currentTime", 1, ">");
+                    resolve();
+                }
+            });
+        });
+    }
+
+    window.addEventListener('load', async event => {
+        try {
+            findMediaElement();
+
+            loader = new MediaSourceLoader('content/test-vp9-manifest.json');
+            await loaderPromise(loader);
+
+            source = new MediaSource();
+            run('video.src = URL.createObjectURL(source)');
+            await waitFor(source, 'sourceopen');
+            waitForEventAndFail('error');
+
+            run('source.duration = loader.duration()');
+            run('sourceBuffer = source.addSourceBuffer(loader.type())');
+            run('sourceBuffer.appendBuffer(loader.initSegment())');
+            await waitFor(sourceBuffer, 'update');
+
+            run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
+            await waitFor(sourceBuffer, 'update');
+            run('source.endOfStream()');
+
+            await video.play();
+            consoleWrite("RUN(await video.play())");
+            testExpected("video.paused", false);
+
+            await waitFor(video, 'ended');
+
+            run('video.currentTime = 0');
+            await waitFor(video, 'seeked');
+            await video.play();
+            consoleWrite("RUN(await video.play())");
+
+            await timeUpdatePromise(video);
+
+            endTest();
+        } catch (e) {
+            failTest(`Caught exception: "${e}"`);
+        }
+    });
+    </script>
+</head>
+<body>
+    <div>
+        This tests that a SourceBuffer can accept an initialization segment and a media segment and fire "update" events,
+        the element can play and seek back properly when it's ended.
+    </div>
+    <video controls></video>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2151,6 +2151,7 @@ webkit.org/b/215926 svg/custom/object-sizing.xhtml [ Pass Failure ]
 
 # rdar://problem/66487888 media/media-source/media-source-webm.html is a constant failure
 media/media-source/media-source-webm.html [ Failure ]
+media/media-source/media-source-seek-back-after-ended.html [ Skip ]
 
 webkit.org/b/216492 imported/w3c/web-platform-tests/selection/collapse-45.html [ Slow ]
 webkit.org/b/216492 imported/w3c/web-platform-tests/selection/collapse-15.html [ Slow ]

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -312,6 +312,8 @@ void MediaPlayerPrivateGStreamerMSE::didPreroll()
 
     if (m_isSeeking) {
         m_isSeeking = false;
+        m_canFallBackToLastFinishedSeekPosition = true;
+        invalidateCachedPosition();
         GST_DEBUG("Seek complete because of preroll. currentMediaTime = %s", currentTime().toString().utf8().data());
         // By calling timeChanged(), m_isSeeking will be checked an a "seeked" event will be emitted.
         timeChanged(currentTime());


### PR DESCRIPTION
#### d36ed108e92fb350723da8e7a88e7a7e8be1ef45
<pre>
[MSE][GStreamer] allow fallback to seeked position on seek finish
<a href="https://bugs.webkit.org/show_bug.cgi?id=275104">https://bugs.webkit.org/show_bug.cgi?id=275104</a>

Reviewed by Philippe Normand.

MediaPlayerPrivateGStreamer may report incorrect position (last cached) immediately after seek. This can happen when
didPreroll is called on async-done with pipeline still in async transition to playing state: current: PAUSED, pending:
PLAYING, result: ASYNC. r277541 disables querying position from the sinks in this case resulting in last cached
value (before seek) to be returned. Which confuses some tests from YouTube WV SFR/HFR suite, and makes it trigger
multiple seeks one after another.

The proposed change works around the problem by allowing fall back to last seeked position until pipeline preroll
completes. Similar to MediaPlayerPrivateGStreamer::finishSeek().

Patch by Eugene Mutavchi &lt;Ievgen_Mutavchi@comcast.com&gt;.

* LayoutTests/media/media-source/media-source-seek-back-after-ended-expected.txt: Added.
* LayoutTests/media/media-source/media-source-seek-back-after-ended.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::didPreroll):

Canonical link: <a href="https://commits.webkit.org/279901@main">https://commits.webkit.org/279901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5723324b421b20d1fd0e3d3a5cf487c42a1e8da

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54806 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7384 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58084 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5537 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57106 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44387 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3745 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56901 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47479 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25511 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29151 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4815 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3678 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50975 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59674 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30054 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5181 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51808 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31195 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47560 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51220 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12056 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32205 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30983 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->