### PR TITLE
[WPE][GTK][WTF] Implement SystemTracing.h with Sysprof

### DIFF
--- a/Source/JavaScriptCore/jit/JITPlan.cpp
+++ b/Source/JavaScriptCore/jit/JITPlan.cpp
@@ -180,7 +180,7 @@ void JITPlan::compileInThread(JITWorklistThread* thread)
         StringPrintStream stream;
         stream.print(m_mode, " ", *m_codeBlock, " instructions size = ", m_codeBlock->instructionsSize());
         signpostMessage = stream.toCString();
-        WTFBeginSignpost(this, JSCJITCompiler, "%" PUBLIC_LOG_STRING, signpostMessage.data());
+        WTFBeginSignpost(this, JSCJITCompiler, "%" PUBLIC_LOG_STRING, signpostMessage.data() ? signpostMessage.data() : "(nullptr)");
     }
 
     CompilationPath path = compileInThreadImpl();
@@ -188,7 +188,7 @@ void JITPlan::compileInThread(JITWorklistThread* thread)
     RELEASE_ASSERT((path == CancelPath) == (m_stage == JITPlanStage::Canceled));
 
     if (UNLIKELY(Options::useCompilerSignpost()))
-        WTFEndSignpost(this, JSCJITCompiler, "%" PUBLIC_LOG_STRING, signpostMessage.data());
+        WTFEndSignpost(this, JSCJITCompiler, "%" PUBLIC_LOG_STRING, signpostMessage.data() ? signpostMessage.data() : "(nullptr)");
 
     if (LIKELY(!computeCompileTimes))
         return;

