### PR TITLE
[webkitpy] Increase current iOS version to 18.

### DIFF
--- a/Tools/Scripts/webkitpy/port/ios.py
+++ b/Tools/Scripts/webkitpy/port/ios.py
@@ -36,7 +36,7 @@ _log = logging.getLogger(__name__)
 class IOSPort(DevicePort):
     port_name = "ios"
 
-    CURRENT_VERSION = Version(17)
+    CURRENT_VERSION = Version(18)
     DEVICE_TYPE = DeviceType(software_variant='iOS')
 
     def __init__(self, host, port_name, **kwargs):

--- a/Tools/Scripts/webkitpy/port/ios_device_unittest.py
+++ b/Tools/Scripts/webkitpy/port/ios_device_unittest.py
@@ -119,18 +119,18 @@ class IOSDeviceTest(ios_testcase.IOSTest):
             search_path = self.make_port().default_baseline_search_path()
 
         self.assertEqual(search_path, [
-            '/additional_testing_path/ios-device-add-ios17-wk1',
-            '/mock-checkout/LayoutTests/platform/ios-device-17-wk1',
-            '/additional_testing_path/ios-device-add-ios17',
-            '/mock-checkout/LayoutTests/platform/ios-device-17',
+            '/additional_testing_path/ios-device-add-ios18-wk1',
+            '/mock-checkout/LayoutTests/platform/ios-device-18-wk1',
+            '/additional_testing_path/ios-device-add-ios18',
+            '/mock-checkout/LayoutTests/platform/ios-device-18',
             '/additional_testing_path/ios-device-wk1',
             '/mock-checkout/LayoutTests/platform/ios-device-wk1',
             '/additional_testing_path/ios-device',
             '/mock-checkout/LayoutTests/platform/ios-device',
-            '/additional_testing_path/ios-add-ios17-wk1',
-            '/mock-checkout/LayoutTests/platform/ios-17-wk1',
-            '/additional_testing_path/ios-add-ios17',
-            '/mock-checkout/LayoutTests/platform/ios-17',
+            '/additional_testing_path/ios-add-ios18-wk1',
+            '/mock-checkout/LayoutTests/platform/ios-18-wk1',
+            '/additional_testing_path/ios-add-ios18',
+            '/mock-checkout/LayoutTests/platform/ios-18',
             '/additional_testing_path/ios-wk1',
             '/mock-checkout/LayoutTests/platform/ios-wk1',
             '/additional_testing_path/ios',
@@ -138,46 +138,46 @@ class IOSDeviceTest(ios_testcase.IOSTest):
         ])
 
     def test_layout_test_searchpath_without_apple_additions(self):
-        search_path = self.make_port(port_name='ios-device-wk2', os_version=Version(17)).default_baseline_search_path()
+        search_path = self.make_port(port_name='ios-device-wk2', os_version=Version(18)).default_baseline_search_path()
 
         self.assertEqual(search_path, [
-            '/mock-checkout/LayoutTests/platform/ios-device-17-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-device-17',
+            '/mock-checkout/LayoutTests/platform/ios-device-18-wk2',
+            '/mock-checkout/LayoutTests/platform/ios-device-18',
             '/mock-checkout/LayoutTests/platform/ios-device-wk2',
             '/mock-checkout/LayoutTests/platform/ios-device',
-            '/mock-checkout/LayoutTests/platform/ios-17-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-17',
+            '/mock-checkout/LayoutTests/platform/ios-18-wk2',
+            '/mock-checkout/LayoutTests/platform/ios-18',
             '/mock-checkout/LayoutTests/platform/ios-wk2',
             '/mock-checkout/LayoutTests/platform/ios',
             '/mock-checkout/LayoutTests/platform/wk2',
         ])
 
     def test_layout_searchpath_wih_device_type(self):
