### PR TITLE
Resolve CSS gradient color stop positions to Lengths at style builder time

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/calc-linear-radial-conic-gradient-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/calc-linear-radial-conic-gradient-001-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL testing background-image: linear-gradient(rgb(0, 128, 0) calc(0%), rgb(0, 0, 255)) assert_equals: expected "linear-gradient(rgb(0, 128, 0) 0%, rgb(0, 0, 255))" but got "linear-gradient(rgb(0, 128, 0) calc(0%), rgb(0, 0, 255))"
+PASS testing background-image: linear-gradient(rgb(0, 128, 0) calc(0%), rgb(0, 0, 255))
 FAIL testing background-image: linear-gradient(calc(90deg), rgb(0, 128, 0), rgb(0, 0, 255)) assert_equals: expected "linear-gradient(90deg, rgb(0, 128, 0), rgb(0, 0, 255))" but got "linear-gradient(calc(90deg), rgb(0, 128, 0), rgb(0, 0, 255))"
-FAIL testing background-position: linear-gradient(calc(90deg), rgb(0, 128, 0) calc(0%), rgb(0, 0, 255)) assert_equals: expected "linear-gradient(90deg, rgb(0, 128, 0) 0%, rgb(0, 0, 255))" but got "linear-gradient(calc(90deg), rgb(0, 128, 0) calc(0%), rgb(0, 0, 255))"
+FAIL testing background-position: linear-gradient(calc(90deg), rgb(0, 128, 0) calc(0%), rgb(0, 0, 255)) assert_equals: expected "linear-gradient(90deg, rgb(0, 128, 0) 0%, rgb(0, 0, 255))" but got "linear-gradient(calc(90deg), rgb(0, 128, 0) 0%, rgb(0, 0, 255))"
 FAIL testing background-image: linear-gradient(calc(0.1turn + 0.15turn), rgb(0, 128, 0), rgb(0, 0, 255)) assert_equals: expected "linear-gradient(90deg, rgb(0, 128, 0), rgb(0, 0, 255))" but got "linear-gradient(calc(90deg), rgb(0, 128, 0), rgb(0, 0, 255))"
 FAIL testing background-image: linear-gradient(calc(150grad - 50grad), rgb(0, 128, 0), rgb(0, 0, 255)) assert_equals: expected "linear-gradient(90deg, rgb(0, 128, 0), rgb(0, 0, 255))" but got "linear-gradient(calc(90deg), rgb(0, 128, 0), rgb(0, 0, 255))"
 FAIL testing background-image: linear-gradient(calc(200grad - 90deg), rgb(0, 128, 0), rgb(0, 0, 255)) assert_equals: expected "linear-gradient(90deg, rgb(0, 128, 0), rgb(0, 0, 255))" but got "linear-gradient(calc(90deg), rgb(0, 128, 0), rgb(0, 0, 255))"
-FAIL testing background-image: radial-gradient(rgb(0, 128, 0) calc(10% + 20%), rgb(0, 0, 255) calc(30% + 40%)) assert_equals: expected "radial-gradient(rgb(0, 128, 0) 30%, rgb(0, 0, 255) 70%)" but got "radial-gradient(rgb(0, 128, 0) calc(30%), rgb(0, 0, 255) calc(70%))"
-FAIL testing background-image: conic-gradient(rgb(0, 128, 0) calc(50% + 10%), rgb(0, 0, 255) calc(60% + 20%)) assert_equals: expected "conic-gradient(rgb(0, 128, 0) 60%, rgb(0, 0, 255) 80%)" but got "conic-gradient(rgb(0, 128, 0) calc(60%), rgb(0, 0, 255) calc(80%))"
+PASS testing background-image: radial-gradient(rgb(0, 128, 0) calc(10% + 20%), rgb(0, 0, 255) calc(30% + 40%))
+PASS testing background-image: conic-gradient(rgb(0, 128, 0) calc(50% + 10%), rgb(0, 0, 255) calc(60% + 20%))
 

