### PR TITLE
API URL change request can be cancelled by JS navigation

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1474,6 +1474,13 @@ void FrameLoader::loadURL(FrameLoadRequest&& frameLoadRequest, const String& ref
     if (m_inStopAllLoaders || m_inClearProvisionalLoadForPolicyCheck)
         return;
 
+#if PLATFORM(WPE) || PLATFORM(GTK)
+    if ((m_policyDocumentLoader && m_policyDocumentLoader->isRequestFromClientOrUserInput()) || (m_provisionalDocumentLoader && m_provisionalDocumentLoader->isRequestFromClientOrUserInput())) {
+        FRAMELOADER_RELEASE_LOG(ResourceLoading, "loadURL: newURL: %s is cancelled because of ongoing 'API URL change request'", frameLoadRequest.resourceRequest().url().string().utf8().data());
+        return;
+    }
+#endif
+
     Ref frame = m_frame.get();
 
     // Anchor target is ignored when the download attribute is set since it will download the hyperlink rather than follow it.


### PR DESCRIPTION
#### 6242c638fbfd3fdf602b01294306a5b45f0030ff
<pre>
API URL change request can be cancelled by JS navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=274745">https://bugs.webkit.org/show_bug.cgi?id=274745</a>

Reviewed by NOBODY (OOPS!).

The problem can be reproduced with very quick (in each 10ms) fragment navigation
(JS call of window.location.href). In such case, it is not possible to navigate to
other site via &quot;API URL change request&quot;.

To solve the problem, this change cancels the fragment navigation if there is an ongoing
&quot;API URL change request&quot;.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadURL):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b16312891c6da0bda74cd5af001d52c493145f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54788 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34220 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7366 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58066 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5519 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57088 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5533 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44375 "Found 1 new test failure: http/tests/history/back-with-fragment-change.py (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3734 "Passed tests") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56883 "Build is in progress. Recent messages:OS: Unknown (10.15.7), Xcode: 11.7; Running apply-patch; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32349 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47466 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25499 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29140 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4803 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3660 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50958 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59656 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30035 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5167 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51798 "Found 1 new test failure: http/tests/history/back-with-fragment-change.py (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31176 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47548 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51207 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32185 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30964 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->