-        search_path = self.make_port(port_name='ios-device-wk2', os_version=Version(17)).default_baseline_search_path(DeviceType.from_string('iPhone SE'))
+        search_path = self.make_port(port_name='ios-device-wk2', os_version=Version(18)).default_baseline_search_path(DeviceType.from_string('iPhone SE'))
 
         self.assertEqual(search_path, [
-            '/mock-checkout/LayoutTests/platform/iphone-se-device-17-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-se-device-17',
+            '/mock-checkout/LayoutTests/platform/iphone-se-device-18-wk2',
+            '/mock-checkout/LayoutTests/platform/iphone-se-device-18',
             '/mock-checkout/LayoutTests/platform/iphone-se-device-wk2',
             '/mock-checkout/LayoutTests/platform/iphone-se-device',
-            '/mock-checkout/LayoutTests/platform/iphone-device-17-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-device-17',
+            '/mock-checkout/LayoutTests/platform/iphone-device-18-wk2',
+            '/mock-checkout/LayoutTests/platform/iphone-device-18',
             '/mock-checkout/LayoutTests/platform/iphone-device-wk2',
             '/mock-checkout/LayoutTests/platform/iphone-device',
-            '/mock-checkout/LayoutTests/platform/ios-device-17-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-device-17',
+            '/mock-checkout/LayoutTests/platform/ios-device-18-wk2',
+            '/mock-checkout/LayoutTests/platform/ios-device-18',
             '/mock-checkout/LayoutTests/platform/ios-device-wk2',
             '/mock-checkout/LayoutTests/platform/ios-device',
-            '/mock-checkout/LayoutTests/platform/iphone-se-17-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-se-17',
+            '/mock-checkout/LayoutTests/platform/iphone-se-18-wk2',
+            '/mock-checkout/LayoutTests/platform/iphone-se-18',
             '/mock-checkout/LayoutTests/platform/iphone-se-wk2',
             '/mock-checkout/LayoutTests/platform/iphone-se',
-            '/mock-checkout/LayoutTests/platform/iphone-17-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-17',
+            '/mock-checkout/LayoutTests/platform/iphone-18-wk2',
+            '/mock-checkout/LayoutTests/platform/iphone-18',
             '/mock-checkout/LayoutTests/platform/iphone-wk2',
             '/mock-checkout/LayoutTests/platform/iphone',
-            '/mock-checkout/LayoutTests/platform/ios-17-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-17',
+            '/mock-checkout/LayoutTests/platform/ios-18-wk2',
+            '/mock-checkout/LayoutTests/platform/ios-18',
             '/mock-checkout/LayoutTests/platform/ios-wk2',
             '/mock-checkout/LayoutTests/platform/ios',
             '/mock-checkout/LayoutTests/platform/wk2',

--- a/Tools/Scripts/webkitpy/port/ios_simulator_unittest.py
+++ b/Tools/Scripts/webkitpy/port/ios_simulator_unittest.py
@@ -39,7 +39,7 @@ class IOSSimulatorTest(ios_testcase.IOSTest):
     port_name = 'ios-simulator'
     port_maker = IOSSimulatorPort
 
-    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=Version(17), **kwargs):
+    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=Version(18), **kwargs):
         port = super(IOSSimulatorTest, self).make_port(host=host, port_name=port_name, options=options, os_name=os_name, os_version=os_version, kwargs=kwargs)
         port.set_option('child_processes', 1)
         return port
