### PR TITLE
[Static Analyzer CI] parse-static-analyzer-results fails with KeyError when there are no issues of a particular type

### DIFF
--- a/Tools/Scripts/generate-dirty-files
+++ b/Tools/Scripts/generate-dirty-files
@@ -87,39 +87,37 @@ def parse_results_file(args, file_path):
 
 def find_project_results(args, project, file_list, results_data):
     bug_counts = {}
-    files_per_project = {}
+    files_per_project = {key: set() for key in CHECKER_MAP.values()}
 
     for result_file in file_list:
-        if result_file:
-            file_name, issue_hash, bug_type, _ = parse_results_file(args, result_file)
-            if not file_name:
-                continue
+        file_name, issue_hash, bug_type, _ = parse_results_file(args, result_file)
+        if not file_name:
+            continue
 
-            if bug_type not in bug_counts:
-                bug_counts[bug_type] = 0
-            bug_counts[bug_type] += 1
+        if bug_type not in bug_counts:
+            bug_counts[bug_type] = 0
+        bug_counts[bug_type] += 1
 
-            # Truncate path after project name to match the expectations file
-            try:
-                file_name = file_name.split(f'{project}/')[1]
-            except IndexError:
-                continue
+        # Truncate path after project name to match the expectations file
+        try:
+            file_name = file_name.split(f'{project}/')[1]
+        except IndexError:
+            # Ignore WebKitBuild/Debug files that are included in other projects
+            continue
 
-            # Map filename to issues for each bug type
-            file_dict = results_data.get(CHECKER_MAP[bug_type], {})
-            if not file_name in file_dict:
-                file_dict[file_name] = []
-            file_dict[file_name].append(issue_hash)
-            results_data[CHECKER_MAP[bug_type]] = file_dict
+        # Map filename to issues for each bug type
+        file_dict = results_data.get(CHECKER_MAP[bug_type], {})
+        if not file_name in file_dict:
+            file_dict[file_name] = []
+        file_dict[file_name].append(issue_hash)
+        results_data[CHECKER_MAP[bug_type]] = file_dict
 
-            output_file_name = os.path.abspath(f'{args.output_dir}/{project}/{CHECKER_MAP[bug_type]}Issues')
-            with open(output_file_name, 'a') as f:
-                f.write(f'{issue_hash}\n')
+        output_file_name = os.path.abspath(f'{args.output_dir}/{project}/{CHECKER_MAP[bug_type]}Issues')
+        with open(output_file_name, 'a') as f:
+            f.write(f'{issue_hash}\n')
 
-            # Map checker to all files with bugs of that type
-            if not CHECKER_MAP[bug_type] in files_per_project:
-                files_per_project[CHECKER_MAP[bug_type]] = set()
-            files_per_project[CHECKER_MAP[bug_type]].add(file_name)
+        # Map checker to all files with bugs of that type
+        files_per_project[CHECKER_MAP[bug_type]].add(file_name)
 
     for checker in CHECKER_MAP.values():
         output_file_name_2 = os.path.abspath(f'{args.output_dir}/{project}/{checker}Files')


### PR DESCRIPTION
#### c03e7771fc1d726fe48c95c7385377ab5865f04d
<pre>
[Static Analyzer CI] parse-static-analyzer-results fails with KeyError when there are no issues of a particular type
<a href="https://bugs.webkit.org/show_bug.cgi?id=275372">https://bugs.webkit.org/show_bug.cgi?id=275372</a>
<a href="https://rdar.apple.com/129623451">rdar://129623451</a>

Reviewed by Ryan Haddad.

Initialize the files_per_project dictionary with all the checker types before adding data.

* Tools/Scripts/generate-dirty-files:
(find_project_results):

Canonical link: <a href="https://commits.webkit.org/279927@main">https://commits.webkit.org/279927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff081dab43939c2133b725060a88e11fc5ac5808

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54957 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7546 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58235 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5688 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57257 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5720 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44505 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/3862 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57052 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/32497 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/47610 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/25631 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/29286 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/4953 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3829 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/5177 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59826 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/30221 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/5329 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/51924 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31354 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/47688 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51362 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32369 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8135 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31142 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->