### PR TITLE
[Win][MiniBrowser] Rounding fractional device scale factor

### DIFF
--- a/Tools/MiniBrowser/win/BrowserWindow.h
+++ b/Tools/MiniBrowser/win/BrowserWindow.h
@@ -70,4 +70,6 @@ public:
 
     virtual void clearCookies() = 0;
     virtual void clearWebsiteData() = 0;
+
+    virtual void adjustScaleFactors() = 0;
 };

--- a/Tools/MiniBrowser/win/MainWindow.cpp
+++ b/Tools/MiniBrowser/win/MainWindow.cpp
@@ -391,6 +391,7 @@ LRESULT CALLBACK MainWindow::WndProc(HWND hWnd, UINT message, WPARAM wParam, LPA
         break;
     case WM_DPICHANGED: {
         thisWindow->updateDeviceScaleFactor();
+        thisWindow->browserWindow()->adjustScaleFactors();
         auto& rect = *reinterpret_cast<RECT*>(lParam);
         SetWindowPos(hWnd, nullptr, rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top, SWP_NOZORDER | SWP_NOACTIVATE);
         break;

--- a/Tools/MiniBrowser/win/WebKitBrowserWindow.h
+++ b/Tools/MiniBrowser/win/WebKitBrowserWindow.h
@@ -67,6 +67,7 @@ private:
     void clearWebsiteData() override;
 
     void updateProxySettings();
+    void adjustScaleFactors() override;
 
     bool canTrustServerCertificate(WKProtectionSpaceRef);
 
@@ -99,4 +100,6 @@ private:
     std::unordered_map<std::wstring, std::wstring> m_acceptedServerTrustCerts;
     std::vector<WKRetainPtr<WKStringRef>> m_experimentalFeatureKeys;
     std::vector<WKRetainPtr<WKStringRef>> m_internalDebugFeatureKeys;
+
+    float m_defaultResetPageZoomFactor = 1;
 };


### PR DESCRIPTION
#### 007289d10afb4e15f07fbef9135148b4e81bfdc2
<pre>
[Win][MiniBrowser] Rounding fractional device scale factor
<a href="https://bugs.webkit.org/show_bug.cgi?id=275420">https://bugs.webkit.org/show_bug.cgi?id=275420</a>

Reviewed by Fujii Hironori.

Non-integral device scale factor is possible on Windows, although it
isn&apos;t on other platform e.g. Mac or GTK.
Using fractional device scale factor isn&apos;t supported by current WebKit,
rendering noises remain when repainting display.

So far, we set custom device scale factor value 1 and used zoom factor
instead of device scale factor to avoid these noises.
But using zoom factor doesn&apos;t scale scroll bar width, it seems weird
especially on high DPI. It&apos;s better to round device scale factor,
scale the contents based on integral device scale factor
and let MiniBrowser adjust by page zoom factor.

* Source/WebKit/WebProcess/WebCoreSupport/win/WebPopupMenuWin.cpp:
* Tools/MiniBrowser/win/BrowserWindow.h:
* Tools/MiniBrowser/win/MainWindow.cpp:
* Tools/MiniBrowser/win/WebKitBrowserWindow.cpp:
* Tools/MiniBrowser/win/WebKitBrowserWindow.h:

Canonical link: <a href="https://commits.webkit.org/279967@main">https://commits.webkit.org/279967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f574c984f4da431f6f6274f9a264c82be44bc16

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55059 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58341 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5791 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57359 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5828 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44586 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3957 "Passed tests") 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57154 "Build is in progress. Recent messages:OS: Unknown (10.15.7), Xcode: 11.7; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32603 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/47704 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25710 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29387 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5049 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3935 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5284 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59931 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30337 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5436 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52008 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/31461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47773 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51461 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32488 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8154 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/31252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->