### PR TITLE
[MiniBrowser] Add setting to configure WKWebpagePreferences.allowsContentJavascript

### DIFF
--- a/Tools/MiniBrowser/mac/SettingsController.h
+++ b/Tools/MiniBrowser/mac/SettingsController.h
@@ -67,6 +67,7 @@ typedef NS_ENUM(NSInteger, AttachmentElementEnabledState) {
 @property (nonatomic, readonly) BOOL networkCacheSpeculativeRevalidationDisabled;
 @property (nonatomic, readonly) BOOL advancedPrivacyProtectionsEnabled;
 @property (nonatomic, readonly) BOOL siteIsolationOverlayEnabled;
+@property (nonatomic, readonly) BOOL allowsContentJavascript;
 
 @property (nonatomic, readonly) NSString *defaultURL;
 @property (nonatomic, readonly) NSString *customUserAgent;

--- a/Tools/MiniBrowser/mac/SettingsController.m
+++ b/Tools/MiniBrowser/mac/SettingsController.m
@@ -69,6 +69,7 @@ static NSString * const DataDetectorsEnabledPreferenceKey = @"DataDetectorsEnabl
 static NSString * const UseMockCaptureDevicesPreferenceKey = @"UseMockCaptureDevices";
 static NSString * const AttachmentElementEnabledPreferenceKey = @"AttachmentElementEnabled";
 static NSString * const AdvancedPrivacyProtectionsPreferenceKey = @"AdvancedPrivacyProtectionsEnabled";
+static NSString * const AllowsContentJavascriptPreferenceKey = @"AllowsContentJavascript";
 
 static NSString * const SiteIsolationOverlayPreferenceKey = @"SiteIsolationOverlayEnabled";
 
@@ -108,6 +109,7 @@ typedef NS_ENUM(NSInteger, AttachmentElementEnabledMenuItemTag) {
         AnimatedImageAsyncDecodingEnabledPreferenceKey,
         WebViewFillsWindowKey,
         ResourceLoadStatisticsEnabledPreferenceKey,
+        AllowsContentJavascriptPreferenceKey,
     ];
 
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
@@ -210,6 +212,7 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
     addItem(@"Load All Site Icons Per-Page", @selector(toggleLoadsAllSiteIcons:));
     addItem(@"Use GameController.framework on macOS (Restart required)", @selector(toggleUsesGameControllerFramework:));
     addItem(@"Disable network cache speculative revalidation", @selector(toggleNetworkCacheSpeculativeRevalidationDisabled:));
+    addItem(@"Allow JavaScript from web content to run", @selector(toggleAllowsContentJavascript:));
     indent = NO;
 
     NSMenu *debugOverlaysMenu = addSubmenu(@"Debug Overlays");
@@ -385,6 +388,8 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
         [menuItem setState:[self useMockCaptureDevices] ? NSControlStateValueOn : NSControlStateValueOff];
     else if (action == @selector(toggleAdvancedPrivacyProtections:))
         [menuItem setState:[self advancedPrivacyProtectionsEnabled] ? NSControlStateValueOn : NSControlStateValueOff];
+    else if (action == @selector(toggleAllowsContentJavascript:))
+        [menuItem setState:[self allowsContentJavascript] ? NSControlStateValueOn : NSControlStateValueOff];
     else if (action == @selector(toggleReserveSpaceForBanners:))
         [menuItem setState:[self isSpaceReservedForBanners] ? NSControlStateValueOn : NSControlStateValueOff];
     else if (action == @selector(toggleShowTiledScrollingIndicator:))
@@ -715,6 +720,16 @@ static NSMenu *addSubmenuToMenu(NSMenu *menu, NSString *title)
 - (BOOL)advancedPrivacyProtectionsEnabled
 {
     return [[NSUserDefaults standardUserDefaults] boolForKey:AdvancedPrivacyProtectionsPreferenceKey];
+}
+
+- (void)toggleAllowsContentJavascript:(id)sender
+{
+    [self _toggleBooleanDefault:AllowsContentJavascriptPreferenceKey];
+}
+
+- (BOOL)allowsContentJavascript
+{
+    return [[NSUserDefaults standardUserDefaults] boolForKey:AllowsContentJavascriptPreferenceKey];
 }
 
 - (BOOL)nonFastScrollableRegionOverlayVisible

--- a/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
+++ b/Tools/MiniBrowser/mac/WK2BrowserWindowController.m
@@ -856,6 +856,8 @@ static BOOL isJavaScriptURL(NSURL *url)
             | _WKWebsiteNetworkConnectionIntegrityPolicySanitizeLookalikeCharacters;
     }();
 
+    preferences.allowsContentJavaScript = NSApplication.sharedApplication.browserAppDelegate.settingsController.allowsContentJavascript;
+
     if (navigationAction._canHandleRequest) {
         decisionHandler(WKNavigationActionPolicyAllow, preferences);
         return;


### PR DESCRIPTION
#### 08a02b76e6f32e0f4401b68a5691625e1b52596b
<pre>
[MiniBrowser] Add setting to configure WKWebpagePreferences.allowsContentJavascript
<a href="https://bugs.webkit.org/show_bug.cgi?id=275418">https://bugs.webkit.org/show_bug.cgi?id=275418</a>
<a href="https://rdar.apple.com/129708840">rdar://129708840</a>

Reviewed by Wenson Hsieh.

This is a mechanical patch that adds a setting which allows users to
opt-out of Javascript evaluation from web content, namely by configuring
the `WKWebpagePreferences.allowsContentJavascript` bit.

* Tools/MiniBrowser/mac/SettingsController.h:
* Tools/MiniBrowser/mac/SettingsController.m:
(-[SettingsController initWithMenu:]):
(-[SettingsController _populateMenu:]):
(-[SettingsController validateMenuItem:]):
(-[SettingsController toggleAllowsContentJavascript:]):
(-[SettingsController allowsContentJavascript]):
* Tools/MiniBrowser/mac/WK2BrowserWindowController.m:
(-[WK2BrowserWindowController webView:decidePolicyForNavigationAction:preferences:decisionHandler:]):

Canonical link: <a href="https://commits.webkit.org/279969@main">https://commits.webkit.org/279969@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3ffd2a9fd866885feda87934319df959e64a0ff

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7668 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58338 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5788 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57356 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5825 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44576 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3953 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32596 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47703 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25700 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29380 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5048 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3932 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5283 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59928 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30334 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5433 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52007 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31458 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47772 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12107 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32487 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31249 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->