### PR TITLE
[WebDriver] If Safari window is not focused, WebDriver-automated mouse events do not get sent to the page

### DIFF
--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -227,6 +227,7 @@ public:
 #endif
 
 #if PLATFORM(MAC)
+    static const int synthesizedMouseEventMagicEventNumber = 0;
     bool wasEventSynthesizedForAutomation(NSEvent *);
     void markEventAsSynthesizedForAutomation(NSEvent *);
 #endif

--- a/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
+++ b/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
@@ -72,7 +72,6 @@ void WebAutomationSession::inspectBrowsingContext(const Inspector::Protocol::Aut
 
 #pragma mark AppKit Event Simulation Support
 
-static const NSInteger synthesizedMouseEventMagicEventNumber = 0;
 static const void *synthesizedAutomationEventAssociatedObjectKey = &synthesizedAutomationEventAssociatedObjectKey;
 
 void WebAutomationSession::sendSynthesizedEventsToPage(WebPageProxy& page, NSArray *eventsToSend)
@@ -145,7 +144,7 @@ bool WebAutomationSession::wasEventSynthesizedForAutomation(NSEvent *event)
     case NSEventTypeRightMouseUp:
         // Use this as a backup for checking mouse events, which are frequently copied
         // and/or faked by AppKit, causing them to lose their associated object tag.
-        return event.eventNumber == synthesizedMouseEventMagicEventNumber;
+        return event.eventNumber == WebAutomationSession::synthesizedMouseEventMagicEventNumber;
     default:
         break;
     }