--- a/Source/WTF/wtf/PlatformGTK.cmake
+++ b/Source/WTF/wtf/PlatformGTK.cmake
@@ -39,6 +39,7 @@ list(APPEND WTF_PUBLIC_HEADERS
     glib/RunLoopSourcePriority.h
     glib/Sandbox.h
     glib/SocketConnection.h
+    glib/SysprofAnnotator.h
     glib/WTFGType.h
 
     linux/CurrentProcessMemoryStatus.h

--- a/Source/WTF/wtf/PlatformWPE.cmake
+++ b/Source/WTF/wtf/PlatformWPE.cmake
@@ -42,6 +42,7 @@ list(APPEND WTF_PUBLIC_HEADERS
     glib/RunLoopSourcePriority.h
     glib/Sandbox.h
     glib/SocketConnection.h
+    glib/SysprofAnnotator.h
     glib/WTFGType.h
 
     linux/CurrentProcessMemoryStatus.h

--- a/Source/WTF/wtf/glib/SysprofAnnotator.h
+++ b/Source/WTF/wtf/glib/SysprofAnnotator.h
@@ -1,0 +1,456 @@
+/*
+ * Copyright (C) 2024 Igalia, S.L.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Library General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Library General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Library General Public License
+ *  along with this library; see the file COPYING.LIB.  If not, write to
+ *  the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *  Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include <sysprof-capture.h>
+#include <wtf/HashMap.h>
+#include <wtf/Lock.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/Vector.h>
+#include <wtf/text/ASCIILiteral.h>
+
+namespace WTF {
+
+class SysprofAnnotator final {
+    WTF_MAKE_NONCOPYABLE(SysprofAnnotator);
+
+    using RawPointerPair = std::pair<const void*, const void*>;
+    using TimestampAndString = std::pair<int64_t, Vector<char>>;
+
+public:
+
+    static SysprofAnnotator* singletonIfCreated()
+    {
+        return s_annotator;
+    }
+
+    void instantMark(std::span<const char> name, const char* description, ...) WTF_ATTRIBUTE_PRINTF(3, 4)
+    {
+        va_list args;
+        va_start(args, description);
+        sysprof_collector_mark_vprintf(SYSPROF_CAPTURE_CURRENT_TIME, 0, m_processName, name.data(), description, args);
+        va_end(args);
+    }
+
+    void mark(Seconds timeDelta, std::span<const char> name, const char* description, ...) WTF_ATTRIBUTE_PRINTF(4, 5)
+    {
+        va_list args;
+        va_start(args, description);
+        sysprof_collector_mark_vprintf(SYSPROF_CAPTURE_CURRENT_TIME, timeDelta.microsecondsAs<int64_t>(), m_processName, name.data(), description, args);
+        va_end(args);
+    }
+
+    void beginMark(const void* pointer, std::span<const char> name, const char* description, ...) WTF_ATTRIBUTE_PRINTF(4, 5)
+    {
+        auto key = std::make_pair(pointer, static_cast<const void*>(name.data()));
+
+        Vector<char, 1024> buffer;
+        va_list args;
+        va_start(args, description);
+        vsnprintf(buffer.data(), 1024, description, args);
+        va_end(args);
+
+        auto value = std::make_pair(SYSPROF_CAPTURE_CURRENT_TIME, WTFMove(buffer));
+
+        Locker locker { m_lock };
+        m_ongoingMarks.set(key, value);
+    }
+
+    void endMark(const void* pointer, std::span<const char> name, const char* description, ...) WTF_ATTRIBUTE_PRINTF(4, 5)
+    {
+        auto key = std::make_pair(pointer, static_cast<const void*>(name.data()));
+        std::optional<TimestampAndString> value;
+
+        {
+            Locker locker { m_lock };
+
+            TimestampAndString v = m_ongoingMarks.take(key);
+            if (v.first)
+                value = WTFMove(v);
+        }
+
+        if (value) {
+            int64_t startTime = std::get<0>(*value);
+            const Vector<char>& description = std::get<1>(*value);
+            sysprof_collector_mark(startTime, SYSPROF_CAPTURE_CURRENT_TIME - startTime, m_processName, name.data(), description.data());
+        } else {
+            va_list args;
+            va_start(args, description);
+            sysprof_collector_mark_vprintf(SYSPROF_CAPTURE_CURRENT_TIME, 0, m_processName, name.data(), description, args);
+            va_end(args);
+        }
+    }
+
+    void tracePoint(TracePointCode code)
+    {
+        switch (code) {
+        case VMEntryScopeStart:
+        case WebAssemblyCompileStart:
+        case WebAssemblyExecuteStart:
+        case DumpJITMemoryStart:
+        case FromJSStart:
+        case IncrementalSweepStart:
+        case MainResourceLoadDidStartProvisional:
+        case SubresourceLoadWillStart:
+        case FetchCookiesStart:
+        case StyleRecalcStart:
+        case RenderTreeBuildStart:
+        case PerformLayoutStart:
+        case PaintLayerStart:
+        case AsyncImageDecodeStart:
+        case RAFCallbackStart:
+        case MemoryPressureHandlerStart:
+        case UpdateTouchRegionsStart:
+        case DisplayListRecordStart:
+        case ComputeEventRegionsStart:
+        case RenderingUpdateStart:
+        case CompositingUpdateStart:
+        case DispatchTouchEventsStart:
+        case ParseHTMLStart:
+        case DisplayListReplayStart:
+        case ScrollingThreadRenderUpdateSyncStart:
+        case ScrollingThreadDisplayDidRefreshStart:
+        case RenderTreeLayoutStart:
+        case PerformOpportunisticallyScheduledTasksStart:
+        case WebXRLayerStartFrameStart:
+        case WebXRLayerEndFrameStart:
+        case WebXRSessionFrameCallbacksStart:
+        case WebHTMLViewPaintStart:
+        case BackingStoreFlushStart:
+        case BuildTransactionStart:
+        case SyncMessageStart:
+        case SyncTouchEventStart:
+        case InitializeWebProcessStart:
+        case RenderingUpdateRunLoopObserverStart:
+        case LayerTreeFreezeStart:
+        case FlushRemoteImageBufferStart:
+        case CreateInjectedBundleStart:
+        case PaintSnapshotStart:
+        case RenderServerSnapshotStart:
+        case TakeSnapshotStart:
+        case SyntheticMomentumStart:
+        case CommitLayerTreeStart:
+        case ProcessLaunchStart:
+        case InitializeSandboxStart:
+        case WebXRCPFrameWaitStart:
+        case WebXRCPFrameStartSubmissionStart:
+        case WebXRCPFrameEndSubmissionStart:
+        case WakeUpAndApplyDisplayListStart:
+            beginMark(nullptr, tracePointCodeName(code).spanIncludingNullTerminator(), "%s", "");
+            break;
+
+        case VMEntryScopeEnd:
+        case WebAssemblyCompileEnd:
+        case WebAssemblyExecuteEnd:
+        case DumpJITMemoryStop:
+        case FromJSStop:
+        case IncrementalSweepEnd:
+        case MainResourceLoadDidEnd:
+        case SubresourceLoadDidEnd:
+        case FetchCookiesEnd:
+        case StyleRecalcEnd:
+        case RenderTreeBuildEnd:
+        case PerformLayoutEnd:
+        case PaintLayerEnd:
+        case AsyncImageDecodeEnd:
+        case RAFCallbackEnd:
+        case MemoryPressureHandlerEnd:
+        case UpdateTouchRegionsEnd:
+        case DisplayListRecordEnd:
+        case ComputeEventRegionsEnd:
+        case RenderingUpdateEnd:
+        case CompositingUpdateEnd:
+        case DispatchTouchEventsEnd:
+        case ParseHTMLEnd:
+        case DisplayListReplayEnd:
+        case ScrollingThreadRenderUpdateSyncEnd:
+        case ScrollingThreadDisplayDidRefreshEnd:
+        case RenderTreeLayoutEnd:
+        case PerformOpportunisticallyScheduledTasksEnd:
+        case WebXRLayerStartFrameEnd:
+        case WebXRLayerEndFrameEnd:
+        case WebXRSessionFrameCallbacksEnd:
+        case WebHTMLViewPaintEnd:
+        case BackingStoreFlushEnd:
+        case BuildTransactionEnd:
+        case SyncMessageEnd:
+        case SyncTouchEventEnd:
+        case InitializeWebProcessEnd:
+        case RenderingUpdateRunLoopObserverEnd:
+        case LayerTreeFreezeEnd:
+        case FlushRemoteImageBufferEnd:
+        case CreateInjectedBundleEnd:
+        case PaintSnapshotEnd:
+        case RenderServerSnapshotEnd:
+        case TakeSnapshotEnd:
+        case SyntheticMomentumEnd:
+        case CommitLayerTreeEnd:
+        case ProcessLaunchEnd:
+        case InitializeSandboxEnd:
+        case WebXRCPFrameWaitEnd:
+        case WebXRCPFrameStartSubmissionEnd:
+        case WebXRCPFrameEndSubmissionEnd:
+        case WakeUpAndApplyDisplayListEnd:
+            endMark(nullptr, tracePointCodeName(code).spanIncludingNullTerminator(), "%s", "");
+            break;
+
+        case DisplayRefreshDispatchingToMainThread:
+        case ScheduleRenderingUpdate:
+        case TriggerRenderingUpdate:
+        case ScrollingTreeDisplayDidRefresh:
+        case SyntheticMomentumEvent:
+        case RemoteLayerTreeScheduleRenderingUpdate:
+            instantMark(tracePointCodeName(code).spanIncludingNullTerminator(), "%s", "");
+            break;
+
+        case WTFRange:
+        case JavaScriptRange:
+        case WebCoreRange:
+        case WebKitRange:
+        case WebKit2Range:
+        case UIProcessRange:
+        case GPUProcessRange:
+            break;
+        }
+    }
+
+    static void createIfNeeded(ASCIILiteral processName)
+    {
+        if (!getenv("SYSPROF_CONTROL_FD"))
+            return;
+
+        static LazyNeverDestroyed<SysprofAnnotator> instance;
+        static std::once_flag onceFlag;
+        std::call_once(onceFlag, [&] {
+            instance.construct(processName);
+        });
+    }
+
+private:
+    friend class LazyNeverDestroyed<SysprofAnnotator>;
+
+    static ASCIILiteral tracePointCodeName(TracePointCode code)
+    {
+        switch (code) {
+        case VMEntryScopeStart:
+        case VMEntryScopeEnd:
+            return "VMEntryScope"_s;
+        case WebAssemblyCompileStart:
+        case WebAssemblyCompileEnd:
+            return "WebAssemblyCompile"_s;
+        case WebAssemblyExecuteStart:
+        case WebAssemblyExecuteEnd:
+            return "WebAssemblyExecute"_s;
+        case DumpJITMemoryStart:
+        case DumpJITMemoryStop:
+            return "DumpJITMemory"_s;
+        case FromJSStart:
+        case FromJSStop:
+            return "FromJS"_s;
+        case IncrementalSweepStart:
+        case IncrementalSweepEnd:
+            return "IncrementalSweep"_s;
+
+        case MainResourceLoadDidStartProvisional:
+        case MainResourceLoadDidEnd:
+            return "MainResourceLoad"_s;
+        case SubresourceLoadWillStart:
+        case SubresourceLoadDidEnd:
+            return "SubresourceLoad"_s;
+        case FetchCookiesStart:
+        case FetchCookiesEnd:
+            return "FetchCookies"_s;
+        case StyleRecalcStart:
+        case StyleRecalcEnd:
+            return "StyleRecalc"_s;
+        case RenderTreeBuildStart:
+        case RenderTreeBuildEnd:
+            return "RenderTreeBuild"_s;
+        case PerformLayoutStart:
+        case PerformLayoutEnd:
+            return "PerformLayout"_s;
+        case PaintLayerStart:
+        case PaintLayerEnd:
+            return "PaintLayer"_s;
+        case AsyncImageDecodeStart:
+        case AsyncImageDecodeEnd:
+            return "AsyncImageDecode"_s;
+        case RAFCallbackStart:
+        case RAFCallbackEnd:
+            return "RAFCallback"_s;
+        case MemoryPressureHandlerStart:
+        case MemoryPressureHandlerEnd:
+            return "MemoryPressureHandler"_s;
+        case UpdateTouchRegionsStart:
+        case UpdateTouchRegionsEnd:
+            return "UpdateTouchRegions"_s;
+        case DisplayListRecordStart:
+        case DisplayListRecordEnd:
+            return "DisplayListRecord"_s;
+        case DisplayRefreshDispatchingToMainThread:
+            return "DisplayRefreshDispatchingToMainThread"_s;
+        case ComputeEventRegionsStart:
+        case ComputeEventRegionsEnd:
+            return "ComputeEventRegions"_s;
+        case ScheduleRenderingUpdate:
+            return "ScheduleRenderingUpdate"_s;
+        case TriggerRenderingUpdate:
+            return "TriggerRenderingUpdate"_s;
+        case RenderingUpdateStart:
+        case RenderingUpdateEnd:
+            return "RenderingUpdate"_s;
+        case CompositingUpdateStart:
+        case CompositingUpdateEnd:
+            return "CompositingUpdate"_s;
+        case DispatchTouchEventsStart:
+        case DispatchTouchEventsEnd:
+            return "DispatchTouchEvents"_s;
+        case ParseHTMLStart:
+        case ParseHTMLEnd:
+            return "ParseHTML"_s;
+        case DisplayListReplayStart:
+        case DisplayListReplayEnd:
+            return "DisplayListReplay"_s;
+        case ScrollingThreadRenderUpdateSyncStart:
+        case ScrollingThreadRenderUpdateSyncEnd:
+            return "ScrollingThreadRenderUpdateSync"_s;
+        case ScrollingThreadDisplayDidRefreshStart:
+        case ScrollingThreadDisplayDidRefreshEnd:
+            return "ScrollingThreadDisplayDidRefresh"_s;
+        case ScrollingTreeDisplayDidRefresh:
+            return "ScrollingTreeDisplayDidRefresh"_s;
+        case RenderTreeLayoutStart:
+        case RenderTreeLayoutEnd:
+            return "RenderTreeLayout"_s;
+        case PerformOpportunisticallyScheduledTasksStart:
+        case PerformOpportunisticallyScheduledTasksEnd:
+            return "PerformOpportunisticallyScheduledTasks"_s;
+        case WebXRLayerStartFrameStart:
+        case WebXRLayerStartFrameEnd:
+            return "WebXRLayerStartFrame"_s;
+        case WebXRLayerEndFrameStart:
+        case WebXRLayerEndFrameEnd:
+            return "WebXRLayerEndFrame"_s;
+        case WebXRSessionFrameCallbacksStart:
+        case WebXRSessionFrameCallbacksEnd:
+            return "WebXRSessionFrameCallbacks"_s;
+
+        case WebHTMLViewPaintStart:
+        case WebHTMLViewPaintEnd:
+            return "WebHTMLViewPaint"_s;
+
+        case BackingStoreFlushStart:
+        case BackingStoreFlushEnd:
+            return "BackingStoreFlush"_s;
+        case BuildTransactionStart:
+        case BuildTransactionEnd:
+            return "BuildTransaction"_s;
+        case SyncMessageStart:
+        case SyncMessageEnd:
+            return "SyncMessage"_s;
+        case SyncTouchEventStart:
+        case SyncTouchEventEnd:
+            return "SyncTouchEvent"_s;
+        case InitializeWebProcessStart:
+        case InitializeWebProcessEnd:
+            return "InitializeWebProcess"_s;
+        case RenderingUpdateRunLoopObserverStart:
+        case RenderingUpdateRunLoopObserverEnd:
+            return "RenderingUpdateRunLoopObserver"_s;
+        case LayerTreeFreezeStart:
+        case LayerTreeFreezeEnd:
+            return "LayerTreeFreeze"_s;
+        case FlushRemoteImageBufferStart:
+        case FlushRemoteImageBufferEnd:
+            return "FlushRemoteImageBuffer"_s;
+        case CreateInjectedBundleStart:
+        case CreateInjectedBundleEnd:
+            return "CreateInjectedBundle"_s;
+        case PaintSnapshotStart:
+        case PaintSnapshotEnd:
+            return "PaintSnapshot"_s;
+        case RenderServerSnapshotStart:
+        case RenderServerSnapshotEnd:
+            return "RenderServerSnapshot"_s;
+        case TakeSnapshotStart:
+        case TakeSnapshotEnd:
+            return "TakeSnapshot"_s;
+        case SyntheticMomentumStart:
+        case SyntheticMomentumEnd:
+            return "SyntheticMomentum"_s;
+        case SyntheticMomentumEvent:
+            return "SyntheticMomentumEvent"_s;
+        case RemoteLayerTreeScheduleRenderingUpdate:
+            return "RemoteLayerTreeScheduleRenderingUpdate"_s;
+
+        case CommitLayerTreeStart:
+        case CommitLayerTreeEnd:
+            return "CommitLayerTree"_s;
+        case ProcessLaunchStart:
+        case ProcessLaunchEnd:
+            return "ProcessLaunch"_s;
+        case InitializeSandboxStart:
+        case InitializeSandboxEnd:
+            return "InitializeSandbox"_s;
+        case WebXRCPFrameWaitStart:
+        case WebXRCPFrameWaitEnd:
+            return "WebXRCPFrameWait"_s;
+        case WebXRCPFrameStartSubmissionStart:
+        case WebXRCPFrameStartSubmissionEnd:
+            return "WebXRCPFrameStartSubmission"_s;
+        case WebXRCPFrameEndSubmissionStart:
+        case WebXRCPFrameEndSubmissionEnd:
+            return "WebXRCPFrameEndSubmission"_s;
+
+        case WakeUpAndApplyDisplayListStart:
+        case WakeUpAndApplyDisplayListEnd:
+            return "WakeUpAndApplyDisplayList"_s;
+
+        case WTFRange:
+        case JavaScriptRange:
+        case WebCoreRange:
+        case WebKitRange:
+        case WebKit2Range:
+        case UIProcessRange:
+        case GPUProcessRange:
+            return nullptr;
+        }
+
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    explicit SysprofAnnotator(ASCIILiteral processName)
+        : m_processName(processName)
+    {
+        sysprof_collector_init();
+        s_annotator = this;
+    }
+
+    ASCIILiteral m_processName;
+    Lock m_lock;
+    HashMap<RawPointerPair, TimestampAndString> m_ongoingMarks WTF_GUARDED_BY_LOCK(m_lock);
+    static SysprofAnnotator* s_annotator;
+};
+
+inline SysprofAnnotator* SysprofAnnotator::s_annotator;
+
+} // namespace WTF
+
+using WTF::SysprofAnnotator;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1825,7 +1825,7 @@ void Document::setReadyState(ReadyState readyState)
                 eventTiming->domLoading = now;
             // We do this here instead of in the Document constructor because monotonicTimestamp() is 0 when the Document constructor is running.
             if (!url().isEmpty())
-                WTFBeginSignpostWithTimeDelta(this, NavigationAndPaintTiming, -Seconds(monotonicTimestamp()), "Loading %{public}s | isMainFrame: %d", url().string().utf8().data(), frame() && frame()->isMainFrame());
+                WTFBeginSignpostWithTimeDelta(this, NavigationAndPaintTiming, -Seconds(monotonicTimestamp()), "Loading %" PUBLIC_LOG_STRING " | isMainFrame: %d", url().string().utf8().data(), frame() && frame()->isMainFrame());
             WTFEmitSignpost(this, NavigationAndPaintTiming, "domLoading");
         }
         break;

--- a/Source/WebKit/GPUProcess/glib/GPUProcessMainGLib.cpp
+++ b/Source/WebKit/GPUProcess/glib/GPUProcessMainGLib.cpp
@@ -31,17 +31,28 @@
 #include "GPUProcess.h"
 #endif
 
+#if USE(SYSPROF_CAPTURE)
+#include <wtf/SystemTracing.h>
+#endif
+
 namespace WebKit {
 
 #if ENABLE(GPU_PROCESS) && (PLATFORM(GTK) || PLATFORM(WPE))
-class GPUProcessMainGStreamer final: public AuxiliaryProcessMainBase<GPUProcess> {
+class GPUProcessMainGLib final: public AuxiliaryProcessMainBase<GPUProcess> {
+public:
+    bool platformInitialize() override
+    {
+#if USE(SYSPROF_CAPTURE)
+        SysprofAnnotator::createIfNeeded("WebKit (GPU)"_s);
+#endif
+    }
 };
 #endif
 
 int GPUProcessMain(int argc, char** argv)
 {
 #if ENABLE(GPU_PROCESS) && (PLATFORM(GTK) || PLATFORM(WPE))
-    return AuxiliaryProcessMain<GPUProcessMainGStreamer>(argc, argv);
+    return AuxiliaryProcessMain<GPUProcessMainGLib>(argc, argv);
 #else
     return 0;
 #endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitInitialize.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitInitialize.cpp
@@ -39,6 +39,10 @@
 #include <skia/core/SkGraphics.h>
 #endif
 
+#if USE(SYSPROF_CAPTURE)
+#include <wtf/SystemTracing.h>
+#endif
+
 namespace WebKit {
 
 #if ENABLE(REMOTE_INSPECTOR)
@@ -104,6 +108,9 @@ void webkitInitialize()
     static std::once_flag onceFlag;
 
     std::call_once(onceFlag, [] {
+#if USE(SYSPROF_CAPTURE)
+        SysprofAnnotator::createIfNeeded("WebKit (UI)"_s);
+#endif
         InitializeWebKit2();
 #if USE(SKIA)
         SkGraphics::Init();

--- a/Source/WebKit/WebProcess/gtk/WebProcessMainGtk.cpp
+++ b/Source/WebKit/WebProcess/gtk/WebProcessMainGtk.cpp
@@ -44,6 +44,10 @@
 #include <skia/core/SkGraphics.h>
 #endif
 
+#if USE(SYSPROF_CAPTURE)
+#include <wtf/SystemTracing.h>
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -51,6 +55,10 @@ class WebProcessMainGtk final: public AuxiliaryProcessMainBase<WebProcess> {
 public:
     bool platformInitialize() override
     {
+#if USE(SYSPROF_CAPTURE)
+        SysprofAnnotator::createIfNeeded("WebKit (Web)"_s);
+#endif
+
 #if USE(GCRYPT)
         PAL::GCrypt::initialize();
 #endif

--- a/Source/WebKit/WebProcess/wpe/WebProcessMainWPE.cpp
+++ b/Source/WebKit/WebProcess/wpe/WebProcessMainWPE.cpp
@@ -43,6 +43,10 @@
 #include <skia/core/SkGraphics.h>
 #endif
 
+#if USE(SYSPROF_CAPTURE)
+#include <wtf/SystemTracing.h>
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -50,6 +54,10 @@ class WebProcessMainWPE final : public AuxiliaryProcessMainBase<WebProcess> {
 public:
     bool platformInitialize() override
     {
+#if USE(SYSPROF_CAPTURE)
+        SysprofAnnotator::createIfNeeded("WebKit (Web)"_s);
+#endif
+
 #if USE(GCRYPT)
         PAL::GCrypt::initialize();
 #endif

--- a/Tools/Scripts/webkitpy/common/system/abstractexecutive.py
+++ b/Tools/Scripts/webkitpy/common/system/abstractexecutive.py
@@ -111,7 +111,7 @@ class AbstractExecutive(object):
         return string_utils.decode(string_utils.encode((b' ' if isinstance(args[0], bytes) else ' ').join(args), encoding='unicode_escape'))
 
     def run_command(self, args, cwd=None, env=None, input=None, stdout=None, error_handler=None, ignore_errors=False,
-        return_exit_code=False, return_stderr=True, decode_output=True):
+                    return_exit_code=False, return_stderr=True, decode_output=True, pass_fds=()):
         raise NotImplementedError('subclasses must implement')
 
     def popen(self, args, **kwargs):

--- a/Tools/Scripts/webkitpy/common/system/executive.py
+++ b/Tools/Scripts/webkitpy/common/system/executive.py
@@ -403,7 +403,8 @@ class Executive(AbstractExecutive):
                     ignore_errors=False,
                     return_exit_code=False,
                     return_stderr=True,
-                    decode_output=True):
+                    decode_output=True,
+                    pass_fds=()):
         """Popen wrapper for convenience and to work around python bugs."""
         assert(isinstance(args, list) or isinstance(args, tuple))
         start_time = time.time()
@@ -417,7 +418,8 @@ class Executive(AbstractExecutive):
                              stderr=stderr,
                              cwd=cwd,
                              env=env,
-                             close_fds=self._should_close_fds())
+                             close_fds=self._should_close_fds(),
+                             pass_fds=pass_fds)
         with process:
             if not string_to_communicate:
                 output = process.communicate()[0]

--- a/Tools/Scripts/webkitpy/common/system/executive_mock.py
+++ b/Tools/Scripts/webkitpy/common/system/executive_mock.py
@@ -132,7 +132,8 @@ class MockExecutive(object):
                     return_exit_code=False,
                     return_stderr=True,
                     decode_output=False,
-                    env=None):
+                    env=None,
+                    pass_fds=()):
 
         self.calls.append(args)
 


### PR DESCRIPTION
#### cb1a4a419f2189c993f8e1e8df93d08800750b0f
<pre>
[WPE][GTK][WTF] Implement SystemTracing.h with Sysprof
<a href="https://bugs.webkit.org/show_bug.cgi?id=275314">https://bugs.webkit.org/show_bug.cgi?id=275314</a>

Reviewed by Nikolas Zimmermann and Michael Catanzaro.

Implement the tracing macros provided by SystemTracing.h using the
Sysprof collector API.

Sysprof collector operates by passing a control fd as an environment
variable. This env var is set when running any executable with the
sysprof-cli utility, or through Sysprof&apos;s main interface.

The control fd needs to be propagated to child processes properly. For
the case of run-minibrowser script - a Python script that spawns the
actual MiniBrowser executable - and for the subprocess launcher. To do
that, duplicate the control fd and pass it as an environment variable
to subprocesses well. The Python script neatly supports that, but the
subprocess launcher needed some more manual mangling to get that done.

This initial work covers all pre-existing tracing groups implemented
on kdebug.

This patch does not introduce new tracing points.

There are limitations with the tracing macros though, for example,
they are most meaningful when there&apos;s a single WebKit view running.
Once more views are created, they all output into the same tracing
group. In the future, this can be fixed by using the subprocesses&apos;
pids as part of the tracing name, but right now it&apos;s most useless
as the sandbox makes all subprocesses have pid 3.

Another limitation is that tracing only truly works when disabling
the sandboxing of subprocesses. Working around it might require some
reengineering of the subprocess launching mechanism, so this is left
out of this patch as well.

To run WebKitGTK with Sysprof tracing, run the following command in
the WebKit source directory:

```
$ sysprof-cli --force -e WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1 -- Tools/Scripts/run-minibrowser --gtk
```

For WPE WebKit, run the following command:

```
$ sysprof-cli --force -e WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1 -- Tools/Scripts/run-minibrowser --wpe
```

It is also possible to get GNOME Shell marks by passing `--gnome-shell`
to the sysprof-cli command.

Co-authored-by: Carlos Garcia Campos &lt;cgarcia@igalia.com&gt;

* Source/JavaScriptCore/jit/JITPlan.cpp:
(JSC::JITPlan::compileInThread):
* Source/WTF/wtf/PlatformGTK.cmake:
* Source/WTF/wtf/PlatformWPE.cmake:
* Source/WTF/wtf/SystemTracing.h:
(WTF::tracePoint):
* Source/WTF/wtf/glib/SysprofAnnotator.h: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setReadyState):
* Source/WebKit/GPUProcess/glib/GPUProcessMainGLib.cpp:
(WebKit::GPUProcessMain):
* Source/WebKit/UIProcess/API/glib/WebKitInitialize.cpp:
(WebKit::webkitInitialize):
* Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp:
(WebKit::ProcessLauncher::launchProcess):
* Source/WebKit/WebProcess/gtk/WebProcessMainGtk.cpp:
* Source/WebKit/WebProcess/wpe/WebProcessMainWPE.cpp:
* Tools/Scripts/webkitpy/common/system/abstractexecutive.py:
(AbstractExecutive.run_command):
* Tools/Scripts/webkitpy/common/system/executive.py:
(Executive.run_command):
* Tools/Scripts/webkitpy/common/system/executive_mock.py:
(MockExecutive.run_command):
* Tools/Scripts/webkitpy/port/gtk.py:
(GtkPort.run_minibrowser):

Canonical link: <a href="https://commits.webkit.org/280690@main">https://commits.webkit.org/280690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/385fb1143e6fa9255d999e3bf9fd9e5461a3a900

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36662 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60956 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7777 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59462 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46428 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5499 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59364 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34403 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49514 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27291 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/56860 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31185 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6825 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6782 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/50426 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7096 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62635 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/56576 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1247 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7188 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53690 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1252 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49548 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53770 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12672 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1060 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/78336 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32491 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12975 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33576 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34661 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33322 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->