@@ -86,18 +86,18 @@ class IOSSimulatorTest(ios_testcase.IOSTest):
             search_path = self.make_port().default_baseline_search_path()
 
         self.assertEqual(search_path, [
-            '/additional_testing_path/ios-simulator-add-ios17-wk1',
-            '/mock-checkout/LayoutTests/platform/ios-simulator-17-wk1',
-            '/additional_testing_path/ios-simulator-add-ios17',
-            '/mock-checkout/LayoutTests/platform/ios-simulator-17',
+            '/additional_testing_path/ios-simulator-add-ios18-wk1',
+            '/mock-checkout/LayoutTests/platform/ios-simulator-18-wk1',
+            '/additional_testing_path/ios-simulator-add-ios18',
+            '/mock-checkout/LayoutTests/platform/ios-simulator-18',
             '/additional_testing_path/ios-simulator-wk1',
             '/mock-checkout/LayoutTests/platform/ios-simulator-wk1',
             '/additional_testing_path/ios-simulator',
             '/mock-checkout/LayoutTests/platform/ios-simulator',
-            '/additional_testing_path/ios-add-ios17-wk1',
-            '/mock-checkout/LayoutTests/platform/ios-17-wk1',
-            '/additional_testing_path/ios-add-ios17',
-            '/mock-checkout/LayoutTests/platform/ios-17',
+            '/additional_testing_path/ios-add-ios18-wk1',
+            '/mock-checkout/LayoutTests/platform/ios-18-wk1',
+            '/additional_testing_path/ios-add-ios18',
+            '/mock-checkout/LayoutTests/platform/ios-18',
             '/additional_testing_path/ios-wk1',
             '/mock-checkout/LayoutTests/platform/ios-wk1',
             '/additional_testing_path/ios',
@@ -105,46 +105,46 @@ class IOSSimulatorTest(ios_testcase.IOSTest):
         ])
 
     def test_layout_test_searchpath_without_apple_additions(self):
-        search_path = self.make_port(port_name='ios-simulator-wk2', os_version=Version(17)).default_baseline_search_path()
+        search_path = self.make_port(port_name='ios-simulator-wk2', os_version=Version(18)).default_baseline_search_path()
 
         self.assertEqual(search_path, [
-            '/mock-checkout/LayoutTests/platform/ios-simulator-17-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-simulator-17',
+            '/mock-checkout/LayoutTests/platform/ios-simulator-18-wk2',
+            '/mock-checkout/LayoutTests/platform/ios-simulator-18',
             '/mock-checkout/LayoutTests/platform/ios-simulator-wk2',
             '/mock-checkout/LayoutTests/platform/ios-simulator',
-            '/mock-checkout/LayoutTests/platform/ios-17-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-17',
+            '/mock-checkout/LayoutTests/platform/ios-18-wk2',
+            '/mock-checkout/LayoutTests/platform/ios-18',
             '/mock-checkout/LayoutTests/platform/ios-wk2',
             '/mock-checkout/LayoutTests/platform/ios',
             '/mock-checkout/LayoutTests/platform/wk2',
         ])
 
     def test_layout_searchpath_wih_device_type(self):
