### PR TITLE
REGRESSION(279833@main): [ macOS iOS ] 4 TestWebKitAPI.GPUProcess tests are constant failure

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -237,6 +237,8 @@ std::unique_ptr<RemoteDisplayListRecorderProxy> RemoteRenderingBackendProxy::cre
 
 void RemoteRenderingBackendProxy::releaseImageBuffer(RenderingResourceIdentifier renderingResourceIdentifier)
 {
+    if (!m_connection)
+        return;
     send(Messages::RemoteRenderingBackend::ReleaseImageBuffer(renderingResourceIdentifier));
 }
 
@@ -254,6 +256,8 @@ void RemoteRenderingBackendProxy::releaseRemoteImageBufferSet(RemoteImageBufferS
 {
     bool success = m_bufferSets.remove(bufferSet.identifier());
     ASSERT_UNUSED(success, success);
+    if (!m_connection)
+        return;
     send(Messages::RemoteRenderingBackend::ReleaseRemoteImageBufferSet(bufferSet.identifier()));
 }
 
@@ -369,16 +373,22 @@ void RemoteRenderingBackendProxy::cacheFilter(Ref<Filter>&& filter)
 
 void RemoteRenderingBackendProxy::releaseAllDrawingResources()
 {
+    if (!m_connection)
+        return;
     send(Messages::RemoteRenderingBackend::ReleaseAllDrawingResources());
 }
 
 void RemoteRenderingBackendProxy::releaseRenderingResource(RenderingResourceIdentifier renderingResourceIdentifier)
 {
+    if (!m_connection)
+        return;
     send(Messages::RemoteRenderingBackend::ReleaseRenderingResource(renderingResourceIdentifier));
 }
 
 void RemoteRenderingBackendProxy::releaseAllImageResources()
 {
+    if (!m_connection)
+        return;
     send(Messages::RemoteRenderingBackend::ReleaseAllImageResources());
 }
 
@@ -466,6 +476,8 @@ void RemoteRenderingBackendProxy::didMarkLayersAsVolatile(MarkSurfacesAsVolatile
 
 void RemoteRenderingBackendProxy::finalizeRenderingUpdate()
 {
+    if (!m_connection)
+        return;
     send(Messages::RemoteRenderingBackend::FinalizeRenderingUpdate(m_renderingUpdateID));
     m_renderingUpdateID.increment();
 }


### PR DESCRIPTION
#### 73b90f15221afd87fbd8e6cf1f0db6021e851acc
<pre>
REGRESSION(279833@main): [ macOS iOS ] 4 TestWebKitAPI.GPUProcess tests are constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=275324">https://bugs.webkit.org/show_bug.cgi?id=275324</a>
<a href="https://rdar.apple.com/129515722">rdar://129515722</a>

Reviewed by Cameron McCormack.

Add back early returns that avoid creating a connection to GPUP
for messages that do not need to be sent if the connection does not
exist.

Fixes tests:
TestWebKitAPI.GPUProcess.OnlyLaunchesGPUProcessWhenNecessarySVG
TestWebKitAPI.GPUProcess.OnlyLaunchesGPUProcessWhenNecessaryMediaFeatureDetection
TestWebKitAPI.GPUProcess.ExitsUnderMemoryPressureVideoCase
TestWebKitAPI.GPUProcess.OnlyLaunchesGPUProcessWhenNecessary

* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::releaseImageBuffer):
(WebKit::RemoteRenderingBackendProxy::releaseRemoteImageBufferSet):
(WebKit::RemoteRenderingBackendProxy::releaseAllDrawingResources):
(WebKit::RemoteRenderingBackendProxy::releaseRenderingResource):
(WebKit::RemoteRenderingBackendProxy::releaseAllImageResources):
(WebKit::RemoteRenderingBackendProxy::finalizeRenderingUpdate):

Canonical link: <a href="https://commits.webkit.org/279886@main">https://commits.webkit.org/279886@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2571d754e310da838074e8ebdd480d4fa70dd173

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58101 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5554 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5571 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/3760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56918 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32380 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47494 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/25524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/29170 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3695 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/50998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/5048 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59691 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/30073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/5201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/51823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31212 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47574 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32223 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8116 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31000 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->