### PR TITLE
IPC testing API is unable to reply with nullopt optional

### DIFF
--- a/LayoutTests/ipc/async-with-reply-optional-expected.txt
+++ b/LayoutTests/ipc/async-with-reply-optional-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test that async messages can reply with optionals
+

--- a/LayoutTests/ipc/async-with-reply-optional.html
+++ b/LayoutTests/ipc/async-with-reply-optional.html
@@ -1,0 +1,43 @@
+<!doctype html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<title>Test that async messages can reply with optionals</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/ipc.js"></script>
+<body>
+<script>
+async function runTest() {
+    const testerID = 0;
+    const IPCTester_AsyncOptionalExceptionData = IPC.messages.IPCTester_AsyncOptionalExceptionData.name;
+    const IPCTester_AsyncOptionalExceptionDataReply = IPC.messages.IPCTester_AsyncOptionalExceptionDataReply.name;
+
+    for (const processTarget of IPC.processTargets) {
+        // Test starts here.
+        let results = { };
+
+        let connection = IPC.connectionForProcessTarget(processTarget);
+        let result1 = IPC.sendWithPromisedReply(processTarget, testerID, IPCTester_AsyncOptionalExceptionData, [{type: 'bool', value: 0}]);
+        let result2 = IPC.sendWithPromisedReply(processTarget, testerID, IPCTester_AsyncOptionalExceptionData, [{type: 'bool', value: 1}]);
+        let result = await result1;
+        assert_equals(typeof result, "object");
+        assert_equals(typeof result.arguments[0], "undefined");
+        assert_equals(result.arguments[1].type, "String");
+        assert_equals(result.arguments[1].value, "b");
+        result = await result2;
+        assert_equals(typeof result, "object");
+        assert_equals(result.arguments[0].type, "ExceptionData");
+        assert_equals(result.arguments[0].code, "WrongDocumentError");
+        assert_equals(result.arguments[0].message, "m");
+        assert_equals(result.arguments[1].type, "String");
+        assert_equals(result.arguments[1].value, "a");
+    }
+    done();
+}
+
+setup({ single_test: true });
+if (window.IPC)
+    runTest();
+else
+    done();
+
+</script>
+</body>

--- a/Source/WebKit/Platform/IPC/JSIPCBinding.h
+++ b/Source/WebKit/Platform/IPC/JSIPCBinding.h
@@ -50,6 +50,7 @@ namespace WebCore {
 class FloatRect;
 class IntRect;
 class RegistrableDomain;
+struct ExceptionData;
 
 }
 
@@ -60,7 +61,8 @@ class Semaphore;
 template<typename T, std::enable_if_t<!std::is_arithmetic<T>::value && !std::is_enum<T>::value>* = nullptr>
 JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject*, T&&)
 {
-    return JSC::jsUndefined();
+    // Report that we don't recognize this type.
+    return JSC::JSValue();
 }
 
 template<> JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject*, String&&);
@@ -109,6 +111,7 @@ JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject* globalObject, A
 
 template<> JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject*, WebCore::IntRect&&);
 template<> JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject*, WebCore::FloatRect&&);
+template<> JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject*, WebCore::ExceptionData&&);
 
 template<typename U>
 JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject* globalObject, OptionSet<U>&& value)
@@ -126,11 +129,9 @@ template<typename U>
 JSC::JSValue jsValueForDecodedArgumentValue(JSC::JSGlobalObject* globalObject, std::optional<U>&& value)
 {
     if (!value)
-        return JSC::JSValue();
+        return JSC::jsUndefined();
     return jsValueForDecodedArgumentValue(globalObject, std::forward<U>(*value));
 }
-
-bool putJSValueForDecodedArgumentAtIndexOrArrayBufferIfUndefined(JSC::JSGlobalObject*, JSC::JSArray*, unsigned index, JSC::JSValue, std::span<const uint8_t> buffer);
 
 template<typename... Elements>
 std::optional<JSC::JSValue> putJSValueForDecodeArgumentInArray(JSC::JSGlobalObject*, IPC::Decoder&, JSC::JSArray*, size_t currentIndex, std::tuple<Elements...>*);
