### PR TITLE
AX: Clean up construction of TextUnderElementMode and implementation of AccessibilityObject::style.

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -730,18 +730,12 @@ struct TextUnderElementMode {
         IncludeNameFromContentsChildren, // This corresponds to ARIA concept: nameFrom
     };
 
-    Children childrenInclusion;
-    bool includeFocusableContent;
+    Children childrenInclusion { Children::SkipIgnoredChildren };
+    bool includeFocusableContent { false };
     bool considerHiddenState { true };
     bool inHiddenSubtree { false };
     TrimWhitespace trimWhitespace { TrimWhitespace::Yes };
-    Node* ignoredChildNode;
-
-    TextUnderElementMode(Children childrenInclusion = Children::SkipIgnoredChildren, bool includeFocusable = false, Node* ignoredChild = nullptr)
-        : childrenInclusion(childrenInclusion)
-        , includeFocusableContent(includeFocusable)
-        , ignoredChildNode(ignoredChild)
-    { }
+    Node* ignoredChildNode { nullptr };
 
     bool isHidden() { return considerHiddenState && inHiddenSubtree; }
 };
@@ -1143,7 +1137,7 @@ public:
 
     // Methods for determining accessibility text.
     virtual String stringValue() const = 0;
-    virtual String textUnderElement(TextUnderElementMode = TextUnderElementMode()) const = 0;
+    virtual String textUnderElement(TextUnderElementMode = { }) const = 0;
     virtual String text() const = 0;
     virtual unsigned textLength() const = 0;
 #if PLATFORM(COCOA)

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -2352,7 +2352,7 @@ String AccessibilityNodeObject::textUnderElement(TextUnderElementMode mode) cons
     StringBuilder builder;
     RefPtr<AXCoreObject> previous;
     bool previousRequiresSpace = false;
-    auto appendTextUnderElement = [&] (AXCoreObject& object) {
+    auto appendTextUnderElement = [&] (auto& object) {
         // We don't want to trim whitespace in these intermediate calls to textUnderElement, as doing so will wipe out
         // spaces we need to build the string properly. If anything (depending on the original `mode`), we will trim
         // whitespace at the very end.
@@ -2474,7 +2474,7 @@ String AccessibilityNodeObject::title() const
     if (isLink())
         return textUnderElement();
     if (isHeading())
-        return textUnderElement(TextUnderElementMode(TextUnderElementMode::Children::SkipIgnoredChildren, true));
+        return textUnderElement({ TextUnderElementMode::Children::SkipIgnoredChildren, true });
 
     return { };
 }
@@ -2658,7 +2658,7 @@ static String accessibleNameForNode(Node& node, Node* labelledbyNode)
     String text;
     if (axObject) {
         if (axObject->accessibleNameDerivesFromContent())
-            text = axObject->textUnderElement(TextUnderElementMode(TextUnderElementMode::Children::IncludeNameFromContentsChildren, true, labelledbyNode));
+            text = axObject->textUnderElement({ TextUnderElementMode::Children::IncludeNameFromContentsChildren, true, true, false, TrimWhitespace::Yes, labelledbyNode });
     } else
         text = (element ? element->innerText() : node.textContent()).simplifyWhiteSpace(isASCIIWhitespace);
 

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -2976,14 +2976,12 @@ Element* AccessibilityObject::element() const
 
 const RenderStyle* AccessibilityObject::style() const
 {
-    const RenderStyle* style = nullptr;
     if (auto* renderer = this->renderer())
-        style = &renderer->style();
-    if (!style) {
-        if (auto* element = this->element())
-            style = element->computedStyle();
-    }
-    return style;
+        return &renderer->style();
+
+    if (auto* element = this->element())
+        return element->computedStyle();
+    return nullptr;
 }
 
 bool AccessibilityObject::isValueAutofillAvailable() const
@@ -3932,8 +3930,8 @@ bool AccessibilityObject::isAXHidden() const
 {
     if (isFocused())
         return false;
-    
-    return Accessibility::findAncestor<AccessibilityObject>(*this, true, [] (const AccessibilityObject& object) {
+
+    return Accessibility::findAncestor<AccessibilityObject>(*this, true, [] (const auto& object) {
         return object.isARIAHidden();
     }) != nullptr;
 }

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -385,7 +385,7 @@ public:
     bool isARIAStaticText() const { return ariaRoleAttribute() == AccessibilityRole::StaticText; }
     String stringValue() const override { return { }; }
     bool dependsOnTextUnderElement() const;
-    String textUnderElement(TextUnderElementMode = TextUnderElementMode()) const override { return { }; }
+    String textUnderElement(TextUnderElementMode = { }) const override { return { }; }
     String text() const override { return { }; }
     unsigned textLength() const final;
 #if ENABLE(AX_THREAD_TEXT_APIS)

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -433,7 +433,7 @@ private:
     void setPreventKeyboardDOMEventDispatch(bool) final;
 #endif
 
-    String textUnderElement(TextUnderElementMode = TextUnderElementMode()) const final;
+    String textUnderElement(TextUnderElementMode = { }) const final;
     std::optional<SimpleRange> misspellingRange(const SimpleRange&, AccessibilitySearchDirection) const final;
     FloatRect convertFrameToSpace(const FloatRect&, AccessibilityConversionSpace) const final;
     void increment() final;


### PR DESCRIPTION
#### f72e630473a8785eefb9311e96392874062233a8
<pre>
AX: Clean up construction of TextUnderElementMode and implementation of AccessibilityObject::style.
<a href="https://bugs.webkit.org/show_bug.cgi?id=275402">https://bugs.webkit.org/show_bug.cgi?id=275402</a>
&lt;<a href="https://rdar.apple.com/problem/129683965">rdar://problem/129683965</a>&gt;

Reviewed by Tyler Wilcock.

Some of the member variables were being initialized with default parameter in a constructor while others were initialize with initializers. This patch makes the code consistent and more understandable by using initializers for all members.
It also straightens out the code of AccessibilityObject::style avoiding unnecessary copies.

This is a byproduct of investigation to solve <a href="https://bugs.webkit.org/show_bug.cgi?id=275059.">https://bugs.webkit.org/show_bug.cgi?id=275059.</a>

* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::textUnderElement):
(WebCore::TextUnderElementMode::TextUnderElementMode): Deleted.
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::textUnderElement const):
(WebCore::AccessibilityNodeObject::title const):
(WebCore::accessibleNameForNode):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::style const):
(WebCore::AccessibilityObject::isAXHidden const):
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::textUnderElement):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:

Canonical link: <a href="https://commits.webkit.org/279976@main">https://commits.webkit.org/279976@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d7ce03fe2e945a0e3b3fea587d16779f6aa76a0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58302 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5753 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57321 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42038 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5789 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44553 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3925 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47675 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25678 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29347 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5020 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-autofocus.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3897 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51213 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5243 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59893 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5404 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51980 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31422 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47748 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51429 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12110 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32447 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31214 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->