### PR TITLE
[WebXR] Copy rate map samples into IPC message

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebufferCocoa.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebufferCocoa.cpp
@@ -382,7 +382,7 @@ bool WebXROpaqueFramebuffer::setupFramebuffer(GraphicsContextGL& gl, const Platf
     if (foveationChange) {
         if (m_usingFoveation) {
             const auto& frmd = data.foveationRateMapDesc;
-            if (!gl.addFoveation(leftPhysicalSize, rightPhysicalSize, frmd.screenSize, frmd.horizontalSamples[0], frmd.verticalSamples, frmd.horizontalSamples[1]))
+            if (!gl.addFoveation(leftPhysicalSize, rightPhysicalSize, frmd.screenSize, frmd.horizontalSamplesLeft, frmd.verticalSamples, frmd.horizontalSamplesRight))
                 return false;
             gl.enableFoveation(m_drawAttachments.colorBuffer);
         } else

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -261,9 +261,10 @@ struct FrameData {
 #if PLATFORM(COCOA)
     struct RateMapDescription {
         WebCore::IntSize screenSize;
-        std::array<std::span<const float>, 2> horizontalSamples;
+        Vector<float> horizontalSamplesLeft;
+        Vector<float> horizontalSamplesRight;
         // Vertical samples is shared by both horizontalSamples
-        std::span<const float> verticalSamples;
+        Vector<float> verticalSamples;
     };
 
     static constexpr auto LayerSetupSizeMax = std::numeric_limits<uint16_t>::max();

--- a/Source/WebKit/Shared/XR/PlatformXR.serialization.in
+++ b/Source/WebKit/Shared/XR/PlatformXR.serialization.in
@@ -103,8 +103,9 @@ enum class PlatformXR::XRTargetRayMode : uint8_t {
 #if PLATFORM(COCOA)
 [Nested] struct PlatformXR::FrameData::RateMapDescription {
     WebCore::IntSize screenSize;
-    std::array<std::span<const float>, 2> horizontalSamples;
-    std::span<const float> verticalSamples;
+    Vector<float> horizontalSamplesLeft;
+    Vector<float> horizontalSamplesRight;
+    Vector<float> verticalSamples;
 };
 
 [Nested, RValue] struct PlatformXR::FrameData::LayerSetupData {


### PR DESCRIPTION
#### 8ad29aa0d4c444c556f1d387c26ceecc5c43df63
<pre>
[WebXR] Copy rate map samples into IPC message
<a href="https://bugs.webkit.org/show_bug.cgi?id=275389">https://bugs.webkit.org/show_bug.cgi?id=275389</a>
<a href="https://rdar.apple.com/129658002">rdar://129658002</a>

Reviewed by Mike Wyrzykowski and Kimmo Kinnunen.

Intermittent corruption of WebXR rendering has been observed which is resulting
from a corruption of the first few horizontal samples for the rasterization rate
maps to support static foveation between creating the message payload and the
point at which the message is sent over IPC.

This change copies the rate map samples into the message, storing them in
Vectors.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebufferCocoa.cpp:
(WebCore::WebXROpaqueFramebuffer::setupFramebuffer):
* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebKit/Shared/XR/PlatformXR.serialization.in:

Canonical link: <a href="https://commits.webkit.org/279972@main">https://commits.webkit.org/279972@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa27eacd96c86c6e7039387cca5954435b35f7a1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58267 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5720 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57289 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/41996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5752 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44534 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3893 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57084 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47642 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25660 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29318 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4986 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3861 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59858 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30256 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5365 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51956 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31386 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47718 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51403 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32408 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8157 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31177 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->