### PR TITLE
Unskip trusted types reporting tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5468,9 +5468,6 @@ webkit.org/b/261849 imported/w3c/web-platform-tests/css/css-scroll-anchoring/sta
 
 # Trusted Types aren't fully implemented yet
 webkit.org/b/272196 imported/w3c/web-platform-tests/trusted-types/trusted-types-createHTMLDocument.html [ Pass Failure ]
-webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting.html [ Skip ]
-webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html [ Skip ]
-webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-report-only.html [ Skip ]
 webkit.org/b/274519 imported/w3c/web-platform-tests/trusted-types/HTMLScriptElement-in-xhtml-document.tentative.https.xhtml [ Skip ]
 webkit.org/b/274519 imported/w3c/web-platform-tests/trusted-types/Document-write-exception-order.xhtml [ Skip ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/WorkerGlobalScope-importScripts.html [ Pass Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-no-unsafe-eval-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-no-unsafe-eval-expected.txt
@@ -1,9 +1,10 @@
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: Refused to load because it does not appear in the object-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Refused to load because it does not appear in the object-src directive of the Content Security Policy.
 CONSOLE MESSAGE: Refused to load because it does not appear in the object-src directive of the Content Security Policy.
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Trusted Type violation report: evaluating a string violates both script-src and trusted-types. Test timed out
-NOTRUN Trusted Type violation report: evaluating a Trusted Script violates script-src.
-NOTRUN Trusted Type violation report: script-src restrictions apply after the default policy runs.
+PASS Trusted Type violation report: evaluating a string violates both script-src and trusted-types.
+PASS Trusted Type violation report: evaluating a Trusted Script violates script-src.
+PASS Trusted Type violation report: script-src restrictions apply after the default policy runs.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
 <head>
   <script nonce="123" src="/resources/testharness.js"></script>
   <script nonce="123"src="/resources/testharnessreport.js"></script>
@@ -91,20 +91,22 @@
     expect_throws(_ => eval(scriptyPolicy.createScript('script_run_beacon="i ran"')));
     flush();
     assert_not_equals(script_run_beacon, 'i ran'); // Code did not run.
+    assert_equals(script_run_beacon, 'never_overwritten');
     return p;
   }, "Trusted Type violation report: evaluating a Trusted Script violates script-src.");
 
   promise_test(t => {
     trustedTypes.createPolicy('default', {
-      createScript: s => s.replace('payload', 'default policy'),
+      createScript: s => s,
     }, true);
     let p = Promise.resolve()
         .then(promise_violation((e) =>
            e.effectiveDirective.includes('script-src') &&
-           e.sample.includes("default policy")))
+           e.sample.includes("should not run")))
         .then(promise_flush());
-    expect_throws(_ => eval('script_run_beacon="payload"')); // script-src will block.
-    assert_not_equals(script_run_beacon, 'default policy'); // Code did not run.
+    expect_throws(_ => eval('script_run_beacon="should not run"')); // script-src will block.
+    assert_not_equals(script_run_beacon, 'should not run'); // Code did not run.
+    assert_equals(script_run_beacon, 'never_overwritten');
     flush();
     return p;
   }, "Trusted Type violation report: script-src restrictions apply after the default policy runs.");

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-report-only-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-report-only-expected.txt
@@ -1,10 +1,11 @@
 CONSOLE MESSAGE: The Content Security Policy 'require-trusted-types-for 'script'' was delivered in report-only mode, but does not specify a 'report-to'; the policy will have no effect. Please either add a 'report-to' directive, or deliver the policy via the 'Content-Security-Policy' header.
+CONSOLE MESSAGE: [Report Only] This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: Refused to load because it does not appear in the object-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Refused to load because it does not appear in the object-src directive of the Content Security Policy.
 CONSOLE MESSAGE: Refused to load because it does not appear in the object-src directive of the Content Security Policy.
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Trusted Type violation report: evaluating a string. Test timed out
-NOTRUN Trusted Type violation report: evaluating a Trusted Script.
-NOTRUN Trusted Type violation report: default policy runs in report-only mode.
+PASS Trusted Type violation report: evaluating a string.
+PASS Trusted Type violation report: evaluating a Trusted Script.
+PASS Trusted Type violation report: default policy runs in report-only mode.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-report-only.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-report-only.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
 <head>
   <script nonce="123" src="/resources/testharness.js"></script>
   <script nonce="123"src="/resources/testharnessreport.js"></script>
@@ -94,11 +94,11 @@
 
   promise_test(t => {
     trustedTypes.createPolicy('default', {
-      createScript: s => s.replace('payload', 'default policy'),
+      createScript: s => s,
     }, true);
     let p = promise_flush()();
     eval('script_run_beacon="payload"');
-    assert_equals(script_run_beacon, 'default policy');
+    assert_equals(script_run_beacon, 'payload');
     flush();
     return p;
   }, "Trusted Type violation report: default policy runs in report-only mode.");

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-expected.txt
@@ -12,11 +12,19 @@ CONSOLE MESSAGE: Refused to load because it does not appear in the object-src di
 CONSOLE MESSAGE: This requires a TrustedHTML value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
 CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: Refused to load because it does not appear in the object-src directive of the Content Security Policy.
