### PR TITLE
Prefer '= default' for constructors at WebCore/platform/graphics/

### DIFF
--- a/Source/WebCore/platform/graphics/FloatLine.h
+++ b/Source/WebCore/platform/graphics/FloatLine.h
@@ -37,7 +37,7 @@ namespace WebCore {
 
 class FloatLine {
 public:
-    FloatLine() { }
+    FloatLine() = default;
     FloatLine(const FloatPoint& start, const FloatPoint& end)
         : m_start(start)
         , m_end(end)

--- a/Source/WebCore/platform/graphics/FloatRoundedRect.h
+++ b/Source/WebCore/platform/graphics/FloatRoundedRect.h
@@ -47,7 +47,7 @@ public:
     class Radii {
     WTF_MAKE_FAST_ALLOCATED;
     public:
-        Radii() { }
+        Radii() = default;
         Radii(const FloatSize& topLeft, const FloatSize& topRight, const FloatSize& bottomLeft, const FloatSize& bottomRight)
             : m_topLeft(topLeft)
             , m_topRight(topRight)

--- a/Source/WebCore/platform/graphics/GeneratedImage.h
+++ b/Source/WebCore/platform/graphics/GeneratedImage.h
@@ -47,7 +47,7 @@ protected:
     // FIXME: Implement this to be less conservative.
     bool currentFrameKnownToBeOpaque() const override { return false; }
 
-    GeneratedImage() { }
+    GeneratedImage() = default;
 
 private:
     bool isGeneratedImage() const override { return true; }

--- a/Source/WebCore/platform/graphics/IntRect.h
+++ b/Source/WebCore/platform/graphics/IntRect.h
@@ -66,7 +66,7 @@ class LayoutRect;
 class IntRect {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    IntRect() { }
+    IntRect() = default;
     IntRect(const IntPoint& location, const IntSize& size)
         : m_location(location), m_size(size) { }
     IntRect(int x, int y, int width, int height)

--- a/Source/WebCore/platform/graphics/LayoutPoint.h
+++ b/Source/WebCore/platform/graphics/LayoutPoint.h
@@ -37,7 +37,7 @@ namespace WebCore {
 
 class LayoutPoint {
 public:
-    constexpr LayoutPoint() { }
+    constexpr LayoutPoint() = default;
     template<typename T, typename U> LayoutPoint(T x, U y) : m_x(x), m_y(y) { }
     LayoutPoint(const IntPoint& point) : m_x(point.x()), m_y(point.y()) { }
     explicit LayoutPoint(const FloatPoint& size) : m_x(size.x()), m_y(size.y()) { }

--- a/Source/WebCore/platform/graphics/LayoutRect.h
+++ b/Source/WebCore/platform/graphics/LayoutRect.h
@@ -45,7 +45,7 @@ namespace WebCore {
 
 class LayoutRect {
 public:
-    LayoutRect() { }
+    LayoutRect() = default;
     LayoutRect(const LayoutPoint& location, const LayoutSize& size)
         : m_location(location), m_size(size) { }
     template<typename T1, typename T2, typename U1, typename U2>

--- a/Source/WebCore/platform/graphics/LayoutSize.h
+++ b/Source/WebCore/platform/graphics/LayoutSize.h
@@ -49,7 +49,7 @@ enum AspectRatioFit {
 
 class LayoutSize {
 public:
-    LayoutSize() { }
+    LayoutSize() = default;
     LayoutSize(const IntSize& size) : m_width(size.width()), m_height(size.height()) { }
     template<typename T, typename U> LayoutSize(T width, U height) : m_width(width), m_height(height) { }
 

--- a/Source/WebCore/platform/graphics/PathTraversalState.cpp
+++ b/Source/WebCore/platform/graphics/PathTraversalState.cpp
@@ -35,7 +35,7 @@ static inline float distanceLine(const FloatPoint& start, const FloatPoint& end)
 }
 
 struct QuadraticBezier {
-    QuadraticBezier() { }
+    QuadraticBezier() = default;
     QuadraticBezier(const FloatPoint& s, const FloatPoint& c, const FloatPoint& e)
         : start(s)
         , control(c)
@@ -71,7 +71,7 @@ struct QuadraticBezier {
 };
 
 struct CubicBezier {
-    CubicBezier() { }
+    CubicBezier() = default;
     CubicBezier(const FloatPoint& s, const FloatPoint& c1, const FloatPoint& c2, const FloatPoint& e)
         : start(s)
         , control1(c1)

--- a/Source/WebCore/platform/graphics/PathUtilities.cpp
+++ b/Source/WebCore/platform/graphics/PathUtilities.cpp
@@ -41,7 +41,7 @@ namespace WebCore {
 class FloatPointGraph {
     WTF_MAKE_NONCOPYABLE(FloatPointGraph);
 public:
-    FloatPointGraph() { }
+    FloatPointGraph() = default;
 
     class Node : public FloatPoint {
         WTF_MAKE_NONCOPYABLE(Node);


### PR DESCRIPTION
#### 26e12e7e19387fd8bbf91c6a8cdd605e849403c6
<pre>
Prefer &apos;= default&apos; for constructors at WebCore/platform/graphics/
<a href="https://bugs.webkit.org/show_bug.cgi?id=275340">https://bugs.webkit.org/show_bug.cgi?id=275340</a>
<a href="https://rdar.apple.com/problem/129545769">rdar://problem/129545769</a>

Reviewed by Darin Adler.

We prefer to let the compiler generate default constructors
rather than explicitly defining it. This patch cleans up
specifically the constructors under WebCore/platform/graphics/

* Source/WebCore/platform/graphics/FloatLine.h:
* Source/WebCore/platform/graphics/FloatRoundedRect.h:
* Source/WebCore/platform/graphics/GeneratedImage.h:
(WebCore::GeneratedImage::GeneratedImage): Deleted.
* Source/WebCore/platform/graphics/IntRect.h:
* Source/WebCore/platform/graphics/LayoutPoint.h:
* Source/WebCore/platform/graphics/LayoutRect.h:
* Source/WebCore/platform/graphics/LayoutSize.h:
* Source/WebCore/platform/graphics/PathTraversalState.cpp:
* Source/WebCore/platform/graphics/PathUtilities.cpp:
(WebCore::FloatPointGraph::FloatPointGraph): Deleted.

Canonical link: <a href="https://commits.webkit.org/279930@main">https://commits.webkit.org/279930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80ba5474ba0ceb573a3e08e440ee0a9c87f99507

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58225 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5678 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57247 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5710 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44497 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3850 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57042 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32486 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25623 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29276 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4943 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3819 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5166 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59816 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30211 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5319 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51918 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31343 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47679 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51359 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12080 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32359 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31132 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->