### PR TITLE
[WTF] Add Invocable concept for callbacks and start adoption

### DIFF
--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -175,7 +175,7 @@ public:
         }
 
         for (Variable* variable : m_procedure.variables()) {
-            auto addResult = m_variableToTmps.add(variable, Vector<Tmp, 1>(m_procedure.resultCount(variable->type())));
+            auto addResult = m_variableToTmps.add(variable, Vector<Tmp>(m_procedure.resultCount(variable->type())));
             ASSERT(addResult.isNewEntry);
             for (unsigned i = 0; i < m_procedure.resultCount(variable->type()); ++i)
                 addResult.iterator->value[i] = tmpForType(m_procedure.typeAtOffset(variable->type(), i));

--- a/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
@@ -199,7 +199,7 @@ public:
         }
 
         for (Variable* variable : m_procedure.variables()) {
-            auto addResult = m_variableToTmps.add(variable, Vector<Tmp, 1>(m_procedure.resultCount(variable->type())));
+            auto addResult = m_variableToTmps.add(variable, Vector<Tmp>(m_procedure.resultCount(variable->type())));
             ASSERT(addResult.isNewEntry);
             for (unsigned i = 0; i < m_procedure.resultCount(variable->type()); ++i)
                 addResult.iterator->value[i] = tmpForType(m_procedure.typeAtOffset(variable->type(), i));

--- a/Source/JavaScriptCore/dfg/DFGTierUpCheckInjectionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGTierUpCheckInjectionPhase.cpp
@@ -147,7 +147,7 @@ public:
             }
 
             if (!tierUpCandidates.isEmpty())
-                m_graph.m_plan.tierUpInLoopHierarchy().add(entry.key, tierUpCandidates);
+                m_graph.m_plan.tierUpInLoopHierarchy().ensure(entry.key, [&] { return FixedVector<BytecodeIndex>(WTFMove(tierUpCandidates)); });
         }
         m_graph.m_plan.setWillTryToTierUp(true);
         return true;

--- a/Source/WTF/wtf/FixedVector.h
+++ b/Source/WTF/wtf/FixedVector.h
@@ -95,6 +95,8 @@ public:
         : m_storage(other.isEmpty() ? nullptr : Storage::createFromVector(other).moveToUniquePtr())
     { }
 
+    // FIXME: Should we remove this now that it's not required for HashTable::add? This assignment is non-trivial and
+    // should probably go through the explicit constructor.
     template<size_t inlineCapacity, typename OverflowHandler>
     FixedVector& operator=(const Vector<T, inlineCapacity, OverflowHandler>& other)
     {
@@ -109,6 +111,8 @@ public:
         m_storage = target.isEmpty() ? nullptr : Storage::createFromVector(WTFMove(target)).moveToUniquePtr();
     }
 
