### PR TITLE
import-w3c-tests deletes tests even when it doesn't match a directory

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_importer.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer.py
@@ -212,6 +212,14 @@ class TestImporter(object):
     def do_import(self):
         if self.source_directory:
             source_path = str(Path(self.source_directory) / 'web-platform-tests')
+            if not Path(source_path).exists():
+                _log.error("There isn't a web-platform-tests directory in the path you have provided: %s" % source_path)
+                exit(1)
+            for test_path in self.test_paths:
+                full_test_path = Path(self.source_directory) / test_path
+                if not Path(full_test_path).exists():
+                    _log.error("The source directory doesn't exist: %s" % full_test_path)
+                    exit(1)
             try:
                 git = self.test_downloader().git(source_path)
                 self.upstream_revision = git.rev_parse('HEAD')


### PR DESCRIPTION
#### 74a4a695fe7d66684920f1d160afab7ccea67518
<pre>
import-w3c-tests deletes tests even when it doesn&apos;t match a directory
<a href="https://bugs.webkit.org/show_bug.cgi?id=274880">https://bugs.webkit.org/show_bug.cgi?id=274880</a>
<a href="https://rdar.apple.com/128981568">rdar://128981568</a>

Reviewed by NOBODY (OOPS!).

When importing a local source directory for WPT:
- If web-platform-tests directory doesn&apos;t exist, it exits with an error
  message.
- If web-platform-tests directory does exist but foo/ doesn&apos;t exist,
  it exists with an error message.

* Tools/Scripts/webkitpy/w3c/test_importer.py:
(TestImporter.do_import):

Co-authored-by: Marcos Caceres &lt;marcosc@apple.com&gt;
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74a4a695fe7d66684920f1d160afab7ccea67518

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54863 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7443 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58141 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5594 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57163 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41849 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5616 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44430 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3787 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56958 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47531 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25557 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/54689 "Found 40 webkitpy test failures: webkitpy.w3c.test_importer_unittest.TestImporterTest.test_crash_test_with_resource_file, webkitpy.w3c.test_importer_unittest.TestImporterTest.test_import_dir_with_empty_init_py, webkitpy.w3c.test_importer_unittest.TestImporterTest.test_import_dir_with_no_tests, webkitpy.w3c.test_importer_unittest.TestImporterTest.test_import_dir_with_no_tests_and_no_hg, webkitpy.w3c.test_importer_unittest.TestImporterTest.test_keep_original_reftest_reference, webkitpy.w3c.test_importer_unittest.TestImporterTest.test_no_implicit_skip_with_source, webkitpy.w3c.test_importer_unittest.TestImporterTest.test_skip_test_import_source, webkitpy.w3c.test_importer_unittest.TestImporterTest.test_webkit_test_runner_import_reftests_with_absolute_paths_from_source_dir, webkitscmpy.test.log_unittest.TestLog.test_git, webkitscmpy.test.log_unittest.TestLog.test_git_svn ...") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29205 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4869 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3735 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51047 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5089 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59731 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30116 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51853 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31253 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51282 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32268 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31040 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->