### PR TITLE
git-webkit setup fails if you say no to creating forks

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
@@ -185,13 +185,12 @@ class Setup(Command):
                 log.info("User already owns a fork of '{}'!".format(parent_name))
                 return result
 
-        if repository.owner == username or args.defaults or Terminal.choose(
-            "Create a private fork of '{}/{}' named '{}' belonging to '{}'".format(
-                repository.owner, repository.name, forked_name, username
-            ), default='Yes',
-        ) == 'No':
+        if repository.owner == username or args.defaults:
             log.info("Continuing without forking '{}/{}'".format(repository.owner, repository.name))
             return 1
+        print("Create a private fork of '{}/{}' named '{}' belonging to '{}'".format(repository.owner, repository.name, forked_name, username))
+        print('For detailed information about forking, please see: https://github.com/WebKit/WebKit/wiki/Git-Config#forking')
+        input('Press Enter to continue (Ctrl+C to exit)')
 
         data = dict(
             owner=username,

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/setup_unittest.py
@@ -62,8 +62,11 @@ class TestSetup(testing.PathTestCase):
 
         self.assertEqual(
             captured.stdout.getvalue(),
-            "Create a private fork of 'WebKit/WebKit' named 'WebKit' belonging to 'username' ([Yes]/No): \n"
-            'Setup succeeded!\n',
+            '''Create a private fork of 'WebKit/WebKit' named 'WebKit' belonging to 'username'
+For detailed information about forking, please see: https://github.com/WebKit/WebKit/wiki/Git-Config#forking
+Press Enter to continue (Ctrl+C to exit)
+Setup succeeded!
+''',
         )
         self.assertEqual(captured.stderr.getvalue(), '')
         self.assertEqual(
@@ -163,7 +166,9 @@ a pull request branch? ([when-user-owned]/disabled/always/never):
 Pick a commit message editor for this repository:
     {}
 : 
-Create a private fork of 'WebKit/WebKit' named 'WebKit' belonging to 'username' ([Yes]/No): 
+Create a private fork of 'WebKit/WebKit' named 'WebKit' belonging to 'username'
+For detailed information about forking, please see: https://github.com/WebKit/WebKit/wiki/Git-Config#forking
+Press Enter to continue (Ctrl+C to exit)
 Setup succeeded!
 '''.format('\n    '.join([
             '{}) {}'.format(


### PR DESCRIPTION
#### efe2c1b2143c274ffd9d9f425039bf551f8ee5ef
<pre>
git-webkit setup fails if you say no to creating forks
<a href="https://bugs.webkit.org/show_bug.cgi?id=275130">https://bugs.webkit.org/show_bug.cgi?id=275130</a>
<a href="https://rdar.apple.com/129174097">rdar://129174097</a>

Reviewed by Ryan Haddad.

Changes prompt to include informative link and remove &quot;no&quot; option.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py:
(Setup.github):

Canonical link: <a href="https://commits.webkit.org/280044@main">https://commits.webkit.org/280044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d62df69437ce7532d66cf46367ab30e74e555f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58243 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5696 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57265 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41970 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5728 "") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44512 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3869 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57060 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32506 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47619 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25638 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/54791 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29294 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4963 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3837 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51144 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59834 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30229 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/5728 "") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51932 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/54961 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31362 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47697 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51370 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32377 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8196 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31150 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->