+CONSOLE MESSAGE: This requires a TrustedScript value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: This requires a TrustedScriptURL value else it violates the following Content Security Policy directive: "require-trusted-types-for 'script'"
+CONSOLE MESSAGE: Refused to load because it does not appear in the object-src directive of the Content Security Policy.
 
 abc
 
-
-Harness Error (TIMEOUT), message = null
 
 PASS Trusted Type violation report: creating a forbidden policy.
 PASS Trusted Type violation report: creating a report-only-forbidden policy.
@@ -28,12 +36,12 @@ PASS Trusted Type violation report: assign trusted HTML to html; no report
 PASS Trusted Type violation report: sample for innerHTML assignment
 PASS Trusted Type violation report: sample for text assignment
 PASS Trusted Type violation report: sample for script.src assignment
-TIMEOUT Trusted Type violation report: sample for script innerText assignment Test timed out
-NOTRUN Trusted Type violation report: sample for SVGScriptElement href assignment
-NOTRUN Trusted Type violation report: sample for SVGScriptElement href assignment by setAttribute
-NOTRUN Trusted Type violation report: sample for SVGScriptElement text assignment
-NOTRUN Trusted Type violation report: sample for eval
-NOTRUN Trusted Type violation report: large values should be handled sanely.
-NOTRUN Trusted Type violation report: sample for custom element assignment
-NOTRUN Trusted Type violation report: Worker constructor
+PASS Trusted Type violation report: sample for script innerText assignment
+PASS Trusted Type violation report: sample for SVGScriptElement href assignment
+PASS Trusted Type violation report: sample for SVGScriptElement href assignment by setAttribute
+PASS Trusted Type violation report: sample for SVGScriptElement text assignment
+PASS Trusted Type violation report: sample for eval
+PASS Trusted Type violation report: large values should be handled sanely.
+PASS Trusted Type violation report: sample for custom element assignment
+PASS Trusted Type violation report: Worker constructor
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useTrustedTypes=true ] -->
 <head>
   <meta name="timeout" content="long">
   <script src="/resources/testharness.js"></script>
@@ -182,7 +182,7 @@
     let p = Promise.resolve()
         .then(promise_violation("require-trusted-types-for 'script'"))
         .then(expect_blocked_uri("trusted-types-sink"))
-        .then(expect_sample("HTMLElement innerText|2+2;"));
+        .then(expect_sample("HTMLScriptElement innerText|2+2;"));
     expect_throws(_ => document.getElementById("script").innerText = "2+2;");
     return p;
   }, "Trusted Type violation report: sample for script innerText assignment");
@@ -194,7 +194,7 @@
     let p = Promise.resolve()
         .then(promise_violation("require-trusted-types-for 'script'"))
         .then(expect_blocked_uri("trusted-types-sink"))
-        .then(expect_sample("SVGAnimatedString baseVal"));
+        .then(expect_sample("SVGScriptElement href"));
       expect_throws(_ => { document.getElementById("svgscript").href.baseVal = "" });
     return p;
   }, "Trusted Type violation report: sample for SVGScriptElement href assignment");
@@ -203,7 +203,7 @@
     let p = Promise.resolve()
         .then(promise_violation("require-trusted-types-for 'script'"))
         .then(expect_blocked_uri("trusted-types-sink"))
-        .then(expect_sample("Element setAttribute"));
+        .then(expect_sample("SVGScriptElement href"));
       expect_throws(_ => { document.getElementById("svgscript").setAttribute('href', "test"); });
     return p;
   }, "Trusted Type violation report: sample for SVGScriptElement href assignment by setAttribute");
@@ -234,7 +234,7 @@
     let p = Promise.resolve()
         .then(promise_violation("require-trusted-types-for 'script'"))
         .then(expect_blocked_uri("trusted-types-sink"))
-        .then(expect_sample("HTMLElement innerText|abbb"))
+        .then(expect_sample("HTMLScriptElement innerText|abbb"))
         .then(e => assert_less_than(e.sample.length, 150));
     const value = "a" + "b".repeat(50000);
     expect_throws(_ => document.getElementById("script").innerText = value);


### PR DESCRIPTION
#### e105514fe7efa49a67a766bcdd0fa8e44167b133
<pre>
Unskip trusted types reporting tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=275363">https://bugs.webkit.org/show_bug.cgi?id=275363</a>

Reviewed by Tim Nguyen.

This unskips tests related to CSP reporting and trusted types. Some assertions are updated to match latest specs.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-no-unsafe-eval-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-no-unsafe-eval.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-report-only-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-eval-reporting-report-only.html:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting.html:

Canonical link: <a href="https://commits.webkit.org/279940@main">https://commits.webkit.org/279940@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/780cdb6ba4383161d5796602b15c1ecc0b8c96e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34383 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58210 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5663 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5694 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44484 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3839 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32473 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47591 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25611 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29266 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4932 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3804 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51122 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5154 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59800 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5301 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51906 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31328 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47668 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51345 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12087 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32344 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31117 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->