### PR TITLE
Remove and replace `WKBundlePageSetScaleAtOrigin`

### DIFF
--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -403,11 +403,6 @@ double WKBundlePageGetPageZoomFactor(WKBundlePageRef pageRef)
     return WebKit::toImpl(pageRef)->pageZoomFactor();
 }
 
-void WKBundlePageSetScaleAtOrigin(WKBundlePageRef pageRef, double scale, WKPoint origin)
-{
-    WebKit::toImpl(pageRef)->scalePage(scale, WebKit::toIntPoint(origin));
-}
-
 WKStringRef WKBundlePageDumpHistoryForTesting(WKBundlePageRef page, WKStringRef directory)
 {
     return WebKit::toCopiedAPI(WebKit::toImpl(page)->dumpHistoryForTesting(WebKit::toWTFString(directory)));

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePagePrivate.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePagePrivate.h
@@ -59,8 +59,6 @@ WK_EXPORT void WKBundlePageExecuteEditingCommand(WKBundlePageRef page, WKStringR
 WK_EXPORT double WKBundlePageGetTextZoomFactor(WKBundlePageRef page);
 WK_EXPORT double WKBundlePageGetPageZoomFactor(WKBundlePageRef page);
 
-WK_EXPORT void WKBundlePageSetScaleAtOrigin(WKBundlePageRef page, double scale, WKPoint origin);
-
 WK_EXPORT void WKBundlePageForceRepaint(WKBundlePageRef page);
 WK_EXPORT void WKBundlePageFlushPendingEditorStateUpdate(WKBundlePageRef page);
 

--- a/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
@@ -497,8 +497,12 @@ void EventSendingController::zoomPageOut()
 
 void EventSendingController::scalePageBy(double scale, double x, double y)
 {
-    WKPoint origin = { x, y };
-    WKBundlePageSetScaleAtOrigin(InjectedBundle::singleton().page()->page(), scale, origin);
+    auto body = adoptWK(WKMutableDictionaryCreate());
+    setValue(body, "SubMessage", "ScalePage");
+    setValue(body, "Scale", scale);
+    setValue(body, "OriginX", x);
+    setValue(body, "OriginY", y);
+    postSynchronousPageMessage("EventSender", body);
 }
 
 MonitorWheelEventsOptions* toMonitorWheelEventsOptions(JSContextRef context, JSValueRef argument)

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -352,9 +352,6 @@ void InjectedBundlePage::prepare()
 {
     WKBundlePageClearMainFrameName(m_page);
 
-    WKPoint origin = { 0, 0 };
-    WKBundlePageSetScaleAtOrigin(m_page, 1, origin);
-    
     WKBundleClearHistoryForTesting(m_page);
 
     WKBundleFrameClearOpener(WKBundlePageGetMainFrame(m_page));

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -2337,6 +2337,13 @@ void TestController::didReceiveSynchronousMessageFromInjectedBundle(WKStringRef 
             return completionHandler(nullptr);
         }
 
+        if (WKStringIsEqualToUTF8CString(subMessageName, "ScalePage")) {
+            auto* page = mainWebView()->page();
+            WKPoint origin { doubleValue(dictionary, "OriginX"), doubleValue(dictionary, "OriginY") };
+            WKPageSetScaleFactor(page, doubleValue(dictionary, "Scale"), origin);
+            return completionHandler(nullptr);
+        }
+
         ASSERT_NOT_REACHED();
     }
 

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -179,6 +179,8 @@ void TestInvocation::invoke()
     WKPageSetPageZoomFactor(TestController::singleton().mainWebView()->page(), 1);
     WKPageSetTextZoomFactor(TestController::singleton().mainWebView()->page(), 1);
 
+    WKPageSetScaleFactor(TestController::singleton().mainWebView()->page(), 1, WKPointMake(0, 0));
+
     postPageMessage("BeginTest", createTestSettingsDictionary());
 
     m_startedTesting = true;


### PR DESCRIPTION
#### 1dbaf94501941355cbc55ac4a2963ccb4be4ddd3
<pre>
Remove and replace `WKBundlePageSetScaleAtOrigin`
<a href="https://bugs.webkit.org/show_bug.cgi?id=275347">https://bugs.webkit.org/show_bug.cgi?id=275347</a>
<a href="https://rdar.apple.com/129562459">rdar://129562459</a>

Reviewed by NOBODY (OOPS!).

Injected bundle API will not work with site isolation, and this API is only used by WKTR.

* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundlePageSetScaleAtOrigin): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePagePrivate.h:
* Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp:
(WTR::EventSendingController::scalePageBy):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:
(WTR::InjectedBundlePage::prepare):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::didReceiveSynchronousMessageFromInjectedBundle):
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::invoke):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1dbaf94501941355cbc55ac4a2963ccb4be4ddd3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58169 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5622 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57191 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41884 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5646 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44452 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3809 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/56986 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32438 "Found 2 new test failures: compositing/tiling/tile-cache-zoomed.html fast/css/sticky/sticky-top-zoomed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47556 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25579 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29228 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4896 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3763 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51075 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5116 "Found 1 new test failure: compositing/tiling/tile-cache-zoomed.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59759 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30147 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5266 "Found 1 new test failure: compositing/tiling/tile-cache-zoomed.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51876 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31285 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47634 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51294 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32299 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31073 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->