### PR TITLE
[browserperfdash-benchmark] Support using a streaming http response when receiving the status update from the remote dashboard

### DIFF
--- a/Tools/Scripts/webkitpy/browserperfdash/browserperfdash_runner.py
+++ b/Tools/Scripts/webkitpy/browserperfdash/browserperfdash_runner.py
@@ -190,6 +190,43 @@ class BrowserPerfDashRunner(object):
         except urllib.error.HTTPError as e:
             return e
 
+    # browserperfdash uses code 202 for handling long StreamingHttpResponses that ouput text meanwhile
+    # processing to avoid timeouts and then put the real reply at the end.
+    def _read_stream_response(self, post_request, server_name):
+        try:
+            reply_code = post_request.getcode()
+            if reply_code != 202:
+                return reply_code, post_request.read().decode('utf-8', errors='ignore')
+            post_reply = b''
+            last_status_update = datetime.now()
+            while True:
+                chunk = post_request.read(1)
+                if not chunk:
+                    break
+                post_reply += chunk
+                seconds_elapased_since_status_update = (datetime.now() - last_status_update).total_seconds()
+                # Each minute log an status update to avoid timeouts on the worker side due to not output
+                if seconds_elapased_since_status_update > 60:
+                    _log.info('Waiting for server {server_name} to process the results from {test_name} and browser {browser_name} version {browser_version} ...'.format(
+                              server_name=server_name, test_name=self._result_data['test_id'], browser_name=self._result_data['browser_id'], browser_version=self._result_data['browser_version']))
+                    last_status_update = datetime.now()
+            post_reply = post_reply.decode('utf-8', errors='ignore')
+            recording_reply_msg = False
+            reply_msg = ''
+            for line in post_reply.splitlines():
+                if line.startswith('HTTP_202_FINAL_STATUS_CODE') and '=' in line:
+                    reply_code = int(line.split("=")[1].strip())
+                if recording_reply_msg:
+                    reply_msg += line + '\n'
+                if line.startswith('HTTP_202_FINAL_MSG_NEXT_LINES'):
+                    recording_reply_msg = True
+            reply_msg = reply_msg.strip()
+            return reply_code, reply_msg
+        except Exception as e:
+            reply_code = 400
+            reply_msg = ('Exception when trying to read the response from server {server_name}: {e}'.format(server_name=server_name, e=str(e)))
+            return reply_code, reply_msg
+
     def _upload_result(self):
         upload_failed = False
         for server in self._config_parser.sections():
@@ -201,13 +238,14 @@ class BrowserPerfDashRunner(object):
             post_url = self._config_parser.get(server, 'post_url')
             try:
                 post_request = self._send_post_request_data(post_url, post_data)
-                if post_request.getcode() == 200:
+                reply_code, reply_msg = self._read_stream_response(post_request, server)
+                if reply_code == 200:
                     _log.info('Sucesfully uploaded results to server {server_name} for test {test_name} and browser {browser_name} version {browser_version}'.format(
                                server_name=server, test_name=self._result_data['test_id'], browser_name=self._result_data['browser_id'], browser_version=self._result_data['browser_version']))
                 else:
                     upload_failed = True
-                    _log.error('The server {server_name} returned an error code: {http_error}'.format(server_name=server, http_error=post_request.getcode()))
-                    _log.error('The error text from the server {server_name} was: "{error_text}"'.format(server_name=server, error_text=post_request.read().decode('utf-8')))
+                    _log.error('The server {server_name} returned an error code: {http_error}'.format(server_name=server, http_error=reply_code))
+                    _log.error('The error text from the server {server_name} was: "{error_text}"'.format(server_name=server, error_text=reply_msg))
             except Exception as e:
                 upload_failed = True
                 _log.error('Exception while trying to upload results to server {server_name}'.format(server_name=server))


### PR DESCRIPTION
#### 7cc16166ce74d1b1697ae8498200ad7b2d2d5a9c
<pre>
[browserperfdash-benchmark] Support using a streaming http response when receiving the status update from the remote dashboard
<a href="https://bugs.webkit.org/show_bug.cgi?id=275393">https://bugs.webkit.org/show_bug.cgi?id=275393</a>

Reviewed by Nikolas Zimmermann.

The browserperfdash server now sends the reply back to the worker using a streaming http response
that each second outputs a dot (&apos;.&apos;) to indicate that the processing of the data is ongoing on
the remote server. This keeps the connection open on the intermediate gateway.
At the end of the reply it sends the status code and the message with the result of the operation.
Refs: <a href="https://github.com/Igalia/browserperfdash/commit/0193bf5">https://github.com/Igalia/browserperfdash/commit/0193bf5</a>

Implement on the runner support for this new type of reply.

* Tools/Scripts/webkitpy/browserperfdash/browserperfdash_runner.py:
(BrowserPerfDashRunner):
(BrowserPerfDashRunner._read_stream_response):
(BrowserPerfDashRunner._upload_result):

Canonical link: <a href="https://commits.webkit.org/280196@main">https://commits.webkit.org/280196@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ceff6cc64a45ead8c0805ea4d352d2446eb5b30d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/54997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58275 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5728 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57297 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42004 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44542 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3898 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57092 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32538 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47647 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25668 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/54823 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29324 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/4991 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3869 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51203 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59866 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30264 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5372 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51961 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31394 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47723 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51409 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32416 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8276 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31185 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->