### PR TITLE
[Nicosia] Images with translate-Z get unloaded when out of view

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -914,10 +914,15 @@ void CoordinatedGraphicsLayer::flushCompositingStateForThisLayerOnly()
 
         // Update the image contents only when the image layer is visible and the native image changed.
         auto& layerState = m_nicosia.imageBacking->layerState();
-        layerState.imageID = imageID;
-        layerState.update.isVisible = transformedVisibleRect().intersects(IntRect(contentsRect()));
-        if (layerState.update.isVisible && (!nativeImageID || layerState.update.nativeImageID != nativeImageID)) {
+        bool nativeImageChanged = layerState.update.nativeImageID != nativeImageID;
+        if (nativeImageChanged)
             layerState.update.nativeImageID = nativeImageID;
+
+        bool wasVisible = layerState.update.isVisible;
+        layerState.update.isVisible = transformedVisibleRect().intersects(IntRect(contentsRect()));
+
+        // Update the image contents only when the image layer is visible and it was previously hidden or the native image changed.
+        if (layerState.update.isVisible && (!wasVisible || nativeImageChanged)) {
             layerState.update.imageBackingStore = m_coordinator->imageBackingStore(nativeImageID, [&] {
                 return paintImage(image);
             });


### PR DESCRIPTION
#### 3deb4217571cff34029b6f4bf3f8eaf3e2e3a58d
<pre>
[Nicosia] Images with translate-Z get unloaded when out of view
<a href="https://bugs.webkit.org/show_bug.cgi?id=271379">https://bugs.webkit.org/show_bug.cgi?id=271379</a>

Reviewed by Miguel Gomez.

We pass a nullptr image backing store to the compositor to indicate to
use the current image when the layer is visible. When the layer becomes
invisible, the layer contents is set to nullptr, but when it becomes
visible again, we don&apos;t update the image backing store in the update,
because the native image didn&apos;t change. When the layer becomes visible
we always need to set the image backing store again to make sure the
compositor updates the layer contents.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp:
(WebCore::CoordinatedGraphicsLayer::flushCompositingStateForThisLayerOnly):

Canonical link: <a href="https://commits.webkit.org/279898@main">https://commits.webkit.org/279898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/206d882d6d723401c206ec6eb610281a31d05218

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34223 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58069 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5522 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57091 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5536 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44377 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3736 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56886 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47468 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25501 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29142 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4805 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3663 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/50961 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5022 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59659 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30038 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5169 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51800 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47550 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51212 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32188 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8125 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/30967 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->