### PR TITLE
[Writing Tools] Reverting a list transformation leaves a single errant bullet

### DIFF
--- a/Source/WebCore/editing/ReplaceSelectionCommand.h
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.h
@@ -27,11 +27,11 @@
 #pragma once
 
 #include "CompositeEditCommand.h"
+#include "DocumentFragment.h"
 #include "NodeTraversal.h"
 
 namespace WebCore {
 
-class DocumentFragment;
 class Range;
 class ReplacementFragment;
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4894,7 +4894,12 @@ void Page::updateStateForSelectedReplacementIfNeeded()
     m_unifiedTextReplacementController->updateStateForSelectedReplacementIfNeeded();
 }
 
-void Page::textReplacementSessionDidReceiveEditAction(const UnifiedTextReplacement::Session& session, WebCore::UnifiedTextReplacement::EditAction action)
+std::optional<SimpleRange> Page::contextRangeForSessionWithID(const UnifiedTextReplacement::Session::ID& sessionID) const
+{
+    return m_unifiedTextReplacementController->contextRangeForSessionWithID(sessionID);
+}
+
+void Page::textReplacementSessionDidReceiveEditAction(const UnifiedTextReplacement::Session& session, UnifiedTextReplacement::EditAction action)
 {
     m_unifiedTextReplacementController->textReplacementSessionDidReceiveEditAction(session, action);
 }

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1164,7 +1164,7 @@ public:
 
     WEBCORE_EXPORT void updateStateForSelectedReplacementIfNeeded();
 
-    const UnifiedTextReplacementController& unifiedTextReplacementController() const { return m_unifiedTextReplacementController.get(); }
+    WEBCORE_EXPORT std::optional<SimpleRange> contextRangeForSessionWithID(const UnifiedTextReplacement::SessionID&) const;
 #endif
 
 private:

--- a/Source/WebCore/page/unified-text-replacement/UnifiedTextReplacementController.h
+++ b/Source/WebCore/page/unified-text-replacement/UnifiedTextReplacementController.h
@@ -27,6 +27,8 @@
 
 #if ENABLE(WRITING_TOOLS)
 
