### PR TITLE
[WebGPU] Exception thrown in Queue::commandBufferWithDescriptor when newSharedEvent returns nil

### DIFF
--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -143,8 +143,8 @@ std::pair<id<MTLCommandBuffer>, id<MTLSharedEvent>> Queue::commandBufferWithDesc
         WTFLogAlways("Metal capture enabled: %s", captureEnabled ? "YES" : "NO");
     });
     if (devicePtr && [buffer respondsToSelector:@selector(encodeConditionalAbortEvent:)] && !captureEnabled) {
-        sharedEvent = [devicePtr->device() newSharedEvent];
-        [(id<MTLCommandBufferSPI>)buffer encodeConditionalAbortEvent:sharedEvent];
+        if ((sharedEvent = [devicePtr->device() newSharedEvent]))
+            [(id<MTLCommandBufferSPI>)buffer encodeConditionalAbortEvent:sharedEvent];
     }
 
     return std::make_pair(buffer, sharedEvent);


### PR DESCRIPTION
#### 3963a92c82c11694752a00d0050cc3168b2a73c8
<pre>
[WebGPU] Exception thrown in Queue::commandBufferWithDescriptor when newSharedEvent returns nil
<a href="https://bugs.webkit.org/show_bug.cgi?id=275417">https://bugs.webkit.org/show_bug.cgi?id=275417</a>
&lt;radar://129708391&gt;

Reviewed by Dan Glastonbury.

It is unclear why newSharedEvent returns nil, but I have seen it occur
occassionally running <a href="http://chat.webllm.ai">http://chat.webllm.ai</a>

There is no harm not creating the shared event, but the command buffer will
needlessly stay around until it reaches zero references and ARC deallocs it,
but only for command buffers which are not committed.

* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::commandBufferWithDescriptor):

Canonical link: <a href="https://commits.webkit.org/279975@main">https://commits.webkit.org/279975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8371518ba612b2c3a8a472c4e7e610de0548f0e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55054 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58336 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5786 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5823 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44575 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3951 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57149 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32595 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47701 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25699 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29379 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3930 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51239 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5281 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59926 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5456 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52004 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47770 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51463 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12111 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32482 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31247 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->