@@ -228,7 +227,7 @@ void WebAutomationSession::platformSimulateMouseInteraction(WebPageProxy& page, 
 
     auto eventsToBeSent = adoptNS([[NSMutableArray alloc] init]);
 
-    NSInteger eventNumber = synthesizedMouseEventMagicEventNumber;
+    NSInteger eventNumber = WebAutomationSession::synthesizedMouseEventMagicEventNumber;
 
     switch (interaction) {
     case MouseInteraction::Move: {

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -47,6 +47,7 @@
 #import "WKBrowsingContextControllerInternal.h"
 #import "WKQuickLookPreviewController.h"
 #import "WKSharingServicePickerDelegate.h"
+#import "WebAutomationSession.h"
 #import "WebContextMenuProxyMac.h"
 #import "WebPageMessages.h"
 #import "WebPageProxyInternals.h"
@@ -364,6 +365,10 @@ bool WebPageProxy::shouldDelayWindowOrderingForEvent(const WebKit::WebMouseEvent
 
 bool WebPageProxy::acceptsFirstMouse(int eventNumber, const WebKit::WebMouseEvent& event)
 {
+    // FIXME <https://webkit.org/b/275500>: Find a way to properly ensure that automated events get delivered into an unfocused window.
+    if (eventNumber == WebAutomationSession::synthesizedMouseEventMagicEventNumber)
+        return true;
+
     if (!hasRunningProcess())
         return false;
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -43,6 +43,7 @@
 #include "ProvisionalFrameCreationParameters.h"
 #include "WKAPICast.h"
 #include "WKBundleAPICast.h"
+#include "WebAutomationSession.h"
 #include "WebChromeClient.h"
 #include "WebContextMenu.h"
 #include "WebCoreArgumentCoders.h"
@@ -1319,18 +1320,23 @@ WebCore::HandleUserInputEventResult WebFrame::handleMouseEvent(const WebMouseEve
             coreLocalFrame->eventHandler().invalidateClick();
         return coreLocalFrame->eventHandler().handleMouseReleaseEvent(platformMouseEvent);
 
-    case PlatformEvent::Type::MouseMoved:
+    case PlatformEvent::Type::MouseMoved: {
 #if PLATFORM(COCOA)
+        // FIXME <https://webkit.org/b/275500>: Find a way to properly ensure that automated events get delivered into an unfocused window.
+        bool isEventSynthesized = false;
+#if PLATFORM(MAC)
+        isEventSynthesized = platformMouseEvent.eventNumber() == WebAutomationSession::synthesizedMouseEventMagicEventNumber;
+#endif
         // We need to do a full, normal hit test during this mouse event if the page is active or if a mouse
         // button is currently pressed. It is possible that neither of those things will be true since on
         // Lion when legacy scrollbars are enabled, WebKit receives mouse events all the time. If it is one
         // of those cases where the page is not active and the mouse is not pressed, then we can fire a more
         // efficient scrollbars-only version of the event.
-        if (!(page()->corePage()->focusController().isActive() || (mouseEvent.button() != WebMouseEventButton::None)))
+        if (!isEventSynthesized && !page()->corePage()->focusController().isActive() && mouseEvent.button() == WebMouseEventButton::None)
             return coreLocalFrame->eventHandler().passMouseMovedEventToScrollbars(platformMouseEvent);
-#endif
+#endif // PLATFORM(COCOA)
         return coreLocalFrame->eventHandler().mouseMoved(platformMouseEvent);
-
+    }
     case PlatformEvent::Type::MouseForceChanged:
     case PlatformEvent::Type::MouseForceDown:
     case PlatformEvent::Type::MouseForceUp:

--- a/Tools/TestWebKitAPI/Tests/mac/AcceptsFirstMouse.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/AcceptsFirstMouse.mm
@@ -56,11 +56,11 @@ void AcceptsFirstMouse::runTest(View view)
     CGFloat viewHeight = view.bounds.size.height;
 
     NSPoint pointInsideSelection = NSMakePoint(50, viewHeight - 50);
-    NSEvent *mouseEventInsideSelection = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown location:pointInsideSelection modifierFlags:0 timestamp:0 windowNumber:[window.get() windowNumber] context:nil eventNumber:0 clickCount:1 pressure:1];
+    NSEvent *mouseEventInsideSelection = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown location:pointInsideSelection modifierFlags:0 timestamp:0 windowNumber:[window.get() windowNumber] context:nil eventNumber:1 clickCount:1 pressure:1];
     EXPECT_TRUE([[view hitTest:pointInsideSelection] acceptsFirstMouse:mouseEventInsideSelection]);
 
     NSPoint pointOutsideSelection = NSMakePoint(150, viewHeight - 150);
-    NSEvent *mouseEventOutsideSelection = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown location:pointOutsideSelection modifierFlags:0 timestamp:0 windowNumber:[window.get() windowNumber] context:nil eventNumber:0 clickCount:1 pressure:1];
+    NSEvent *mouseEventOutsideSelection = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown location:pointOutsideSelection modifierFlags:0 timestamp:0 windowNumber:[window.get() windowNumber] context:nil eventNumber:1 clickCount:1 pressure:1];
     EXPECT_FALSE([[view hitTest:pointInsideSelection] acceptsFirstMouse:mouseEventOutsideSelection]);
 }
 


### PR DESCRIPTION
#### 3e29d37be2b6cd98183fd643223f0070f55c913e
<pre>
[WebDriver] If Safari window is not focused, WebDriver-automated mouse events do not get sent to the page
<a href="https://rdar.apple.com/117035696">rdar://117035696</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=275326">https://bugs.webkit.org/show_bug.cgi?id=275326</a>

Reviewed by Patrick Angle.

When the Safari window is not currently focused, AKA not the key window
using AppKit&apos;s terminology, safaridriver-automated mouse events get
sent to the window but not to the webpage within it.

The patch <a href="https://github.com/WebKit/WebKit/commit/f41c94d11e5a0b8900cf768adeb76d94ef681444#diff-8eae0c0334ee2210a82eef8240463d484f408aceba25aef9f96093c9ca042863">https://github.com/WebKit/WebKit/commit/f41c94d11e5a0b8900cf768adeb76d94ef681444#diff-8eae0c0334ee2210a82eef8240463d484f408aceba25aef9f96093c9ca042863</a>
attempted to make the window key, but according to AppKit engineers,
making the window key requires the application to currently be active.
Unfortunately, neither `[NSApplication.sharedApplication activate]` nor
`[NSApplication.sharedApplication activateIgnoringOtherApps:YES]`
actually guarantee activating the app immediately. This results in us
failing to ensure that the window is key before sending the mouse
events, so the mouse events could not get delivered.

   - For `mousemove` events, there is the patch <a href="https://github.com/WebKit/WebKit/pull/1431">https://github.com/WebKit/WebKit/pull/1431</a>
     that make the delivery bypass the window level and sent directly
     into the web view. However, a more recent enhancement <a href="https://github.com/WebKit/WebKit/pull/17145">https://github.com/WebKit/WebKit/pull/17145</a>
     deliberately prevented `mousemove` events from being sent to the
     web page if the page is not active, which effectively nullified the
     former patch for `mousemove` events.

To work around that, a simple solution I found was to give automated
mouse events privileges to bypass certain filtering checks, rather than
always forcing the window to steal input focus. Automated mouse events
are assigned a special, &quot;magic&quot; event number (0), so we can recognize
them in the places below in the code.

I have tested the code
   (1) Manually with Python code using Selenium launching the newly
       compiled safaridriver and seeing that mouse events always get
       delivered successfully
   (2) With `wpt run safari webdriver/tests/classic/element-click webdriver/tests/classic/element_send_keys`
       and seeing that the result are the same before and after my
       changes with the same passes and failures.

* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm:
(WebKit::WebAutomationSession::wasEventSynthesizedForAutomation):
(WebKit::WebAutomationSession::platformSimulateMouseInteraction):
   - Make the magic event number accessible in other places needing to
     check if an event was synthesized.

* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::acceptsFirstMouse):
   - If the mouse event is automated, bypass the check to let the window
     always accept it.
   - I don&apos;t fully understand why this works -- this is a suggestion
     from an AppKit engineer, and I thought this function was meant to
     return whether the mouse event should be deemed as &quot;activating the
     window&quot; versus &quot;activating the window and sent to the contents&quot;,
     but apparently it&apos;s just whether the event gets sent to the
     contents because automated events still don&apos;t activate the window
     regardless the function&apos;s return value.

* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::handleMouseEvent):
   - If the mouse event is automated, don&apos;t use the enhancement of
     sending the event straight to the scrollbars and still send it
     to the web page.

* Tools/TestWebKitAPI/Tests/mac/AcceptsFirstMouse.mm:
(TestWebKitAPI::AcceptsFirstMouse::runTest):
   - Creating the event with eventNumber:0 for testing resulted in the
     event being considered as synthesized and acceptsFirstMouse always
     returned YES. Use a different eventNumber instead as a workaround.

Canonical link: <a href="https://commits.webkit.org/280047@main">https://commits.webkit.org/280047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1433b9f10bd5c5fca313d152591cbc6517f95b75

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58549 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5995 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57691 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42510 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6194 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44747 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4116 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47891 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25874 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29577 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5220 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4139 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51510 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5487 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60140 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30719 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5611 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52178 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31804 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47961 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51658 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12315 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32885 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31551 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->