### PR TITLE
Enable Trusted Types in stable

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-clips-sample.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-clips-sample.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
+<!DOCTYPE html>
 <html>
 <head>
   <script src="/resources/testharness.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/source-file.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/source-file.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
 <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script';" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-eval.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-eval.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
+<!doctype html>
 <html>
 <head>
   <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script';">

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-eval-function-constructor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-eval-function-constructor.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
+<!DOCTYPE html>
 <link rel="help" href="https://w3c.github.io/webappsec-csp/#can-compile-strings">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/csp-block-eval.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/csp-block-eval.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
+<!DOCTYPE html>
 <html>
 <head>
   <script nonce="abc" src="/resources/testharness.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-no-tt.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-no-tt.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
+<!DOCTYPE html>
 <html>
 <head>
   <script nonce="abc" src="/resources/testharness.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy-mutate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy-mutate.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
+<!DOCTYPE html>
 <html>
 <head>
   <script nonce="abc" src="/resources/testharness.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
+<!DOCTYPE html>
 <html>
 <head>
   <script nonce="abc" src="/resources/testharness.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-no-default-policy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-no-default-policy.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
+<!DOCTYPE html>
 <html>
 <head>
   <script nonce="abc" src="/resources/testharness.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-untrusted-arguments-and-applying-default-policy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-untrusted-arguments-and-applying-default-policy.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
+<!DOCTYPE html>
 <html>
 <head>
   <link rel="help" href="https://w3c.github.io/webappsec-csp/#can-compile-strings">

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-untrusted-arguments-and-default-policy-throwing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-untrusted-arguments-and-default-policy-throwing.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
+<!DOCTYPE html>
 <html>
 <head>
   <link rel="help" href="https://w3c.github.io/webappsec-csp/#can-compile-strings">

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
+<!DOCTYPE html>
 <html>
 <head>
   <link rel="help" href="https://w3c.github.io/webappsec-csp/#can-compile-strings">

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-no-csp-no-tt-default-policy.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-no-csp-no-tt-default-policy.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
+<!DOCTYPE html>
 <html>
 <head>
   <script nonce="abc" src="/resources/testharness.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-no-csp-no-tt.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-no-csp-no-tt.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
+<!DOCTYPE html>
 <html>
 <head>
   <script nonce="abc" src="/resources/testharness.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-permissive-csp.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-permissive-csp.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
+<!DOCTYPE html>
 <html>
 <head>
   <script nonce="abc" src="/resources/testharness.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
+<!DOCTYPE html>
 <head>
   <script nonce="123" src="/resources/testharness.js"></script>
   <script nonce="123"src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-report-only.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-report-only.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
+<!DOCTYPE html>
 <head>
   <script nonce="123" src="/resources/testharness.js"></script>
   <script nonce="123" src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
+<!DOCTYPE html>
 <head>
   <script nonce="123" src="/resources/testharness.js"></script>
   <script nonce="123" src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
+<!DOCTYPE html>
 <head>
   <meta name="timeout" content="long">
   <script src="/resources/testharness.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/tt-block-eval.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/tt-block-eval.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
+<!DOCTYPE html>
 <html>
 <head>
   <script src="/resources/testharness.js"></script>

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -621,7 +621,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useSharedArrayBuffer, false, Normal, nullptr) \
     v(Bool, useShadowRealm, false, Normal, "Expose the ShadowRealm object."_s) \
     v(Bool, useTemporal, false, Normal, "Expose the Temporal object."_s) \
-    v(Bool, useTrustedTypes, false, Normal, "Enable trusted types eval protection feature."_s) \
+    v(Bool, useTrustedTypes, true, Normal, "Enable trusted types eval protection feature."_s) \
     v(Bool, useWasmSIMD, true, Normal, "Allow the new simd instructions and types from the wasm simd spec."_s) \
     v(Bool, useWasmRelaxedSIMD, false, Normal, "Allow the relaxed simd instructions and types from the wasm relaxed simd spec."_s) \
     v(Bool, useWasmTailCalls, true, Normal, "Allow the new instructions from the wasm tail calls spec."_s) \

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7765,7 +7765,7 @@ TreatsAnyTextCSSLinkAsStylesheet:
 
 TrustedTypesEnabled:
   type: bool
-  status: testable
+  status: stable
   category: dom
   humanReadableName: "Trusted Types"
   humanReadableDescription: "Enable Trusted Types"
@@ -7773,9 +7773,9 @@ TrustedTypesEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      default: false
+      default: true
     WebCore:
-      default: false
+      default: true
 
 UAVisualTransitionDetectionEnabled:
   type: bool


### PR DESCRIPTION
#### 971b9ba19d62aad183c5e3e47e2c1eff7c92f7c6
<pre>
Enable Trusted Types in stable
<a href="https://bugs.webkit.org/show_bug.cgi?id=275349">https://bugs.webkit.org/show_bug.cgi?id=275349</a>

Reviewed by Tim Nguyen.

Changes TrustedTypes UnifiedWebPreferences.yaml flag from testable to stable.
TrustedTypes remains disabled by default in WebKitLegacy.

The JSC useTrustedTypes option is also enabled by default.

Also updates WPT test files to no longer manually set useTrustedTypes JSC option to true.

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/reporting/report-clips-sample.https.html:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/securitypolicyviolation/source-file.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-eval.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/block-eval-function-constructor.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/csp-block-eval.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-no-tt.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy-mutate.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-default-policy.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-csp-tt-no-default-policy.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-untrusted-arguments-and-applying-default-policy.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor-untrusted-arguments-and-default-policy-throwing.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-function-constructor.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-no-csp-no-tt-default-policy.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-no-csp-no-tt.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/eval-with-permissive-csp.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-report-only.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/tt-block-eval.html:
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:

Canonical link: <a href="https://commits.webkit.org/291409@main">https://commits.webkit.org/291409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ac1c6fd7a5aed4228ae7c609ee3e5cf1e9ebf16

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96736 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42422 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19783 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70465 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27960 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94781 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8936 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83154 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50792 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8682 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/746 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41622 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/84576 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78995 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/747 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98751 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90522 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18924 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13966 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79484 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78708 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19691 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23233 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/562 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11995 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18912 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24144 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/113109 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18615 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32955 "Found 13 new JSC stress test failures: microbenchmarks/memcpy-wasm-small.js.dfg-eager, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.default-wasm, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-slow-memory, wasm.yaml/wasm/stress/repro_1289.js.default-wasm, wasm.yaml/wasm/stress/repro_1289.js.wasm-collect-continuously, wasm.yaml/wasm/stress/repro_1289.js.wasm-slow-memory, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate-catch.js.default-wasm, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate-catch.js.wasm-eager, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-tag-arg.js.wasm-slow-memory, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch.js.wasm-slow-memory ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22070 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->