+#include "Range.h"
+#include "ReplaceSelectionCommand.h"
 #include "UnifiedTextReplacementTypes.h"
 
 namespace WebCore {
@@ -34,10 +36,8 @@ namespace WebCore {
 class Document;
 class DocumentFragment;
 class DocumentMarker;
-class Editor;
 class Node;
 class Page;
-class Range;
 
 struct SimpleRange;
 
@@ -64,9 +64,52 @@ public:
 
     void updateStateForSelectedReplacementIfNeeded();
 
-    WEBCORE_EXPORT std::optional<SimpleRange> contextRangeForSessionWithID(const UnifiedTextReplacement::Session::ID&) const;
+    // FIXME: Refactor `TextIndicatorStyleController` in such a way so as to not explicitly depend on `UnifiedTextReplacementController`,
+    // and then remove this method after doing so.
+    std::optional<SimpleRange> contextRangeForSessionWithID(const UnifiedTextReplacement::Session::ID&) const;
 
 private:
+    struct RichTextState : CanMakeCheckedPtr<RichTextState> {
+        WTF_MAKE_STRUCT_FAST_ALLOCATED;
+        WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(RichTextState);
+
+        RichTextState(const Ref<Range>& contextRange, const Vector<Ref<ReplaceSelectionCommand>>& commands)
+            : contextRange(contextRange)
+            , commands(commands)
+        {
+        }
+
+        Ref<Range> contextRange;
+        Vector<Ref<ReplaceSelectionCommand>> commands;
+    };
+
+    struct PlainTextState : CanMakeCheckedPtr<PlainTextState> {
+        WTF_MAKE_STRUCT_FAST_ALLOCATED;
+        WTF_STRUCT_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlainTextState);
+
+        PlainTextState(const Ref<Range>& contextRange, int replacementLocationOffset)
+            : contextRange(contextRange)
+            , replacementLocationOffset(replacementLocationOffset)
+        {
+        }
+
+        Ref<Range> contextRange;
+        int replacementLocationOffset { 0 };
+    };
+
+    template<UnifiedTextReplacement::Session::ReplacementType Type>
+    struct StateFromReplacementType { };
+
+    template<>
+    struct StateFromReplacementType<UnifiedTextReplacement::Session::ReplacementType::PlainText> {
+        using Value = PlainTextState;
+    };
+
+    template<>
+    struct StateFromReplacementType<UnifiedTextReplacement::Session::ReplacementType::RichText> {
+        using Value = RichTextState;
+    };
+
     enum MatchStyle : bool {
         No, Yes
     };
@@ -76,12 +119,16 @@ private:
     static uint64_t characterCount(const SimpleRange&);
     static String plainText(const SimpleRange&);
 
+    template<UnifiedTextReplacement::Session::ReplacementType Type>
+    StateFromReplacementType<Type>::Value* stateForSession(const UnifiedTextReplacement::Session&);
+
     std::optional<std::tuple<Node&, DocumentMarker&>> findReplacementMarkerContainingRange(const SimpleRange&) const;
     std::optional<std::tuple<Node&, DocumentMarker&>> findReplacementMarkerByID(const SimpleRange& outerRange, const UnifiedTextReplacement::Replacement::ID&) const;
 
-    void replaceContentsOfRangeInSessionInternal(const UnifiedTextReplacement::Session::ID&, const SimpleRange&, WTF::Function<void(Editor&)>&&);
-    void replaceContentsOfRangeInSession(const UnifiedTextReplacement::Session::ID&, const SimpleRange&, const String&);
-    void replaceContentsOfRangeInSession(const UnifiedTextReplacement::Session::ID&, const SimpleRange&, DocumentFragment&, MatchStyle = MatchStyle::No);
+    template<typename State>
+    void replaceContentsOfRangeInSessionInternal(State&, const SimpleRange&, WTF::Function<void()>&&);
+    void replaceContentsOfRangeInSession(PlainTextState&, const SimpleRange&, const String&);
+    void replaceContentsOfRangeInSession(RichTextState&, const SimpleRange&, RefPtr<DocumentFragment>&&, MatchStyle);
 
     template<UnifiedTextReplacement::Session::ReplacementType Type>
     void textReplacementSessionDidReceiveEditAction(const UnifiedTextReplacement::Session&, UnifiedTextReplacement::EditAction);
@@ -93,11 +140,7 @@ private:
 
     SingleThreadWeakPtr<Page> m_page;
 
-    // FIXME: Unify these states into a single `State` struct.
-    HashMap<UnifiedTextReplacement::Session::ID, Ref<Range>> m_contextRanges;
-    HashMap<UnifiedTextReplacement::Session::ID, int> m_replacementLocationOffsets;
-    HashMap<UnifiedTextReplacement::Session::ID, Ref<DocumentFragment>> m_originalDocumentNodes;
-    HashMap<UnifiedTextReplacement::Session::ID, Ref<DocumentFragment>> m_replacedDocumentNodes;
+    HashMap<UnifiedTextReplacement::Session::ID, std::variant<std::monostate, PlainTextState, RichTextState>> m_states;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextIndicatorStyleController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextIndicatorStyleController.mm
@@ -37,7 +37,7 @@
 #include <WebCore/SimpleRange.h>
 #include <WebCore/TextIndicator.h>
 #include <WebCore/TextIterator.h>
-#include <WebCore/UnifiedTextReplacementController.h>
+#include <WebCore/UnifiedTextReplacementTypes.h>
 
 namespace WebKit {
 
@@ -90,7 +90,7 @@ std::optional<WebCore::SimpleRange> TextIndicatorStyleController::contextRangeFo
         return std::nullopt;
     }
 
-    return corePage->unifiedTextReplacementController().contextRangeForSessionWithID(sessionID);
+    return corePage->contextRangeForSessionWithID(sessionID);
 }
 
 std::optional<WebCore::SimpleRange> TextIndicatorStyleController::contextRangeForTextIndicatorStyle(const WTF::UUID& uuid) const


