### PR TITLE
Safari hangs for 650ms to 1100ms in WebKit::WebExtensionWindow::tabs(WebKit::WebExtensionWindow::SkipValidation).

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -2156,8 +2156,7 @@ void WebExtensionContext::didCloseTab(WebExtensionTab& tab, WindowIsClosing wind
     if (!isLoaded() || !tab.extensionHasAccess() || suppressEvents == SuppressEvents::Yes)
         return;
 
-    // SkipValidation::Yes since the window might not contain the tab anymore since things are closing.
-    RefPtr window = tab.window(WebExtensionTab::SkipValidation::Yes);
+    RefPtr window = tab.window();
     auto windowIdentifier = window ? window->identifier() : WebExtensionWindowConstants::NoneIdentifier;
 
     fireTabsRemovedEventIfNeeded(tab.identifier(), windowIdentifier, windowIsClosing);

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm
@@ -264,7 +264,7 @@ bool WebExtensionTab::extensionHasTemporaryPermission() const
     return temporaryPattern && temporaryPattern->matchesURL(url());
 }
 
-RefPtr<WebExtensionWindow> WebExtensionTab::window(SkipValidation skipValidation) const
+RefPtr<WebExtensionWindow> WebExtensionTab::window() const
 {
     if (!isValid() || !m_respondsToWindow)
         return nullptr;
@@ -275,17 +275,7 @@ RefPtr<WebExtensionWindow> WebExtensionTab::window(SkipValidation skipValidation
 
     THROW_UNLESS([window conformsToProtocol:@protocol(_WKWebExtensionWindow)], @"Object returned by windowForWebExtensionContext: does not conform to the _WKWebExtensionWindow protocol");
 
-    Ref result = m_extensionContext->getOrCreateWindow(window);
-
-    if (skipValidation == SkipValidation::No) {
-        if (!result->tabs().contains(*this)) {
-            RELEASE_LOG_ERROR(Extensions, "%{public}@ returned by windowForWebExtensionContext: does not contain the tab %{public}@", window, delegate());
-            ASSERT_NOT_REACHED();
-            return nullptr;
-        }
-    }
-
-    return result.ptr();
+    return m_extensionContext->getOrCreateWindow(window);
 }
 
 size_t WebExtensionTab::index() const
@@ -377,8 +367,7 @@ bool WebExtensionTab::isActive() const
     if (!isValid())
         return false;
 
-    // SkipValidation::Yes for windows() since activeTab() does validation too.
-    RefPtr window = this->window(SkipValidation::Yes);
+    RefPtr window = this->window();
     return window ? window->activeTab() == this : false;
 }
 
@@ -446,9 +435,7 @@ bool WebExtensionTab::isPrivate() const
     if (!isValid())
         return false;
 
-    // SkipValidation::Yes is used to avoid a loop, and it isn't critical since this is checking
-    // the window's private state and does not care about tabs validation that window() does.
-    RefPtr window = this->window(SkipValidation::Yes);
+    RefPtr window = this->window();
     if (!window)
         return false;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -98,7 +98,6 @@ public:
     using ImageFormat = WebExtensionTabImageFormat;
 
     enum class AssumeWindowMatches : bool { No, Yes };
-    enum class SkipValidation : bool { No, Yes };
 
     using WebProcessProxySet = HashSet<Ref<WebProcessProxy>>;
 
@@ -125,7 +124,7 @@ public:
     void addChangedProperties(OptionSet<ChangedProperties> properties) { m_changedProperties.add(properties); }
     void clearChangedProperties() { m_changedProperties = { }; }
 
-    RefPtr<WebExtensionWindow> window(SkipValidation = SkipValidation::No) const;
+    RefPtr<WebExtensionWindow> window() const;
     size_t index() const;
 
     RefPtr<WebExtensionTab> parentTab() const;


### PR DESCRIPTION
#### 5f3191a6ba07ef36bdc3b6fea7a7b944cf07fd16
<pre>
Safari hangs for 650ms to 1100ms in WebKit::WebExtensionWindow::tabs(WebKit::WebExtensionWindow::SkipValidation).
<a href="https://webkit.org/b/275378">https://webkit.org/b/275378</a>
<a href="https://rdar.apple.com/129456659">rdar://129456659</a>

Reviewed by Brian Weinstein.

The validation added in e1a34394bf94 to check if the tab tab was contained in the window
ended up being recursive with how it is called multiple times, and per tab when opening
a new window that has a lot of tabs. Just remove this validation, since it isn&apos;t needed.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::didCloseTab): Drop SkipValidation::Yes param.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionTabCocoa.mm:
(WebKit::WebExtensionTab::window const): Remove validation.
(WebKit::WebExtensionTab::isActive const): Drop SkipValidation::Yes param.
(WebKit::WebExtensionTab::isPrivate const): Ditto.
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:

Canonical link: <a href="https://commits.webkit.org/279929@main">https://commits.webkit.org/279929@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1834f0ab3225ed8d2caaa14a64efc1c2959672d1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54967 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34421 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58245 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5698 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5730 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/3871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57062 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/32508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/47620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/25640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/29296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3839 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/5187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59836 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/30232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/5339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/51935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31364 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/47698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32381 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8137 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31153 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->