### PR TITLE
[WebGPU] RenderBundleEncoder will crash if Device is destroyed before calling GPURenderBundleEncoder.finish()

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-275371-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-275371-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-275371.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-275371.html
@@ -1,0 +1,9761 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script>
+globalThis.testRunner?.waitUntilDone();
+const log = globalThis.$vm?.print ?? console.log;
+
+function gc() {
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ */
+function pseudoSubmit(device) {
+  for (let i = 0; i < 63; i++) {
+    device.createCommandEncoder();
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUBuffer} buffer
+ */
+function dissociateBuffer(device, buffer) {
+  let commandEncoder = device.createCommandEncoder();
+  if (buffer.usage & GPUBufferUsage.COPY_DST) {
+    let writeBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+    commandEncoder.copyBufferToBuffer(writeBuffer, 0, buffer, 0, 0);
+  } else if (buffer.usage & GPUBufferUsage.COPY_SRC) {
+    let readBuffer = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+    commandEncoder.copyBufferToBuffer(buffer, 0, readBuffer, 0, 0);
+  }
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+/**
+* @returns {Promise<HTMLVideoElement>}
+*/
+function videoWithData() {
+  const veryBrightVideo = `data:video/mp4;base64,AAAAHGZ0eXBpc29tAAACAGlzb21pc28ybXA0MQAAAAhmcmVlAAAAvG1kYXQAAAAfTgEFGkdWStxcTEM/lO/FETzRQ6gD7gAA7gIAA3EYgAAAAEgoAa8iNjAkszOL+e58c//cEe//0TT//scp1n/381P/RWP/zOW4QtxorfVogeh8nQDbQAAAAwAQMCcWUTAAAAMAAAMAAAMA84AAAAAVAgHQAyu+KT35E7gAADFgAAADABLQAAAAEgIB4AiS76MTkNbgAAF3AAAPSAAAABICAeAEn8+hBOTXYAADUgAAHRAAAAPibW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAAKcAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAw10cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAABAAAAAQAAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAACnAAAAAAABAAAAAAKFbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABdwAAAD6BVxAAAAAAAMWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABDb3JlIE1lZGlhIFZpZGVvAAAAAixtaW5mAAAAFHZtaGQAAAABAAAAAAAAAAAAAAAkZGluZgAAABxkcmVmAAAAAAAAAAEAAAAMdXJsIAAAAAEAAAHsc3RibAAAARxzdHNkAAAAAAAAAAEAAAEMaHZjMQAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAQABAASAAAAEgAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABj//wAAAHVodmNDAQIgAAAAsAAAAAAAPPAA/P36+gAACwOgAAEAGEABDAH//wIgAAADALAAAAMAAAMAPBXAkKEAAQAmQgEBAiAAAAMAsAAAAwAAAwA8oBQgQcCTDLYgV7kWVYC1CRAJAICiAAEACUQBwChkuNBTJAAAAApmaWVsAQAAAAATY29scm5jbHgACQAQAAkAAAAAEHBhc3AAAAABAAAAAQAAABRidHJ0AAAAAAAALPwAACz8AAAAKHN0dHMAAAAAAAAAAwAAAAIAAAPoAAAAAQAAAAEAAAABAAAD6AAAABRzdHNzAAAAAAAAAAEAAAABAAAAEHNkdHAAAAAAIBAQGAAAAChjdHRzAAAAAAAAAAMAAAABAAAAAAAAAAEAAAfQAAAAAgAAAAAAAAAcc3RzYwAAAAAAAAABAAAAAQAAAAQAAAABAAAAJHN0c3oAAAAAAAAAAAAAAAQAAABvAAAAGQAAABYAAAAWAAAAFHN0Y28AAAAAAAAAAQAAACwAAABhdWR0YQAAAFltZXRhAAAAAAAAACFoZGxyAAAAAAAAAABtZGlyYXBwbAAAAAAAAAAAAAAAACxpbHN0AAAAJKl0b28AAAAcZGF0YQAAAAEAAAAATGF2ZjYwLjMuMTAw`;
+  let video = document.createElement('video');
+  video.src = veryBrightVideo;
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+onload = async () => {
+  try {
+let promise0 = navigator.gpu.requestAdapter({});
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  label: '\u742a\u0af8\u0638\u9903\u{1f9ff}\u0848\u473e\u0a85',
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 11,
+    maxColorAttachmentBytesPerSample: 58,
+    maxVertexAttributes: 18,
+    maxVertexBufferArrayStride: 5090,
+    maxStorageTexturesPerShaderStage: 13,
+    maxStorageBuffersPerShaderStage: 32,
+    maxDynamicStorageBuffersPerPipelineLayout: 61249,
+    maxDynamicUniformBuffersPerPipelineLayout: 54428,
+    maxBindingsPerBindGroup: 4415,
+    maxTextureArrayLayers: 272,
+    maxTextureDimension1D: 8849,
+    maxTextureDimension2D: 8913,
+    maxVertexBuffers: 11,
+    maxBindGroupsPlusVertexBuffers: 26,
+    minStorageBufferOffsetAlignment: 128,
+    minUniformBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 179396651,
+    maxStorageBufferBindingSize: 184759477,
+    maxUniformBuffersPerShaderStage: 33,
+    maxSampledTexturesPerShaderStage: 19,
+    maxInterStageShaderVariables: 45,
+    maxInterStageShaderComponents: 102,
+    maxSamplersPerShaderStage: 20,
+  },
+});
+let commandEncoder0 = device0.createCommandEncoder({label: '\ub5a6\u{1f853}\u0751'});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  label: '\ud221\u1826\ud73e',
+  colorFormats: ['rg8unorm', 'rg32float', 'rg16sint', 'r16uint', 'r16uint', 'r8uint', 'rgba8sint', 'bgra8unorm-srgb'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let bindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 3494, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 2754,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let computePassEncoder0 = commandEncoder0.beginComputePass();
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 262});
+let promise1 = device0.queue.onSubmittedWorkDone();
+let offscreenCanvas0 = new OffscreenCanvas(1011, 349);
+let bindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 1187,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder1 = device0.createCommandEncoder();
+let querySet1 = device0.createQuerySet({label: '\u079f\u0d28\u16d0', type: 'occlusion', count: 1775});
+let pipelineLayout0 = device0.createPipelineLayout({
+  label: '\u98be\u51f1',
+  bindGroupLayouts: [bindGroupLayout1, bindGroupLayout0, bindGroupLayout1, bindGroupLayout0, bindGroupLayout0, bindGroupLayout1, bindGroupLayout0, bindGroupLayout0, bindGroupLayout0, bindGroupLayout1, bindGroupLayout1],
+});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  colorFormats: ['rg8unorm', 'rg32float', 'rg16sint', 'r16uint', 'r16uint', 'r8uint', 'rgba8sint', 'bgra8unorm-srgb'],
+  stencilReadOnly: true,
+});
+let sampler0 = device0.createSampler({
+  label: '\u0014\u{1f7c7}\u3dc2',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 21.95,
+  lodMaxClamp: 57.97,
+  maxAnisotropy: 6,
+});
+let canvas0 = document.createElement('canvas');
+let shaderModule0 = device0.createShaderModule({
+  label: '\ud40a\u121b\u{1fbdd}\u53c9\u0944\ud28b\ub021\u3d3e',
+  code: `@group(1) @binding(3494)
+var<storage, read_write> type0: array<u32>;
+@group(8) @binding(2754)
+var<storage, read_write> field0: array<u32>;
+@group(6) @binding(3494)
+var<storage, read_write> function0: array<u32>;
+@group(3) @binding(2754)
+var<storage, read_write> global0: array<u32>;
+@group(2) @binding(1187)
+var<storage, read_write> global1: array<u32>;
+@group(4) @binding(3494)
+var<storage, read_write> parameter0: array<u32>;
+@group(10) @binding(1187)
+var<storage, read_write> field1: array<u32>;
+@group(0) @binding(1187)
+var<storage, read_write> global2: array<u32>;
+@group(1) @binding(2754)
+var<storage, read_write> function1: array<u32>;
+@group(7) @binding(3494)
+var<storage, read_write> parameter1: array<u32>;
+@group(8) @binding(3494)
+var<storage, read_write> global3: array<u32>;
+@group(4) @binding(2754)
+var<storage, read_write> n0: array<u32>;
+@group(3) @binding(3494)
+var<storage, read_write> field2: array<u32>;
+
+@compute @workgroup_size(2, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @builtin(sample_mask) f1: u32,
+  @location(1) f2: vec2<f32>,
+  @location(3) f3: vec4<u32>,
+  @location(7) f4: vec4<f32>,
+  @location(2) f5: vec2<i32>,
+  @location(4) f6: u32,
+  @location(5) f7: vec4<u32>,
+  @location(6) f8: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(sample_mask) a1: u32, @builtin(front_facing) a2: bool, @builtin(position) a3: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S0 {
+  @location(11) f0: vec4<f32>,
+  @location(0) f1: vec3<f16>,
+  @location(14) f2: vec2<i32>,
+  @location(17) f3: vec3<i32>,
+  @location(3) f4: vec2<f16>,
+  @location(10) f5: vec3<f16>,
+  @location(1) f6: vec4<i32>,
+  @location(2) f7: vec4<u32>,
+  @location(13) f8: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(16) a0: vec3<i32>, @location(7) a1: f16, @location(8) a2: vec4<f32>, @location(12) a3: vec2<u32>, @location(5) a4: vec2<f16>, @location(9) a5: vec3<f16>, @location(15) a6: vec3<f32>, @location(6) a7: vec2<f16>, @builtin(instance_index) a8: u32, @location(4) a9: vec2<u32>, a10: S0, @builtin(vertex_index) a11: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder2 = device0.createCommandEncoder({label: '\u6c4e\uac27\u7685\uefd7\uf518\uefd6\u{1ff4d}\u{1fb5e}\u{1f8b1}\ubca3'});
+let querySet2 = device0.createQuerySet({
+  label: '\ue76b\u65a5\u{1fcb1}\ub198\u707e\u8eed\u433a\u9aff\u{1f8c7}\u{1fb3d}',
+  type: 'occlusion',
+  count: 1282,
+});
+let texture0 = device0.createTexture({
+  label: '\uef42\u{1faa0}\u906f\u0506\u8ea2\u{1fc81}\u{1fee6}\u5d5c\uece3\u13ed',
+  size: {width: 320, height: 2, depthOrArrayLayers: 218},
+  mipLevelCount: 1,
+  dimension: '2d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+canvas0.width = 13;
+gc();
+let imageData0 = new ImageData(16, 256);
+let commandEncoder3 = device0.createCommandEncoder({});
+let textureView0 = texture0.createView({dimension: '2d', baseArrayLayer: 150});
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+let canvas1 = document.createElement('canvas');
+let textureView1 = texture0.createView({dimension: '2d', aspect: 'all', baseArrayLayer: 23});
+let computePassEncoder1 = commandEncoder3.beginComputePass({});
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  label: '\uc297\u87ee\u3334\ufab5\u026e',
+  code: `@group(7) @binding(2754)
+var<storage, read_write> function2: array<u32>;
+@group(4) @binding(2754)
+var<storage, read_write> parameter2: array<u32>;
+@group(0) @binding(1187)
+var<storage, read_write> field3: array<u32>;
+@group(10) @binding(1187)
+var<storage, read_write> type1: array<u32>;
+@group(5) @binding(1187)
+var<storage, read_write> local0: array<u32>;
+@group(3) @binding(3494)
+var<storage, read_write> function3: array<u32>;
+@group(6) @binding(2754)
+var<storage, read_write> parameter3: array<u32>;
+@group(9) @binding(1187)
+var<storage, read_write> local1: array<u32>;
+@group(6) @binding(3494)
+var<storage, read_write> global4: array<u32>;
+@group(7) @binding(3494)
+var<storage, read_write> parameter4: array<u32>;
+@group(1) @binding(3494)
+var<storage, read_write> global5: array<u32>;
+@group(1) @binding(2754)
+var<storage, read_write> local2: array<u32>;
+@group(4) @binding(3494)
+var<storage, read_write> type2: array<u32>;
+
+@compute @workgroup_size(1, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S2 {
+  @location(8) f0: vec3<i32>,
+  @location(26) f1: f16,
+  @location(18) f2: vec3<u32>,
+  @location(38) f3: vec4<f16>,
+  @location(43) f4: vec4<f16>,
+  @location(40) f5: vec4<u32>,
+  @location(30) f6: vec3<f32>,
+  @location(10) f7: i32,
+  @location(35) f8: vec2<i32>,
+  @builtin(front_facing) f9: bool,
+  @builtin(sample_mask) f10: u32,
+  @builtin(sample_index) f11: u32,
+  @location(33) f12: vec3<f32>,
+  @location(22) f13: f32,
+  @location(7) f14: vec4<u32>,
+  @location(42) f15: u32,
+  @location(2) f16: vec2<u32>,
+  @location(29) f17: vec2<i32>,
+  @location(21) f18: vec2<f32>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec2<f32>,
+  @location(2) f1: vec4<i32>,
+  @location(0) f2: vec2<f32>,
+  @location(7) f3: vec4<f32>,
+  @location(6) f4: vec4<i32>,
+  @location(3) f5: u32,
+  @location(4) f6: vec2<u32>,
+  @location(5) f7: vec3<u32>
+}
+
+@fragment
+fn fragment0(@location(11) a0: vec3<u32>, @location(28) a1: vec4<u32>, a2: S2) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S1 {
+  @location(11) f0: vec4<f16>,
+  @location(2) f1: f32,
+  @location(8) f2: u32,
+  @builtin(instance_index) f3: u32,
+  @location(15) f4: vec3<i32>,
+  @location(7) f5: f16,
+  @location(6) f6: vec2<u32>,
+  @location(17) f7: vec3<u32>,
+  @location(1) f8: vec3<u32>,
+  @location(4) f9: vec2<i32>,
+  @location(16) f10: vec3<f16>,
+  @location(9) f11: vec3<f32>,
+  @builtin(vertex_index) f12: u32,
+  @location(3) f13: vec2<f32>,
+  @location(13) f14: vec2<u32>,
+  @location(14) f15: f16,
+  @location(5) f16: vec3<i32>,
+  @location(0) f17: vec2<i32>,
+  @location(10) f18: f32,
+  @location(12) f19: i32
+}
+struct VertexOutput0 {
+  @location(10) f0: i32,
+  @location(40) f1: vec4<u32>,
+  @location(32) f2: vec3<u32>,
+  @location(43) f3: vec4<f16>,
+  @location(13) f4: vec4<i32>,
+  @location(36) f5: vec3<i32>,
+  @location(23) f6: u32,
+  @location(38) f7: vec4<f16>,
+  @location(20) f8: vec4<u32>,
+  @location(8) f9: vec3<i32>,
+  @location(11) f10: vec3<u32>,
+  @location(42) f11: u32,
+  @location(35) f12: vec2<i32>,
+  @location(30) f13: vec3<f32>,
+  @location(2) f14: vec2<u32>,
+  @builtin(position) f15: vec4<f32>,
+  @location(18) f16: vec3<u32>,
+  @location(28) f17: vec4<u32>,
+  @location(21) f18: vec2<f32>,
+  @location(33) f19: vec3<f32>,
+  @location(26) f20: f16,
+  @location(29) f21: vec2<i32>,
+  @location(34) f22: f16,
+  @location(22) f23: f32,
+  @location(3) f24: vec3<i32>,
+  @location(7) f25: vec4<u32>
+}
+
+@vertex
+fn vertex0(a0: S1) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder4 = device0.createCommandEncoder({label: '\ue37d\u{1f8eb}\ucbe3\u0c0b\u444d\u2be1\udf81\u{1ff71}\u0e29\u2390\u0d2b'});
+let renderBundle0 = renderBundleEncoder1.finish({label: '\u2a85\u{1f68c}\u{1f632}'});
+let sampler1 = device0.createSampler({
+  label: '\u3187\uaddd\ub74b\u{1fe8f}\u{1f64a}\u1bfb\uec72\u0d6d\ub3dc\u{1fc5e}\u1e6a',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 91.88,
+  lodMaxClamp: 92.78,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder0.end();
+} catch {}
+let commandEncoder5 = device0.createCommandEncoder({label: '\u0d76\u{1f6d5}\ufd11\u00ad\u0588\ud62c\u6ab5'});
+let pipeline0 = await device0.createRenderPipelineAsync({
+  label: '\u03cc\u{1f71a}\u135f',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'src-alpha'},
+  },
+  writeMask: 0,
+}, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rg16sint', writeMask: 0}, {
+  format: 'r16uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r8uint', writeMask: 0}, {format: 'rgba8sint'}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'zero', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 72,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 0, shaderLocation: 14},
+          {format: 'float32x3', offset: 0, shaderLocation: 10},
+          {format: 'snorm8x2', offset: 6, shaderLocation: 16},
+          {format: 'uint16x2', offset: 4, shaderLocation: 1},
+          {format: 'unorm16x2', offset: 0, shaderLocation: 7},
+          {format: 'snorm8x4', offset: 8, shaderLocation: 2},
+          {format: 'sint32x4', offset: 20, shaderLocation: 5},
+          {format: 'float16x4', offset: 8, shaderLocation: 9},
+          {format: 'sint32x2', offset: 0, shaderLocation: 15},
+          {format: 'snorm16x4', offset: 24, shaderLocation: 3},
+          {format: 'unorm8x2', offset: 4, shaderLocation: 11},
+          {format: 'uint8x4', offset: 8, shaderLocation: 17},
+          {format: 'uint32', offset: 20, shaderLocation: 8},
+          {format: 'uint8x4', offset: 28, shaderLocation: 13},
+          {format: 'sint16x2', offset: 4, shaderLocation: 4},
+          {format: 'sint8x4', offset: 8, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 1200,
+        attributes: [
+          {format: 'uint16x4', offset: 8, shaderLocation: 6},
+          {format: 'sint8x2', offset: 912, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let adapter1 = await navigator.gpu.requestAdapter({});
+let commandEncoder6 = device0.createCommandEncoder({});
+let sampler2 = device0.createSampler({
+  label: '\u{1fe95}\u2de0\uffae\udf9a\u{1ff03}\ubc2f\u4846\u0c76\u8105',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 93.94,
+  lodMaxClamp: 97.91,
+});
+try {
+computePassEncoder1.end();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise2 = device0.createComputePipelineAsync({
+  label: '\u7f78\u{1f8f2}\u41df\u6766\u{1f997}\ub678\u00e7\u{1fb72}',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0'},
+});
+let gpuCanvasContext1 = offscreenCanvas0.getContext('webgpu');
+let imageData1 = new ImageData(60, 140);
+let commandEncoder7 = device0.createCommandEncoder({label: '\u{1fd32}\u0ad2\u062c\ua9ea\u4b0d\uf319\u15d5\ua051\u68bb\u246b'});
+try {
+renderBundleEncoder0.setPipeline(pipeline0);
+} catch {}
+let canvas2 = document.createElement('canvas');
+let computePassEncoder2 = commandEncoder0.beginComputePass();
+let renderBundle1 = renderBundleEncoder0.finish({});
+let sampler3 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 50.31,
+  lodMaxClamp: 90.43,
+});
+try {
+canvas2.getContext('webgpu');
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  code: `@group(10) @binding(1187)
+var<storage, read_write> type3: array<u32>;
+@group(2) @binding(1187)
+var<storage, read_write> function4: array<u32>;
+@group(4) @binding(2754)
+var<storage, read_write> global6: array<u32>;
+@group(0) @binding(1187)
+var<storage, read_write> field4: array<u32>;
+@group(8) @binding(3494)
+var<storage, read_write> global7: array<u32>;
+@group(6) @binding(2754)
+var<storage, read_write> parameter5: array<u32>;
+@group(8) @binding(2754)
+var<storage, read_write> n1: array<u32>;
+@group(6) @binding(3494)
+var<storage, read_write> function5: array<u32>;
+@group(3) @binding(3494)
+var<storage, read_write> function6: array<u32>;
+@group(7) @binding(2754)
+var<storage, read_write> type4: array<u32>;
+@group(5) @binding(1187)
+var<storage, read_write> parameter6: array<u32>;
+@group(7) @binding(3494)
+var<storage, read_write> local3: array<u32>;
+@group(3) @binding(2754)
+var<storage, read_write> local4: array<u32>;
+@group(1) @binding(3494)
+var<storage, read_write> n2: array<u32>;
+@group(1) @binding(2754)
+var<storage, read_write> parameter7: array<u32>;
+
+@compute @workgroup_size(4, 4, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S3 {
+  @builtin(sample_index) f0: u32
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec4<f32>,
+  @location(0) f1: vec2<i32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, a1: S3, @builtin(front_facing) a2: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(11) a0: vec2<u32>, @location(12) a1: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder8 = device0.createCommandEncoder({label: '\u0a92\u0580\u518d\u123a\u01fa\u0feb\u0750\ucbfc\u0086\u20cd'});
+let texture1 = device0.createTexture({
+  label: '\u8c5f\u0d19\u0d4e\uc690',
+  size: {width: 185, height: 16, depthOrArrayLayers: 88},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba32float'],
+});
+let renderBundle2 = renderBundleEncoder0.finish({label: '\u1493\u{1f92f}\u9370'});
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let querySet3 = device0.createQuerySet({label: '\u41e4\uad09\u3b05', type: 'occlusion', count: 3579});
+let textureView2 = texture0.createView({label: '\u095f\u0247\u3e5d\u5f25', dimension: '2d', baseArrayLayer: 170});
+let computePassEncoder3 = commandEncoder7.beginComputePass({label: '\u0e0a\u8547\u8138'});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({label: '\uc96a\ubc31\ue921', colorFormats: ['r8sint', 'rgba32float'], stencilReadOnly: true});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let img0 = await imageWithData(130, 17, '#3b0f8880', '#c4946a78');
+let commandEncoder9 = device0.createCommandEncoder({});
+let textureView3 = texture0.createView({label: '\u92b8\u9380\u{1f6bc}', dimension: '2d', baseArrayLayer: 145});
+let pipeline1 = await device0.createComputePipelineAsync({
+  label: '\ub38e\u1ff8\u01f2\u{1fd88}\u9d6e\u0927\ud96b\u{1fb3e}\u{1f674}\udfee\u0048',
+  layout: 'auto',
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+try {
+  await promise1;
+} catch {}
+let offscreenCanvas1 = new OffscreenCanvas(198, 549);
+let video0 = await videoWithData();
+let buffer0 = device0.createBuffer({
+  label: '\u0e7b\uf467\u1be0\u7496\u{1ff51}',
+  size: 66868,
+  usage: GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: true,
+});
+let texture2 = device0.createTexture({
+  label: '\u{1f644}\u{1fcef}\ucf93\u0eaf\u735e',
+  size: [160],
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let textureView4 = texture1.createView({label: '\u{1fcde}\u73e6\u{1f7ab}\u{1f6da}\u2fd6\u04d1\u02aa\u0ec3\u02a4\u0322\u087e'});
+let renderBundle3 = renderBundleEncoder0.finish({});
+try {
+computePassEncoder3.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(5960, undefined);
+} catch {}
+let arrayBuffer0 = buffer0.getMappedRange(38256);
+let commandEncoder10 = device0.createCommandEncoder();
+let textureView5 = texture1.createView({label: '\u{1fee3}\u6fb8', baseMipLevel: 1});
+try {
+commandEncoder9.resolveQuerySet(querySet3, 160, 1962, buffer0, 23552);
+} catch {}
+let texture3 = device0.createTexture({
+  label: '\u7fed\u{1f921}\u{1fe38}\u0117',
+  size: {width: 185, height: 16, depthOrArrayLayers: 88},
+  mipLevelCount: 3,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgb10a2unorm', 'rgb10a2unorm', 'rgb10a2unorm'],
+});
+let textureView6 = texture3.createView({label: '\u{1ffd3}\u1666\u06b3\u0720\u{1fc04}\uce30\u357b', aspect: 'all', mipLevelCount: 1});
+try {
+renderBundleEncoder2.setVertexBuffer(8659, undefined, 0, 604129884);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+sampler2.label = '\u346b\u4594\u7c8a\u{1f63e}\u{1fab9}\u2355';
+} catch {}
+let querySet4 = device0.createQuerySet({
+  label: '\ua5c2\u090e\uf22b\u0594\u{1fa87}\u0984\u164c\u359c\u8711\ubb23',
+  type: 'occlusion',
+  count: 1357,
+});
+let renderBundle4 = renderBundleEncoder1.finish();
+try {
+renderBundleEncoder2.setVertexBuffer(6591, undefined, 2946360635, 521985525);
+} catch {}
+let canvas3 = document.createElement('canvas');
+let shaderModule3 = device0.createShaderModule({
+  label: '\ue0d1\uafe3\u02ca\u35c8\u{1f82d}\u0494\u016d',
+  code: `@group(0) @binding(1187)
+var<storage, read_write> n3: array<u32>;
+@group(3) @binding(3494)
+var<storage, read_write> function7: array<u32>;
+@group(10) @binding(1187)
+var<storage, read_write> global8: array<u32>;
+@group(6) @binding(3494)
+var<storage, read_write> field5: array<u32>;
+@group(1) @binding(3494)
+var<storage, read_write> local5: array<u32>;
+@group(4) @binding(3494)
+var<storage, read_write> global9: array<u32>;
+@group(8) @binding(3494)
+var<storage, read_write> n4: array<u32>;
+@group(7) @binding(2754)
+var<storage, read_write> global10: array<u32>;
+@group(8) @binding(2754)
+var<storage, read_write> local6: array<u32>;
+@group(6) @binding(2754)
+var<storage, read_write> global11: array<u32>;
+@group(3) @binding(2754)
+var<storage, read_write> function8: array<u32>;
+@group(2) @binding(1187)
+var<storage, read_write> n5: array<u32>;
+@group(5) @binding(1187)
+var<storage, read_write> global12: array<u32>;
+
+@compute @workgroup_size(6, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2<i32>,
+  @location(1) f1: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_mask) a0: u32, @builtin(front_facing) a1: bool) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f26: vec4<f32>
+}
+
+@vertex
+fn vertex0(@location(7) a0: vec3<u32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let renderBundle5 = renderBundleEncoder0.finish({});
+let externalTexture0 = device0.importExternalTexture({label: '\u7997\ue9fb\ufd9a\u0c91', source: video0, colorSpace: 'display-p3'});
+try {
+commandEncoder10.resolveQuerySet(querySet0, 25, 216, buffer0, 48640);
+} catch {}
+let pipeline2 = device0.createRenderPipeline({
+  label: '\u9fe8\u5346\u246a\u6ce0\u50a0\u069c\u{1fcc3}\u{1fc7e}\u{1fe98}',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8sint', writeMask: GPUColorWrite.ALL}, {format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'equal', failOp: 'increment-clamp', depthFailOp: 'replace', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'never', failOp: 'invert', depthFailOp: 'increment-wrap', passOp: 'decrement-wrap'},
+    stencilReadMask: 135211783,
+    stencilWriteMask: 1714657438,
+    depthBiasSlopeScale: 968.046569401657,
+    depthBiasClamp: 4.745075271673869,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 424,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x4', offset: 32, shaderLocation: 7}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'cw', cullMode: 'back'},
+});
+try {
+adapter1.label = '\u45b0\u431c\u{1f73d}\u0fb2\u0d4e\u{1fe34}';
+} catch {}
+let commandEncoder11 = device0.createCommandEncoder();
+let commandBuffer0 = commandEncoder9.finish({label: '\u7345\u4fee\u871a\u{1f6f1}\uf0fa'});
+let computePassEncoder4 = commandEncoder11.beginComputePass({label: '\u0b67\u01be'});
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder8.resolveQuerySet(querySet1, 50, 990, buffer0, 51200);
+} catch {}
+let promise3 = device0.createComputePipelineAsync({
+  label: '\u1801\u03f8',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext2 = canvas3.getContext('webgpu');
+let img1 = await imageWithData(91, 273, '#61356cd6', '#68a6cc59');
+let commandEncoder12 = device0.createCommandEncoder({label: '\uc33c\u6466\u0976\u0659\u{1fbac}\u0633\u1d70\udae3\u{1fce5}\u1047\ude87'});
+let textureView7 = texture3.createView({label: '\u0003\u9d0e\u9bde\ue45b\u009f\u{1ffda}\u0497', baseMipLevel: 2});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  label: '\u{1fec7}\ubb79\u0c4d\uc688\u8e72\ucdb1',
+  colorFormats: ['rgb10a2unorm', 'rgba32uint', 'r8uint', 'rgba16uint', 'r16float', 'bgra8unorm-srgb', 'r16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+});
+try {
+commandEncoder3.resolveQuerySet(querySet2, 872, 175, buffer0, 10496);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\u0444\u0595\u{1f7b8}\u2fb4\u{1fb56}\u0a14\uf2a3\u3095\u04a1',
+  colorFormats: ['rgb10a2unorm', 'rgba32uint', 'r8uint', 'rgba16uint', 'r16float', 'bgra8unorm-srgb', 'r16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true,
+});
+let renderBundle6 = renderBundleEncoder2.finish({label: '\ud283\u53b6\u{1fa62}'});
+let arrayBuffer1 = buffer0.getMappedRange(25808, 9656);
+try {
+buffer0.destroy();
+} catch {}
+let pipeline3 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8sint'}, {format: 'rgba32float', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 312,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x2', offset: 12, shaderLocation: 11}],
+      },
+      {arrayStride: 92, attributes: [{format: 'float32x4', offset: 4, shaderLocation: 12}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+try {
+canvas1.getContext('webgpu');
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let video1 = await videoWithData();
+let commandBuffer1 = commandEncoder6.finish({label: '\u{1ff4c}\u1f4b'});
+let textureView8 = texture2.createView({label: '\u{1f771}\u{1fa53}\ue7cf\u{1fb4e}'});
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm'],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 969 */
+{offset: 721, bytesPerRow: 531}, {width: 124, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+let commandEncoder13 = device0.createCommandEncoder();
+let querySet5 = device0.createQuerySet({label: '\u4284\uee81\u80ee', type: 'occlusion', count: 3855});
+let renderBundle7 = renderBundleEncoder4.finish({label: '\u82e7\u6825'});
+try {
+device0.addEventListener('uncapturederror', e => { log('device0.uncapturederror'); log(e); e.label = device0.label; });
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(canvas2);
+gc();
+let img2 = await imageWithData(247, 297, '#080727ae', '#33a1f186');
+let imageData2 = new ImageData(84, 24);
+try {
+offscreenCanvas1.getContext('webgl');
+} catch {}
+let commandEncoder14 = device0.createCommandEncoder({});
+let querySet6 = device0.createQuerySet({label: '\u{1f970}\u{1fefd}\u082e\ude0d\u{1fe8e}\u9f0a\u{1f6bd}', type: 'occlusion', count: 3452});
+let texture4 = device0.createTexture({
+  label: '\u{1f60f}\u0b34\u28cf\ue7ad',
+  size: [92],
+  dimension: '1d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView9 = texture1.createView({label: '\u0c7e\u{1f92d}\u2210\u19b7', baseMipLevel: 1});
+try {
+computePassEncoder4.setPipeline(pipeline1);
+} catch {}
+let promise6 = adapter1.requestDevice({
+  requiredFeatures: [
+    'depth-clip-control',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+  ],
+  requiredLimits: {
+    maxBindGroups: 6,
+    maxColorAttachmentBytesPerSample: 41,
+    maxVertexAttributes: 19,
+    maxVertexBufferArrayStride: 34632,
+    maxStorageTexturesPerShaderStage: 29,
+    maxStorageBuffersPerShaderStage: 39,
+    maxDynamicStorageBuffersPerPipelineLayout: 47317,
+    maxDynamicUniformBuffersPerPipelineLayout: 58408,
+    maxBindingsPerBindGroup: 6560,
+    maxTextureArrayLayers: 486,
+    maxTextureDimension1D: 13074,
+    maxTextureDimension2D: 13749,
+    maxVertexBuffers: 10,
+    maxBindGroupsPlusVertexBuffers: 27,
+    minStorageBufferOffsetAlignment: 64,
+    minUniformBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 101066564,
+    maxStorageBufferBindingSize: 149327799,
+    maxUniformBuffersPerShaderStage: 38,
+    maxSampledTexturesPerShaderStage: 35,
+    maxInterStageShaderVariables: 121,
+    maxInterStageShaderComponents: 93,
+    maxSamplersPerShaderStage: 16,
+  },
+});
+let bindGroupLayout2 = device0.createBindGroupLayout({
+  label: '\u0673\u{1fdc7}\u45cf\u1654\ufea9\u0962\ufca1\uf727',
+  entries: [
+    {
+      binding: 682,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {binding: 1139, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 226,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let commandEncoder15 = device0.createCommandEncoder();
+try {
+computePassEncoder3.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder5.resolveQuerySet(querySet0, 31, 60, buffer0, 28160);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm'],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let imageData3 = new ImageData(116, 248);
+let buffer1 = device0.createBuffer({
+  label: '\u0c6d\u09b2\u0937\ud9b6\u09da\uac12',
+  size: 961564,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 3852});
+let renderBundle8 = renderBundleEncoder1.finish();
+let sampler4 = device0.createSampler({
+  label: '\u01c9\u03ff\u438c\uea29\u9904\u{1fc61}',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 46.93,
+  lodMaxClamp: 66.08,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+  await promise4;
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder({label: '\u{1ff02}\uef1e'});
+let commandBuffer2 = commandEncoder8.finish({label: '\u09fb\u0996'});
+let texture5 = device0.createTexture({
+  label: '\u43c1\u{1f95c}\u02fd\u5719',
+  size: [80, 1, 218],
+  mipLevelCount: 5,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r8uint'],
+});
+let textureView10 = texture2.createView({});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['r8sint', 'rgba32float'], depthReadOnly: true});
+let sampler5 = device0.createSampler({addressModeV: 'clamp-to-edge', magFilter: 'linear', mipmapFilter: 'linear', lodMaxClamp: 44.95});
+try {
+commandEncoder3.copyBufferToTexture({
+  /* bytesInLastRow: 242 widthInBlocks: 121 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2228 */
+  offset: 1986,
+  buffer: buffer1,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 121, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let canvas4 = document.createElement('canvas');
+let textureView11 = texture0.createView({label: '\u0ee1\u{1fd1c}\u70f0\u4263\u0525\ufae3\u0090\u038c', dimension: '2d', baseArrayLayer: 92});
+let sampler6 = device0.createSampler({
+  label: '\u0214\u0e19\u080c\uad1b\u0c6b',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMinClamp: 51.67,
+  lodMaxClamp: 92.03,
+});
+let offscreenCanvas2 = new OffscreenCanvas(605, 171);
+let commandEncoder17 = device0.createCommandEncoder({});
+try {
+computePassEncoder4.setPipeline(pipeline1);
+} catch {}
+try {
+  await promise5;
+} catch {}
+gc();
+let commandEncoder18 = device0.createCommandEncoder({label: '\u1b70\u868e\uf49e\u0155\u029d\u9c28\u{1f8ea}\u05cb\u0a95\u{1fb9b}'});
+try {
+renderBundleEncoder5.setPipeline(pipeline3);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let pipeline4 = device0.createRenderPipeline({
+  label: '\u{1f688}\ua4a5\u0d53\u090c\u{1f9ab}\u27a3',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r16uint', writeMask: GPUColorWrite.RED}, {format: 'r8uint', writeMask: GPUColorWrite.ALPHA}, {format: 'rgba8sint', writeMask: 0}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'add', srcFactor: 'src-alpha-saturated', dstFactor: 'dst'},
+    alpha: {operation: 'subtract', srcFactor: 'src', dstFactor: 'one-minus-constant'},
+  },
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {
+      compare: 'greater-equal',
+      failOp: 'increment-wrap',
+      depthFailOp: 'decrement-wrap',
+      passOp: 'increment-clamp',
+    },
+    stencilBack: {compare: 'equal', failOp: 'zero', depthFailOp: 'increment-wrap', passOp: 'keep'},
+    stencilWriteMask: 4294967295,
+    depthBias: 0,
+    depthBiasClamp: 576.121449012112,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 148,
+        attributes: [
+          {format: 'sint16x4', offset: 56, shaderLocation: 4},
+          {format: 'sint8x2', offset: 14, shaderLocation: 0},
+          {format: 'unorm16x2', offset: 16, shaderLocation: 7},
+          {format: 'sint32x3', offset: 4, shaderLocation: 15},
+          {format: 'uint16x4', offset: 12, shaderLocation: 8},
+          {format: 'uint8x2', offset: 36, shaderLocation: 17},
+          {format: 'unorm8x2', offset: 0, shaderLocation: 3},
+          {format: 'uint16x4', offset: 20, shaderLocation: 1},
+          {format: 'float16x4', offset: 44, shaderLocation: 10},
+          {format: 'uint8x2', offset: 72, shaderLocation: 6},
+          {format: 'unorm16x4', offset: 20, shaderLocation: 9},
+          {format: 'sint32x3', offset: 4, shaderLocation: 12},
+          {format: 'float32x4', offset: 20, shaderLocation: 11},
+          {format: 'uint32x4', offset: 0, shaderLocation: 13},
+          {format: 'sint32x3', offset: 0, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 632,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32x4', offset: 20, shaderLocation: 16},
+          {format: 'snorm16x2', offset: 16, shaderLocation: 2},
+        ],
+      },
+      {arrayStride: 168, stepMode: 'instance', attributes: []},
+      {arrayStride: 1252, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 772,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x2', offset: 66, shaderLocation: 14}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', unclippedDepth: true},
+});
+let gpuCanvasContext3 = canvas4.getContext('webgpu');
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let img3 = await imageWithData(174, 238, '#af04a632', '#68d35a45');
+let commandBuffer3 = commandEncoder0.finish();
+let texture6 = device0.createTexture({
+  label: '\u0ae7\u0ee7\ud6b8\u059b\u01cb\u02fb\u0db3\u7b93\u7981',
+  size: [80],
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder4.setPipeline(pipeline1);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm', 'rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer1), /* required buffer size: 201 */
+{offset: 201}, {width: 24, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline5 = await promise2;
+canvas0.width = 266;
+let video2 = await videoWithData();
+let commandBuffer4 = commandEncoder13.finish({label: '\u5bc5\u07d6'});
+let textureView12 = texture1.createView({label: '\u{1fd37}\u0712\udca8\u7eac', aspect: 'all', baseMipLevel: 1});
+let computePassEncoder5 = commandEncoder18.beginComputePass({label: '\u0047\uc322'});
+let renderBundle9 = renderBundleEncoder3.finish();
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(301), /* required buffer size: 301 */
+{offset: 301}, {width: 158, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline6 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}}});
+let offscreenCanvas3 = new OffscreenCanvas(544, 420);
+let img4 = await imageWithData(167, 7, '#58db43c0', '#6f946536');
+let commandEncoder19 = device0.createCommandEncoder({label: '\uc196\u860a\u6f82'});
+let textureView13 = texture2.createView({label: '\uae17\u{1f8e9}\uc2a8\u5f7c\u72a5\u0952\u1f38\u{1ff21}', aspect: 'all'});
+let sampler7 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 89.55,
+});
+try {
+computePassEncoder4.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(4026, undefined);
+} catch {}
+try {
+commandEncoder4.resolveQuerySet(querySet6, 1563, 1277, buffer0, 22272);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 3_390_347 */
+{offset: 139, bytesPerRow: 1088, rowsPerImage: 164}, {width: 56, height: 0, depthOrArrayLayers: 20});
+} catch {}
+let gpuCanvasContext4 = offscreenCanvas3.getContext('webgpu');
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder({label: '\u9370\u{1f7c0}\u0179\ud6aa\ub81c'});
+let commandBuffer5 = commandEncoder4.finish({label: '\u0f1b\u87fe\u{1f83d}\u{1f979}\ub29c\u07f7\ubd1a'});
+let textureView14 = texture6.createView({label: '\u{1fad6}\u{1f8e2}\u08c3\u{1fec2}\ufae6\u0940', dimension: '1d'});
+let computePassEncoder6 = commandEncoder12.beginComputePass({label: '\ue6b3\u8b1c\u0d6a\u0514\u5de0'});
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm', 'rgba8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder21 = device0.createCommandEncoder({label: '\u{1fd31}\u0403\u{1fb21}\ue4f4\uba0f\u{1f9f7}\u{1f9fb}\u{1f7ac}\ufab3'});
+let querySet8 = device0.createQuerySet({
+  label: '\u06b9\u{1fb73}\u{1f6c3}\u248f\u{1fbe8}\u{1f71b}\u65be\u09bd\u8900',
+  type: 'occlusion',
+  count: 262,
+});
+let texture7 = device0.createTexture({
+  label: '\u{1fba0}\u{1fe94}\u{1f609}\u716a',
+  size: {width: 46, height: 4, depthOrArrayLayers: 22},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['r8uint'],
+});
+let textureView15 = texture2.createView({baseArrayLayer: 0});
+let renderBundle10 = renderBundleEncoder1.finish({label: '\u560a\u0341\u9385\u7d44\u8a97\u0070\u0013\u3541\u0652'});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let computePassEncoder7 = commandEncoder7.beginComputePass({});
+let renderBundle11 = renderBundleEncoder4.finish();
+let externalTexture1 = device0.importExternalTexture({label: '\u7027\ue774\u57f4\u0c90', source: video2, colorSpace: 'srgb'});
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 217 */
+{offset: 35}, {width: 91, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline7 = device0.createComputePipeline({
+  label: '\u{1fda8}\uf819\u6f86',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}},
+});
+let renderBundle12 = renderBundleEncoder2.finish({label: '\u4e10\u48e3\ub9c9'});
+let sampler8 = device0.createSampler({
+  label: '\u6075\u{1fbb0}\u59aa\uf8a9\u0322\uf542\u{1fd1d}\u0115\uf2fb',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 83.40,
+  lodMaxClamp: 99.12,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder7.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder2.pushDebugGroup('\u0536');
+} catch {}
+let gpuCanvasContext5 = offscreenCanvas2.getContext('webgpu');
+let shaderModule4 = device0.createShaderModule({
+  label: '\u2e0b\ue3f4',
+  code: `@group(8) @binding(3494)
+var<storage, read_write> parameter8: array<u32>;
+@group(3) @binding(3494)
+var<storage, read_write> field6: array<u32>;
+@group(9) @binding(1187)
+var<storage, read_write> field7: array<u32>;
+@group(2) @binding(1187)
+var<storage, read_write> field8: array<u32>;
+@group(8) @binding(2754)
+var<storage, read_write> field9: array<u32>;
+@group(0) @binding(1187)
+var<storage, read_write> parameter9: array<u32>;
+@group(6) @binding(3494)
+var<storage, read_write> global13: array<u32>;
+@group(1) @binding(3494)
+var<storage, read_write> local7: array<u32>;
+@group(5) @binding(1187)
+var<storage, read_write> parameter10: array<u32>;
+@group(10) @binding(1187)
+var<storage, read_write> field10: array<u32>;
+@group(4) @binding(3494)
+var<storage, read_write> type5: array<u32>;
+@group(7) @binding(2754)
+var<storage, read_write> function9: array<u32>;
+@group(1) @binding(2754)
+var<storage, read_write> local8: array<u32>;
+
+@compute @workgroup_size(7, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S4 {
+  @builtin(front_facing) f0: bool,
+  @location(3) f1: vec3<u32>,
+  @location(2) f2: vec3<f32>,
+  @location(40) f3: f16,
+  @location(25) f4: f32,
+  @builtin(position) f5: vec4<f32>,
+  @location(43) f6: f16,
+  @location(9) f7: vec3<u32>,
+  @location(0) f8: vec2<u32>,
+  @location(23) f9: vec3<f32>,
+  @location(20) f10: i32,
+  @location(35) f11: vec4<f32>,
+  @location(11) f12: i32,
+  @location(4) f13: vec2<f16>,
+  @location(14) f14: f16,
+  @location(36) f15: i32,
+  @location(15) f16: vec4<f16>,
+  @location(17) f17: f32,
+  @location(33) f18: vec3<u32>,
+  @location(34) f19: u32,
+  @builtin(sample_mask) f20: u32,
+  @location(19) f21: u32,
+  @location(32) f22: vec3<i32>,
+  @location(1) f23: vec3<u32>,
+  @builtin(sample_index) f24: u32,
+  @location(10) f25: vec2<f16>,
+  @location(8) f26: vec4<u32>,
+  @location(7) f27: vec4<f32>,
+  @location(39) f28: vec3<u32>,
+  @location(41) f29: vec3<f16>,
+  @location(30) f30: vec2<f32>,
+  @location(31) f31: vec3<u32>,
+  @location(24) f32: f16
+}
+struct FragmentOutput0 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) f1: vec3<i32>,
+  @location(3) f2: vec4<f32>,
+  @location(1) f3: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(29) a0: f32, @location(22) a1: vec4<u32>, a2: S4, @location(38) a3: vec3<f16>, @location(26) a4: vec3<u32>, @location(16) a5: vec2<i32>, @location(28) a6: i32, @location(18) a7: vec4<i32>, @location(13) a8: f16, @location(37) a9: f32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(25) f27: f32,
+  @location(9) f28: vec3<u32>,
+  @location(34) f29: u32,
+  @location(36) f30: i32,
+  @location(22) f31: vec4<u32>,
+  @builtin(position) f32: vec4<f32>,
+  @location(24) f33: f16,
+  @location(16) f34: vec2<i32>,
+  @location(2) f35: vec3<f32>,
+  @location(40) f36: f16,
+  @location(15) f37: vec4<f16>,
+  @location(38) f38: vec3<f16>,
+  @location(30) f39: vec2<f32>,
+  @location(19) f40: u32,
+  @location(26) f41: vec3<u32>,
+  @location(7) f42: vec4<f32>,
+  @location(13) f43: f16,
+  @location(39) f44: vec3<u32>,
+  @location(20) f45: i32,
+  @location(31) f46: vec3<u32>,
+  @location(4) f47: vec2<f16>,
+  @location(1) f48: vec3<u32>,
+  @location(14) f49: f16,
+  @location(18) f50: vec4<i32>,
+  @location(37) f51: f32,
+  @location(28) f52: i32,
+  @location(3) f53: vec3<u32>,
+  @location(8) f54: vec4<u32>,
+  @location(32) f55: vec3<i32>,
+  @location(29) f56: f32,
+  @location(35) f57: vec4<f32>,
+  @location(11) f58: i32,
+  @location(33) f59: vec3<u32>,
+  @location(41) f60: vec3<f16>,
+  @location(10) f61: vec2<f16>,
+  @location(0) f62: vec2<u32>,
+  @location(43) f63: f16,
+  @location(17) f64: f32,
+  @location(23) f65: vec3<f32>
+}
+
+@vertex
+fn vertex0(@location(8) a0: vec3<f16>, @location(12) a1: vec2<u32>, @location(17) a2: vec3<f16>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet9 = device0.createQuerySet({label: '\u{1f923}\u{1f83d}\u310d\ufef8\u{1fdaa}\uea09\ub299\u{1faff}', type: 'occlusion', count: 2930});
+let computePassEncoder8 = commandEncoder5.beginComputePass({label: '\u{1feb6}\u0820\uee3d\ue408\u0b8f'});
+let renderBundle13 = renderBundleEncoder4.finish({label: '\u09a5\u0ad2\u{1fac8}'});
+document.body.prepend(canvas0);
+let shaderModule5 = device0.createShaderModule({
+  code: `@group(8) @binding(3494)
+var<storage, read_write> parameter11: array<u32>;
+@group(8) @binding(2754)
+var<storage, read_write> n6: array<u32>;
+@group(1) @binding(2754)
+var<storage, read_write> local9: array<u32>;
+@group(10) @binding(1187)
+var<storage, read_write> global14: array<u32>;
+@group(1) @binding(3494)
+var<storage, read_write> type6: array<u32>;
+@group(7) @binding(2754)
+var<storage, read_write> n7: array<u32>;
+@group(0) @binding(1187)
+var<storage, read_write> field11: array<u32>;
+@group(7) @binding(3494)
+var<storage, read_write> n8: array<u32>;
+@group(4) @binding(3494)
+var<storage, read_write> type7: array<u32>;
+@group(5) @binding(1187)
+var<storage, read_write> parameter12: array<u32>;
+@group(9) @binding(1187)
+var<storage, read_write> n9: array<u32>;
+@group(6) @binding(3494)
+var<storage, read_write> parameter13: array<u32>;
+@group(6) @binding(2754)
+var<storage, read_write> type8: array<u32>;
+
+@compute @workgroup_size(5, 4, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(5) f0: vec2<u32>,
+  @location(3) f1: vec3<u32>,
+  @location(2) f2: vec2<i32>,
+  @location(6) f3: vec4<i32>,
+  @location(1) f4: vec4<f32>,
+  @location(0) f5: vec4<f32>,
+  @location(4) f6: u32,
+  @location(7) f7: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(5) a0: vec3<u32>, @location(10) a1: vec4<i32>, @location(40) a2: vec2<i32>, @location(8) a3: u32, @location(1) a4: vec2<i32>, @location(39) a5: vec3<i32>, @location(44) a6: vec3<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S5 {
+  @location(10) f0: vec3<i32>,
+  @builtin(instance_index) f1: u32,
+  @builtin(vertex_index) f2: u32
+}
+struct VertexOutput0 {
+  @location(8) f66: u32,
+  @location(34) f67: vec4<i32>,
+  @location(2) f68: vec3<u32>,
+  @location(19) f69: vec2<f32>,
+  @location(9) f70: f16,
+  @location(1) f71: vec2<i32>,
+  @location(36) f72: u32,
+  @builtin(position) f73: vec4<f32>,
+  @location(41) f74: u32,
+  @location(43) f75: vec2<u32>,
+  @location(10) f76: vec4<i32>,
+  @location(25) f77: vec4<f16>,
+  @location(12) f78: u32,
+  @location(44) f79: vec3<i32>,
+  @location(20) f80: u32,
+  @location(40) f81: vec2<i32>,
+  @location(5) f82: vec3<u32>,
+  @location(22) f83: vec2<i32>,
+  @location(17) f84: vec2<u32>,
+  @location(39) f85: vec3<i32>,
+  @location(27) f86: vec4<i32>,
+  @location(16) f87: vec3<f16>
+}
+
+@vertex
+fn vertex0(@location(5) a0: i32, @location(13) a1: f32, @location(15) a2: vec3<f32>, @location(8) a3: vec3<f32>, @location(9) a4: vec4<f32>, @location(0) a5: f16, @location(11) a6: vec3<i32>, @location(16) a7: vec2<f16>, @location(4) a8: i32, @location(14) a9: u32, @location(17) a10: i32, @location(12) a11: i32, @location(3) a12: vec3<f32>, @location(2) a13: u32, @location(7) a14: vec2<i32>, @location(6) a15: vec2<f16>, @location(1) a16: vec2<f16>, a17: S5) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({
+  label: '\u{1f7a1}\u{1fcc9}\u0313\uc84f\u56fa\ud861\ubef2\ub92f\uc396',
+  colorFormats: ['rgba16uint', 'bgra8unorm', 'rg16float', 'r8uint'],
+});
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+commandEncoder19.copyBufferToTexture({
+  /* bytesInLastRow: 688 widthInBlocks: 43 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 4240 */
+  offset: 3552,
+  buffer: buffer1,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 43, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.submit([commandBuffer2, commandBuffer5]);
+} catch {}
+let pipeline8 = await promise3;
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let commandEncoder22 = device0.createCommandEncoder({label: '\u059c\u93ea\u9116\u418d\ua667\ucd0b\u0ee7'});
+let texture8 = device0.createTexture({
+  label: '\udae6\u{1fa3c}',
+  size: [92],
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16sint'],
+});
+let textureView16 = texture0.createView({
+  label: '\ue73d\u{1fa01}\u0472\u61b6\u9580\u91c9\u7cfa\u{1fbb2}\u4a01\u{1fa00}\u5dc8',
+  baseArrayLayer: 153,
+  arrayLayerCount: 36,
+});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({
+  label: '\u6d95\u{1fa86}\u{1f9db}\u5f58\u{1fa6e}',
+  colorFormats: ['r8sint', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder7.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder16.copyBufferToTexture({
+  /* bytesInLastRow: 234 widthInBlocks: 117 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 8954 */
+  offset: 8954,
+  buffer: buffer1,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 117, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.popDebugGroup();
+} catch {}
+let textureView17 = texture0.createView({
+  label: '\u032f\u0cdd\u4e94\u{1f77a}\u{1f774}\ub440\uc624\u{1f6f4}\ueb2c',
+  dimension: '2d',
+  format: 'rg16sint',
+  baseArrayLayer: 194,
+  arrayLayerCount: 1,
+});
+try {
+commandEncoder5.copyBufferToTexture({
+  /* bytesInLastRow: 248 widthInBlocks: 124 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 14206 */
+  offset: 14206,
+  bytesPerRow: 512,
+  rowsPerImage: 279,
+  buffer: buffer1,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 124, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+gc();
+let imageBitmap0 = await createImageBitmap(offscreenCanvas2);
+try {
+renderBundleEncoder5.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(8279, undefined, 1503490631, 2454590367);
+} catch {}
+try {
+commandEncoder19.copyBufferToTexture({
+  /* bytesInLastRow: 10 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 43924 */
+  offset: 10122,
+  bytesPerRow: 256,
+  rowsPerImage: 130,
+  buffer: buffer1,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 10, height: 3, depthOrArrayLayers: 2});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder17.resolveQuerySet(querySet8, 220, 22, buffer1, 422912);
+} catch {}
+let textureView18 = texture1.createView({label: '\uf1c8\u1af9\u01cc\u08f0\u{1f812}\u02ac', baseMipLevel: 1});
+try {
+commandEncoder1.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 15},
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder17.resolveQuerySet(querySet4, 958, 195, buffer0, 61440);
+} catch {}
+let shaderModule6 = device0.createShaderModule({
+  label: '\u80f9\ucd99\u248b',
+  code: `@group(10) @binding(1187)
+var<storage, read_write> type9: array<u32>;
+@group(0) @binding(1187)
+var<storage, read_write> n10: array<u32>;
+@group(3) @binding(3494)
+var<storage, read_write> global15: array<u32>;
+@group(8) @binding(2754)
+var<storage, read_write> parameter14: array<u32>;
+@group(6) @binding(3494)
+var<storage, read_write> field12: array<u32>;
+@group(3) @binding(2754)
+var<storage, read_write> field13: array<u32>;
+@group(4) @binding(3494)
+var<storage, read_write> function10: array<u32>;
+@group(5) @binding(1187)
+var<storage, read_write> local10: array<u32>;
+@group(8) @binding(3494)
+var<storage, read_write> field14: array<u32>;
+@group(7) @binding(2754)
+var<storage, read_write> global16: array<u32>;
+@group(4) @binding(2754)
+var<storage, read_write> n11: array<u32>;
+@group(6) @binding(2754)
+var<storage, read_write> local11: array<u32>;
+@group(1) @binding(2754)
+var<storage, read_write> type10: array<u32>;
+
+@compute @workgroup_size(7, 1, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(6) f0: vec4<i32>,
+  @location(7) f1: vec4<f32>,
+  @location(1) f2: vec4<f32>,
+  @location(3) f3: vec4<u32>,
+  @location(5) f4: vec2<u32>,
+  @location(0) f5: vec4<f32>,
+  @location(4) f6: vec3<u32>,
+  @location(2) f7: vec2<i32>
+}
+
+@fragment
+fn fragment0(@location(5) a0: vec4<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S6 {
+  @location(6) f0: vec3<u32>,
+  @location(13) f1: vec2<u32>,
+  @location(17) f2: f32,
+  @location(4) f3: f32,
+  @location(1) f4: i32,
+  @location(9) f5: vec3<f16>,
+  @location(7) f6: vec3<f32>,
+  @location(8) f7: vec2<i32>
+}
+struct VertexOutput0 {
+  @location(33) f88: vec4<i32>,
+  @location(44) f89: i32,
+  @builtin(position) f90: vec4<f32>,
+  @location(6) f91: vec4<f16>,
+  @location(28) f92: vec2<f32>,
+  @location(19) f93: vec4<u32>,
+  @location(22) f94: vec3<u32>,
+  @location(4) f95: f32,
+  @location(38) f96: f16,
+  @location(36) f97: vec3<f32>,
+  @location(27) f98: f16,
+  @location(10) f99: vec2<f16>,
+  @location(15) f100: vec3<i32>,
+  @location(26) f101: vec2<f32>,
+  @location(31) f102: f16,
+  @location(1) f103: u32,
+  @location(12) f104: vec4<i32>,
+  @location(23) f105: vec3<u32>,
+  @location(29) f106: vec3<i32>,
+  @location(17) f107: u32,
+  @location(42) f108: vec3<i32>,
+  @location(32) f109: f32,
+  @location(30) f110: vec2<i32>,
+  @location(5) f111: vec4<i32>,
+  @location(18) f112: vec4<u32>,
+  @location(21) f113: vec3<f16>,
+  @location(14) f114: vec2<u32>,
+  @location(35) f115: vec4<f16>
+}
+
+@vertex
+fn vertex0(@location(3) a0: vec2<f32>, @location(5) a1: vec3<f32>, a2: S6, @location(0) a3: vec3<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let textureView19 = texture5.createView({
+  label: '\u3049\uae7a\uddc0\ua2da\u5112\u8d14\u5561',
+  dimension: '2d',
+  baseMipLevel: 3,
+  baseArrayLayer: 41,
+});
+let computePassEncoder9 = commandEncoder5.beginComputePass({label: '\ucff1\ub9ec\u0906\u012e\ubd03\ue57f\u0a0f'});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  label: '\u0c66\uf100\u0e9a\u{1fa22}\u10dc\u2502',
+  colorFormats: ['rgba16uint', 'bgra8unorm', 'rg16float', 'r8uint'],
+  depthReadOnly: true,
+});
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 3323});
+let textureView20 = texture7.createView({label: '\ueb4b\u0e03\uf304', mipLevelCount: 1});
+let renderBundle14 = renderBundleEncoder2.finish({label: '\u27a2\u6921\u21ea\u0c3a\u0e57\u4c52\u51c3\u0ee9\u{1fbef}'});
+let pipeline9 = await device0.createRenderPipelineAsync({
+  label: '\u009b\ub2f7\u{1f7cf}\ucfe4\u0bc8\u91de',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule3,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8sint', writeMask: 0}, {
+  format: 'rgba32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilFront: {compare: 'never', failOp: 'zero', depthFailOp: 'decrement-clamp', passOp: 'replace'},
+    stencilBack: {compare: 'greater-equal', failOp: 'replace', depthFailOp: 'replace', passOp: 'increment-clamp'},
+    stencilReadMask: 2745015073,
+    stencilWriteMask: 853070369,
+  },
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 656,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x2', offset: 12, shaderLocation: 7}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', cullMode: 'front', unclippedDepth: true},
+});
+canvas3.height = 3262;
+let imageBitmap1 = await createImageBitmap(canvas3);
+let textureView21 = texture8.createView({label: '\u2251\u{1fdb3}\u6689\u6429\ue74a\u{1f8d2}\uf918\u5ac2', aspect: 'all'});
+try {
+commandEncoder10.resolveQuerySet(querySet8, 159, 89, buffer1, 418816);
+} catch {}
+let pipeline10 = await device0.createRenderPipelineAsync({
+  label: '\u24a5\u0bd7\u7fe5\u{1f674}\u0891\u0821\u{1f62d}\u0582\u9c1c\u{1f9e8}',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0xcb153595},
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8unorm', writeMask: 0}, {format: 'rg32float', writeMask: 0}, {format: 'rg16sint', writeMask: 0}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}, {
+  format: 'rgba8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {format: 'bgra8unorm-srgb'}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {failOp: 'keep', depthFailOp: 'zero', passOp: 'increment-clamp'},
+    stencilBack: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'increment-wrap', passOp: 'increment-wrap'},
+    stencilReadMask: 269151257,
+    stencilWriteMask: 1333697676,
+    depthBias: 753641000,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 400,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 132, shaderLocation: 4},
+          {format: 'uint32', offset: 12, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 44,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x2', offset: 0, shaderLocation: 9},
+          {format: 'snorm8x2', offset: 10, shaderLocation: 13},
+          {format: 'unorm8x2', offset: 18, shaderLocation: 16},
+          {format: 'unorm16x2', offset: 4, shaderLocation: 15},
+          {format: 'snorm8x2', offset: 6, shaderLocation: 1},
+        ],
+      },
+      {
+        arrayStride: 1508,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'float32x4', offset: 80, shaderLocation: 8},
+          {format: 'float32', offset: 100, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 48,
+        attributes: [
+          {format: 'sint8x4', offset: 0, shaderLocation: 17},
+          {format: 'unorm8x2', offset: 2, shaderLocation: 6},
+          {format: 'sint32x4', offset: 0, shaderLocation: 12},
+          {format: 'sint32x2', offset: 8, shaderLocation: 5},
+          {format: 'sint8x2', offset: 4, shaderLocation: 10},
+          {format: 'sint8x4', offset: 4, shaderLocation: 7},
+          {format: 'float32', offset: 12, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 264,
+        attributes: [
+          {format: 'uint32x2', offset: 64, shaderLocation: 2},
+          {format: 'sint32x2', offset: 24, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', unclippedDepth: true},
+});
+try {
+  await adapter0.requestAdapterInfo();
+} catch {}
+let shaderModule7 = device0.createShaderModule({
+  label: '\ub131\u0e3c\ub880\u5c97\ude70\ue5cd\u60a0\u4e49\u95df',
+  code: `@group(7) @binding(2754)
+var<storage, read_write> local12: array<u32>;
+@group(3) @binding(3494)
+var<storage, read_write> function11: array<u32>;
+@group(10) @binding(1187)
+var<storage, read_write> parameter15: array<u32>;
+@group(6) @binding(2754)
+var<storage, read_write> parameter16: array<u32>;
+@group(1) @binding(3494)
+var<storage, read_write> global17: array<u32>;
+@group(4) @binding(3494)
+var<storage, read_write> global18: array<u32>;
+@group(8) @binding(2754)
+var<storage, read_write> local13: array<u32>;
+@group(4) @binding(2754)
+var<storage, read_write> parameter17: array<u32>;
+@group(1) @binding(2754)
+var<storage, read_write> global19: array<u32>;
+@group(7) @binding(3494)
+var<storage, read_write> global20: array<u32>;
+@group(6) @binding(3494)
+var<storage, read_write> local14: array<u32>;
+@group(2) @binding(1187)
+var<storage, read_write> parameter18: array<u32>;
+@group(0) @binding(1187)
+var<storage, read_write> type11: array<u32>;
+@group(3) @binding(2754)
+var<storage, read_write> global21: array<u32>;
+@group(9) @binding(1187)
+var<storage, read_write> type12: array<u32>;
+@group(5) @binding(1187)
+var<storage, read_write> global22: array<u32>;
+
+@compute @workgroup_size(5, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: vec2<i32>,
+  @location(7) f1: vec4<f32>,
+  @location(6) f2: vec4<i32>,
+  @location(5) f3: vec3<u32>,
+  @location(0) f4: vec3<f32>,
+  @location(3) f5: u32,
+  @location(1) f6: vec2<f32>,
+  @location(4) f7: vec4<u32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(position) a1: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @builtin(position) f116: vec4<f32>
+}
+
+@vertex
+fn vertex0() -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let buffer2 = device0.createBuffer({
+  label: '\udb2a\u066f\u{1f945}\ua7ce\u690d\u2698\u0bb9\u{1ffe4}\u{1fb8b}\u0ba9\u7130',
+  size: 43432,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let renderBundle15 = renderBundleEncoder3.finish({label: '\u2740\u58e4\u07fa'});
+let sampler9 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 39.19,
+  maxAnisotropy: 11,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 659 */
+{offset: 381}, {width: 139, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline11 = device0.createComputePipeline({
+  label: '\uc191\u{1faa9}\u00a2\u4bb7\u0d7f\ubc0f\u1447\u{1f6c7}\u{1fc66}\u40b2',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule5, entryPoint: 'compute0', constants: {}},
+});
+let commandEncoder23 = device0.createCommandEncoder({});
+let texture9 = device0.createTexture({
+  label: '\u0d5a\u9aaa\u{1fe8b}',
+  size: {width: 80},
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture10 = gpuCanvasContext3.getCurrentTexture();
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({
+  label: '\u4874\u4a14\u0545\u06b1\u010f\uc52f',
+  colorFormats: ['rg8unorm', 'rg32float', 'rg16sint', 'r16uint', 'r16uint', 'r8uint', 'rgba8sint', 'bgra8unorm-srgb'],
+  sampleCount: 1,
+});
+try {
+buffer0.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+adapter1.label = '\u171f\u7d93\u76b6\u46e0\u{1ff2b}\ubf23';
+} catch {}
+let commandEncoder24 = device0.createCommandEncoder({label: '\u0c16\u3bf0\u0948\u3fcc\u050e\u0a3a\u0730\u{1fe6e}\u{1f679}'});
+let texture11 = device0.createTexture({
+  label: '\ub4eb\u0f1d\u{1fa58}',
+  size: {width: 92, height: 8, depthOrArrayLayers: 201},
+  mipLevelCount: 7,
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Int32Array(new ArrayBuffer(16)), /* required buffer size: 492 */
+{offset: 492}, {width: 72, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline12 = device0.createRenderPipeline({
+  layout: pipelineLayout0,
+  multisample: {mask: 0xe11cff8a},
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8sint'}, {format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {
+      compare: 'greater-equal',
+      failOp: 'decrement-wrap',
+      depthFailOp: 'decrement-clamp',
+      passOp: 'increment-clamp',
+    },
+    stencilBack: {failOp: 'decrement-clamp', depthFailOp: 'zero', passOp: 'zero'},
+    stencilReadMask: 2594818178,
+    stencilWriteMask: 3424706869,
+    depthBias: -424469948,
+    depthBiasClamp: 501.1016170822885,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 2948,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint8x4', offset: 208, shaderLocation: 11},
+          {format: 'unorm8x2', offset: 68, shaderLocation: 12},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', cullMode: 'front'},
+});
+let texture12 = device0.createTexture({
+  size: {width: 160, height: 1, depthOrArrayLayers: 1407},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rg32float', 'rg32float'],
+});
+let renderBundle16 = renderBundleEncoder3.finish();
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 753 */
+{offset: 657, rowsPerImage: 255}, {width: 24, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline13 = await device0.createComputePipelineAsync({
+  label: '\u6783\u0767\u0c4e\u0c94\u0a50\u092f',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule1, entryPoint: 'compute0'},
+});
+let offscreenCanvas4 = new OffscreenCanvas(777, 106);
+let querySet11 = device0.createQuerySet({
+  label: '\ub270\u{1fd0c}\u7c72\u0a38\u{1ff6d}\u0964\ube0c\ua5fe\u30ad\u0b75\u56bf',
+  type: 'occlusion',
+  count: 2712,
+});
+let texture13 = device0.createTexture({
+  label: '\u04ba\u0ad0',
+  size: {width: 320, height: 2, depthOrArrayLayers: 218},
+  mipLevelCount: 7,
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView22 = texture1.createView({baseMipLevel: 1, mipLevelCount: 1});
+try {
+commandEncoder23.copyBufferToTexture({
+  /* bytesInLastRow: 752 widthInBlocks: 47 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 6224 */
+  offset: 5472,
+  buffer: buffer1,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 47, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder17.resolveQuerySet(querySet11, 781, 1133, buffer0, 12800);
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+try {
+  await promise7;
+} catch {}
+try {
+offscreenCanvas4.getContext('webgpu');
+} catch {}
+let buffer3 = device0.createBuffer({
+  label: '\u0836\u{1fc6c}\u546d\u{1f7e5}\u093e\udfcc\u1d0b\u6dc4\u11d0\u{1fa45}\u7743',
+  size: 290405,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder25 = device0.createCommandEncoder({});
+let commandBuffer6 = commandEncoder10.finish({label: '\u0e32\u0011'});
+let textureView23 = texture2.createView({});
+let computePassEncoder10 = commandEncoder23.beginComputePass();
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({
+  label: '\u0b37\uc68f\u031b\u453b\u0b93\u0f0d\ua2c4\u151d\u{1fee3}\ub301\ueaf3',
+  colorFormats: ['r8sint', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle17 = renderBundleEncoder8.finish({label: '\u3c78\u0dbd\u{1fc98}\u{1fc27}\u{1fd6a}\u{1f7c4}\u{1feb7}\u0160\u0356\u0870'});
+let sampler10 = device0.createSampler({
+  label: '\uf91e\u{1fa14}\u0e94\ud37f\u{1fa0f}',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 32.50,
+  lodMaxClamp: 52.83,
+});
+let externalTexture2 = device0.importExternalTexture({label: '\u0603\u{1fc51}', source: video1});
+try {
+renderBundleEncoder9.setPipeline(pipeline0);
+} catch {}
+try {
+gpuCanvasContext4.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb', 'rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+});
+} catch {}
+let textureView24 = texture9.createView({label: '\u0d2a\u5a13\u506b', format: 'rgba8sint'});
+try {
+renderBundleEncoder7.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder2.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 12236 */
+  offset: 12236,
+  buffer: buffer1,
+}, {
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder2.resolveQuerySet(querySet6, 1525, 1492, buffer0, 3328);
+} catch {}
+let querySet12 = device0.createQuerySet({label: '\u{1fcae}\u0000\u4dc6\u{1fd5e}\u0b7f', type: 'occlusion', count: 3676});
+let texture14 = device0.createTexture({
+  label: '\uc87d\ud57b\u0430\u{1ff95}\u{1fdf7}\u0fbe',
+  size: {width: 80, height: 1, depthOrArrayLayers: 189},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView25 = texture13.createView({
+  label: '\uba16\u092b\u10be\u01fc\u{1fe69}\u47bc\u0d41\u{1ff74}\u02f0\u{1fef7}',
+  aspect: 'stencil-only',
+  baseMipLevel: 5,
+  baseArrayLayer: 198,
+  arrayLayerCount: 11,
+});
+let renderBundle18 = renderBundleEncoder6.finish({label: '\u023f\u5a1b\ud7ef\u{1f7fc}'});
+let sampler11 = device0.createSampler({
+  label: '\u{1f8d1}\u23ad\ub325\u6bfa\u{1fd1d}\ue894\u4fee\u1876\u0265',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 17.85,
+});
+let querySet13 = device0.createQuerySet({
+  label: '\u{1f7bd}\u{1fdcb}\u{1fd78}\u{1fa9d}\u{1fa68}\u0ff9\u{1f872}\u02a8\u{1fee2}\u46ef\u063a',
+  type: 'occlusion',
+  count: 162,
+});
+let computePassEncoder11 = commandEncoder25.beginComputePass({label: '\u{1f838}\u4a22\uba0c\uffe8\ue921\u{1fca3}\u008c\u{1fe3a}\u{1f68b}\u76cb\u0e91'});
+let renderBundle19 = renderBundleEncoder10.finish();
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder15.copyBufferToTexture({
+  /* bytesInLastRow: 1120 widthInBlocks: 70 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 18416 */
+  offset: 17296,
+  buffer: buffer3,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 70, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+let video3 = await videoWithData();
+let buffer4 = device0.createBuffer({
+  label: '\u1561\u0cfc\u{1ffbc}\u{1f7f6}\u94b9\u94b4\u10c1\ubce8',
+  size: 156265,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+try {
+commandEncoder15.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 504 widthInBlocks: 63 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 21352 */
+  offset: 21352,
+  buffer: buffer4,
+}, {width: 63, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder24.clearBuffer(buffer4, 55540, 6656);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder24.resolveQuerySet(querySet11, 2147, 485, buffer1, 627968);
+} catch {}
+let commandEncoder26 = device0.createCommandEncoder({label: '\u018c\u0daa\u00f6\ud00e\u04bb'});
+let texture15 = device0.createTexture({
+  label: '\u{1ffc0}\u009d\u0913\u970d',
+  size: {width: 40, height: 1, depthOrArrayLayers: 218},
+  mipLevelCount: 4,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView26 = texture1.createView({});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({
+  label: '\u0eb3\ubb48\ud8a4\u4277\u18ae\u7822\u02ec\uffe5',
+  colorFormats: ['r8sint', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle20 = renderBundleEncoder3.finish({label: '\u09ec\uf4b9\u8b7e\ud9f7'});
+let sampler12 = device0.createSampler({
+  label: '\u0e67\uf82f\u{1fde9}\ua040\u9d32\u5199\u{1fe23}\u3824\ue707',
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 58.34,
+  lodMaxClamp: 77.88,
+  maxAnisotropy: 8,
+});
+try {
+buffer1.destroy();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 1652, new Float32Array(43200), 21245, 1700);
+} catch {}
+let video4 = await videoWithData();
+let querySet14 = device0.createQuerySet({type: 'occlusion', count: 3668});
+let renderBundle21 = renderBundleEncoder6.finish({});
+let pipeline14 = await device0.createRenderPipelineAsync({
+  label: '\uc541\u83e7\u41d8\ue205\u1302\ud4f3\u1af8\udf40\ua874\u0c66',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rgba32float'}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {failOp: 'decrement-clamp', depthFailOp: 'decrement-wrap'},
+    stencilBack: {failOp: 'decrement-clamp', depthFailOp: 'zero', passOp: 'invert'},
+    stencilReadMask: 430822404,
+    stencilWriteMask: 2357872437,
+    depthBiasSlopeScale: 320.00080057624643,
+    depthBiasClamp: 365.202843484258,
+  },
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 1336, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 20,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm16x4', offset: 0, shaderLocation: 12}],
+      },
+      {
+        arrayStride: 224,
+        stepMode: 'instance',
+        attributes: [{format: 'uint16x4', offset: 4, shaderLocation: 11}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'ccw', unclippedDepth: true},
+});
+let video5 = await videoWithData();
+let bindGroupLayout3 = device0.createBindGroupLayout({
+  label: '\ue00d\u08da\u6554\u{1fe03}\u3d63\u0142\u{1fa17}\u3126',
+  entries: [
+    {
+      binding: 3010,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+  ],
+});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({
+  label: '\u4429\u{1f876}\u{1ffd6}',
+  colorFormats: ['rgba16uint', 'bgra8unorm', 'rg16float', 'r8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle22 = renderBundleEncoder1.finish({label: '\uef8e\u0082\u57d3\u3661\u07a5'});
+try {
+commandEncoder1.resolveQuerySet(querySet3, 1999, 446, buffer1, 412672);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint16Array(new ArrayBuffer(8)), /* required buffer size: 769 */
+{offset: 677}, {width: 23, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline15 = device0.createComputePipeline({
+  label: '\u{1f7e4}\u054c\u0f6d',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let pipeline16 = await device0.createRenderPipelineAsync({
+  label: '\u02d7\u266f\u2322\u{1f8bf}\u0b64\u53e5\u{1ffe5}\ucbb0\u{1fd75}',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0x408f27bf},
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rg32float', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'rg16sint'}, {format: 'r16uint', writeMask: GPUColorWrite.ALL}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r8uint'}, {
+  format: 'rgba8sint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED,
+}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'add', srcFactor: 'src-alpha', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1824,
+        attributes: [
+          {format: 'uint32x3', offset: 184, shaderLocation: 1},
+          {format: 'sint8x4', offset: 372, shaderLocation: 5},
+          {format: 'snorm16x4', offset: 52, shaderLocation: 16},
+          {format: 'snorm16x2', offset: 216, shaderLocation: 7},
+          {format: 'sint32', offset: 616, shaderLocation: 15},
+          {format: 'unorm10-10-10-2', offset: 32, shaderLocation: 14},
+          {format: 'uint16x4', offset: 0, shaderLocation: 8},
+          {format: 'float16x2', offset: 40, shaderLocation: 3},
+          {format: 'sint16x2', offset: 204, shaderLocation: 4},
+          {format: 'sint32x3', offset: 540, shaderLocation: 0},
+          {format: 'uint32x4', offset: 568, shaderLocation: 6},
+          {format: 'uint32x2', offset: 488, shaderLocation: 17},
+          {format: 'float32x3', offset: 72, shaderLocation: 11},
+          {format: 'unorm8x2', offset: 386, shaderLocation: 9},
+          {format: 'uint32x4', offset: 196, shaderLocation: 13},
+          {format: 'sint16x2', offset: 240, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 228, shaderLocation: 10},
+        ],
+      },
+      {arrayStride: 1248, attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'float32x2', offset: 120, shaderLocation: 2}],
+      },
+    ],
+  },
+});
+offscreenCanvas4.height = 25;
+let commandEncoder27 = device0.createCommandEncoder({label: '\u9df7\u0a3f\u758f\u26b1\u0b1e\u8001'});
+let computePassEncoder12 = commandEncoder3.beginComputePass();
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({
+  label: '\u467b\u02ec',
+  colorFormats: ['rg8unorm', 'rg32float', 'rg16sint', 'r16uint', 'r16uint', 'r8uint', 'rgba8sint', 'bgra8unorm-srgb'],
+  depthReadOnly: true,
+});
+try {
+computePassEncoder11.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder11.setPipeline(pipeline3);
+} catch {}
+try {
+  await device0.popErrorScope();
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let imageBitmap2 = await createImageBitmap(offscreenCanvas3);
+let imageData4 = new ImageData(80, 208);
+let textureView27 = texture8.createView({arrayLayerCount: 1});
+let computePassEncoder13 = commandEncoder21.beginComputePass({label: '\u89df\u5066\u8bb8\uf6e3\uc2e7\u008b\ua8a2\u6881\u0ecf'});
+let externalTexture3 = device0.importExternalTexture({label: '\u73dc\uf348\ufec6\u0579\u71c9\u93b9', source: video1, colorSpace: 'srgb'});
+try {
+commandEncoder14.resolveQuerySet(querySet3, 3445, 11, buffer0, 18432);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, new Int16Array(arrayBuffer1), /* required buffer size: 471 */
+{offset: 471}, {width: 37, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline17 = device0.createRenderPipeline({
+  label: '\uc0f9\u{1f793}\uf067\u{1fd53}\u6a35',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0xccbc95ce},
+  fragment: {
+  module: shaderModule7,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'constant'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'dst-alpha'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rg32float'}, {format: 'rg16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba8sint'}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}],
+},
+  vertex: {module: shaderModule7, entryPoint: 'vertex0', buffers: []},
+  primitive: {topology: 'line-strip', frontFace: 'cw', cullMode: 'back'},
+});
+let textureView28 = texture1.createView({label: '\u{1fd63}\u04ca\u{1faaa}\u4ea7\u{1f966}', aspect: 'all', baseMipLevel: 1});
+try {
+renderBundleEncoder5.setVertexBuffer(2923, undefined, 947301038, 2443162111);
+} catch {}
+try {
+commandEncoder22.copyBufferToBuffer(buffer2, 12728, buffer4, 42332, 24380);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder27.copyBufferToTexture({
+  /* bytesInLastRow: 37 widthInBlocks: 37 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 28276 */
+  offset: 28276,
+  buffer: buffer1,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 4},
+  aspect: 'all',
+}, {width: 37, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture1,
+  mipLevel: 1,
+  origin: {x: 4, y: 2, z: 6},
+  aspect: 'all',
+}, new ArrayBuffer(40), /* required buffer size: 3_037_819 */
+{offset: 901, bytesPerRow: 1038, rowsPerImage: 225}, {width: 48, height: 1, depthOrArrayLayers: 14});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 46, height: 4, depthOrArrayLayers: 201}
+*/
+{
+  source: video5,
+  origin: { x: 3, y: 3 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 42},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+window.someLabel = externalTexture3.label;
+} catch {}
+let bindGroupLayout4 = device0.createBindGroupLayout({label: '\ucde4\ud156\u2bdc', entries: []});
+let commandEncoder28 = device0.createCommandEncoder();
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({
+  label: '\ucc16\u9a88\u0dd0\u1ed7',
+  colorFormats: ['rgba16uint', 'bgra8unorm', 'rg16float', 'r8uint'],
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder11.setPipeline(pipeline3);
+} catch {}
+try {
+commandEncoder27.resolveQuerySet(querySet4, 639, 296, buffer0, 22016);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 381 */
+{offset: 381, bytesPerRow: 60}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 201}
+*/
+{
+  source: img1,
+  origin: { x: 19, y: 9 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 59},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout1 = device0.createPipelineLayout({label: '\ufa38\u0a74\u9c88\u093b\u{1fa10}\u{1fdde}', bindGroupLayouts: [bindGroupLayout0]});
+let commandEncoder29 = device0.createCommandEncoder({label: '\u0ec2\uf138\u8f8d\u502e\ua032\ub211\u0453'});
+let computePassEncoder14 = commandEncoder26.beginComputePass({});
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({label: '\u{1f918}\u728e\u{1fb3a}', colorFormats: ['r8sint', 'rgba32float']});
+let renderBundle23 = renderBundleEncoder2.finish({label: '\u23ec\u098a\u0f7b\ub78d\u{1fb96}\u{1fa35}'});
+try {
+commandEncoder19.copyTextureToBuffer({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 236 widthInBlocks: 59 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 25736 */
+  offset: 25500,
+  buffer: buffer4,
+}, {width: 59, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer4);
+} catch {}
+let canvas5 = document.createElement('canvas');
+try {
+window.someLabel = renderBundle21.label;
+} catch {}
+let sampler13 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 98.17,
+  compare: 'always',
+});
+try {
+renderBundleEncoder7.setPipeline(pipeline3);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let offscreenCanvas5 = new OffscreenCanvas(701, 982);
+let commandEncoder30 = device0.createCommandEncoder({label: '\u{1fa7e}\u{1f879}\u0f9d\u0cd6\uc53f'});
+let computePassEncoder15 = commandEncoder1.beginComputePass();
+try {
+computePassEncoder14.end();
+} catch {}
+try {
+commandEncoder29.copyBufferToTexture({
+  /* bytesInLastRow: 32 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 5192 */
+  offset: 5192,
+  buffer: buffer3,
+}, {
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 8, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer3);
+} catch {}
+let pipeline18 = device0.createComputePipeline({
+  label: '\u395a\u0511\u5699\u0725\u004d\u04bb\u01db\u9278\ua5ae\u1645',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule1, entryPoint: 'compute0', constants: {}},
+});
+let bindGroupLayout5 = device0.createBindGroupLayout({
+  label: '\u07d1\u8d2a\u840e\u0122\ub6c5\u15f1\u07df',
+  entries: [
+    {binding: 3171, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 4204,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32sint', access: 'read-write', viewDimension: '2d-array' },
+    },
+    {binding: 371, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let buffer5 = device0.createBuffer({
+  label: '\u2d48\u523c\u9b66\uf162\u0047\u{1fa05}\u08f2\u{1f97d}\uae21',
+  size: 225365,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+});
+let renderBundle24 = renderBundleEncoder11.finish({label: '\u{1f774}\u5885\u{1fd4d}\u{1fc0a}\u{1f6db}\u5862\u{1f9b6}\u05d3\u02c6\u{1fd3f}'});
+try {
+computePassEncoder9.end();
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline6);
+} catch {}
+let arrayBuffer2 = buffer2.getMappedRange();
+try {
+commandEncoder22.clearBuffer(buffer4, 79224, 6732);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+let img5 = await imageWithData(115, 261, '#a32b2891', '#848d86ad');
+let imageBitmap3 = await createImageBitmap(img3);
+let bindGroupLayout6 = device0.createBindGroupLayout({
+  label: '\u89f9\ucb1f\uac5c\u2b63\ube59\u4414\u8453\u37e1\u968a',
+  entries: [{binding: 3944, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let commandEncoder31 = device0.createCommandEncoder({label: '\u0c9b\u{1facd}\u8e27\u0f16\u6bbc\u2ed3\u0019\u{1fad4}\ue0b9'});
+let texture16 = device0.createTexture({
+  label: '\u0891\u1805\u2a7e\u{1f71c}\ubfcc',
+  size: {width: 80, height: 1, depthOrArrayLayers: 207},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r8uint', 'r8uint'],
+});
+let textureView29 = texture12.createView({baseMipLevel: 2});
+let computePassEncoder16 = commandEncoder26.beginComputePass({label: '\u0010\ua397'});
+let sampler14 = device0.createSampler({
+  label: '\uc14e\u072d\u0746\udc55\u5980\u{1fdd5}\uc706\uba01\u43d9\uf560\uda2a',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 59.64,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder12.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder17.copyBufferToBuffer(buffer2, 9424, buffer4, 75888, 18020);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder24.copyBufferToTexture({
+  /* bytesInLastRow: 1264 widthInBlocks: 79 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 13072 */
+  offset: 13072,
+  bytesPerRow: 1280,
+  rowsPerImage: 264,
+  buffer: buffer3,
+}, {
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 79, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer3);
+} catch {}
+try {
+computePassEncoder4.pushDebugGroup('\u0af7');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData5 = new ImageData(128, 148);
+let videoFrame0 = new VideoFrame(canvas2, {timestamp: 0});
+let commandEncoder32 = device0.createCommandEncoder();
+let textureView30 = texture12.createView({label: '\ue3b1\u{1ff55}', baseMipLevel: 2, arrayLayerCount: 1});
+let renderBundle25 = renderBundleEncoder14.finish({label: '\u{1f76f}\u16b1'});
+let sampler15 = device0.createSampler({
+  label: '\u{1fac0}\u012a\uc331\uf717',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 24.70,
+  lodMaxClamp: 52.42,
+  maxAnisotropy: 3,
+});
+try {
+commandEncoder20.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 107},
+  aspect: 'all',
+},
+{
+  texture: texture11,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder31.clearBuffer(buffer4, 98064, 39476);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder14.resolveQuerySet(querySet7, 1332, 801, buffer0, 4864);
+} catch {}
+try {
+computePassEncoder4.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 30428, new BigUint64Array(49883), 49602, 0);
+} catch {}
+let promise9 = device0.createRenderPipelineAsync({
+  label: '\u{1fc8e}\ue518\u9452\u0c67\u{1f70b}\u40c3\ubebc\ude84\ua94c\uc83d\u{1f8b9}',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule5,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+}, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg16sint', writeMask: 0}, {format: 'r16uint', writeMask: 0}, {format: 'r16uint', writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba8sint', writeMask: GPUColorWrite.BLUE}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'less-equal', failOp: 'decrement-clamp', depthFailOp: 'zero', passOp: 'zero'},
+    stencilBack: {compare: 'equal', depthFailOp: 'zero', passOp: 'decrement-clamp'},
+    stencilReadMask: 3743278907,
+    stencilWriteMask: 545822813,
+    depthBiasSlopeScale: 105.32722364725157,
+    depthBiasClamp: 558.1954404407737,
+  },
+  vertex: {
+    module: shaderModule5,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 20,
+        attributes: [
+          {format: 'float16x4', offset: 0, shaderLocation: 15},
+          {format: 'snorm16x4', offset: 0, shaderLocation: 16},
+          {format: 'snorm8x2', offset: 6, shaderLocation: 13},
+          {format: 'snorm16x2', offset: 0, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 372, shaderLocation: 17},
+          {format: 'sint8x4', offset: 92, shaderLocation: 5},
+          {format: 'sint16x4', offset: 104, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 204, shaderLocation: 9},
+          {format: 'sint16x4', offset: 528, shaderLocation: 10},
+          {format: 'uint32x2', offset: 892, shaderLocation: 2},
+          {format: 'unorm8x2', offset: 308, shaderLocation: 8},
+          {format: 'sint32x4', offset: 4916, shaderLocation: 7},
+          {format: 'snorm16x4', offset: 1160, shaderLocation: 3},
+          {format: 'unorm10-10-10-2', offset: 120, shaderLocation: 6},
+          {format: 'uint8x4', offset: 132, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 608,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 228, shaderLocation: 1},
+          {format: 'sint32x2', offset: 600, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 532, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x4', offset: 40, shaderLocation: 4}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', unclippedDepth: true},
+});
+let img6 = await imageWithData(52, 257, '#908fe700', '#ff71f325');
+let commandEncoder33 = device0.createCommandEncoder({});
+let sampler16 = device0.createSampler({
+  label: '\u0c53\u37e2\u93a1\ud6e2\u0b4c\u045d\u{1fde9}\u0aa8\u0e2d\u0de1',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 88.34,
+  lodMaxClamp: 91.19,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder5.setPipeline(pipeline18);
+} catch {}
+let arrayBuffer3 = buffer2.getMappedRange(43432, 0);
+let promise10 = buffer3.mapAsync(GPUMapMode.WRITE, 201880, 24652);
+try {
+commandEncoder2.clearBuffer(buffer4, 117376, 300);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.submit([commandBuffer6, commandBuffer1]);
+} catch {}
+let video6 = await videoWithData();
+let bindGroupLayout7 = device0.createBindGroupLayout({
+  label: '\u0e84\u9e85\ucfd6',
+  entries: [
+    {
+      binding: 3170,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'non-filtering' },
+    },
+    {binding: 2685, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {binding: 3254, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+  ],
+});
+let bindGroup0 = device0.createBindGroup({
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 3254, resource: sampler6},
+    {binding: 3170, resource: sampler7},
+    {binding: 2685, resource: externalTexture1},
+  ],
+});
+let renderBundle26 = renderBundleEncoder1.finish({label: '\u{1fab8}\u5961\u0b65\u0151\u{1f6b5}\u0b16\u{1f97a}\u9604'});
+let sampler17 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 77.00,
+  lodMaxClamp: 83.43,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup0, new Uint32Array(1861), 72, 0);
+} catch {}
+try {
+commandEncoder22.copyBufferToTexture({
+  /* bytesInLastRow: 164 widthInBlocks: 82 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 21988 */
+  offset: 21988,
+  buffer: buffer1,
+}, {
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 82, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder22.clearBuffer(buffer4, 110036, 10332);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+gpuCanvasContext5.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgba8unorm', 'rgba8unorm'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await promise8;
+} catch {}
+let bindGroupLayout8 = device0.createBindGroupLayout({
+  label: '\u3e1c\ubb23',
+  entries: [
+    {binding: 158, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {binding: 364, visibility: 0, buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false }},
+    {
+      binding: 2827,
+      visibility: 0,
+      storageTexture: { format: 'r32sint', access: 'write-only', viewDimension: '3d' },
+    },
+  ],
+});
+let texture17 = device0.createTexture({
+  size: [320, 2, 118],
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  label: '\u05e0\uf74a\u{1fee7}\ubf67\u013b',
+  colorFormats: ['rgba16uint', 'bgra8unorm', 'rg16float', 'r8uint'],
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder4.setBindGroup(10, bindGroup0);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(3, bindGroup0, new Uint32Array(8207), 3926, 0);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+commandEncoder27.copyTextureToBuffer({
+  texture: texture16,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 61571 */
+  offset: 61570,
+  rowsPerImage: 45,
+  buffer: buffer4,
+}, {width: 1, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder17.copyTextureToTexture({
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 478},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 3},
+  aspect: 'all',
+},
+{width: 45, height: 1, depthOrArrayLayers: 2});
+} catch {}
+let textureView31 = texture16.createView({label: '\u0d9b\ued53\u{1f92a}', baseMipLevel: 2, mipLevelCount: 4});
+let sampler18 = device0.createSampler({
+  label: '\uee56\u{1fb33}\u163a\ube77',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 33.60,
+  lodMaxClamp: 89.29,
+});
+try {
+commandEncoder17.copyBufferToBuffer(buffer1, 941324, buffer4, 145504, 2164);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder15.copyTextureToBuffer({
+  texture: texture3,
+  mipLevel: 2,
+  origin: {x: 4, y: 0, z: 4},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 72 widthInBlocks: 18 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 125560 */
+  offset: 18736,
+  bytesPerRow: 256,
+  rowsPerImage: 46,
+  buffer: buffer4,
+}, {width: 18, height: 4, depthOrArrayLayers: 10});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder16.clearBuffer(buffer4, 93424, 60228);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+let pipeline19 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule2, entryPoint: 'compute0', constants: {}}});
+let pipelineLayout2 = device0.createPipelineLayout({
+  label: '\u{1fdf1}\u81e6\u5d0c\uec41\u3d01\u8c89\u{1fa2e}\u0eb6\u01c0\ufcaa',
+  bindGroupLayouts: [bindGroupLayout3, bindGroupLayout5, bindGroupLayout6, bindGroupLayout8],
+});
+let commandEncoder34 = device0.createCommandEncoder({label: '\ua871\u0d5a\u{1fd82}\u0ba9\u2656\u4dcb\ubff5\u006d\u05a1'});
+let sampler19 = device0.createSampler({
+  label: '\u7e43\u5a77\u3c1d\ud779',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 48.21,
+  lodMaxClamp: 91.54,
+});
+try {
+computePassEncoder15.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(2851, undefined, 1527132941, 187726370);
+} catch {}
+try {
+commandEncoder2.copyBufferToBuffer(buffer1, 7640, buffer4, 152352, 2360);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder19.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 30164 */
+  offset: 30164,
+  buffer: buffer1,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 38988, new DataView(new ArrayBuffer(51844)), 32229, 6028);
+} catch {}
+let pipeline20 = device0.createRenderPipeline({
+  label: '\uad55\u{1fb81}\u7e60\uc635\u{1fe2c}\u{1fc14}\u9068\u{1f7d3}\u{1fc93}\ubae8\ub80d',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'rg32float', writeMask: GPUColorWrite.RED}, {format: 'rg16sint'}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE}, {format: 'r16uint', writeMask: 0}, {format: 'r8uint'}, {format: 'rgba8sint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'bgra8unorm-srgb', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'not-equal', failOp: 'invert', depthFailOp: 'invert', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'greater', failOp: 'decrement-wrap', depthFailOp: 'increment-clamp', passOp: 'keep'},
+    stencilReadMask: 804652539,
+    stencilWriteMask: 1772822389,
+    depthBias: 829488837,
+    depthBiasSlopeScale: 883.5406538058021,
+    depthBiasClamp: 389.462493444679,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'uint8x4', offset: 664, shaderLocation: 4},
+          {format: 'sint16x2', offset: 280, shaderLocation: 1},
+          {format: 'float32', offset: 276, shaderLocation: 9},
+          {format: 'float32x4', offset: 112, shaderLocation: 8},
+          {format: 'sint8x4', offset: 2436, shaderLocation: 14},
+          {format: 'snorm16x4', offset: 84, shaderLocation: 7},
+          {format: 'float32x3', offset: 968, shaderLocation: 15},
+          {format: 'float16x4', offset: 1272, shaderLocation: 10},
+          {format: 'uint32x3', offset: 396, shaderLocation: 12},
+          {format: 'unorm16x2', offset: 1448, shaderLocation: 6},
+          {format: 'unorm8x2', offset: 678, shaderLocation: 11},
+          {format: 'uint8x2', offset: 1008, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 1020,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x4', offset: 320, shaderLocation: 17},
+          {format: 'float32x2', offset: 20, shaderLocation: 3},
+          {format: 'float32x3', offset: 208, shaderLocation: 5},
+          {format: 'sint32', offset: 220, shaderLocation: 16},
+          {format: 'float32x3', offset: 76, shaderLocation: 0},
+          {format: 'uint32', offset: 228, shaderLocation: 2},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-list', unclippedDepth: true},
+});
+let video7 = await videoWithData();
+let shaderModule8 = device0.createShaderModule({
+  label: '\u{1f896}\u{1fef7}\ubdc7\u8f71\u3316\u0eb3\u{1f7e4}\u43c2\uaede',
+  code: `@group(1) @binding(4204)
+var<storage, read_write> type13: array<u32>;
+@group(0) @binding(3010)
+var<storage, read_write> field15: array<u32>;
+@group(3) @binding(364)
+var<storage, read_write> parameter19: array<u32>;
+@group(3) @binding(158)
+var<storage, read_write> function12: array<u32>;
+@group(1) @binding(3171)
+var<storage, read_write> n12: array<u32>;
+@group(1) @binding(371)
+var<storage, read_write> local15: array<u32>;
+@group(3) @binding(2827)
+var<storage, read_write> global23: array<u32>;
+
+@compute @workgroup_size(3, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S7 {
+  @builtin(front_facing) f0: bool,
+  @builtin(sample_index) f1: u32,
+  @builtin(sample_mask) f2: u32,
+  @builtin(position) f3: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec3<i32>,
+  @location(2) f1: vec2<i32>,
+  @location(1) f2: vec4<f32>
+}
+
+@fragment
+fn fragment0(a0: S7) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(13) a0: i32, @location(15) a1: vec3<f16>, @location(0) a2: f32, @location(1) a3: vec3<f32>, @builtin(vertex_index) a4: u32) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup0, new Uint32Array(8399), 8234, 0);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(9873, undefined, 2962546350, 1270734806);
+} catch {}
+try {
+commandEncoder20.resolveQuerySet(querySet7, 3005, 388, buffer0, 58368);
+} catch {}
+let gpuCanvasContext6 = canvas5.getContext('webgpu');
+let commandEncoder35 = device0.createCommandEncoder({});
+let renderBundle27 = renderBundleEncoder8.finish({});
+try {
+renderBundleEncoder5.setBindGroup(7, bindGroup0, new Uint32Array(6450), 1370, 0);
+} catch {}
+try {
+commandEncoder24.copyBufferToBuffer(buffer3, 32428, buffer4, 115808, 39260);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder31.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 87, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let video8 = await videoWithData();
+let commandEncoder36 = device0.createCommandEncoder({label: '\u0bfd\u3dc2'});
+let textureView32 = texture6.createView({label: '\u3063\u{1fb5f}\u0290\u271d\u{1fae8}\u36f4'});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup0, new Uint32Array(6289), 4314, 0);
+} catch {}
+try {
+commandEncoder28.copyTextureToBuffer({
+  texture: texture11,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 14},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 99488 */
+  offset: 99488,
+  bytesPerRow: 0,
+  rowsPerImage: 17,
+  buffer: buffer4,
+}, {width: 0, height: 0, depthOrArrayLayers: 50});
+dissociateBuffer(device0, buffer4);
+} catch {}
+let pipeline21 = await device0.createRenderPipelineAsync({
+  label: '\uf7c8\ua6ac\u04e5\u43e8\u078d\u{1fe40}\u5f5f\u018f',
+  layout: pipelineLayout2,
+  multisample: {mask: 0xa1fb3156},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'greater-equal',
+    stencilFront: {compare: 'equal', failOp: 'decrement-wrap', depthFailOp: 'increment-wrap', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'greater', failOp: 'zero', depthFailOp: 'increment-clamp', passOp: 'increment-wrap'},
+    stencilReadMask: 1029984593,
+    stencilWriteMask: 3678435366,
+    depthBias: 0,
+    depthBiasSlopeScale: 309.97023865244006,
+    depthBiasClamp: 306.50197061803647,
+  },
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 164,
+        attributes: [
+          {format: 'snorm16x4', offset: 76, shaderLocation: 7},
+          {format: 'float32x4', offset: 12, shaderLocation: 9},
+          {format: 'float16x4', offset: 0, shaderLocation: 11},
+          {format: 'uint32', offset: 28, shaderLocation: 2},
+          {format: 'unorm16x2', offset: 160, shaderLocation: 8},
+          {format: 'sint8x4', offset: 8, shaderLocation: 17},
+          {format: 'sint32', offset: 8, shaderLocation: 14},
+          {format: 'unorm8x4', offset: 32, shaderLocation: 5},
+          {format: 'unorm8x2', offset: 32, shaderLocation: 6},
+          {format: 'sint8x2', offset: 14, shaderLocation: 1},
+          {format: 'float32x4', offset: 16, shaderLocation: 10},
+          {format: 'float16x4', offset: 44, shaderLocation: 15},
+          {format: 'uint16x2', offset: 24, shaderLocation: 4},
+          {format: 'sint16x2', offset: 0, shaderLocation: 16},
+          {format: 'uint8x2', offset: 2, shaderLocation: 13},
+          {format: 'float32x3', offset: 56, shaderLocation: 3},
+          {format: 'unorm16x2', offset: 4, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 1592, attributes: []},
+      {arrayStride: 1924, stepMode: 'instance', attributes: []},
+      {arrayStride: 0, attributes: []},
+      {
+        arrayStride: 1612,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x2', offset: 68, shaderLocation: 12}],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+let bindGroup1 = device0.createBindGroup({label: '\u{1fc0f}\u7e8e\u{1fe49}\u5454\u{1fb27}', layout: bindGroupLayout4, entries: []});
+let pipelineLayout3 = device0.createPipelineLayout({
+  label: '\u8840\u065b\u{1fe9a}\u{1fbe6}\u{1f63a}\u041c\u19cf\u18bb\u06be\u078d\u088b',
+  bindGroupLayouts: [],
+});
+let buffer6 = device0.createBuffer({
+  label: '\uf5fc\uf8e7\u0cb7\u0b4d\u092e\u737a\u93a2\ue83c',
+  size: 371949,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+});
+let querySet15 = device0.createQuerySet({
+  label: '\u7c38\u{1f8d6}\u2770\ueabf\u0f62\u8c03\u7756\u4955\u0281\u3c34',
+  type: 'occlusion',
+  count: 2901,
+});
+let texture18 = device0.createTexture({
+  size: {width: 23},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rg16sint'],
+});
+let texture19 = gpuCanvasContext5.getCurrentTexture();
+let renderBundle28 = renderBundleEncoder1.finish({label: '\u5a6e\u8c53\ue549\u848e\u0ce6\u{1fbbd}\u{1f8f0}\uac01\uae21\u{1fdc0}\u8de6'});
+let sampler20 = device0.createSampler({
+  label: '\u{1fa4e}\udf64\uef06\uc9db\u6ac1\u0f06\u06dc\u0b21',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 41.70,
+  lodMaxClamp: 66.72,
+  compare: 'never',
+});
+try {
+renderBundleEncoder15.setBindGroup(6, bindGroup1, []);
+} catch {}
+try {
+commandEncoder33.copyBufferToTexture({
+  /* bytesInLastRow: 272 widthInBlocks: 68 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 7936 */
+  offset: 7936,
+  rowsPerImage: 104,
+  buffer: buffer1,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 68, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+commandEncoder30.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 13},
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 6});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer0), /* required buffer size: 730 */
+{offset: 730}, {width: 155, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let gpuCanvasContext7 = offscreenCanvas5.getContext('webgpu');
+let canvas6 = document.createElement('canvas');
+let commandEncoder37 = device0.createCommandEncoder({label: '\ue3f5\u33bf\u0b96\u9cee\u1508\u0b68\u{1f7fb}\u{1f7a3}\u09eb\uf6ed'});
+let textureView33 = texture19.createView({label: '\u03c3\u0dce\u8a99\u0d58\u29d0\u896d\u0173\ud9c9\u0510'});
+let renderBundleEncoder17 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgb10a2unorm', 'rgba32uint', 'r8uint', 'rgba16uint', 'r16float', 'bgra8unorm-srgb', 'r16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder16.setBindGroup(6, bindGroup0, new Uint32Array(1252), 71, 0);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(8, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(8162, undefined, 3790437605, 446719091);
+} catch {}
+try {
+commandEncoder30.copyBufferToBuffer(buffer1, 658972, buffer6, 312784, 20072);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder29.copyTextureToTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 38, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder13.insertDebugMarker('\u5494');
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer0, /* required buffer size: 537 */
+{offset: 537, rowsPerImage: 223}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 5, height: 1, depthOrArrayLayers: 201}
+*/
+{
+  source: imageBitmap3,
+  origin: { x: 12, y: 67 },
+  flipY: true,
+}, {
+  texture: texture11,
+  mipLevel: 4,
+  origin: {x: 1, y: 0, z: 19},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise10;
+} catch {}
+let video9 = await videoWithData();
+let texture20 = device0.createTexture({
+  label: '\u{1f768}\u8eba\u08ab\u{1fbcc}\u0d95\u05b5\u5766\u{1fcef}\u{1fa4a}\u949f',
+  size: [185, 16, 1],
+  mipLevelCount: 8,
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let renderBundleEncoder18 = device0.createRenderBundleEncoder({label: '\ucf5c\u44bd\u{1f7a6}', colorFormats: ['r8sint', 'rgba32float'], depthReadOnly: true});
+let sampler21 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 65.90,
+  lodMaxClamp: 89.99,
+  maxAnisotropy: 2,
+});
+try {
+buffer5.destroy();
+} catch {}
+try {
+commandEncoder15.resolveQuerySet(querySet13, 12, 18, buffer1, 693248);
+} catch {}
+let pipeline22 = device0.createComputePipeline({
+  label: '\u9553\ue467\u4df7\u89d9\u00f5\u{1fca1}\u3d55\u39dc',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule3, entryPoint: 'compute0', constants: {}},
+});
+let pipeline23 = await device0.createRenderPipelineAsync({
+  label: '\ub09e\u0a3d\u1546\u{1fe2e}\u0948\u0e1b\uf9c0\u0280\u{1ff4e}\u0e2c\u494b',
+  layout: pipelineLayout2,
+  multisample: {count: 4, mask: 0xfb8dba16},
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8sint', writeMask: 0}, {format: 'rgba32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'never', failOp: 'increment-clamp', depthFailOp: 'decrement-clamp', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'greater-equal', failOp: 'zero', depthFailOp: 'increment-clamp', passOp: 'increment-wrap'},
+    stencilReadMask: 1402306185,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1112,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm16x2', offset: 132, shaderLocation: 15},
+          {format: 'snorm8x4', offset: 208, shaderLocation: 0},
+          {format: 'unorm8x2', offset: 170, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 0, attributes: [{format: 'sint8x2', offset: 972, shaderLocation: 13}]},
+    ],
+  },
+  primitive: {topology: 'triangle-list', frontFace: 'ccw', cullMode: 'back'},
+});
+let bindGroupLayout9 = device0.createBindGroupLayout({
+  label: '\u08d6\u86c7\u{1f96e}\u{1fe5e}\u8067\u8cce\u72e5\u0a66',
+  entries: [
+    {
+      binding: 2471,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rg32uint', access: 'write-only', viewDimension: '3d' },
+    },
+    {
+      binding: 3599,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba16uint', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let commandEncoder38 = device0.createCommandEncoder({label: '\u5b30\u479a\uc1c6\u7cb2\u6efd\u1f5d\u{1fc17}\uc26d\u8476\u{1f62b}\u1a5f'});
+let texture21 = device0.createTexture({
+  label: '\u00f9\u{1fda7}\u43a6\u3925\u{1f61e}\u0895\ucf7e',
+  size: {width: 23, height: 2, depthOrArrayLayers: 11},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8unorm', 'rg8unorm', 'rg8unorm'],
+});
+let textureView34 = texture19.createView({label: '\u{1f63b}\u{1f98f}\u3870\u577c\u3330\u{1fcfe}', arrayLayerCount: 1});
+let renderBundle29 = renderBundleEncoder6.finish({label: '\u692f\u6dc6'});
+try {
+renderBundleEncoder18.setPipeline(pipeline3);
+} catch {}
+try {
+querySet13.destroy();
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+});
+} catch {}
+let renderBundleEncoder19 = device0.createRenderBundleEncoder({
+  label: '\u083c\u0484\u390c',
+  colorFormats: ['rgb10a2unorm', 'rgba32uint', 'r8uint', 'rgba16uint', 'r16float', 'bgra8unorm-srgb', 'r16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle30 = renderBundleEncoder3.finish({label: '\u5aea\u12f1\u580c\u0a03\ue1be\ua2e5'});
+try {
+commandEncoder14.copyBufferToBuffer(buffer3, 247440, buffer4, 70044, 31808);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder28.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 520 widthInBlocks: 65 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 41064 */
+  offset: 40544,
+  bytesPerRow: 768,
+  rowsPerImage: 72,
+  buffer: buffer4,
+}, {width: 65, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 4676, new Float32Array(60396), 5607, 1896);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 33_558 */
+{offset: 566, bytesPerRow: 64, rowsPerImage: 103}, {width: 16, height: 1, depthOrArrayLayers: 6});
+} catch {}
+try {
+window.someLabel = renderBundle16.label;
+} catch {}
+let textureView35 = texture5.createView({
+  label: '\u{1fcbb}\u5c9f\u{1fb31}',
+  dimension: '2d',
+  baseMipLevel: 1,
+  mipLevelCount: 3,
+  baseArrayLayer: 70,
+});
+let externalTexture4 = device0.importExternalTexture({
+  label: '\uf1d2\u09b6\u6be7\u8b24\u{1f8ee}\u{1faf9}\uaba7\u00d0\u8955\u0e52\ubd36',
+  source: videoFrame0,
+});
+try {
+renderBundleEncoder5.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(4139, undefined, 4000066380);
+} catch {}
+try {
+commandEncoder30.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 280119 */
+  offset: 20019,
+  bytesPerRow: 256,
+  rowsPerImage: 145,
+  buffer: buffer1,
+}, {
+  texture: texture7,
+  mipLevel: 1,
+  origin: {x: 4, y: 0, z: 1},
+  aspect: 'all',
+}, {width: 4, height: 2, depthOrArrayLayers: 8});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 41576, new BigUint64Array(54320), 53069, 44);
+} catch {}
+let pipeline24 = device0.createRenderPipeline({
+  layout: pipelineLayout1,
+  multisample: {count: 4, mask: 0x1932475d},
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'src-alpha-saturated'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN}, {format: 'rg16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r16uint'}, {format: 'r16uint', writeMask: GPUColorWrite.RED}, {format: 'r8uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'rgba8sint', writeMask: GPUColorWrite.RED}, {format: 'bgra8unorm-srgb'}],
+},
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'not-equal', failOp: 'zero', depthFailOp: 'increment-clamp', passOp: 'invert'},
+    stencilBack: {compare: 'never', failOp: 'replace', depthFailOp: 'replace', passOp: 'zero'},
+    stencilReadMask: 827494108,
+    stencilWriteMask: 3143105607,
+    depthBias: 1788013111,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1096,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 4, shaderLocation: 17},
+          {format: 'unorm16x2', offset: 100, shaderLocation: 4},
+          {format: 'sint32x2', offset: 48, shaderLocation: 1},
+          {format: 'sint16x4', offset: 20, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 1044,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 84, shaderLocation: 9},
+          {format: 'uint8x4', offset: 28, shaderLocation: 13},
+          {format: 'uint32x3', offset: 84, shaderLocation: 6},
+          {format: 'sint8x2', offset: 390, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 2368,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm16x2', offset: 764, shaderLocation: 3},
+          {format: 'float32x2', offset: 64, shaderLocation: 5},
+          {format: 'snorm16x2', offset: 100, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+});
+try {
+canvas6.getContext('webgl');
+} catch {}
+let commandEncoder39 = device0.createCommandEncoder({label: '\u03d9\u0c80\uf2e7\u0f40\u487b\u029a\u0062\u0d1e'});
+let textureView36 = texture15.createView({
+  label: '\u3cfc\u0289\u{1f9ca}\u05db\u0bbf\u146b\u9333\u70b2',
+  dimension: '2d',
+  baseMipLevel: 2,
+  baseArrayLayer: 10,
+});
+let renderBundle31 = renderBundleEncoder13.finish({label: '\ude8f\ud3b9\u02ce\ud519\u{1f742}'});
+let externalTexture5 = device0.importExternalTexture({source: videoFrame0});
+try {
+commandEncoder36.copyTextureToBuffer({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 560 widthInBlocks: 70 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 51912 */
+  offset: 51912,
+  rowsPerImage: 137,
+  buffer: buffer6,
+}, {width: 70, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer6);
+} catch {}
+let textureView37 = texture8.createView({
+  label: '\u7418\u{1fe87}\u6459\u{1f760}\u9ab8\u266c\uba9b\u0ba6\u{1fa71}\u9770',
+  aspect: 'all',
+  baseMipLevel: 0,
+});
+let externalTexture6 = device0.importExternalTexture({source: video0, colorSpace: 'display-p3'});
+try {
+computePassEncoder4.setBindGroup(4, bindGroup1, new Uint32Array(3546), 739, 0);
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline18);
+} catch {}
+try {
+commandEncoder32.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 14},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 3828, new Int16Array(49556), 35197, 3688);
+} catch {}
+try {
+device0.destroy();
+} catch {}
+document.body.prepend(canvas2);
+let canvas7 = document.createElement('canvas');
+let offscreenCanvas6 = new OffscreenCanvas(735, 795);
+try {
+canvas7.getContext('webgpu');
+} catch {}
+canvas1.width = 488;
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let video10 = await videoWithData();
+let canvas8 = document.createElement('canvas');
+let img7 = await imageWithData(186, 187, '#5c80ef9c', '#6fa59486');
+let offscreenCanvas7 = new OffscreenCanvas(226, 986);
+video4.height = 124;
+try {
+adapter1.label = '\u467f\u71be\u6906\u05c8\u6625\u87b9\u060c\u2aa4\uca67\ucd27\ub838';
+} catch {}
+let imageData6 = new ImageData(36, 164);
+let gpuCanvasContext8 = offscreenCanvas6.getContext('webgpu');
+let offscreenCanvas8 = new OffscreenCanvas(135, 315);
+let promise11 = adapter0.requestAdapterInfo();
+document.body.prepend(canvas3);
+try {
+offscreenCanvas8.getContext('2d');
+} catch {}
+canvas5.height = 3251;
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+canvas4.width = 968;
+try {
+  await promise11;
+} catch {}
+let adapter2 = await navigator.gpu.requestAdapter();
+let texture22 = device0.createTexture({
+  label: '\u05f3\u0028\uf18d\u564c\uf515\u087e\u{1f612}\u5db2',
+  size: [80, 1, 191],
+  dimension: '3d',
+  format: 'bgra8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm'],
+});
+let sampler22 = device0.createSampler({
+  label: '\ucaca\u073d\u0542\u0213\ubf6a\u0024\uc7db\u0fa1\uc8a8',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 88.24,
+  lodMaxClamp: 92.84,
+  maxAnisotropy: 8,
+});
+try {
+renderBundleEncoder15.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+commandEncoder14.copyBufferToBuffer(buffer1, 117916, buffer4, 15724, 125132);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder32.copyBufferToTexture({
+  /* bytesInLastRow: 40 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 12496 */
+  offset: 12496,
+  bytesPerRow: 512,
+  buffer: buffer1,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 10, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+offscreenCanvas7.getContext('webgl2');
+} catch {}
+let device1 = await adapter2.requestDevice({
+  label: '\u95e4\u3078\u7744',
+  defaultQueue: {label: '\u4814\u0784'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+  ],
+  requiredLimits: {
+    maxBindGroups: 6,
+    maxColorAttachmentBytesPerSample: 49,
+    maxVertexAttributes: 27,
+    maxVertexBufferArrayStride: 64064,
+    maxStorageTexturesPerShaderStage: 34,
+    maxStorageBuffersPerShaderStage: 31,
+    maxDynamicStorageBuffersPerPipelineLayout: 19253,
+    maxDynamicUniformBuffersPerPipelineLayout: 18815,
+    maxBindingsPerBindGroup: 9943,
+    maxTextureArrayLayers: 891,
+    maxTextureDimension1D: 10876,
+    maxTextureDimension2D: 16324,
+    maxVertexBuffers: 10,
+    maxBindGroupsPlusVertexBuffers: 29,
+    minStorageBufferOffsetAlignment: 128,
+    maxUniformBufferBindingSize: 209118996,
+    maxStorageBufferBindingSize: 255858176,
+    maxUniformBuffersPerShaderStage: 32,
+    maxSampledTexturesPerShaderStage: 31,
+    maxInterStageShaderVariables: 75,
+    maxInterStageShaderComponents: 75,
+    maxSamplersPerShaderStage: 22,
+  },
+});
+let commandEncoder40 = device1.createCommandEncoder({label: '\uff74\ud9a4\ucb2e'});
+let querySet16 = device1.createQuerySet({type: 'occlusion', count: 3703});
+let texture23 = device1.createTexture({
+  label: '\uc7c4\u{1fbf2}\u0c4e\u{1f974}\u{1f8ed}\ud6d4',
+  size: [461, 1, 1037],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+texture23.destroy();
+} catch {}
+canvas6.height = 617;
+let buffer7 = device1.createBuffer({
+  label: '\u10aa\ub9f4\ucb50\u{1f648}\u3d45\u75e3\u0297\u0284\uc1bc',
+  size: 285685,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+});
+let commandEncoder41 = device1.createCommandEncoder({label: '\u7d4e\u{1fdae}\u89f1\ua655\u04cb\u{1fc1c}\u{1fb33}\u0743'});
+let textureView38 = texture23.createView({dimension: '3d'});
+let renderBundleEncoder20 = device1.createRenderBundleEncoder({label: '\u{1fd68}\u3e5b', colorFormats: ['rgba8uint'], depthReadOnly: true});
+let querySet17 = device1.createQuerySet({label: '\ucf3a\u6f7a', type: 'occlusion', count: 387});
+let renderBundleEncoder21 = device1.createRenderBundleEncoder({
+  label: '\u072b\uc056\u08ff\u0ab3\uebe8\ucbf4\u0134\u0862\u{1fabb}',
+  colorFormats: ['rgba8uint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+window.someLabel = textureView13.label;
+} catch {}
+let offscreenCanvas9 = new OffscreenCanvas(393, 174);
+document.body.prepend(img5);
+let commandEncoder42 = device1.createCommandEncoder();
+let texture24 = device1.createTexture({
+  size: {width: 3692},
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint'],
+});
+let textureView39 = texture24.createView({});
+let offscreenCanvas10 = new OffscreenCanvas(428, 1012);
+try {
+renderBundleEncoder20.setVertexBuffer(4232, undefined);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder43 = device1.createCommandEncoder({label: '\u{1ff69}\ue843\u{1fcdf}\u04b7\u3254\u08a6\u05fc\u{1f62b}\u{1ff65}\u4e3f\u0b6c'});
+let textureView40 = texture24.createView({label: '\uf548\u95de'});
+let computePassEncoder17 = commandEncoder43.beginComputePass({label: '\u4923\u{1fe8e}'});
+let sampler23 = device1.createSampler({
+  label: '\u0a9b\u{1fccd}\u{1fe42}\u{1f980}',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 82.52,
+  maxAnisotropy: 16,
+});
+try {
+renderBundleEncoder20.setVertexBuffer(3470, undefined, 1745306669, 823829795);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+let commandEncoder44 = device1.createCommandEncoder({label: '\u{1f693}\u{1f99d}\u8120\u0616'});
+let textureView41 = texture23.createView({label: '\u0c2b\u9b7b\u0b81\u0f02\u7efd\u1176\u050e'});
+let computePassEncoder18 = commandEncoder41.beginComputePass({label: '\ue5bf\u59e5\uf56a\u047d\u0d99'});
+let promise12 = buffer7.mapAsync(GPUMapMode.WRITE, 0, 255920);
+offscreenCanvas9.width = 1492;
+let videoFrame1 = new VideoFrame(offscreenCanvas3, {timestamp: 0});
+let buffer8 = device1.createBuffer({
+  label: '\u{1f7cb}\u{1fd65}\u{1fc82}\u07ea\uf18e\u61a2\u714d\u3b52\u6a90',
+  size: 196915,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder45 = device1.createCommandEncoder({label: '\u7c44\ue855\ubf78\u7c1a\u1249\ua4cb\u0312\u8284\u{1fdc4}'});
+let querySet18 = device1.createQuerySet({label: '\u0616\u{1ff7e}', type: 'occlusion', count: 2662});
+let textureView42 = texture24.createView({});
+let sampler24 = device1.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 42.01,
+});
+try {
+renderBundleEncoder21.setVertexBuffer(1421, undefined);
+} catch {}
+try {
+pipeline21.label = '\u2dee\u{1ffa3}\u{1f668}\u{1fb79}';
+} catch {}
+gc();
+let texture25 = device1.createTexture({
+  label: '\u4835\u1fc1\u4dc9\ud03a\u{1fdc9}\ud48d\u{1fb7f}\u018f\u111a',
+  size: [461],
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint'],
+});
+let textureView43 = texture23.createView({label: '\u{1f62f}\u{1f621}\u5e2f\u7230\uaf47\u064e\u167b\u41ef\u997f'});
+let computePassEncoder19 = commandEncoder40.beginComputePass({label: '\u4b3a\u224b\uf3a4\u{1fcf5}\u01cf'});
+let sampler25 = device1.createSampler({
+  label: '\u{1fc8e}\u0be1\u2c9e\u{1fc81}\u9608\udb1b\u0ebc\u692f\ua57d\u0db8',
+  magFilter: 'nearest',
+  lodMinClamp: 11.66,
+});
+let externalTexture7 = device1.importExternalTexture({label: '\u0329\u0e61\u0c08\u5ba4', source: videoFrame1, colorSpace: 'display-p3'});
+let gpuCanvasContext9 = canvas8.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let adapter3 = await promise0;
+let canvas9 = document.createElement('canvas');
+try {
+  await promise12;
+} catch {}
+let commandEncoder46 = device0.createCommandEncoder({label: '\u{1ff41}\ua8c3\ub545\u{1fbba}\u244f\u0f96\u0e9e\uadc6\u0b1c\ucf7e\u{1fde4}'});
+let texture26 = device0.createTexture({
+  label: '\ub8ab\u{1ff7a}\u{1fa45}\u0e72\ua073\u0515',
+  size: [92, 8, 129],
+  mipLevelCount: 5,
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+commandEncoder30.copyBufferToBuffer(buffer3, 105616, buffer4, 18532, 12088);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+commandEncoder5.copyBufferToTexture({
+  /* bytesInLastRow: 1 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 3807 */
+  offset: 3807,
+  rowsPerImage: 5,
+  buffer: buffer1,
+}, {
+  texture: texture20,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let video11 = await videoWithData();
+let textureView44 = texture25.createView({label: '\u{1fb99}\u0407', dimension: '1d'});
+let externalTexture8 = device1.importExternalTexture({source: video6, colorSpace: 'srgb'});
+let bindGroupLayout10 = device1.createBindGroupLayout({
+  label: '\u2596\u0da8\uf93d\uccc8\uf280\u5312\u0a08\u049c\u00e1',
+  entries: [
+    {
+      binding: 5570,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 1574,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 6711,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', minBindingSize: 176372383, hasDynamicOffset: false },
+    },
+  ],
+});
+let pipelineLayout4 = device1.createPipelineLayout({
+  label: '\u{1f62f}\u0de4\ua50a\u5471\u08ba\ua2db',
+  bindGroupLayouts: [bindGroupLayout10, bindGroupLayout10],
+});
+let querySet19 = device1.createQuerySet({label: '\u0bd8\u0371\u07d3', type: 'occlusion', count: 1939});
+let textureView45 = texture23.createView({label: '\u0b66\u{1fe17}'});
+try {
+renderBundleEncoder21.setVertexBuffer(123, undefined, 992527281, 3077269151);
+} catch {}
+try {
+texture24.destroy();
+} catch {}
+try {
+computePassEncoder17.pushDebugGroup('\u8aba');
+} catch {}
+gc();
+try {
+commandEncoder42.resolveQuerySet(querySet18, 1708, 672, buffer8, 163072);
+} catch {}
+try {
+gpuCanvasContext8.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let videoFrame2 = new VideoFrame(video4, {timestamp: 0});
+let adapter4 = await navigator.gpu.requestAdapter({powerPreference: 'high-performance'});
+let imageBitmap4 = await createImageBitmap(canvas7);
+let video12 = await videoWithData();
+let shaderModule9 = device1.createShaderModule({
+  label: '\u8bd6\u{1f662}\u8033\u4ff3\u224f',
+  code: `@group(0) @binding(1574)
+var<storage, read_write> function13: array<u32>;
+@group(1) @binding(1574)
+var<storage, read_write> n13: array<u32>;
+@group(0) @binding(5570)
+var<storage, read_write> n14: array<u32>;
+@group(1) @binding(5570)
+var<storage, read_write> field16: array<u32>;
+
+@compute @workgroup_size(4, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S9 {
+  @location(16) f0: vec3<u32>,
+  @location(9) f1: vec2<u32>,
+  @location(6) f2: vec2<f16>,
+  @location(73) f3: vec4<f16>,
+  @location(46) f4: vec2<f32>,
+  @location(10) f5: vec2<i32>,
+  @location(27) f6: vec4<f32>,
+  @location(28) f7: i32,
+  @location(39) f8: f16,
+  @location(25) f9: vec2<f16>,
+  @location(14) f10: vec3<f32>,
+  @location(63) f11: vec2<u32>
+}
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(6) f1: vec2<u32>,
+  @location(4) f2: vec4<i32>
+}
+
+@fragment
+fn fragment0(@location(36) a0: vec3<u32>, @location(43) a1: f16, @location(7) a2: vec3<u32>, @location(58) a3: vec2<f16>, @location(52) a4: vec4<f16>, @location(55) a5: vec3<u32>, @location(57) a6: vec3<f16>, @location(74) a7: vec4<i32>, @location(37) a8: i32, a9: S9, @location(19) a10: vec2<f32>, @location(23) a11: vec2<i32>, @location(64) a12: vec4<f32>, @location(4) a13: f16, @location(51) a14: vec3<u32>, @location(2) a15: vec4<u32>, @location(70) a16: vec3<u32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S8 {
+  @builtin(vertex_index) f0: u32,
+  @location(15) f1: i32,
+  @location(22) f2: vec2<f16>,
+  @location(14) f3: vec3<u32>,
+  @location(8) f4: u32,
+  @location(20) f5: f16,
+  @location(13) f6: vec2<i32>,
+  @location(1) f7: vec4<i32>,
+  @location(4) f8: vec2<f32>,
+  @location(24) f9: vec4<i32>,
+  @location(18) f10: u32
+}
+struct VertexOutput0 {
+  @location(28) f117: i32,
+  @location(25) f118: vec2<f16>,
+  @location(57) f119: vec3<f16>,
+  @location(10) f120: vec2<i32>,
+  @location(27) f121: vec4<f32>,
+  @location(51) f122: vec3<u32>,
+  @location(55) f123: vec3<u32>,
+  @location(36) f124: vec3<u32>,
+  @location(74) f125: vec4<i32>,
+  @location(6) f126: vec2<f16>,
+  @location(4) f127: f16,
+  @builtin(position) f128: vec4<f32>,
+  @location(39) f129: f16,
+  @location(58) f130: vec2<f16>,
+  @location(63) f131: vec2<u32>,
+  @location(46) f132: vec2<f32>,
+  @location(56) f133: vec4<f16>,
+  @location(52) f134: vec4<f16>,
+  @location(43) f135: f16,
+  @location(37) f136: i32,
+  @location(14) f137: vec3<f32>,
+  @location(23) f138: vec2<i32>,
+  @location(9) f139: vec2<u32>,
+  @location(7) f140: vec3<u32>,
+  @location(16) f141: vec3<u32>,
+  @location(64) f142: vec4<f32>,
+  @location(19) f143: vec2<f32>,
+  @location(73) f144: vec4<f16>,
+  @location(70) f145: vec3<u32>,
+  @location(2) f146: vec4<u32>
+}
+
+@vertex
+fn vertex0(@location(11) a0: vec4<f32>, @location(16) a1: u32, @location(2) a2: u32, @location(9) a3: vec4<u32>, @location(6) a4: vec2<f16>, @builtin(instance_index) a5: u32, @location(12) a6: vec4<f32>, @location(23) a7: vec3<f32>, @location(7) a8: vec4<f32>, @location(25) a9: vec4<i32>, @location(17) a10: vec4<u32>, @location(26) a11: vec2<u32>, @location(5) a12: vec3<u32>, a13: S8) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+});
+let commandEncoder47 = device1.createCommandEncoder({label: '\u{1fd91}\u0081\u0934\u8125\uc3fc\u857c\u12d2\u{1fc38}'});
+let textureView46 = texture25.createView({label: '\u825e\u0e8b\u2f79\u1440', dimension: '1d'});
+let computePassEncoder20 = commandEncoder47.beginComputePass({label: '\u08dc\u{1f7f3}\u0397'});
+let sampler26 = device1.createSampler({
+  label: '\u0838\u{1fa4f}\u0678\u61f2\u027d',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 47.64,
+  lodMaxClamp: 61.15,
+  maxAnisotropy: 17,
+});
+try {
+computePassEncoder17.insertDebugMarker('\u14b4');
+} catch {}
+let bindGroupLayout11 = device1.createBindGroupLayout({
+  entries: [
+    {
+      binding: 6834,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32uint', access: 'write-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 7394,
+      visibility: 0,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 8535,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube-array', sampleType: 'unfilterable-float', multisampled: false },
+    },
+  ],
+});
+let commandBuffer7 = commandEncoder45.finish({label: '\u8d2d\u67d3'});
+let pipeline25 = await device1.createComputePipelineAsync({
+  label: '\ub7df\ucc4e\u0b24\u61d0\u53e5\u8ec1\u954f\u8096\u0236\u0765',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+let imageData7 = new ImageData(16, 252);
+let imageData8 = new ImageData(148, 188);
+let commandEncoder48 = device1.createCommandEncoder({label: '\uc313\uef72\ua2f1\u{1f98e}'});
+let commandBuffer8 = commandEncoder48.finish({label: '\u9813\u{1fea4}\uf958\u157d\u49ad\u5971'});
+let texture27 = device1.createTexture({
+  label: '\ub9c0\uc0d6\u6839\u{1fa37}\u0f0f',
+  size: {width: 1846, height: 3, depthOrArrayLayers: 614},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16sint', 'rgba16sint', 'rgba16sint'],
+});
+let textureView47 = texture24.createView({
+  label: '\u6d67\u{1f772}\u6144\u0329\u{1f6e3}\u{1f921}\u{1fa59}\u9d22\uf2f8\u{1fd31}\u81b8',
+  baseMipLevel: 0,
+});
+let sampler27 = device1.createSampler({
+  label: '\u0c74\u5c26',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'clamp-to-edge',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 12.84,
+  lodMaxClamp: 20.84,
+});
+try {
+commandEncoder42.resolveQuerySet(querySet18, 203, 2180, buffer8, 109824);
+} catch {}
+let pipeline26 = device1.createComputePipeline({
+  label: '\ucb2b\u7fe0\ua9c5\ub4e5\u0a6d\u1b94\u1cf6',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+let pipeline27 = await device1.createRenderPipelineAsync({
+  label: '\u4d4e\u012c\u{1fefa}\u{1f9c2}\uf946\u0418\uee1f\u08de\u{1fecc}\u5e15',
+  layout: pipelineLayout4,
+  fragment: {module: shaderModule9, entryPoint: 'fragment0', targets: [{format: 'rgba8uint'}]},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 4100,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint8x4', offset: 64, shaderLocation: 17},
+          {format: 'unorm16x2', offset: 1072, shaderLocation: 6},
+          {format: 'uint32x2', offset: 808, shaderLocation: 14},
+          {format: 'uint16x4', offset: 468, shaderLocation: 18},
+          {format: 'snorm8x4', offset: 24, shaderLocation: 11},
+          {format: 'sint8x2', offset: 728, shaderLocation: 1},
+          {format: 'snorm16x4', offset: 632, shaderLocation: 22},
+          {format: 'sint32x3', offset: 36, shaderLocation: 25},
+          {format: 'snorm8x2', offset: 108, shaderLocation: 23},
+          {format: 'uint32x3', offset: 536, shaderLocation: 9},
+          {format: 'uint8x2', offset: 346, shaderLocation: 5},
+          {format: 'uint32', offset: 724, shaderLocation: 16},
+          {format: 'sint32x3', offset: 288, shaderLocation: 15},
+        ],
+      },
+      {
+        arrayStride: 748,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 92, shaderLocation: 8},
+          {format: 'uint8x2', offset: 0, shaderLocation: 26},
+          {format: 'unorm8x2', offset: 4, shaderLocation: 20},
+          {format: 'snorm16x2', offset: 28, shaderLocation: 12},
+          {format: 'float32x4', offset: 120, shaderLocation: 4},
+          {format: 'float32x3', offset: 80, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 2396,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 504, shaderLocation: 2},
+          {format: 'sint32x4', offset: 160, shaderLocation: 24},
+          {format: 'sint32x3', offset: 140, shaderLocation: 13},
+        ],
+      },
+    ],
+  },
+});
+let offscreenCanvas11 = new OffscreenCanvas(647, 58);
+let buffer9 = device1.createBuffer({
+  label: '\u{1f67d}\u0bec\u{1f82d}\u831e',
+  size: 57471,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT,
+});
+let arrayBuffer4 = buffer7.getMappedRange(0, 176436);
+try {
+commandEncoder44.resolveQuerySet(querySet16, 1732, 238, buffer8, 129280);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer9, 39136, new DataView(new ArrayBuffer(14080)), 3676, 1044);
+} catch {}
+let querySet20 = device1.createQuerySet({label: '\u0d18\u8970\u0b29\u{1fe43}\u5d10\u8659\u{1fc54}', type: 'occlusion', count: 3981});
+let textureView48 = texture25.createView({label: '\u0a8b\u9add', arrayLayerCount: 1});
+let renderBundle32 = renderBundleEncoder21.finish({label: '\u799b\u3fd6\ueebb\u92f4\u{1fc37}\u0edd\u0739\u2a76'});
+try {
+renderBundleEncoder20.setIndexBuffer(buffer9, 'uint16', 26240, 21194);
+} catch {}
+try {
+commandEncoder44.copyBufferToBuffer(buffer7, 216860, buffer9, 55184, 24);
+dissociateBuffer(device1, buffer7);
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+commandEncoder44.insertDebugMarker('\ua89f');
+} catch {}
+try {
+device1.queue.writeBuffer(buffer9, 21604, new Float32Array(17868), 9139, 408);
+} catch {}
+let pipeline28 = await device1.createComputePipelineAsync({
+  label: '\u0823\uebd8\u0722\u055b\u7d8c\u1942\u0972',
+  layout: pipelineLayout4,
+  compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}},
+});
+let pipeline29 = device1.createRenderPipeline({
+  label: '\u5e0d\u0f1b',
+  layout: pipelineLayout4,
+  multisample: {},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'never',
+    stencilFront: {compare: 'always', failOp: 'decrement-wrap', depthFailOp: 'replace', passOp: 'increment-wrap'},
+    stencilBack: {compare: 'greater-equal', failOp: 'increment-clamp', passOp: 'decrement-wrap'},
+    stencilReadMask: 3295982163,
+    stencilWriteMask: 179005206,
+    depthBiasSlopeScale: 68.39413456935816,
+  },
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x4', offset: 1504, shaderLocation: 17},
+          {format: 'float32', offset: 21172, shaderLocation: 23},
+          {format: 'uint32x4', offset: 11756, shaderLocation: 18},
+          {format: 'unorm16x4', offset: 17716, shaderLocation: 12},
+          {format: 'float32x3', offset: 3780, shaderLocation: 11},
+          {format: 'sint16x2', offset: 2464, shaderLocation: 24},
+        ],
+      },
+      {
+        arrayStride: 20188,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 3400, shaderLocation: 16},
+          {format: 'float32', offset: 1920, shaderLocation: 4},
+        ],
+      },
+      {
+        arrayStride: 14564,
+        attributes: [
+          {format: 'snorm16x2', offset: 1168, shaderLocation: 20},
+          {format: 'sint16x2', offset: 4344, shaderLocation: 15},
+          {format: 'uint32', offset: 3848, shaderLocation: 5},
+          {format: 'uint32x4', offset: 2280, shaderLocation: 26},
+          {format: 'uint32x2', offset: 2436, shaderLocation: 8},
+          {format: 'sint8x2', offset: 1790, shaderLocation: 1},
+          {format: 'uint32x3', offset: 4904, shaderLocation: 9},
+          {format: 'uint8x4', offset: 2036, shaderLocation: 14},
+          {format: 'uint16x2', offset: 1840, shaderLocation: 2},
+          {format: 'sint32', offset: 1780, shaderLocation: 25},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 23672, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 680, shaderLocation: 7},
+          {format: 'unorm16x4', offset: 2868, shaderLocation: 6},
+          {format: 'unorm8x4', offset: 18644, shaderLocation: 22},
+        ],
+      },
+    ],
+  },
+});
+let gpuCanvasContext10 = offscreenCanvas10.getContext('webgpu');
+let texture28 = device1.createTexture({
+  label: '\u5a2f\u239f\u{1f729}\u062e\u0e55\u04b2\u09f8',
+  size: {width: 923},
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderBundleEncoder22 = device1.createRenderBundleEncoder({label: '\u{1fe9f}\u08ee\u195e\u{1f8c0}', colorFormats: ['rgba8uint'], depthReadOnly: true});
+try {
+renderBundleEncoder22.setVertexBuffer(8845, undefined, 0);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+}, new BigInt64Array(arrayBuffer4), /* required buffer size: 379 */
+{offset: 379}, {width: 310, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline30 = await device1.createRenderPipelineAsync({
+  label: '\u4163\u27fc\u0163\u{1f6d1}\u{1ff3d}',
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 9972,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 2484, shaderLocation: 15},
+          {format: 'snorm8x4', offset: 2436, shaderLocation: 4},
+          {format: 'unorm8x2', offset: 4448, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 1040, shaderLocation: 6},
+          {format: 'uint32x3', offset: 7056, shaderLocation: 26},
+          {format: 'snorm8x2', offset: 668, shaderLocation: 12},
+          {format: 'snorm16x2', offset: 5248, shaderLocation: 20},
+          {format: 'sint32x3', offset: 2084, shaderLocation: 24},
+          {format: 'sint32x2', offset: 2736, shaderLocation: 25},
+          {format: 'unorm16x4', offset: 344, shaderLocation: 23},
+          {format: 'uint16x2', offset: 2824, shaderLocation: 14},
+          {format: 'sint8x2', offset: 922, shaderLocation: 1},
+          {format: 'snorm8x4', offset: 688, shaderLocation: 22},
+          {format: 'uint32x4', offset: 480, shaderLocation: 16},
+          {format: 'uint32x4', offset: 1652, shaderLocation: 18},
+          {format: 'uint32x4', offset: 2356, shaderLocation: 2},
+          {format: 'uint32x4', offset: 4932, shaderLocation: 9},
+          {format: 'sint8x2', offset: 1458, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 564, attributes: [{format: 'uint32x3', offset: 40, shaderLocation: 5}]},
+      {
+        arrayStride: 5844,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 4, shaderLocation: 7},
+          {format: 'uint32x3', offset: 1184, shaderLocation: 8},
+        ],
+      },
+      {arrayStride: 10168, stepMode: 'instance', attributes: []},
+      {arrayStride: 5104, attributes: []},
+      {arrayStride: 29576, stepMode: 'instance', attributes: []},
+      {arrayStride: 6764, attributes: []},
+      {arrayStride: 9040, stepMode: 'instance', attributes: []},
+      {arrayStride: 3452, attributes: []},
+      {
+        arrayStride: 15448,
+        stepMode: 'instance',
+        attributes: [{format: 'uint32x2', offset: 480, shaderLocation: 17}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', cullMode: 'back', unclippedDepth: true},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let offscreenCanvas12 = new OffscreenCanvas(973, 226);
+try {
+canvas9.getContext('webgl2');
+} catch {}
+let computePassEncoder21 = commandEncoder42.beginComputePass({label: '\u03bd\u0cba\u0f6b\u{1f708}\u15ad\ud642\ub52e\u0022\u2b79\u0544\u7c3c'});
+let renderBundle33 = renderBundleEncoder21.finish({});
+let externalTexture9 = device1.importExternalTexture({label: '\u{1fd2b}\ufd17\u7c75\u02ac', source: videoFrame2, colorSpace: 'srgb'});
+try {
+computePassEncoder17.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline30);
+} catch {}
+try {
+computePassEncoder17.pushDebugGroup('\u5424');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let imageData9 = new ImageData(208, 220);
+canvas5.height = 696;
+gc();
+let offscreenCanvas13 = new OffscreenCanvas(845, 837);
+offscreenCanvas3.width = 573;
+let bindGroupLayout12 = device1.createBindGroupLayout({label: '\u4a0b\u{1ffa7}\u{1fefb}\u{1f71f}\u0460\u0372\u0900\u0ec3\u0f7a', entries: []});
+let commandEncoder49 = device1.createCommandEncoder({label: '\u0acd\u{1fd78}\u59e2\ue8f1\u0711\ua1b9'});
+let textureView49 = texture27.createView({label: '\u{1f918}\u0a32', baseMipLevel: 3, mipLevelCount: 1});
+let externalTexture10 = device1.importExternalTexture({label: '\u2210\ub688\uebfd', source: video9, colorSpace: 'srgb'});
+try {
+computePassEncoder17.setPipeline(pipeline26);
+} catch {}
+let pipeline31 = await device1.createComputePipelineAsync({layout: pipelineLayout4, compute: {module: shaderModule9, entryPoint: 'compute0', constants: {}}});
+offscreenCanvas13.width = 279;
+let commandEncoder50 = device1.createCommandEncoder({label: '\ubd51\u4317'});
+try {
+renderBundleEncoder22.setIndexBuffer(buffer9, 'uint16', 23086, 452);
+} catch {}
+try {
+renderBundleEncoder20.setPipeline(pipeline30);
+} catch {}
+try {
+commandEncoder50.copyBufferToTexture({
+  /* bytesInLastRow: 776 widthInBlocks: 194 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 27448 */
+  offset: 27448,
+  buffer: buffer7,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 20, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 194, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+  await device1.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline32 = device1.createRenderPipeline({
+  label: '\uaf07\ud25f\u6868\u{1fa37}\u09bb\u982f\udab0\u{1f67f}\u02e0\u8f65\ue2ee',
+  layout: 'auto',
+  multisample: {count: 4, mask: 0xb476626d},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 28516,
+        attributes: [
+          {format: 'uint32x2', offset: 2452, shaderLocation: 26},
+          {format: 'float32x3', offset: 4748, shaderLocation: 11},
+          {format: 'snorm16x2', offset: 3804, shaderLocation: 23},
+          {format: 'uint16x4', offset: 9076, shaderLocation: 9},
+          {format: 'uint16x4', offset: 1024, shaderLocation: 16},
+          {format: 'float32x4', offset: 7500, shaderLocation: 4},
+          {format: 'sint16x2', offset: 1948, shaderLocation: 25},
+        ],
+      },
+      {
+        arrayStride: 64064,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 26920, shaderLocation: 5},
+          {format: 'uint8x2', offset: 11780, shaderLocation: 2},
+          {format: 'uint32x4', offset: 18456, shaderLocation: 14},
+          {format: 'uint8x2', offset: 17098, shaderLocation: 8},
+          {format: 'uint32x3', offset: 1872, shaderLocation: 18},
+          {format: 'sint8x4', offset: 47672, shaderLocation: 24},
+          {format: 'sint32x2', offset: 19856, shaderLocation: 13},
+          {format: 'unorm10-10-10-2', offset: 5724, shaderLocation: 7},
+          {format: 'sint32x4', offset: 3256, shaderLocation: 15},
+          {format: 'unorm10-10-10-2', offset: 6532, shaderLocation: 22},
+        ],
+      },
+      {
+        arrayStride: 11828,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 2504, shaderLocation: 17},
+          {format: 'float32', offset: 4808, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 4012,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm10-10-10-2', offset: 2264, shaderLocation: 6},
+          {format: 'float16x2', offset: 404, shaderLocation: 20},
+          {format: 'sint8x4', offset: 940, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', cullMode: 'none', unclippedDepth: true},
+});
+let bindGroupLayout13 = device0.createBindGroupLayout({
+  label: '\u{1fd25}\u{1fc8a}\u{1f6d7}\u{1f62b}\u10bf\u7bdc\u0f0b',
+  entries: [
+    {
+      binding: 118,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 2213,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {binding: 3324, visibility: 0, externalTexture: {}},
+  ],
+});
+let commandBuffer9 = commandEncoder31.finish({label: '\u617e\u4b2a\u5f18\uacc8\u{1fd7e}\u050f\u62f5'});
+let textureView50 = texture18.createView({label: '\ucfde\u080f\u73ff\u{1f9cf}\u{1f71b}\ue54a\u{1f8f0}\u{1fc66}\u012b\u4f69'});
+try {
+commandEncoder28.copyBufferToBuffer(buffer1, 282860, buffer4, 87372, 60916);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer4);
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img7);
+gc();
+let video13 = await videoWithData();
+let shaderModule10 = device1.createShaderModule({
+  code: `@group(0) @binding(5570)
+var<storage, read_write> field17: array<u32>;
+@group(1) @binding(1574)
+var<storage, read_write> local16: array<u32>;
+
+@compute @workgroup_size(7, 2, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @builtin(sample_mask) a1: u32, @builtin(sample_index) a2: u32) -> @location(200) vec4<u32> {
+return vec4<u32>();
+}
+
+
+
+@vertex
+fn vertex0(@location(9) a0: vec4<f32>, @location(16) a1: vec4<i32>, @location(2) a2: f16, @location(11) a3: f32, @location(8) a4: f16, @location(15) a5: i32, @location(25) a6: f16, @location(0) a7: vec2<u32>, @location(18) a8: vec3<f32>, @location(23) a9: vec2<i32>, @location(17) a10: vec2<u32>, @location(5) a11: vec2<u32>, @location(20) a12: vec2<i32>, @location(26) a13: vec2<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+});
+let bindGroupLayout14 = pipeline28.getBindGroupLayout(1);
+let pipelineLayout5 = device1.createPipelineLayout({bindGroupLayouts: []});
+let commandEncoder51 = device1.createCommandEncoder({label: '\ue8db\u1e99\u{1fb4c}\u0dec'});
+let texture29 = device1.createTexture({
+  label: '\u5fc2\u0177\u0661\ucb19\u0e68\u0790\u4fcc\u{1fe61}\u2604\u45d6\u04f1',
+  size: {width: 3692, height: 6, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint'],
+});
+let texture30 = gpuCanvasContext3.getCurrentTexture();
+let textureView51 = texture29.createView({label: '\u16c1\u{1f8b6}\u0d43\u05d3\u856a\u02f0', dimension: '2d', baseArrayLayer: 0});
+try {
+device1.queue.writeBuffer(buffer9, 684, new Int16Array(42881), 21804, 1684);
+} catch {}
+document.body.prepend(video13);
+let video14 = await videoWithData();
+try {
+offscreenCanvas9.getContext('2d');
+} catch {}
+let commandEncoder52 = device1.createCommandEncoder({label: '\uee5f\ud9de\u02b2\u0cc2'});
+let textureView52 = texture28.createView({label: '\u{1fb5e}\ua04b\u3bdc', dimension: '1d', baseMipLevel: 0, mipLevelCount: 1});
+try {
+commandEncoder44.copyBufferToTexture({
+  /* bytesInLastRow: 11252 widthInBlocks: 2813 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 34384 */
+  offset: 604,
+  bytesPerRow: 11264,
+  buffer: buffer7,
+}, {
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 63, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 2813, height: 3, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder44.copyTextureToBuffer({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 78, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 1328 widthInBlocks: 332 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 17228 */
+  offset: 17228,
+  buffer: buffer9,
+}, {width: 332, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+commandEncoder51.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 1,
+  origin: {x: 295, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture29,
+  mipLevel: 1,
+  origin: {x: 1153, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 60, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline33 = await device1.createRenderPipelineAsync({
+  label: '\u768c\uc970\uf988\u0f0b',
+  layout: 'auto',
+  multisample: {},
+  fragment: {module: shaderModule9, entryPoint: 'fragment0', targets: [{format: 'rgba8uint', writeMask: 0}]},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 1400, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 7640,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'unorm8x4', offset: 2604, shaderLocation: 23},
+          {format: 'uint32x3', offset: 2380, shaderLocation: 2},
+          {format: 'unorm8x4', offset: 712, shaderLocation: 20},
+          {format: 'sint16x2', offset: 1004, shaderLocation: 15},
+          {format: 'sint32x3', offset: 480, shaderLocation: 13},
+          {format: 'uint8x4', offset: 1916, shaderLocation: 14},
+          {format: 'uint32x3', offset: 1992, shaderLocation: 5},
+          {format: 'unorm8x2', offset: 1780, shaderLocation: 12},
+          {format: 'float32x2', offset: 3016, shaderLocation: 6},
+          {format: 'uint32', offset: 3736, shaderLocation: 16},
+          {format: 'float32x4', offset: 1916, shaderLocation: 7},
+        ],
+      },
+      {
+        arrayStride: 2556,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint8x4', offset: 348, shaderLocation: 17},
+          {format: 'snorm16x2', offset: 80, shaderLocation: 4},
+          {format: 'sint32x4', offset: 52, shaderLocation: 24},
+          {format: 'uint32x3', offset: 516, shaderLocation: 18},
+          {format: 'sint16x4', offset: 268, shaderLocation: 1},
+          {format: 'snorm8x2', offset: 820, shaderLocation: 22},
+          {format: 'uint32x3', offset: 988, shaderLocation: 8},
+          {format: 'uint8x2', offset: 370, shaderLocation: 26},
+        ],
+      },
+      {
+        arrayStride: 10488,
+        attributes: [
+          {format: 'uint32', offset: 2640, shaderLocation: 9},
+          {format: 'unorm8x2', offset: 256, shaderLocation: 11},
+          {format: 'sint16x2', offset: 1464, shaderLocation: 25},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', unclippedDepth: true},
+});
+let imageData10 = new ImageData(112, 44);
+try {
+offscreenCanvas11.getContext('bitmaprenderer');
+} catch {}
+let buffer10 = device1.createBuffer({
+  label: '\u{1f71f}\u{1fe3a}\u{1fbd6}\u59c1\u16b4',
+  size: 51528,
+  usage: GPUBufferUsage.MAP_WRITE,
+  mappedAtCreation: true,
+});
+let commandEncoder53 = device1.createCommandEncoder({label: '\u503d\u667f\uc14d\u4e36\u069e\u9631'});
+let computePassEncoder22 = commandEncoder51.beginComputePass({});
+let renderBundle34 = renderBundleEncoder21.finish({label: '\uf17a\ud047\u83a6'});
+try {
+computePassEncoder18.end();
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline26);
+} catch {}
+try {
+renderBundleEncoder22.setIndexBuffer(buffer9, 'uint32', 25224);
+} catch {}
+try {
+renderBundleEncoder22.setPipeline(pipeline30);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+try {
+commandEncoder49.copyTextureToTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 159, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture29,
+  mipLevel: 1,
+  origin: {x: 124, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 169, height: 2, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder53.clearBuffer(buffer9, 53976, 1436);
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+window.someLabel = externalTexture9.label;
+} catch {}
+let commandEncoder54 = device1.createCommandEncoder({label: '\u0231\u{1feb3}\u005f\u043a\u8295\u6132'});
+let textureView53 = texture29.createView({dimension: '2d-array', baseArrayLayer: 0});
+let renderBundle35 = renderBundleEncoder20.finish({});
+try {
+commandEncoder50.copyBufferToTexture({
+  /* bytesInLastRow: 912 widthInBlocks: 228 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8328 */
+  offset: 8328,
+  buffer: buffer7,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 31, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 228, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder54.clearBuffer(buffer9, 32364, 13352);
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer9, 10880, new DataView(new ArrayBuffer(31791)), 24419, 3320);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 472, y: 5, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(56), /* required buffer size: 15 */
+{offset: 15}, {width: 701, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let texture31 = device1.createTexture({
+  size: [923, 1, 1],
+  mipLevelCount: 7,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint', 'rgba8uint'],
+});
+let externalTexture11 = device1.importExternalTexture({
+  label: '\u0041\u0721\u2d70\u0c39\ufa2c\u3f69\u{1fc4c}\u{1fddf}\u{1f7cd}\u{1fc62}\u06a3',
+  source: video7,
+  colorSpace: 'display-p3',
+});
+try {
+commandEncoder52.clearBuffer(buffer9, 47308, 6036);
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+computePassEncoder17.popDebugGroup();
+} catch {}
+let texture32 = device1.createTexture({
+  label: '\u035b\u52de\u0332\u03a9\u{1fb2d}\ua12d',
+  size: [461, 1, 1],
+  mipLevelCount: 4,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8uint'],
+});
+let renderBundle36 = renderBundleEncoder22.finish();
+try {
+device1.pushErrorScope('internal');
+} catch {}
+try {
+commandEncoder53.resolveQuerySet(querySet16, 3017, 384, buffer8, 75008);
+} catch {}
+let pipeline34 = await device1.createRenderPipelineAsync({
+  label: '\u020e\u0045\u0e0a\u{1f7e8}\u1ac5\u1131\u9439\ua469\u{1fe46}',
+  layout: pipelineLayout4,
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 6620,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm8x2', offset: 108, shaderLocation: 20},
+          {format: 'uint32x4', offset: 544, shaderLocation: 14},
+          {format: 'uint16x2', offset: 3816, shaderLocation: 2},
+          {format: 'unorm16x4', offset: 48, shaderLocation: 12},
+          {format: 'sint8x2', offset: 3410, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 96, shaderLocation: 7},
+          {format: 'uint16x2', offset: 0, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 1840,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 452, shaderLocation: 26},
+          {format: 'uint32x4', offset: 32, shaderLocation: 5},
+          {format: 'unorm16x4', offset: 68, shaderLocation: 22},
+          {format: 'float32', offset: 20, shaderLocation: 11},
+          {format: 'sint16x4', offset: 360, shaderLocation: 15},
+          {format: 'uint8x2', offset: 602, shaderLocation: 18},
+          {format: 'sint32x4', offset: 140, shaderLocation: 25},
+          {format: 'sint16x2', offset: 232, shaderLocation: 1},
+          {format: 'float32x4', offset: 1136, shaderLocation: 4},
+          {format: 'unorm10-10-10-2', offset: 72, shaderLocation: 6},
+          {format: 'sint32', offset: 112, shaderLocation: 24},
+          {format: 'uint32x3', offset: 48, shaderLocation: 9},
+        ],
+      },
+      {
+        arrayStride: 32660,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x2', offset: 3336, shaderLocation: 23}],
+      },
+      {arrayStride: 2440, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 5744,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'uint32x2', offset: 68, shaderLocation: 16},
+          {format: 'uint32x3', offset: 440, shaderLocation: 17},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+let gpuCanvasContext11 = offscreenCanvas12.getContext('webgpu');
+gc();
+let offscreenCanvas14 = new OffscreenCanvas(897, 735);
+let imageBitmap5 = await createImageBitmap(imageData7);
+let gpuCanvasContext12 = offscreenCanvas14.getContext('webgpu');
+let bindGroupLayout15 = device1.createBindGroupLayout({
+  label: '\u0bca\ud596\u07a0\u{1fcf2}\u{1f85c}\uf037\ua9e2',
+  entries: [{binding: 546, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}}],
+});
+let textureView54 = texture25.createView({label: '\u0ed5\u21fb\u0a33\u0323\u{1f86c}\u{1f6bf}\ufed8\u0594\uea3f'});
+let computePassEncoder23 = commandEncoder49.beginComputePass({label: '\u0a5c\u{1f74a}\u03d3\u{1fa24}\u{1fea8}\u529e\u{1fb21}\u{1fe09}\u00da\uf26d\u0666'});
+let externalTexture12 = device1.importExternalTexture({source: videoFrame0, colorSpace: 'display-p3'});
+try {
+commandEncoder52.copyBufferToBuffer(buffer7, 21180, buffer9, 44216, 1048);
+dissociateBuffer(device1, buffer7);
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+commandEncoder44.resolveQuerySet(querySet20, 2590, 1297, buffer8, 170496);
+} catch {}
+let pipeline35 = await device1.createComputePipelineAsync({
+  label: '\u087a\u03fa\u88d8\u{1f97a}\u0d19\u{1faab}\uaabb',
+  layout: pipelineLayout5,
+  compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}},
+});
+let pipeline36 = await device1.createRenderPipelineAsync({
+  label: '\u{1f9f6}\ua998\u0dfa\u8bca',
+  layout: pipelineLayout4,
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}],
+},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 20604,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 2048, shaderLocation: 7},
+          {format: 'sint16x2', offset: 5196, shaderLocation: 13},
+          {format: 'uint32x2', offset: 660, shaderLocation: 8},
+          {format: 'uint32', offset: 536, shaderLocation: 2},
+          {format: 'uint32', offset: 2624, shaderLocation: 9},
+          {format: 'sint8x4', offset: 0, shaderLocation: 15},
+          {format: 'sint8x4', offset: 1728, shaderLocation: 1},
+          {format: 'sint16x2', offset: 964, shaderLocation: 25},
+          {format: 'float32x4', offset: 4892, shaderLocation: 6},
+          {format: 'unorm16x2', offset: 8032, shaderLocation: 12},
+          {format: 'uint32x2', offset: 7136, shaderLocation: 5},
+          {format: 'unorm8x2', offset: 780, shaderLocation: 23},
+          {format: 'unorm8x4', offset: 4980, shaderLocation: 4},
+          {format: 'uint16x4', offset: 4244, shaderLocation: 18},
+          {format: 'snorm8x4', offset: 4632, shaderLocation: 11},
+          {format: 'uint32x2', offset: 596, shaderLocation: 14},
+          {format: 'uint32x4', offset: 7252, shaderLocation: 17},
+          {format: 'uint8x2', offset: 1422, shaderLocation: 16},
+          {format: 'snorm8x2', offset: 4218, shaderLocation: 22},
+        ],
+      },
+      {arrayStride: 10396, attributes: [{format: 'sint8x2', offset: 2682, shaderLocation: 24}]},
+      {
+        arrayStride: 48392,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 8140, shaderLocation: 26},
+          {format: 'float16x2', offset: 12276, shaderLocation: 20},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-list', cullMode: 'front', unclippedDepth: true},
+});
+video7.height = 258;
+let videoFrame3 = new VideoFrame(offscreenCanvas3, {timestamp: 0});
+let video15 = await videoWithData();
+let imageData11 = new ImageData(12, 160);
+let querySet21 = device1.createQuerySet({
+  label: '\u{1f794}\u5a7b\uc0ba\ub0d2\u{1fd2e}\u{1f994}\uced7\u09f6\u0882\uf729\u{1fa95}',
+  type: 'occlusion',
+  count: 2446,
+});
+let texture33 = device1.createTexture({
+  label: '\u30b2\u0e39\u91b5\u260d\u{1f82b}\u{1f983}',
+  size: [1846, 3, 1],
+  mipLevelCount: 10,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+commandEncoder54.copyBufferToTexture({
+  /* bytesInLastRow: 204 widthInBlocks: 51 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1180 */
+  offset: 976,
+  buffer: buffer7,
+}, {
+  texture: texture33,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 51, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+device1.destroy();
+} catch {}
+let offscreenCanvas15 = new OffscreenCanvas(110, 71);
+gc();
+let video16 = await videoWithData();
+let commandEncoder55 = device0.createCommandEncoder({label: '\u957a\u{1fb3e}\u933c\u8f00\u858f\u7ced\u0097\u{1f876}'});
+let querySet22 = device0.createQuerySet({
+  label: '\u{1f7a2}\ud55d\u8164\u{1fa23}\u0eb6\u1bcf\u0cba\uec5a\u8668\u{1fa6d}',
+  type: 'occlusion',
+  count: 3002,
+});
+let texture34 = device0.createTexture({
+  label: '\u50bf\uea30\u0c61',
+  size: [46, 4, 20],
+  mipLevelCount: 3,
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16float', 'r16float', 'r16float'],
+});
+let textureView55 = texture9.createView({label: '\u0613\u{1f75f}\u0c99'});
+let sampler28 = device0.createSampler({
+  label: '\uc9bb\u{1fa04}\u07bf\uda06\ud7de\u{1fdba}',
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 98.62,
+});
+try {
+computePassEncoder15.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder18.setVertexBuffer(3112, undefined, 3018689253, 1219898432);
+} catch {}
+let arrayBuffer5 = buffer3.getMappedRange(201880, 17320);
+try {
+commandEncoder27.clearBuffer(buffer4, 660, 45396);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let pipeline37 = device0.createComputePipeline({
+  label: '\u8228\u968f\u0e5d\u747f\u00c0\ub91f\u{1f651}',
+  layout: pipelineLayout0,
+  compute: {module: shaderModule4, entryPoint: 'compute0'},
+});
+let gpuCanvasContext13 = offscreenCanvas15.getContext('webgpu');
+let imageBitmap6 = await createImageBitmap(canvas3);
+let offscreenCanvas16 = new OffscreenCanvas(503, 1012);
+let imageData12 = new ImageData(72, 176);
+offscreenCanvas0.width = 106;
+try {
+offscreenCanvas16.getContext('webgpu');
+} catch {}
+document.body.prepend(img6);
+try {
+offscreenCanvas13.getContext('webgpu');
+} catch {}
+video13.width = 43;
+let canvas10 = document.createElement('canvas');
+let videoFrame4 = new VideoFrame(video3, {timestamp: 0});
+let img8 = await imageWithData(96, 101, '#b034a95e', '#aa1a9341');
+gc();
+let querySet23 = device0.createQuerySet({label: '\u0021\u{1fd18}\u829d\u0a01\u7693\u{1feab}\u42e5\u30f1\uafa7', type: 'occlusion', count: 2131});
+let commandBuffer10 = commandEncoder16.finish({label: '\u{1fe97}\u0f78\u{1f78c}\ue88f\u0d44'});
+let textureView56 = texture8.createView({});
+try {
+renderBundleEncoder19.setBindGroup(7, bindGroup1);
+} catch {}
+let promise13 = buffer4.mapAsync(GPUMapMode.READ, 0, 133728);
+let pipeline38 = device0.createComputePipeline({
+  label: '\ua8b1\u{1f7d6}\u9e26\u1cae\u864f',
+  layout: pipelineLayout1,
+  compute: {module: shaderModule5, entryPoint: 'compute0'},
+});
+try {
+  await promise13;
+} catch {}
+let videoFrame5 = new VideoFrame(offscreenCanvas0, {timestamp: 0});
+let img9 = await imageWithData(2, 95, '#c6b76750', '#517262fe');
+let imageBitmap7 = await createImageBitmap(imageBitmap6);
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+let offscreenCanvas17 = new OffscreenCanvas(140, 1024);
+let img10 = await imageWithData(203, 262, '#cd65485a', '#09c7fabe');
+let imageBitmap8 = await createImageBitmap(offscreenCanvas7);
+let gpuCanvasContext14 = offscreenCanvas17.getContext('webgpu');
+try {
+canvas10.getContext('webgl2');
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let canvas11 = document.createElement('canvas');
+let imageData13 = new ImageData(120, 152);
+let bindGroupLayout16 = pipeline26.getBindGroupLayout(0);
+let commandEncoder56 = device1.createCommandEncoder({label: '\ucb49\u42d9\ud56e\ue869\ue67a\u0d11'});
+let sampler29 = device1.createSampler({mipmapFilter: 'nearest', lodMinClamp: 22.47, lodMaxClamp: 29.23, compare: 'not-equal'});
+let externalTexture13 = device1.importExternalTexture({label: '\u39e5\u{1fb41}\u{1f9e4}\u{1fe68}', source: video0, colorSpace: 'display-p3'});
+try {
+commandEncoder41.copyBufferToBuffer(buffer7, 138600, buffer9, 29492, 9196);
+dissociateBuffer(device1, buffer7);
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+commandEncoder56.copyTextureToBuffer({
+  texture: texture33,
+  mipLevel: 3,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 120 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 26916 */
+  offset: 26916,
+  buffer: buffer9,
+}, {width: 30, height: 1, depthOrArrayLayers: 0});
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let device2 = await adapter4.requestDevice({
+  label: '\u4e76\u{1fcc0}\u6c48\u{1fc8d}\u4d50\u5bb7\u03c4\u{1f626}\u0656\ubaa1\u{1f777}',
+  requiredFeatures: [
+    'depth-clip-control',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 5,
+    maxColorAttachmentBytesPerSample: 47,
+    maxVertexAttributes: 25,
+    maxVertexBufferArrayStride: 6435,
+    maxStorageTexturesPerShaderStage: 17,
+    maxStorageBuffersPerShaderStage: 13,
+    maxDynamicStorageBuffersPerPipelineLayout: 60320,
+    maxDynamicUniformBuffersPerPipelineLayout: 30810,
+    maxBindingsPerBindGroup: 7933,
+    maxTextureArrayLayers: 348,
+    maxTextureDimension1D: 14543,
+    maxTextureDimension2D: 12193,
+    maxBindGroupsPlusVertexBuffers: 26,
+    maxUniformBufferBindingSize: 237862429,
+    maxStorageBufferBindingSize: 152639051,
+    maxUniformBuffersPerShaderStage: 21,
+    maxSampledTexturesPerShaderStage: 38,
+    maxInterStageShaderVariables: 63,
+    maxInterStageShaderComponents: 118,
+    maxSamplersPerShaderStage: 19,
+  },
+});
+let texture35 = device2.createTexture({
+  size: [2304, 1, 308],
+  format: 'depth24plus-stencil8',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['depth24plus-stencil8', 'depth24plus-stencil8'],
+});
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+let texture36 = device2.createTexture({
+  size: [48, 1, 436],
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+device2.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'stencil-only',
+}, arrayBuffer5, /* required buffer size: 8_154_432 */
+{offset: 832, bytesPerRow: 2450, rowsPerImage: 128}, {width: 2304, height: 0, depthOrArrayLayers: 27});
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder57 = device2.createCommandEncoder({});
+try {
+device2.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 66},
+  aspect: 'stencil-only',
+}, new Int32Array(arrayBuffer0), /* required buffer size: 19_284_627 */
+{offset: 507, bytesPerRow: 2346, rowsPerImage: 274}, {width: 2304, height: 0, depthOrArrayLayers: 31});
+} catch {}
+let offscreenCanvas18 = new OffscreenCanvas(141, 1011);
+let bindGroupLayout17 = device2.createBindGroupLayout({
+  label: '\ufdf3\u0847\u34f2\ue796\u7fd9\u03a6\u0037\u074c',
+  entries: [
+    {
+      binding: 2854,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 6967,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '3d', sampleType: 'sint', multisampled: false },
+    },
+    {
+      binding: 3410,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'r32sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let commandEncoder58 = device2.createCommandEncoder({label: '\u{1fe17}\u9bb9\u0db0'});
+let commandBuffer11 = commandEncoder58.finish();
+let texture37 = device2.createTexture({
+  label: '\u{1f88f}\u{1fc96}\u099c\u{1f791}\ua13a\u09c9\uf2f3\u0680\u{1ff25}',
+  size: [607, 1, 1],
+  mipLevelCount: 7,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: ['rgba8unorm'],
+});
+let textureView57 = texture36.createView({
+  label: '\u{1fb6a}\uefd7\u0c5a\u{1fcaa}\u{1fcc1}\u3dd9\u{1fcbc}',
+  format: 'rgba8sint',
+  baseMipLevel: 3,
+  mipLevelCount: 2,
+});
+let computePassEncoder24 = commandEncoder57.beginComputePass({label: '\ub61a\ub30d\u0b19\u0d94\u261e\u{1ff24}\u{1f61e}\u0e13\ud076\u{1fd21}\u0ad6'});
+try {
+computePassEncoder24.end();
+} catch {}
+offscreenCanvas16.height = 551;
+let canvas12 = document.createElement('canvas');
+let offscreenCanvas19 = new OffscreenCanvas(60, 248);
+let img11 = await imageWithData(62, 262, '#2aa3db1f', '#c94137c2');
+let commandEncoder59 = device0.createCommandEncoder({});
+let commandBuffer12 = commandEncoder2.finish({label: '\u6530\ubb14'});
+let renderBundle37 = renderBundleEncoder4.finish({label: '\u0a9f\u0fa9\u0df4\u180c\u2aa8\uaa54\u01c5\u0c5f'});
+try {
+computePassEncoder10.setPipeline(pipeline15);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(0, bindGroup0, new Uint32Array(7929), 7762, 0);
+} catch {}
+try {
+commandEncoder35.copyBufferToBuffer(buffer1, 953768, buffer6, 34708, 5800);
+dissociateBuffer(device0, buffer1);
+dissociateBuffer(device0, buffer6);
+} catch {}
+try {
+commandEncoder15.copyBufferToTexture({
+  /* bytesInLastRow: 114 widthInBlocks: 114 aspectSpecificFormat.texelBlockSize: 1 */
+  /* end: 17470 */
+  offset: 17470,
+  bytesPerRow: 256,
+  buffer: buffer1,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 10, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 114, height: 7, depthOrArrayLayers: 0});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let img12 = await imageWithData(152, 91, '#84e889b3', '#464c666e');
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let canvas13 = document.createElement('canvas');
+let imageData14 = new ImageData(132, 208);
+try {
+canvas12.getContext('webgl2');
+} catch {}
+let pipelineLayout6 = device2.createPipelineLayout({
+  label: '\u8a08\u5792',
+  bindGroupLayouts: [bindGroupLayout17, bindGroupLayout17, bindGroupLayout17, bindGroupLayout17, bindGroupLayout17],
+});
+let texture38 = device2.createTexture({
+  label: '\u{1fb3e}\u586a\u04ac\u{1f73c}\ud743',
+  size: {width: 1152, height: 1, depthOrArrayLayers: 1557},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2unorm'],
+});
+let renderBundleEncoder23 = device2.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb', 'rg8sint', 'r8sint', 'rgb10a2unorm'], depthReadOnly: true});
+let renderBundle38 = renderBundleEncoder23.finish({});
+try {
+device2.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 33},
+  aspect: 'stencil-only',
+}, new Int16Array(arrayBuffer0), /* required buffer size: 552_234 */
+{offset: 283, bytesPerRow: 2359, rowsPerImage: 233}, {width: 2304, height: 1, depthOrArrayLayers: 2});
+} catch {}
+let canvas14 = document.createElement('canvas');
+let buffer11 = device0.createBuffer({
+  label: '\u619a\u0368',
+  size: 142248,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let commandEncoder60 = device0.createCommandEncoder({});
+let textureView58 = texture1.createView({label: '\u{1fb72}\u0f7c\u89f1\u9015\ub6c9\uf294\u09cd\ub14e\u905e\u{1f69d}\u01ef', baseMipLevel: 1});
+try {
+renderBundleEncoder9.setBindGroup(6, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup0, new Uint32Array(5532), 3139, 0);
+} catch {}
+try {
+commandEncoder37.resolveQuerySet(querySet3, 1206, 1117, buffer1, 585984);
+} catch {}
+document.body.prepend(canvas13);
+try {
+offscreenCanvas18.getContext('webgl');
+} catch {}
+let querySet24 = device2.createQuerySet({label: '\u494d\u1874\u042c\u770c\u1fcb\ud867', type: 'occlusion', count: 2997});
+let texture39 = device2.createTexture({
+  label: '\u5015\u9e7c\u5b71\u6e4d\u0089',
+  size: [200, 30, 1],
+  mipLevelCount: 7,
+  format: 'astc-10x10-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['astc-10x10-unorm'],
+});
+let computePassEncoder25 = commandEncoder57.beginComputePass({label: '\u7649\u0167\u0a1c\u{1f7ff}\u89f7\u6e3e\uaf5c'});
+let renderBundle39 = renderBundleEncoder23.finish({});
+let sampler30 = device2.createSampler({
+  label: '\ud511\ube38\u{1f9fd}\u1c6a\ube66\u74b5\u0fc8',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 26.99,
+  lodMaxClamp: 92.87,
+  compare: 'not-equal',
+  maxAnisotropy: 10,
+});
+let videoFrame6 = new VideoFrame(canvas2, {timestamp: 0});
+let commandEncoder61 = device2.createCommandEncoder({});
+let querySet25 = device2.createQuerySet({label: '\u302e\u0fc0\uc554\u{1fa0f}\u9c42\u1c2a\ue58a\u{1fca7}', type: 'occlusion', count: 1003});
+let textureView59 = texture38.createView({label: '\u3ccf\u0dcf\ub20d\u7724\u88ce\u0567\u26c1\u06c4\ubd04', baseMipLevel: 2, mipLevelCount: 2});
+try {
+gpuCanvasContext13.configure({
+  device: device2,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['bgra8unorm-srgb', 'bgra8unorm-srgb', 'bgra8unorm-srgb'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device2.queue.submit([commandBuffer11]);
+} catch {}
+let canvas15 = document.createElement('canvas');
+let video17 = await videoWithData();
+let commandEncoder62 = device2.createCommandEncoder({});
+let querySet26 = device2.createQuerySet({label: '\u{1f9f4}\u91b4\u{1fc0f}\u276d\u09eb\u{1fdc1}', type: 'occlusion', count: 914});
+let texture40 = device2.createTexture({
+  size: {width: 384, height: 1, depthOrArrayLayers: 322},
+  mipLevelCount: 8,
+  dimension: '3d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgb10a2unorm'],
+});
+let externalTexture14 = device2.importExternalTexture({source: videoFrame0, colorSpace: 'display-p3'});
+try {
+device2.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+}, arrayBuffer1, /* required buffer size: 256_189 */
+{offset: 472, bytesPerRow: 123, rowsPerImage: 297}, {width: 1, height: 0, depthOrArrayLayers: 8});
+} catch {}
+document.body.prepend(video15);
+let commandEncoder63 = device2.createCommandEncoder({label: '\u0c9d\ucbe4\u5b48\u{1f899}\u{1fbcb}\u{1f97f}\u7ab4\u0f8d\u7d42'});
+let querySet27 = device2.createQuerySet({label: '\u0416\u0dbb\ub8e3\ub972\u{1fc39}\u0383\u47b7\u7b4c\u{1f665}', type: 'occlusion', count: 3805});
+let texture41 = device2.createTexture({
+  label: '\u1ccb\u00c5\u6cb5\u80dd\u0444\u20a8\u0732\u03d1\uc892\u0cee',
+  size: {width: 1215},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler31 = device2.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 7.631,
+  lodMaxClamp: 87.72,
+  maxAnisotropy: 9,
+});
+try {
+offscreenCanvas19.getContext('bitmaprenderer');
+} catch {}
+let shaderModule11 = device2.createShaderModule({
+  code: `@group(2) @binding(2854)
+var<storage, read_write> local17: array<u32>;
+@group(2) @binding(6967)
+var<storage, read_write> global24: array<u32>;
+@group(2) @binding(3410)
+var<storage, read_write> parameter20: array<u32>;
+@group(4) @binding(6967)
+var<storage, read_write> parameter21: array<u32>;
+@group(3) @binding(2854)
+var<storage, read_write> parameter22: array<u32>;
+@group(1) @binding(2854)
+var<storage, read_write> local18: array<u32>;
+@group(0) @binding(3410)
+var<storage, read_write> global25: array<u32>;
+@group(0) @binding(2854)
+var<storage, read_write> field18: array<u32>;
+
+@compute @workgroup_size(6, 2, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(3) f1: vec4<f32>,
+  @location(1) f2: vec4<i32>,
+  @location(2) f3: vec4<i32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>, @location(2) a1: vec3<u32>, @location(48) a2: vec3<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S10 {
+  @location(13) f0: vec2<f32>,
+  @location(3) f1: vec2<f32>,
+  @location(18) f2: vec2<i32>,
+  @location(20) f3: vec2<i32>,
+  @location(21) f4: vec4<f16>,
+  @location(15) f5: i32,
+  @location(0) f6: vec3<u32>,
+  @location(8) f7: vec2<f16>,
+  @location(12) f8: vec3<u32>,
+  @location(2) f9: vec3<f32>,
+  @location(23) f10: vec3<u32>,
+  @location(17) f11: vec4<f32>
+}
+struct VertexOutput0 {
+  @location(47) f147: vec3<u32>,
+  @location(44) f148: i32,
+  @location(61) f149: vec2<f16>,
+  @location(37) f150: vec3<f32>,
+  @location(48) f151: vec3<i32>,
+  @location(4) f152: vec4<u32>,
+  @location(34) f153: vec2<i32>,
+  @location(12) f154: vec2<u32>,
+  @location(62) f155: vec4<f32>,
+  @location(51) f156: vec3<i32>,
+  @location(2) f157: vec3<u32>,
+  @location(38) f158: vec2<f32>,
+  @location(7) f159: vec4<f16>,
+  @location(35) f160: f16,
+  @location(22) f161: i32,
+  @location(49) f162: vec3<f16>,
+  @location(54) f163: f16,
+  @location(58) f164: vec2<f16>,
+  @location(16) f165: u32,
+  @location(13) f166: vec4<i32>,
+  @location(36) f167: vec3<f16>,
+  @location(30) f168: vec3<i32>,
+  @location(42) f169: vec4<u32>,
+  @builtin(position) f170: vec4<f32>,
+  @location(31) f171: vec2<i32>,
+  @location(24) f172: f32,
+  @location(3) f173: vec4<u32>,
+  @location(14) f174: vec3<i32>,
+  @location(25) f175: f32,
+  @location(55) f176: vec4<f32>,
+  @location(33) f177: u32,
+  @location(46) f178: vec3<i32>,
+  @location(29) f179: f32,
+  @location(50) f180: vec4<u32>,
+  @location(60) f181: vec2<f32>,
+  @location(39) f182: vec3<f16>,
+  @location(6) f183: vec4<f32>,
+  @location(57) f184: vec4<f32>,
+  @location(11) f185: vec2<f32>,
+  @location(18) f186: f32,
+  @location(53) f187: f32,
+  @location(56) f188: vec3<f32>,
+  @location(45) f189: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(1) a0: vec2<f16>, @location(14) a1: vec2<u32>, @location(24) a2: vec2<u32>, @location(16) a3: u32, @location(4) a4: vec2<i32>, @location(11) a5: f16, @location(19) a6: f16, @location(10) a7: f32, @location(5) a8: vec4<i32>, a9: S10) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let renderBundleEncoder24 = device2.createRenderBundleEncoder({
+  label: '\u{1fc31}\u7304\u{1f61b}\ud28e\u{1f97e}\uc15c\ud18f\u67a8\uaf1e\u299f',
+  colorFormats: ['rgba8unorm-srgb', 'rg8sint', 'r8sint', 'rgb10a2unorm'],
+  stencilReadOnly: true,
+});
+let pipeline39 = device2.createComputePipeline({
+  label: '\u2198\u0d92\u0735\u{1f6ea}\uf3a7',
+  layout: pipelineLayout6,
+  compute: {module: shaderModule11, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext15 = canvas13.getContext('webgpu');
+let shaderModule12 = device2.createShaderModule({
+  label: '\uf2e6\u348f\u{1fb72}\u{1fa99}\ub4c9\u41d2\u7ac7',
+  code: `@group(4) @binding(2854)
+var<storage, read_write> global26: array<u32>;
+@group(3) @binding(3410)
+var<storage, read_write> n15: array<u32>;
+@group(0) @binding(3410)
+var<storage, read_write> local19: array<u32>;
+@group(3) @binding(6967)
+var<storage, read_write> function14: array<u32>;
+@group(3) @binding(2854)
+var<storage, read_write> global27: array<u32>;
+@group(0) @binding(6967)
+var<storage, read_write> n16: array<u32>;
+@group(1) @binding(6967)
+var<storage, read_write> field19: array<u32>;
+@group(2) @binding(6967)
+var<storage, read_write> field20: array<u32>;
+@group(2) @binding(3410)
+var<storage, read_write> type14: array<u32>;
+@group(0) @binding(2854)
+var<storage, read_write> global28: array<u32>;
+@group(4) @binding(3410)
+var<storage, read_write> type15: array<u32>;
+
+@compute @workgroup_size(7, 3, 1)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(2) f0: i32,
+  @location(0) f1: vec4<f32>,
+  @location(1) f2: vec3<i32>,
+  @location(5) f3: f32,
+  @location(3) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@builtin(sample_index) a0: u32, @builtin(sample_mask) a1: u32, @builtin(front_facing) a2: bool, @builtin(position) a3: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+
+
+@vertex
+fn vertex0(@location(5) a0: vec4<f16>, @builtin(vertex_index) a1: u32, @location(1) a2: vec2<f32>, @location(19) a3: vec4<i32>, @location(16) a4: vec4<i32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  hints: {},
+});
+let commandEncoder64 = device2.createCommandEncoder({label: '\u{1fe76}\u1b21\u{1fc5b}\ub0f3\u{1fc9c}'});
+let computePassEncoder26 = commandEncoder61.beginComputePass({});
+let pipeline40 = await device2.createRenderPipelineAsync({
+  label: '\ud72a\ud94e\u0367\u2e27\u09dc\u0f0f\ue102\u09f1\u{1f994}\ub9e3\ucbc0',
+  layout: pipelineLayout6,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'one'},
+    alpha: {operation: 'subtract', srcFactor: 'one-minus-src', dstFactor: 'zero'},
+  },
+  writeMask: GPUColorWrite.ALL,
+}, {format: 'rg8sint', writeMask: 0}, {format: 'r8sint', writeMask: 0}, {
+  format: 'rgb10a2unorm',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2868,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint8x4', offset: 540, shaderLocation: 18},
+          {format: 'sint32x4', offset: 992, shaderLocation: 15},
+          {format: 'uint32x3', offset: 632, shaderLocation: 16},
+          {format: 'sint32', offset: 1204, shaderLocation: 20},
+          {format: 'uint32x2', offset: 956, shaderLocation: 23},
+          {format: 'float32x4', offset: 476, shaderLocation: 13},
+          {format: 'float16x2', offset: 112, shaderLocation: 2},
+          {format: 'float32x2', offset: 452, shaderLocation: 1},
+          {format: 'sint32', offset: 552, shaderLocation: 5},
+          {format: 'unorm8x4', offset: 556, shaderLocation: 3},
+          {format: 'sint16x2', offset: 1072, shaderLocation: 4},
+          {format: 'uint16x4', offset: 0, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 624,
+        attributes: [
+          {format: 'unorm16x4', offset: 120, shaderLocation: 19},
+          {format: 'uint32', offset: 80, shaderLocation: 14},
+          {format: 'snorm8x2', offset: 68, shaderLocation: 8},
+          {format: 'float32x4', offset: 24, shaderLocation: 17},
+          {format: 'uint32x2', offset: 28, shaderLocation: 24},
+          {format: 'float32', offset: 20, shaderLocation: 11},
+          {format: 'uint16x4', offset: 40, shaderLocation: 0},
+          {format: 'snorm8x2', offset: 22, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 2164,
+        stepMode: 'vertex',
+        attributes: [{format: 'unorm10-10-10-2', offset: 240, shaderLocation: 10}],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'ccw', cullMode: 'back', unclippedDepth: true},
+});
+let imageBitmap9 = await createImageBitmap(imageBitmap4);
+try {
+canvas15.getContext('webgpu');
+} catch {}
+let pipelineLayout7 = device2.createPipelineLayout({label: '\u4c3e\u0ab4\u{1ffec}\u0383\uf38c\ucadc\u1fcc', bindGroupLayouts: []});
+let commandEncoder65 = device2.createCommandEncoder({label: '\ua1bc\u00e9'});
+let texture42 = device2.createTexture({
+  label: '\u068c\u02d4\u6497\u{1fcfc}\u0682\u0050\u1dd4\ubcac\u{1fdf3}\u{1ffd1}',
+  size: [48],
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle40 = renderBundleEncoder23.finish({label: '\u3557\u76a6\u7610\u0f37\u0001\ue35d\u{1ff2d}\u7aed\u{1fb8e}\u686c\u{1f982}'});
+let externalTexture15 = device2.importExternalTexture({label: '\u{1f986}\u{1fb7b}\ub46b\uf109\u27dc\u8b41\u5b53\u0b70', source: video0, colorSpace: 'srgb'});
+try {
+texture36.destroy();
+} catch {}
+try {
+adapter3.label = '\u{1fefb}\u{1fcd8}\u07fc\u0739\uc548\ueb42\u0e1c\u0f49\u026d';
+} catch {}
+let pipeline41 = device2.createRenderPipeline({
+  label: '\u6415\u0e73\u3d8e\u{1f8f4}\u9164\u497f\u785a\uaff2\u087c',
+  layout: 'auto',
+  depthStencil: {
+    format: 'stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'always',
+    stencilFront: {compare: 'never', failOp: 'zero', depthFailOp: 'decrement-wrap', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'never', failOp: 'decrement-clamp', depthFailOp: 'zero', passOp: 'invert'},
+    stencilReadMask: 3982833682,
+    stencilWriteMask: 3076376524,
+    depthBias: 787913509,
+    depthBiasSlopeScale: 0.0,
+  },
+  vertex: {
+    module: shaderModule12,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 176,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x4', offset: 172, shaderLocation: 1}],
+      },
+      {arrayStride: 0, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 436,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 0, shaderLocation: 16},
+          {format: 'snorm8x4', offset: 8, shaderLocation: 5},
+        ],
+      },
+      {
+        arrayStride: 856,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x2', offset: 232, shaderLocation: 19}],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', frontFace: 'ccw', unclippedDepth: true},
+});
+let offscreenCanvas20 = new OffscreenCanvas(519, 640);
+let texture43 = gpuCanvasContext4.getCurrentTexture();
+let textureView60 = texture39.createView({label: '\u098e\u4a7e\ua741', dimension: '2d-array', baseMipLevel: 5});
+try {
+device2.queue.writeTexture({
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 165 */
+{offset: 165}, {width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let pipeline42 = device2.createComputePipeline({layout: pipelineLayout7, compute: {module: shaderModule12, entryPoint: 'compute0', constants: {}}});
+let pipeline43 = device2.createRenderPipeline({
+  label: '\u2d16\ueeaa\u0fa3\u0638\ub122\u17ed\u05be',
+  layout: pipelineLayout6,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-constant', dstFactor: 'dst'},
+  },
+  writeMask: GPUColorWrite.ALL,
+}, {format: 'rg8sint', writeMask: GPUColorWrite.BLUE}, {format: 'r8sint', writeMask: 0}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'greater-equal',
+    stencilFront: {failOp: 'replace', depthFailOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'greater-equal', failOp: 'decrement-clamp', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilReadMask: 513598949,
+    stencilWriteMask: 442779897,
+    depthBias: 30713425,
+    depthBiasSlopeScale: 657.0492328156264,
+    depthBiasClamp: 834.2149040892587,
+  },
+  vertex: {
+    module: shaderModule12,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 176, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 2360,
+        attributes: [
+          {format: 'sint16x2', offset: 424, shaderLocation: 19},
+          {format: 'sint32x4', offset: 444, shaderLocation: 16},
+          {format: 'float32x3', offset: 856, shaderLocation: 5},
+          {format: 'float16x4', offset: 132, shaderLocation: 1},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'front', unclippedDepth: true},
+});
+let textureView61 = texture41.createView({label: '\u0ca5\udd1f\u15aa\u0806\u0222\uc367\uc050\u3fe1\u5121', dimension: '1d'});
+let computePassEncoder27 = commandEncoder62.beginComputePass({label: '\u6578\u22ee\u{1f7e9}'});
+let renderBundleEncoder25 = device2.createRenderBundleEncoder({
+  label: '\u00a4\u0232\u04eb\u8245\u04fa\u{1fd02}\u{1fbae}\u{1fd44}\u0403\u0a66\ucca2',
+  colorFormats: ['rgba8unorm-srgb', 'rg8sint', 'r8sint', 'rgb10a2unorm'],
+  depthReadOnly: true,
+});
+let externalTexture16 = device2.importExternalTexture({label: '\ue981\u6587\u0404\u355a\ucfd2\u07d7\uacce', source: videoFrame4, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder24.setVertexBuffer(1795, undefined);
+} catch {}
+try {
+commandEncoder65.pushDebugGroup('\u5009');
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+let buffer12 = device2.createBuffer({label: '\udc83\u06ee', size: 561650, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+try {
+commandEncoder64.copyBufferToTexture({
+  /* bytesInLastRow: 3508 widthInBlocks: 877 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 62988 */
+  offset: 59480,
+  buffer: buffer12,
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 877, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device2, buffer12);
+} catch {}
+try {
+commandEncoder64.copyTextureToTexture({
+  texture: texture39,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture39,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+gc();
+let imageData15 = new ImageData(176, 96);
+video16.width = 244;
+let img13 = await imageWithData(207, 14, '#16cd882a', '#54d14fcc');
+let video18 = await videoWithData();
+gc();
+let offscreenCanvas21 = new OffscreenCanvas(1002, 894);
+let gpuCanvasContext16 = offscreenCanvas20.getContext('webgpu');
+let commandBuffer13 = commandEncoder63.finish({label: '\u1042\u5e37\u9129\u27d6\u0f7c\ub484'});
+let textureView62 = texture35.createView({
+  label: '\u0527\uedc8\u07a4\u023b',
+  aspect: 'depth-only',
+  format: 'depth24plus',
+  baseArrayLayer: 203,
+  arrayLayerCount: 59,
+});
+try {
+computePassEncoder27.setPipeline(pipeline39);
+} catch {}
+try {
+gpuCanvasContext9.configure({
+  device: device2,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float', 'rgba16float', 'rgba16float'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let commandEncoder66 = device2.createCommandEncoder({label: '\u04ef\uba9f'});
+let textureView63 = texture43.createView({
+  label: '\u5dd3\uafc7\u{1f66e}\u6d6e\u0d93\u02ce\u{1f904}\u65f0',
+  dimension: '2d-array',
+  format: 'rgba8unorm-srgb',
+});
+let pipeline44 = await device2.createComputePipelineAsync({layout: pipelineLayout7, compute: {module: shaderModule12, entryPoint: 'compute0', constants: {}}});
+let pipeline45 = device2.createRenderPipeline({
+  label: '\u0fce\u0304\u{1faff}\u077d\u82a6\u428d\u5cee\u13d7\ub64f\u7d56',
+  layout: 'auto',
+  multisample: {count: 4, mask: 0x5585cbb0},
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8unorm-srgb'}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r8sint', writeMask: 0}, {
+  format: 'rgb10a2unorm',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'src-alpha-saturated', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'zero'},
+  },
+}],
+},
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 0,
+        attributes: [
+          {format: 'float16x2', offset: 548, shaderLocation: 1},
+          {format: 'unorm8x4', offset: 1920, shaderLocation: 10},
+          {format: 'uint32x2', offset: 60, shaderLocation: 12},
+          {format: 'unorm16x4', offset: 824, shaderLocation: 21},
+          {format: 'sint32x3', offset: 172, shaderLocation: 4},
+          {format: 'unorm8x2', offset: 220, shaderLocation: 2},
+          {format: 'snorm8x2', offset: 652, shaderLocation: 8},
+          {format: 'sint8x4', offset: 2604, shaderLocation: 5},
+          {format: 'snorm8x2', offset: 4180, shaderLocation: 3},
+          {format: 'sint32', offset: 932, shaderLocation: 20},
+        ],
+      },
+      {
+        arrayStride: 356,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 28, shaderLocation: 15},
+          {format: 'uint32x2', offset: 4, shaderLocation: 24},
+          {format: 'uint32x2', offset: 12, shaderLocation: 0},
+        ],
+      },
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 504, shaderLocation: 17},
+          {format: 'uint32', offset: 172, shaderLocation: 16},
+          {format: 'snorm16x2', offset: 1584, shaderLocation: 19},
+          {format: 'uint8x2', offset: 322, shaderLocation: 14},
+          {format: 'snorm8x4', offset: 232, shaderLocation: 11},
+          {format: 'uint32x2', offset: 900, shaderLocation: 23},
+        ],
+      },
+      {arrayStride: 0, attributes: [{format: 'sint8x4', offset: 180, shaderLocation: 18}]},
+      {arrayStride: 648, stepMode: 'instance', attributes: []},
+      {arrayStride: 2112, attributes: []},
+      {arrayStride: 2184, attributes: [{format: 'float16x4', offset: 308, shaderLocation: 13}]},
+    ],
+  },
+  primitive: {frontFace: 'ccw', unclippedDepth: true},
+});
+gc();
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+let texture44 = device2.createTexture({
+  label: '\u2424\u{1fb4a}\u0adc\u{1f6cc}\u6596\u{1f6a0}\u074b\u8ace\ucf4d\uc6b8',
+  size: [607, 1, 1],
+  mipLevelCount: 2,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba8unorm', 'rgba8unorm-srgb'],
+});
+let renderBundleEncoder26 = device2.createRenderBundleEncoder({
+  label: '\uda93\u{1fc25}\u{1ff96}\u09f8\u006b\ub038\u7323\uee7d\u{1fccd}',
+  colorFormats: ['rgba8unorm-srgb', 'rg8sint', 'r8sint', 'rgb10a2unorm'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let promise14 = buffer12.mapAsync(GPUMapMode.WRITE, 0, 336508);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+try {
+  await promise14;
+} catch {}
+gc();
+let canvas16 = document.createElement('canvas');
+let commandEncoder67 = device2.createCommandEncoder({label: '\u7839\u{1ff2d}\u0acd\ubc38\u024d\u7198\ufcdc\ua757\u{1fce6}\u07d8'});
+let renderBundle41 = renderBundleEncoder24.finish();
+try {
+device2.pushErrorScope('validation');
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+commandEncoder65.copyTextureToTexture({
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let pipeline46 = device2.createComputePipeline({layout: 'auto', compute: {module: shaderModule12, entryPoint: 'compute0', constants: {}}});
+let offscreenCanvas22 = new OffscreenCanvas(475, 766);
+let texture45 = device2.createTexture({
+  size: [1215],
+  dimension: '1d',
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView64 = texture43.createView({dimension: '2d-array'});
+let computePassEncoder28 = commandEncoder67.beginComputePass({label: '\u1d9f\u0938\u6a92\u206f\uad14'});
+let renderBundleEncoder27 = device2.createRenderBundleEncoder({
+  label: '\ub80a\uadc2\u{1ff71}\u{1ff03}\uf521\u0dd2\u0f3e\u937a\u79ab\ubceb',
+  colorFormats: ['rgba8unorm-srgb', 'rg8sint', 'r8sint', 'rgb10a2unorm'],
+});
+let renderBundle42 = renderBundleEncoder25.finish({label: '\u{1fee4}\ub854\u9ce3\ud9c7\u{1fd93}\uce88'});
+try {
+  await device2.popErrorScope();
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 10},
+  aspect: 'stencil-only',
+}, new BigInt64Array(arrayBuffer4), /* required buffer size: 10_125_415 */
+{offset: 415, bytesPerRow: 2500, rowsPerImage: 150}, {width: 2304, height: 0, depthOrArrayLayers: 28});
+} catch {}
+let pipeline47 = device2.createComputePipeline({
+  label: '\u6741\udd22\ub4ef\u79ba',
+  layout: 'auto',
+  compute: {module: shaderModule12, entryPoint: 'compute0'},
+});
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+gc();
+let bindGroupLayout18 = device2.createBindGroupLayout({label: '\uaf01\u0a50\u322b\u0ee6\u0fbd\u{1f80e}\u48a4', entries: []});
+let commandEncoder68 = device2.createCommandEncoder({label: '\uc1c0\u2eb9\u{1fdc1}'});
+let textureView65 = texture44.createView({label: '\u1a0c\ub9a8\u{1faed}\ud0f3\u07c9\u02cc\u1ad2\u1dc8', dimension: '2d-array', mipLevelCount: 1});
+let pipeline48 = await device2.createRenderPipelineAsync({
+  label: '\u82fe\u0c1c\u{1ffc8}\uab22\ue214\u0529\u08dd\u{1f9e1}\u1950\u{1fd83}',
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule11,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'rg8sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}, {format: 'r8sint', writeMask: 0}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule11,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 964,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'snorm8x2', offset: 264, shaderLocation: 10},
+          {format: 'uint32x3', offset: 52, shaderLocation: 14},
+          {format: 'snorm8x4', offset: 76, shaderLocation: 21},
+          {format: 'uint16x4', offset: 28, shaderLocation: 0},
+          {format: 'sint32', offset: 128, shaderLocation: 4},
+          {format: 'float32', offset: 160, shaderLocation: 8},
+          {format: 'float32x2', offset: 8, shaderLocation: 13},
+          {format: 'unorm8x2', offset: 128, shaderLocation: 11},
+          {format: 'sint32x2', offset: 40, shaderLocation: 15},
+          {format: 'float16x4', offset: 176, shaderLocation: 17},
+          {format: 'snorm16x2', offset: 64, shaderLocation: 3},
+          {format: 'sint32', offset: 88, shaderLocation: 20},
+          {format: 'unorm8x2', offset: 160, shaderLocation: 19},
+          {format: 'snorm16x4', offset: 72, shaderLocation: 1},
+          {format: 'sint32x2', offset: 404, shaderLocation: 5},
+          {format: 'uint16x2', offset: 172, shaderLocation: 23},
+          {format: 'float32x3', offset: 16, shaderLocation: 2},
+          {format: 'uint32x4', offset: 64, shaderLocation: 16},
+          {format: 'sint16x4', offset: 344, shaderLocation: 18},
+          {format: 'uint8x2', offset: 154, shaderLocation: 12},
+          {format: 'uint32', offset: 140, shaderLocation: 24},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', unclippedDepth: true},
+});
+try {
+canvas16.getContext('webgpu');
+} catch {}
+let imageData16 = new ImageData(108, 64);
+let canvas17 = document.createElement('canvas');
+let textureView66 = texture37.createView({label: '\u6b52\uf62b\u0784\u{1f85a}', baseMipLevel: 1, mipLevelCount: 4, baseArrayLayer: 0});
+try {
+commandEncoder65.copyTextureToTexture({
+  texture: texture40,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter4.label = '\u33e9\udd90\u80bd\u6509\ue613\u4621\u00c0';
+} catch {}
+let commandEncoder69 = device1.createCommandEncoder({label: '\udb6c\u83da\u0932\u0a50\u0049\u2165\u010d\ud6e9\u{1fabf}'});
+let texture46 = device1.createTexture({
+  label: '\uc8e0\u4c75',
+  size: [1846, 3, 1150],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8uint', 'rgba8uint', 'rgba8uint'],
+});
+let textureView67 = texture25.createView({label: '\u5552\ue058\u436d\ue748\u{1fbd4}\u0b39\u82fd\u{1f726}\uc227', arrayLayerCount: 1});
+let renderBundleEncoder28 = device1.createRenderBundleEncoder({colorFormats: ['rgba8uint'], depthReadOnly: true});
+let externalTexture17 = device1.importExternalTexture({label: '\ua229\u7d3a\u03d5\u0344', source: video18, colorSpace: 'display-p3'});
+document.body.prepend(canvas1);
+video12.height = 198;
+let shaderModule13 = device2.createShaderModule({
+  label: '\u07b3\ue743\u{1f7c8}\u08cb\ud443',
+  code: `@group(4) @binding(6967)
+var<storage, read_write> type16: array<u32>;
+@group(0) @binding(2854)
+var<storage, read_write> local20: array<u32>;
+@group(1) @binding(3410)
+var<storage, read_write> global29: array<u32>;
+@group(0) @binding(6967)
+var<storage, read_write> n17: array<u32>;
+@group(2) @binding(3410)
+var<storage, read_write> n18: array<u32>;
+@group(4) @binding(2854)
+var<storage, read_write> type17: array<u32>;
+@group(1) @binding(6967)
+var<storage, read_write> local21: array<u32>;
+@group(2) @binding(2854)
+var<storage, read_write> local22: array<u32>;
+@group(0) @binding(3410)
+var<storage, read_write> function15: array<u32>;
+@group(1) @binding(2854)
+var<storage, read_write> type18: array<u32>;
+@group(2) @binding(6967)
+var<storage, read_write> field21: array<u32>;
+@group(3) @binding(2854)
+var<storage, read_write> local23: array<u32>;
+@group(4) @binding(3410)
+var<storage, read_write> field22: array<u32>;
+
+@compute @workgroup_size(1, 3, 4)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<f32>,
+  @location(1) f1: vec4<i32>,
+  @location(3) f2: vec4<f32>,
+  @location(2) f3: vec4<i32>,
+  @location(5) f4: vec2<f32>
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S11 {
+  @location(24) f0: f16,
+  @location(22) f1: vec3<f16>,
+  @location(11) f2: vec2<u32>,
+  @location(17) f3: vec4<u32>,
+  @location(19) f4: i32,
+  @builtin(instance_index) f5: u32,
+  @location(10) f6: f32,
+  @location(15) f7: f32
+}
+struct VertexOutput0 {
+  @builtin(position) f190: vec4<f32>,
+  @location(58) f191: vec2<f16>,
+  @location(38) f192: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(14) a0: vec3<f32>, @builtin(vertex_index) a1: u32, a2: S11, @location(9) a3: vec4<f16>, @location(3) a4: vec4<u32>, @location(5) a5: vec2<u32>, @location(2) a6: i32, @location(13) a7: vec2<f32>, @location(21) a8: vec2<i32>, @location(16) a9: vec3<f32>, @location(23) a10: vec4<f16>, @location(0) a11: vec4<i32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let bindGroupLayout19 = device2.createBindGroupLayout({
+  label: '\uc8a0\u2955\u{1fec9}',
+  entries: [
+    {
+      binding: 3828,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let bindGroup2 = device2.createBindGroup({
+  label: '\u1215\u2658\u{1fa52}\u0197\u{1f9f4}\u{1febd}\u{1fac5}\uc53f\u4b43',
+  layout: bindGroupLayout18,
+  entries: [],
+});
+let pipelineLayout8 = device2.createPipelineLayout({label: '\u{1f807}\ud5be', bindGroupLayouts: [bindGroupLayout19, bindGroupLayout18]});
+let textureView68 = texture39.createView({
+  label: '\u9b11\u1b4e\u001e\ue371\u5e33\u871c\ue84c',
+  format: 'astc-10x10-unorm',
+  baseMipLevel: 1,
+  mipLevelCount: 4,
+  baseArrayLayer: 0,
+});
+try {
+renderBundleEncoder26.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder26.setPipeline(pipeline48);
+} catch {}
+try {
+commandEncoder65.copyTextureToTexture({
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 105, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 299, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 178, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder68.insertDebugMarker('\u{1ffb3}');
+} catch {}
+let pipeline49 = device2.createRenderPipeline({
+  layout: pipelineLayout7,
+  fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8unorm-srgb', writeMask: GPUColorWrite.ALPHA}, {format: 'rg8sint'}, {format: 'r8sint', writeMask: 0}, {format: 'rgb10a2unorm', writeMask: 0}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {compare: 'greater', failOp: 'increment-wrap', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilBack: {failOp: 'decrement-clamp', depthFailOp: 'decrement-clamp', passOp: 'decrement-wrap'},
+    stencilReadMask: 3989134584,
+  },
+  vertex: {
+    module: shaderModule12,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 1264,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x4', offset: 224, shaderLocation: 5},
+          {format: 'sint32', offset: 172, shaderLocation: 19},
+          {format: 'unorm8x2', offset: 108, shaderLocation: 1},
+        ],
+      },
+      {arrayStride: 2440, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 1480,
+        stepMode: 'instance',
+        attributes: [{format: 'sint16x2', offset: 672, shaderLocation: 16}],
+      },
+    ],
+  },
+  primitive: {frontFace: 'cw', unclippedDepth: true},
+});
+try {
+gpuCanvasContext11.unconfigure();
+} catch {}
+try {
+buffer5.label = '\u04ae\u04c0\u3ebc\u{1fced}\u0823\u088a\u032d\u003d';
+} catch {}
+canvas3.height = 636;
+let video19 = await videoWithData();
+try {
+adapter4.label = '\u{1f8b9}\ub6f5\u0ebd\u{1fe46}';
+} catch {}
+let gpuCanvasContext17 = offscreenCanvas22.getContext('webgpu');
+let bindGroup3 = device2.createBindGroup({label: '\udf30\u0983\uf7e5\u096a', layout: bindGroupLayout18, entries: []});
+let pipelineLayout9 = device2.createPipelineLayout({
+  label: '\u0a98\u{1fe75}\ubbfe\ub397\u8852\u74bf\u{1fd13}\uab0e\u584f\ud50a',
+  bindGroupLayouts: [bindGroupLayout17],
+});
+let renderBundle43 = renderBundleEncoder26.finish({label: '\u0cb5\u0471\uda15\u05f3\ubba2\u4a9f\u4e45'});
+try {
+renderBundleEncoder27.setPipeline(pipeline48);
+} catch {}
+try {
+  await device2.popErrorScope();
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let video20 = await videoWithData();
+let querySet28 = device2.createQuerySet({label: '\ua1bc\u81c7\u5354\u9ac6', type: 'occlusion', count: 31});
+let texture47 = device2.createTexture({
+  label: '\u0c00\u{1f863}\uda8c\u0f92\u0579\u82a8\u{1f86f}\u6407',
+  size: [2430, 1, 1],
+  mipLevelCount: 3,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+});
+let textureView69 = texture45.createView({label: '\u00e9\u7956\u568e\u27ce\uf36f', format: 'rgb10a2unorm'});
+let renderBundle44 = renderBundleEncoder27.finish({label: '\u0ede\u2ab6\ub2f6\ue2c0\u{1fdac}'});
+let externalTexture18 = device2.importExternalTexture({label: '\ub326\u10fd\ub79a', source: video16});
+try {
+commandEncoder65.popDebugGroup();
+} catch {}
+let gpuCanvasContext18 = offscreenCanvas21.getContext('webgpu');
+let commandEncoder70 = device1.createCommandEncoder({label: '\u{1fb91}\u{1f7ef}\u{1fa3a}\u{1fc98}\u2391\u{1ff89}\u0fb9\u69b7'});
+let textureView70 = texture32.createView({label: '\u{1fa76}\uc316\u2597\u{1f8fa}\u{1f9a3}', baseMipLevel: 2, mipLevelCount: 1});
+let computePassEncoder29 = commandEncoder56.beginComputePass({});
+try {
+computePassEncoder21.setPipeline(pipeline28);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(4693, undefined, 0, 1811207059);
+} catch {}
+try {
+commandEncoder50.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 42212 */
+  offset: 42212,
+  buffer: buffer7,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 40, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder69.copyTextureToTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 65, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture33,
+  mipLevel: 8,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder17.popDebugGroup();
+} catch {}
+let textureView71 = texture4.createView({label: '\u{1fd9d}\u{1faab}\u{1ffe8}\ub4d3\uf55f\uadbb\u{1fbb3}', dimension: '1d'});
+let renderBundleEncoder29 = device0.createRenderBundleEncoder({
+  label: '\u067b\u3421\u{1fab3}\u290e\u7c37\u0943\u8ded\u802b',
+  colorFormats: ['r8sint', 'rgba32float'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder17.setIndexBuffer(buffer5, 'uint16');
+} catch {}
+try {
+  await buffer6.mapAsync(GPUMapMode.READ, 0, 351400);
+} catch {}
+try {
+commandEncoder33.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 19, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder29.clearBuffer(buffer11);
+dissociateBuffer(device0, buffer11);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer2, /* required buffer size: 376 */
+{offset: 376}, {width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline50 = await device0.createRenderPipelineAsync({
+  label: '\u{1f918}\ua3d6\uf3ac\u5dc2\u3cfd\u2aec\u{1fd46}',
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule2,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {
+  format: 'rgba32float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN,
+}],
+},
+  vertex: {
+    module: shaderModule2,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1192,
+        attributes: [
+          {format: 'snorm16x4', offset: 120, shaderLocation: 12},
+          {format: 'uint8x2', offset: 46, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', cullMode: 'back', unclippedDepth: true},
+});
+let querySet29 = device2.createQuerySet({
+  label: '\u1b93\u46af\u8a86\ued24\u5d97\u{1fd7b}\u7aac\u1962\u9d7c\u1a02',
+  type: 'occlusion',
+  count: 1247,
+});
+let textureView72 = texture42.createView({label: '\u{1ff1a}\u{1fa74}\u6490\ua85a\u0029\u5051'});
+let renderBundleEncoder30 = device2.createRenderBundleEncoder({colorFormats: ['rgba8unorm-srgb', 'rg8sint', 'r8sint', 'rgb10a2unorm']});
+let externalTexture19 = device2.importExternalTexture({
+  label: '\u01d2\u094a\ub52e\u00e6\u{1f78f}\u9fe4\u0940\u{1fff6}\u0306\u8a51\u{1f8fc}',
+  source: videoFrame0,
+  colorSpace: 'display-p3',
+});
+try {
+device2.queue.submit([]);
+} catch {}
+try {
+  await device2.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1215, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: video3,
+  origin: { x: 5, y: 2 },
+  flipY: false,
+}, {
+  texture: texture47,
+  mipLevel: 1,
+  origin: {x: 128, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline51 = await device2.createRenderPipelineAsync({
+  label: '\u09dd\u1018\u0c57\u074f\u{1fe42}\u7b21\u0ee1\u01d1\u734f\u{1fdbf}\u{1f6a5}',
+  layout: pipelineLayout9,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'add', srcFactor: 'zero', dstFactor: 'one-minus-src-alpha'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'constant', dstFactor: 'one-minus-dst-alpha'},
+  },
+  writeMask: GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}, {format: 'r8sint', writeMask: 0}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'less', failOp: 'zero', depthFailOp: 'increment-wrap', passOp: 'decrement-wrap'},
+    stencilBack: {compare: 'never', failOp: 'replace', depthFailOp: 'zero', passOp: 'replace'},
+    stencilReadMask: 3800319346,
+    stencilWriteMask: 1738968756,
+    depthBias: 1910506505,
+    depthBiasClamp: 534.8445838162141,
+  },
+  vertex: {
+    module: shaderModule12,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 248,
+        attributes: [
+          {format: 'unorm8x4', offset: 20, shaderLocation: 1},
+          {format: 'sint32', offset: 36, shaderLocation: 19},
+          {format: 'sint32x3', offset: 100, shaderLocation: 16},
+        ],
+      },
+      {arrayStride: 432, stepMode: 'instance', attributes: []},
+      {arrayStride: 396, attributes: []},
+      {arrayStride: 2024, attributes: []},
+      {
+        arrayStride: 1592,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm8x2', offset: 478, shaderLocation: 5}],
+      },
+    ],
+  },
+});
+let img14 = await imageWithData(19, 2, '#a9f2e06c', '#5a2fbe54');
+let bindGroupLayout20 = device2.createBindGroupLayout({
+  label: '\u20be\u{1fa81}\u04d0\u5c0b\uabca\u0ba9\uf7c4\uf65e\u{1f806}\u40f9\ue351',
+  entries: [
+    {binding: 2348, visibility: GPUShaderStage.VERTEX, sampler: { type: 'filtering' }},
+    {binding: 6939, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {binding: 1697, visibility: 0, externalTexture: {}},
+  ],
+});
+let buffer13 = device2.createBuffer({
+  label: '\ue9bd\u03c5\u052d\u0e27\u39ed',
+  size: 298723,
+  usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let texture48 = device2.createTexture({
+  label: '\ued1c\u121b\u{1fa7f}\u897e\u03cf\u0655',
+  size: {width: 96, height: 1, depthOrArrayLayers: 781},
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rg8sint', 'rg8sint'],
+});
+let computePassEncoder30 = commandEncoder64.beginComputePass({label: '\u{1fae5}\u5d7a\u7325\u76b3\u0415'});
+try {
+renderBundleEncoder30.setPipeline(pipeline48);
+} catch {}
+try {
+renderBundleEncoder30.setVertexBuffer(7, buffer13);
+} catch {}
+try {
+commandEncoder68.copyBufferToTexture({
+  /* bytesInLastRow: 1352 widthInBlocks: 338 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 38500 */
+  offset: 38500,
+  bytesPerRow: 1536,
+  rowsPerImage: 296,
+  buffer: buffer12,
+}, {
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 353, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 338, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer12);
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture39,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Float64Array(arrayBuffer5), /* required buffer size: 727 */
+{offset: 727, bytesPerRow: 99, rowsPerImage: 241}, {width: 10, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let promise15 = device2.queue.onSubmittedWorkDone();
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 607, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas22,
+  origin: { x: 0, y: 13 },
+  flipY: false,
+}, {
+  texture: texture47,
+  mipLevel: 2,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 461, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let promise16 = adapter3.requestAdapterInfo();
+try {
+gpuCanvasContext7.unconfigure();
+} catch {}
+gc();
+try {
+canvas11.getContext('webgpu');
+} catch {}
+let bindGroup4 = device0.createBindGroup({
+  label: '\ua179\uc0a3\u{1fb3e}\ud262\u343e\ue975\u0fcc\u{1fac2}\ue78e\u8a4d\u{1f901}',
+  layout: bindGroupLayout3,
+  entries: [{binding: 3010, resource: sampler20}],
+});
+let commandEncoder71 = device0.createCommandEncoder({label: '\u0d3e\uc1dd\u1d50'});
+let textureView73 = texture10.createView({});
+let computePassEncoder31 = commandEncoder27.beginComputePass({label: '\u7451\u04b9\u0f65\u{1ffb6}\u2995\u76a9\u{1f6cf}'});
+let externalTexture20 = device0.importExternalTexture({label: '\u78b4\u0f75\u{1fdc9}\u08fd\u0689', source: video2, colorSpace: 'srgb'});
+try {
+renderBundleEncoder18.setBindGroup(9, bindGroup1, new Uint32Array(5262), 2773, 0);
+} catch {}
+try {
+commandEncoder71.resolveQuerySet(querySet10, 759, 249, buffer1, 897280);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 11, height: 1, depthOrArrayLayers: 5}
+*/
+{
+  source: video10,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture21,
+  mipLevel: 1,
+  origin: {x: 2, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData17 = new ImageData(12, 136);
+let bindGroupLayout21 = device2.createBindGroupLayout({label: '\u6ba6\u6384\ucda2\u8345\u{1fcd6}', entries: []});
+let commandEncoder72 = device2.createCommandEncoder({});
+try {
+commandEncoder68.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 23120 */
+  offset: 23120,
+  buffer: buffer12,
+}, {
+  texture: texture43,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer12);
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 2430, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: canvas12,
+  origin: { x: 23, y: 14 },
+  flipY: true,
+}, {
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 473, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 100, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline52 = await device2.createComputePipelineAsync({
+  label: '\ue89c\u03b7\uc203\u{1fb38}\u2e16\ud204\ua21a\u{1fb6c}\ucfd5\u{1f906}',
+  layout: 'auto',
+  compute: {module: shaderModule13, entryPoint: 'compute0'},
+});
+let gpuCanvasContext19 = canvas14.getContext('webgpu');
+try {
+canvas17.getContext('webgl2');
+} catch {}
+let textureView74 = texture47.createView({dimension: '2d-array', baseMipLevel: 2});
+let renderBundle45 = renderBundleEncoder25.finish({label: '\u06ca\u06bb\u8455\u0686\u71d0\u0d66'});
+try {
+renderBundleEncoder30.setPipeline(pipeline48);
+} catch {}
+try {
+  await buffer12.mapAsync(GPUMapMode.WRITE, 211688, 141932);
+} catch {}
+try {
+commandEncoder66.copyTextureToTexture({
+  texture: texture39,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture39,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let videoFrame7 = new VideoFrame(video12, {timestamp: 0});
+let imageData18 = new ImageData(180, 80);
+let bindGroupLayout22 = device2.createBindGroupLayout({
+  label: '\u4479\u1560\u{1f97d}\u712e\u0993\u{1f850}',
+  entries: [
+    {
+      binding: 3122,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d-array', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let textureView75 = texture40.createView({label: '\u179a\u0140\ued74\ud460\uf3cb', aspect: 'all'});
+try {
+computePassEncoder28.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder30.setBindGroup(0, bindGroup3, new Uint32Array(580), 348, 0);
+} catch {}
+try {
+commandEncoder66.copyTextureToTexture({
+  texture: texture40,
+  mipLevel: 6,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let img15 = await imageWithData(142, 272, '#ffa2badc', '#e8e9b826');
+let renderBundleEncoder31 = device2.createRenderBundleEncoder({
+  label: '\u{1fe86}\u{1f96f}\u4ad1\u8859\u0970\u4c6b\u0e45',
+  colorFormats: ['rgba8unorm-srgb', 'rg8sint', 'r8sint', 'rgb10a2unorm'],
+});
+let externalTexture21 = device2.importExternalTexture({label: '\u7b0d\u0c71', source: video19, colorSpace: 'display-p3'});
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 2430, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas10,
+  origin: { x: 165, y: 242 },
+  flipY: true,
+}, {
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 125, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 21, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline53 = device2.createRenderPipeline({
+  label: '\u{1fa71}\u{1fc0c}\u0971\u{1f85e}\u9184',
+  layout: pipelineLayout9,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8unorm-srgb', writeMask: 0}, {format: 'rg8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'r8sint', writeMask: 0}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'equal',
+    stencilFront: {compare: 'greater', failOp: 'decrement-clamp', depthFailOp: 'decrement-clamp'},
+    stencilBack: {compare: 'less', failOp: 'increment-clamp', depthFailOp: 'decrement-clamp', passOp: 'replace'},
+    stencilWriteMask: 1248395108,
+    depthBiasSlopeScale: 834.445243492826,
+    depthBiasClamp: 433.55162943134474,
+  },
+  vertex: {
+    module: shaderModule12,
+    entryPoint: 'vertex0',
+    buffers: [
+      {arrayStride: 1000, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x2', offset: 1520, shaderLocation: 16},
+          {format: 'float32x2', offset: 140, shaderLocation: 1},
+          {format: 'unorm10-10-10-2', offset: 1372, shaderLocation: 5},
+          {format: 'sint8x4', offset: 304, shaderLocation: 19},
+        ],
+      },
+    ],
+  },
+  primitive: {cullMode: 'back', unclippedDepth: true},
+});
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+let bindGroup5 = device0.createBindGroup({
+  label: '\u3e1b\u{1fbb1}\u46b1',
+  layout: bindGroupLayout7,
+  entries: [
+    {binding: 3170, resource: sampler6},
+    {binding: 3254, resource: sampler19},
+    {binding: 2685, resource: externalTexture20},
+  ],
+});
+let textureView76 = texture21.createView({
+  label: '\u{1f665}\u1917\uf7d0\u2dc3\uecfc\u0bbb\u61ff\u0517\u{1f913}\u0b23',
+  format: 'rg8unorm',
+  baseMipLevel: 1,
+  baseArrayLayer: 0,
+});
+let renderBundleEncoder32 = device0.createRenderBundleEncoder({colorFormats: ['r8sint', 'rgba32float'], sampleCount: 1, depthReadOnly: true, stencilReadOnly: true});
+let externalTexture22 = device0.importExternalTexture({source: videoFrame7, colorSpace: 'display-p3'});
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(9, bindGroup4, new Uint32Array(367), 338, 0);
+} catch {}
+try {
+commandEncoder34.clearBuffer(buffer11);
+dissociateBuffer(device0, buffer11);
+} catch {}
+let video21 = await videoWithData();
+let imageBitmap10 = await createImageBitmap(offscreenCanvas4);
+let videoFrame8 = new VideoFrame(canvas6, {timestamp: 0});
+let computePassEncoder32 = commandEncoder72.beginComputePass();
+let renderBundleEncoder33 = device2.createRenderBundleEncoder({
+  label: '\u8940\u{1fe0d}\u2eea\u0bb2\uc178\u0d05',
+  colorFormats: ['rgba8unorm-srgb', 'rg8sint', 'r8sint', 'rgb10a2unorm'],
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder32.setBindGroup(3, bindGroup3, new Uint32Array(5030), 1990, 0);
+} catch {}
+try {
+renderBundleEncoder33.setBindGroup(4, bindGroup2, new Uint32Array(51), 36, 0);
+} catch {}
+try {
+renderBundleEncoder33.setVertexBuffer(0, buffer13, 221056, 76738);
+} catch {}
+let shaderModule14 = device2.createShaderModule({
+  label: '\u{1f96b}\u522f',
+  code: `@group(0) @binding(3828)
+var<storage, read_write> n19: array<u32>;
+
+@compute @workgroup_size(6, 2, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S13 {
+  @location(21) f0: vec2<i32>,
+  @location(36) f1: vec3<f32>,
+  @location(62) f2: f32,
+  @location(61) f3: vec3<i32>,
+  @location(37) f4: vec3<u32>,
+  @location(28) f5: vec2<f16>,
+  @location(41) f6: u32,
+  @location(38) f7: vec2<f32>,
+  @location(22) f8: vec4<f16>,
+  @location(18) f9: vec2<i32>,
+  @location(55) f10: vec3<f16>,
+  @location(52) f11: vec2<f16>,
+  @location(53) f12: f32,
+  @location(44) f13: vec2<i32>,
+  @location(19) f14: vec2<i32>,
+  @location(15) f15: f16,
+  @location(58) f16: i32,
+  @location(11) f17: i32,
+  @location(4) f18: vec3<i32>,
+  @location(6) f19: vec2<f32>,
+  @location(35) f20: i32,
+  @location(14) f21: vec4<f16>,
+  @location(42) f22: vec4<i32>,
+  @location(40) f23: vec2<f32>
+}
+struct FragmentOutput0 {
+  @location(2) f0: vec2<i32>,
+  @location(5) f1: vec2<u32>,
+  @location(0) f2: vec4<f32>,
+  @location(1) f3: vec4<i32>,
+  @location(3) f4: vec4<f32>
+}
+
+@fragment
+fn fragment0(@location(32) a0: vec4<f32>, @location(54) a1: vec3<f16>, @location(60) a2: vec2<f16>, @location(25) a3: vec2<i32>, @builtin(position) a4: vec4<f32>, @location(57) a5: vec2<f32>, @location(17) a6: f16, @location(23) a7: vec2<f16>, @builtin(front_facing) a8: bool, a9: S13, @location(2) a10: vec4<f16>, @location(39) a11: vec3<i32>, @location(9) a12: vec4<i32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S12 {
+  @location(20) f0: vec3<u32>,
+  @location(22) f1: vec3<f16>,
+  @location(21) f2: vec3<u32>,
+  @location(11) f3: vec2<f16>,
+  @location(23) f4: vec2<i32>,
+  @location(24) f5: vec4<f16>,
+  @location(1) f6: vec4<u32>,
+  @location(5) f7: vec2<i32>,
+  @location(2) f8: f32,
+  @location(13) f9: vec2<i32>,
+  @location(15) f10: f32,
+  @location(19) f11: vec4<u32>,
+  @location(3) f12: vec4<i32>,
+  @builtin(vertex_index) f13: u32,
+  @location(18) f14: vec3<i32>,
+  @builtin(instance_index) f15: u32,
+  @location(16) f16: vec4<i32>,
+  @location(8) f17: vec2<i32>,
+  @location(14) f18: vec3<f16>,
+  @location(10) f19: i32
+}
+struct VertexOutput0 {
+  @location(32) f193: vec4<f32>,
+  @location(22) f194: vec4<f16>,
+  @location(37) f195: vec3<u32>,
+  @builtin(position) f196: vec4<f32>,
+  @location(53) f197: f32,
+  @location(35) f198: i32,
+  @location(39) f199: vec3<i32>,
+  @location(55) f200: vec3<f16>,
+  @location(54) f201: vec3<f16>,
+  @location(17) f202: f16,
+  @location(4) f203: vec3<i32>,
+  @location(6) f204: vec2<f32>,
+  @location(2) f205: vec4<f16>,
+  @location(19) f206: vec2<i32>,
+  @location(21) f207: vec2<i32>,
+  @location(57) f208: vec2<f32>,
+  @location(9) f209: vec4<i32>,
+  @location(14) f210: vec4<f16>,
+  @location(60) f211: vec2<f16>,
+  @location(62) f212: f32,
+  @location(25) f213: vec2<i32>,
+  @location(18) f214: vec2<i32>,
+  @location(40) f215: vec2<f32>,
+  @location(61) f216: vec3<i32>,
+  @location(36) f217: vec3<f32>,
+  @location(44) f218: vec2<i32>,
+  @location(28) f219: vec2<f16>,
+  @location(15) f220: f16,
+  @location(58) f221: i32,
+  @location(52) f222: vec2<f16>,
+  @location(23) f223: vec2<f16>,
+  @location(11) f224: i32,
+  @location(42) f225: vec4<i32>,
+  @location(41) f226: u32,
+  @location(38) f227: vec2<f32>
+}
+
+@vertex
+fn vertex0(@location(7) a0: i32, @location(9) a1: i32, @location(0) a2: vec4<f32>, @location(6) a3: vec4<f16>, @location(4) a4: f32, @location(12) a5: vec3<i32>, a6: S12, @location(17) a7: vec3<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let texture49 = device2.createTexture({
+  label: '\u4277\u9fff\u0e92\u9710\u3080\u0ff1\ufcce\u{1fc5f}\u{1fd25}\u{1ffdc}',
+  size: {width: 1152, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  sampleCount: 1,
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba8unorm-srgb', 'rgba8unorm-srgb'],
+});
+let renderBundle46 = renderBundleEncoder26.finish({});
+try {
+renderBundleEncoder33.setPipeline(pipeline48);
+} catch {}
+try {
+device2.destroy();
+} catch {}
+let imageData19 = new ImageData(108, 212);
+try {
+window.someLabel = externalTexture21.label;
+} catch {}
+try {
+  await promise16;
+} catch {}
+let canvas18 = document.createElement('canvas');
+let img16 = await imageWithData(49, 81, '#99089b4b', '#b917e021');
+try {
+canvas18.getContext('bitmaprenderer');
+} catch {}
+try {
+texture1.label = '\u{1fd49}\u{1f775}\u0056\u0852\u{1faf2}\u68e6\u0b17\u07bc';
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+try {
+  await promise15;
+} catch {}
+try {
+gpuCanvasContext8.unconfigure();
+} catch {}
+let offscreenCanvas23 = new OffscreenCanvas(131, 177);
+let imageData20 = new ImageData(36, 28);
+gc();
+offscreenCanvas8.height = 155;
+canvas8.height = 2182;
+gc();
+try {
+adapter0.label = '\u83d7\u0611\u06b6\u68e1\u33cd';
+} catch {}
+gc();
+let imageBitmap11 = await createImageBitmap(video0);
+let offscreenCanvas24 = new OffscreenCanvas(714, 444);
+let video22 = await videoWithData();
+let gpuCanvasContext20 = offscreenCanvas24.getContext('webgpu');
+try {
+offscreenCanvas23.getContext('webgl2');
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let imageBitmap12 = await createImageBitmap(imageData2);
+try {
+externalTexture6.label = '\u0fb0\u{1fda1}';
+} catch {}
+let videoFrame9 = new VideoFrame(offscreenCanvas15, {timestamp: 0});
+let videoFrame10 = new VideoFrame(img14, {timestamp: 0});
+let offscreenCanvas25 = new OffscreenCanvas(52, 782);
+let img17 = await imageWithData(200, 164, '#c133d2c9', '#cd49a730');
+let gpuCanvasContext21 = offscreenCanvas25.getContext('webgpu');
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let imageBitmap13 = await createImageBitmap(offscreenCanvas10);
+let video23 = await videoWithData();
+let img18 = await imageWithData(213, 231, '#2b33788f', '#8e998869');
+let offscreenCanvas26 = new OffscreenCanvas(747, 356);
+let videoFrame11 = new VideoFrame(offscreenCanvas11, {timestamp: 0});
+try {
+gpuCanvasContext17.unconfigure();
+} catch {}
+let canvas19 = document.createElement('canvas');
+let texture50 = device0.createTexture({
+  label: '\u{1f680}\u01e6\ua625\u0f22\u08a3\u{1f9ad}\uc70a\u03df\u43a2\u5097\u{1fcb4}',
+  size: {width: 40, height: 1, depthOrArrayLayers: 527},
+  mipLevelCount: 9,
+  dimension: '3d',
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r16uint', 'r16uint'],
+});
+let renderBundle47 = renderBundleEncoder11.finish({});
+let externalTexture23 = device0.importExternalTexture({label: '\u0b43\u{1fcab}\u783d\u8d94\u45a4\u{1fcc3}\ua1fc\u{1fd1a}\u668d\u597d', source: video2});
+try {
+renderBundleEncoder12.setBindGroup(9, bindGroup4, new Uint32Array(2067), 687, 0);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(2103, undefined, 2609574492, 1636878302);
+} catch {}
+try {
+commandEncoder22.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 1,
+  origin: {x: 6, y: 0, z: 54},
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 5});
+} catch {}
+let pipeline54 = await promise9;
+let canvas20 = document.createElement('canvas');
+let video24 = await videoWithData();
+video1.height = 120;
+let imageData21 = new ImageData(80, 52);
+offscreenCanvas8.height = 289;
+try {
+gpuCanvasContext15.unconfigure();
+} catch {}
+try {
+offscreenCanvas26.getContext('bitmaprenderer');
+} catch {}
+let offscreenCanvas27 = new OffscreenCanvas(87, 668);
+let img19 = await imageWithData(201, 11, '#cf693531', '#80873918');
+canvas8.height = 1275;
+offscreenCanvas5.width = 82;
+try {
+if (!arrayBuffer2.detached) { new Uint8Array(arrayBuffer2).fill(0x55) };
+} catch {}
+let videoFrame12 = new VideoFrame(img19, {timestamp: 0});
+let commandEncoder73 = device0.createCommandEncoder({label: '\u{1fe90}\u0eee\u{1f947}'});
+let querySet30 = device0.createQuerySet({label: '\ufca1\u{1f7dc}', type: 'occlusion', count: 1261});
+let renderBundleEncoder34 = device0.createRenderBundleEncoder({
+  label: '\u07d4\u091a\u{1f8df}',
+  colorFormats: ['rgb10a2unorm', 'rgba32uint', 'r8uint', 'rgba16uint', 'r16float', 'bgra8unorm-srgb', 'r16uint'],
+  depthStencilFormat: 'depth24plus-stencil8',
+  depthReadOnly: true,
+});
+try {
+computePassEncoder16.setBindGroup(10, bindGroup5, new Uint32Array(6886), 311, 0);
+} catch {}
+try {
+computePassEncoder31.end();
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer5, 'uint32');
+} catch {}
+try {
+renderBundleEncoder32.setVertexBuffer(4929, undefined);
+} catch {}
+try {
+gpuCanvasContext20.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.destroy();
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let video25 = await videoWithData();
+try {
+device2.queue.label = '\ud5aa\u{1f628}\uc9bd\u0dbd\u463d\ud736';
+} catch {}
+try {
+canvas19.getContext('webgl');
+} catch {}
+let video26 = await videoWithData();
+let videoFrame13 = new VideoFrame(video19, {timestamp: 0});
+let querySet31 = device2.createQuerySet({
+  label: '\u04f0\u08fd\u03f1\u{1fc9f}\u{1fec2}\ua5a3\u8a38\u0f3f\u{1fe35}\u6aaf\u6a87',
+  type: 'occlusion',
+  count: 2490,
+});
+let renderBundleEncoder35 = device2.createRenderBundleEncoder({
+  label: '\u014a\u71d1\u{1fe02}\u0518\u{1f7bc}\u8793\u2209',
+  colorFormats: ['rgba8unorm-srgb', 'rg8sint', 'r8sint', 'rgb10a2unorm'],
+  sampleCount: 1,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let externalTexture24 = device2.importExternalTexture({label: '\u154b\u0737\ue19f\u{1f67d}', source: videoFrame0, colorSpace: 'srgb'});
+let arrayBuffer6 = buffer12.getMappedRange(268088, 69260);
+try {
+buffer13.unmap();
+} catch {}
+try {
+device2.queue.writeTexture({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 44, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer3), /* required buffer size: 927 */
+{offset: 927, bytesPerRow: 1692}, {width: 398, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 1215, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas18,
+  origin: { x: 31, y: 227 },
+  flipY: true,
+}, {
+  texture: texture47,
+  mipLevel: 1,
+  origin: {x: 113, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline55 = device2.createRenderPipeline({
+  label: '\u0433\uc57c\uc9d3',
+  layout: pipelineLayout6,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule12,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rgba8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.BLUE,
+}, {format: 'rg8sint'}, {format: 'r8sint', writeMask: 0}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule12,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 788,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32x3', offset: 248, shaderLocation: 16},
+          {format: 'float16x4', offset: 32, shaderLocation: 1},
+          {format: 'unorm10-10-10-2', offset: 24, shaderLocation: 5},
+        ],
+      },
+      {arrayStride: 0, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 148,
+        stepMode: 'instance',
+        attributes: [{format: 'sint8x4', offset: 52, shaderLocation: 19}],
+      },
+    ],
+  },
+});
+try {
+adapter4.label = '\u03cd\u8a17\uc60b\u0cc7\u075e\u0602\u0a54\u070a';
+} catch {}
+let canvas21 = document.createElement('canvas');
+let img20 = await imageWithData(50, 258, '#04d02e55', '#00b18123');
+let promise17 = adapter1.requestAdapterInfo();
+document.body.prepend(canvas12);
+let canvas22 = document.createElement('canvas');
+try {
+adapter1.label = '\u0567\u9ead\u7275';
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let gpuCanvasContext22 = canvas22.getContext('webgpu');
+let video27 = await videoWithData();
+let canvas23 = document.createElement('canvas');
+try {
+canvas20.getContext('bitmaprenderer');
+} catch {}
+let gpuCanvasContext23 = canvas23.getContext('webgpu');
+gc();
+try {
+  await promise17;
+} catch {}
+video5.height = 104;
+offscreenCanvas7.width = 121;
+document.body.prepend(canvas2);
+let gpuCanvasContext24 = offscreenCanvas27.getContext('webgpu');
+try {
+textureView40.label = '\u0f38\uec0c\u6a8c\u2a52\u2981\u6b12\u{1fff6}\u{1fc1e}';
+} catch {}
+let offscreenCanvas28 = new OffscreenCanvas(849, 141);
+try {
+canvas21.getContext('2d');
+} catch {}
+let offscreenCanvas29 = new OffscreenCanvas(445, 418);
+let imageBitmap14 = await createImageBitmap(offscreenCanvas28);
+let gpuCanvasContext25 = offscreenCanvas28.getContext('webgpu');
+let offscreenCanvas30 = new OffscreenCanvas(346, 203);
+let videoFrame14 = new VideoFrame(video21, {timestamp: 0});
+gc();
+let canvas24 = document.createElement('canvas');
+let videoFrame15 = new VideoFrame(video8, {timestamp: 0});
+document.body.prepend(video23);
+let commandEncoder74 = device1.createCommandEncoder({label: '\u00f5\u2826\u55f1'});
+let renderBundle48 = renderBundleEncoder21.finish({label: '\u{1f63d}\u9ada\u0094'});
+try {
+renderBundleEncoder28.setPipeline(pipeline30);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(6642, undefined, 3534428578);
+} catch {}
+try {
+commandEncoder41.clearBuffer(buffer9, 14364, 37644);
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+gpuCanvasContext23.configure({
+  device: device1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise18 = device1.queue.onSubmittedWorkDone();
+document.body.prepend(video7);
+let gpuCanvasContext26 = canvas24.getContext('webgpu');
+let offscreenCanvas31 = new OffscreenCanvas(469, 715);
+try {
+externalTexture0.label = '\uc17a\u{1f805}\u2fab\u0efd\u1b1d\u0e5e\ub298\uda1c\udb29\u08fb';
+} catch {}
+try {
+offscreenCanvas30.getContext('webgl');
+} catch {}
+let offscreenCanvas32 = new OffscreenCanvas(202, 534);
+let videoFrame16 = new VideoFrame(video7, {timestamp: 0});
+try {
+adapter1.label = '\u2a3d\u6dbb\u{1f8cd}\uc929\uf309\u{1ffc0}\ufa36\u{1fabc}';
+} catch {}
+canvas9.height = 403;
+let offscreenCanvas33 = new OffscreenCanvas(764, 1024);
+let imageData22 = new ImageData(144, 108);
+try {
+offscreenCanvas29.getContext('bitmaprenderer');
+} catch {}
+gc();
+try {
+  await promise18;
+} catch {}
+gc();
+let imageData23 = new ImageData(108, 108);
+let bindGroupLayout23 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 3609, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 2937,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {
+      binding: 365,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let buffer14 = device0.createBuffer({
+  label: '\u{1feee}\u046c\u1135',
+  size: 353371,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  mappedAtCreation: false,
+});
+let commandEncoder75 = device0.createCommandEncoder({label: '\u{1ff84}\u972f\ud9f3\ua6dc\u{1fdae}\ue425\u{1ffea}\u02fe\ua9fc\u4e25'});
+let textureView77 = texture10.createView({});
+let renderBundleEncoder36 = device0.createRenderBundleEncoder({
+  colorFormats: ['rg8unorm', 'rg32float', 'rg16sint', 'r16uint', 'r16uint', 'r8uint', 'rgba8sint', 'bgra8unorm-srgb'],
+  stencilReadOnly: true,
+});
+let externalTexture25 = device0.importExternalTexture({source: video26, colorSpace: 'srgb'});
+try {
+computePassEncoder16.setBindGroup(9, bindGroup1, new Uint32Array(5371), 3336, 0);
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline19);
+} catch {}
+try {
+renderBundleEncoder19.setBindGroup(8, bindGroup0);
+} catch {}
+try {
+  await buffer14.mapAsync(GPUMapMode.READ, 26384, 26900);
+} catch {}
+try {
+commandEncoder19.copyBufferToBuffer(buffer2, 12336, buffer14, 42924, 6520);
+dissociateBuffer(device0, buffer2);
+dissociateBuffer(device0, buffer14);
+} catch {}
+try {
+commandEncoder20.resolveQuerySet(querySet0, 87, 150, buffer1, 63488);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(80), /* required buffer size: 250 */
+{offset: 214}, {width: 9, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline56 = await device0.createRenderPipelineAsync({
+  label: '\u0b5b\u{1fc5f}\uf124',
+  layout: pipelineLayout0,
+  multisample: {count: 4, mask: 0x42e06ba9},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{
+  format: 'rg8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'one-minus-src-alpha'},
+    alpha: {operation: 'add', srcFactor: 'one', dstFactor: 'dst-alpha'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE}, {format: 'rg16sint'}, {format: 'r16uint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}, {format: 'r16uint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'r8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rgba8sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.RED}, {format: 'bgra8unorm-srgb', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule0,
+    entryPoint: 'vertex0',
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 1912,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm16x4', offset: 212, shaderLocation: 0},
+          {format: 'sint32x3', offset: 116, shaderLocation: 16},
+          {format: 'unorm16x2', offset: 216, shaderLocation: 6},
+          {format: 'float32x2', offset: 472, shaderLocation: 11},
+          {format: 'float16x2', offset: 436, shaderLocation: 3},
+          {format: 'unorm16x4', offset: 32, shaderLocation: 7},
+          {format: 'uint32x4', offset: 16, shaderLocation: 13},
+          {format: 'float32x2', offset: 356, shaderLocation: 8},
+          {format: 'uint8x4', offset: 1016, shaderLocation: 12},
+          {format: 'sint8x2', offset: 22, shaderLocation: 17},
+          {format: 'unorm16x4', offset: 8, shaderLocation: 5},
+          {format: 'uint8x4', offset: 192, shaderLocation: 4},
+          {format: 'snorm16x2', offset: 1068, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 416,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 32, shaderLocation: 1},
+          {format: 'uint32', offset: 40, shaderLocation: 2},
+          {format: 'sint32', offset: 0, shaderLocation: 14},
+        ],
+      },
+      {arrayStride: 548, attributes: [{format: 'unorm16x2', offset: 92, shaderLocation: 15}]},
+      {arrayStride: 912, attributes: [{format: 'float16x2', offset: 12, shaderLocation: 9}]},
+    ],
+  },
+});
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+let promise19 = navigator.gpu.requestAdapter();
+try {
+window.someLabel = texture29.label;
+} catch {}
+let canvas25 = document.createElement('canvas');
+video3.height = 182;
+let img21 = await imageWithData(254, 115, '#9d67659e', '#44c0e481');
+let imageData24 = new ImageData(8, 120);
+let commandEncoder76 = device1.createCommandEncoder({label: '\u732b\u6f2b\u0fe8\u004e\u4d89\u0155\uabc8'});
+let commandBuffer14 = commandEncoder53.finish({});
+let textureView78 = texture46.createView({label: '\u135e\u0d1a\u7f88\ue218', baseMipLevel: 4, mipLevelCount: 1});
+let computePassEncoder33 = commandEncoder76.beginComputePass();
+let sampler32 = device1.createSampler({
+  label: '\u709e\uc03b\u00c4\u0bd7\ub24c',
+  addressModeU: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 47.92,
+  compare: 'greater-equal',
+});
+try {
+renderBundleEncoder28.setIndexBuffer(buffer9, 'uint32', 42524, 9983);
+} catch {}
+canvas17.width = 85;
+let offscreenCanvas34 = new OffscreenCanvas(684, 586);
+try {
+offscreenCanvas32.getContext('2d');
+} catch {}
+let promise20 = adapter3.requestDevice({
+  label: '\u0964\u7b43\u7f5f\u2f0b\ud7d6',
+  defaultQueue: {},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'bgra8unorm-storage',
+  ],
+  requiredLimits: {
+    maxBindGroups: 11,
+    maxColorAttachmentBytesPerSample: 35,
+    maxVertexAttributes: 25,
+    maxVertexBufferArrayStride: 18723,
+    maxStorageTexturesPerShaderStage: 18,
+    maxStorageBuffersPerShaderStage: 44,
+    maxDynamicStorageBuffersPerPipelineLayout: 3855,
+    maxDynamicUniformBuffersPerPipelineLayout: 48874,
+    maxBindingsPerBindGroup: 1745,
+    maxTextureArrayLayers: 2017,
+    maxTextureDimension1D: 12259,
+    maxTextureDimension2D: 12422,
+    maxBindGroupsPlusVertexBuffers: 24,
+    minStorageBufferOffsetAlignment: 128,
+    minUniformBufferOffsetAlignment: 32,
+    maxUniformBufferBindingSize: 130802442,
+    maxStorageBufferBindingSize: 182711807,
+    maxSampledTexturesPerShaderStage: 25,
+    maxInterStageShaderVariables: 68,
+    maxSamplersPerShaderStage: 20,
+  },
+});
+canvas17.height = 366;
+let gpuCanvasContext27 = canvas25.getContext('webgpu');
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+canvas12.width = 1369;
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+let imageData25 = new ImageData(84, 88);
+try {
+offscreenCanvas33.getContext('bitmaprenderer');
+} catch {}
+try {
+adapter2.label = '\u095a\ub574\u{1fc7b}\u7c1b';
+} catch {}
+document.body.prepend(canvas19);
+offscreenCanvas16.width = 7;
+gc();
+let gpuCanvasContext28 = offscreenCanvas34.getContext('webgpu');
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+let img22 = await imageWithData(290, 106, '#89983b24', '#d1c7c99d');
+let videoFrame17 = new VideoFrame(canvas9, {timestamp: 0});
+try {
+offscreenCanvas31.getContext('webgl');
+} catch {}
+offscreenCanvas4.width = 140;
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+gc();
+let video28 = await videoWithData();
+let videoFrame18 = new VideoFrame(imageBitmap11, {timestamp: 0});
+try {
+adapter3.label = '\u09a4\u{1fbde}\u{1fa0c}\u{1fe9a}\uf50c\u0b81\u04f0\ude4a\u0075\u{1f93e}';
+} catch {}
+let imageData26 = new ImageData(160, 40);
+offscreenCanvas7.width = 175;
+let img23 = await imageWithData(177, 300, '#803353b0', '#1372f0cc');
+document.body.prepend(video2);
+video27.height = 121;
+let commandEncoder77 = device1.createCommandEncoder({label: '\ueeee\u83bc\u9b1c\u8923\u0bef\u849e\u{1fc71}\u{1f785}'});
+let textureView79 = texture46.createView({baseMipLevel: 4});
+let renderPassEncoder0 = commandEncoder41.beginRenderPass({
+  label: '\u3bbc\ufe3d\u06b1\u6922',
+  colorAttachments: [{
+  view: textureView70,
+  clearValue: { r: 805.6, g: -27.46, b: 703.1, a: 855.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 1006163019,
+});
+let sampler33 = device1.createSampler({
+  label: '\u0d4b\u4c34\u6c71\u{1fc8d}\u4751\u04ae\u{1fa61}',
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 84.68,
+  lodMaxClamp: 96.54,
+  maxAnisotropy: 19,
+});
+try {
+renderPassEncoder0.setStencilReference(949);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline36);
+} catch {}
+try {
+renderBundleEncoder28.setPipeline(pipeline30);
+} catch {}
+try {
+commandEncoder70.resolveQuerySet(querySet17, 236, 32, buffer8, 178688);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer3, /* required buffer size: 350 */
+{offset: 350}, {width: 416, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext4.unconfigure();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+try {
+adapter0.label = '\u900d\uba60\u0d70\u0058\ueae3\u0e7a\u05bc\u0cee';
+} catch {}
+try {
+window.someLabel = externalTexture17.label;
+} catch {}
+let imageBitmap15 = await createImageBitmap(video2);
+let commandEncoder78 = device0.createCommandEncoder({label: '\u5466\u589a\u1d29\u{1fc5a}\ud0af\u0aaf\u8222\u0ce2\ue02f\ufea6'});
+let textureView80 = texture5.createView({aspect: 'all', format: 'r8uint', baseMipLevel: 2, baseArrayLayer: 56, arrayLayerCount: 108});
+let externalTexture26 = device0.importExternalTexture({label: '\u095d\u5190\u{1f94a}\u{1f8ac}\u0f46\u0d97', source: video12, colorSpace: 'display-p3'});
+try {
+computePassEncoder6.setBindGroup(10, bindGroup0, new Uint32Array(8005), 3146, 0);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(1177, undefined, 0, 1730707514);
+} catch {}
+let pipeline57 = device0.createRenderPipeline({
+  label: '\u57e7\u{1fc67}\u{1f7ce}',
+  layout: pipelineLayout3,
+  multisample: {mask: 0x6a011384},
+  fragment: {
+  module: shaderModule8,
+  entryPoint: 'fragment0',
+  targets: [{format: 'r8sint'}, {format: 'rgba32float'}],
+},
+  vertex: {
+    module: shaderModule8,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 2124,
+        attributes: [
+          {format: 'snorm8x4', offset: 412, shaderLocation: 1},
+          {format: 'sint8x2', offset: 108, shaderLocation: 13},
+          {format: 'unorm16x4', offset: 64, shaderLocation: 0},
+          {format: 'float32x4', offset: 36, shaderLocation: 15},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint16', cullMode: 'front', unclippedDepth: true},
+});
+try {
+adapter2.label = '\u61dd\u4662\uc44a\u0368\u{1f9ec}\u2cc3';
+} catch {}
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+offscreenCanvas0.height = 2601;
+let canvas26 = document.createElement('canvas');
+try {
+gpuCanvasContext16.unconfigure();
+} catch {}
+document.body.prepend(canvas13);
+let videoFrame19 = new VideoFrame(offscreenCanvas21, {timestamp: 0});
+let adapter5 = await navigator.gpu.requestAdapter({});
+let offscreenCanvas35 = new OffscreenCanvas(989, 564);
+document.body.prepend(canvas5);
+let videoFrame20 = new VideoFrame(img21, {timestamp: 0});
+try {
+canvas26.getContext('2d');
+} catch {}
+document.body.prepend(canvas17);
+gc();
+let promise21 = adapter3.requestAdapterInfo();
+let canvas27 = document.createElement('canvas');
+offscreenCanvas9.height = 1582;
+let imageBitmap16 = await createImageBitmap(offscreenCanvas26);
+try {
+offscreenCanvas35.getContext('webgpu');
+} catch {}
+let imageData27 = new ImageData(72, 104);
+let gpuCanvasContext29 = canvas27.getContext('webgpu');
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+offscreenCanvas4.width = 1797;
+document.body.prepend(canvas18);
+try {
+window.someLabel = externalTexture0.label;
+} catch {}
+try {
+  await promise21;
+} catch {}
+let canvas28 = document.createElement('canvas');
+let img24 = await imageWithData(55, 159, '#04f014fd', '#74aa9ce6');
+let videoFrame21 = new VideoFrame(offscreenCanvas28, {timestamp: 0});
+let gpuCanvasContext30 = canvas28.getContext('webgpu');
+try {
+gpuCanvasContext6.unconfigure();
+} catch {}
+gc();
+let commandEncoder79 = device1.createCommandEncoder();
+let texture51 = device1.createTexture({
+  label: '\uc2c9\u{1ff63}\u06ee\u0b92\uce79\ub57b\u0907\u0f3b\u59af\ud370\u0669',
+  size: {width: 1846, height: 3, depthOrArrayLayers: 1},
+  mipLevelCount: 7,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8uint', 'rgba8uint', 'rgba8uint'],
+});
+let textureView81 = texture23.createView({label: '\u378d\u775c\u982d\u057f\u0719\u6470\ube5d\u085f\ub69d', arrayLayerCount: 1});
+let renderPassEncoder1 = commandEncoder52.beginRenderPass({
+  colorAttachments: [{
+  view: textureView78,
+  depthSlice: 28,
+  clearValue: { r: 428.4, g: 430.8, b: 6.912, a: 622.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet16,
+  maxDrawCount: 955747851,
+});
+try {
+renderPassEncoder0.setIndexBuffer(buffer9, 'uint16', 2786, 44201);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline36);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(1956, undefined, 2347069882, 808992824);
+} catch {}
+try {
+commandEncoder77.copyBufferToTexture({
+  /* bytesInLastRow: 5912 widthInBlocks: 1478 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6284 */
+  offset: 6284,
+  rowsPerImage: 259,
+  buffer: buffer7,
+}, {
+  texture: texture29,
+  mipLevel: 1,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1478, height: 0, depthOrArrayLayers: 1});
+dissociateBuffer(device1, buffer7);
+} catch {}
+try {
+commandEncoder77.resolveQuerySet(querySet19, 1781, 23, buffer8, 175616);
+} catch {}
+let offscreenCanvas36 = new OffscreenCanvas(876, 357);
+try {
+adapter1.label = '\u03db\u0674\ud4d6\u2e16\ud3ac\ued1a\u{1fb72}';
+} catch {}
+let img25 = await imageWithData(244, 211, '#8cfb67cd', '#83d779fa');
+let bindGroup6 = device1.createBindGroup({
+  label: '\u{1ff9f}\u{1f7fa}\u{1fab3}\uaf98\u{1fd64}\uf3be\u0bde\u82a7',
+  layout: bindGroupLayout12,
+  entries: [],
+});
+let sampler34 = device1.createSampler({
+  label: '\ua76e\uc2eb\u0e33\u7e25\u3d33\uae95\u0131\u{1f8e8}\u2d49\u99cd\u55ff',
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 24.16,
+  lodMaxClamp: 42.50,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder21.end();
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: -171.7, g: -950.5, b: 413.7, a: -870.2, });
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(78, 1, 16, 0);
+} catch {}
+try {
+renderPassEncoder1.setViewport(97.38, 0.1005, 9.618, 0.6191, 0.9636, 0.9801);
+} catch {}
+try {
+commandEncoder44.clearBuffer(buffer9, 34156, 15660);
+dissociateBuffer(device1, buffer9);
+} catch {}
+try {
+device1.queue.submit([commandBuffer14]);
+} catch {}
+try {
+device1.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 89, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(90), /* required buffer size: 90 */
+{offset: 90, bytesPerRow: 357}, {width: 58, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let promise22 = device1.queue.onSubmittedWorkDone();
+let pipeline58 = await device1.createComputePipelineAsync({layout: pipelineLayout5, compute: {module: shaderModule10, entryPoint: 'compute0', constants: {}}});
+let gpuCanvasContext31 = offscreenCanvas36.getContext('webgpu');
+let texture52 = device2.createTexture({
+  label: '\u978c\u{1f986}\u109c\u{1fbec}',
+  size: {width: 1152, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView82 = texture41.createView({label: '\u048e\u30f8\u{1f7f6}', mipLevelCount: 1});
+let computePassEncoder34 = commandEncoder65.beginComputePass();
+let externalTexture27 = device2.importExternalTexture({source: videoFrame12, colorSpace: 'srgb'});
+try {
+computePassEncoder27.setPipeline(pipeline47);
+} catch {}
+try {
+renderBundleEncoder33.draw(199, 110, 1_492_094_486, 262_587_588);
+} catch {}
+let pipeline59 = device2.createRenderPipeline({
+  label: '\u41c9\u00bc\u{1fa2f}\u2ece\ua3fb\u{1f905}',
+  layout: pipelineLayout7,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule14,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8unorm-srgb'}, {format: 'rg8sint'}, {format: 'r8sint', writeMask: 0}, {format: 'rgb10a2unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN}],
+},
+  vertex: {
+    module: shaderModule14,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1708,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 256, shaderLocation: 9},
+          {format: 'snorm8x2', offset: 280, shaderLocation: 24},
+          {format: 'float16x2', offset: 152, shaderLocation: 11},
+        ],
+      },
+      {arrayStride: 1232, attributes: []},
+      {
+        arrayStride: 1208,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint32', offset: 764, shaderLocation: 8},
+          {format: 'sint8x4', offset: 180, shaderLocation: 23},
+          {format: 'uint32', offset: 132, shaderLocation: 19},
+          {format: 'unorm8x2', offset: 130, shaderLocation: 14},
+          {format: 'snorm16x4', offset: 60, shaderLocation: 0},
+          {format: 'snorm8x4', offset: 728, shaderLocation: 17},
+          {format: 'unorm10-10-10-2', offset: 76, shaderLocation: 2},
+          {format: 'sint16x2', offset: 164, shaderLocation: 12},
+          {format: 'sint32x3', offset: 312, shaderLocation: 7},
+          {format: 'uint8x4', offset: 64, shaderLocation: 20},
+          {format: 'float32', offset: 248, shaderLocation: 22},
+          {format: 'unorm16x2', offset: 332, shaderLocation: 15},
+          {format: 'uint16x4', offset: 92, shaderLocation: 21},
+        ],
+      },
+      {
+        arrayStride: 736,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'sint32', offset: 520, shaderLocation: 5},
+          {format: 'sint32x4', offset: 24, shaderLocation: 3},
+          {format: 'uint16x2', offset: 28, shaderLocation: 1},
+          {format: 'sint32x3', offset: 36, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 908,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float16x2', offset: 196, shaderLocation: 6},
+          {format: 'sint16x2', offset: 48, shaderLocation: 16},
+          {format: 'sint32x4', offset: 36, shaderLocation: 10},
+          {format: 'sint16x4', offset: 28, shaderLocation: 18},
+          {format: 'float32x4', offset: 132, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+});
+let imageData28 = new ImageData(188, 92);
+let videoFrame22 = new VideoFrame(canvas16, {timestamp: 0});
+let canvas29 = document.createElement('canvas');
+let gpuCanvasContext32 = canvas29.getContext('webgpu');
+gc();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let video29 = await videoWithData();
+let videoFrame23 = videoFrame14.clone();
+try {
+if (!arrayBuffer6.detached) { new Uint8Array(arrayBuffer6).fill(0x55) };
+} catch {}
+let img26 = await imageWithData(125, 279, '#9aa97180', '#7fcd5ea1');
+let video30 = await videoWithData();
+try {
+gpuCanvasContext13.unconfigure();
+} catch {}
+let img27 = await imageWithData(84, 130, '#e1cb10ee', '#1ea1069a');
+try {
+  await promise22;
+} catch {}
+let canvas30 = document.createElement('canvas');
+let imageData29 = new ImageData(252, 176);
+let videoFrame24 = new VideoFrame(img0, {timestamp: 0});
+video12.height = 274;
+let adapter6 = await promise19;
+let videoFrame25 = new VideoFrame(img11, {timestamp: 0});
+video15.height = 254;
+try {
+window.someLabel = renderBundleEncoder7.label;
+} catch {}
+video17.width = 72;
+offscreenCanvas22.width = 30;
+let canvas31 = document.createElement('canvas');
+let imageData30 = new ImageData(208, 192);
+try {
+canvas31.getContext('2d');
+} catch {}
+let img28 = await imageWithData(99, 265, '#d253299e', '#c9a545de');
+let imageBitmap17 = await createImageBitmap(imageBitmap2);
+let gpuCanvasContext33 = canvas30.getContext('webgpu');
+let videoFrame26 = new VideoFrame(video18, {timestamp: 0});
+let device3 = await promise6;
+canvas21.width = 265;
+gc();
+let imageBitmap18 = await createImageBitmap(offscreenCanvas0);
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+let commandEncoder80 = device3.createCommandEncoder({label: '\ue945\u0798\ufa3a\u{1fe3d}\u{1fb30}\uf46c\ub19a\u{1f7b5}\u{1fcc1}'});
+let texture53 = device3.createTexture({
+  label: '\u0033\u0b35',
+  size: {width: 2640, height: 5, depthOrArrayLayers: 54},
+  mipLevelCount: 5,
+  format: 'astc-10x5-unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView83 = texture53.createView({dimension: '2d', mipLevelCount: 3, baseArrayLayer: 13});
+try {
+gpuCanvasContext6.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let img29 = await imageWithData(91, 112, '#e5d56371', '#e9b6b93f');
+gc();
+let imageBitmap19 = await createImageBitmap(videoFrame14);
+try {
+if (!arrayBuffer4.detached) { new Uint8Array(arrayBuffer4).fill(0x55) };
+} catch {}
+gc();
+try {
+device3.queue.label = '\u8725\u48a7\u0428\u9ff9\u{1f8f2}\u{1fe23}\u{1f984}\u3cd5\u00a3\u08b0';
+} catch {}
+let commandEncoder81 = device3.createCommandEncoder({label: '\u{1f9a4}\u0969\u{1fa3c}\u{1f73d}\ubc38\u968a'});
+let commandEncoder82 = device3.createCommandEncoder({label: '\u{1fd97}\u{1fc6c}\u009b\u08a2\u2bb4\uf46a\u556f\u8490\u034d\u967c\u04dc'});
+let texture54 = device3.createTexture({
+  label: '\u{1f899}\u205a\ud491\ud51a',
+  size: [2, 3, 17],
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let computePassEncoder35 = commandEncoder82.beginComputePass({label: '\u053b\u{1f6d4}\u9449\u2444\u{1fa22}\u4ee1\u060a\u{1f970}\udb15\u{1fd99}\u4c2c'});
+let externalTexture28 = device3.importExternalTexture({label: '\u28f6\u0a1b\u{1f7d8}\u0e25\u2c83', source: video27, colorSpace: 'srgb'});
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 4}
+*/
+{
+  source: videoFrame23,
+  origin: { x: 3, y: 1 },
+  flipY: false,
+}, {
+  texture: texture54,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData31 = new ImageData(236, 164);
+let buffer15 = device3.createBuffer({size: 26156, usage: GPUBufferUsage.MAP_WRITE});
+let textureView84 = texture53.createView({
+  label: '\ud7d2\u{1fc03}\u6a7d\u08f5\uda12\u6380\u{1fb36}',
+  dimension: '2d',
+  baseMipLevel: 2,
+  baseArrayLayer: 38,
+});
+try {
+commandEncoder80.copyTextureToTexture({
+  texture: texture54,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 9},
+  aspect: 'all',
+}, new BigInt64Array(new ArrayBuffer(0)), /* required buffer size: 63_141 */
+{offset: 741, bytesPerRow: 96, rowsPerImage: 130}, {width: 1, height: 0, depthOrArrayLayers: 6});
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 8}
+*/
+{
+  source: canvas20,
+  origin: { x: 30, y: 4 },
+  flipY: true,
+}, {
+  texture: texture54,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas32 = document.createElement('canvas');
+let imageBitmap20 = await createImageBitmap(videoFrame16);
+let commandEncoder83 = device1.createCommandEncoder({label: '\u5ba2\u0dc9\u0816\u3f67\u015a\u4acd\u3572\u0779'});
+let textureView85 = texture27.createView({label: '\u6ffb\u{1f7ba}', baseMipLevel: 5});
+try {
+renderPassEncoder1.setBlendConstant({ r: 453.1, g: 576.6, b: -672.9, a: -672.9, });
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline33);
+} catch {}
+try {
+renderBundleEncoder28.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderBundleEncoder28.setVertexBuffer(1677, undefined);
+} catch {}
+try {
+commandEncoder79.resolveQuerySet(querySet16, 2197, 230, buffer8, 9472);
+} catch {}
+try {
+device1.queue.writeBuffer(buffer9, 6520, new DataView(new ArrayBuffer(19249)), 16379, 156);
+} catch {}
+let pipeline60 = await device1.createRenderPipelineAsync({
+  label: '\u71e8\u0fbf\u{1febc}\u127a\u06e3\u01b7\ub884\u8afc\u0724\u2849',
+  layout: pipelineLayout5,
+  multisample: {mask: 0x6d09f1eb},
+  fragment: {
+  module: shaderModule9,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rgba8uint', writeMask: GPUColorWrite.ALL}],
+},
+  vertex: {
+    module: shaderModule9,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 26084,
+        stepMode: 'vertex',
+        attributes: [
+          {format: 'unorm8x2', offset: 1548, shaderLocation: 23},
+          {format: 'uint32', offset: 6684, shaderLocation: 2},
+          {format: 'sint16x4', offset: 4632, shaderLocation: 13},
+        ],
+      },
+      {
+        arrayStride: 1356,
+        attributes: [
+          {format: 'snorm8x4', offset: 412, shaderLocation: 22},
+          {format: 'uint32x2', offset: 432, shaderLocation: 5},
+          {format: 'snorm16x4', offset: 176, shaderLocation: 20},
+          {format: 'unorm16x4', offset: 920, shaderLocation: 11},
+        ],
+      },
+      {
+        arrayStride: 6804,
+        stepMode: 'instance',
+        attributes: [{format: 'uint8x2', offset: 2764, shaderLocation: 9}],
+      },
+      {
+        arrayStride: 36692,
+        attributes: [
+          {format: 'sint32x3', offset: 3332, shaderLocation: 15},
+          {format: 'sint32x3', offset: 6512, shaderLocation: 25},
+          {format: 'uint32', offset: 300, shaderLocation: 16},
+          {format: 'uint16x4', offset: 5696, shaderLocation: 17},
+          {format: 'uint16x2', offset: 572, shaderLocation: 14},
+          {format: 'float32x2', offset: 7792, shaderLocation: 4},
+          {format: 'uint32x4', offset: 1424, shaderLocation: 18},
+          {format: 'sint8x2', offset: 474, shaderLocation: 1},
+          {format: 'snorm16x2', offset: 8756, shaderLocation: 6},
+        ],
+      },
+      {arrayStride: 14772, stepMode: 'instance', attributes: []},
+      {
+        arrayStride: 18712,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 232, shaderLocation: 8},
+          {format: 'sint8x4', offset: 2548, shaderLocation: 24},
+          {format: 'uint16x2', offset: 1696, shaderLocation: 26},
+          {format: 'float32x4', offset: 2224, shaderLocation: 12},
+        ],
+      },
+      {arrayStride: 51540, attributes: [{format: 'snorm16x4', offset: 3328, shaderLocation: 7}]},
+    ],
+  },
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'front', unclippedDepth: true},
+});
+let img30 = await imageWithData(208, 59, '#cb89ce40', '#be88c300');
+try {
+window.someLabel = externalTexture5.label;
+} catch {}
+let commandEncoder84 = device3.createCommandEncoder({label: '\u0a74\ue578\u0a4c\u93ad\u0005'});
+let textureView86 = texture53.createView({label: '\u025c\u3fbf', dimension: '2d', baseMipLevel: 1, mipLevelCount: 2, baseArrayLayer: 45});
+let sampler35 = device3.createSampler({
+  label: '\uab33\u0484\u7e19\u{1f8f5}\u6dd7\u0af5\ub7b4\u4de8\u{1fc9b}\uc7d6\u49d5',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 22.44,
+  lodMaxClamp: 24.55,
+});
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 4}
+*/
+{
+  source: canvas25,
+  origin: { x: 13, y: 3 },
+  flipY: true,
+}, {
+  texture: texture54,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroupLayout24 = device3.createBindGroupLayout({
+  label: '\u8f43\u3611\u{1f649}\u946d\ub99d\u{1fc29}\u{1fb50}\udaed\u96fe',
+  entries: [
+    {
+      binding: 560,
+      visibility: GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 5433,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 62794307, hasDynamicOffset: true },
+    },
+    {binding: 3799, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let pipelineLayout10 = device3.createPipelineLayout({bindGroupLayouts: [bindGroupLayout24, bindGroupLayout24, bindGroupLayout24]});
+let renderBundleEncoder37 = device3.createRenderBundleEncoder({
+  label: '\u859f\ue038\u{1fb26}\uc103\ub82e',
+  colorFormats: ['r8uint', 'rg32float', 'r8unorm', 'rgba16sint'],
+  stencilReadOnly: true,
+});
+let renderBundle49 = renderBundleEncoder37.finish({label: '\uf389\u37aa\u9eb4\ucc2d\u{1fe10}\ua7a5\u{1f7be}\u0294\u0e4c'});
+let sampler36 = device3.createSampler({
+  label: '\uea80\u{1f646}\u15bb\u6b42',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 67.18,
+  lodMaxClamp: 78.71,
+  compare: 'not-equal',
+  maxAnisotropy: 16,
+});
+let canvas33 = document.createElement('canvas');
+try {
+gpuCanvasContext5.unconfigure();
+} catch {}
+video2.width = 122;
+let offscreenCanvas37 = new OffscreenCanvas(612, 924);
+document.body.prepend(img3);
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let renderBundle50 = renderBundleEncoder37.finish({label: '\u{1f85e}\ub087\u{1f636}\u{1fcbd}\u05b6\u{1f70d}\u{1f98c}'});
+let sampler37 = device3.createSampler({
+  label: '\u0af7\ub8fd\u4170\u58c8\ud0ab\u0d62\u083c\uaba1\u1f84\u5a70\u360e',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 68.92,
+  lodMaxClamp: 79.37,
+});
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: offscreenCanvas36,
+  origin: { x: 7, y: 6 },
+  flipY: true,
+}, {
+  texture: texture54,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device3.label = '\u{1fb49}\ud5fb\uabb6\ue6e1\u96ba\u9898\u07f6';
+} catch {}
+let textureView87 = texture54.createView({label: '\ufb02\ub1e5', baseMipLevel: 2, mipLevelCount: 1});
+let renderBundleEncoder38 = device3.createRenderBundleEncoder({
+  label: '\u6b6c\u0844\u014a\u267f\u000f',
+  colorFormats: ['r8uint', 'rg32float', 'r8unorm', 'rgba16sint'],
+});
+let renderBundle51 = renderBundleEncoder38.finish({label: '\uc08e\u300a\uc1eb'});
+try {
+commandEncoder84.copyTextureToTexture({
+  texture: texture54,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 2},
+  aspect: 'all',
+},
+{
+  texture: texture54,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 4}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 58, y: 22 },
+  flipY: false,
+}, {
+  texture: texture54,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder85 = device3.createCommandEncoder({label: '\u740c\u{1f87f}\u{1f897}'});
+let texture55 = device3.createTexture({
+  label: '\u4a6a\u0e91\u99cc\u9d1c\u{1fa77}',
+  size: {width: 132, height: 1, depthOrArrayLayers: 106},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: ['r8uint', 'r8uint', 'r8uint'],
+});
+try {
+commandEncoder84.insertDebugMarker('\u0fd8');
+} catch {}
+try {
+if (!arrayBuffer3.detached) { new Uint8Array(arrayBuffer3).fill(0x55) };
+} catch {}
+try {
+canvas32.getContext('webgpu');
+} catch {}
+let querySet32 = device2.createQuerySet({label: '\u{1fa24}\u0946', type: 'occlusion', count: 1116});
+let textureView88 = texture35.createView({
+  label: '\u0610\u0b3c\u29b6\u063c\u3924\u52e1\u79ca\u09f0\u065a',
+  dimension: '2d',
+  aspect: 'stencil-only',
+  baseArrayLayer: 230,
+});
+let renderBundleEncoder39 = device2.createRenderBundleEncoder({
+  label: '\u0d36\uf1d7\u1f94\u{1fcdc}',
+  colorFormats: ['rgba8unorm-srgb', 'rg8sint', 'r8sint', 'rgb10a2unorm'],
+});
+try {
+renderBundleEncoder33.draw(468, 87);
+} catch {}
+try {
+renderBundleEncoder33.drawIndexed(736, 20, 2_319_858_259);
+} catch {}
+try {
+buffer12.destroy();
+} catch {}
+let shaderModule15 = device3.createShaderModule({
+  code: `@group(2) @binding(3799)
+var<storage, read_write> field23: array<u32>;
+@group(1) @binding(560)
+var<storage, read_write> function16: array<u32>;
+@group(2) @binding(560)
+var<storage, read_write> type19: array<u32>;
+@group(0) @binding(5433)
+var<storage, read_write> global30: array<u32>;
+@group(1) @binding(5433)
+var<storage, read_write> field24: array<u32>;
+@group(2) @binding(5433)
+var<storage, read_write> parameter23: array<u32>;
+@group(0) @binding(560)
+var<storage, read_write> parameter24: array<u32>;
+@group(1) @binding(3799)
+var<storage, read_write> global31: array<u32>;
+
+@compute @workgroup_size(8, 1, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec2<u32>,
+  @location(3) f1: vec4<i32>,
+  @location(1) f2: vec4<f32>,
+  @location(2) f3: f32
+}
+
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S14 {
+  @location(17) f0: vec3<i32>,
+  @location(9) f1: vec4<f32>,
+  @location(15) f2: vec3<f16>,
+  @location(3) f3: vec4<i32>,
+  @location(10) f4: vec2<f32>,
+  @location(5) f5: vec3<u32>,
+  @builtin(vertex_index) f6: u32,
+  @location(14) f7: vec2<u32>,
+  @location(16) f8: vec2<f16>,
+  @location(6) f9: vec3<f16>,
+  @location(4) f10: vec2<u32>,
+  @location(2) f11: vec2<i32>,
+  @location(13) f12: i32,
+  @location(1) f13: vec3<f16>,
+  @location(11) f14: vec2<i32>,
+  @location(12) f15: vec2<i32>,
+  @location(18) f16: f32,
+  @location(0) f17: vec2<i32>,
+  @location(7) f18: f16
+}
+
+@vertex
+fn vertex0(@builtin(instance_index) a0: u32, @location(8) a1: vec2<i32>, a2: S14) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let querySet33 = device3.createQuerySet({label: '\u{1fcb8}\u4328\u0ade\u4321', type: 'occlusion', count: 2127});
+let textureView89 = texture54.createView({label: '\uaa7c\u420f\uc4a2\ud9a1\ueb28\ufd32\u8a6d\u0b83\u6865\u6c76', mipLevelCount: 1});
+let renderBundleEncoder40 = device3.createRenderBundleEncoder({
+  label: '\ud934\u8014\u0316',
+  colorFormats: ['r8uint', 'rg32float', 'r8unorm', 'rgba16sint'],
+  stencilReadOnly: true,
+});
+let sampler38 = device3.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', lodMinClamp: 36.87, lodMaxClamp: 73.31});
+let externalTexture29 = device3.importExternalTexture({
+  label: '\u{1f8e1}\u04dd\ua2fe\u{1f756}\u{1fa1c}\uf4f9\ud8a8\u70d0\uabc3',
+  source: video1,
+  colorSpace: 'srgb',
+});
+try {
+buffer15.unmap();
+} catch {}
+let pipeline61 = await device3.createComputePipelineAsync({
+  label: '\u59a0\uda13\u0868',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule15, entryPoint: 'compute0', constants: {}},
+});
+let gpuCanvasContext34 = offscreenCanvas37.getContext('webgpu');
+try {
+gpuCanvasContext28.unconfigure();
+} catch {}
+try {
+textureView64.label = '\ub02e\u05ed\u0f02\u6481';
+} catch {}
+let shaderModule16 = device3.createShaderModule({
+  label: '\ud264\uc412\u4284\u1158\u99c3\u08be\u08a5\u6889\u{1fec0}',
+  code: `@group(1) @binding(560)
+var<storage, read_write> n20: array<u32>;
+@group(1) @binding(3799)
+var<storage, read_write> global32: array<u32>;
+@group(1) @binding(5433)
+var<storage, read_write> n21: array<u32>;
+@group(2) @binding(3799)
+var<storage, read_write> local24: array<u32>;
+@group(2) @binding(5433)
+var<storage, read_write> local25: array<u32>;
+@group(2) @binding(560)
+var<storage, read_write> local26: array<u32>;
+@group(0) @binding(560)
+var<storage, read_write> field25: array<u32>;
+@group(0) @binding(5433)
+var<storage, read_write> type20: array<u32>;
+@group(0) @binding(3799)
+var<storage, read_write> parameter25: array<u32>;
+
+@compute @workgroup_size(8, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(0) f0: vec4<u32>,
+  @location(2) f1: vec3<f32>,
+  @location(3) f2: vec4<i32>,
+  @location(1) f3: vec2<f32>,
+  @location(5) f4: vec3<u32>
+}
+
+@fragment
+fn fragment0(@builtin(position) a0: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S15 {
+  @location(6) f0: i32,
+  @location(13) f1: i32,
+  @location(2) f2: vec3<f16>,
+  @location(16) f3: f16,
+  @location(17) f4: vec3<i32>,
+  @builtin(instance_index) f5: u32
+}
+struct VertexOutput0 {
+  @location(23) f228: f32,
+  @location(50) f229: f32,
+  @builtin(position) f230: vec4<f32>,
+  @location(77) f231: vec2<u32>
+}
+
+@vertex
+fn vertex0(@location(9) a0: vec4<f16>, @location(5) a1: vec3<f32>, @location(1) a2: vec2<f32>, @location(4) a3: f16, @location(8) a4: vec4<u32>, a5: S15, @location(15) a6: vec2<u32>, @location(18) a7: vec4<u32>, @location(7) a8: f16, @location(3) a9: vec3<f32>, @location(12) a10: vec2<f16>, @location(14) a11: vec2<f32>) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder86 = device3.createCommandEncoder({label: '\u0b97\u706e\u01d7\u{1fef7}\u0e88\ua4a1\u0898\u{1f83e}\u7232\uedca\uceb2'});
+let querySet34 = device3.createQuerySet({label: '\u09eb\u7e7e\u0085\u01d9\u0674\udae3\u0bcc\u{1fda5}\u{1f9aa}', type: 'occlusion', count: 3087});
+let textureView90 = texture54.createView({aspect: 'all', baseMipLevel: 1, mipLevelCount: 3});
+try {
+renderBundleEncoder40.setVertexBuffer(8122, undefined);
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture54,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint32Array(arrayBuffer0), /* required buffer size: 25_748 */
+{offset: 44, bytesPerRow: 252, rowsPerImage: 51}, {width: 1, height: 0, depthOrArrayLayers: 3});
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 4}
+*/
+{
+  source: video20,
+  origin: { x: 2, y: 16 },
+  flipY: true,
+}, {
+  texture: texture54,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame27 = new VideoFrame(canvas23, {timestamp: 0});
+let bindGroupLayout25 = device0.createBindGroupLayout({
+  label: '\u050b\uc927\u{1f617}',
+  entries: [
+    {binding: 2503, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 4035,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: true },
+    },
+    {binding: 2980, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+  ],
+});
+let textureView91 = texture26.createView({
+  label: '\uc94a\u601d\ub316\u9334',
+  dimension: '2d',
+  baseMipLevel: 2,
+  mipLevelCount: 1,
+  baseArrayLayer: 24,
+});
+let sampler39 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 45.14,
+  lodMaxClamp: 72.15,
+});
+let externalTexture30 = device0.importExternalTexture({source: videoFrame13, colorSpace: 'display-p3'});
+try {
+renderBundleEncoder7.setVertexBuffer(8935, undefined, 0, 4271999554);
+} catch {}
+try {
+commandEncoder46.copyTextureToTexture({
+  texture: texture5,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 60},
+  aspect: 'all',
+},
+{
+  texture: texture16,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 8, height: 1, depthOrArrayLayers: 41});
+} catch {}
+try {
+computePassEncoder15.pushDebugGroup('\uecfa');
+} catch {}
+try {
+adapter1.label = '\uba43\ufda8\u3ac1\u2c6d\uf580\u00ba\u{1fd42}';
+} catch {}
+let querySet35 = device3.createQuerySet({label: '\u5444\u{1fde3}\u024f\u04d0', type: 'occlusion', count: 1265});
+try {
+renderBundleEncoder40.setVertexBuffer(3390, undefined, 0, 1714038857);
+} catch {}
+try {
+  await buffer15.mapAsync(GPUMapMode.WRITE);
+} catch {}
+try {
+commandEncoder84.pushDebugGroup('\ua25b');
+} catch {}
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+gc();
+let gpuCanvasContext35 = canvas33.getContext('webgpu');
+document.body.prepend(canvas32);
+let imageBitmap21 = await createImageBitmap(videoFrame5);
+let bindGroupLayout26 = device3.createBindGroupLayout({
+  label: '\udd2a\u4814\u006a\u4451\u5de7\u01e4\u{1fb06}\ud9c4\uc6a8\uba04\u1765',
+  entries: [
+    {
+      binding: 256,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '3d', sampleType: 'depth', multisampled: false },
+    },
+    {binding: 4407, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+    {binding: 1964, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+  ],
+});
+let textureView92 = texture54.createView({label: '\ud9ab\uea5f\uf0b0\ua127\uf1d9\u0dfd\u2acb\u7266\u{1f74e}\u02dd\uc004', baseMipLevel: 2});
+let sampler40 = device3.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 9.119,
+  lodMaxClamp: 88.78,
+});
+try {
+renderBundleEncoder40.pushDebugGroup('\uf3d5');
+} catch {}
+let pipeline62 = device3.createComputePipeline({
+  label: '\uafdd\u4047\u05f1\u018a\ud30d\u2c56\ub840\u{1f6c2}\u1c08',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule16, entryPoint: 'compute0'},
+});
+let commandEncoder87 = device0.createCommandEncoder({label: '\u000e\u0094\u6f75\u02b6\u0f6d\u9ccb\ub156\u48a0\u{1fc20}\ubdfd\u59e1'});
+let commandBuffer15 = commandEncoder17.finish();
+try {
+computePassEncoder15.setBindGroup(3, bindGroup5, new Uint32Array(6614), 4427, 0);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(7, bindGroup1);
+} catch {}
+try {
+commandEncoder35.copyBufferToBuffer(buffer3, 77912, buffer4, 155968, 292);
+dissociateBuffer(device0, buffer3);
+dissociateBuffer(device0, buffer4);
+} catch {}
+let commandEncoder88 = device2.createCommandEncoder({label: '\u2804\u2a58\u{1f81e}'});
+try {
+computePassEncoder32.setPipeline(pipeline44);
+} catch {}
+try {
+renderBundleEncoder31.setPipeline(pipeline48);
+} catch {}
+try {
+commandEncoder88.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 154456 */
+  offset: 6996,
+  bytesPerRow: 256,
+  rowsPerImage: 144,
+  buffer: buffer12,
+}, {
+  texture: texture36,
+  mipLevel: 5,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 1, depthOrArrayLayers: 5});
+dissociateBuffer(device2, buffer12);
+} catch {}
+let offscreenCanvas38 = new OffscreenCanvas(504, 924);
+let video31 = await videoWithData();
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0x55) };
+} catch {}
+let canvas34 = document.createElement('canvas');
+let commandEncoder89 = device3.createCommandEncoder({label: '\u{1fa60}\u0ba0\uf811\ua257'});
+let querySet36 = device3.createQuerySet({label: '\u0a82\u0d1f\u4e62\u{1fc06}\u{1f7be}\u22ae\u{1f96c}\u9df0', type: 'occlusion', count: 1751});
+let texture56 = device3.createTexture({
+  label: '\ud71c\u0892\u09da\u9cc4\u0750',
+  size: [9, 15, 72],
+  mipLevelCount: 3,
+  format: 'r8uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['r8uint', 'r8uint'],
+});
+let renderBundleEncoder41 = device3.createRenderBundleEncoder({
+  label: '\ud944\ud913\u069c\u0ec9\u091e\u0d04\u07b9\u4a1f\u{1facf}\uac4e',
+  colorFormats: ['r8uint', 'rg32float', 'r8unorm', 'rgba16sint'],
+});
+let sampler41 = device3.createSampler({addressModeU: 'repeat', addressModeW: 'clamp-to-edge', minFilter: 'nearest', lodMaxClamp: 85.42});
+try {
+computePassEncoder35.setPipeline(pipeline62);
+} catch {}
+try {
+renderBundleEncoder40.popDebugGroup();
+} catch {}
+try {
+renderBundleEncoder41.insertDebugMarker('\u{1fa35}');
+} catch {}
+let canvas35 = document.createElement('canvas');
+let video32 = await videoWithData();
+try {
+device3.addEventListener('uncapturederror', e => { log('device3.uncapturederror'); log(e); e.label = device3.label; });
+} catch {}
+try {
+buffer15.unmap();
+} catch {}
+try {
+commandEncoder80.copyTextureToTexture({
+  texture: texture54,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture54,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+commandEncoder84.popDebugGroup();
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new ArrayBuffer(921), /* required buffer size: 921 */
+{offset: 919}, {width: 2, height: 1, depthOrArrayLayers: 1});
+} catch {}
+let pipeline63 = device3.createComputePipeline({
+  label: '\u0d3d\u14bb\uf45d\u{1f74c}\uaea8\u6b24\u{1f9e3}\u{1fc92}\u0c72',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule15, entryPoint: 'compute0'},
+});
+canvas17.width = 695;
+let video33 = await videoWithData();
+try {
+canvas34.getContext('webgl2');
+} catch {}
+let imageBitmap22 = await createImageBitmap(imageBitmap21);
+try {
+offscreenCanvas38.getContext('webgl');
+} catch {}
+let offscreenCanvas39 = new OffscreenCanvas(413, 930);
+try {
+if (!arrayBuffer5.detached) { new Uint8Array(arrayBuffer5).fill(0x55) };
+} catch {}
+document.body.prepend(canvas18);
+try {
+adapter3.label = '\u{1fc05}\u02f9\u6bd9';
+} catch {}
+let canvas36 = document.createElement('canvas');
+try {
+  await adapter3.requestAdapterInfo();
+} catch {}
+let buffer16 = device0.createBuffer({
+  label: '\u0ab6\u{1fa1a}\uda05\u0318\u082b\u{1fc21}',
+  size: 62372,
+  usage: GPUBufferUsage.MAP_READ,
+  mappedAtCreation: true,
+});
+let querySet37 = device0.createQuerySet({type: 'occlusion', count: 563});
+try {
+computePassEncoder6.setBindGroup(6, bindGroup0);
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline6);
+} catch {}
+try {
+renderBundleEncoder36.setBindGroup(1, bindGroup1, []);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture16,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+}, arrayBuffer5, /* required buffer size: 9_833 */
+{offset: 311, bytesPerRow: 46, rowsPerImage: 69}, {width: 0, height: 1, depthOrArrayLayers: 4});
+} catch {}
+let pipeline64 = device0.createRenderPipeline({
+  label: '\u{1fc47}\u0f13\u5d9b',
+  layout: pipelineLayout3,
+  multisample: {mask: 0x8a360581},
+  fragment: {
+  module: shaderModule6,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'rg8unorm', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg32float', writeMask: 0}, {format: 'rg16sint', writeMask: 0}, {format: 'r16uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {format: 'r16uint', writeMask: 0}, {format: 'r8uint', writeMask: GPUColorWrite.BLUE}, {format: 'rgba8sint', writeMask: GPUColorWrite.RED}, {
+  format: 'bgra8unorm-srgb',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one', dstFactor: 'dst-alpha'},
+  },
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.GREEN,
+}],
+},
+  depthStencil: {
+    format: 'depth32float-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'not-equal',
+    stencilFront: {failOp: 'increment-wrap', depthFailOp: 'keep', passOp: 'zero'},
+    stencilBack: {compare: 'always', failOp: 'zero', depthFailOp: 'decrement-clamp', passOp: 'replace'},
+    stencilReadMask: 3914987633,
+    stencilWriteMask: 3645068136,
+    depthBiasSlopeScale: -46.32675906746739,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule6,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 168,
+        stepMode: 'vertex',
+        attributes: [{format: 'snorm8x4', offset: 0, shaderLocation: 17}],
+      },
+      {
+        arrayStride: 764,
+        stepMode: 'instance',
+        attributes: [{format: 'snorm16x4', offset: 32, shaderLocation: 4}],
+      },
+      {
+        arrayStride: 128,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32x3', offset: 16, shaderLocation: 5},
+          {format: 'float32x4', offset: 0, shaderLocation: 9},
+          {format: 'uint32x2', offset: 16, shaderLocation: 13},
+          {format: 'sint32', offset: 40, shaderLocation: 0},
+          {format: 'sint16x2', offset: 20, shaderLocation: 8},
+          {format: 'unorm10-10-10-2', offset: 12, shaderLocation: 7},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 3},
+          {format: 'sint32x3', offset: 0, shaderLocation: 1},
+          {format: 'uint16x4', offset: 76, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+});
+let shaderModule17 = device3.createShaderModule({
+  code: `@group(0) @binding(3799)
+var<storage, read_write> global33: array<u32>;
+@group(2) @binding(3799)
+var<storage, read_write> function17: array<u32>;
+@group(2) @binding(560)
+var<storage, read_write> n22: array<u32>;
+@group(1) @binding(5433)
+var<storage, read_write> global34: array<u32>;
+@group(1) @binding(560)
+var<storage, read_write> local27: array<u32>;
+@group(0) @binding(5433)
+var<storage, read_write> parameter26: array<u32>;
+@group(2) @binding(5433)
+var<storage, read_write> parameter27: array<u32>;
+@group(1) @binding(3799)
+var<storage, read_write> field26: array<u32>;
+
+@compute @workgroup_size(6, 3, 2)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct FragmentOutput0 {
+  @location(1) f0: vec2<f32>,
+  @location(3) f1: vec4<i32>,
+  @location(0) f2: vec4<u32>,
+  @location(5) f3: vec2<u32>,
+  @location(2) f4: vec3<f32>
+}
+
+@fragment
+fn fragment0(@location(108) a0: vec4<i32>, @location(35) a1: vec3<f32>, @builtin(position) a2: vec4<f32>) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct VertexOutput0 {
+  @location(81) f232: vec3<i32>,
+  @location(4) f233: vec3<f32>,
+  @builtin(position) f234: vec4<f32>,
+  @location(57) f235: vec3<f16>,
+  @location(13) f236: u32,
+  @location(94) f237: vec2<f16>,
+  @location(25) f238: vec2<f32>,
+  @location(22) f239: vec2<f32>,
+  @location(63) f240: vec2<i32>,
+  @location(75) f241: vec3<f32>,
+  @location(61) f242: f32,
+  @location(46) f243: vec4<i32>,
+  @location(19) f244: vec4<i32>,
+  @location(109) f245: vec2<u32>,
+  @location(26) f246: vec3<f32>,
+  @location(101) f247: vec4<f32>,
+  @location(18) f248: f16,
+  @location(82) f249: vec3<u32>,
+  @location(108) f250: vec4<i32>,
+  @location(35) f251: vec3<f32>,
+  @location(83) f252: vec3<f16>,
+  @location(1) f253: vec2<f16>,
+  @location(6) f254: vec3<f16>,
+  @location(103) f255: vec2<f16>,
+  @location(89) f256: vec4<f16>,
+  @location(15) f257: vec4<f16>,
+  @location(104) f258: vec4<u32>,
+  @location(79) f259: u32,
+  @location(117) f260: vec3<u32>,
+  @location(33) f261: vec4<f16>,
+  @location(102) f262: vec3<f32>,
+  @location(32) f263: vec2<i32>,
+  @location(76) f264: u32,
+  @location(72) f265: vec4<i32>,
+  @location(47) f266: f16,
+  @location(12) f267: vec2<f16>
+}
+
+@vertex
+fn vertex0(@location(5) a0: vec3<i32>, @location(4) a1: vec3<u32>, @location(7) a2: f32) -> VertexOutput0 {
+  return VertexOutput0();
+}
+
+`,
+  hints: {},
+});
+let buffer17 = device3.createBuffer({
+  label: '\ucfd9\u2b5f\u0db1\u1bc1\ue78d\u{1f7e7}\u2445\u0cab',
+  size: 3297,
+  usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder90 = device3.createCommandEncoder({label: '\ubb53\ub567\u6327\u4893\ub86c\ub387\u8260\ua984\u{1fc7b}'});
+let querySet38 = device3.createQuerySet({label: '\u061f\ud555\u{1fed3}', type: 'occlusion', count: 883});
+let textureView93 = texture55.createView({
+  label: '\u028b\u9ac8\u{1fee1}\u0044\u944f\u416a\u{1fc20}\u{1faca}\ue403',
+  dimension: '3d',
+  format: 'r8uint',
+  baseMipLevel: 3,
+  mipLevelCount: 1,
+  arrayLayerCount: 1,
+});
+let renderBundle52 = renderBundleEncoder40.finish({});
+try {
+renderBundleEncoder41.setVertexBuffer(4, buffer17, 344, 1942);
+} catch {}
+try {
+buffer15.destroy();
+} catch {}
+try {
+commandEncoder89.copyTextureToTexture({
+  texture: texture54,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture54,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+gpuCanvasContext22.configure({
+  device: device3,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba16float', 'rgba16float'],
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Float32Array(arrayBuffer3), /* required buffer size: 235_838 */
+{offset: 608, bytesPerRow: 81, rowsPerImage: 242}, {width: 6, height: 1, depthOrArrayLayers: 13});
+} catch {}
+let pipeline65 = await device3.createComputePipelineAsync({
+  label: '\u4908\ua2bf\u95d5',
+  layout: 'auto',
+  compute: {module: shaderModule17, entryPoint: 'compute0', constants: {}},
+});
+let pipeline66 = device3.createRenderPipeline({
+  label: '\u{1f7b1}\u9090',
+  layout: pipelineLayout10,
+  multisample: {mask: 0xdebc6cb5},
+  fragment: {
+  module: shaderModule17,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'r8uint',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rg32float', writeMask: GPUColorWrite.RED}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one', dstFactor: 'one-minus-src'},
+    alpha: {operation: 'add', srcFactor: 'dst', dstFactor: 'one-minus-src'},
+  },
+  writeMask: GPUColorWrite.ALL,
+}, {format: 'rgba16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'not-equal', failOp: 'decrement-clamp', depthFailOp: 'increment-clamp', passOp: 'replace'},
+    stencilBack: {compare: 'less-equal', failOp: 'decrement-wrap', depthFailOp: 'invert', passOp: 'increment-clamp'},
+    stencilReadMask: 1442056969,
+    stencilWriteMask: 1742472509,
+    depthBiasClamp: 465.54528262132817,
+  },
+  vertex: {
+    module: shaderModule17,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 1772,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 252, shaderLocation: 5},
+          {format: 'uint32', offset: 1008, shaderLocation: 4},
+          {format: 'float32x3', offset: 128, shaderLocation: 7},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'ccw',
+  cullMode: 'back',
+  unclippedDepth: true,
+},
+});
+let imageData32 = new ImageData(20, 100);
+let texture57 = device3.createTexture({
+  label: '\u2809\u0cfe\u01f9\u0b7c\u2144\udde6\u{1ffe1}\ufe62\u0727\ub848\uc369',
+  size: {width: 480, height: 32, depthOrArrayLayers: 1},
+  mipLevelCount: 6,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['rgba8uint'],
+});
+let computePassEncoder36 = commandEncoder81.beginComputePass({label: '\u{1fb5f}\u{1fc19}\u9ca4\u4338\u0984\u2c52\uf01f'});
+let externalTexture31 = device3.importExternalTexture({label: '\u{1f8fa}\u{1ff78}\u0703\u0a75\u6158\u6dd6\u9f34\u{1fa8f}', source: video7});
+try {
+renderBundleEncoder41.setVertexBuffer(6, buffer17);
+} catch {}
+try {
+commandEncoder84.copyTextureToTexture({
+  texture: texture55,
+  mipLevel: 4,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture55,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 2},
+  aspect: 'all',
+},
+{width: 2, height: 1, depthOrArrayLayers: 1});
+} catch {}
+canvas18.width = 990;
+document.body.prepend(canvas16);
+let commandEncoder91 = device3.createCommandEncoder();
+let textureView94 = texture57.createView({
+  label: '\u{1f9e7}\u{1f92c}\u{1f73e}\u{1fbe3}\u0045\ub783\u5eca\u0529\u91df',
+  dimension: '2d-array',
+  baseMipLevel: 3,
+});
+let gpuCanvasContext36 = offscreenCanvas39.getContext('webgpu');
+try {
+gpuCanvasContext18.unconfigure();
+} catch {}
+try {
+externalTexture9.label = '\u8a25\u063d\ud713\ue123\u0782\u6447\u0df4\u05bc\ub548';
+} catch {}
+document.body.prepend(canvas11);
+let video34 = await videoWithData();
+offscreenCanvas1.width = 1883;
+let imageData33 = new ImageData(72, 208);
+let commandEncoder92 = device3.createCommandEncoder({label: '\u2eff\u71ab\u{1f6b0}\u0a5f\uf7d6\u{1ff02}'});
+let texture58 = device3.createTexture({
+  size: {width: 132, height: 1, depthOrArrayLayers: 1016},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r8uint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder37 = commandEncoder91.beginComputePass({label: '\ucd49\u2e6a\u0e1b\u{1f716}\u9945\u00f1\ubb57'});
+let sampler42 = device3.createSampler({
+  label: '\u8eaf\u3cf6\u66e9\u609c\ucf44',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 69.10,
+  lodMaxClamp: 91.23,
+  compare: 'less-equal',
+});
+let externalTexture32 = device3.importExternalTexture({label: '\u0414\u4a32', source: video20, colorSpace: 'display-p3'});
+let pipeline67 = await device3.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {mask: 0xe036dd15},
+  fragment: {
+  module: shaderModule17,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint'}, {format: 'rg32float', writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-src', dstFactor: 'one-minus-src'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-constant', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}, {format: 'rgba16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.RED}],
+},
+  depthStencil: {
+    format: 'depth24plus-stencil8',
+    depthWriteEnabled: true,
+    depthCompare: 'less-equal',
+    stencilFront: {compare: 'less-equal', failOp: 'replace', depthFailOp: 'replace', passOp: 'decrement-clamp'},
+    stencilBack: {compare: 'greater', failOp: 'increment-wrap', depthFailOp: 'increment-clamp', passOp: 'zero'},
+    stencilReadMask: 3374311807,
+    depthBias: -1271276798,
+    depthBiasClamp: 937.6327519453741,
+  },
+  vertex: {
+    module: shaderModule17,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 5204,
+        attributes: [
+          {format: 'sint16x4', offset: 1920, shaderLocation: 5},
+          {format: 'float32x2', offset: 1164, shaderLocation: 7},
+          {format: 'uint8x2', offset: 6, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {frontFace: 'ccw', unclippedDepth: true},
+});
+gc();
+try {
+externalTexture0.label = '\u12ff\u5e85\u00eb\u{1f82b}\uc054\u{1ff29}';
+} catch {}
+let shaderModule18 = device3.createShaderModule({
+  label: '\ubd84\u0c8a\ued60\u0f13\u{1f993}\u9898\u83ff\u0676\udab7\u{1f81f}',
+  code: `@group(2) @binding(5433)
+var<storage, read_write> local28: array<u32>;
+@group(0) @binding(5433)
+var<storage, read_write> field27: array<u32>;
+@group(0) @binding(3799)
+var<storage, read_write> global35: array<u32>;
+@group(0) @binding(560)
+var<storage, read_write> n23: array<u32>;
+@group(1) @binding(5433)
+var<storage, read_write> field28: array<u32>;
+@group(2) @binding(3799)
+var<storage, read_write> type21: array<u32>;
+
+@compute @workgroup_size(5, 3, 3)
+fn compute0(@builtin(global_invocation_id) global_id : vec3<u32>, @builtin(local_invocation_id) local_id : vec3<u32>) {}
+
+struct S17 {
+  @builtin(position) f0: vec4<f32>
+}
+struct FragmentOutput0 {
+  @location(1) f0: vec2<f32>,
+  @location(2) f1: vec4<f32>,
+  @builtin(sample_mask) f2: u32,
+  @location(0) f3: u32,
+  @location(7) f4: vec2<f32>,
+  @location(3) f5: vec4<i32>
+}
+
+@fragment
+fn fragment0(a0: S17, @builtin(front_facing) a1: bool, @builtin(sample_mask) a2: u32, @builtin(sample_index) a3: u32) -> FragmentOutput0 {
+  return FragmentOutput0();
+}
+
+struct S16 {
+  @location(0) f0: vec4<i32>,
+  @location(5) f1: i32,
+  @location(10) f2: u32,
+  @location(16) f3: vec2<i32>,
+  @location(4) f4: vec3<f32>,
+  @location(12) f5: vec2<u32>
+}
+
+@vertex
+fn vertex0(@builtin(vertex_index) a0: u32, @location(2) a1: vec3<u32>, a2: S16, @location(15) a3: u32, @location(14) a4: vec3<f16>, @location(8) a5: vec2<i32>, @location(9) a6: vec4<u32>, @location(17) a7: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+`,
+  sourceMap: {},
+  hints: {},
+});
+let commandEncoder93 = device3.createCommandEncoder({label: '\ucaee\u6249\u053c\u4560\uae08\u{1fd95}\ud5ff\u0ba9\u6254\u0a99'});
+let querySet39 = device3.createQuerySet({label: '\uc0f9\u6b6c\ud6c2', type: 'occlusion', count: 968});
+offscreenCanvas12.height = 538;
+let bindGroupLayout27 = device3.createBindGroupLayout({
+  label: '\u1f21\u0708\u{1f8a1}\uef8e\u{1fc55}\u{1fc42}',
+  entries: [
+    {
+      binding: 5178,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+  ],
+});
+let commandEncoder94 = device3.createCommandEncoder({label: '\u{1fc8e}\u38ee\u7c32\u{1f8b6}\u2adc'});
+let querySet40 = device3.createQuerySet({
+  label: '\u422e\u{1fec9}\u051b\u{1ff3d}\u7e9a\u00b0\u3e0d\u{1fbb5}\u7872\u6950',
+  type: 'occlusion',
+  count: 3363,
+});
+let textureView95 = texture55.createView({label: '\ufbf3\u0e14\u1e36\uaca6\u5be6\u{1fd08}\u85b6\u{1fc79}', baseMipLevel: 1, mipLevelCount: 1});
+let renderBundleEncoder42 = device3.createRenderBundleEncoder({
+  label: '\uf96e\u787e\u37bc\u2a02\u{1f868}\u006d\u03ef\u{1fc1f}\u{1f8c2}',
+  colorFormats: ['rgba16sint'],
+});
+let renderBundle53 = renderBundleEncoder37.finish({});
+try {
+buffer17.unmap();
+} catch {}
+try {
+device3.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(arrayBuffer3), /* required buffer size: 408_326 */
+{offset: 298, bytesPerRow: 132, rowsPerImage: 281}, {width: 16, height: 1, depthOrArrayLayers: 12});
+} catch {}
+let pipeline68 = device3.createRenderPipeline({
+  label: '\u2af3\uec6c\u002a\u5514\u0c4f\u1e2b\u045f\u0006\u{1ff4f}\u0a6d\u0123',
+  layout: pipelineLayout10,
+  multisample: {mask: 0x39ece1e1},
+  fragment: {
+  module: shaderModule15,
+  entryPoint: 'fragment0',
+  constants: {},
+  targets: [{format: 'r8uint', writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED}, {format: 'rg32float', writeMask: 0}, {
+  format: 'r8unorm',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN,
+}, {format: 'rgba16sint', writeMask: 0}],
+},
+  vertex: {
+    module: shaderModule15,
+    entryPoint: 'vertex0',
+    buffers: [
+      {
+        arrayStride: 3112,
+        attributes: [
+          {format: 'sint32x4', offset: 416, shaderLocation: 12},
+          {format: 'unorm16x2', offset: 20, shaderLocation: 1},
+          {format: 'sint8x2', offset: 342, shaderLocation: 3},
+          {format: 'sint32x2', offset: 168, shaderLocation: 2},
+          {format: 'snorm8x2', offset: 1130, shaderLocation: 16},
+          {format: 'snorm8x2', offset: 394, shaderLocation: 15},
+          {format: 'sint32x2', offset: 212, shaderLocation: 11},
+          {format: 'unorm8x2', offset: 468, shaderLocation: 7},
+          {format: 'uint32x2', offset: 620, shaderLocation: 4},
+          {format: 'snorm16x4', offset: 460, shaderLocation: 10},
+          {format: 'snorm8x4', offset: 376, shaderLocation: 9},
+          {format: 'uint32x4', offset: 284, shaderLocation: 14},
+        ],
+      },
+      {
+        arrayStride: 4472,
+        attributes: [
+          {format: 'snorm16x4', offset: 248, shaderLocation: 18},
+          {format: 'sint32', offset: 556, shaderLocation: 8},
+        ],
+      },
+      {
+        arrayStride: 9852,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 112, shaderLocation: 6},
+          {format: 'sint16x2', offset: 740, shaderLocation: 17},
+          {format: 'sint32', offset: 720, shaderLocation: 0},
+        ],
+      },
+      {arrayStride: 5572, stepMode: 'vertex', attributes: []},
+      {
+        arrayStride: 2788,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'sint16x4', offset: 580, shaderLocation: 13},
+          {format: 'uint32x4', offset: 880, shaderLocation: 5},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', frontFace: 'cw', unclippedDepth: true},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let adapter7 = await navigator.gpu.requestAdapter({powerPreference: 'low-power'});
+gc();
+let commandEncoder95 = device3.createCommandEncoder({label: '\u{1f650}\u{1ffbe}'});
+let querySet41 = device3.createQuerySet({label: '\u5931\u87ee\u{1fb17}\u1b27\u0641', type: 'occlusion', count: 3480});
+let textureView96 = texture56.createView({label: '\u{1f7a8}\u95e0', dimension: '2d', baseArrayLayer: 8});
+let renderBundle54 = renderBundleEncoder38.finish({label: '\uf84e\ub6d6\u{1fd8e}\u6f98\u{1ff21}'});
+try {
+renderBundleEncoder42.setVertexBuffer(5, buffer17, 0, 1224);
+} catch {}
+try {
+gpuCanvasContext11.configure({
+  device: device3,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 4}
+*/
+{
+  source: imageBitmap14,
+  origin: { x: 361, y: 11 },
+  flipY: false,
+}, {
+  texture: texture54,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder96 = device3.createCommandEncoder();
+let renderBundle55 = renderBundleEncoder40.finish({});
+let sampler43 = device3.createSampler({
+  label: '\u0d86\u{1f9de}\u04e4',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+});
+let promise23 = device3.queue.onSubmittedWorkDone();
+gc();
+let offscreenCanvas40 = new OffscreenCanvas(269, 797);
+let videoFrame28 = new VideoFrame(canvas25, {timestamp: 0});
+let promise24 = adapter3.requestAdapterInfo();
+let offscreenCanvas41 = new OffscreenCanvas(682, 311);
+try {
+offscreenCanvas41.getContext('webgl');
+} catch {}
+let bindGroupLayout28 = device3.createBindGroupLayout({
+  entries: [
+    {
+      binding: 5823,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'write-only', viewDimension: '3d' },
+    },
+    {binding: 2036, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let querySet42 = device3.createQuerySet({label: '\ud38a\ue08a\u{1f7df}', type: 'occlusion', count: 1965});
+let textureView97 = texture55.createView({aspect: 'all', format: 'r8uint', baseMipLevel: 2, mipLevelCount: 1});
+let computePassEncoder38 = commandEncoder92.beginComputePass({});
+let canvas37 = document.createElement('canvas');
+let img31 = await imageWithData(133, 164, '#78224a8f', '#c98ffb56');
+document.body.prepend(video29);
+let img32 = await imageWithData(183, 87, '#65651631', '#4f0ffcb7');
+canvas6.width = 14;
+let imageBitmap23 = await createImageBitmap(img28);
+let promise25 = adapter6.requestDevice({
+  label: '\u0e74\u5c4d\u04ad\u1be5\ube39\u097e\ud709',
+  defaultQueue: {label: '\u00a9\u12f1\u79da\u6e8d\u{1fd29}\u0713\u{1f856}\u{1fac2}\u1553\u647b\u{1f896}'},
+  requiredLimits: {
+    maxColorAttachmentBytesPerSample: 54,
+    maxVertexAttributes: 23,
+    maxVertexBufferArrayStride: 38928,
+    maxStorageTexturesPerShaderStage: 39,
+    maxStorageBuffersPerShaderStage: 15,
+    maxDynamicStorageBuffersPerPipelineLayout: 13915,
+    maxDynamicUniformBuffersPerPipelineLayout: 40601,
+    maxBindingsPerBindGroup: 6112,
+    maxTextureArrayLayers: 607,
+    maxTextureDimension1D: 8768,
+    maxTextureDimension2D: 13449,
+    maxBindGroupsPlusVertexBuffers: 25,
+    minStorageBufferOffsetAlignment: 128,
+    minUniformBufferOffsetAlignment: 64,
+    maxUniformBufferBindingSize: 52860648,
+    maxStorageBufferBindingSize: 198509232,
+    maxUniformBuffersPerShaderStage: 31,
+    maxSampledTexturesPerShaderStage: 21,
+    maxInterStageShaderVariables: 91,
+    maxInterStageShaderComponents: 88,
+    maxSamplersPerShaderStage: 21,
+  },
+});
+let commandEncoder97 = device3.createCommandEncoder({label: '\u0678\u1841\u{1f7cd}\u1470\u7d1a'});
+let querySet43 = device3.createQuerySet({type: 'occlusion', count: 3532});
+let texture59 = device3.createTexture({
+  label: '\u0064\u8dd1\u818a\ud646\u0147\uecb3',
+  size: [2, 3, 149],
+  format: 'r8uint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler44 = device3.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 72.39,
+  lodMaxClamp: 87.47,
+});
+try {
+  await device3.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline69 = await device3.createComputePipelineAsync({
+  label: '\u4bb5\u8977',
+  layout: pipelineLayout10,
+  compute: {module: shaderModule15, entryPoint: 'compute0', constants: {}},
+});
+let buffer18 = device2.createBuffer({size: 108661, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView98 = texture38.createView({mipLevelCount: 2});
+let renderBundleEncoder43 = device2.createRenderBundleEncoder({
+  label: '\uc256\u5208\ufb56',
+  colorFormats: ['rgba8unorm-srgb', 'rg8sint', 'r8sint', 'rgb10a2unorm'],
+  depthReadOnly: true,
+});
+try {
+buffer13.unmap();
+} catch {}
+try {
+commandEncoder68.copyBufferToTexture({
+  /* bytesInLastRow: 756 widthInBlocks: 189 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 26100 */
+  offset: 26100,
+  bytesPerRow: 768,
+  buffer: buffer12,
+}, {
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 112, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 189, height: 0, depthOrArrayLayers: 0});
+dissociateBuffer(device2, buffer12);
+} catch {}
+try {
+device2.queue.writeBuffer(buffer18, 10736, new Int16Array(17370), 8226, 3892);
+} catch {}
+let offscreenCanvas42 = new OffscreenCanvas(210, 132);
+canvas32.height = 115;
+let imageBitmap24 = await createImageBitmap(canvas11);
+try {
+offscreenCanvas42.getContext('webgl');
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(0x55) };
+} catch {}
+try {
+  await promise23;
+} catch {}
+canvas5.width = 370;
+try {
+adapter7.label = '\u{1ff28}\u687d\ub8c3\u1856\u{1f804}\u6314\u01da\u036e\u0ab3\uc63f\u66a3';
+} catch {}
+let bindGroup7 = device2.createBindGroup({label: '\u{1fa50}\u{1ff76}\u1310\u0fc8\u534f', layout: bindGroupLayout18, entries: []});
+let textureView99 = texture48.createView({label: '\u3412\u{1fca2}\u415b', baseMipLevel: 2, mipLevelCount: 3});
+let renderBundle56 = renderBundleEncoder33.finish({label: '\ufaec\u{1fa45}\uc6d9\ud369\ud603\u{1f894}\ufa86\u95c6\u{1f817}\u8b69'});
+try {
+renderBundleEncoder31.setPipeline(pipeline48);
+} catch {}
+try {
+commandEncoder88.clearBuffer(buffer18, 54680, 28324);
+dissociateBuffer(device2, buffer18);
+} catch {}
+try {
+computePassEncoder27.pushDebugGroup('\ua8d6');
+} catch {}
+let promise26 = device2.queue.onSubmittedWorkDone();
+try {
+device2.queue.copyExternalImageToTexture(/*
+{width: 607, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: offscreenCanvas39,
+  origin: { x: 29, y: 85 },
+  flipY: false,
+}, {
+  texture: texture47,
+  mipLevel: 2,
+  origin: {x: 159, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 53, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas27);
+let video35 = await videoWithData();
+let commandEncoder98 = device0.createCommandEncoder({label: '\u6ab8\uc8d7\udc8f\u2786\ud341\u085b\u{1fdb0}'});
+let renderBundle57 = renderBundleEncoder8.finish({label: '\u67fd\u074e\u01f0\u0a23\u23ff\u089f'});
+let externalTexture33 = device0.importExternalTexture({label: '\u0c5d\u4f74\u01ba\u3bed', source: video7});
+try {
+renderBundleEncoder32.setPipeline(pipeline50);
+} catch {}
+try {
+commandEncoder37.copyBufferToTexture({
+  /* bytesInLastRow: 88 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2496 */
+  offset: 2408,
+  buffer: buffer1,
+}, {
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 22, height: 1, depthOrArrayLayers: 1});
+dissociateBuffer(device0, buffer1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 7,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, arrayBuffer6, /* required buffer size: 480 */
+{offset: 480, rowsPerImage: 41}, {width: 1, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let querySet44 = device3.createQuerySet({type: 'occlusion', count: 125});
+let textureView100 = texture57.createView({label: '\ud182\u0844\u02e3', dimension: '2d-array', baseMipLevel: 5, baseArrayLayer: 0});
+let renderBundle58 = renderBundleEncoder41.finish();
+try {
+renderBundleEncoder42.setVertexBuffer(1, buffer17, 1896);
+} catch {}
+try {
+device3.queue.copyExternalImageToTexture(/*
+{width: 1, height: 1, depthOrArrayLayers: 4}
+*/
+{
+  source: img2,
+  origin: { x: 85, y: 40 },
+  flipY: false,
+}, {
+  texture: texture54,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext20.unconfigure();
+} catch {}
+video30.width = 205;
+offscreenCanvas14.height = 497;
+let imageData34 = new ImageData(80, 96);
+let texture60 = device3.createTexture({
+  size: {width: 18, height: 30, depthOrArrayLayers: 138},
+  mipLevelCount: 6,
+  dimension: '3d',
+  format: 'rg32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg32float', 'rg32float', 'rg32float'],
+});
+let textureView101 = texture57.createView({label: '\ud4a3\u4366\u0a27', dimension: '2d-array', baseMipLevel: 5, baseArrayLayer: 0});
+let computePassEncoder39 = commandEncoder89.beginComputePass({label: '\u0d70\u8294\u0faa\u804a\u0983\u0314'});
+let renderBundle59 = renderBundleEncoder41.finish({label: '\u3bc9\u{1fa23}\u00f0\ua2d6\u054d\u7e68\u7f4e'});
+try {
+computePassEncoder35.setPipeline(pipeline69);
+} catch {}
+let promise27 = device3.queue.onSubmittedWorkDone();
+let gpuCanvasContext37 = canvas36.getContext('webgpu');
+try {
+gpuCanvasContext29.unconfigure();
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame4.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame18.close();
+videoFrame19.close();
+videoFrame20.close();
+videoFrame21.close();
+videoFrame22.close();
+videoFrame23.close();
+videoFrame24.close();
+videoFrame25.close();
+videoFrame26.close();
+videoFrame27.close();
+videoFrame28.close();
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -834,7 +834,7 @@ bool RenderBundleEncoder::validToEncodeCommand() const
 
 Ref<RenderBundle> RenderBundleEncoder::finish(const WGPURenderBundleDescriptor& descriptor)
 {
-    if (!m_icbDescriptor || m_debugGroupStackSize) {
+    if (!m_icbDescriptor || m_debugGroupStackSize || !m_device->isValid()) {
         m_device->generateAValidationError(m_lastErrorString);
         return RenderBundle::createInvalid(m_device, m_lastErrorString);
     }
@@ -873,7 +873,7 @@ bool RenderBundleEncoder::isValid() const
 
 void RenderBundleEncoder::replayCommands(RenderPassEncoder& renderPassEncoder)
 {
-    if (!renderPassEncoder.renderCommandEncoder() || !isValid())
+    if (!renderPassEncoder.renderCommandEncoder() || !isValid() || !m_device->isValid())
         return;
 
     m_renderPassEncoder = &renderPassEncoder;


### PR DESCRIPTION
#### e91b9416d35d02968ccb1554d14e94568c762be5
<pre>
[WebGPU] RenderBundleEncoder will crash if Device is destroyed before calling GPURenderBundleEncoder.finish()
<a href="https://bugs.webkit.org/show_bug.cgi?id=275371">https://bugs.webkit.org/show_bug.cgi?id=275371</a>
&lt;radar://129605612&gt;

Reviewed by Dan Glastonbury.

If the MTLDevice is destroyed, then we should skip attempting to perform
any work in finish() or replayCommands().

Specifically the crash occurs because the dynamic offsets buffer can not
be allocated on a MTLDevice which is nil.

* LayoutTests/fast/webgpu/nocrash/fuzz-275371-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-275371.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::finish):
(WebGPU::RenderBundleEncoder::replayCommands):

Canonical link: <a href="https://commits.webkit.org/279935@main">https://commits.webkit.org/279935@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8059152e59cda266b61b55a5f7d07997a4f39301

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54955 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7544 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58233 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5686 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5718 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44503 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3860 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57050 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47608 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25629 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29283 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4951 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3827 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5175 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59824 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30219 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5327 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51923 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31352 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47686 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51361 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12084 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32367 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31140 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->