+    // FIXME: Should we remove this now that it's not required for HashTable::add? This assignment is non-trivial and
+    // should probably go through the explicit constructor.
     template<size_t inlineCapacity, typename OverflowHandler>
     FixedVector& operator=(Vector<T, inlineCapacity, OverflowHandler>&& other)
     {

--- a/Source/WTF/wtf/FunctionTraits.h
+++ b/Source/WTF/wtf/FunctionTraits.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <tuple>
 #include <type_traits>
 
 namespace WTF {

--- a/Source/WTF/wtf/HashMap.h
+++ b/Source/WTF/wtf/HashMap.h
@@ -155,13 +155,13 @@ public:
     template<typename V> AddResult fastAdd(const KeyType&, V&&);
     template<typename V> AddResult fastAdd(KeyType&&, V&&);
 
-    template<typename Functor> AddResult ensure(const KeyType&, Functor&&);
-    template<typename Functor> AddResult ensure(KeyType&&, Functor&&);
+    AddResult ensure(const KeyType&, const Invocable<MappedType()> auto&);
+    AddResult ensure(KeyType&&, const Invocable<MappedType()> auto&);
 
     bool remove(const KeyType&);
     bool remove(iterator);
-    template<typename Functor>
-    bool removeIf(Functor&&);
+    // FIXME: This feels like it should be Invocable<bool(const KeyValuePairType&)>
+    bool removeIf(const Invocable<bool(KeyValuePairType&)> auto&);
     void clear();
 
     MappedTakeType take(const KeyType&); // efficient combination of get with remove
@@ -187,7 +187,7 @@ public:
     //   static bool equal(const ValueType&, const T&);
     //   static translate(ValueType&, const T&, unsigned hashCode);
     template<typename HashTranslator, typename K, typename V> AddResult add(K&&, V&&);
-    template<typename HashTranslator, typename K, typename Functor> AddResult ensure(K&&, Functor&&);
+    template<typename HashTranslator> AddResult ensure(auto&& key, const Invocable<MappedType()> auto&);
 
     // Overloads for smart pointer keys that take the raw pointer type as the parameter.
     template<typename K = KeyType> typename std::enable_if<IsSmartPtr<K>::value, iterator>::type find(std::add_const_t<typename GetPtrHelper<K>::UnderlyingType>*);
@@ -218,8 +218,7 @@ private:
     template<typename K, typename V>
     AddResult inlineAdd(K&&, V&&);
 
-    template<typename K, typename F>
-    AddResult inlineEnsure(K&&, F&&);
+    AddResult inlineEnsure(auto&& key, const Invocable<MappedType()> auto&);
 
     template<typename... Items>
     void addForInitialization(KeyValuePairType&& item, Items&&... items)
@@ -238,20 +237,20 @@ private:
 
 template<typename ValueTraits, typename HashFunctions>
 struct HashMapTranslator {
-    template<typename T> static unsigned hash(const T& key) { return HashFunctions::hash(key); }
-    template<typename T, typename U> static bool equal(const T& a, const U& b) { return HashFunctions::equal(a, b); }
-    template<typename T, typename U, typename V> static void translate(T& location, U&& key, V&& mapped)
+    static unsigned hash(const auto& key) { return HashFunctions::hash(key); }
+    static bool equal(const auto& a, const auto& b) { return HashFunctions::equal(a, b); }
+    template<typename U> static void translate(auto& location, U&& key, const Invocable<typename ValueTraits::ValueTraits::TraitType()> auto& functor)
     {
         ValueTraits::KeyTraits::assignToEmpty(location.key, std::forward<U>(key));
-        ValueTraits::ValueTraits::assignToEmpty(location.value, std::forward<V>(mapped));
+        ValueTraits::ValueTraits::assignToEmpty(location.value, functor());
     }
 };
 
 template<typename ValueTraits, typename HashFunctions>
 struct HashMapEnsureTranslator {
-    template<typename T> static unsigned hash(const T& key) { return HashFunctions::hash(key); }
-    template<typename T, typename U> static bool equal(const T& a, const U& b) { return HashFunctions::equal(a, b); }
-    template<typename T, typename U, typename Functor> static void translate(T& location, U&& key, Functor&& functor)
+    static unsigned hash(const auto& key) { return HashFunctions::hash(key); }
+    static bool equal(const auto& a, const auto& b) { return HashFunctions::equal(a, b); }
+    template<typename U> static void translate(auto& location, U&& key, const Invocable<typename ValueTraits::ValueTraits::TraitType()> auto& functor)
     {
         ValueTraits::KeyTraits::assignToEmpty(location.key, std::forward<U>(key));
         ValueTraits::ValueTraits::assignToEmpty(location.value, functor());
@@ -260,20 +259,20 @@ struct HashMapEnsureTranslator {
 
 template<typename ValueTraits, typename Translator>
 struct HashMapTranslatorAdapter {
-    template<typename T> static unsigned hash(const T& key) { return Translator::hash(key); }
-    template<typename T, typename U> static bool equal(const T& a, const U& b) { return Translator::equal(a, b); }
-    template<typename T, typename U, typename V> static void translate(T& location, U&& key, V&& mapped, unsigned hashCode)
+    static unsigned hash(const auto& key) { return Translator::hash(key); }
+    static bool equal(const auto& a, const auto& b) { return Translator::equal(a, b); }
+    static void translate(auto& location, auto&& key, const Invocable<typename ValueTraits::ValueTraits::TraitType()> auto& functor, unsigned hashCode)
     {
         Translator::translate(location.key, key, hashCode);
-        location.value = std::forward<V>(mapped);
+        location.value = functor();
     }
 };
 
 template<typename ValueTraits, typename Translator>
 struct HashMapEnsureTranslatorAdapter {
-    template<typename T> static unsigned hash(const T& key) { return Translator::hash(key); }
-    template<typename T, typename U> static bool equal(const T& a, const U& b) { return Translator::equal(a, b); }
-    template<typename T, typename U, typename Functor> static void translate(T& location, U&& key, Functor&& functor, unsigned hashCode)
+    static unsigned hash(const auto& key) { return Translator::hash(key); }
+    static bool equal(const auto& a, const auto& b) { return Translator::equal(a, b); }
+    static void translate(auto& location, auto&& key, const Invocable<typename ValueTraits::ValueTraits::TraitType()> auto& functor, unsigned hashCode)
     {
         Translator::translate(location.key, key, hashCode);
         location.value = functor();
@@ -420,14 +419,14 @@ template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTrai
 template<typename K, typename V>
 ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::inlineAdd(K&& key, V&& value) -> AddResult
 {
-    return m_impl.template add<HashMapTranslator<KeyValuePairTraits, HashFunctions>>(std::forward<K>(key), std::forward<V>(value));
+    return m_impl.template add<HashMapTranslator<KeyValuePairTraits, HashFunctions>>(std::forward<K>(key), [&] () ALWAYS_INLINE_LAMBDA -> MappedType { return std::forward<V>(value); });
 }
 
 template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>
-template<typename K, typename F>
-ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::inlineEnsure(K&& key, F&& functor) -> AddResult
+template<typename K>
+ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::inlineEnsure(K&& key, const Invocable<MappedType()> auto& functor) -> AddResult
 {
-    return m_impl.template add<HashMapEnsureTranslator<KeyValuePairTraits, HashFunctions>>(std::forward<K>(key), std::forward<F>(functor));
+    return m_impl.template add<HashMapEnsureTranslator<KeyValuePairTraits, HashFunctions>>(std::forward<K>(key), functor);
 }
 
 template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>
@@ -445,17 +444,17 @@ auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTra
 }
 
 template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>
-template<typename HashTranslator, typename K, typename Functor>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::ensure(K&& key, Functor&& functor) -> AddResult
+template<typename HashTranslator, typename K>
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::ensure(K&& key, const Invocable<MappedType()> auto& functor) -> AddResult
 {
-    return m_impl.template addPassingHashCode<HashMapEnsureTranslatorAdapter<KeyValuePairTraits, HashTranslator>>(std::forward<K>(key), std::forward<Functor>(functor));
+    return m_impl.template addPassingHashCode<HashMapEnsureTranslatorAdapter<KeyValuePairTraits, HashTranslator>>(std::forward<K>(key), functor);
 }
 
 template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>
 template<typename HashTranslator, typename K, typename V>
 auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::add(K&& key, V&& value) -> AddResult
 {
-    return m_impl.template addPassingHashCode<HashMapTranslatorAdapter<KeyValuePairTraits, HashTranslator>>(std::forward<K>(key), std::forward<V>(value));
+    return m_impl.template addPassingHashCode<HashMapTranslatorAdapter<KeyValuePairTraits, HashTranslator>>(std::forward<K>(key), [&] () ALWAYS_INLINE_LAMBDA -> MappedType { return std::forward<V>(value); });
 }
 
 template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>
@@ -487,17 +486,15 @@ ALWAYS_INLINE auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTrait
 }
 
 template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>
-template<typename Functor>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::ensure(const KeyType& key, Functor&& functor) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::ensure(const KeyType& key, const Invocable<MappedType()> auto& functor) -> AddResult
 {
-    return inlineEnsure(key, std::forward<Functor>(functor));
+    return inlineEnsure(key, functor);
 }
 
 template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg, typename TableTraitsArg>
-template<typename Functor>
-auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::ensure(KeyType&& key, Functor&& functor) -> AddResult
+auto HashMap<KeyArg, MappedArg, HashArg, KeyTraitsArg, MappedTraitsArg, TableTraitsArg>::ensure(KeyType&& key, const Invocable<MappedType()> auto& functor) -> AddResult
 {
-    return inlineEnsure(std::forward<KeyType>(key), std::forward<Functor>(functor));
+    return inlineEnsure(std::forward<KeyType>(key), functor);
 }
     
 template<typename T, typename U, typename V, typename W, typename X, typename Y>
@@ -535,10 +532,9 @@ inline bool HashMap<T, U, V, W, X, Y>::remove(iterator it)
 }
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y>
-template<typename Functor>
-inline bool HashMap<T, U, V, W, X, Y>::removeIf(Functor&& functor)
+inline bool HashMap<T, U, V, W, X, Y>::removeIf(const Invocable<bool(KeyValuePairType&)> auto& functor)
 {
-    return m_impl.removeIf(std::forward<Functor>(functor));
+    return m_impl.removeIf(functor);
 }
 
 template<typename T, typename U, typename V, typename W, typename X, typename Y>

--- a/Source/WTF/wtf/HashSet.h
+++ b/Source/WTF/wtf/HashSet.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2006, 2007, 2008, 2011, 2013, 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -113,7 +113,7 @@ public:
     // function members:
     //   static unsigned hash(const T&);
     //   static bool equal(const ValueType&, const T&);
-    template<typename HashTranslator, typename T, typename Functor> AddResult ensure(T&&, Functor&&);
+    template<typename HashTranslator> AddResult ensure(auto&&, const Invocable<ValueType()> auto&);
 
     // Attempts to add a list of things to the set. Returns true if any of
     // them are new to the set. Returns false if the set is unchanged.
@@ -124,8 +124,7 @@ public:
 
     bool remove(const ValueType&);
     bool remove(iterator);
-    template<typename Functor>
-    bool removeIf(const Functor&);
+    bool removeIf(const Invocable<bool(const ValueType&)> auto&);
     void clear();
 
     TakeType take(const ValueType&);
@@ -199,19 +198,19 @@ struct IdentityExtractor {
 
 template<typename ValueTraits, typename HashFunctions>
 struct HashSetTranslator {
-    template<typename T> static unsigned hash(const T& key) { return HashFunctions::hash(key); }
-    template<typename T, typename U> static bool equal(const T& a, const U& b) { return HashFunctions::equal(a, b); }
-    template<typename T, typename U, typename V> static void translate(T& location, U&&, V&& value)
+    static unsigned hash(const auto& key) { return HashFunctions::hash(key); }
+    static bool equal(const auto& a, const auto& b) { return HashFunctions::equal(a, b); }
+    static void translate(auto& location, auto&&, const Invocable<typename ValueTraits::TraitType()> auto& functor)
     { 
-        ValueTraits::assignToEmpty(location, std::forward<V>(value));
+        ValueTraits::assignToEmpty(location, functor());
     }
 };
 
 template<typename Translator>
 struct HashSetTranslatorAdapter {
-    template<typename T> static unsigned hash(const T& key) { return Translator::hash(key); }
-    template<typename T, typename U> static bool equal(const T& a, const U& b) { return Translator::equal(a, b); }
-    template<typename T, typename U> static void translate(T& location, const U& key, const U&, unsigned hashCode)
+    static unsigned hash(const auto& key) { return Translator::hash(key); }
+    static bool equal(const auto& a, const auto& b) { return Translator::equal(a, b); }
+    static void translate(auto& location, const auto& key, const auto&, unsigned hashCode)
     {
         Translator::translate(location, key, hashCode);
     }
@@ -219,9 +218,9 @@ struct HashSetTranslatorAdapter {
 
 template<typename ValueTraits, typename Translator>
 struct HashSetEnsureTranslatorAdaptor {
-    template<typename T> static unsigned hash(const T& key) { return Translator::hash(key); }
-    template<typename T, typename U> static bool equal(const T& a, const U& b) { return Translator::equal(a, b); }
-    template<typename T, typename U, typename Functor> static void translate(T& location, U&&, Functor&& functor)
+    static unsigned hash(const auto& key) { return Translator::hash(key); }
+    static bool equal(const auto& a, const auto& b) { return Translator::equal(a, b); }
+    static void translate(auto& location, auto&&, const Invocable<typename ValueTraits::TraitType()> auto& functor)
     {
         ValueTraits::assignToEmpty(location, functor());
     }
@@ -296,10 +295,10 @@ inline bool HashSet<Value, HashFunctions, Traits, TableTraits>::contains(const T
 }
 
 template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>
-template<typename HashTranslator, typename T, typename Functor>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::ensure(T&& key, Functor&& functor) -> AddResult
+template<typename HashTranslator, typename T>
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::ensure(T&& key, const Invocable<ValueType()> auto& functor) -> AddResult
 {
-    return m_impl.template add<HashSetEnsureTranslatorAdaptor<Traits, HashTranslator>>(std::forward<T>(key), std::forward<Functor>(functor));
+    return m_impl.template add<HashSetEnsureTranslatorAdaptor<Traits, HashTranslator>>(std::forward<T>(key), functor);
 }
 
 template<typename T, typename U, typename V, typename W>
@@ -327,10 +326,10 @@ inline void HashSet<T, U, V, W>::addVoid(ValueType&& value)
 }
 
 template<typename Value, typename HashFunctions, typename Traits, typename TableTraits>
-template<typename HashTranslator, typename T>
-inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::add(const T& value) -> AddResult
+template<typename HashTranslator>
+inline auto HashSet<Value, HashFunctions, Traits, TableTraits>::add(const auto& value) -> AddResult
 {
-    return m_impl.template addPassingHashCode<HashSetTranslatorAdapter<HashTranslator>>(value, value);
+    return m_impl.template addPassingHashCode<HashSetTranslatorAdapter<HashTranslator>>(value, [&] ALWAYS_INLINE_LAMBDA { return value; });
 }
 
 template<typename T, typename U, typename V, typename W>
@@ -370,8 +369,7 @@ inline bool HashSet<T, U, V, W>::remove(const ValueType& value)
 }
 
 template<typename T, typename U, typename V, typename W>
-template<typename Functor>
-inline bool HashSet<T, U, V, W>::removeIf(const Functor& functor)
+inline bool HashSet<T, U, V, W>::removeIf(const Invocable<bool(const ValueType&)> auto& functor)
 {
     return m_impl.removeIf(functor);
 }

--- a/Source/WTF/wtf/HashTable.h
+++ b/Source/WTF/wtf/HashTable.h
@@ -295,13 +295,14 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         const_iterator m_iterator;
     };
 
-    template<typename ValueTraits, typename HashFunctions> class IdentityHashTranslator {
+    template<typename ValueTraits, typename HashFunctions>
+    class IdentityHashTranslator {
     public:
-        template<typename T> static unsigned hash(const T& key) { return HashFunctions::hash(key); }
-        template<typename T, typename U> static bool equal(const T& a, const U& b) { return HashFunctions::equal(a, b); }
-        template<typename T, typename U, typename V> static void translate(T& location, const U&, V&& value)
-        { 
-            ValueTraits::assignToEmpty(location, std::forward<V>(value)); 
+        static unsigned hash(const auto& key) { return HashFunctions::hash(key); }
+        static bool equal(const auto& a, const auto& b) { return HashFunctions::equal(a, b); }
+        static void translate(auto& location, const auto&, const Invocable<typename ValueTraits::TraitType()> auto& functor)
+        {
+            ValueTraits::assignToEmpty(location, functor());
         }
     };
 
@@ -476,14 +477,14 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
             setKeyCount(0);
         }
 
-        AddResult add(const ValueType& value) { return add<IdentityTranslatorType>(Extractor::extract(value), value); }
-        AddResult add(ValueType&& value) { return add<IdentityTranslatorType>(Extractor::extract(value), WTFMove(value)); }
+        AddResult add(const ValueType& value) { return add<IdentityTranslatorType>(Extractor::extract(value), [&] ALWAYS_INLINE_LAMBDA { return value; }); }
+        AddResult add(ValueType&& value) { return add<IdentityTranslatorType>(Extractor::extract(value), [&] ALWAYS_INLINE_LAMBDA { return WTFMove(value); }); }
 
         // A special version of add() that finds the object by hashing and comparing
         // with some other type, to avoid the cost of type conversion if the object is already
         // in the table.
-        template<typename HashTranslator, typename T, typename Extra> AddResult add(T&& key, Extra&&);
-        template<typename HashTranslator, typename T, typename Extra> AddResult addPassingHashCode(T&& key, Extra&&);
+        template<typename HashTranslator> AddResult add(auto&& key, const std::invocable<> auto& functor);
+        template<typename HashTranslator> AddResult addPassingHashCode(auto&& key, const std::invocable<> auto& functor);
 
         iterator find(const KeyType& key) { return find<IdentityTranslatorType>(key); }
         const_iterator find(const KeyType& key) const { return find<IdentityTranslatorType>(key); }
@@ -536,7 +537,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         template<typename HashTranslator, typename T> ValueType* lookupForReinsert(const T&);
         template<typename HashTranslator, typename T> FullLookupType fullLookupForWriting(const T&);
 
-        template<typename HashTranslator, typename T, typename Extra> void addUniqueForInitialization(T&& key, Extra&&);
+        template<typename HashTranslator> void addUniqueForInitialization(auto&& key, const std::invocable<> auto& functor);
 
         template<typename HashTranslator, typename T> void checkKey(const T&);
 
@@ -823,8 +824,8 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
     }
 
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits>
-    template<typename HashTranslator, typename T, typename Extra>
-    ALWAYS_INLINE void HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits>::addUniqueForInitialization(T&& key, Extra&& extra)
+    template<typename HashTranslator, typename T>
+    ALWAYS_INLINE void HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits>::addUniqueForInitialization(T&& key, const std::invocable<> auto& functor)
     {
         ASSERT(m_table);
 
@@ -835,7 +836,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         internalCheckTableConsistency();
 
         Value* entry = lookupForReinsert<HashTranslator>(key);
-        HashTranslator::translate(*entry, std::forward<T>(key), std::forward<Extra>(extra));
+        HashTranslator::translate(*entry, std::forward<T>(key), functor);
 
         internalCheckTableConsistency();
     }
@@ -866,8 +867,8 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
     }
 
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits>
-    template<typename HashTranslator, typename T, typename Extra>
-    ALWAYS_INLINE auto HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits>::add(T&& key, Extra&& extra) -> AddResult
+    template<typename HashTranslator, typename T>
+    ALWAYS_INLINE auto HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits>::add(T&& key, const std::invocable<> auto& functor) -> AddResult
     {
         checkKey<HashTranslator>(key);
 
@@ -938,7 +939,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
             setDeletedCount(deletedCount() - 1);
         }
 
-        HashTranslator::translate(*entry, std::forward<T>(key), std::forward<Extra>(extra));
+        HashTranslator::translate(*entry, std::forward<T>(key), functor);
         setKeyCount(keyCount() + 1);
         
         if (shouldExpand())
@@ -950,8 +951,8 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
     }
 
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits>
-    template<typename HashTranslator, typename T, typename Extra>
-    inline auto HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits>::addPassingHashCode(T&& key, Extra&& extra) -> AddResult
+    template<typename HashTranslator, typename T>
+    inline auto HashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits>::addPassingHashCode(T&& key, const std::invocable<> auto& functor) -> AddResult
     {
         checkKey<HashTranslator>(key);
 
@@ -976,7 +977,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
             setDeletedCount(deletedCount() - 1);
         }
 
-        HashTranslator::translate(*entry, std::forward<T>(key), std::forward<Extra>(extra), h);
+        HashTranslator::translate(*entry, std::forward<T>(key), functor, h);
         setKeyCount(keyCount() + 1);
 
         if (shouldExpand())
@@ -1341,7 +1342,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         setDeletedCount(0);
 
         for (const auto& otherValue : other)
-            addUniqueForInitialization<IdentityTranslatorType>(Extractor::extract(otherValue), otherValue);
+            addUniqueForInitialization<IdentityTranslatorType>(Extractor::extract(otherValue), [&] ALWAYS_INLINE_LAMBDA { return otherValue; });
     }
 
     template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits>

--- a/Source/WTF/wtf/ListHashSet.h
+++ b/Source/WTF/wtf/ListHashSet.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2011, Benjamin Poulain <ikipou@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
@@ -567,7 +567,7 @@ inline bool ListHashSet<T, U>::contains(const ValueType& value) const
 template<typename T, typename U>
 auto ListHashSet<T, U>::add(const ValueType& value) -> AddResult
 {
-    auto result = m_impl.template add<BaseTranslator>(value, nullptr);
+    auto result = m_impl.template add<BaseTranslator>(value, [] { return nullptr; });
     if (result.isNewEntry)
         appendNode(*result.iterator);
     return AddResult(makeIterator(*result.iterator), result.isNewEntry);
@@ -576,7 +576,7 @@ auto ListHashSet<T, U>::add(const ValueType& value) -> AddResult
 template<typename T, typename U>
 auto ListHashSet<T, U>::add(ValueType&& value) -> AddResult
 {
-    auto result = m_impl.template add<BaseTranslator>(WTFMove(value), nullptr);
+    auto result = m_impl.template add<BaseTranslator>(WTFMove(value), [] { return nullptr; });
     if (result.isNewEntry)
         appendNode(*result.iterator);
     return AddResult(makeIterator(*result.iterator), result.isNewEntry);
@@ -585,7 +585,7 @@ auto ListHashSet<T, U>::add(ValueType&& value) -> AddResult
 template<typename T, typename U>
 auto ListHashSet<T, U>::appendOrMoveToLast(const ValueType& value) -> AddResult
 {
-    auto result = m_impl.template add<BaseTranslator>(value, nullptr);
+    auto result = m_impl.template add<BaseTranslator>(value, [] { return nullptr; });
     Node* node = *result.iterator;
     if (!result.isNewEntry)
         unlink(node);
@@ -597,7 +597,7 @@ auto ListHashSet<T, U>::appendOrMoveToLast(const ValueType& value) -> AddResult
 template<typename T, typename U>
 auto ListHashSet<T, U>::appendOrMoveToLast(ValueType&& value) -> AddResult
 {
-    auto result = m_impl.template add<BaseTranslator>(WTFMove(value), nullptr);
+    auto result = m_impl.template add<BaseTranslator>(WTFMove(value), [] { return nullptr; });
     Node* node = *result.iterator;
     if (!result.isNewEntry)
         unlink(node);
@@ -621,7 +621,7 @@ bool ListHashSet<T, U>::moveToLastIfPresent(const ValueType& value)
 template<typename T, typename U>
 auto ListHashSet<T, U>::prependOrMoveToFirst(const ValueType& value) -> AddResult
 {
-    auto result = m_impl.template add<BaseTranslator>(value, nullptr);
+    auto result = m_impl.template add<BaseTranslator>(value, [] { return nullptr; });
     Node* node = *result.iterator;
     if (!result.isNewEntry)
         unlink(node);
@@ -633,7 +633,7 @@ auto ListHashSet<T, U>::prependOrMoveToFirst(const ValueType& value) -> AddResul
 template<typename T, typename U>
 auto ListHashSet<T, U>::prependOrMoveToFirst(ValueType&& value) -> AddResult
 {
-    auto result = m_impl.template add<BaseTranslator>(WTFMove(value), nullptr);
+    auto result = m_impl.template add<BaseTranslator>(WTFMove(value), [] { return nullptr; });
     Node* node = *result.iterator;
     if (!result.isNewEntry)
         unlink(node);
@@ -657,7 +657,7 @@ auto ListHashSet<T, U>::insertBefore(const ValueType& beforeValue, ValueType&& n
 template<typename T, typename U>
 auto ListHashSet<T, U>::insertBefore(iterator it, const ValueType& newValue) -> AddResult
 {
-    auto result = m_impl.template add<BaseTranslator>(newValue, nullptr);
+    auto result = m_impl.template add<BaseTranslator>(newValue, [] { return nullptr; });
     if (result.isNewEntry)
         insertNodeBefore(it.node(), *result.iterator);
     return AddResult(makeIterator(*result.iterator), result.isNewEntry);
@@ -666,7 +666,7 @@ auto ListHashSet<T, U>::insertBefore(iterator it, const ValueType& newValue) -> 
 template<typename T, typename U>
 auto ListHashSet<T, U>::insertBefore(iterator it, ValueType&& newValue) -> AddResult
 {
-    auto result = m_impl.template add<BaseTranslator>(WTFMove(newValue), nullptr);
+    auto result = m_impl.template add<BaseTranslator>(WTFMove(newValue), [] { return nullptr; });
     if (result.isNewEntry)
         insertNodeBefore(it.node(), *result.iterator);
     return AddResult(makeIterator(*result.iterator), result.isNewEntry);

--- a/Source/WTF/wtf/PriorityQueue.h
+++ b/Source/WTF/wtf/PriorityQueue.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/MathExtras.h>
+#include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
 
 namespace WTF {
@@ -62,8 +63,7 @@ public:
         return result;
     }
 
-    template<typename Functor>
-    void decreaseKey(const Functor& desiredElement)
+    void decreaseKey(const Invocable<bool(T&)> auto& desiredElement)
     {
         for (size_t i = 0; i < m_buffer.size(); ++i) {
             if (desiredElement(m_buffer[i])) {
@@ -74,8 +74,7 @@ public:
         ASSERT(isValidHeap());
     }
 
-    template<typename Functor>
-    void increaseKey(const Functor& desiredElement)
+    void increaseKey(const Invocable<bool(T&)> auto& desiredElement)
     {
         for (size_t i = 0; i < m_buffer.size(); ++i) {
             if (desiredElement(m_buffer[i])) {

--- a/Source/WTF/wtf/RobinHoodHashTable.h
+++ b/Source/WTF/wtf/RobinHoodHashTable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -175,14 +175,14 @@ public:
         internalCheckTableConsistency();
     }
 
-    AddResult add(const ValueType& value) { return add<IdentityTranslatorType>(Extractor::extract(value), value); }
-    AddResult add(ValueType&& value) { return add<IdentityTranslatorType>(Extractor::extract(value), WTFMove(value)); }
+    AddResult add(const ValueType& value) { return add<IdentityTranslatorType>(Extractor::extract(value), [&] ALWAYS_INLINE_LAMBDA { return value; }); }
+    AddResult add(ValueType&& value) { return add<IdentityTranslatorType>(Extractor::extract(value), [&] ALWAYS_INLINE_LAMBDA { return WTFMove(value); }); }
 
     // A special version of add() that finds the object by hashing and comparing
     // with some other type, to avoid the cost of type conversion if the object is already
     // in the table.
-    template<typename HashTranslator, typename T, typename Extra> AddResult add(T&& key, Extra&&);
-    template<typename HashTranslator, typename T, typename Extra> AddResult addPassingHashCode(T&& key, Extra&&);
+    template<typename HashTranslator> AddResult add(auto&& key, const std::invocable<> auto& functor);
+    template<typename HashTranslator> AddResult addPassingHashCode(auto&& key, const std::invocable<> auto& functor);
 
     iterator find(const KeyType& key) { return find<IdentityTranslatorType>(key); }
     const_iterator find(const KeyType& key) const { return find<IdentityTranslatorType>(key); }
@@ -385,8 +385,8 @@ inline void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, Key
 }
 
 template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy>
-template<typename HashTranslator, typename T, typename Extra>
-ALWAYS_INLINE auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy>::add(T&& key, Extra&& extra) -> AddResult
+template<typename HashTranslator, typename T>
+ALWAYS_INLINE auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy>::add(T&& key, const std::invocable<> auto& functor) -> AddResult
 {
     checkKey<HashTranslator>(key);
 
@@ -414,7 +414,7 @@ ALWAYS_INLINE auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Trai
         if (isEmptyBucket(*entry)) {
             if (distance >= probeDistanceThreshold)
                 m_willExpand = true;
-            HashTranslator::translate(*entry, std::forward<T>(key), std::forward<Extra>(extra));
+            HashTranslator::translate(*entry, std::forward<T>(key), functor);
             break;
         }
 
@@ -428,7 +428,7 @@ ALWAYS_INLINE auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Trai
             ValueType existingEntry = WTFMove(*entry);
             entry->~ValueType();
             initializeBucket(*entry);
-            HashTranslator::translate(*entry, std::forward<T>(key), std::forward<Extra>(extra));
+            HashTranslator::translate(*entry, std::forward<T>(key), functor);
             maintainProbeDistanceForAdd(WTFMove(existingEntry), index, entryDistance, size, sizeMask, tableHash);
             break;
         }
@@ -475,8 +475,8 @@ ALWAYS_INLINE void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Trai
 
 
 template<typename Key, typename Value, typename Extractor, typename HashFunctions, typename Traits, typename KeyTraits, typename SizePolicy>
-template<typename HashTranslator, typename T, typename Extra>
-inline auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy>::addPassingHashCode(T&& key, Extra&& extra) -> AddResult
+template<typename HashTranslator, typename T>
+inline auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits, SizePolicy>::addPassingHashCode(T&& key, const std::invocable<> auto& functor) -> AddResult
 {
     checkKey<HashTranslator>(key);
 
@@ -505,7 +505,7 @@ inline auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, Key
         if (isEmptyBucket(*entry)) {
             if (distance >= probeDistanceThreshold)
                 m_willExpand = true;
-            HashTranslator::translate(*entry, std::forward<T>(key), std::forward<Extra>(extra), originalHash);
+            HashTranslator::translate(*entry, std::forward<T>(key), functor, originalHash);
             break;
         }
 
@@ -519,7 +519,7 @@ inline auto RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, Key
             ValueType existingEntry = WTFMove(*entry);
             entry->~ValueType();
             initializeBucket(*entry);
-            HashTranslator::translate(*entry, std::forward<T>(key), std::forward<Extra>(extra), originalHash);
+            HashTranslator::translate(*entry, std::forward<T>(key), functor, originalHash);
             maintainProbeDistanceForAdd(WTFMove(existingEntry), index, entryDistance, size, sizeMask, tableHash);
             break;
         }

--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <cstring>
+#include <functional>
 #include <memory>
 #include <span>
 #include <type_traits>
@@ -765,6 +766,13 @@ template<ByteType T, typename U> constexpr auto byteCast(const U& value)
     return ByteCastTraits<U>::template cast<T>(value);
 }
 
+// This is like std::invocable but it takes the expected signature rather than just the arguments.
+template<typename Functor, typename Signature>
+concept Invocable = requires(std::decay_t<Functor>&& f, std::function<Signature> expected)
+{
+    { expected = std::move(f) };
+};
+
 } // namespace WTF
 
 #define WTFMove(value) std::move<WTF::CheckMoveParameter>(value)
@@ -826,3 +834,4 @@ using WTF::tryBinarySearch;
 using WTF::valueOrCompute;
 using WTF::valueOrDefault;
 using WTF::toTwosComplement;
+using WTF::Invocable;

--- a/Source/WTF/wtf/TinyPtrSet.h
+++ b/Source/WTF/wtf/TinyPtrSet.h
@@ -27,6 +27,7 @@
 
 #include <wtf/Assertions.h>
 #include <wtf/FastMalloc.h>
+#include <wtf/StdLibExtras.h>
 
 namespace JSC { namespace DFG {
 class StructureAbstractValue;
@@ -167,8 +168,7 @@ public:
         return mergeOtherOutOfLine(other);
     }
     
-    template<typename Functor>
-    void forEach(const Functor& functor) const
+    void forEach(const Invocable<void(const T&)> auto& functor) const
     {
         if (isThin()) {
             if (!singleEntry())
@@ -182,8 +182,7 @@ public:
             functor(list->list()[i]);
     }
         
-    template<typename Functor>
-    void genericFilter(const Functor& functor)
+    void genericFilter(const Invocable<bool(const T&)> auto& functor)
     {
         if (isThin()) {
             if (!singleEntry())

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -711,7 +711,7 @@ public:
             TypeOperations::uninitializedFill(begin(), end(), val);
     }
 
-    template<typename Functor, typename = typename std::enable_if_t<std::is_invocable_v<Functor, size_t>>>
+    template<std::invocable<size_t> Functor>
     Vector(size_t size, const Functor& valueGenerator)
     {
         reserveInitialCapacity(size);
@@ -852,14 +852,14 @@ public:
         return result;
     }
     
-    template<typename U> bool contains(const U&) const;
-    template<typename U> size_t find(const U&) const;
-    template<typename MatchFunction> size_t findIf(const MatchFunction&) const;
-    template<typename U> size_t reverseFind(const U&) const;
-    template<typename MatchFunction> size_t reverseFindIf(const MatchFunction&) const;
-    template<typename MatchFunction> bool containsIf(const MatchFunction& matches) const { return findIf(matches) != notFound; }
+    bool contains(const auto&) const;
+    size_t find(const auto&) const;
+    size_t findIf(const Invocable<bool(const T&)> auto& matches) const;
+    size_t reverseFind(const auto&) const;
+    size_t reverseFindIf(const Invocable<bool(const T&)> auto& matches) const;
+    bool containsIf(const Invocable<bool(const T&)> auto& matches) const { return findIf(matches) != notFound; }
 
-    template<typename U> bool appendIfNotContains(const U&);
+    bool appendIfNotContains(const auto&);
 
     void shrink(size_t size);
     ALWAYS_INLINE void grow(size_t size) { growImpl<FailureAction::Crash>(size); }
@@ -893,8 +893,7 @@ public:
     template<typename U, size_t otherCapacity, typename OtherOverflowHandler, size_t otherMinCapacity, typename OtherMalloc> void appendVector(const Vector<U, otherCapacity, OtherOverflowHandler, otherMinCapacity, OtherMalloc>&);
     template<typename U, size_t otherCapacity, typename OtherOverflowHandler, size_t otherMinCapacity, typename OtherMalloc> void appendVector(Vector<U, otherCapacity, OtherOverflowHandler, otherMinCapacity, OtherMalloc>&&);
 
-    template<typename Functor, typename = typename std::enable_if_t<std::is_invocable_v<Functor, size_t>>>
-    void appendUsingFunctor(size_t, const Functor&);
+    void appendUsingFunctor(size_t, const Invocable<T(size_t)> auto&);
 
     void insert(size_t position, value_type&& value) { insert<value_type>(position, std::forward<value_type>(value)); }
     void insertFill(size_t position, const T& value, size_t dataSize);
@@ -904,15 +903,15 @@ public:
 
     void remove(size_t position);
     void remove(size_t position, size_t length);
-    template<typename U> bool removeFirst(const U&);
-    template<typename MatchFunction> bool removeFirstMatching(const MatchFunction&, size_t startIndex = 0);
-    template<typename U> bool removeLast(const U&);
-    template<typename MatchFunction> bool removeLastMatching(const MatchFunction&);
-    template<typename MatchFunction> bool removeLastMatching(const MatchFunction&, size_t startIndex);
-    template<typename U> unsigned removeAll(const U&);
-    template<typename MatchFunction> unsigned removeAllMatching(const MatchFunction&, size_t startIndex = 0);
+    bool removeFirst(const auto&);
+    bool removeFirstMatching(const Invocable<bool(T&)> auto&, size_t startIndex = 0);
+    bool removeLast(const auto&);
+    bool removeLastMatching(const Invocable<bool(T&)> auto&);
+    bool removeLastMatching(const Invocable<bool(T&)> auto&, size_t startIndex);
+    unsigned removeAll(const auto&);
+    unsigned removeAllMatching(const Invocable<bool(T&)> auto&, size_t startIndex = 0);
 
-    void removeLast() 
+    void removeLast()
     {
         if (UNLIKELY(isEmpty()))
             OverflowHandler::overflowed();
@@ -949,11 +948,11 @@ public:
 
     void checkConsistency();
 
-    template<typename ResultVector, typename MapFunction>
-    auto map(MapFunction&&) const -> std::enable_if_t<std::is_invocable_v<MapFunction, const T&>, ResultVector>;
+    template<typename ResultVector>
+    ResultVector map(const std::invocable<const T&> auto& mapFunction) const;
 
-    template<typename MapFunction>
-    auto map(MapFunction&&) const -> std::enable_if_t<std::is_invocable_v<MapFunction, const T&>, Vector<typename std::invoke_result_t<MapFunction, const T&>>>;
+    template<std::invocable<const T&> MapFunction>
+    Vector<std::invoke_result_t<MapFunction, const T&>> map(const MapFunction&) const;
 
     bool isHashTableDeletedValue() const { return m_size == std::numeric_limits<decltype(m_size)>::max(); }
 
@@ -1116,15 +1115,13 @@ inline Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>& Vector<T
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-template<typename U>
-bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::contains(const U& value) const
+bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::contains(const auto& value) const
 {
     return find(value) != notFound;
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-template<typename MatchFunction>
-size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::findIf(const MatchFunction& matches) const
+size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::findIf(const Invocable<bool(const T&)> auto& matches) const
 {
     for (size_t i = 0; i < size(); ++i) {
         if (matches(at(i)))
@@ -1134,8 +1131,7 @@ size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::findIf(c
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-template<typename U>
-size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::find(const U& value) const
+size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::find(const auto& value) const
 {
     return findIf([&](auto& item) {
         return item == value;
@@ -1143,8 +1139,7 @@ size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::find(con
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-template<typename U>
-size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::reverseFind(const U& value) const
+size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::reverseFind(const auto& value) const
 {
     for (size_t i = 1; i <= size(); ++i) {
         const size_t index = size() - i;
@@ -1155,8 +1150,7 @@ size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::reverseF
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-template<typename MatchFunction>
-size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::reverseFindIf(const MatchFunction& matches) const
+size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::reverseFindIf(const Invocable<bool(const T&)> auto& matches) const
 {
     for (size_t i = 1; i <= size(); ++i) {
         const size_t index = size() - i;
@@ -1167,8 +1161,7 @@ size_t Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::reverseF
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-template<typename U>
-bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::appendIfNotContains(const U& value)
+bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::appendIfNotContains(const auto& value)
 {
     if (contains(value))
         return false;
@@ -1213,8 +1206,7 @@ void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::appendRang
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-template<typename Functor, typename>
-void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::appendUsingFunctor(size_t size, const Functor& valueGenerator)
+void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::appendUsingFunctor(size_t size, const Invocable<T(size_t)> auto& valueGenerator)
 {
     reserveCapacity(this->size() + size);
     for (size_t i = 0; i < size; ++i)
@@ -1694,8 +1686,7 @@ inline void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::rem
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-template<typename U>
-inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeFirst(const U& value)
+inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeFirst(const auto& value)
 {
     return removeFirstMatching([&value] (const T& current) {
         return current == value;
@@ -1703,8 +1694,7 @@ inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::rem
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-template<typename MatchFunction>
-inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeFirstMatching(const MatchFunction& matches, size_t startIndex)
+inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeFirstMatching(const Invocable<bool(T&)> auto& matches, size_t startIndex)
 {
     for (size_t i = startIndex; i < size(); ++i) {
         if (matches(at(i))) {
@@ -1716,8 +1706,7 @@ inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::rem
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-template<typename U>
-inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeLast(const U& value)
+inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeLast(const auto& value)
 {
     return removeLastMatching([&value] (const T& current) {
         return current == value;
@@ -1725,15 +1714,13 @@ inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::rem
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-template<typename MatchFunction>
-inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeLastMatching(const MatchFunction& matches)
+inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeLastMatching(const Invocable<bool(T&)> auto& matches)
 {
     return removeLastMatching(matches, size());
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-template<typename MatchFunction>
-inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeLastMatching(const MatchFunction& matches, size_t startIndex)
+inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeLastMatching(const Invocable<bool(T&)> auto& matches, size_t startIndex)
 {
     for (size_t i = std::min(startIndex + 1, size()); i > 0; --i) {
         if (matches(at(i - 1))) {
@@ -1745,8 +1732,7 @@ inline bool Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::rem
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-template<typename U>
-inline unsigned Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeAll(const U& value)
+inline unsigned Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeAll(const auto& value)
 {
     return removeAllMatching([&value] (const T& current) {
         return current == value;
@@ -1754,8 +1740,7 @@ inline unsigned Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>:
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-template<typename MatchFunction>
-inline unsigned Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeAllMatching(const MatchFunction& matches, size_t startIndex)
+inline unsigned Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::removeAllMatching(const Invocable<bool(T&)> auto& matches, size_t startIndex)
 {
     iterator holeBegin = end();
     iterator holeEnd = end();
@@ -1788,8 +1773,8 @@ inline void Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::rev
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-template<typename ResultVector, typename MapFunction>
-inline auto Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::map(MapFunction&& mapFunction) const -> std::enable_if_t<std::is_invocable_v<MapFunction, const T&>, ResultVector>
+template<typename ResultVector>
+inline ResultVector Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::map(const std::invocable<const T&> auto& mapFunction) const
 {
     ResultVector result;
     result.reserveInitialCapacity(size());
@@ -1802,10 +1787,10 @@ template <typename ContainerType>
 size_t containerSize(const ContainerType& container) { return std::size(container); }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
-template<typename MapFunction>
-inline auto Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::map(MapFunction&& mapFunction) const -> std::enable_if_t<std::is_invocable_v<MapFunction, const T&>, Vector<typename std::invoke_result_t<MapFunction, const T&>>>
+template<std::invocable<const T&> MapFunction>
+inline Vector<std::invoke_result_t<MapFunction, const T&>> Vector<T, inlineCapacity, OverflowHandler, minCapacity, Malloc>::map(const MapFunction& mapFunction) const
 {
-    return map<Vector<typename std::invoke_result_t<MapFunction, const T&>>, MapFunction>(std::forward<MapFunction>(mapFunction));
+    return map<Vector<typename std::invoke_result_t<MapFunction, const T&>>, MapFunction>(mapFunction);
 }
 
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>

--- a/Source/WTF/wtf/glib/SysprofAnnotator.h
+++ b/Source/WTF/wtf/glib/SysprofAnnotator.h
@@ -67,7 +67,7 @@ public:
         vsnprintf(buffer.data(), 1024, description, args);
         va_end(args);
 
-        auto value = std::make_pair(SYSPROF_CAPTURE_CURRENT_TIME, WTFMove(buffer));
+        auto value = std::make_pair(SYSPROF_CAPTURE_CURRENT_TIME, Vector<char>(buffer));
 
         Locker locker { m_lock };
         m_ongoingMarks.set(key, value);

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -951,7 +951,7 @@ void GStreamerMediaEndpoint::getStats(RTCRtpReceiver& receiver, Ref<DeferredProm
 
 MediaStream& GStreamerMediaEndpoint::mediaStreamFromRTCStream(String mediaStreamId)
 {
-    auto mediaStream = m_remoteStreamsById.ensure(mediaStreamId, [mediaStreamId, this]() mutable {
+    auto mediaStream = m_remoteStreamsById.ensure(mediaStreamId, [&] {
         auto& document = downcast<Document>(*m_peerConnectionBackend.connection().scriptExecutionContext());
         return MediaStream::create(document, MediaStreamPrivate::create(document.logger(), { }, WTFMove(mediaStreamId)));
     });

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
@@ -319,7 +319,7 @@ void LibWebRTCMediaEndpoint::OnSignalingChange(webrtc::PeerConnectionInterface::
 
 MediaStream& LibWebRTCMediaEndpoint::mediaStreamFromRTCStreamId(const String& id)
 {
-    auto mediaStream = m_remoteStreamsById.ensure(id, [id, this]() mutable {
+    auto mediaStream = m_remoteStreamsById.ensure(id, [id, this]() {
         auto& document = downcast<Document>(*m_peerConnectionBackend.connection().scriptExecutionContext());
         auto stream = MediaStream::create(document, MediaStreamPrivate::create(document.logger(), { }, String(id)));
         return stream;

--- a/Source/WebCore/platform/xr/openxr/OpenXRSwapchain.cpp
+++ b/Source/WebCore/platform/xr/openxr/OpenXRSwapchain.cpp
@@ -48,7 +48,7 @@ std::unique_ptr<OpenXRSwapchain> OpenXRSwapchain::create(XrInstance instance, Xr
         return createStructure<XrSwapchainImageOpenGLKHR, XR_TYPE_SWAPCHAIN_IMAGE_OPENGL_KHR>();
     }());
 
-    Vector<XrSwapchainImageBaseHeader*> imageHeaders = imageBuffers.map([](auto& image) mutable {
+    Vector<XrSwapchainImageBaseHeader*> imageHeaders = imageBuffers.map([](auto& image) {
         return (XrSwapchainImageBaseHeader*) &image;
     });
 

--- a/Source/WebCore/svg/SVGToOTFFontConversion.cpp
+++ b/Source/WebCore/svg/SVGToOTFFontConversion.cpp
@@ -1444,7 +1444,7 @@ SVGToOTFFontConverter::SVGToOTFFontConverter(const SVGFontElement& fontElement)
                 m_glyphNameToIndexMap.add(glyphName, i);
         }
         if (m_codepointsToIndicesMap.isValidKey(glyph.codepoints)) {
-            auto& glyphVector = m_codepointsToIndicesMap.add(glyph.codepoints, Vector<Glyph>()).iterator->value;
+            auto& glyphVector = m_codepointsToIndicesMap.add(glyph.codepoints, Vector<Glyph, 1>()).iterator->value;
             // Prefer isolated arabic forms
             if (glyph.glyphElement && equalLettersIgnoringASCIICase(glyph.glyphElement->attributeWithoutSynchronization(SVGNames::arabic_formAttr), "isolated"_s))
                 glyphVector.insert(0, i);

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.cpp
@@ -60,7 +60,7 @@ void BackgroundFetchEngine::startBackgroundFetch(SWServerRegistration& registrat
         return;
     }
 
-    auto result = iterator->value.ensure(backgroundFetchIdentifier, [&]() mutable {
+    auto result = iterator->value.ensure(backgroundFetchIdentifier, [&]() {
         return makeUnique<BackgroundFetch>(registration, backgroundFetchIdentifier, WTFMove(requests), WTFMove(options), Ref { m_store }, [weakThis = WeakPtr { *this }](auto& fetch) {
             if (weakThis)
                 weakThis->notifyBackgroundFetchUpdate(fetch);

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchManager.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchManager.cpp
@@ -84,7 +84,7 @@ static ExceptionOr<Vector<Ref<FetchRequest>>> buildBackgroundFetchRequests(Scrip
 Ref<BackgroundFetchRegistration> BackgroundFetchManager::backgroundFetchRegistrationInstance(ScriptExecutionContext& context, BackgroundFetchInformation&& data)
 {
     auto identifier = data.identifier;
-    auto result = m_backgroundFetchRegistrations.ensure(identifier, [&]() mutable {
+    auto result = m_backgroundFetchRegistrations.ensure(identifier, [&] {
         return BackgroundFetchRegistration::create(context, WTFMove(data));
     });
 

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -667,7 +667,7 @@ void GPUConnectionToWebProcess::createRenderingBackend(RenderingBackendIdentifie
     auto streamConnection = IPC::StreamServerConnection::tryCreate(WTFMove(connectionHandle), params);
     MESSAGE_CHECK(streamConnection);
 
-    auto addResult = m_remoteRenderingBackendMap.ensure(identifier, [&, streamConnection] () mutable {
+    auto addResult = m_remoteRenderingBackendMap.ensure(identifier, [&] {
         return IPC::ScopedActiveMessageReceiveQueue { RemoteRenderingBackend::create(*this, identifier, streamConnection.releaseNonNull()) };
     });
     if (!addResult.isNewEntry) {
@@ -700,7 +700,7 @@ void GPUConnectionToWebProcess::createGraphicsContextGL(GraphicsContextGLIdentif
     auto streamConnection = IPC::StreamServerConnection::tryCreate(WTFMove(connectionHandle), params);
     MESSAGE_CHECK(streamConnection);
 
-    auto addResult = m_remoteGraphicsContextGLMap.ensure(identifier, [&, streamConnection = WTFMove(streamConnection)] () mutable {
+    auto addResult = m_remoteGraphicsContextGLMap.ensure(identifier, [&] {
         return IPC::ScopedActiveMessageReceiveQueue { RemoteGraphicsContextGL::create(*this, WTFMove(attributes), identifier, *renderingBackend, streamConnection.releaseNonNull()) };
     });
     ASSERT_UNUSED(addResult, addResult.isNewEntry);
@@ -760,7 +760,7 @@ void GPUConnectionToWebProcess::createGPU(WebGPUIdentifier identifier, Rendering
     auto streamConnection = IPC::StreamServerConnection::tryCreate(WTFMove(connectionHandle), params);
     MESSAGE_CHECK(streamConnection);
 
-    auto addResult = m_remoteGPUMap.ensure(identifier, [&, streamConnection = WTFMove(streamConnection)] () mutable {
+    auto addResult = m_remoteGPUMap.ensure(identifier, [&] {
         return IPC::ScopedActiveMessageReceiveQueue { RemoteGPU::create(identifier, *this, *renderingBackend, streamConnection.releaseNonNull()) };
     });
     ASSERT_UNUSED(addResult, addResult.isNewEntry);

--- a/Source/WebKit/Platform/IPC/ThreadSafeObjectHeap.h
+++ b/Source/WebKit/Platform/IPC/ThreadSafeObjectHeap.h
@@ -104,7 +104,7 @@ template<typename Identifier, typename HeldType>
 bool ThreadSafeObjectHeap<Identifier, HeldType>::add(const Reference& ref, HeldType object)
 {
     Locker locker { m_objectsLock };
-    auto addResult = m_objects.ensure(ref, [&object]() mutable {
+    auto addResult = m_objects.ensure(ref, [&] {
         return ReferenceState { WTFMove(object) };
     });
     if (!addResult.isNewEntry) {

--- a/Source/WebKit/UIProcess/DeviceIdHashSaltStorage.cpp
+++ b/Source/WebKit/UIProcess/DeviceIdHashSaltStorage.cpp
@@ -145,9 +145,7 @@ void DeviceIdHashSaltStorage::loadStorageFromDisk(CompletionHandler<void(HashMap
                 continue;
 
             auto origins = makeString(hashSaltForOrigin->documentOrigin.toString(), hashSaltForOrigin->parentOrigin.toString());
-            auto deviceIdHashSaltForOrigin = deviceIdHashSaltForOrigins.ensure(origins, [hashSaltForOrigin = WTFMove(hashSaltForOrigin)] () mutable {
-                return WTFMove(hashSaltForOrigin);
-            });
+            auto deviceIdHashSaltForOrigin = deviceIdHashSaltForOrigins.add(origins, WTFMove(hashSaltForOrigin));
 
             if (!deviceIdHashSaltForOrigin.isNewEntry)
                 RELEASE_LOG_ERROR(DiskPersistency, "DeviceIdHashSaltStorage: There are two files with different hash salts for the same origin: '%s'", originPath.utf8().data());
@@ -209,7 +207,7 @@ void DeviceIdHashSaltStorage::storeHashSaltToDisk(const HashSaltForOrigin& hashS
 void DeviceIdHashSaltStorage::completeDeviceIdHashSaltForOriginCall(SecurityOriginData&& documentOrigin, SecurityOriginData&& parentOrigin, CompletionHandler<void(String&&)>&& completionHandler)
 {
     auto origins = makeString(documentOrigin.toString(), parentOrigin.toString());
-    auto& deviceIdHashSalt = m_deviceIdHashSaltForOrigins.ensure(origins, [documentOrigin = WTFMove(documentOrigin), parentOrigin = WTFMove(parentOrigin)] () mutable {
+    auto& deviceIdHashSalt = m_deviceIdHashSaltForOrigins.ensure(origins, [&] {
         std::array<uint64_t, randomDataSize> randomData;
         cryptographicallyRandomValues(asWritableBytes(std::span<uint64_t> { randomData }));
 

--- a/Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp
@@ -995,7 +995,7 @@ TEST(WTF_HashMap, Ref_Value)
 
         HashMap<int, Ref<RefLogger>> map;
 
-        map.ensure(1, [&]() mutable {
+        map.ensure(1, [&] {
             Ref<RefLogger> ref(a);
             return ref; 
         });

--- a/Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashMap.cpp
@@ -997,7 +997,7 @@ TEST(WTF_RobinHoodHashMap, Ref_Value)
 
         MemoryCompactLookupOnlyRobinHoodHashMap<int, Ref<RefLogger>, RobinHoodHash<int>> map;
 
-        map.ensure(1, [&]() mutable {
+        map.ensure(1, [&] {
             Ref<RefLogger> ref(a);
             return ref;
         });


### PR DESCRIPTION
#### b945d56c49fadf2d353b34095e062236fa5ea119
<pre>
[WTF] Add Invocable concept for callbacks and start adoption
<a href="https://bugs.webkit.org/show_bug.cgi?id=275398">https://bugs.webkit.org/show_bug.cgi?id=275398</a>
<a href="https://rdar.apple.com/129668606">rdar://129668606</a>

Reviewed by Yusuke Suzuki.

Right now in WebKit if you want to have a callback the standard practice
is to write your function as:

`template&lt;typename Functor&gt; foo(const Functor&amp; callback)`
or
`foo(const auto&amp; callback)`

this tends to make it unclear what the expected signature of the callback
is. Now that we have concepts it would have been nice to do something like:

`foo(const std::invocable&lt;...&gt; auto&amp; callback)`

however that doesn&apos;t provide a clean way to declare the return type, as
far as I could tell. This patch adds a new concept to WTF, which should,
make this a bit cleaner, `Invocable`. Invocable can be used like the following:

`foo(const Invocable&lt;T(U, const V&amp;, ...)&gt; auto&amp; callback)`

This allows us to use function declaration like syntax to tell folks what
type of callback we&apos;re expecting.

In the process of adding Invocable concepts to arguments there were two
other notable changes:

1) HashTable/Map/Set took functions by r-value reference, which seemed
weird so I tried changing it. I then noticed that a lot of users of `ensure`
were passing lambdas that capture variables by copy rather than reference.
Since `ensure`&apos;s use of the lambda is scoped to the call there&apos;s no reason to
copy data in.

2) the HashTranslator versions of add now take a callback rather than a
arbitrary r-value reference type. This makes the logic of the code a bit
easier to follow and allows adding invocable concepts. Since the new wrapper
lambdas are marked ALWAYS_INLINE_LAMBDA there shouldn&apos;t be any performance
overhead.

* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp:
* Source/JavaScriptCore/dfg/DFGTierUpCheckInjectionPhase.cpp:
(JSC::DFG::TierUpCheckInjectionPhase::run):
* Source/WTF/wtf/FixedVector.h:
* Source/WTF/wtf/FunctionTraits.h:
* Source/WTF/wtf/HashMap.h:
(WTF::HashMapTranslator::hash):
(WTF::HashMapTranslator::equal):
(WTF::HashMapTranslator::translate):
(WTF::HashMapEnsureTranslator::hash):
(WTF::HashMapEnsureTranslator::equal):
(WTF::HashMapEnsureTranslator::translate):
(WTF::HashMapTranslatorAdapter::hash):
(WTF::HashMapTranslatorAdapter::equal):
(WTF::HashMapTranslatorAdapter::translate):
(WTF::HashMapEnsureTranslatorAdapter::hash):
(WTF::HashMapEnsureTranslatorAdapter::equal):
(WTF::HashMapEnsureTranslatorAdapter::translate):
(WTF::TableTraitsArg&gt;::inlineAdd):
(WTF::TableTraitsArg&gt;::inlineEnsure):
(WTF::TableTraitsArg&gt;::ensure):
(WTF::TableTraitsArg&gt;::add):
(WTF::Y&gt;::removeIf):
* Source/WTF/wtf/HashSet.h:
(WTF::HashSetTranslator::hash):
(WTF::HashSetTranslator::equal):
(WTF::HashSetTranslator::translate):
(WTF::HashSetTranslatorAdapter::hash):
(WTF::HashSetTranslatorAdapter::equal):
(WTF::HashSetTranslatorAdapter::translate):
(WTF::HashSetEnsureTranslatorAdaptor::hash):
(WTF::HashSetEnsureTranslatorAdaptor::equal):
(WTF::HashSetEnsureTranslatorAdaptor::translate):
(WTF::TableTraits&gt;::ensure):
(WTF::TableTraits&gt;::add):
(WTF::W&gt;::removeIf):
* Source/WTF/wtf/HashTable.h:
(WTF::IdentityHashTranslator::hash):
(WTF::IdentityHashTranslator::equal):
(WTF::IdentityHashTranslator::translate):
(WTF::HashTable::add):
(WTF::KeyTraits&gt;::addUniqueForInitialization):
(WTF::KeyTraits&gt;::add):
(WTF::KeyTraits&gt;::addPassingHashCode):
(WTF::KeyTraits&gt;::HashTable):
* Source/WTF/wtf/ListHashSet.h:
(WTF::U&gt;::add):
(WTF::U&gt;::appendOrMoveToLast):
(WTF::U&gt;::prependOrMoveToFirst):
(WTF::U&gt;::insertBefore):
* Source/WTF/wtf/LocklessBag.h:
* Source/WTF/wtf/PriorityQueue.h:
* Source/WTF/wtf/RobinHoodHashTable.h:
(WTF::RobinHoodHashTable::add):
(WTF::SizePolicy&gt;::add):
(WTF::SizePolicy&gt;::addPassingHashCode):
* Source/WTF/wtf/StdLibExtras.h:
(WTF::requires):
* Source/WTF/wtf/TinyPtrSet.h:
(WTF::TinyPtrSet::forEach const):
(WTF::TinyPtrSet::genericFilter):
* Source/WTF/wtf/Vector.h:
(WTF::Vector::containsIf const):
(WTF::Vector::removeLast):
(WTF::Malloc&gt;::contains const):
(WTF::Malloc&gt;::findIf const):
(WTF::Malloc&gt;::find const):
(WTF::Malloc&gt;::reverseFind const):
(WTF::Malloc&gt;::reverseFindIf const):
(WTF::Malloc&gt;::appendIfNotContains):
(WTF::Malloc&gt;::appendUsingFunctor):
(WTF::Malloc&gt;::removeFirst):
(WTF::Malloc&gt;::removeFirstMatching):
(WTF::Malloc&gt;::removeLast):
(WTF::Malloc&gt;::removeLastMatching):
(WTF::Malloc&gt;::removeAll):
(WTF::Malloc&gt;::removeAllMatching):
(WTF::Malloc&gt;::map const):
(WTF:: const const):
(WTF::Malloc&gt;::map const const): Deleted.
(WTF::Malloc&gt;::map const const const): Deleted.
* Source/WTF/wtf/glib/SysprofAnnotator.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::mediaStreamFromRTCStream):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp:
(WebCore::LibWebRTCMediaEndpoint::mediaStreamFromRTCStreamId):
* Source/WebCore/platform/xr/openxr/OpenXRSwapchain.cpp:
(PlatformXR::OpenXRSwapchain::create):
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::uniteInteractionRegions):
(WebCore::EventRegionContext::convertGuardContainersToInterationIfNeeded):
* Source/WebCore/svg/SVGToOTFFontConversion.cpp:
(WebCore::SVGToOTFFontConverter::SVGToOTFFontConverter):
* Source/WebCore/workers/service/background-fetch/BackgroundFetchEngine.cpp:
(WebCore::BackgroundFetchEngine::startBackgroundFetch):
* Source/WebCore/workers/service/background-fetch/BackgroundFetchManager.cpp:
(WebCore::BackgroundFetchManager::backgroundFetchRegistrationInstance):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::createRenderingBackend):
(WebKit::GPUConnectionToWebProcess::createGraphicsContextGL):
(WebKit::GPUConnectionToWebProcess::createGPU):
* Source/WebKit/Platform/IPC/ThreadSafeObjectHeap.h:
(IPC::HeldType&gt;::add):
* Source/WebKit/UIProcess/DeviceIdHashSaltStorage.cpp:
(WebKit::DeviceIdHashSaltStorage::loadStorageFromDisk):
(WebKit::DeviceIdHashSaltStorage::completeDeviceIdHashSaltForOriginCall):
* Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp:
(TestWebKitAPI::TEST(WTF_HashMap, Ref_Value)):
* Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashMap.cpp:
(TestWebKitAPI::TEST(WTF_RobinHoodHashMap, Ref_Value)):

Canonical link: <a href="https://commits.webkit.org/280952@main">https://commits.webkit.org/280952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7db56ebbafd2673b6193b4cfdb7c5bf226464056

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58146 "10 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61771 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8591 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60274 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8783 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/47112 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6127 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60176 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/35133 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50268 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27946 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31896 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7565 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7595 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/51238 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53846 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7832 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63472 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57388 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2060 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/7890 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54405 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2067 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50280 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54484 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12852 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1761 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/79149 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33303 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13155 "Found 12 new JSC stress test failures: stress/proxy-get-and-set-recursion-stack-overflow.js.eager-jettison-no-cjit, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-collect-continuously, stress/proxy-get-and-set-recursion-stack-overflow.js.no-cjit-validate-phases, stress/proxy-set.js.bytecode-cache, stress/proxy-set.js.default, stress/proxy-set.js.dfg-eager, stress/proxy-set.js.dfg-eager-no-cjit-validate, stress/proxy-set.js.eager-jettison-no-cjit, stress/proxy-set.js.mini-mode, stress/proxy-set.js.no-cjit-collect-continuously ... (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34389 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35473 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34134 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->