### PR TITLE
[webkitpy] Add ability to run commands at simulator launch.

### DIFF
--- a/Tools/Scripts/webkitpy/port/device.py
+++ b/Tools/Scripts/webkitpy/port/device.py
@@ -73,6 +73,11 @@ class Device(object):
             return self.platform_device.release_worker_resources()
         return None
 
+    def set_up_environment_extras(self):
+        if hasattr(self.platform_device, 'set_up_environment_extras'):
+            return self.platform_device.set_up_environment_extras()
+        return True
+
     @property
     def executive(self):
         return self.platform_device.executive

--- a/Tools/Scripts/webkitpy/xcode/simulated_device.py
+++ b/Tools/Scripts/webkitpy/xcode/simulated_device.py
@@ -452,6 +452,7 @@ class SimulatedDeviceManager(object):
         deadline = time.time() + timeout
         for device in SimulatedDeviceManager.INITIALIZED_DEVICES:
             cls._wait_until_device_is_usable(device, deadline)
+            device.set_up_environment_extras()
 
         return SimulatedDeviceManager.INITIALIZED_DEVICES
 
@@ -547,6 +548,8 @@ class SimulatedDevice(object):
         self.executive = host.executive
         self.filesystem = host.filesystem
         self.platform = host.platform
+
+        self.environment_extras = []
 
         # Determine tear down behavior
         self.booted_by_script = False
@@ -679,6 +682,13 @@ class SimulatedDevice(object):
             raise RuntimeError(u'Failed to find process id for {}: {}'.format(bundle_id, output))
         _log.debug(u'Returning pid {} of launched process'.format(match.group('pid')))
         return int(match.group('pid'))
+
+    def set_up_environment_extras(self):
+        if len(self.environment_extras) == 0:
+            return
+        _log.debug(u'Running extra environment setup commands.')
+        for command in self.environment_extras:
+            self.executive.run_command(command)
 
     def __eq__(self, other):
         return self.udid == other.udid


### PR DESCRIPTION
#### e47135440c5eda25ced4b969fb8b76df38e39f8d
<pre>
[webkitpy] Add ability to run commands at simulator launch.
<a href="https://bugs.webkit.org/show_bug.cgi?id=275427">https://bugs.webkit.org/show_bug.cgi?id=275427</a>
<a href="https://rdar.apple.com/129724565">rdar://129724565</a>

Reviewed by Ryan Haddad.

Adds the ability to explicitly define and run commands when a simulated device is usable.

* Tools/Scripts/webkitpy/port/device.py:
(Device.set_up_environment_extras):
* Tools/Scripts/webkitpy/xcode/simulated_device.py:
(SimulatedDeviceManager.initialize_devices):
(SimulatedDevice.__init__):
(SimulatedDevice.set_up_environment_extras):

Canonical link: <a href="https://commits.webkit.org/280123@main">https://commits.webkit.org/280123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03121e12598ddf0db2e7914f130ce8302e9b2595

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55088 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34562 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58370 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5820 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57388 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/5861 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44599 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/3977 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57183 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32629 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47730 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25727 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/54915 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29408 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5078 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/3964 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51788 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/59960 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30369 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5465 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52029 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31491 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47798 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51484 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12367 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32518 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31281 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->