@@ -150,12 +151,19 @@ std::optional<JSC::JSValue> putJSValueForDecodeArgumentInArray(JSC::JSGlobalObje
     if (!value)
         return std::nullopt;
 
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
     auto jsValue = jsValueForDecodedArgumentValue(globalObject, WTFMove(*value));
-    if (jsValue.isEmpty())
-        return jsValue;
-
-    auto span = decoder.span().subspan(startingBufferOffset, decoder.currentBufferOffset() - startingBufferOffset);
-    putJSValueForDecodedArgumentAtIndexOrArrayBufferIfUndefined(globalObject, array, currentIndex, jsValue, span);
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
+    if (jsValue.isEmpty()) {
+        // Create array buffers out of types we don't recognize.
+        auto span = decoder.span().subspan(startingBufferOffset, decoder.currentBufferOffset() - startingBufferOffset);
+        auto arrayBuffer = JSC::ArrayBuffer::create(span);
+        if (auto* structure = globalObject->arrayBufferStructure(arrayBuffer->sharingMode()))
+            jsValue = JSC::JSArrayBuffer::create(Ref { globalObject->vm() }, structure, WTFMove(arrayBuffer));
+        RETURN_IF_EXCEPTION(scope, std::nullopt);
+    }
+    array->putDirectIndex(globalObject, currentIndex, jsValue);
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
 
     std::tuple<Elements...>* dummyArguments = nullptr;
     return putJSValueForDecodeArgumentInArray<Elements...>(globalObject, decoder, array, currentIndex + 1, dummyArguments);

--- a/Source/WebKit/Shared/IPCTester.cpp
+++ b/Source/WebKit/Shared/IPCTester.cpp
@@ -35,6 +35,7 @@
 #include "IPCTesterReceiverMessages.h"
 #include "IPCUtilities.h"
 
+#include <WebCore/ExceptionData.h>
 #include <atomic>
 #include <dlfcn.h>
 #include <stdio.h>
@@ -216,6 +217,15 @@ void IPCTester::syncPingEmptyReply(IPC::Connection&, uint32_t value, CompletionH
 {
     UNUSED_PARAM(value);
     completionHandler();
+}
+
+void IPCTester::asyncOptionalExceptionData(IPC::Connection&, bool sendEngaged, CompletionHandler<void(std::optional<WebCore::ExceptionData>, String)>&& completionHandler)
+{
+    if (sendEngaged) {
+        completionHandler(WebCore::ExceptionData { WebCore::ExceptionCode::WrongDocumentError, "m"_s }, "a"_s);
+        return;
+    }
+    completionHandler(std::nullopt, "b"_s);
 }
 
 void IPCTester::stopIfNeeded()

--- a/Source/WebKit/Shared/IPCTester.h
+++ b/Source/WebKit/Shared/IPCTester.h
@@ -74,6 +74,7 @@ private:
     void asyncPing(uint32_t value, CompletionHandler<void(uint32_t)>&&);
     void syncPing(IPC::Connection&, uint32_t value, CompletionHandler<void(uint32_t)>&&);
     void syncPingEmptyReply(IPC::Connection&, uint32_t value, CompletionHandler<void()>&&);
+    void asyncOptionalExceptionData(IPC::Connection&, bool sendEngaged, CompletionHandler<void(std::optional<WebCore::ExceptionData>, String)>&&);
 
     void stopIfNeeded();
 

--- a/Source/WebKit/Shared/IPCTester.messages.in
+++ b/Source/WebKit/Shared/IPCTester.messages.in
@@ -40,6 +40,7 @@ messages -> IPCTester NotRefCounted {
     SyncPingEmptyReply(uint32_t value) -> () Synchronous
 
     SendAsyncMessageToReceiver(uint32_t arg0)
+    AsyncOptionalExceptionData(bool sendEngaged) -> (std::optional<WebCore::ExceptionData> exceptionData, String other)
 }
 
 #endif

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -527,8 +527,8 @@ static JSValueRef jsSendWithAsyncReply(IPC::Connection& connection, uint64_t des
                 jsResult = jsResultFromReplyDecoder(globalObject, messageName, *replyDecoder);
             JSValueRef arguments[1] = { nullptr };
             if (auto* exception = scope.exception()) {
-                scope.clearException();
                 arguments[0] = toRef(globalObject, exception);
+                scope.clearException();
             } else
                 arguments[0] = toRef(globalObject, jsResult);
             JSObjectCallAsFunction(context, callback, callback, 1, arguments, nullptr);


### PR DESCRIPTION
#### 8ebae84b5572e076d84b8ead18258c48a72e9280
<pre>
IPC testing API is unable to reply with nullopt optional
<a href="https://bugs.webkit.org/show_bug.cgi?id=275409">https://bugs.webkit.org/show_bug.cgi?id=275409</a>
<a href="https://rdar.apple.com/129669346">rdar://129669346</a>

Reviewed by Cameron McCormack.

Decoding std::optional would return empty JSValue (JSValue()) if the
optional was std::nullopt. This would be interpreted as a decoding
failure.

Fix this by returning the more natural value, jsUndefined value. Fix the
result array construction to not use jsUndefined to signify that the
value should be a array buffer containing the data. Use empty JSValue to
signify this. Use exception scope to detect when JS exception would
cancel the decoding as a decoding failure.

Decoding failures would use the already cleared exception as the result
JS object, causing a crash.

Fix by first constructing the JS value, then clearing the exception from
the scope.

Add decoder for WebCore::ExceptionData, to be used in testing the
message this problem was noted.

* LayoutTests/ipc/async-with-reply-optional.html: Added.
* Source/WebKit/Platform/IPC/JSIPCBinding.cpp:
(IPC::jsValueForDecodedArgumentValue):
(IPC::putJSValueForDecodedArgumentAtIndexOrArrayBufferIfUndefined): Deleted.
* Source/WebKit/Platform/IPC/JSIPCBinding.h:
(IPC::jsValueForDecodedArgumentValue):
(IPC::putJSValueForDecodeArgumentInArray):
* Source/WebKit/Shared/IPCTester.cpp:
(WebKit::IPCTester::asyncOptionalExceptionData):
* Source/WebKit/Shared/IPCTester.h:
* Source/WebKit/Shared/IPCTester.messages.in:
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::jsSendWithAsyncReply):

Canonical link: <a href="https://commits.webkit.org/279999@main">https://commits.webkit.org/279999@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a57230c6dea695abb2d30370adc2040879a8f70

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7955 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58475 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5921 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6116 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/4059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57517 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/32720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/47820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/25811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/29505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/5148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4065 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/5416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60065 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30643 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/5540 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31727 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/47890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32810 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8174 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31476 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->