### PR TITLE
[WPE][GTK] REGRESSION(279912@main): fast/canvas/canvas-filter-repaint-rect.html fails

### DIFF
--- a/LayoutTests/fast/canvas/canvas-filter-bounding-rect.html
+++ b/LayoutTests/fast/canvas/canvas-filter-bounding-rect.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=0-26; totalPixels=0-1000" />
+<meta name="fuzzy" content="maxDifference=0-35; totalPixels=0-1000" />
 <style>
      canvas {
          width: 700px;

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1468,7 +1468,6 @@ webkit.org/b/274830 imported/w3c/web-platform-tests/html/canvas/offscreen/shadow
 webkit.org/b/274830 imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.image.transparent.2.html [ Failure ]
 webkit.org/b/274830 imported/w3c/web-platform-tests/html/canvas/offscreen/shadows/2d.shadow.image.transparent.2.worker.html [ Failure ]
 webkit.org/b/273766 fast/canvas/canvas-scale-shadowBlur.html [ Failure ]
-webkit.org/b/275353 fast/canvas/canvas-filter-repaint-rect.html [ Failure ]
 
 # Minor reftest image differences introduced with skia.
 http/tests/css/css-masking/mask-external-svg-fragment.html [ ImageOnlyFailure ]

--- a/Source/WebCore/html/canvas/CanvasFilterTargetSwitcher.cpp
+++ b/Source/WebCore/html/canvas/CanvasFilterTargetSwitcher.cpp
@@ -47,7 +47,7 @@ std::unique_ptr<CanvasFilterTargetSwitcher> CanvasFilterTargetSwitcher::create(C
     filter->setFilterRenderingModes(filter->filterRenderingModes() - FilterRenderingMode::GraphicsContext);
 
     ASSERT(!bounds.isEmpty());
-    auto* destinationContext = context.drawingContext();
+    auto* destinationContext = context.effectiveDrawingContext();
 
     auto filterTargetSwitcher = FilterTargetSwitcher::create(*destinationContext, *filter, bounds, colorSpace);
     if (!filterTargetSwitcher)
@@ -78,7 +78,7 @@ CanvasFilterTargetSwitcher::~CanvasFilterTargetSwitcher()
 {
     m_context.setFilterTargetSwitcher(nullptr);
 
-    auto* destinationContext = m_context.drawingContext();
+    auto* destinationContext = m_context.effectiveDrawingContext();
     m_filterTargetSwitcher->endDrawSourceImage(*destinationContext, DestinationColorSpace::SRGB());
 }
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -106,7 +106,7 @@ RefPtr<Filter> CanvasRenderingContext2D::createFilter(const Function<FloatRect()
 {
     ASSERT(!state().filterOperations.isEmpty());
 
-    auto* context = drawingContext();
+    auto* context = effectiveDrawingContext();
     if (!context)
         return nullptr;
 
@@ -157,7 +157,7 @@ void CanvasRenderingContext2D::drawFocusIfNeeded(Path2D& path, Element& element)
 
 void CanvasRenderingContext2D::drawFocusIfNeededInternal(const Path& path, Element& element)
 {
-    auto* context = drawingContext();
+    auto* context = effectiveDrawingContext();
     if (!element.focused() || !state().hasInvertibleTransform || path.isEmpty() || !element.isDescendantOf(canvas()) || !context)
         return;
     context->drawFocusRing(path, 1, RenderTheme::singleton().focusRingColor(element.document().styleColorOptions(canvas().computedStyle())));

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -523,7 +523,7 @@ void CanvasRenderingContext2DBase::setStrokeStyle(CanvasStyle style)
     realizeSaves();
     State& state = modifiableState();
     state.strokeStyle = WTFMove(style);
-    GraphicsContext* c = drawingContext();
+    GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return;
     state.strokeStyle.applyStrokeColor(*c);
@@ -547,7 +547,7 @@ void CanvasRenderingContext2DBase::setFillStyle(CanvasStyle style)
     realizeSaves();
     State& state = modifiableState();
     state.fillStyle = WTFMove(style);
-    GraphicsContext* c = drawingContext();
+    GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return;
 
@@ -570,7 +570,7 @@ void CanvasRenderingContext2DBase::setLineWidth(double width)
         return;
     realizeSaves();
     modifiableState().lineWidth = width;
-    GraphicsContext* c = drawingContext();
+    GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return;
     c->setStrokeThickness(width);
@@ -583,7 +583,7 @@ void CanvasRenderingContext2DBase::setLineCap(CanvasLineCap canvasLineCap)
         return;
     realizeSaves();
     modifiableState().lineCap = lineCap;
-    GraphicsContext* c = drawingContext();
+    GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return;
     c->setLineCap(lineCap);
@@ -611,7 +611,7 @@ void CanvasRenderingContext2DBase::setLineJoin(CanvasLineJoin canvasLineJoin)
         return;
     realizeSaves();
     modifiableState().lineJoin = lineJoin;
-    GraphicsContext* c = drawingContext();
+    GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return;
     c->setLineJoin(lineJoin);
@@ -640,7 +640,7 @@ void CanvasRenderingContext2DBase::setMiterLimit(double limit)
         return;
     realizeSaves();
     modifiableState().miterLimit = limit;
-    GraphicsContext* c = drawingContext();
+    GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return;
     c->setMiterLimit(limit);
@@ -738,7 +738,7 @@ void CanvasRenderingContext2DBase::setLineDashOffset(double offset)
 
 void CanvasRenderingContext2DBase::applyLineDash() const
 {
-    GraphicsContext* c = drawingContext();
+    GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return;
     DashArray convertedLineDash(state().lineDash.size());
@@ -755,7 +755,7 @@ void CanvasRenderingContext2DBase::setGlobalAlpha(double alpha)
         return;
     realizeSaves();
     modifiableState().globalAlpha = alpha;
-    GraphicsContext* c = drawingContext();
+    GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return;
     c->setAlpha(alpha);
@@ -772,7 +772,7 @@ void CanvasRenderingContext2DBase::setGlobalCompositeOperation(const String& ope
     realizeSaves();
     modifiableState().globalComposite = op;
     modifiableState().globalBlend = blendMode;
-    GraphicsContext* c = drawingContext();
+    GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return;
     c->setCompositeOperation(op, blendMode);
@@ -805,7 +805,7 @@ void CanvasRenderingContext2DBase::setFilterString(const String& filterString)
 
 void CanvasRenderingContext2DBase::scale(double sx, double sy)
 {
-    GraphicsContext* c = drawingContext();
+    GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return;
     if (!state().hasInvertibleTransform)
@@ -833,7 +833,7 @@ void CanvasRenderingContext2DBase::scale(double sx, double sy)
 
 void CanvasRenderingContext2DBase::rotate(double angleInRadians)
 {
-    GraphicsContext* c = drawingContext();
+    GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return;
     if (!state().hasInvertibleTransform)
@@ -856,7 +856,7 @@ void CanvasRenderingContext2DBase::rotate(double angleInRadians)
 
 void CanvasRenderingContext2DBase::translate(double tx, double ty)
 {
-    GraphicsContext* c = drawingContext();
+    GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return;
     if (!state().hasInvertibleTransform)
@@ -879,7 +879,7 @@ void CanvasRenderingContext2DBase::translate(double tx, double ty)
 
 void CanvasRenderingContext2DBase::transform(double m11, double m12, double m21, double m22, double dx, double dy)
 {
-    GraphicsContext* c = drawingContext();
+    GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return;
     if (!state().hasInvertibleTransform)
@@ -911,7 +911,7 @@ Ref<DOMMatrix> CanvasRenderingContext2DBase::getTransform() const
 
 void CanvasRenderingContext2DBase::setTransform(double m11, double m12, double m21, double m22, double dx, double dy)
 {
-    GraphicsContext* c = drawingContext();
+    GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return;
 
@@ -934,7 +934,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::setTransform(DOMMatrix2DInit&& m
 
 void CanvasRenderingContext2DBase::resetTransform()
 {
-    GraphicsContext* c = drawingContext();
+    GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return;
 
@@ -1123,7 +1123,7 @@ void CanvasRenderingContext2DBase::fillInternal(const Path& path, CanvasFillRule
         });
     }
 
-    auto* c = drawingContext();
+    auto* c = effectiveDrawingContext();
     if (!c)
         return;
     if (!state().hasInvertibleTransform)
@@ -1169,7 +1169,7 @@ void CanvasRenderingContext2DBase::strokeInternal(const Path& path)
         });
     }
 
-    auto* c = drawingContext();
+    auto* c = effectiveDrawingContext();
     if (!c)
         return;
     if (!state().hasInvertibleTransform)
@@ -1203,7 +1203,7 @@ void CanvasRenderingContext2DBase::strokeInternal(const Path& path)
 
 void CanvasRenderingContext2DBase::clipInternal(const Path& path, CanvasFillRule windingRule)
 {
-    auto* c = drawingContext();
+    auto* c = effectiveDrawingContext();
     if (!c)
         return;
     if (!state().hasInvertibleTransform)
@@ -1216,7 +1216,7 @@ void CanvasRenderingContext2DBase::clipInternal(const Path& path, CanvasFillRule
 void CanvasRenderingContext2DBase::beginCompositeLayer()
 {
 #if !USE(CAIRO)
-    auto* context = drawingContext();
+    auto* context = effectiveDrawingContext();
     context->beginTransparencyLayer(state().globalComposite, state().globalBlend);
 #endif
 }
@@ -1224,7 +1224,7 @@ void CanvasRenderingContext2DBase::beginCompositeLayer()
 void CanvasRenderingContext2DBase::endCompositeLayer()
 {
 #if !USE(CAIRO)
-    auto* context = drawingContext();
+    auto* context = effectiveDrawingContext();
     context->endTransparencyLayer();
 #endif
 }
@@ -1254,7 +1254,7 @@ bool CanvasRenderingContext2DBase::isPointInPathInternal(const Path& path, doubl
     if (!std::isfinite(x) || !std::isfinite(y))
         return false;
     
-    if (!drawingContext())
+    if (!effectiveDrawingContext())
         return false;
     auto& state = this->state();
     if (!state.hasInvertibleTransform)
@@ -1271,7 +1271,7 @@ bool CanvasRenderingContext2DBase::isPointInStrokeInternal(const Path& path, dou
     if (!std::isfinite(x) || !std::isfinite(y))
         return false;
 
-    if (!drawingContext())
+    if (!effectiveDrawingContext())
         return false;
     auto& state = this->state();
     if (!state.hasInvertibleTransform)
@@ -1297,7 +1297,7 @@ void CanvasRenderingContext2DBase::clearRect(double x, double y, double width, d
 {
     if (!validateRectForCanvas(x, y, width, height))
         return;
-    auto* context = drawingContext();
+    auto* context = effectiveDrawingContext();
     if (!context)
         return;
     if (!state().hasInvertibleTransform)
@@ -1341,7 +1341,7 @@ void CanvasRenderingContext2DBase::fillRect(double x, double y, double width, do
     if (!state().filterOperations.isEmpty())
         targetSwitcher = CanvasFilterTargetSwitcher::create(*this, colorSpace(), rect);
 
-    auto* c = drawingContext();
+    auto* c = effectiveDrawingContext();
     if (!c)
         return;
     if (!state().hasInvertibleTransform)
@@ -1398,7 +1398,7 @@ void CanvasRenderingContext2DBase::strokeRect(double x, double y, double width, 
     if (!state().filterOperations.isEmpty())
         targetSwitcher = CanvasFilterTargetSwitcher::create(*this, colorSpace(), inflatedStrokeRect);
 
-    auto* c = drawingContext();
+    auto* c = effectiveDrawingContext();
     if (!c)
         return;
     if (!state().hasInvertibleTransform)
@@ -1481,7 +1481,7 @@ void CanvasRenderingContext2DBase::setShadow(const FloatSize& offset, float blur
 
 void CanvasRenderingContext2DBase::applyShadow()
 {
-    auto* c = drawingContext();
+    auto* c = effectiveDrawingContext();
     if (!c)
         return;
 
@@ -1673,7 +1673,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(WebCodecsVideoFrame& f
     if (frame.isDetached())
         return Exception { ExceptionCode::InvalidStateError, "frame is detached"_s };
 
-    auto* context = drawingContext();
+    auto* context = effectiveDrawingContext();
     if (!context)
         return { };
 
@@ -1718,7 +1718,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(Document& document, Ca
     if (!state().filterOperations.isEmpty())
         targetSwitcher = CanvasFilterTargetSwitcher::create(*this, colorSpace(), normalizedDstRect);
 
-    GraphicsContext* c = drawingContext();
+    GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return { };
     if (!state().hasInvertibleTransform)
@@ -1804,7 +1804,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(CanvasBase& sourceCanv
     if (!state().filterOperations.isEmpty())
         targetSwitcher = CanvasFilterTargetSwitcher::create(*this, colorSpace(), normalizedDstRect);
 
-    GraphicsContext* c = drawingContext();
+    GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return { };
     if (!state().hasInvertibleTransform)
@@ -1871,7 +1871,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(HTMLVideoElement& vide
     if (!state().filterOperations.isEmpty())
         targetSwitcher = CanvasFilterTargetSwitcher::create(*this, colorSpace(), normalizedDstRect);
 
-    GraphicsContext* c = drawingContext();
+    GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return { };
     if (!state().hasInvertibleTransform)
@@ -1931,7 +1931,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(ImageBitmap& imageBitm
     if (!state().filterOperations.isEmpty())
         targetSwitcher = CanvasFilterTargetSwitcher::create(*this, colorSpace(), dstRect);
 
-    GraphicsContext* c = drawingContext();
+    GraphicsContext* c = effectiveDrawingContext();
     if (!c)
         return { };
     if (!state().hasInvertibleTransform)
@@ -1976,7 +1976,7 @@ void CanvasRenderingContext2DBase::drawImageFromRect(HTMLImageElement& imageElem
 
 void CanvasRenderingContext2DBase::clearCanvas()
 {
-    auto* c = drawingContext();
+    auto* c = effectiveDrawingContext();
     if (!c)
         return;
 
@@ -2026,7 +2026,7 @@ void CanvasRenderingContext2DBase::compositeBuffer(ImageBuffer& buffer, const In
     IntRect canvasRect(0, 0, canvasBase().width(), canvasBase().height());
     canvasRect = baseTransform().mapRect(canvasRect);
 
-    auto* c = drawingContext();
+    auto* c = effectiveDrawingContext();
     if (!c)
         return;
 
@@ -2063,7 +2063,7 @@ template<class T> void CanvasRenderingContext2DBase::fullCanvasCompositedDrawIma
         return;
     }
 
-    auto* c = drawingContext();
+    auto* c = effectiveDrawingContext();
     if (!c)
         return;
 
@@ -2311,7 +2311,7 @@ void CanvasRenderingContext2DBase::didDraw(std::optional<FloatRect> rect, Option
     if (!options.contains(DidDrawOption::PreserveCachedContents))
         m_cachedContents.emplace<CachedContentsUnknown>();
 
-    if (!drawingContext())
+    if (!effectiveDrawingContext())
         return;
 
     m_hasDeferredOperations = true;
@@ -2342,7 +2342,7 @@ void CanvasRenderingContext2DBase::didDraw(std::optional<FloatRect> rect, Option
     }
 
     // Inflate dirty rect to cover antialiasing on image buffers.
-    if (drawingContext()->shouldAntialias())
+    if (effectiveDrawingContext()->shouldAntialias())
         dirtyRect.inflate(1);
 
     // FIXME: This does not apply the clip because we have no way of reading the clip out of the GraphicsContext.
@@ -2401,13 +2401,9 @@ const Vector<CanvasRenderingContext2DBase::State, 1>& CanvasRenderingContext2DBa
 GraphicsContext* CanvasRenderingContext2DBase::drawingContext() const
 {
     // FIXME(https://bugs.webkit.org/show_bug.cgi?id=275100): The image buffer from CanvasBase should be moved to CanvasRenderingContext2DBase.
-    auto* buffer = canvasBase().buffer();
-    if (!buffer)
-        return nullptr;
-    auto& context = buffer->context();
-    if (UNLIKELY(m_targetSwitcher))
-        return m_targetSwitcher->drawingContext(context);
-    return &context;
+    if (auto* buffer = canvasBase().buffer())
+        return &buffer->context();
+    return nullptr;
 }
 
 GraphicsContext* CanvasRenderingContext2DBase::existingDrawingContext() const
@@ -2415,6 +2411,16 @@ GraphicsContext* CanvasRenderingContext2DBase::existingDrawingContext() const
     if (!canvasBase().hasCreatedImageBuffer())
         return nullptr;
     return drawingContext();
+}
+
+GraphicsContext* CanvasRenderingContext2DBase::effectiveDrawingContext() const
+{
+    auto context = drawingContext();
+    if (!context)
+        return nullptr;
+    if (UNLIKELY(m_targetSwitcher))
+        return m_targetSwitcher->drawingContext(*context);
+    return context;
 }
 
 AffineTransform CanvasRenderingContext2DBase::baseTransform() const
@@ -2685,7 +2691,7 @@ void CanvasRenderingContext2DBase::setImageSmoothingQuality(ImageSmoothingQualit
     if (!state().imageSmoothingEnabled)
         return;
 
-    if (auto* context = drawingContext())
+    if (auto* context = effectiveDrawingContext())
         context->setImageInterpolationQuality(smoothingToInterpolationQuality(quality));
 }
 
@@ -2696,7 +2702,7 @@ void CanvasRenderingContext2DBase::setImageSmoothingEnabled(bool enabled)
 
     realizeSaves();
     modifiableState().imageSmoothingEnabled = enabled;
-    auto* c = drawingContext();
+    auto* c = effectiveDrawingContext();
     if (c)
         c->setImageInterpolationQuality(enabled ? smoothingToInterpolationQuality(state().imageSmoothingQuality) : InterpolationQuality::DoNotInterpolate);
 }
@@ -2743,7 +2749,7 @@ bool CanvasRenderingContext2DBase::canDrawText(double x, double y, bool fill, st
     if (!fontProxy()->realized())
         return false;
 
-    auto* c = drawingContext();
+    auto* c = effectiveDrawingContext();
     if (!c)
         return false;
     if (!state().hasInvertibleTransform)
@@ -2829,7 +2835,7 @@ void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, dou
     if (!state().filterOperations.isEmpty())
         targetSwitcher = CanvasFilterTargetSwitcher::create(*this, colorSpace(), textRect);
 
-    auto* c = drawingContext();
+    auto* c = effectiveDrawingContext();
 
 #if USE(CG)
     const CanvasStyle& drawStyle = fill ? state().fillStyle : state().strokeStyle;

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -321,6 +321,7 @@ protected:
 
     virtual GraphicsContext* drawingContext() const;
     virtual GraphicsContext* existingDrawingContext() const;
+    virtual GraphicsContext* effectiveDrawingContext() const;
     virtual AffineTransform baseTransform() const;
 
     enum class DidDrawOption {

--- a/Source/WebCore/html/canvas/PaintRenderingContext2D.h
+++ b/Source/WebCore/html/canvas/PaintRenderingContext2D.h
@@ -44,6 +44,7 @@ public:
 
     GraphicsContext* drawingContext() const final;
     GraphicsContext* existingDrawingContext() const final;
+    GraphicsContext* effectiveDrawingContext() const final { return drawingContext(); }
     AffineTransform baseTransform() const final;
 
     CustomPaintCanvas& canvas() const;


### PR DESCRIPTION
#### 5d58ef776121e63743ef363b09b6158adb97dbf0
<pre>
[WPE][GTK] REGRESSION(279912@main): fast/canvas/canvas-filter-repaint-rect.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=275353">https://bugs.webkit.org/show_bug.cgi?id=275353</a>
<a href="https://rdar.apple.com/129719858">rdar://129719858</a>

Reviewed by Kimmo Kinnunen.

Before 279912@main, existingDrawingContext() was returning the destination context
of the canvas if it exists.

After 279912@main, existingDrawingContext() returns drawingContext() which may
return the FilterTargetSwitcher context. This causes a problem when this function
is called from RenderHTMLCanvas::requiresLayer() via isAccelerated().

Usually the canvas is backed by an accelerated ImageBuffer. But the filter target
switcher is backed by un-accelerated ImageBuffer. So returning the RenderingMode
of the target switcher will give the wrong answer to requiresLayer().

The fix is to restore the old behavior of drawingContext() back by returning the
canvas destination context and creating it if it does not exist. Also add
effectiveDrawingContext() which returns the FilterTargetSwitcher if it is active.
Otherwise it returns drawingContext().

* LayoutTests/fast/canvas/canvas-filter-bounding-rect.html:
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/html/canvas/CanvasFilterTargetSwitcher.cpp:
(WebCore::CanvasFilterTargetSwitcher::create):
(WebCore::CanvasFilterTargetSwitcher::~CanvasFilterTargetSwitcher):
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
(WebCore::CanvasRenderingContext2D::createFilter const):
(WebCore::CanvasRenderingContext2D::drawFocusIfNeededInternal):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::setStrokeStyle):
(WebCore::CanvasRenderingContext2DBase::setFillStyle):
(WebCore::CanvasRenderingContext2DBase::setLineWidth):
(WebCore::CanvasRenderingContext2DBase::setLineCap):
(WebCore::CanvasRenderingContext2DBase::setLineJoin):
(WebCore::CanvasRenderingContext2DBase::setMiterLimit):
(WebCore::CanvasRenderingContext2DBase::applyLineDash const):
(WebCore::CanvasRenderingContext2DBase::setGlobalAlpha):
(WebCore::CanvasRenderingContext2DBase::setGlobalCompositeOperation):
(WebCore::CanvasRenderingContext2DBase::scale):
(WebCore::CanvasRenderingContext2DBase::rotate):
(WebCore::CanvasRenderingContext2DBase::translate):
(WebCore::CanvasRenderingContext2DBase::transform):
(WebCore::CanvasRenderingContext2DBase::setTransform):
(WebCore::CanvasRenderingContext2DBase::resetTransform):
(WebCore::CanvasRenderingContext2DBase::fillInternal):
(WebCore::CanvasRenderingContext2DBase::strokeInternal):
(WebCore::CanvasRenderingContext2DBase::clipInternal):
(WebCore::CanvasRenderingContext2DBase::beginCompositeLayer):
(WebCore::CanvasRenderingContext2DBase::endCompositeLayer):
(WebCore::CanvasRenderingContext2DBase::isPointInPathInternal):
(WebCore::CanvasRenderingContext2DBase::isPointInStrokeInternal):
(WebCore::CanvasRenderingContext2DBase::clearRect):
(WebCore::CanvasRenderingContext2DBase::fillRect):
(WebCore::CanvasRenderingContext2DBase::strokeRect):
(WebCore::CanvasRenderingContext2DBase::applyShadow):
(WebCore::CanvasRenderingContext2DBase::drawImage):
(WebCore::CanvasRenderingContext2DBase::clearCanvas):
(WebCore::CanvasRenderingContext2DBase::compositeBuffer):
(WebCore::CanvasRenderingContext2DBase::fullCanvasCompositedDrawImage):
(WebCore::CanvasRenderingContext2DBase::didDraw):
(WebCore::CanvasRenderingContext2DBase::drawingContext const):
(WebCore::CanvasRenderingContext2DBase::effectiveDrawingContext const):
(WebCore::CanvasRenderingContext2DBase::setImageSmoothingQuality):
(WebCore::CanvasRenderingContext2DBase::setImageSmoothingEnabled):
(WebCore::CanvasRenderingContext2DBase::canDrawText):
(WebCore::CanvasRenderingContext2DBase::drawTextUnchecked):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/html/canvas/PaintRenderingContext2D.h:

Canonical link: <a href="https://commits.webkit.org/280091@main">https://commits.webkit.org/280091@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb4ab28573998aa4041d4cc90b4dad6ffbb5ed0a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8201 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58718 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6165 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57860 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42679 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6363 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44884 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4241 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57763 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32953 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26016 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29740 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5371 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4308 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51712 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5638 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60309 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5768 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52311 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48112 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51811 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12344 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30888 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31973 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33054 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31720 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->