### PR TITLE
[CG] An Image with video source may allocate too much memory for caching all the video frames

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.h
@@ -87,7 +87,7 @@ public:
     WEBCORE_EXPORT void setExpectedContentSize(long long) final;
     WEBCORE_EXPORT void setData(const FragmentedSharedBuffer&, bool allDataReceived) final;
     bool isAllDataReceived() const final { return m_isAllDataReceived; }
-    WEBCORE_EXPORT void clearFrameBufferCache(size_t) final;
+    void clearFrameBufferCache(size_t) final { }
 
     bool hasTrack() const { return !!m_track; }
     WEBCORE_EXPORT Vector<ImageDecoder::FrameInfo> frameInfos() const;
@@ -98,7 +98,7 @@ private:
     AVAssetTrack *firstEnabledTrack();
     void readSamples();
     void readTrackMetadata();
-    bool storeSampleBuffer(CMSampleBufferRef);
+    bool createFrameImageFromSampleBuffer(CMSampleBufferRef, CGImageRef *imageOut);
     void advanceCursor();
     void setTrack(AVAssetTrack *);
 


### PR DESCRIPTION
#### 22ed0bf86c1fb602cdc5de10b52eeb377fde7329
<pre>
[CG] An Image with video source may allocate too much memory for caching all the video frames
<a href="https://bugs.webkit.org/show_bug.cgi?id=275331">https://bugs.webkit.org/show_bug.cgi?id=275331</a>
<a href="https://rdar.apple.com/126993116">rdar://126993116</a>

Reviewed by Jer Noble.

Both BitmapImageSource and ImageDecoderAVFObjC cache the decoded frames. When
deleting the decoded frames, BitmapImageSource::destroyDecodedData() calls
ImageDecoderAVFObjC::clearFrameBufferCache() to let it release any unnecessary
cached data. But BitmapImageSource does not communicate what frames it actually
released. So the caches in BitmapImageSource and ImageDecoderAVFObjC can get of
sync. And ImageDecoderAVFObjC may end up holding many decoded frames which
BitmapImageSource does not need.

BitmapImageSource will ask ImageDecoderAVFObjC to re-decode any frame when it is
needed. BitmapImageSource should not use too much memory for caching the decoded
frames. ImageDecoderAVFObjC should cache only what is needed to decode the next
frame. BitmapImageSource will always ask ImageDecoderAVFObjC to decode frames
in order.

The fix is to make ImageDecoderAVFObjC not cache any decoded frame and let
BitmapImageSource be responsible for this.

* Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm:
(WebCore::ImageDecoderAVFObjCSample::setAlpha):
(WebCore::ImageDecoderAVFObjC::createFrameImageFromSampleBuffer):
(WebCore::ImageDecoderAVFObjC::createFrameImageAtIndex):
(WebCore::ImageDecoderAVFObjCSample::image const): Deleted.
(WebCore::ImageDecoderAVFObjCSample::setImage): Deleted.
(WebCore::ImageDecoderAVFObjC::storeSampleBuffer): Deleted.
(WebCore::ImageDecoderAVFObjC::clearFrameBufferCache): Deleted.

Canonical link: <a href="https://commits.webkit.org/279926@main">https://commits.webkit.org/279926@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/255dd0dbfdd97f04d0334aa8bf211690b76a8483

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7538 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58227 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5680 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57249 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41950 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44495 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3854 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57044 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32488 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47602 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25621 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29274 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4945 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3821 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59818 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30213 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5320 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51917 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31346 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47680 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51352 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12079 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32361 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31134 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->