### PR TITLE
[CSS] StyleRuleWithNesting should be cacheable.

### DIFF
--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -356,9 +356,9 @@ Ref<StyleRuleWithNesting> StyleRuleWithNesting::create(StyleRule&& styleRule)
 }
 
 StyleRuleWithNesting::StyleRuleWithNesting(Ref<StyleProperties>&& properties, bool hasDocumentSecurityOrigin, CSSSelectorList&& selectors, Vector<Ref<StyleRuleBase>>&& nestedRules)
-    : StyleRule(WTFMove(properties), hasDocumentSecurityOrigin, WTFMove(selectors))
+    : StyleRule(WTFMove(properties), hasDocumentSecurityOrigin, { })
     , m_nestedRules(WTFMove(nestedRules))
-    , m_originalSelectorList(selectorList())
+    , m_originalSelectorList(WTFMove(selectors))
 {
     setType(StyleRuleType::StyleWithNesting);
 }

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -476,8 +476,9 @@ inline void StyleRule::wrapperAdoptSelectorList(CSSSelectorList&& selectors)
 
 inline void StyleRuleWithNesting::wrapperAdoptOriginalSelectorList(CSSSelectorList&& selectors)
 {
-    m_originalSelectorList = CSSSelectorList { selectors };
-    StyleRule::wrapperAdoptSelectorList(WTFMove(selectors));
+    m_originalSelectorList = WTFMove(selectors);
+    // Clean the old resolved selector list, it will be resolved later.
+    wrapperAdoptSelectorList({ });
 }
 
 #if ENABLE(CSS_SELECTOR_JIT)

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -138,8 +138,10 @@ bool StyleSheetContents::isCacheable() const
     // FIXME: Valid mime type avoids the check too.
     if (!m_hasSyntacticallyValidCSSHeader)
         return false;
+    /*
     if (m_hasNestingRules)
         return false;
+    */
     return true;
 }
 

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -271,8 +271,11 @@ void RuleSetBuilder::resolveSelectorListWithNesting(StyleRuleWithNesting& rule)
         parentResolvedSelectorList =  m_selectorListStack.last();
 
     // If it's a top-level rule without a nesting parent selector, keep the selector list as is.
-    if (!rule.originalSelectorList().hasExplicitNestingParent() && !parentResolvedSelectorList)
+    if (!rule.originalSelectorList().hasExplicitNestingParent() && !parentResolvedSelectorList) {
+        auto originalSelectorList = rule.originalSelectorList();
+        rule.wrapperAdoptSelectorList(WTFMove(originalSelectorList));
         return;
+    }
 
     auto resolvedSelectorList = CSSSelectorParser::resolveNestingParent(rule.originalSelectorList(), parentResolvedSelectorList);
     rule.wrapperAdoptSelectorList(WTFMove(resolvedSelectorList));
@@ -293,7 +296,7 @@ void RuleSetBuilder::addStyleRuleWithSelectorList(const CSSSelectorList& selecto
 
 void RuleSetBuilder::addStyleRule(StyleRuleWithNesting& rule)
 {
-    if (m_shouldResolveNesting == ShouldResolveNesting::Yes)
+    if (m_shouldResolveNesting == ShouldResolveNesting::Yes && rule.selectorList().isEmpty())
         resolveSelectorListWithNesting(rule);
 
     auto& selectorList = rule.selectorList();


### PR DESCRIPTION
#### 669cd63e9cf9a8977cccc9dba7d89738ec19d77d
<pre>
[CSS] StyleRuleWithNesting should be cacheable.
<a href="https://bugs.webkit.org/show_bug.cgi?id=270810">https://bugs.webkit.org/show_bug.cgi?id=270810</a>
<a href="https://rdar.apple.com/124398506">rdar://124398506</a>

Reviewed by NOBODY (OOPS!).

StyleInvalidation classes contain non owning raw pointer to
CSSSelector, which are getting dangling when rule set building rewrite the resolved selector list.

This patch makes the resolving happens only once, to avoid the issue of rewriting the resolved selector list to an identical one (but somewhere else in memory).

* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRuleWithNesting::StyleRuleWithNesting):
(WebCore::m_originalSelectorList):
* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRuleWithNesting::wrapperAdoptOriginalSelectorList):
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::isCacheable const):
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::resolveSelectorListWithNesting):
(WebCore::Style::RuleSetBuilder::addStyleRule):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/669cd63e9cf9a8977cccc9dba7d89738ec19d77d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54939 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7528 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58217 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5670 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57239 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41939 "Hash 669cd63e for PR 29719 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5701 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44490 "Found 3 new test failures: fast/css/rule-selector-nesting-overflow.html imported/w3c/web-platform-tests/css/css-nesting/cssom.html imported/w3c/web-platform-tests/css/css-nesting/invalidation-004.html (failure)") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3844 "Found 1 new test failure: fast/css/rule-selector-nesting-overflow.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57034 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/41939 "Hash 669cd63e for PR 29719 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47595 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25616 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/41939 "Hash 669cd63e for PR 29719 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4936 "Found 3 new test failures: fast/css/rule-selector-nesting-overflow.html imported/w3c/web-platform-tests/css/css-nesting/cssom.html imported/w3c/web-platform-tests/css/css-nesting/invalidation-004.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3811 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/41939 "Hash 669cd63e for PR 29719 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5159 "11 flakes 3 failures") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59807 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30203 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5313 "Found 3 new test failures: fast/css/rule-selector-nesting-overflow.html imported/w3c/web-platform-tests/css/css-nesting/cssom.html imported/w3c/web-platform-tests/css/css-nesting/invalidation-004.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51911 "Found 3 new test failures: fast/css/rule-selector-nesting-overflow.html imported/w3c/web-platform-tests/css/css-nesting/cssom.html imported/w3c/web-platform-tests/css/css-nesting/invalidation-004.html (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47672 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51347 "3 api tests failed or timed out") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32350 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31124 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->