-        search_path = self.make_port(port_name='ios-simulator-wk2', os_version=Version(17)).default_baseline_search_path(DeviceType.from_string('iPhone SE'))
+        search_path = self.make_port(port_name='ios-simulator-wk2', os_version=Version(18)).default_baseline_search_path(DeviceType.from_string('iPhone SE'))
 
         self.assertEqual(search_path, [
-            '/mock-checkout/LayoutTests/platform/iphone-se-simulator-17-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-se-simulator-17',
+            '/mock-checkout/LayoutTests/platform/iphone-se-simulator-18-wk2',
+            '/mock-checkout/LayoutTests/platform/iphone-se-simulator-18',
             '/mock-checkout/LayoutTests/platform/iphone-se-simulator-wk2',
             '/mock-checkout/LayoutTests/platform/iphone-se-simulator',
-            '/mock-checkout/LayoutTests/platform/iphone-simulator-17-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-simulator-17',
+            '/mock-checkout/LayoutTests/platform/iphone-simulator-18-wk2',
+            '/mock-checkout/LayoutTests/platform/iphone-simulator-18',
             '/mock-checkout/LayoutTests/platform/iphone-simulator-wk2',
             '/mock-checkout/LayoutTests/platform/iphone-simulator',
-            '/mock-checkout/LayoutTests/platform/ios-simulator-17-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-simulator-17',
+            '/mock-checkout/LayoutTests/platform/ios-simulator-18-wk2',
+            '/mock-checkout/LayoutTests/platform/ios-simulator-18',
             '/mock-checkout/LayoutTests/platform/ios-simulator-wk2',
             '/mock-checkout/LayoutTests/platform/ios-simulator',
-            '/mock-checkout/LayoutTests/platform/iphone-se-17-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-se-17',
+            '/mock-checkout/LayoutTests/platform/iphone-se-18-wk2',
+            '/mock-checkout/LayoutTests/platform/iphone-se-18',
             '/mock-checkout/LayoutTests/platform/iphone-se-wk2',
             '/mock-checkout/LayoutTests/platform/iphone-se',
-            '/mock-checkout/LayoutTests/platform/iphone-17-wk2',
-            '/mock-checkout/LayoutTests/platform/iphone-17',
+            '/mock-checkout/LayoutTests/platform/iphone-18-wk2',
+            '/mock-checkout/LayoutTests/platform/iphone-18',
             '/mock-checkout/LayoutTests/platform/iphone-wk2',
             '/mock-checkout/LayoutTests/platform/iphone',
-            '/mock-checkout/LayoutTests/platform/ios-17-wk2',
-            '/mock-checkout/LayoutTests/platform/ios-17',
+            '/mock-checkout/LayoutTests/platform/ios-18-wk2',
+            '/mock-checkout/LayoutTests/platform/ios-18',
             '/mock-checkout/LayoutTests/platform/ios-wk2',
             '/mock-checkout/LayoutTests/platform/ios',
             '/mock-checkout/LayoutTests/platform/wk2',

--- a/Tools/Scripts/webkitpy/port/ios_testcase.py
+++ b/Tools/Scripts/webkitpy/port/ios_testcase.py
@@ -28,7 +28,7 @@ from webkitpy.port import darwin_testcase
 class IOSTest(darwin_testcase.DarwinTest):
     disable_setup = True
 
-    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=Version(17), **kwargs):
+    def make_port(self, host=None, port_name=None, options=None, os_name=None, os_version=Version(18), **kwargs):
         port = super(IOSTest, self).make_port(host=host, port_name=port_name, options=options, os_name=os_name, os_version=None, kwargs=kwargs)
         port.set_option('version', str(os_version))
         return port


### PR DESCRIPTION
#### 2b5f4397ad4283ed0adb6f01431198f85e9b7821
<pre>
[webkitpy] Increase current iOS version to 18.
<a href="https://bugs.webkit.org/show_bug.cgi?id=275329">https://bugs.webkit.org/show_bug.cgi?id=275329</a>
<a href="https://rdar.apple.com/129522351">rdar://129522351</a>

Reviewed by Ryan Haddad.

This bumps the current version of iOS from 17 -&gt; 18 in webkitpy to reflect the new iOS
version Apple announced at WWDC today.

* Tools/Scripts/webkitpy/port/ios.py:
(IOSPort):
* Tools/Scripts/webkitpy/port/ios_device_unittest.py:
* Tools/Scripts/webkitpy/port/ios_simulator_unittest.py:
(IOSSimulatorTest.make_port):
(IOSSimulatorTest.test_layout_test_searchpath_with_apple_additions):
(IOSSimulatorTest.test_layout_test_searchpath_without_apple_additions):
(IOSSimulatorTest.test_layout_searchpath_wih_device_type):
* Tools/Scripts/webkitpy/port/ios_testcase.py:
(IOSTest.make_port):

Canonical link: <a href="https://commits.webkit.org/279954@main">https://commits.webkit.org/279954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3d1b37149f976ac3b4b7bcd9ae75539bfb2bb96

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58105 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5558 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57127 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5576 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44404 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3768 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32389 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47506 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25528 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/54847 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29179 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4840 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3699 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51013 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5060 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59695 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30077 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5205 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51827 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31216 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47585 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51242 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12102 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32228 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31004 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->