### PR TITLE
[Writing Tools] Smart replies erases all content in mail compose, fails to insert reply, WebKit.content crashes @ com.apple.WebKit: IPC::ArgumentCoder<WebKit::CoreIPCData, void>::encode

### DIFF
--- a/Source/WebCore/page/unified-text-replacement/UnifiedTextReplacementController.mm
+++ b/Source/WebCore/page/unified-text-replacement/UnifiedTextReplacementController.mm
@@ -128,6 +128,16 @@ void UnifiedTextReplacementController::willBeginTextReplacementSession(const std
 
     auto selectedTextRange = document->selection().selection().firstRange();
 
+    if (session && session->correctionType == UnifiedTextReplacement::Session::CorrectionType::Spelling) {
+        ASSERT(session->replacementType == UnifiedTextReplacement::Session::ReplacementType::RichText);
+
+        auto liveRange = createLiveRange(*selectedTextRange);
+        m_states.set(session->identifier, RichTextState { liveRange, { } });
+
+        completionHandler({ { WTF::UUID { 0 }, AttributedString::fromNSAttributedString(adoptNS([[NSAttributedString alloc] initWithString:@""])), CharacterRange { 0, 0 } } });
+        return;
+    }
+
     auto attributedStringFromRange = editingAttributedString(*contextRange, { IncludedElement::Images, IncludedElement::Attachments });
     auto selectedTextCharacterRange = characterRange(*contextRange, *selectedTextRange);
 


### PR DESCRIPTION
#### 42f4341e3c1b709ecd35df29d4756df51038122e
<pre>
[Writing Tools] Smart replies erases all content in mail compose, fails to insert reply, WebKit.content crashes @ com.apple.WebKit: IPC::ArgumentCoder&lt;WebKit::CoreIPCData, void&gt;::encode
<a href="https://bugs.webkit.org/show_bug.cgi?id=275419">https://bugs.webkit.org/show_bug.cgi?id=275419</a>
<a href="https://rdar.apple.com/129697243">rdar://129697243</a>

Reviewed by Megan Gardner and Aditya Keerthi.

When using Smart Replies, an attributed string was being generated using the entire editable content.
However, Smart Replies doesn&apos;t actually need any attributed string context at all, so fix by returning
an empty attributed string in this case.

* Source/WebCore/page/unified-text-replacement/UnifiedTextReplacementController.mm:
(WebCore::UnifiedTextReplacementController::willBeginTextReplacementSession):

Canonical link: <a href="https://commits.webkit.org/279968@main">https://commits.webkit.org/279968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37f29bf5192806478ea7aeacd2729fb1e186c8bb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58362 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5812 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57380 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/42111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5851 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3969 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57175 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/42111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47718 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/25719 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/42111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/5065 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3956 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/42111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59952 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/30360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/5452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/31483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47786 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/32510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8155 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/31273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->