### PR TITLE
REGRESSION (275831@main): Music video can't be played after tapping music video in Music app

### DIFF
--- a/LayoutTests/media/picture-in-picture/video-playback-system-interruption-and-resume-expected.txt
+++ b/LayoutTests/media/picture-in-picture/video-playback-system-interruption-and-resume-expected.txt
@@ -1,0 +1,22 @@
+
+RUN(internals.setMediaElementRestrictions(video, 'NoRestrictions'))
+RUN(window.internals.settings.setAllowsPictureInPictureMediaPlayback(true))
+RUN(internals.setMockVideoPresentationModeEnabled(true))
+RUN(video.volume = 0.1)
+RUN(video.src = findMediaFile("video", "../content/test"))
+EVENT(canplaythrough)
+RUN(video.play())
+EVENT(playing)
+EXPECTED (video.paused == 'false') OK
+EVENT(webkitpresentationmodechanged)
+RUN(internals.beginMediaSessionInterruption("EnteringBackground"))
+EXPECTED (internals.mediaSessionState(video) != 'Interrupted') OK
+EXPECTED (video.paused == 'false') OK
+RUN(internals.beginMediaSessionInterruption("System"))
+EXPECTED (video.paused == 'true') OK
+EXPECTED (internals.mediaSessionState(video) == 'Interrupted') OK
+RUN(internals.endMediaSessionInterruption("MayResumePlaying"))
+RUN(internals.endMediaSessionInterruption(""))
+EXPECTED (internals.mediaSessionState(video) != 'Interrupted') OK
+END OF TEST
+

--- a/LayoutTests/media/picture-in-picture/video-playback-system-interruption-and-resume.html
+++ b/LayoutTests/media/picture-in-picture/video-playback-system-interruption-and-resume.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src="../media-file.js"></script>
+        <script src="../video-test.js"></script>
+        <script>
+
+            window.addEventListener('load', async event => {
+                if (!window.internals) {
+                    failTest('This test must be run in DumpRenderTree or WebKitTestRunner.');
+                    return;
+                }
+    
+                findMediaElement();
+                run(`internals.setMediaElementRestrictions(video, 'NoRestrictions')`);
+                run(`window.internals.settings.setAllowsPictureInPictureMediaPlayback(true)`);
+                run(`internals.setMockVideoPresentationModeEnabled(true)`);
+                run('video.volume = 0.1');
+                run('video.src = findMediaFile("video", "../content/test")');
+
+                await waitFor(video, 'canplaythrough');
+                run('video.play()');
+                await waitFor(video, 'playing');
+                testExpected('video.paused', false);
+
+                runWithKeyDown(() => {
+                    video.webkitSetPresentationMode('picture-in-picture');
+                });
+                await waitFor(video, 'webkitpresentationmodechanged');
+
+                run('internals.beginMediaSessionInterruption("EnteringBackground")');
+                testExpected('internals.mediaSessionState(video)', 'Interrupted', '!=');
+                testExpected('video.paused', false);
+                run('internals.beginMediaSessionInterruption("System")');
+                testExpected('video.paused', true);
+                testExpected('internals.mediaSessionState(video)', 'Interrupted');
+                run('internals.endMediaSessionInterruption("MayResumePlaying")');
+                run('internals.endMediaSessionInterruption("")');
+                testExpected('internals.mediaSessionState(video)', 'Interrupted', '!=');
+
+                // Wait some time before ending the test to ensure the session interruption is cancelled.
+                endTestLater();
+            });
+            
+        </script>
+    </head>
+    <body>
+        <video autoplay controls></video>
+    </body>
+</html>

--- a/Source/WebCore/platform/audio/PlatformMediaSession.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.cpp
@@ -179,28 +179,40 @@ void PlatformMediaSession::setState(State state)
     PlatformMediaSessionManager::sharedManager().sessionStateChanged(*this);
 }
 
