### PR TITLE
[JSC] Continue using inlined access in DataIC

### DIFF
--- a/Source/JavaScriptCore/bytecode/InlineAccess.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineAccess.cpp
@@ -174,12 +174,12 @@ ALWAYS_INLINE static bool linkCodeInline(const char* name, CCallHelpers& jit, St
     return false;
 }
 
-bool InlineAccess::generateSelfPropertyAccess(CodeBlock* codeBlock, StructureStubInfo& stubInfo, Structure* structure, PropertyOffset offset)
+bool InlineAccess::generateSelfPropertyAccess(StructureStubInfo& stubInfo, Structure* structure, PropertyOffset offset)
 {
     if (!hasConstantIdentifier(stubInfo.accessType))
         return false;
 
-    if (codeBlock->useDataIC()) {
+    if (stubInfo.useDataIC) {
         // These dynamic slots get filled in by StructureStubInfo. Nothing else to do.
         return true;
     }
@@ -233,12 +233,12 @@ ALWAYS_INLINE static bool hasFreeRegister(StructureStubInfo& stubInfo)
     return getScratchRegister(stubInfo) != InvalidGPRReg;
 }
 
-bool InlineAccess::canGenerateSelfPropertyReplace(CodeBlock* codeBlock, StructureStubInfo& stubInfo, PropertyOffset offset)
+bool InlineAccess::canGenerateSelfPropertyReplace(StructureStubInfo& stubInfo, PropertyOffset offset)
 {
     if (!hasConstantIdentifier(stubInfo.accessType))
         return false;
 
-    if (codeBlock->useDataIC())
+    if (stubInfo.useDataIC)
         return true;
 
     if (isInlineOffset(offset))
@@ -247,14 +247,14 @@ bool InlineAccess::canGenerateSelfPropertyReplace(CodeBlock* codeBlock, Structur
     return hasFreeRegister(stubInfo);
 }
 
-bool InlineAccess::generateSelfPropertyReplace(CodeBlock* codeBlock, StructureStubInfo& stubInfo, Structure* structure, PropertyOffset offset)
+bool InlineAccess::generateSelfPropertyReplace(StructureStubInfo& stubInfo, Structure* structure, PropertyOffset offset)
 {
     if (!hasConstantIdentifier(stubInfo.accessType))
         return false;
 
-    ASSERT(canGenerateSelfPropertyReplace(codeBlock, stubInfo, offset));
+    ASSERT(canGenerateSelfPropertyReplace(stubInfo, offset));
 
-    if (codeBlock->useDataIC()) {
+    if (stubInfo.useDataIC) {
         // These dynamic slots get filled in by StructureStubInfo. Nothing else to do.
         return true;
     }
@@ -284,14 +284,14 @@ bool InlineAccess::generateSelfPropertyReplace(CodeBlock* codeBlock, StructureSt
     return linkCodeInline("property replace", jit, stubInfo);
 }
 
-bool InlineAccess::isCacheableArrayLength(CodeBlock* codeBlock, StructureStubInfo& stubInfo, JSArray* array)
+bool InlineAccess::isCacheableArrayLength(StructureStubInfo& stubInfo, JSArray* array)
 {
     ASSERT(array->indexingType() & IsArray);
 
     if (!hasConstantIdentifier(stubInfo.accessType))
         return false;
 
-    if (codeBlock->useDataIC())
+    if (stubInfo.useDataIC)
         return false;
 
     if (!hasFreeRegister(stubInfo))
@@ -300,10 +300,10 @@ bool InlineAccess::isCacheableArrayLength(CodeBlock* codeBlock, StructureStubInf
     return !hasAnyArrayStorage(array->indexingType()) && array->indexingType() != ArrayClass;
 }
 
-bool InlineAccess::generateArrayLength(CodeBlock* codeBlock, StructureStubInfo& stubInfo, JSArray* array)
+bool InlineAccess::generateArrayLength(StructureStubInfo& stubInfo, JSArray* array)
 {
-    ASSERT_UNUSED(codeBlock, !codeBlock->useDataIC());
-    ASSERT_UNUSED(codeBlock, isCacheableArrayLength(codeBlock, stubInfo, array));
+    ASSERT(!stubInfo.useDataIC);
+    ASSERT(isCacheableArrayLength(stubInfo, array));
 
     if (!hasConstantIdentifier(stubInfo.accessType))
         return false;
@@ -325,21 +325,21 @@ bool InlineAccess::generateArrayLength(CodeBlock* codeBlock, StructureStubInfo& 
     return linkCodeInline("array length", jit, stubInfo);
 }
 
-bool InlineAccess::isCacheableStringLength(CodeBlock* codeBlock, StructureStubInfo& stubInfo)
+bool InlineAccess::isCacheableStringLength(StructureStubInfo& stubInfo)
 {
     if (!hasConstantIdentifier(stubInfo.accessType))
         return false;
 
-    if (codeBlock->useDataIC())
+    if (stubInfo.useDataIC)
         return false;
 
     return hasFreeRegister(stubInfo);
 }
 
-bool InlineAccess::generateStringLength(CodeBlock* codeBlock, StructureStubInfo& stubInfo)
+bool InlineAccess::generateStringLength(StructureStubInfo& stubInfo)
 {
-    ASSERT_UNUSED(codeBlock, !codeBlock->useDataIC());
-    ASSERT_UNUSED(codeBlock, isCacheableStringLength(codeBlock, stubInfo));
+    ASSERT(!stubInfo.useDataIC);
+    ASSERT(isCacheableStringLength(stubInfo));
 
     if (!hasConstantIdentifier(stubInfo.accessType))
         return false;
@@ -370,14 +370,14 @@ bool InlineAccess::generateStringLength(CodeBlock* codeBlock, StructureStubInfo&
 }
 
 
-bool InlineAccess::generateSelfInAccess(CodeBlock* codeBlock, StructureStubInfo& stubInfo, Structure* structure)
+bool InlineAccess::generateSelfInAccess(StructureStubInfo& stubInfo, Structure* structure)
 {
     CCallHelpers jit;
 
     if (!hasConstantIdentifier(stubInfo.accessType))
         return false;
 
-    if (codeBlock->useDataIC()) {
+    if (stubInfo.useDataIC) {
         // These dynamic slots get filled in by StructureStubInfo. Nothing else to do.
         return true;
     }

--- a/Source/JavaScriptCore/bytecode/InlineAccess.h
+++ b/Source/JavaScriptCore/bytecode/InlineAccess.h
@@ -91,14 +91,14 @@ public:
         return std::max(size, sizeForPropertyAccess());
     }
 
-    static bool generateSelfPropertyAccess(CodeBlock*, StructureStubInfo&, Structure*, PropertyOffset);
-    static bool canGenerateSelfPropertyReplace(CodeBlock*, StructureStubInfo&, PropertyOffset);
-    static bool generateSelfPropertyReplace(CodeBlock*, StructureStubInfo&, Structure*, PropertyOffset);
-    static bool isCacheableArrayLength(CodeBlock*, StructureStubInfo&, JSArray*);
-    static bool isCacheableStringLength(CodeBlock*, StructureStubInfo&);
-    static bool generateArrayLength(CodeBlock*, StructureStubInfo&, JSArray*);
-    static bool generateSelfInAccess(CodeBlock*, StructureStubInfo&, Structure*);
-    static bool generateStringLength(CodeBlock*, StructureStubInfo&);
+    static bool generateSelfPropertyAccess(StructureStubInfo&, Structure*, PropertyOffset);
+    static bool canGenerateSelfPropertyReplace(StructureStubInfo&, PropertyOffset);
+    static bool generateSelfPropertyReplace(StructureStubInfo&, Structure*, PropertyOffset);
+    static bool isCacheableArrayLength(StructureStubInfo&, JSArray*);
+    static bool isCacheableStringLength(StructureStubInfo&);
+    static bool generateArrayLength(StructureStubInfo&, JSArray*);
+    static bool generateSelfInAccess(StructureStubInfo&, Structure*);
+    static bool generateStringLength(StructureStubInfo&);
 
     // This is helpful when determining the size of an IC on
     // various platforms. When adding a new type of IC, implement


### PR DESCRIPTION
#### 0844491bba9b67f0f4c91e642ee3cfcaa2d517d7
<pre>
[JSC] Continue using inlined access in DataIC
<a href="https://bugs.webkit.org/show_bug.cgi?id=275343">https://bugs.webkit.org/show_bug.cgi?id=275343</a>
<a href="https://rdar.apple.com/129547636">rdar://129547636</a>

Reviewed by Alexey Shvayka.

This patch keeps inlined access even IC starts using Stub path in DataIC. Since this inlined access already exists as a code,
we can cotinue using it as a super fast path and it is efficient. But the main benefit is that, by doing so, whenever we add a new AccessCase,
we only need to consider about this newly added one AccessCase code generation. This is useful for Handler IC&apos;s split code since we do not
need to consider generating two codes at one time, one for this already handled inlined AccessCase and one for the newly added one.
To make this code work, we simplified InlineAccess code. Now we should just use StructureStubInfo::useDataIC bool flag instead of CodeBlock&apos;s information,
removing more dependencies to CodeBlock when generating code / setting up code.

* Source/JavaScriptCore/bytecode/InlineAccess.cpp:
(JSC::InlineAccess::generateSelfPropertyAccess):
(JSC::InlineAccess::canGenerateSelfPropertyReplace):
(JSC::InlineAccess::generateSelfPropertyReplace):
(JSC::InlineAccess::isCacheableArrayLength):
(JSC::InlineAccess::generateArrayLength):
(JSC::InlineAccess::isCacheableStringLength):
(JSC::InlineAccess::generateStringLength):
(JSC::InlineAccess::generateSelfInAccess):
* Source/JavaScriptCore/bytecode/InlineAccess.h:
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::succeed):
(JSC::InlineCacheCompiler::calculateLiveRegistersForCallAndExceptionHandling):
(JSC::InlineCacheCompiler::preserveLiveRegistersToStackForCallWithoutExceptions):
(JSC::InlineCacheCompiler::generateAccessCase):
(JSC::InlineCacheCompiler::emitDOMJITGetter):
(JSC::InlineCacheCompiler::emitProxyObjectAccess):
(JSC::InlineCacheCompiler::compile):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::repatchSlowPathCall):
(JSC::tryCacheGetBy):
(JSC::tryCachePutBy):
(JSC::tryCacheInBy):
* Source/JavaScriptCore/bytecode/StructureStubInfo.cpp:
(JSC::StructureStubInfo::addAccessCase):
(JSC::StructureStubInfo::reset):
(JSC::StructureStubInfo::rewireStubAsJumpInAccess):
(JSC::StructureStubInfo::resetStubAsJumpInAccess):

Canonical link: <a href="https://commits.webkit.org/279895@main">https://commits.webkit.org/279895@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9471ddad6ce34eccd7e4058d62d617f99fc95b4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58149 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5602 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5624 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44434 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3792 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56966 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32420 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47533 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25561 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29210 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4871 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3743 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/48238 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5091 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59739 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/54376 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/30125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5243 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/51857 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47613 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32277 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/66672 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8123 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/31050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/12697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->