### PR TITLE
WebKit Should Log Core Animation Commits on Frame Updates

### DIFF
--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -594,6 +594,7 @@ UIProcess/RemoteLayerTree/ios/ScrollingTreePluginScrollingNodeIOS.mm
 UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
 
 UIProcess/RemoteLayerTree/RemoteAcceleratedEffectStack.mm
+UIProcess/RemoteLayerTree/RemoteLayerTreeCommitTracing.mm
 UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
 UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
 UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeCommitTracing.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeCommitTracing.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+#include <CoreFoundation/CoreFoundation.h>
+#include <QuartzCore/CALayer.h>
+#include <QuartzCore/CATransaction.h>
+
+#include <QuartzCore/CATransactionPrivate.h>
+#include <QuartzCore/QuartzCore.h>
+
+namespace WebKit {
+
+class CAFrameLogging {
+public:
+    CAFrameLogging();
+    ~CAFrameLogging();
+
+private:
+    CAFrameToken m_token;
+};
+
+}

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeCommitTracing.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeCommitTracing.mm
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "RemoteLayerTreeCommitTracing.h"
+
+#include <QuartzCore/CATransactionPrivate.h>
+#include <QuartzCore/QuartzCore.h>
+
+namespace WebKit {
+
+CAFrameLogging::CAFrameLogging()
+{
+    auto beginTime = CACurrentMediaTime();
+    auto commitDeadline = CACurrentMediaTime() + (16.6 / 1000);
+    m_token = [CATransaction startFrameWithReason:kCAFrameReasonAnonymous beginTime:beginTime commitDeadline:commitDeadline];
+};
+
+CAFrameLogging::~CAFrameLogging()
+{
+    [CATransaction finishFrameWithToken:m_token];
+};
+
+}

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -27,6 +27,7 @@
 
 #include "DrawingAreaProxy.h"
 #include "RemoteImageBufferSetIdentifier.h"
+#include "RemoteLayerTreeDrawingAreaProxy.h"
 #include "RemoteLayerTreeHost.h"
 #include "TransactionID.h"
 #include <WebCore/AnimationFrameRate.h>

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
@@ -28,6 +28,7 @@
 
 #if PLATFORM(MAC) && ENABLE(SCROLLING_THREAD)
 
+#include "../RemoteLayerTreeCommitTracing.h"
 #include "DisplayLink.h"
 #include "Logging.h"
 #include "NativeWebWheelEvent.h"
@@ -37,6 +38,8 @@
 #include "RemoteScrollingTree.h"
 #include "WebEventConversion.h"
 #include "WebPageProxy.h"
+#include <QuartzCore/CATransactionPrivate.h>
+#include <QuartzCore/QuartzCore.h>
 #include <WebCore/PlatformWheelEvent.h>
 #include <WebCore/ScrollingCoordinatorTypes.h>
 #include <WebCore/ScrollingNodeID.h>
@@ -190,6 +193,8 @@ void RemoteLayerTreeEventDispatcher::handleWheelEvent(const WebWheelEvent& wheel
     ASSERT(isMainRunLoop());
 
     willHandleWheelEvent(wheelEvent);
+
+    CAFrameLogging frameLogging;
 
     ScrollingThread::dispatch([dispatcher = Ref { *this }, wheelEvent, rubberBandableEdges] {
         dispatcher->scrollingThreadHandleWheelEvent(wheelEvent, rubberBandableEdges);

--- a/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
+++ b/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
@@ -31,6 +31,7 @@
 #import "APIHitTestResult.h"
 #import "MessageSenderInlines.h"
 #import "WKNSURLExtras.h"
+#import "WebFrameProxy.h"
 #import "WebPageMessages.h"
 #import "WebPageProxy.h"
 #import "WebPageProxyMessages.h"


### PR DESCRIPTION
#### 57b86f69e2aa4425580e605dc0137bb94e511a11
<pre>
WebKit Should Log Core Animation Commits on Frame Updates
<a href="https://bugs.webkit.org/show_bug.cgi?id=275373">https://bugs.webkit.org/show_bug.cgi?id=275373</a>
<a href="https://rdar.apple.com/129343146">rdar://129343146</a>

Reviewed by NOBODY (OOPS!).

(WIP) This commit adds CA logging for layer updates in WebKit.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeCommitTracing.h: Added.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeCommitTracing.mm: Added.
(WebKit::CAFrameLogging::CAFrameLogging):
(WebKit::CAFrameLogging::~CAFrameLogging):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::handleWheelEvent):
* Source/WebKit/UIProcess/mac/WKImmediateActionController.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57b86f69e2aa4425580e605dc0137bb94e511a11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57216 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36544 "Hash 57b86f69 for PR 29773 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9691 "Hash 57b86f69 for PR 29773 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60837 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7659 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44168 "Hash 57b86f69 for PR 29773 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7849 "Hash 57b86f69 for PR 29773 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46327 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5393 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59246 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/49/builds/44168 "Hash 57b86f69 for PR 29773 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/9691 "Hash 57b86f69 for PR 29773 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27187 "Found 1 new API test failure: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/service-worker-registrations (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/49/builds/44168 "Hash 57b86f69 for PR 29773 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/9691 "Hash 57b86f69 for PR 29773 does not build (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6664 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/49/builds/44168 "Hash 57b86f69 for PR 29773 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/9691 "Hash 57b86f69 for PR 29773 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62517 "Built successfully") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1129 "Hash 57b86f69 for PR 29773 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/61/builds/7849 "Hash 57b86f69 for PR 29773 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53586 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1134 "Hash 57b86f69 for PR 29773 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/9691 "Hash 57b86f69 for PR 29773 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53658 "2 api tests failed or timed out") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32373 "Hash 57b86f69 for PR 29773 does not build (failure)") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33458 "Hash 57b86f69 for PR 29773 does not build (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34543 "Hash 57b86f69 for PR 29773 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33204 "Hash 57b86f69 for PR 29773 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->