### PR TITLE
Remove Trusted Types enforcement from toggleAttribute

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Element-toggleAttribute-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Element-toggleAttribute-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS TT should not interfere with toggleAttribute on an event handler
+PASS TT should not interfere with toggleAttribute on an iframe srcdoc
+

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Element-toggleAttribute.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/Element-toggleAttribute.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<head>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'">
+</head>
+<body>
+<div>
+  <p id="p" onclick="alert(1)"></p>
+  <iframe id="iframe" srcdoc="abc"></iframe>
+</div>
+<script>
+  // Regression test for crbug.com/341057803.
+  // This tests that TT doesn't interfere with regular DOM behaviour, and so
+  // these tests should pass on any browser, whether they support TT or not.
+
+  test(t => {
+    const elem = document.getElementById("p");
+    elem.toggleAttribute("onclick");
+    assert_false(elem.hasAttribute("onclick"));
+    elem.toggleAttribute("onclick");
+    assert_true(elem.hasAttribute("onclick"));
+  }, "TT should not interfere with toggleAttribute on an event handler");
+
+  test(t => {
+    const elem = document.getElementById("iframe");
+    elem.toggleAttribute("srcdoc");
+    assert_false(elem.hasAttribute("srcdoc"));
+    elem.toggleAttribute("srcdoc");
+    assert_true(elem.hasAttribute("srcdoc"));
+  }, "TT should not interfere with toggleAttribute on an iframe srcdoc");
+</script>
+</body>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2008,19 +2008,7 @@ ExceptionOr<bool> Element::toggleAttribute(const AtomString& qualifiedName, std:
     unsigned index = elementData() ? elementData()->findAttributeIndexByName(caseAdjustedQualifiedName, false) : ElementData::attributeNotFound;
     if (index == ElementData::attributeNotFound) {
         if (!force || *force) {
-            auto name = QualifiedName { nullAtom(), caseAdjustedQualifiedName, nullAtom() };
-            if (!document().scriptExecutionContext()->settingsValues().trustedTypesEnabled)
-                setAttributeInternal(index, name, emptyAtom(), InSynchronizationOfLazyAttribute::No);
-            else {
-                auto attributeTypeAndSink = trustedTypeForAttribute(nodeName(), name.localName().convertToASCIILowercase(), this->namespaceURI(), name.namespaceURI());
-                auto attributeValue = trustedTypesCompliantAttributeValue(attributeTypeAndSink.attributeType, emptyAtom(), this, attributeTypeAndSink.sink);
-
-                if (attributeValue.hasException())
-                    return attributeValue.releaseException();
-
-                index = validateAttributeIndex(index, name);
-                setAttributeInternal(index, name, AtomString(attributeValue.releaseReturnValue()), InSynchronizationOfLazyAttribute::No);
-            }
+            setAttributeInternal(index, QualifiedName { nullAtom(), caseAdjustedQualifiedName, nullAtom() }, emptyAtom(), InSynchronizationOfLazyAttribute::No);
             return true;
         }
         return false;


### PR DESCRIPTION
#### 1ae029b5a34e88b0d89e96f50b70b502d7a47483
<pre>
Remove Trusted Types enforcement from toggleAttribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=275352">https://bugs.webkit.org/show_bug.cgi?id=275352</a>

Reviewed by Darin Adler.

The DOM spec PR no longer enforced Trusted Types within toggleAttribute so this removes that from the implementation.

See <a href="https://github.com/whatwg/dom/pull/1268">https://github.com/whatwg/dom/pull/1268</a>

* LayoutTests/imported/w3c/web-platform-tests/trusted-types/Element-toggleAttribute-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/Element-toggleAttribute.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::toggleAttribute):

Canonical link: <a href="https://commits.webkit.org/279950@main">https://commits.webkit.org/279950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c434c611832fef5dd345e4a6debfbebfd1f67a34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54909 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34357 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58187 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5640 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57209 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41904 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5668 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44466 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3822 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57004 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47570 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25593 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29244 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4911 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3781 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51095 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59777 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30167 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5282 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51890 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31303 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51317 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12099 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32318 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31092 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->