### PR TITLE
Constructible EventTarget does create a path during dispatch

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-single-activation-behavior-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-single-activation-behavior-expected.txt
@@ -1,0 +1,134 @@
+
+PASS When clicking child <INPUT type=checkbox></INPUT> of parent <INPUT type=radio></INPUT>, only child should be activated.
+PASS When clicking child <INPUT type=checkbox></INPUT> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated.
+PASS When clicking child <INPUT type=checkbox></INPUT> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.
+PASS When clicking child <INPUT type=checkbox></INPUT> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated.
+PASS When clicking child <INPUT type=checkbox></INPUT> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <INPUT type=checkbox></INPUT> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <INPUT type=checkbox></INPUT> of parent <A></A>, only child should be activated.
+PASS When clicking child <INPUT type=checkbox></INPUT> of parent <AREA></AREA>, only child should be activated.
+PASS When clicking child <INPUT type=checkbox></INPUT> of parent <DETAILS><SUMMARY></SUMMARY></DETAILS>, only child should be activated.
+PASS When clicking child <INPUT type=checkbox></INPUT> of parent <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL>, only child should be activated.
+PASS When clicking child <INPUT type=checkbox></INPUT> of parent <LABEL><BUTTON type=button></BUTTON></LABEL>, only child should be activated.
+PASS When clicking child <INPUT type=radio></INPUT> of parent <INPUT type=checkbox></INPUT>, only child should be activated.
+PASS When clicking child <INPUT type=radio></INPUT> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated.
+PASS When clicking child <INPUT type=radio></INPUT> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.
+PASS When clicking child <INPUT type=radio></INPUT> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated.
+PASS When clicking child <INPUT type=radio></INPUT> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <INPUT type=radio></INPUT> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <INPUT type=radio></INPUT> of parent <A></A>, only child should be activated.
+PASS When clicking child <INPUT type=radio></INPUT> of parent <AREA></AREA>, only child should be activated.
+PASS When clicking child <INPUT type=radio></INPUT> of parent <DETAILS><SUMMARY></SUMMARY></DETAILS>, only child should be activated.
+PASS When clicking child <INPUT type=radio></INPUT> of parent <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL>, only child should be activated.
+PASS When clicking child <INPUT type=radio></INPUT> of parent <LABEL><BUTTON type=button></BUTTON></LABEL>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <INPUT type=checkbox></INPUT>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <INPUT type=radio></INPUT>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <A></A>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <AREA></AREA>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <DETAILS><SUMMARY></SUMMARY></DETAILS>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <LABEL><BUTTON type=button></BUTTON></LABEL>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <INPUT type=checkbox></INPUT>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <INPUT type=radio></INPUT>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <A></A>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <AREA></AREA>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <DETAILS><SUMMARY></SUMMARY></DETAILS>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <LABEL><BUTTON type=button></BUTTON></LABEL>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <INPUT type=checkbox></INPUT>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <INPUT type=radio></INPUT>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <A></A>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <AREA></AREA>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <DETAILS><SUMMARY></SUMMARY></DETAILS>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <LABEL><BUTTON type=button></BUTTON></LABEL>, only child should be activated.
+FAIL When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <INPUT type=checkbox></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be Element node <form onsubmit="activated(this); return false" class="act... but got Element node <input class="click activates container test55" type="che... (expected array [Element node <form onsubmit="activated(this); return false" class="act...] got [Element node <input class="click activates container test55" type="che...])
+FAIL When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <INPUT type=radio></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be Element node <form onsubmit="activated(this); return false" class="act... but got Element node <input class="click activates container test56" type="rad... (expected array [Element node <form onsubmit="activated(this); return false" class="act...] got [Element node <input class="click activates container test56" type="rad...])
+PASS When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <A></A>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <AREA></AREA>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <DETAILS><SUMMARY></SUMMARY></DETAILS>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <LABEL><BUTTON type=button></BUTTON></LABEL>, only child should be activated.
+FAIL When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <INPUT type=checkbox></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be Element node <form onreset="activated(this)" class="activates test66">... but got Element node <input class="click activates container test66" type="che... (expected array [Element node <form onreset="activated(this)" class="activates test66">...] got [Element node <input class="click activates container test66" type="che...])
+FAIL When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <INPUT type=radio></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be Element node <form onreset="activated(this)" class="activates test67">... but got Element node <input class="click activates container test67" type="rad... (expected array [Element node <form onreset="activated(this)" class="activates test67">...] got [Element node <input class="click activates container test67" type="rad...])
+PASS When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <A></A>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <AREA></AREA>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <DETAILS><SUMMARY></SUMMARY></DETAILS>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <LABEL><BUTTON type=button></BUTTON></LABEL>, only child should be activated.
+FAIL When clicking child <A></A> of parent <INPUT type=checkbox></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be "http://localhost:8800/dom/events/Event-dispatch-single-activation-behavior.html#test77_link" but got Element node <input class="click activates container test77" type="che... (expected array ["http://localhost:8800/dom/events/Event-dispatch-single-activation-behavior.html#test77_link"] got [Element node <input class="click activates container test77" type="che...])
+FAIL When clicking child <A></A> of parent <INPUT type=radio></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be "http://localhost:8800/dom/events/Event-dispatch-single-activation-behavior.html#test78_link" but got Element node <input class="click activates container test78" type="rad... (expected array ["http://localhost:8800/dom/events/Event-dispatch-single-activation-behavior.html#test78_link"] got [Element node <input class="click activates container test78" type="rad...])
+PASS When clicking child <A></A> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated.
+PASS When clicking child <A></A> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.
+PASS When clicking child <A></A> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated.
+PASS When clicking child <A></A> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <A></A> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <A></A> of parent <AREA></AREA>, only child should be activated.
+PASS When clicking child <A></A> of parent <DETAILS><SUMMARY></SUMMARY></DETAILS>, only child should be activated.
+PASS When clicking child <A></A> of parent <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL>, only child should be activated.
+PASS When clicking child <A></A> of parent <LABEL><BUTTON type=button></BUTTON></LABEL>, only child should be activated.
+FAIL When clicking child <AREA></AREA> of parent <INPUT type=checkbox></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be "http://localhost:8800/dom/events/Event-dispatch-single-activation-behavior.html#test88_link" but got Element node <input class="click activates container test88" type="che... (expected array ["http://localhost:8800/dom/events/Event-dispatch-single-activation-behavior.html#test88_link"] got [Element node <input class="click activates container test88" type="che...])
+FAIL When clicking child <AREA></AREA> of parent <INPUT type=radio></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be "http://localhost:8800/dom/events/Event-dispatch-single-activation-behavior.html#test89_link" but got Element node <input class="click activates container test89" type="rad... (expected array ["http://localhost:8800/dom/events/Event-dispatch-single-activation-behavior.html#test89_link"] got [Element node <input class="click activates container test89" type="rad...])
+PASS When clicking child <AREA></AREA> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated.
+PASS When clicking child <AREA></AREA> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.
+PASS When clicking child <AREA></AREA> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated.
+PASS When clicking child <AREA></AREA> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <AREA></AREA> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <AREA></AREA> of parent <A></A>, only child should be activated.
+PASS When clicking child <AREA></AREA> of parent <DETAILS><SUMMARY></SUMMARY></DETAILS>, only child should be activated.
+PASS When clicking child <AREA></AREA> of parent <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL>, only child should be activated.
+PASS When clicking child <AREA></AREA> of parent <LABEL><BUTTON type=button></BUTTON></LABEL>, only child should be activated.
+FAIL When clicking child <DETAILS><SUMMARY></SUMMARY></DETAILS> of parent <INPUT type=checkbox></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be Element node <details ontoggle="activated(this)" class="activates test... but got Element node <input class="click activates container test99" type="che... (expected array [Element node <details ontoggle="activated(this)" class="activates test...] got [Element node <input class="click activates container test99" type="che...])
+FAIL When clicking child <DETAILS><SUMMARY></SUMMARY></DETAILS> of parent <INPUT type=radio></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be Element node <details ontoggle="activated(this)" class="activates test... but got Element node <input class="click activates container test100" type="ra... (expected array [Element node <details ontoggle="activated(this)" class="activates test...] got [Element node <input class="click activates container test100" type="ra...])
+PASS When clicking child <DETAILS><SUMMARY></SUMMARY></DETAILS> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated.
+PASS When clicking child <DETAILS><SUMMARY></SUMMARY></DETAILS> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.
+PASS When clicking child <DETAILS><SUMMARY></SUMMARY></DETAILS> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated.
+PASS When clicking child <DETAILS><SUMMARY></SUMMARY></DETAILS> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <DETAILS><SUMMARY></SUMMARY></DETAILS> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <DETAILS><SUMMARY></SUMMARY></DETAILS> of parent <A></A>, only child should be activated.
+PASS When clicking child <DETAILS><SUMMARY></SUMMARY></DETAILS> of parent <AREA></AREA>, only child should be activated.
+PASS When clicking child <DETAILS><SUMMARY></SUMMARY></DETAILS> of parent <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL>, only child should be activated.
+PASS When clicking child <DETAILS><SUMMARY></SUMMARY></DETAILS> of parent <LABEL><BUTTON type=button></BUTTON></LABEL>, only child should be activated.
+FAIL When clicking child <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL> of parent <INPUT type=checkbox></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be Element node <input type="checkbox" onclick="this.checked ? activated(... but got Element node <input class="click activates container test110" type="ch... (expected array [Element node <input type="checkbox" onclick="this.checked ? activated(...] got [Element node <input class="click activates container test110" type="ch...])
+FAIL When clicking child <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL> of parent <INPUT type=radio></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be Element node <input type="checkbox" onclick="this.checked ? activated(... but got Element node <input class="click activates container test111" type="ra... (expected array [Element node <input type="checkbox" onclick="this.checked ? activated(...] got [Element node <input class="click activates container test111" type="ra...])
+FAIL When clicking child <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated. assert_array_equals: expected property 0 to be Element node <input type="checkbox" onclick="this.checked ? activated(... but got Element node <form onsubmit="activated(this); return false" class="act... (expected array [Element node <input type="checkbox" onclick="this.checked ? activated(...] got [Element node <form onsubmit="activated(this); return false" class="act...])
+FAIL When clicking child <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated. assert_array_equals: expected property 0 to be Element node <input type="checkbox" onclick="this.checked ? activated(... but got Element node <form onsubmit="activated(this); return false" class="act... (expected array [Element node <input type="checkbox" onclick="this.checked ? activated(...] got [Element node <form onsubmit="activated(this); return false" class="act...])
+FAIL When clicking child <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated. assert_array_equals: expected property 0 to be Element node <input type="checkbox" onclick="this.checked ? activated(... but got Element node <form onreset="activated(this)" class="activates test114"... (expected array [Element node <input type="checkbox" onclick="this.checked ? activated(...] got [Element node <form onreset="activated(this)" class="activates test114"...])
+FAIL When clicking child <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated. assert_array_equals: expected property 0 to be Element node <input type="checkbox" onclick="this.checked ? activated(... but got Element node <form onsubmit="activated(this); return false" class="act... (expected array [Element node <input type="checkbox" onclick="this.checked ? activated(...] got [Element node <form onsubmit="activated(this); return false" class="act...])
+FAIL When clicking child <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated. assert_array_equals: expected property 0 to be Element node <input type="checkbox" onclick="this.checked ? activated(... but got Element node <form onreset="activated(this)" class="activates test116"... (expected array [Element node <input type="checkbox" onclick="this.checked ? activated(...] got [Element node <form onreset="activated(this)" class="activates test116"...])
+PASS When clicking child <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL> of parent <A></A>, only child should be activated.
+PASS When clicking child <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL> of parent <AREA></AREA>, only child should be activated.
+PASS When clicking child <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL> of parent <DETAILS><SUMMARY></SUMMARY></DETAILS>, only child should be activated.
+PASS When clicking child <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL> of parent <LABEL><BUTTON type=button></BUTTON></LABEL>, only child should be activated.
+FAIL When clicking child <LABEL><BUTTON type=button></BUTTON></LABEL> of parent <INPUT type=checkbox></INPUT>, only child should be activated. assert_array_equals: lengths differ, expected array [] length 0, got [Element node <input class="click activates container test121" type="ch...] length 1
+FAIL When clicking child <LABEL><BUTTON type=button></BUTTON></LABEL> of parent <INPUT type=radio></INPUT>, only child should be activated. assert_array_equals: lengths differ, expected array [] length 0, got [Element node <input class="click activates container test122" type="ra...] length 1
+FAIL When clicking child <LABEL><BUTTON type=button></BUTTON></LABEL> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated. assert_array_equals: lengths differ, expected array [] length 0, got [Element node <form onsubmit="activated(this); return false" class="act...] length 1
+FAIL When clicking child <LABEL><BUTTON type=button></BUTTON></LABEL> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated. assert_array_equals: lengths differ, expected array [] length 0, got [Element node <form onsubmit="activated(this); return false" class="act...] length 1
+FAIL When clicking child <LABEL><BUTTON type=button></BUTTON></LABEL> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated. assert_array_equals: lengths differ, expected array [] length 0, got [Element node <form onreset="activated(this)" class="activates test125"...] length 1
+FAIL When clicking child <LABEL><BUTTON type=button></BUTTON></LABEL> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated. assert_array_equals: lengths differ, expected array [] length 0, got [Element node <form onsubmit="activated(this); return false" class="act...] length 1
+FAIL When clicking child <LABEL><BUTTON type=button></BUTTON></LABEL> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated. assert_array_equals: lengths differ, expected array [] length 0, got [Element node <form onreset="activated(this)" class="activates test127"...] length 1
+FAIL When clicking child <LABEL><BUTTON type=button></BUTTON></LABEL> of parent <A></A>, only child should be activated. assert_array_equals: lengths differ, expected array [] length 0, got ["http://localhost:8800/dom/events/Event-dispatch-single-activation-behavior.html#test128_link"] length 1
+FAIL When clicking child <LABEL><BUTTON type=button></BUTTON></LABEL> of parent <AREA></AREA>, only child should be activated. assert_array_equals: lengths differ, expected array [] length 0, got ["http://localhost:8800/dom/events/Event-dispatch-single-activation-behavior.html#test129_link"] length 1
+PASS When clicking child <LABEL><BUTTON type=button></BUTTON></LABEL> of parent <DETAILS><SUMMARY></SUMMARY></DETAILS>, only child should be activated.
+PASS When clicking child <LABEL><BUTTON type=button></BUTTON></LABEL> of parent <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL>, only child should be activated.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-single-activation-behavior.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-single-activation-behavior.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title> Only one activation behavior is executed during dispatch</title>
+<link rel="author" title="Vincent Hilla" href="mailto:vhilla@mozilla.com">
+<link rel="help" href="https://dom.spec.whatwg.org/#eventtarget-activation-behavior">
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-event-dispatch">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id=log></div>
+
+<div id=test_container></div>
+
+<!--
+    Three classes:
+    click
+        Element to be clicked to cause activation behavior
+    activates
+        Element that registers the activation behavior
+    container
+        Element in which other elements with activation behavior are placed.
+        We test that those won't be activated too.
+-->
+<template>
+    <!--input, change event bubble, so have to check if checked is true-->
+    <input class="click activates container" type="checkbox" oninput="this.checked ? activated(this) : null">
+    <input class="click activates container" type="radio" oninput="this.checked ? activated(this) : null">
+    <form onsubmit="activated(this); return false" class="activates">
+        <input class="click container" type="submit">
+    </form>
+    <form onsubmit="activated(this); return false" class="activates">
+        <input class="click container" type="image">
+    </form>
+    <form onreset="activated(this)" class="activates">
+        <input class="click container" type="reset">
+    </form>
+    <form onsubmit="activated(this); return false" class="activates">
+        <button class="click container" type="submit"></button>
+    </form>
+    <form onreset="activated(this)" class="activates">
+        <button class="click container" type="reset"></button>
+    </form>
+    <a href="#link" class="click container activates"></a>
+    <area href="#link" class="click container activates">
+    <details ontoggle="activated(this)" class="activates">
+        <summary class="click container"></summary>
+    </details>
+    <label>
+      <input type=checkbox onclick="this.checked ? activated(this) : null" class="activates">
+      <span class="click container">label</span>
+    </label>
+    <!--activation behavior of label for event targeted at interactive content descendant is to do nothing-->
+    <label class="container">
+        <button class="click" type="button"></button>
+    </label>
+</template>
+
+<script>
+let activations = [];
+function activated(e) {
+    activations.push(e);
+}
+
+function getActivations(testidx) {
+    return activations.filter(a =>
+        (a.endsWith && a.endsWith("test"+testidx+"_link"))
+        || (a.classList && a.classList.contains("test"+testidx))
+    );
+}
+
+// for a and area elements
+window.onhashchange = function(e) {
+    if (e.newURL.endsWith("link")) {
+        activated(e.newURL);
+    }
+    window.location.hash = "";
+};
+
+function getElementsByClassNameInclusive(e, clsname) {
+    let ls = Array.from(e.getElementsByClassName(clsname));
+    if (e.classList.contains(clsname)) ls.push(e);
+    return ls;
+}
+
+function getClickTarget(e) {
+    return getElementsByClassNameInclusive(e, "click")[0];
+}
+
+function getContainer(e) {
+    return getElementsByClassNameInclusive(e, "container")[0];
+}
+
+function getExpectedActivations(e) {
+    let ls = getElementsByClassNameInclusive(e, "activates");
+
+    // special case, for a and area the window registers the activation
+    // have to use string, as testrunner cannot stringify the window object
+    ls = ls.map(e => e.tagName === "A" || e.tagName === "AREA" ? e.href : e);
+
+    return ls;
+}
+
+function toString(e) {
+    const children = Array.from(e.children);
+    const childstr = (children.map(toString)).join("");
+    const tag = e.tagName;
+    const typestr = e.type ? " type="+e.type : "";
+    return `<${tag}${typestr}>${childstr}</${tag}>`;
+}
+
+// generate O(n^2) test combinations
+const template = document.querySelector("template");
+const elements = Array.from(template.content.children);
+const tests = []
+for (const target of elements) {
+    for (const parent of elements) {
+        if (target === parent) continue;
+        tests.push([target.cloneNode(true), parent.cloneNode(true)])
+    }
+}
+
+const test_container = document.getElementById("test_container");
+
+/**
+ * Test that if two elements in an event target chain have activation behavior,
+ * only one of them will be activated.
+ *
+ * Each child of <template> represents one case of activation behavior.
+ * The behavior should be triggered by clicking the element of class click
+ * and will manifest as a call to activated().
+ *
+ * For each [target, parent] in tests, we make target a descendant of parent
+ * and test that only target gets activated when dispatching a click.
+ */
+for (let i = 0; i < tests.length; i++) {
+    let [target, parent] = tests[i];
+    async_test(function(t) {
+        let test = document.createElement("div");
+        test_container.appendChild(test);
+        test.appendChild(parent);
+        getContainer(parent).appendChild(target);
+
+        // for later filtering out the activations belonging to this test
+        for (let e of test.getElementsByClassName("activates")) {
+            e.classList.add("test"+i);
+        }
+        for (let e of test.querySelectorAll("a, area")) {
+            e.href = "#test"+i+"_link";
+        }
+
+        getClickTarget(target).click();
+
+        // Need to spin event loop twice, as some clicks might dispatch another task
+        t.step_timeout(() => {
+            t.step_timeout(t.step_func_done(() => {
+                    assert_array_equals(getActivations(i), getExpectedActivations(target));
+            }), 0);
+        }, 0);
+
+        t.add_cleanup(function() {
+            test_container.removeChild(test);
+        });
+    }, `When clicking child ${toString(target)} of parent ${toString(parent)}, only child should be activated.`);
+}
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/EventTarget-constructible.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/EventTarget-constructible.any-expected.txt
@@ -1,4 +1,5 @@
 
 PASS A constructed EventTarget can be used as expected
+PASS A constructed EventTarget implements dispatch correctly
 PASS EventTarget can be subclassed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/EventTarget-constructible.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/EventTarget-constructible.any.js
@@ -24,6 +24,23 @@ test(() => {
 }, "A constructed EventTarget can be used as expected");
 
 test(() => {
+  const target = new EventTarget();
+  const event = new Event("foo");
+
+  function listener(e) {
+    assert_equals(e, event);
+    assert_equals(e.target, target);
+    assert_equals(e.currentTarget, target);
+    assert_array_equals(e.composedPath(), [target]);
+  }
+  target.addEventListener("foo", listener, { once: true });
+  target.dispatchEvent(event);
+  assert_equals(event.target, target);
+  assert_equals(event.currentTarget, null);
+  assert_array_equals(event.composedPath(), []);
+}, "A constructed EventTarget implements dispatch correctly");
+
+test(() => {
   class NicerEventTarget extends EventTarget {
     on(...args) {
       this.addEventListener(...args);

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/EventTarget-constructible.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/EventTarget-constructible.any.worker-expected.txt
@@ -1,4 +1,5 @@
 
 PASS A constructed EventTarget can be used as expected
+PASS A constructed EventTarget implements dispatch correctly
 PASS EventTarget can be subclassed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/event-global-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/event-global-expected.txt
@@ -6,4 +6,5 @@ PASS window.event is undefined if the target is in a shadow tree (event dispatch
 PASS window.event is undefined inside window.onerror if the target is in a shadow tree (ErrorEvent dispatched inside shadow tree)
 PASS window.event is set to the current event during dispatch
 PASS window.event is set to the current event, which is the event passed to dispatch
+PASS window.event is set to the current event, which is the event passed to dispatch (2)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/event-global.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/event-global.html
@@ -114,4 +114,14 @@ async_test(t => {
 
   target.dispatchEvent(new Event("click"));
 }, "window.event is set to the current event, which is the event passed to dispatch");
+
+async_test(t => {
+  let target = new XMLHttpRequest();
+
+  target.onload = t.step_func_done(e => {
+    assert_equals(e, window.event);
+  });
+
+  target.dispatchEvent(new Event("load"));
+}, "window.event is set to the current event, which is the event passed to dispatch (2)");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/pointer-event-document-move-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/pointer-event-document-move-expected.txt
@@ -1,0 +1,5 @@
+TEST
+
+
+PASS Moving a node to new document should move the registered event listeners together
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/pointer-event-document-move.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/pointer-event-document-move.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<link rel="help" href="https://crbug.com/341104769">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<template>
+  <p>TEST</p>
+</template>
+
+<body>
+<script>
+  const clone = document.querySelector("template").content.cloneNode(true);
+  const p = clone.querySelector("p");
+
+  let gotEvent = false;
+  p.addEventListener("pointerup", () => {
+    gotEvent = true;
+  });
+
+  document.body.append(clone);
+
+  promise_test(async () => {
+    await test_driver.click(document.querySelector("p"));
+    assert_true(gotEvent);
+  }, "Moving a node to new document should move the registered event listeners together");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/remove-all-listeners-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/remove-all-listeners-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Removing all listeners and then adding a new one should work.
+PASS Nested usage of once listeners should work.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/remove-all-listeners.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/remove-all-listeners.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<title>Various edge cases where listeners are removed during iteration</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+
+test(function() {
+  var type = "foo";
+  var target = document.createElement("div");
+
+  var listener1CallCount = 0;
+  var listener2CallCount = 0;
+  var listener3CallCount = 0;
+  function listener1() {
+    listener1CallCount++;
+    target.removeEventListener(type, listener1);
+    target.removeEventListener(type, listener2);
+    target.addEventListener(type, listener3);
+  }
+  function listener2() {
+    listener2CallCount++;
+  }
+  function listener3() {
+    listener3CallCount++;
+  }
+
+  target.addEventListener(type, listener1);
+  target.addEventListener(type, listener2);
+
+  // Dispatch the event. Only listener1 should be called because
+  // it removes listener2. And listener3 is added when we've already
+  // started iterating, so it shouldn't be called either.
+  target.dispatchEvent(new Event(type));
+  assert_equals(listener1CallCount, 1);
+  assert_equals(listener2CallCount, 0);
+  assert_equals(listener3CallCount, 0);
+
+  // Now that only listener3 is set, dispatch another event. Only
+  // listener3 should be called.
+  target.dispatchEvent(new Event(type));
+  assert_equals(listener1CallCount, 1);
+  assert_equals(listener2CallCount, 0);
+  assert_equals(listener3CallCount, 1);
+}, "Removing all listeners and then adding a new one should work.");
+
+test(function() {
+  var type = "foo";
+  var target = document.createElement("div");
+
+  var listener1CallCount = 0;
+  var listener2CallCount = 0;
+  var listener3CallCount = 0;
+  function listener1() {
+    listener1CallCount++;
+    // Recursively dispatch another event from this listener.
+    // This will only call listener2 because listener1 is a "once" listener.
+    target.dispatchEvent(new Event(type));
+    assert_equals(listener1CallCount, 1);
+    assert_equals(listener2CallCount, 1);
+    assert_equals(listener3CallCount, 0);
+
+    // Now all listeners are removed - the two "once" listeners have already both
+    // been called once. Add another listener.
+    target.addEventListener(type, listener3);
+  }
+  function listener2() {
+    listener2CallCount++;
+  }
+  function listener3() {
+    listener3CallCount++;
+  }
+
+  // Add two "once" listeners.
+  target.addEventListener(type, listener1, { once: true });
+  target.addEventListener(type, listener2, { once: true });
+
+  // Dispatch the event.
+  target.dispatchEvent(new Event(type));
+
+  // The listener call counts should still match what they were
+  // at the end of listener1.
+  assert_equals(listener1CallCount, 1);
+  assert_equals(listener2CallCount, 1);
+  assert_equals(listener3CallCount, 0);
+
+  // Now that only listener3 is set, dispatch another event. Only
+  // listener3 should be called.
+  target.dispatchEvent(new Event(type));
+  assert_equals(listener1CallCount, 1);
+  assert_equals(listener2CallCount, 1);
+  assert_equals(listener3CallCount, 1);
+}, "Nested usage of once listeners should work.");
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/events/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/events/w3c-import.log
@@ -43,6 +43,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-propagation-stopped.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-redispatch.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-reenter.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-single-activation-behavior.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-target-moved.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-target-removed.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-throwing.html
@@ -92,8 +93,10 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/mouse-event-retarget.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/no-focus-events-at-clicking-editable-content-in-link.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/passive-by-default.html
+/LayoutTests/imported/w3c/web-platform-tests/dom/events/pointer-event-document-move.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/preventDefault-during-activation-behavior.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/relatedTarget.window.js
+/LayoutTests/imported/w3c/web-platform-tests/dom/events/remove-all-listeners.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/replace-event-listener-null-browsing-context-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/shadow-relatedTarget.html
 /LayoutTests/imported/w3c/web-platform-tests/dom/events/webkit-animation-end-event.html

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/dom/events/Event-dispatch-single-activation-behavior-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/dom/events/Event-dispatch-single-activation-behavior-expected.txt
@@ -1,0 +1,134 @@
+
+PASS When clicking child <INPUT type=checkbox></INPUT> of parent <INPUT type=radio></INPUT>, only child should be activated.
+PASS When clicking child <INPUT type=checkbox></INPUT> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated.
+PASS When clicking child <INPUT type=checkbox></INPUT> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.
+PASS When clicking child <INPUT type=checkbox></INPUT> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated.
+PASS When clicking child <INPUT type=checkbox></INPUT> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <INPUT type=checkbox></INPUT> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <INPUT type=checkbox></INPUT> of parent <A></A>, only child should be activated.
+PASS When clicking child <INPUT type=checkbox></INPUT> of parent <AREA></AREA>, only child should be activated.
+PASS When clicking child <INPUT type=checkbox></INPUT> of parent <DETAILS><SUMMARY></SUMMARY></DETAILS>, only child should be activated.
+PASS When clicking child <INPUT type=checkbox></INPUT> of parent <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL>, only child should be activated.
+PASS When clicking child <INPUT type=checkbox></INPUT> of parent <LABEL><BUTTON type=button></BUTTON></LABEL>, only child should be activated.
+PASS When clicking child <INPUT type=radio></INPUT> of parent <INPUT type=checkbox></INPUT>, only child should be activated.
+PASS When clicking child <INPUT type=radio></INPUT> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated.
+PASS When clicking child <INPUT type=radio></INPUT> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.
+PASS When clicking child <INPUT type=radio></INPUT> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated.
+PASS When clicking child <INPUT type=radio></INPUT> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <INPUT type=radio></INPUT> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <INPUT type=radio></INPUT> of parent <A></A>, only child should be activated.
+PASS When clicking child <INPUT type=radio></INPUT> of parent <AREA></AREA>, only child should be activated.
+PASS When clicking child <INPUT type=radio></INPUT> of parent <DETAILS><SUMMARY></SUMMARY></DETAILS>, only child should be activated.
+PASS When clicking child <INPUT type=radio></INPUT> of parent <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL>, only child should be activated.
+PASS When clicking child <INPUT type=radio></INPUT> of parent <LABEL><BUTTON type=button></BUTTON></LABEL>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <INPUT type=checkbox></INPUT>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <INPUT type=radio></INPUT>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <A></A>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <AREA></AREA>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <DETAILS><SUMMARY></SUMMARY></DETAILS>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=submit></INPUT></FORM> of parent <LABEL><BUTTON type=button></BUTTON></LABEL>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <INPUT type=checkbox></INPUT>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <INPUT type=radio></INPUT>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <A></A>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <AREA></AREA>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <DETAILS><SUMMARY></SUMMARY></DETAILS>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=image></INPUT></FORM> of parent <LABEL><BUTTON type=button></BUTTON></LABEL>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <INPUT type=checkbox></INPUT>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <INPUT type=radio></INPUT>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <A></A>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <AREA></AREA>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <DETAILS><SUMMARY></SUMMARY></DETAILS>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL>, only child should be activated.
+PASS When clicking child <FORM><INPUT type=reset></INPUT></FORM> of parent <LABEL><BUTTON type=button></BUTTON></LABEL>, only child should be activated.
+FAIL When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <INPUT type=checkbox></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be Element node <form onsubmit="activated(this); return false" class="act... but got Element node <input class="click activates container test55" type="che... (expected array [Element node <form onsubmit="activated(this); return false" class="act...] got [Element node <input class="click activates container test55" type="che...])
+FAIL When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <INPUT type=radio></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be Element node <form onsubmit="activated(this); return false" class="act... but got Element node <input class="click activates container test56" type="rad... (expected array [Element node <form onsubmit="activated(this); return false" class="act...] got [Element node <input class="click activates container test56" type="rad...])
+PASS When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <A></A>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <AREA></AREA>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <DETAILS><SUMMARY></SUMMARY></DETAILS>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=submit></BUTTON></FORM> of parent <LABEL><BUTTON type=button></BUTTON></LABEL>, only child should be activated.
+FAIL When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <INPUT type=checkbox></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be Element node <form onreset="activated(this)" class="activates test66">... but got Element node <input class="click activates container test66" type="che... (expected array [Element node <form onreset="activated(this)" class="activates test66">...] got [Element node <input class="click activates container test66" type="che...])
+FAIL When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <INPUT type=radio></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be Element node <form onreset="activated(this)" class="activates test67">... but got Element node <input class="click activates container test67" type="rad... (expected array [Element node <form onreset="activated(this)" class="activates test67">...] got [Element node <input class="click activates container test67" type="rad...])
+PASS When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <A></A>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <AREA></AREA>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <DETAILS><SUMMARY></SUMMARY></DETAILS>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL>, only child should be activated.
+PASS When clicking child <FORM><BUTTON type=reset></BUTTON></FORM> of parent <LABEL><BUTTON type=button></BUTTON></LABEL>, only child should be activated.
+FAIL When clicking child <A></A> of parent <INPUT type=checkbox></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be "http://web-platform.test:8800/dom/events/Event-dispatch-single-activation-behavior.html#test77_link" but got Element node <input class="click activates container test77" type="che... (expected array ["http://web-platform.test:8800/dom/events/Event-dispatch-single-activation-behavior.html#test77_link"] got [Element node <input class="click activates container test77" type="che...])
+FAIL When clicking child <A></A> of parent <INPUT type=radio></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be "http://web-platform.test:8800/dom/events/Event-dispatch-single-activation-behavior.html#test78_link" but got Element node <input class="click activates container test78" type="rad... (expected array ["http://web-platform.test:8800/dom/events/Event-dispatch-single-activation-behavior.html#test78_link"] got [Element node <input class="click activates container test78" type="rad...])
+PASS When clicking child <A></A> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated.
+PASS When clicking child <A></A> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.
+PASS When clicking child <A></A> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated.
+PASS When clicking child <A></A> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <A></A> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <A></A> of parent <AREA></AREA>, only child should be activated.
+PASS When clicking child <A></A> of parent <DETAILS><SUMMARY></SUMMARY></DETAILS>, only child should be activated.
+PASS When clicking child <A></A> of parent <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL>, only child should be activated.
+PASS When clicking child <A></A> of parent <LABEL><BUTTON type=button></BUTTON></LABEL>, only child should be activated.
+FAIL When clicking child <AREA></AREA> of parent <INPUT type=checkbox></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be "http://web-platform.test:8800/dom/events/Event-dispatch-single-activation-behavior.html#test88_link" but got Element node <input class="click activates container test88" type="che... (expected array ["http://web-platform.test:8800/dom/events/Event-dispatch-single-activation-behavior.html#test88_link"] got [Element node <input class="click activates container test88" type="che...])
+FAIL When clicking child <AREA></AREA> of parent <INPUT type=radio></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be "http://web-platform.test:8800/dom/events/Event-dispatch-single-activation-behavior.html#test89_link" but got Element node <input class="click activates container test89" type="rad... (expected array ["http://web-platform.test:8800/dom/events/Event-dispatch-single-activation-behavior.html#test89_link"] got [Element node <input class="click activates container test89" type="rad...])
+PASS When clicking child <AREA></AREA> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated.
+PASS When clicking child <AREA></AREA> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.
+PASS When clicking child <AREA></AREA> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated.
+PASS When clicking child <AREA></AREA> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <AREA></AREA> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <AREA></AREA> of parent <A></A>, only child should be activated.
+PASS When clicking child <AREA></AREA> of parent <DETAILS><SUMMARY></SUMMARY></DETAILS>, only child should be activated.
+PASS When clicking child <AREA></AREA> of parent <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL>, only child should be activated.
+PASS When clicking child <AREA></AREA> of parent <LABEL><BUTTON type=button></BUTTON></LABEL>, only child should be activated.
+FAIL When clicking child <DETAILS><SUMMARY></SUMMARY></DETAILS> of parent <INPUT type=checkbox></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be Element node <details ontoggle="activated(this)" class="activates test... but got Element node <input class="click activates container test99" type="che... (expected array [Element node <details ontoggle="activated(this)" class="activates test...] got [Element node <input class="click activates container test99" type="che...])
+FAIL When clicking child <DETAILS><SUMMARY></SUMMARY></DETAILS> of parent <INPUT type=radio></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be Element node <details ontoggle="activated(this)" class="activates test... but got Element node <input class="click activates container test100" type="ra... (expected array [Element node <details ontoggle="activated(this)" class="activates test...] got [Element node <input class="click activates container test100" type="ra...])
+PASS When clicking child <DETAILS><SUMMARY></SUMMARY></DETAILS> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated.
+PASS When clicking child <DETAILS><SUMMARY></SUMMARY></DETAILS> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated.
+PASS When clicking child <DETAILS><SUMMARY></SUMMARY></DETAILS> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated.
+PASS When clicking child <DETAILS><SUMMARY></SUMMARY></DETAILS> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <DETAILS><SUMMARY></SUMMARY></DETAILS> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated.
+PASS When clicking child <DETAILS><SUMMARY></SUMMARY></DETAILS> of parent <A></A>, only child should be activated.
+PASS When clicking child <DETAILS><SUMMARY></SUMMARY></DETAILS> of parent <AREA></AREA>, only child should be activated.
+PASS When clicking child <DETAILS><SUMMARY></SUMMARY></DETAILS> of parent <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL>, only child should be activated.
+PASS When clicking child <DETAILS><SUMMARY></SUMMARY></DETAILS> of parent <LABEL><BUTTON type=button></BUTTON></LABEL>, only child should be activated.
+FAIL When clicking child <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL> of parent <INPUT type=checkbox></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be Element node <input type="checkbox" onclick="this.checked ? activated(... but got Element node <input class="click activates container test110" type="ch... (expected array [Element node <input type="checkbox" onclick="this.checked ? activated(...] got [Element node <input class="click activates container test110" type="ch...])
+FAIL When clicking child <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL> of parent <INPUT type=radio></INPUT>, only child should be activated. assert_array_equals: expected property 0 to be Element node <input type="checkbox" onclick="this.checked ? activated(... but got Element node <input class="click activates container test111" type="ra... (expected array [Element node <input type="checkbox" onclick="this.checked ? activated(...] got [Element node <input class="click activates container test111" type="ra...])
+FAIL When clicking child <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated. assert_array_equals: expected property 0 to be Element node <input type="checkbox" onclick="this.checked ? activated(... but got Element node <form onsubmit="activated(this); return false" class="act... (expected array [Element node <input type="checkbox" onclick="this.checked ? activated(...] got [Element node <form onsubmit="activated(this); return false" class="act...])
+FAIL When clicking child <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated. assert_array_equals: expected property 0 to be Element node <input type="checkbox" onclick="this.checked ? activated(... but got Element node <form onsubmit="activated(this); return false" class="act... (expected array [Element node <input type="checkbox" onclick="this.checked ? activated(...] got [Element node <form onsubmit="activated(this); return false" class="act...])
+FAIL When clicking child <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated. assert_array_equals: expected property 0 to be Element node <input type="checkbox" onclick="this.checked ? activated(... but got Element node <form onreset="activated(this)" class="activates test114"... (expected array [Element node <input type="checkbox" onclick="this.checked ? activated(...] got [Element node <form onreset="activated(this)" class="activates test114"...])
+FAIL When clicking child <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated. assert_array_equals: expected property 0 to be Element node <input type="checkbox" onclick="this.checked ? activated(... but got Element node <form onsubmit="activated(this); return false" class="act... (expected array [Element node <input type="checkbox" onclick="this.checked ? activated(...] got [Element node <form onsubmit="activated(this); return false" class="act...])
+FAIL When clicking child <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated. assert_array_equals: expected property 0 to be Element node <input type="checkbox" onclick="this.checked ? activated(... but got Element node <form onreset="activated(this)" class="activates test116"... (expected array [Element node <input type="checkbox" onclick="this.checked ? activated(...] got [Element node <form onreset="activated(this)" class="activates test116"...])
+PASS When clicking child <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL> of parent <A></A>, only child should be activated.
+PASS When clicking child <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL> of parent <AREA></AREA>, only child should be activated.
+PASS When clicking child <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL> of parent <DETAILS><SUMMARY></SUMMARY></DETAILS>, only child should be activated.
+PASS When clicking child <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL> of parent <LABEL><BUTTON type=button></BUTTON></LABEL>, only child should be activated.
+FAIL When clicking child <LABEL><BUTTON type=button></BUTTON></LABEL> of parent <INPUT type=checkbox></INPUT>, only child should be activated. assert_array_equals: lengths differ, expected array [] length 0, got [Element node <input class="click activates container test121" type="ch...] length 1
+FAIL When clicking child <LABEL><BUTTON type=button></BUTTON></LABEL> of parent <INPUT type=radio></INPUT>, only child should be activated. assert_array_equals: lengths differ, expected array [] length 0, got [Element node <input class="click activates container test122" type="ra...] length 1
+FAIL When clicking child <LABEL><BUTTON type=button></BUTTON></LABEL> of parent <FORM><INPUT type=submit></INPUT></FORM>, only child should be activated. assert_array_equals: lengths differ, expected array [] length 0, got [Element node <form onsubmit="activated(this); return false" class="act...] length 1
+FAIL When clicking child <LABEL><BUTTON type=button></BUTTON></LABEL> of parent <FORM><INPUT type=image></INPUT></FORM>, only child should be activated. assert_array_equals: lengths differ, expected array [] length 0, got [Element node <form onsubmit="activated(this); return false" class="act...] length 1
+FAIL When clicking child <LABEL><BUTTON type=button></BUTTON></LABEL> of parent <FORM><INPUT type=reset></INPUT></FORM>, only child should be activated. assert_array_equals: lengths differ, expected array [] length 0, got [Element node <form onreset="activated(this)" class="activates test125"...] length 1
+FAIL When clicking child <LABEL><BUTTON type=button></BUTTON></LABEL> of parent <FORM><BUTTON type=submit></BUTTON></FORM>, only child should be activated. assert_array_equals: lengths differ, expected array [] length 0, got [Element node <form onsubmit="activated(this); return false" class="act...] length 1
+FAIL When clicking child <LABEL><BUTTON type=button></BUTTON></LABEL> of parent <FORM><BUTTON type=reset></BUTTON></FORM>, only child should be activated. assert_array_equals: lengths differ, expected array [] length 0, got [Element node <form onreset="activated(this)" class="activates test127"...] length 1
+FAIL When clicking child <LABEL><BUTTON type=button></BUTTON></LABEL> of parent <A></A>, only child should be activated. assert_array_equals: lengths differ, expected array [] length 0, got ["http://web-platform.test:8800/dom/events/Event-dispatch-single-activation-behavior.html#test128_link"] length 1
+FAIL When clicking child <LABEL><BUTTON type=button></BUTTON></LABEL> of parent <AREA></AREA>, only child should be activated. assert_array_equals: lengths differ, expected array [] length 0, got ["http://web-platform.test:8800/dom/events/Event-dispatch-single-activation-behavior.html#test129_link"] length 1
+PASS When clicking child <LABEL><BUTTON type=button></BUTTON></LABEL> of parent <DETAILS><SUMMARY></SUMMARY></DETAILS>, only child should be activated.
+PASS When clicking child <LABEL><BUTTON type=button></BUTTON></LABEL> of parent <LABEL><INPUT type=checkbox></INPUT><SPAN></SPAN></LABEL>, only child should be activated.
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/dom/events/pointer-event-document-move-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/dom/events/pointer-event-document-move-expected.txt
@@ -1,0 +1,5 @@
+TEST
+
+
+FAIL Moving a node to new document should move the registered event listeners together assert_true: expected true got false
+

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -243,10 +243,12 @@ void EventTarget::dispatchEvent(Event& event)
     ASSERT(event.isInitialized());
     ASSERT(!event.isBeingDispatched());
 
+    EventPath eventPath { *this };
     event.setTarget(this);
     event.setCurrentTarget(this);
     event.setEventPhase(Event::AT_TARGET);
     event.resetBeforeDispatch();
+    event.setEventPath(eventPath);
     fireEventListeners(event, EventInvokePhase::Capturing);
     fireEventListeners(event, EventInvokePhase::Bubbling);
     event.resetAfterDispatch();


### PR DESCRIPTION
#### c7d9f018702caa871efc4dd4d1d6f04e05908373
<pre>
Constructible EventTarget does create a path during dispatch
<a href="https://bugs.webkit.org/show_bug.cgi?id=275404">https://bugs.webkit.org/show_bug.cgi?id=275404</a>

Reviewed by Wenson Hsieh.

Initialize the path in EventTarget::dispatchEvent. Also synchronize WPT
dom/events (but not dom/events/scrolling) up to this commit:
<a href="https://github.com/web-platform-tests/wpt/commit/33bd9cc8426a14d378cd6b6e4d314f18c7af7773">https://github.com/web-platform-tests/wpt/commit/33bd9cc8426a14d378cd6b6e4d314f18c7af7773</a>

* LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-single-activation-behavior-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/Event-dispatch-single-activation-behavior.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/EventTarget-constructible.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/EventTarget-constructible.any.js:
(test.listener):
(test):
* LayoutTests/imported/w3c/web-platform-tests/dom/events/EventTarget-constructible.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/event-global-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/event-global.html:
* LayoutTests/imported/w3c/web-platform-tests/dom/events/pointer-event-document-move-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/pointer-event-document-move.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/remove-all-listeners-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/remove-all-listeners.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/events/w3c-import.log:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/dom/events/Event-dispatch-single-activation-behavior-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/dom/events/pointer-event-document-move-expected.txt: Added.
* Source/WebCore/dom/EventTarget.cpp:
(WebCore::EventTarget::dispatchEvent):

Canonical link: <a href="https://commits.webkit.org/280014@main">https://commits.webkit.org/280014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9816a40614a4619a4b87a3493c2ae43da908e74

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7950 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58399 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5845 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57460 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6111 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44622 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3996 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57512 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32715 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47814 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25750 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29500 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5142 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3989 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51431 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5410 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59989 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30638 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5535 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52053 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31586 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51513 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12297 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32805 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31471 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->