### PR TITLE
[WASM] V128 should be throwable to match Chrome and the spec

### DIFF
--- a/JSTests/wasm/stress/big-try-simd.js
+++ b/JSTests/wasm/stress/big-try-simd.js
@@ -48,7 +48,7 @@ async function test() {
     const { test } = instance.exports
 
     for (let i = 0; i < 10000; ++i) {
-        assert.throws(() => test(42), TypeError, "an exported wasm function cannot contain a v128 parameter or return value")
+        assert.eq(test(42), undefined);
     }
 }
 

--- a/JSTests/wasm/stress/exception-containing-v128.js
+++ b/JSTests/wasm/stress/exception-containing-v128.js
@@ -1,0 +1,109 @@
+//@ skip unless $isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = `
+(module
+    (tag $vtag (export "vtag") (param v128))
+
+    (func (export "testCatchOwnV128") (result i32)
+        try (result i32)
+            v128.const i32x4 0 0 42 0
+            throw $vtag
+        catch $vtag
+            i32x4.extract_lane 2
+        end
+    )
+
+    (func $innerFunc
+        v128.const i32x4 0 42 0 0
+        throw $vtag
+    )
+
+    (func (export "testCatchCalleeV128") (result i32)
+        try (result i32)
+            call $innerFunc
+            i32.const 0
+        catch $vtag
+            i32x4.extract_lane 1
+        end
+    )
+
+    (tag $interleaved (param v128 i32 v128 f32 v128 i64 v128 f64 v128 f32 i64 v128 f64 i32 v128))
+
+    (func $throwsInterleaved
+        v128.const i32x4 1 2 3 4
+        i32.const 43
+        v128.const i32x4 1 2 3 4
+        f32.const 43
+        v128.const i32x4 1 2 3 4
+        i64.const 43
+        v128.const i32x4 1 2 3 4
+        f64.const 43
+        v128.const i32x4 1 2 3 4
+        f32.const 43
+        i64.const 43
+        v128.const i32x4 1 2 3 4
+        f64.const 43
+        i32.const 43
+        v128.const i32x4 1 2 3 4
+        throw $interleaved
+    )
+
+    (func (export "testLotsOfInterleavedTypes") (result i32) (local v128 v128 v128 v128 v128 v128 v128)
+        try (result i32)
+            call $throwsInterleaved
+            i32.const 0
+        catch $interleaved
+            local.set 0
+            drop
+            drop
+            local.set 1
+            drop
+            drop
+            local.set 2
+            drop
+            local.set 3
+            drop
+            local.set 4
+            drop
+            local.set 5
+            drop
+            local.set 6
+            local.get 0
+            local.get 1
+            local.get 2
+            local.get 3
+            local.get 4
+            local.get 5
+            local.get 6
+            i32x4.add
+            i32x4.add
+            i32x4.add
+            i32x4.add
+            i32x4.add
+            i32x4.add
+            local.tee 0
+            i32x4.extract_lane 1
+            local.get 0
+            i32x4.extract_lane 3
+            i32.add
+        end
+    )
+
+    (func (export "testThrowV128ToJS")
+        v128.const i32x4 0 0 0 0
+        throw $vtag
+    )
+)
+`;
+
+async function test() {
+    const instance = await instantiate(wat, {}, { exceptions: true, simd: true });
+    assert.eq(instance.exports.testCatchOwnV128(), 42);
+    assert.eq(instance.exports.testCatchCalleeV128(), 42);
+    assert.eq(instance.exports.testLotsOfInterleavedTypes(), 42);
+    assert.throws(() => instance.exports.testThrowV128ToJS(), WebAssembly.Exception);
+}
+
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/import-exception-tag-with-v128.js
+++ b/JSTests/wasm/stress/import-exception-tag-with-v128.js
@@ -1,0 +1,57 @@
+//@ skip unless $isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = `
+(module
+    (import "tags" "vtag" (tag $vtag (param v128)))
+    (import "tags" "vvtag" (tag $vvtag (param v128 v128)))
+    (import "tags" "vitag" (tag $vitag (param v128 i32)))
+
+    (func (export "testThrowV128") (result i32)
+        try (result i32)
+            v128.const i32x4 0 0 42 0
+            throw $vtag
+        catch $vtag
+            i32x4.extract_lane 2
+        end
+    )
+
+    (func (export "testThrowV128Pair") (result i32)
+        try (result i32)
+            v128.const i32x4 0 21 42 0
+            v128.const i32x4 0 21 42 0
+            throw $vvtag
+        catch $vvtag
+            i32x4.add
+            i32x4.extract_lane 1
+        end
+    )
+
+    (func (export "testThrowV128AndI32") (result i32)
+        try (result i32)
+            v128.const i32x4 1 2 3 4
+            i32.const 42
+            throw $vitag
+        catch $vitag
+            br 0
+        end
+    )
+)
+`;
+
+async function test() {
+    const vtag = new WebAssembly.Tag({ parameters: ["v128"] });
+    const vvtag = new WebAssembly.Tag({ parameters: ["v128", "v128"] });
+    const vitag = new WebAssembly.Tag({ parameters: ["v128", "i32"] });
+    const instance = await instantiate(wat, { tags: {
+        vtag: vtag,
+        vvtag: vvtag,
+        vitag: vitag
+    } }, { exceptions: true, simd: true });
+    assert.eq(instance.exports.testThrowV128(), 42);
+    assert.eq(instance.exports.testThrowV128Pair(), 42);
+    assert.eq(instance.exports.testThrowV128AndI32(), 42);
+}
+
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/tuple-and-simd.js
+++ b/JSTests/wasm/stress/tuple-and-simd.js
@@ -9,4 +9,4 @@ var f = wasm_instance.exports.main;
 
 assert.throws(() => {
     f();
-}, TypeError, `an exported wasm function cannot contain a v128 parameter or return value`);
+}, WebAssembly.Exception);

--- a/JSTests/wasm/v8/exceptions-simd.js
+++ b/JSTests/wasm/v8/exceptions-simd.js
@@ -23,9 +23,8 @@ load("exceptions-utils.js");
       .exportFunc();
   var instance = builder.instantiate();
 
-  // NOTE: changed from original test since this part of the spec is still in flux.
   for (let i = 0; i < 1000; ++i)
-    assertThrows(() => instance.exports.throw_simd());
+    assertThrows(() => instance.exports.throw_simd(), WebAssembly.Exception);
 })();
 
 (function TestThrowCatchS128Default() {
@@ -49,7 +48,7 @@ load("exceptions-utils.js");
   var instance = builder.instantiate();
 
   for (let i = 0; i < 1000; ++i)
-    assertThrows(() => instance.exports.throw_catch_simd());
+    assertEquals(1, instance.exports.throw_catch_simd());
 })();
 
 (function TestThrowCatchS128WithValue() {
@@ -78,8 +77,9 @@ load("exceptions-utils.js");
   var ref = [0x01, 0x12, 0x23, 0x34, 0x45, 0x56, 0x67, 0x78,
              0x89, 0x9a, 0xab, 0xbc, 0xcd, 0xde, 0xef, 0xf0];
   var array = new Uint8Array(memory.buffer);
-  array.set(ref, in_idx);  // Store reference value in memory.
-  for (let i = 0; i < 1000; ++i)
-    assertThrows(() => instance.exports.throw_catch_simd());
-  // assertArrayEquals(ref, array.slice(out_idx, out_idx + 0x10));
+  for (let i = 0; i < 1000; ++i) {
+    array.set(ref, in_idx);  // Store reference value in memory.
+    instance.exports.throw_catch_simd();
+    assertArrayEquals(ref, array.slice(out_idx, out_idx + 0x10));
+  }
 })();

--- a/Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerStackArgs.cpp
@@ -44,11 +44,10 @@ void lowerStackArgs(Code& code)
         for (Inst& inst : *block) {
             for (Arg& arg : inst.args) {
                 if (arg.isCallArg()) {
-                    // For now, we assume that we use 8 bytes of the call arg. But that's not
-                    // such an awesome assumption.
-                    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=150454
                     ASSERT(arg.offset() >= 0);
-                    code.requestCallArgAreaSizeInBytes(arg.offset() + (code.usesSIMD() ? conservativeRegisterBytes(arg.bank()) : conservativeRegisterBytesWithoutVectors(arg.bank())));
+                    // We always check the conservative register bytes for Bank::FP because
+                    // CallArgs do not store which bank they are.
+                    code.requestCallArgAreaSizeInBytes(arg.offset() + (code.usesSIMD() ? conservativeRegisterBytes(Bank::FP) : conservativeRegisterBytesWithoutVectors(Bank::FP)));
                 }
             }
         }

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp
@@ -2898,13 +2898,14 @@ void BBQJIT::emitCatchImpl(ControlData& dataCatch, const TypeDefinition& excepti
         ScratchScope<1, 0> scratches(*this);
         GPRReg bufferGPR = scratches.gpr(0);
         m_jit.loadPtr(Address(GPRInfo::returnValueGPR, JSWebAssemblyException::offsetOfPayload() + JSWebAssemblyException::Payload::offsetOfStorage()), bufferGPR);
+        unsigned offset = 0;
         for (unsigned i = 0; i < exceptionSignature.as<FunctionSignature>()->argumentCount(); ++i) {
             Type type = exceptionSignature.as<FunctionSignature>()->argumentType(i);
             Value result = Value::fromTemp(type.kind, dataCatch.enclosedHeight() + dataCatch.implicitSlots() + i);
             Location slot = canonicalSlot(result);
             switch (type.kind) {
             case TypeKind::I32:
-                m_jit.load32(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + i * sizeof(uint64_t)), wasmScratchGPR);
+                m_jit.load32(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), wasmScratchGPR);
                 m_jit.store32(wasmScratchGPR, slot.asAddress());
                 break;
             case TypeKind::I31ref:
@@ -2926,20 +2927,20 @@ void BBQJIT::emitCatchImpl(ControlData& dataCatch, const TypeDefinition& excepti
             case TypeKind::Array:
             case TypeKind::Struct:
             case TypeKind::Func: {
-                m_jit.loadPair32(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + i * sizeof(uint64_t)), wasmScratchGPR, wasmScratchGPR2);
+                m_jit.loadPair32(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), wasmScratchGPR, wasmScratchGPR2);
                 m_jit.storePair32(wasmScratchGPR, wasmScratchGPR2, slot.asAddress());
                 break;
             }
             case TypeKind::F32:
-                m_jit.loadFloat(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + i * sizeof(uint64_t)), wasmScratchFPR);
+                m_jit.loadFloat(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), wasmScratchFPR);
                 m_jit.storeFloat(wasmScratchFPR, slot.asAddress());
                 break;
             case TypeKind::F64:
-                m_jit.loadDouble(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + i * sizeof(uint64_t)), wasmScratchFPR);
+                m_jit.loadDouble(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), wasmScratchFPR);
                 m_jit.storeDouble(wasmScratchFPR, slot.asAddress());
                 break;
             case TypeKind::V128:
-                materializeVectorConstant(v128_t { }, Location::fromFPR(wasmScratchFPR));
+                m_jit.loadVector(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), wasmScratchFPR);
                 m_jit.storeVector(wasmScratchFPR, slot.asAddress());
                 break;
             case TypeKind::Void:
@@ -2948,6 +2949,7 @@ void BBQJIT::emitCatchImpl(ControlData& dataCatch, const TypeDefinition& excepti
             }
             bind(result, slot);
             results.append(result);
+            offset += type.kind == TypeKind::V128 ? 2 : 1;
         }
     }
 }

--- a/Source/JavaScriptCore/wasm/WasmExceptionType.h
+++ b/Source/JavaScriptCore/wasm/WasmExceptionType.h
@@ -68,6 +68,7 @@ namespace Wasm {
     macro(NullStructGet, "struct.get to a null reference"_s) \
     macro(NullStructSet, "struct.set to a null reference"_s) \
     macro(TypeErrorInvalidV128Use, "an exported wasm function cannot contain a v128 parameter or return value"_s) \
+    macro(TypeErrorV128TagAccessInJS, "a v128 parameter of a tag may not be accessed from JS"_s) \
     macro(NullRefAsNonNull, "ref.as_non_null to a null reference"_s) \
     macro(CastFailure, "ref.cast failed to cast reference to target heap type"_s) \
     macro(OutOfBoundsDataSegmentAccess, "Offset + array length would exceed the size of a data segment"_s) \
@@ -138,6 +139,7 @@ ALWAYS_INLINE bool isTypeErrorExceptionType(ExceptionType type)
     case ExceptionType::FuncrefNotWasm:
     case ExceptionType::InvalidGCTypeUse:
     case ExceptionType::TypeErrorInvalidV128Use:
+    case ExceptionType::TypeErrorV128TagAccessInJS:
         return true;
     }
     return false;

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -4330,10 +4330,12 @@ PatchpointExceptionHandle OMGIRGenerator::preparePatchpointForExceptions(BasicBl
 auto OMGIRGenerator::addCatchToUnreachable(unsigned exceptionIndex, const TypeDefinition& signature, ControlType& data, ResultList& results) -> PartialResult
 {
     Value* payload = emitCatchImpl(CatchKind::Catch, data, exceptionIndex);
+    unsigned offset = 0;
     for (unsigned i = 0; i < signature.as<FunctionSignature>()->argumentCount(); ++i) {
         Type type = signature.as<FunctionSignature>()->argumentType(i);
-        Value* value = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, toB3Type(type), origin(), payload, i * sizeof(uint64_t));
+        Value* value = m_currentBlock->appendNew<MemoryValue>(m_proc, Load, toB3Type(type), origin(), payload, offset * sizeof(uint64_t));
         results.append(push(value));
+        offset += type.kind == TypeKind::V128 ? 2 : 1;
     }
     TRACE_CF("CATCH");
     return { };
@@ -4433,14 +4435,12 @@ auto OMGIRGenerator::addThrow(unsigned exceptionIndex, Vector<ExpressionType>& a
     PatchpointValue* patch = m_proc.add<PatchpointValue>(B3::Void, origin(), cloningForbidden(Patchpoint));
     patch->effects.terminal = true;
     patch->append(instanceValue(), ValueRep::reg(GPRInfo::argumentGPR0));
-    for (unsigned i = 0; i < args.size(); ++i) {
-        // Note: SIMD values can appear here, but should never be read at runtime because this will throw an un-catchable TypeError instead.
-        // Nonetheless, they may clobber important things if they aren't treated as doubles.
-        auto arg = get(args[i]);
-        if (args[i]->type().isVector())
-            arg = constant(Double, 0);
-        patch->append(arg, ValueRep::stackArgument(i * sizeof(EncodedJSValue)));
+    unsigned offset = 0;
+    for (auto arg : args) {
+        patch->append(get(arg), ValueRep::stackArgument(offset * sizeof(EncodedJSValue)));
+        offset += arg->type().isVector() ? 2 : 1;
     }
+    m_maxNumJSCallArguments = std::max(m_maxNumJSCallArguments, offset);
     patch->clobber(RegisterSetBuilder::registersToSaveForJSCall(m_proc.usesSIMD() ? RegisterSetBuilder::allRegisters() : RegisterSetBuilder::allScalarRegisters()));
     PatchpointExceptionHandle handle = preparePatchpointForExceptions(m_currentBlock, patch);
     patch->setGenerator([this, exceptionIndex, handle] (CCallHelpers& jit, const B3::StackmapGenerationParams& params) {

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -979,18 +979,13 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmThrow, void*, (Instance* instance
 
     const Wasm::Tag& tag = instance->tag(exceptionIndex);
 
-    FixedVector<uint64_t> values(tag.parameterCount());
-    for (unsigned i = 0; i < tag.parameterCount(); ++i)
+    FixedVector<uint64_t> values(tag.parameterBufferSize());
+    for (unsigned i = 0; i < tag.parameterBufferSize(); ++i)
         values[i] = arguments[i];
 
     ASSERT(tag.type().returnsVoid());
-    if (tag.type().numVectors()) {
-        // Note: the spec is still in flux on what to do here, so we conservatively just disallow throwing any vectors.
-        throwException(globalObject, throwScope, createTypeError(globalObject, errorMessageForExceptionType(Wasm::ExceptionType::TypeErrorInvalidV128Use)));
-    } else {
-        JSWebAssemblyException* exception = JSWebAssemblyException::create(vm, globalObject->webAssemblyExceptionStructure(), tag, WTFMove(values));
-        throwException(globalObject, throwScope, exception);
-    }
+    JSWebAssemblyException* exception = JSWebAssemblyException::create(vm, globalObject->webAssemblyExceptionStructure(), tag, WTFMove(values));
+    throwException(globalObject, throwScope, exception);
 
     genericUnwind(vm, callFrame);
     ASSERT(!!vm.callFrameForCatch);

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -1032,8 +1032,8 @@ WASM_SLOW_PATH_DECL(throw)
     auto instruction = pc->as<WasmThrow>();
     const Wasm::Tag& tag = instance->tag(instruction.m_exceptionIndex);
 
-    FixedVector<uint64_t> values(tag.parameterCount());
-    for (unsigned i = 0; i < tag.parameterCount(); ++i)
+    FixedVector<uint64_t> values(tag.parameterBufferSize());
+    for (unsigned i = 0; i < tag.parameterBufferSize(); ++i)
         values[i] = READ((instruction.m_firstValue - i)).encodedJSValue();
 
     JSWebAssemblyException* exception = JSWebAssemblyException::create(vm, globalObject->webAssemblyExceptionStructure(), tag, WTFMove(values));

--- a/Source/JavaScriptCore/wasm/WasmTag.h
+++ b/Source/JavaScriptCore/wasm/WasmTag.h
@@ -39,6 +39,15 @@ public:
     static Ref<Tag> create(const TypeDefinition& type) { return adoptRef(*new Tag(type)); }
 
     FunctionArgCount parameterCount() const { return m_type->as<FunctionSignature>()->argumentCount(); }
+
+    size_t parameterBufferSize() const
+    {
+        size_t result = 0;
+        for (size_t i = 0; i < parameterCount(); i ++)
+            result += m_type->as<FunctionSignature>()->argumentType(i).kind == TypeKind::V128 ? 2 : 1;
+        return result;
+    }
+
     Type parameter(FunctionArgCount i) const { return m_type->as<FunctionSignature>()->argumentType(i); }
     TypeIndex typeIndex() const { return m_type->index(); }
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyException.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyException.cpp
@@ -26,6 +26,8 @@
 
 #include "config.h"
 #include "JSWebAssemblyException.h"
+#include "WasmExceptionType.h"
+#include "WasmTypeDefinition.h"
 
 #if ENABLE(WEBASSEMBLY)
 
@@ -59,9 +61,11 @@ void JSWebAssemblyException::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 
     auto* exception = jsCast<JSWebAssemblyException*>(cell);
     const auto& tagType = exception->tag().type();
+    unsigned offset = 0;
     for (unsigned i = 0; i < tagType.argumentCount(); ++i) {
         if (isRefType(tagType.argumentType(i)))
-            visitor.append(bitwise_cast<WriteBarrier<Unknown>>(exception->payload()[i]));
+            visitor.append(bitwise_cast<WriteBarrier<Unknown>>(exception->payload()[offset]));
+        offset += tagType.argumentType(i).kind == Wasm::TypeKind::V128 ? 2 : 1;
     }
 }
 
@@ -74,8 +78,18 @@ void JSWebAssemblyException::destroy(JSCell* cell)
 
 JSValue JSWebAssemblyException::getArg(JSGlobalObject* globalObject, unsigned i) const
 {
-    ASSERT(i < tag().type().argumentCount());
-    return toJSValue(globalObject, tag().type().argumentType(i), payload()[i]);
+    const auto& tagType = tag().type();
+    ASSERT(i < tagType.argumentCount());
+
+    // It feels like maybe we should throw an exception here, but as far as I can tell,
+    // the current draft spec just asserts that we can't getArg a v128. Maybe we can
+    // revisit this later.
+    RELEASE_ASSERT(tagType.argumentType(i).kind != Wasm::TypeKind::V128);
+
+    unsigned offset = 0;
+    for (unsigned j = 0; j < i; ++j)
+        offset += tagType.argumentType(j).kind == Wasm::TypeKind::V128 ? 2 : 1;
+    return toJSValue(globalObject, tagType.argumentType(i), payload()[offset]);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyTagConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyTagConstructor.cpp
@@ -71,6 +71,8 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyTag, (JSGlobalObject* globalObjec
             type = Wasm::Types::F32;
         else if (valueString == "f64"_s)
             type = Wasm::Types::F64;
+        else if (valueString == "v128"_s)
+            type = Wasm::Types::V128;
         else if (valueString == "funcref"_s || valueString == "anyfunc"_s)
             type = Wasm::funcrefType();
         else if (valueString == "externref"_s)


### PR DESCRIPTION
#### eba05a59d7020b58706e5db7bbab8f5ec2c5f2b2
<pre>
[WASM] V128 should be throwable to match Chrome and the spec
<a href="https://bugs.webkit.org/show_bug.cgi?id=275383">https://bugs.webkit.org/show_bug.cgi?id=275383</a>
<a href="https://rdar.apple.com/106030051">rdar://106030051</a>

Reviewed by Yusuke Suzuki.

Adds support for v128 parameters in tags to BBQ and OMG tiers and the
WASM/JS interface.

* JSTests/wasm/stress/exception-containing-v128.js: Added.
(async test):
* JSTests/wasm/stress/import-exception-tag-with-v128.js: Added.
(async test):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addThrow):
* Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitCatchImpl):
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitCatchImpl):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addCatchToUnreachable):
(JSC::Wasm::OMGIRGenerator::addThrow):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::addCatchToUnreachable):
(JSC::Wasm::OMGIRGenerator::addThrow):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_SLOW_PATH_DECL):
* Source/JavaScriptCore/wasm/WasmTag.h:
* Source/JavaScriptCore/wasm/js/WebAssemblyTagConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/279989@main">https://commits.webkit.org/279989@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bdb58b9a26878bf356eed82b9745575a5324d99

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55447 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7911 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58433 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5879 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42390 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6073 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44649 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4022 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32679 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47781 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25777 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29464 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5109 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4023 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/48526 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51398 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5377 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60023 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/54685 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30598 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5504 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52079 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31682 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51546 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12268 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32765 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/66948 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/31431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12760 "Passed tests") | 
<!--EWS-Status-Bubble-End-->