### PR TITLE
AX: Add test coverage for aria-labelledby when it points to hidden text.

### DIFF
--- a/LayoutTests/accessibility/aria-labelledby-hidden-text-expected.txt
+++ b/LayoutTests/accessibility/aria-labelledby-hidden-text-expected.txt
@@ -1,0 +1,10 @@
+Tests that labels specified via aria-lablledby and aria-label are retrieved according to ARIA specifications in cases where the label text is hidden.
+
+PASS: axButton.title === `AXTitle: ${button.getAttribute('data-expectedlabel')}`
+PASS: axButton.title === `AXTitle: ${button.getAttribute('data-expectedlabel')}`
+PASS: axButton.title === `AXTitle: ${button.getAttribute('data-expectedlabel')}`
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/aria-labelledby-hidden-text.html
+++ b/LayoutTests/accessibility/aria-labelledby-hidden-text.html
@@ -1,0 +1,41 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<button id="button1" aria-labelledby="span1" aria-label="foo" data-expectedlabel="label">
+  <span id="span1" style="display:none;">
+    <span id="span2" style="display:none;">label</span>
+  </span>
+</button>
+
+<button id="button2" aria-labelledby="span3" aria-label="foo" data-expectedlabel="label">
+  <span id="span3" style="visibility:hidden;">
+    <span id="span4" style="visibility:hidden;">label</span>
+  </span>
+</button>
+
+<button id="button3" aria-labelledby="span5" aria-label="foo" data-expectedlabel="foo">
+  <span id="span5">
+    <span id="span6" style="visibility:hidden;">label</span>
+  </span>
+</button>
+
+<script>
+let output = "Tests that labels specified via aria-lablledby and aria-label are retrieved according to ARIA specifications in cases where the label text is hidden.\n\n";
+
+if (window.accessibilityController) {
+    for (let i = 1; i <= 3; ++i) {
+        button = document.getElementById(`button${i}`);
+        axButton = accessibilityController.accessibleElementById(`button${i}`);
+        output += expect("axButton.title", "`AXTitle: ${button.getAttribute('data-expectedlabel')}`");
+    }
+
+    debug(output);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### f98bdf4649bae12b630dd37419e16c0378f75852
<pre>
AX: Add test coverage for aria-labelledby when it points to hidden text.
<a href="https://bugs.webkit.org/show_bug.cgi?id=275414">https://bugs.webkit.org/show_bug.cgi?id=275414</a>
&lt;<a href="https://rdar.apple.com/problem/129703505">rdar://problem/129703505</a>&gt;

Reviewed by Chris Fleizach.

We were missing these test cases spelled out in ARIA specs and in WPT tests where aria-labelledby points to hidden text.

* LayoutTests/accessibility/aria-labelledby-hidden-text-expected.txt: Added.
* LayoutTests/accessibility/aria-labelledby-hidden-text.html: Added.

Canonical link: <a href="https://commits.webkit.org/279974@main">https://commits.webkit.org/279974@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c42995453eb80b25ba732ad3705b855c18e1902d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55048 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7659 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58330 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5780 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42071 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5816 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44571 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3946 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47696 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25694 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29375 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5041 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3924 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59920 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30325 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5424 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/51998 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31450 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47765 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51449 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12109 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32476 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31241 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->