### PR DESCRIPTION
#### c35d1fad75d58b9de8042a06f0fc21a9d411544e
<pre>
[Writing Tools] Reverting a list transformation leaves a single errant bullet
<a href="https://bugs.webkit.org/show_bug.cgi?id=275336">https://bugs.webkit.org/show_bug.cgi?id=275336</a>
<a href="https://rdar.apple.com/126139492">rdar://126139492</a>

Reviewed by Wenson Hsieh and Tim Horton.

Previously, we were undoing and restoring the text by creating and storing document fragments
and replacing the current selection. However, this approach is flawed for cases where lists
or table elements are used, since selecting all contents will exclude the first list bullet.

Fix by changing the implementation to instead just unapply and reapply the editing command itself,
which does not rely on selection.

Also, slightly refactor all the stateful instance variables into a single state struct.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/editing/ReplaceSelectionCommand.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::willBeginTextReplacementSession):
(WebCore::Page::didBeginTextReplacementSession):
(WebCore::Page::textReplacementSessionDidReceiveReplacements):
(WebCore::Page::textReplacementSessionDidUpdateStateForReplacement):
(WebCore::Page::didEndTextReplacementSession):
(WebCore::Page::textReplacementSessionDidReceiveTextWithReplacementRange):
(WebCore::Page::contextRangeForSessionWithID const):
(WebCore::Page::textReplacementSessionDidReceiveEditAction):
* Source/WebCore/page/Page.h:
(WebCore::Page::unifiedTextReplacementController const): Deleted.
* Source/WebCore/page/unified-text-replacement/UnifiedTextReplacementController.h:
* Source/WebCore/page/unified-text-replacement/UnifiedTextReplacementController.mm:
(WebCore::UnifiedTextReplacementController::willBeginTextReplacementSession):
(WebCore::UnifiedTextReplacementController::textReplacementSessionDidReceiveReplacements):
(WebCore::UnifiedTextReplacementController::textReplacementSessionDidUpdateStateForReplacement):
(WebCore::UnifiedTextReplacementController::textReplacementSessionDidReceiveTextWithReplacementRange):
(WebCore::UnifiedTextReplacementController::textReplacementSessionDidReceiveEditAction&lt;UnifiedTextReplacement::Session::ReplacementType::PlainText&gt;):
(WebCore::UnifiedTextReplacementController::textReplacementSessionDidReceiveEditAction&lt;UnifiedTextReplacement::Session::ReplacementType::RichText&gt;):
(WebCore::UnifiedTextReplacementController::textReplacementSessionDidReceiveEditAction):
(WebCore::UnifiedTextReplacementController::didEndTextReplacementSession&lt;UnifiedTextReplacement::Session::ReplacementType::PlainText&gt;):
(WebCore::UnifiedTextReplacementController::didEndTextReplacementSession):
(WebCore::UnifiedTextReplacementController::updateStateForSelectedReplacementIfNeeded):
(WebCore::UnifiedTextReplacementController::contextRangeForSessionWithID const):
(WebCore::UnifiedTextReplacementController::stateForSession):
(WebCore::UnifiedTextReplacementController::replaceContentsOfRangeInSessionInternal):
(WebCore::UnifiedTextReplacementController::replaceContentsOfRangeInSession):
* Source/WebKit/WebProcess/WebPage/Cocoa/TextIndicatorStyleController.mm:
(WebKit::TextIndicatorStyleController::contextRangeForSessionWithID const):

Canonical link: <a href="https://commits.webkit.org/279937@main">https://commits.webkit.org/279937@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d864149d71ec6fbe7b66ffc0f065f2970ae5f79

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7579 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/58264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5717 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57286 "Failed to checkout and rebase branch from PR 29692") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5749 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/58264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/3890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57081 "Failed to checkout and rebase branch from PR 29692") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/32529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/47640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/58264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/29316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/4984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3858 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/5205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59855 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30253 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/5362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/51953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31383 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/47716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32404 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8140 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31174 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->