+size_t PlatformMediaSession::activeInterruptionCount() const
+{
+    size_t count = 0;
+    for (auto& interruption : m_interruptionStack) {
+        if (!interruption.ignored)
+            count++;
+    }
+    return count;
+}
+
 PlatformMediaSession::InterruptionType PlatformMediaSession::interruptionType() const
 {
     if (!m_interruptionStack.size())
         return InterruptionType::NoInterruption;
 
-    return m_interruptionStack.last();
+    return m_interruptionStack.last().type;
 }
 
 void PlatformMediaSession::beginInterruption(InterruptionType type)
 {
     ASSERT(type != InterruptionType::NoInterruption);
 
-    m_interruptionStack.append(type);
-    ALWAYS_LOG(LOGIDENTIFIER, "state = ", m_state, ", interruption count = ", interruptionCount(), ", type = ", type);
+    ALWAYS_LOG(LOGIDENTIFIER, "state = ", m_state, ", interruption count = ", m_interruptionStack.size(), ", type = ", type);
 
-    if (interruptionCount() > 1)
-        return;
-
-    if (client().shouldOverrideBackgroundPlaybackRestriction(type)) {
-        ALWAYS_LOG(LOGIDENTIFIER, "returning early because client says to override interruption");
+    if (activeInterruptionCount()) {
+        m_interruptionStack.append({ type, true });
         return;
     }
+    if (client().shouldOverrideBackgroundPlaybackRestriction(type)) {
+        ALWAYS_LOG(LOGIDENTIFIER, "returning early because client says to override interruption");
+        m_interruptionStack.append({ type, true });
+        return;
+    }
+    m_interruptionStack.append({ type, false });
 
     m_stateToRestore = state();
     m_notifyingClient = true;
@@ -211,15 +223,15 @@ void PlatformMediaSession::beginInterruption(InterruptionType type)
 
 void PlatformMediaSession::endInterruption(OptionSet<EndInterruptionFlags> flags)
 {
-    if (!interruptionCount()) {
+    if (m_interruptionStack.isEmpty()) {
         ALWAYS_LOG(LOGIDENTIFIER, "!! ignoring spurious interruption end !!");
         return;
     }
 
-    m_interruptionStack.removeLast();
-    ALWAYS_LOG(LOGIDENTIFIER, "flags = ", (int)flags.toRaw(), ", interruption count = ", interruptionCount(), ", type = ", interruptionType());
+    auto interruption = m_interruptionStack.takeLast();
+    ALWAYS_LOG(LOGIDENTIFIER, "flags = ", (int)flags.toRaw(), ", interruption count = ", m_interruptionStack.size(), " type = ", interruptionType());
 
-    if (interruptionCount())
+    if (activeInterruptionCount() || interruption.ignored)
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER, "restoring state ", m_stateToRestore);
@@ -390,7 +402,7 @@ PlatformMediaSession::DisplayType PlatformMediaSession::displayType() const
 
 bool PlatformMediaSession::blockedBySystemInterruption() const
 {
-    return interruptionCount() > 1 && interruptionType() == PlatformMediaSession::InterruptionType::SystemInterruption;
+    return activeInterruptionCount() && interruptionType() == PlatformMediaSession::InterruptionType::SystemInterruption;
 }
 
 bool PlatformMediaSession::activeAudioSessionRequired() const

--- a/Source/WebCore/platform/audio/PlatformMediaSession.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.h
@@ -261,14 +261,17 @@ protected:
 
 private:
     bool processClientWillPausePlayback(DelayCallingUpdateNowPlaying);
-    size_t interruptionCount() const { return m_interruptionStack.size(); }
+    size_t activeInterruptionCount() const;
 
     PlatformMediaSessionClient& m_client;
     MediaSessionIdentifier m_mediaSessionIdentifier;
     State m_state { State::Idle };
     State m_stateToRestore { State::Idle };
-    Vector<InterruptionType> m_interruptionStack;
-    int m_interruptionCount { 0 };
+    struct Interruption {
+        InterruptionType type { InterruptionType::NoInterruption };
+        bool ignored { false };
+    };
+    Vector<Interruption> m_interruptionStack;
     bool m_active { false };
     bool m_notifyingClient { false };
     bool m_isPlayingToWirelessPlaybackTarget { false };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -166,6 +166,7 @@ private:
     void notifyTrackModeChanged() final;
     void synchronizeTextTrackState() final;
 
+    bool timeIsProgressing() const final { return effectiveRate(); }
     void platformSetVisible(bool) final;
     void platformPlay() final;
     void platformPause() final;
@@ -224,7 +225,7 @@ private:
     void sizeChanged() final;
     void resolvedURLChanged() final;
 
-    bool isHLS() const { return m_cachedAssetIsHLS.value_or(false); }
+    bool isHLS() const final { return m_cachedAssetIsHLS.value_or(false); }
 
     bool hasAvailableVideoFrame() const final;
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -533,6 +533,7 @@ bool MediaPlayerPrivateRemote::seeking() const
 
 void MediaPlayerPrivateRemote::rateChanged(double rate, MediaTimeUpdateData&& timeData)
 {
+    INFO_LOG(LOGIDENTIFIER, "rate:", rate, " currentTime:", timeData.currentTime, " timeIsProgressing:", timeData.timeIsProgressing);
     m_rate = rate;
     m_currentTimeEstimator.setRate(rate);
     m_currentTimeEstimator.setTime(timeData);


### PR DESCRIPTION
#### d03d3a51627299d0e4de746b80889edf43fe93a5
<pre>
REGRESSION (275831@main): Music video can&apos;t be played after tapping music video in Music app
<a href="https://bugs.webkit.org/show_bug.cgi?id=275391">https://bugs.webkit.org/show_bug.cgi?id=275391</a>
<a href="https://rdar.apple.com/128055030">rdar://128055030</a>

Reviewed by Jer Noble.

Commit 275831@main exposed two long-standing and existing issue:
1- When the video is paused following a system interruption, currentTime can continue to progress
despite the new video rate being 0.
2- The HTMLMediaElement can incorrectly resume playback of a paused video.

1) was due to MediaPlayerPrivateAVFObjC::paused() returning false as it only checks if the AVPlayer
status was AVPlayerTimeControlStatusPaused. This caused the default `timeIsProgressing()`
implementation to return true ; hence the time estimation in the content process to continue.

2) When the PlatformMediaSession was receiving an interruption notification, it would be ignored
on start, but not on end, which would resume playback.

Add test.

* LayoutTests/media/picture-in-picture/video-playback-system-interruption-and-resume-expected.txt: Added.
* LayoutTests/media/picture-in-picture/video-playback-system-interruption-and-resume.html: Added.
* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::PlatformMediaSession::activeInterruptionCount const): We add a flag indicating if the
notification was ignored, in order to determine if playback needs to be resumed later.
(WebCore::PlatformMediaSession::interruptionType const):
(WebCore::PlatformMediaSession::beginInterruption):
(WebCore::PlatformMediaSession::endInterruption):
(WebCore::PlatformMediaSession::blockedBySystemInterruption const):
* Source/WebCore/platform/audio/PlatformMediaSession.h: Add method.
(WebCore::PlatformMediaSession::interruptionCount const): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::rateChanged): Add logging

Canonical link: <a href="https://commits.webkit.org/279977@main">https://commits.webkit.org/279977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4ec4fc47384dad968a575a451bcd25d2ee8f5d9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55082 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58364 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5814 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57382 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5853 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3973 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57177 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32621 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47724 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25722 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29399 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5071 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3958 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59954 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30363 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5455 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52026 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47792 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51480 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12112 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32512 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31275 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->