### PR TITLE
Forward more notifications to the WebContent process

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -1461,8 +1461,16 @@
 #if ENABLE(NOTIFY_BLOCKING)
         ;; Keep in sync with notify_entitlements() in process-entitlements.sh.
         ;; FORWARDED_NOTIFICATIONS
+        "_AXNotification_shouldPerformValidationsAtRuntime"
         "_NS_ctasd"
+        "AppleDatePreferencesChangedNotification"
+        "AppleLanguagePreferencesChangedNotification"
+        "AppleNumberPreferencesChangedNotification"
+        "AppleTextBehaviorPreferencesChangedNotification"
+        "AppleTimePreferencesChangedNotification"
         "LetterFeedbackEnabled.notification"
+        "PhoneticFeedbackEnabled.notification"
+        "QuickTypePredictionFeedbackEnabled.notification"
         "com.apple.CFPreferences._domainsChangedExternally"
         "com.apple.WebKit.LibraryPathDiagnostics"
         "com.apple.WebKit.deleteAllCode"
@@ -1509,7 +1517,9 @@
         ;; NON_FORWARDED_NOTIFICATIONS
         "com.apple.accessibility.cache.app.ax"
         "com.apple.accessibility.cache.ast"
+        "com.apple.accessibility.cache.automation.localized.lookup"
         "com.apple.accessibility.cache.ax"
+        "com.apple.accessibility.cache.enhance.background.contrast"
         "com.apple.accessibility.cache.enhance.text.legibility"
         "com.apple.accessibility.cache.enhance.text.legibilitycom.apple.WebKit.WebContent"
         "com.apple.accessibility.cache.guided.access"

--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -204,8 +204,16 @@ function notify_entitlements()
 
         # Keep in sync with the list in WebProcessPool::registerNotificationObservers.
         FORWARDED_NOTIFICATIONS=(
+            "_AXNotification_shouldPerformValidationsAtRuntime"
             "_NS_ctasd"
+            "AppleDatePreferencesChangedNotification"
+            "AppleLanguagePreferencesChangedNotification"
+            "AppleNumberPreferencesChangedNotification"
+            "AppleTextBehaviorPreferencesChangedNotification"
+            "AppleTimePreferencesChangedNotification"
             "LetterFeedbackEnabled.notification"
+            "PhoneticFeedbackEnabled.notification"
+            "QuickTypePredictionFeedbackEnabled.notification"
             "com.apple.CFPreferences._domainsChangedExternally"
             "com.apple.WebKit.LibraryPathDiagnostics"
             "com.apple.WebKit.deleteAllCode"
@@ -271,7 +279,9 @@ function notify_entitlements()
         NON_FORWARDED_NOTIFICATIONS=(
             "com.apple.accessibility.cache.app.ax"
             "com.apple.accessibility.cache.ast"
+            "com.apple.accessibility.cache.automation.localized.lookup"
             "com.apple.accessibility.cache.ax"
+            "com.apple.accessibility.cache.enhance.background.contrast"
             "com.apple.accessibility.cache.enhance.text.legibility"
             "com.apple.accessibility.cache.enhance.text.legibilitycom.apple.WebKit.WebContent"
             "com.apple.accessibility.cache.guided.access"

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -703,8 +703,16 @@ void WebProcessPool::registerNotificationObservers()
     const Vector<ASCIILiteral> notificationMessages = {
         // Keep in sync with notify_entitlements() in process-entitlements.sh.
         // FORWARDED_NOTIFICATIONS
+        "_AXNotification_shouldPerformValidationsAtRuntime"_s,
         "_NS_ctasd"_s,
+        "AppleDatePreferencesChangedNotification"_s,
+        "AppleLanguagePreferencesChangedNotification"_s,
+        "AppleNumberPreferencesChangedNotification"_s,
+        "AppleTextBehaviorPreferencesChangedNotification"_s,
+        "AppleTimePreferencesChangedNotification"_s,
         "LetterFeedbackEnabled.notification"_s,
+        "PhoneticFeedbackEnabled.notification"_s,
+        "QuickTypePredictionFeedbackEnabled.notification"_s,
         "com.apple.CFPreferences._domainsChangedExternally"_s,
         "com.apple.WebKit.LibraryPathDiagnostics"_s,
         "com.apple.WebKit.deleteAllCode"_s,

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -2033,8 +2033,16 @@
 #if ENABLE(NOTIFY_BLOCKING)
         ;; Keep in sync with notify_entitlements() in process-entitlements.sh.
         ;; FORWARDED_NOTIFICATIONS
+        "_AXNotification_shouldPerformValidationsAtRuntime"
         "_NS_ctasd"
+        "AppleDatePreferencesChangedNotification"
+        "AppleLanguagePreferencesChangedNotification"
+        "AppleNumberPreferencesChangedNotification"
+        "AppleTextBehaviorPreferencesChangedNotification"
+        "AppleTimePreferencesChangedNotification"
         "LetterFeedbackEnabled.notification"
+        "PhoneticFeedbackEnabled.notification"
+        "QuickTypePredictionFeedbackEnabled.notification"
         "com.apple.CFPreferences._domainsChangedExternally"
         "com.apple.WebKit.LibraryPathDiagnostics"
         "com.apple.WebKit.deleteAllCode"
@@ -2089,7 +2097,9 @@
         ;; NON_FORWARDED_NOTIFICATIONS
         "com.apple.accessibility.cache.app.ax"
         "com.apple.accessibility.cache.ast"
+        "com.apple.accessibility.cache.automation.localized.lookup"
         "com.apple.accessibility.cache.ax"
+        "com.apple.accessibility.cache.enhance.background.contrast"
         "com.apple.accessibility.cache.enhance.text.legibility"
         "com.apple.accessibility.cache.enhance.text.legibilitycom.apple.WebKit.WebContent"
         "com.apple.accessibility.cache.guided.access"


### PR DESCRIPTION
#### ff37df0fa9111768cccac40ec5bc6e96dd1190db
<pre>
Forward more notifications to the WebContent process
<a href="https://bugs.webkit.org/show_bug.cgi?id=275360">https://bugs.webkit.org/show_bug.cgi?id=275360</a>
<a href="https://rdar.apple.com/129286598">rdar://129286598</a>

Reviewed by Brady Eidson.

Forward more notifications to the WebContent process. These notifications have been picked up by telemetry
in the WebContent process and we also add them to the entitlement based allow list to avoid further reports.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/Scripts/process-entitlements.sh:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::registerNotificationObservers):
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/280105@main">https://commits.webkit.org/280105@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4cbe4e8a19e0a914afda162407d8e9ee690edab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58193 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5646 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5674 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44473 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3827 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32460 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47576 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25600 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/54741 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29251 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3787 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51101 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59783 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30175 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5286 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51895 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31309 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47654 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51322 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32324 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8226 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31098 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->