--- a/Source/WebCore/css/CSSGradientValue.h
+++ b/Source/WebCore/css/CSSGradientValue.h
@@ -31,7 +31,6 @@
 
 namespace WebCore {
 
-struct StyleGradientImageStop;
 class StyleImage;
 
 namespace Style {
@@ -69,7 +68,7 @@ struct CSSGradientColorInterpolationMethod {
         return { { ColorInterpolationMethod::SRGB { }, alphaPremultiplication }, Default::SRGB };
     }
 
-    friend bool operator==(const CSSGradientColorInterpolationMethod&, const CSSGradientColorInterpolationMethod&) = default;
+    bool operator==(const CSSGradientColorInterpolationMethod&) const = default;
 };
 
 // MARK: Gradient Definitions.
@@ -85,8 +84,8 @@ inline bool operator==(const CSSGradientPosition& a, const CSSGradientPosition& 
 
 class CSSLinearGradientValue final : public CSSValue {
 public:
-    enum class Horizontal { Left, Right };
-    enum class Vertical { Top, Bottom };
+    enum class Horizontal : bool { Left, Right };
+    enum class Vertical : bool { Top, Bottom };
     struct Angle {
         Ref<CSSPrimitiveValue> value;
         friend bool operator==(const Angle&, const Angle&);
@@ -164,8 +163,8 @@ private:
 
 class CSSPrefixedLinearGradientValue final : public CSSValue {
 public:
-    enum class Horizontal { Left, Right };
-    enum class Vertical { Top, Bottom };
+    enum class Horizontal : bool { Left, Right };
+    enum class Vertical : bool { Top, Bottom };
     struct Angle {
         Ref<CSSPrimitiveValue> value;
         friend bool operator==(const Angle&, const Angle&);
@@ -312,8 +311,8 @@ bool operator==(const CSSDeprecatedLinearGradientValue::Data&, const CSSDeprecat
 
 class CSSRadialGradientValue final : public CSSValue {
 public:
-    enum class ShapeKeyword { Circle, Ellipse };
-    enum class ExtentKeyword { ClosestCorner, ClosestSide, FarthestCorner, FarthestSide };
+    enum class ShapeKeyword : bool { Circle, Ellipse };
+    enum class ExtentKeyword : uint8_t { ClosestCorner, ClosestSide, FarthestCorner, FarthestSide };
     struct Shape {
         ShapeKeyword shape;
         std::optional<CSSGradientPosition> position;
@@ -513,8 +512,8 @@ private:
 
 class CSSPrefixedRadialGradientValue final : public CSSValue {
 public:
-    enum class ShapeKeyword { Circle, Ellipse };
-    enum class ExtentKeyword { ClosestSide, ClosestCorner, FarthestSide, FarthestCorner, Contain, Cover };
+    enum class ShapeKeyword : bool { Circle, Ellipse };
+    enum class ExtentKeyword : uint8_t { ClosestSide, ClosestCorner, FarthestSide, FarthestCorner, Contain, Cover };
     struct ShapeAndExtent {
         ShapeKeyword shape;
         ExtentKeyword extent;

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -96,6 +96,7 @@ public:
     bool isX() const { return primitiveType() == CSSUnitType::CSS_X; }
     bool isResolution() const { return unitCategory(primitiveType()) == CSSUnitCategory::Resolution; }
     bool isViewportPercentageLength() const { return isViewportPercentageLength(primitiveUnitType()); }
+    bool isContainerPercentageLength() const { return isContainerPercentageLength(primitiveUnitType()); }
     bool isFlex() const { return primitiveType() == CSSUnitType::CSS_FR; }
     bool isAnchor() const { return primitiveType() == CSSUnitType::CSS_ANCHOR; }
 
@@ -236,6 +237,7 @@ private:
     static constexpr bool isFontIndependentLength(CSSUnitType);
     static constexpr bool isFontRelativeLength(CSSUnitType);
     static constexpr bool isRootFontRelativeLength(CSSUnitType);
+    static constexpr bool isContainerPercentageLength(CSSUnitType);
     static constexpr bool isViewportPercentageLength(CSSUnitType);
 
     union {
@@ -287,6 +289,16 @@ constexpr bool CSSPrimitiveValue::isFontRelativeLength(CSSUnitType type)
         || isRootFontRelativeLength(type);
 }
 
+constexpr bool CSSPrimitiveValue::isContainerPercentageLength(CSSUnitType type)
+{
+    return type == CSSUnitType::CSS_CQW
+        || type == CSSUnitType::CSS_CQH
+        || type == CSSUnitType::CSS_CQI
+        || type == CSSUnitType::CSS_CQB
+        || type == CSSUnitType::CSS_CQMIN
+        || type == CSSUnitType::CSS_CQMAX;
+}
+
 constexpr bool CSSPrimitiveValue::isLength(CSSUnitType type)
 {
     return type == CSSUnitType::CSS_EM
@@ -298,14 +310,9 @@ constexpr bool CSSPrimitiveValue::isLength(CSSUnitType type)
         || type == CSSUnitType::CSS_PT
         || type == CSSUnitType::CSS_PC
         || type == CSSUnitType::CSS_Q
-        || type == CSSUnitType::CSS_CQW
-        || type == CSSUnitType::CSS_CQH
-        || type == CSSUnitType::CSS_CQI
-        || type == CSSUnitType::CSS_CQB
-        || type == CSSUnitType::CSS_CQMIN
-        || type == CSSUnitType::CSS_CQMAX
         || isFontRelativeLength(type)
         || isViewportPercentageLength(type)
+        || isContainerPercentageLength(type)
         || type == CSSUnitType::CSS_QUIRKY_EM;
 }
 

--- a/Source/WebCore/css/ComputedStyleExtractor.h
+++ b/Source/WebCore/css/ComputedStyleExtractor.h
@@ -40,9 +40,10 @@ class RenderStyle;
 class ShadowData;
 class StyleColor;
 class StylePropertyShorthand;
-class TransformationMatrix;
 class TransformOperation;
+class TransformationMatrix;
 
+struct Length;
 struct PropertyValue;
 
 enum CSSPropertyID : uint16_t;
@@ -83,6 +84,7 @@ public:
 
     static Ref<CSSPrimitiveValue> currentColorOrValidColor(const RenderStyle&, const StyleColor&);
     static Ref<CSSFunctionValue> matrixTransformValue(const TransformationMatrix&, const RenderStyle&);
+    static Ref<CSSPrimitiveValue> zoomAdjustedPixelValueForLength(const Length&, const RenderStyle&);
 
     static bool updateStyleIfNeededForProperty(Element&, CSSPropertyID);
 

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -2276,20 +2276,18 @@ ExceptionOr<void> HTMLInputElement::setSelectionRangeForBindings(unsigned start,
 
 static Ref<StyleGradientImage> autoFillStrongPasswordMaskImage()
 {
-    Vector<StyleGradientImage::Stop> stops {
-        { Color::black, CSSPrimitiveValue::create(50, CSSUnitType::CSS_PERCENTAGE) },
-        { Color::transparentBlack, CSSPrimitiveValue::create(100, CSSUnitType::CSS_PERCENTAGE) }
-    };
-
     return StyleGradientImage::create(
         StyleGradientImage::LinearData {
             {
                 CSSLinearGradientValue::Angle { CSSPrimitiveValue::create(90, CSSUnitType::CSS_DEG) }
             },
-            CSSGradientRepeat::NonRepeating
+            CSSGradientRepeat::NonRepeating,
+            {
+                { Color::black, Length(50, LengthType::Percent) },
+                { Color::transparentBlack, Length(100, LengthType::Percent) }
+            }
         },
-        CSSGradientColorInterpolationMethod::legacyMethod(AlphaPremultiplication::Unpremultiplied),
-        WTFMove(stops)
+        CSSGradientColorInterpolationMethod::legacyMethod(AlphaPremultiplication::Unpremultiplied)
     );
 }
 

--- a/Source/WebCore/rendering/style/StyleGradientImage.cpp
+++ b/Source/WebCore/rendering/style/StyleGradientImage.cpp
@@ -43,22 +43,19 @@
 
 namespace WebCore {
 
-static inline bool operator==(const StyleGradientImageStop& a, const StyleGradientImageStop& b)
-{
-    return a.color == b.color
-        && compareCSSValuePtr(a.position, b.position);
-}
-
-static bool stopsAreCacheable(const Vector<StyleGradientImage::Stop>& stops)
+template<typename Stops>
+static bool stopsAreCacheable(const Stops& stops)
 {
     for (auto& stop : stops) {
-        // FIXME: Do we need handle calc() here?
-        if (stop.position && stop.position->isFontRelativeLength())
-            return false;
         if (stop.color && stop.color->containsCurrentColor())
             return false;
     }
     return true;
+}
+
+static bool stopsAreCacheable(const StyleGradientImage::Data& data)
+{
+    return WTF::switchOn(data, [](auto& data) { return stopsAreCacheable(data.stops); } );
 }
 
 static Color resolveColorStopColor(const std::optional<StyleColor>& styleColor, const RenderStyle& style, bool hasColorFilter)
@@ -71,12 +68,47 @@ static Color resolveColorStopColor(const std::optional<StyleColor>& styleColor, 
     return style.colorResolvingCurrentColor(*styleColor);
 }
 
-StyleGradientImage::StyleGradientImage(Data&& data, CSSGradientColorInterpolationMethod colorInterpolationMethod, Vector<StyleGradientImageStop>&& stops)
+static std::optional<float> resolveColorStopPosition(const StyleGradientImageLengthStop& stop, float gradientLength)
+{
+    if (!stop.position)
+        return std::nullopt;
+
+    if (stop.position->isPercent())
+        return stop.position->percent() / 100.0;
+
+    if (gradientLength <= 0)
+        return 0;
+
+    if (stop.position->isFixed())
+        return stop.position->value() / gradientLength;
+
+    if (stop.position->isCalculated())
+        return stop.position->calculationValue().evaluate(gradientLength) / gradientLength;
+
+    ASSERT_NOT_REACHED();
+    return 0;
+}
+
+static std::optional<float> resolveColorStopPosition(const StyleGradientImageAngularStop& stop, float)
+{
+    return WTF::switchOn(stop.position,
+        [](std::monostate) -> std::optional<float> {
+            return std::nullopt;
+        },
+        [](AngleRaw angle) -> std::optional<float> {
+            return CSSPrimitiveValue::computeDegrees(angle.type, angle.value) / 360.0;
+        },
+        [](PercentRaw percent) -> std::optional<float> {
+            return percent.value / 100.0;
+        }
+    );
+}
+
+StyleGradientImage::StyleGradientImage(Data&& data, CSSGradientColorInterpolationMethod colorInterpolationMethod)
     : StyleGeneratedImage { Type::GradientImage, StyleGradientImage::isFixedSize }
     , m_data { WTFMove(data) }
     , m_colorInterpolationMethod { colorInterpolationMethod }
-    , m_stops { WTFMove(stops) }
-    , m_knownCacheableBarringFilter { stopsAreCacheable(m_stops) }
+    , m_knownCacheableBarringFilter { stopsAreCacheable(m_data) }
 {
 }
 
@@ -91,8 +123,7 @@ bool StyleGradientImage::operator==(const StyleImage& other) const
 bool StyleGradientImage::equals(const StyleGradientImage& other) const
 {
     return m_colorInterpolationMethod == other.m_colorInterpolationMethod
-        && m_data == other.m_data
-        && m_stops == other.m_stops;
+        && m_data == other.m_data;
 }
 
 static inline RefPtr<CSSPrimitiveValue> computedStyleValueForColorStopColor(const std::optional<StyleColor>& color, const RenderStyle& style)
@@ -102,33 +133,80 @@ static inline RefPtr<CSSPrimitiveValue> computedStyleValueForColorStopColor(cons
     return ComputedStyleExtractor::currentColorOrValidColor(style, *color);
 }
 
+static inline RefPtr<CSSPrimitiveValue> computedStyleValueForColorStopPosition(const StyleGradientImageLengthStop& stop, const RenderStyle& style)
+{
+    if (!stop.position)
+        return nullptr;
+    return ComputedStyleExtractor::zoomAdjustedPixelValueForLength(*stop.position, style);
+}
+
+static inline RefPtr<CSSPrimitiveValue> computedStyleValueForColorStopPositionDeprecated(const StyleGradientImageLengthStop& stop)
+{
+    if (!stop.position)
+        return nullptr;
+    return CSSPrimitiveValue::create(*stop.position);
+}
+
+static inline RefPtr<CSSPrimitiveValue> computedStyleValueForColorStopPosition(const StyleGradientImageAngularStop& stop, const RenderStyle&)
+{
+    return WTF::switchOn(stop.position,
+        [](std::monostate) -> RefPtr<CSSPrimitiveValue> {
+            return nullptr;
+        },
+        [](AngleRaw angle) -> RefPtr<CSSPrimitiveValue> {
+            return CSSPrimitiveValue::create(angle.value, angle.type);
+        },
+        [](PercentRaw percent) -> RefPtr<CSSPrimitiveValue> {
+            return CSSPrimitiveValue::create(percent.value, CSSUnitType::CSS_PERCENTAGE);
+        }
+    );
+}
+
+template<typename Stops>
+static CSSGradientColorStopList computeStyleStopsList(const RenderStyle& style, const Stops& stops)
+{
+    return stops.template map<CSSGradientColorStopList>([&](auto& stop) -> CSSGradientColorStop {
+        return {
+            computedStyleValueForColorStopColor(stop.color, style),
+            computedStyleValueForColorStopPosition(stop, style)
+        };
+    });
+}
+
+template<typename Stops>
+static CSSGradientColorStopList computeStyleStopsListDeprecated(const RenderStyle& style, const Stops& stops)
+{
+    return stops.template map<CSSGradientColorStopList>([&](auto& stop) -> CSSGradientColorStop {
+        return {
+            computedStyleValueForColorStopColor(stop.color, style),
+            computedStyleValueForColorStopPositionDeprecated(stop)
+        };
+    });
+}
+
 Ref<CSSValue> StyleGradientImage::computedStyleValue(const RenderStyle& style) const
 {
-    auto cssStopList = m_stops.map<CSSGradientColorStopList>([&](auto& stop) -> CSSGradientColorStop {
-        return { computedStyleValueForColorStopColor(stop.color, style), stop.position };
-    });
-
     return WTF::switchOn(m_data,
         [&] (const LinearData& data) -> Ref<CSSValue> {
-            return CSSLinearGradientValue::create(data.data, data.repeating, m_colorInterpolationMethod, WTFMove(cssStopList));
+            return CSSLinearGradientValue::create(data.data, data.repeating, m_colorInterpolationMethod, computeStyleStopsList(style, data.stops));
         },
         [&] (const PrefixedLinearData& data) -> Ref<CSSValue> {
-            return CSSPrefixedLinearGradientValue::create(data.data, data.repeating, m_colorInterpolationMethod, WTFMove(cssStopList));
+            return CSSPrefixedLinearGradientValue::create(data.data, data.repeating, m_colorInterpolationMethod, computeStyleStopsList(style, data.stops));
         },
         [&] (const DeprecatedLinearData& data) -> Ref<CSSValue> {
-            return CSSDeprecatedLinearGradientValue::create(data.data, m_colorInterpolationMethod, WTFMove(cssStopList));
+            return CSSDeprecatedLinearGradientValue::create(data.data, m_colorInterpolationMethod, computeStyleStopsListDeprecated(style, data.stops));
         },
         [&] (const RadialData& data) -> Ref<CSSValue> {
-            return CSSRadialGradientValue::create(data.data, data.repeating, m_colorInterpolationMethod, WTFMove(cssStopList));
+            return CSSRadialGradientValue::create(data.data, data.repeating, m_colorInterpolationMethod, computeStyleStopsList(style, data.stops));
         },
         [&] (const PrefixedRadialData& data) -> Ref<CSSValue> {
-            return CSSPrefixedRadialGradientValue::create(data.data, data.repeating, m_colorInterpolationMethod, WTFMove(cssStopList));
+            return CSSPrefixedRadialGradientValue::create(data.data, data.repeating, m_colorInterpolationMethod, computeStyleStopsList(style, data.stops));
         },
         [&] (const DeprecatedRadialData& data) -> Ref<CSSValue> {
-            return CSSDeprecatedRadialGradientValue::create(data.data, m_colorInterpolationMethod, WTFMove(cssStopList) );
+            return CSSDeprecatedRadialGradientValue::create(data.data, m_colorInterpolationMethod, computeStyleStopsListDeprecated(style, data.stops) );
         },
         [&] (const ConicData& data) -> Ref<CSSValue> {
-            return CSSConicGradientValue::create(data.data, data.repeating, m_colorInterpolationMethod, WTFMove(cssStopList));
+            return CSSConicGradientValue::create(data.data, data.repeating, m_colorInterpolationMethod, computeStyleStopsList(style, data.stops));
         }
     );
 }
@@ -172,15 +250,21 @@ RefPtr<Image> StyleGradientImage::image(const RenderElement* renderer, const Flo
     return newImage;
 }
 
-bool StyleGradientImage::knownToBeOpaque(const RenderElement& renderer) const
+template<typename Stops>
+static bool knownToBeOpaque(const RenderElement& renderer, const Stops& stops)
 {
     auto& style = renderer.style();
     bool hasColorFilter = style.hasAppleColorFilter();
-    for (auto& stop : m_stops) {
+    for (auto& stop : stops) {
         if (!resolveColorStopColor(stop.color, style, hasColorFilter).isOpaque())
             return false;
     }
     return true;
+}
+
+bool StyleGradientImage::knownToBeOpaque(const RenderElement& renderer) const
+{
+    return WTF::switchOn(m_data, [&](auto& data) { return WebCore::knownToBeOpaque(renderer, data.stops); } );
 }
 
 FloatSize StyleGradientImage::fixedSize(const RenderElement&) const
@@ -379,60 +463,43 @@ public:
 
 } // anonymous namespace
 
-template<typename GradientAdapter>
-GradientColorStops StyleGradientImage::computeStopsForDeprecatedVariants(GradientAdapter&, const CSSToLengthConversionData&, const RenderStyle& style) const
+template<typename GradientAdapter, typename Stops>
+GradientColorStops StyleGradientImage::computeStopsForDeprecatedVariants(GradientAdapter&, const Stops& styleStops, const RenderStyle& style) const
 {
     bool hasColorFilter = style.hasAppleColorFilter();
-    auto result = m_stops.map<GradientColorStops::StopVector>([&] (auto& stop) -> GradientColorStop {
+    auto result = styleStops.template map<GradientColorStops::StopVector>([&](auto& stop) -> GradientColorStop {
         return {
-            // FIXME: Use doubleValueDividingBy100IfPercentage? Or float version?
-            stop.position->isPercentage() ? stop.position->floatValue(CSSUnitType::CSS_PERCENTAGE) / 100 : stop.position->floatValue(CSSUnitType::CSS_NUMBER),
+            stop.position->isPercent() ? stop.position->percent() / 100.0f : stop.position->value(),
             resolveColorStopColor(stop.color, style, hasColorFilter)
         };
     });
 
-    std::stable_sort(result.begin(), result.end(), [] (const auto& a, const auto& b) {
+    std::ranges::stable_sort(result, [](const auto& a, const auto& b) {
         return a.offset < b.offset;
     });
 
     return GradientColorStops::Sorted { WTFMove(result) };
 }
 
-template<typename GradientAdapter>
-GradientColorStops StyleGradientImage::computeStops(GradientAdapter& gradientAdapter, const CSSToLengthConversionData& conversionData, const RenderStyle& style, float maxLengthForRepeat, CSSGradientRepeat repeating) const
+template<typename GradientAdapter, typename Stops>
+GradientColorStops StyleGradientImage::computeStops(GradientAdapter& gradientAdapter, const Stops& styleStops, const RenderStyle& style, float maxLengthForRepeat, CSSGradientRepeat repeating) const
 {
     bool hasColorFilter = style.hasAppleColorFilter();
 
-    size_t numberOfStops = m_stops.size();
+    size_t numberOfStops = styleStops.size();
     Vector<ResolvedGradientStop> stops(numberOfStops);
 
     float gradientLength = gradientAdapter.gradientLength();
 
     for (size_t i = 0; i < numberOfStops; ++i) {
-        auto& stop = m_stops[i];
+        auto& stop = styleStops[i];
 
         stops[i].color = resolveColorStopColor(stop.color, style, hasColorFilter);
 
-        if (stop.position) {
-            auto& positionValue = *stop.position;
-            if (positionValue.isPercentage())
-                stops[i].offset = positionValue.floatValue(CSSUnitType::CSS_PERCENTAGE) / 100;
-            else if (positionValue.isLength() || positionValue.isViewportPercentageLength() || positionValue.isCalculatedPercentageWithLength()) {
-                float length;
-                if (positionValue.isLength())
-                    length = positionValue.computeLength<float>(conversionData) * style.usedZoom();
-                else {
-                    Ref<CalculationValue> calculationValue { positionValue.cssCalcValue()->createCalculationValue(conversionData) };
-                    length = calculationValue->evaluate(gradientLength);
-                }
-                stops[i].offset = (gradientLength > 0) ? length / gradientLength : 0;
-            } else if (positionValue.isAngle())
-                stops[i].offset = positionValue.floatValue(CSSUnitType::CSS_DEG) / 360;
-            else {
-                ASSERT_NOT_REACHED();
-                stops[i].offset = 0;
-            }
-        } else {
+        auto offset = resolveColorStopPosition(stop, gradientLength);
+        if (offset)
+            stops[i].offset = *offset;
+        else {
             // If the first color-stop does not have a position, its position defaults to 0%.
             // If the last color-stop does not have a position, its position defaults to 100%.
             if (!i)
@@ -681,7 +748,7 @@ GradientColorStops StyleGradientImage::computeStops(GradientAdapter& gradientAda
         gradientAdapter.normalizeStopsAndEndpointsOutsideRange(stops, m_colorInterpolationMethod.method);
     
     return GradientColorStops::Sorted {
-        stops.map<GradientColorStops::StopVector>([] (auto& stop) -> GradientColorStop {
+        stops.template map<GradientColorStops::StopVector>([](auto& stop) -> GradientColorStop {
             return { *stop.offset, stop.color };
         })
     };
@@ -960,7 +1027,7 @@ Ref<Gradient> StyleGradientImage::createGradient(const LinearData& linear, const
 
     Gradient::LinearData data { firstPoint, secondPoint };
     LinearGradientAdapter adapter { data };
-    auto stops = computeStops(adapter, conversionData, style, 1, linear.repeating);
+    auto stops = computeStops(adapter, linear.stops, style, 1, linear.repeating);
 
     return Gradient::create(WTFMove(data), m_colorInterpolationMethod.method, GradientSpreadMethod::Pad, WTFMove(stops));
 }
@@ -1028,7 +1095,7 @@ Ref<Gradient> StyleGradientImage::createGradient(const PrefixedLinearData& linea
 
     Gradient::LinearData data { firstPoint, secondPoint };
     LinearGradientAdapter adapter { data };
-    auto stops = computeStops(adapter, conversionData, style, 1, linear.repeating);
+    auto stops = computeStops(adapter, linear.stops, style, 1, linear.repeating);
 
     return Gradient::create(WTFMove(data), m_colorInterpolationMethod.method, GradientSpreadMethod::Pad, WTFMove(stops));
 }
@@ -1050,7 +1117,7 @@ Ref<Gradient> StyleGradientImage::createGradient(const DeprecatedLinearData& lin
 
     Gradient::LinearData data { firstPoint, secondPoint };
     LinearGradientAdapter adapter { data };
-    auto stops = computeStopsForDeprecatedVariants(adapter, conversionData, style);
+    auto stops = computeStopsForDeprecatedVariants(adapter, linear.stops, style);
 
     return Gradient::create(WTFMove(data), m_colorInterpolationMethod.method, GradientSpreadMethod::Pad, WTFMove(stops));
 }
@@ -1205,7 +1272,7 @@ Ref<Gradient> StyleGradientImage::createGradient(const RadialData& radial, const
     float maxExtent = radial.repeating == CSSGradientRepeat::Repeating ? distanceToFarthestCorner(data.point1, size).distance : 0;
 
     RadialGradientAdapter adapter { data };
-    auto stops = computeStops(adapter, conversionData, style, maxExtent, radial.repeating);
+    auto stops = computeStops(adapter, radial.stops, style, maxExtent, radial.repeating);
 
     return Gradient::create(WTFMove(data), m_colorInterpolationMethod.method, GradientSpreadMethod::Pad, WTFMove(stops));
 }
@@ -1323,7 +1390,7 @@ Ref<Gradient> StyleGradientImage::createGradient(const PrefixedRadialData& radia
     float maxExtent = radial.repeating == CSSGradientRepeat::Repeating ? distanceToFarthestCorner(data.point1, size).distance : 0;
 
     RadialGradientAdapter adapter { data };
-    auto stops = computeStops(adapter, conversionData, style, maxExtent, radial.repeating);
+    auto stops = computeStops(adapter, radial.stops, style, maxExtent, radial.repeating);
 
     return Gradient::create(WTFMove(data), m_colorInterpolationMethod.method, GradientSpreadMethod::Pad, WTFMove(stops));
 }
@@ -1349,7 +1416,7 @@ Ref<Gradient> StyleGradientImage::createGradient(const DeprecatedRadialData& rad
 
     Gradient::RadialData data { firstPoint, secondPoint, firstRadius, secondRadius, aspectRatio };
     RadialGradientAdapter adapter { data };
-    auto stops = computeStopsForDeprecatedVariants(adapter, conversionData, style);
+    auto stops = computeStopsForDeprecatedVariants(adapter, radial.stops, style);
 
     return Gradient::create(WTFMove(data), m_colorInterpolationMethod.method, GradientSpreadMethod::Pad, WTFMove(stops));
 }
@@ -1371,7 +1438,7 @@ Ref<Gradient> StyleGradientImage::createGradient(const ConicData& conic, const R
 
     Gradient::ConicData data { centerPoint, angleRadians };
     ConicGradientAdapter adapter;
-    auto stops = computeStops(adapter, conversionData, style, 1, conic.repeating);
+    auto stops = computeStops(adapter, conic.stops, style, 1, conic.repeating);
 
     return Gradient::create(WTFMove(data), m_colorInterpolationMethod.method, GradientSpreadMethod::Pad, WTFMove(stops));
 }


### PR DESCRIPTION
#### 0bc9f1178d891a5a0987511a69102304e60cdd7b
<pre>
Resolve CSS gradient color stop positions to Lengths at style builder time
<a href="https://bugs.webkit.org/show_bug.cgi?id=275399">https://bugs.webkit.org/show_bug.cgi?id=275399</a>

Reviewed by Antti Koivisto.

Resolve gradient stop positions to Lengths at style builder time.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/calc-linear-radial-conic-gradient-001-expected.txt:
    - Update results for additional passing cases.

* Source/WebCore/css/CSSGradientValue.cpp:
* Source/WebCore/css/CSSGradientValue.h:
    - Update to resolve stop positions when style building. Now that this is
      done here, we need to update caching logic for cases that used to be
      in StyleGradientImage.

* Source/WebCore/css/ComputedStyleExtractor.cpp:
* Source/WebCore/css/ComputedStyleExtractor.h:
    - Expose zoomAdjustedPixelValueForLength for use by StyleGradientImage.

* Source/WebCore/rendering/style/StyleGradientImage.cpp:
* Source/WebCore/rendering/style/StyleGradientImage.h:
    - Use properly typed stop positions to resolve to computed styles
      and rendering.

Canonical link: <a href="https://commits.webkit.org/280120@main">https://commits.webkit.org/280120@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac50a7c5742fe56c88c2b82a9280d8eb16c3f245

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55631 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34954 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58615 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6061 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57757 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6260 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44797 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4162 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57660 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32878 "Found 60 new test failures: accessibility/accessibility-node-reparent.html accessibility/ancestor-computation.html accessibility/announcement-notification.html accessibility/aria-braillelabel.html accessibility/aria-brailleroledescription.html accessibility/aria-checked-mixed-value.html accessibility/aria-current-state-changed-notification.html accessibility/aria-current.html accessibility/aria-describedby-on-input.html accessibility/aria-description.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47948 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25929 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29665 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5277 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4205 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51771 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60206 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30785 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5670 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52228 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31870 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48018 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51716 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12364 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32951 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31617 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->