### PR TITLE
[macOS] Crash when inserting writing suggestions in an editable `display: grid` container

### DIFF
--- a/LayoutTests/editing/input/mac/inline-prediction-in-grid-container-expected.txt
+++ b/LayoutTests/editing/input/mac/inline-prediction-in-grid-container-expected.txt
@@ -1,0 +1,5 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+To whom it
+This test passes if showing inline predictions when typing in the above container don't cause a crash.

--- a/LayoutTests/editing/input/mac/inline-prediction-in-grid-container.html
+++ b/LayoutTests/editing/input/mac/inline-prediction-in-grid-container.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+[contenteditable] {
+    width: 300px;
+    height: 100px;
+    border: solid 1px black;
+    display: grid;
+}
+</style>
+</head>
+<body>
+<div contenteditable></div>
+<p>This test passes if showing inline predictions when typing in the above container don't cause a crash.</p>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    document.querySelector("[contenteditable]").focus();
+    document.execCommand("InsertText", true, "To whom it");
+
+    await UIHelper.setInlinePrediction("To whom it may concern", 10);
+    await UIHelper.ensurePresentationUpdate();
+
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -304,13 +304,13 @@ void RenderTreeUpdater::GeneratedContent::updateWritingSuggestionsRenderer(Rende
         return;
     }
 
-    CheckedPtr nodeBeforeWritingSuggestionsTextRenderer = dynamicDowncast<RenderText>(nodeBeforeWritingSuggestions->renderer());
+    WeakPtr nodeBeforeWritingSuggestionsTextRenderer = dynamicDowncast<RenderText>(nodeBeforeWritingSuggestions->renderer());
     if (!nodeBeforeWritingSuggestionsTextRenderer) {
         destroyWritingSuggestionsIfNeeded();
         return;
     }
 
-    CheckedPtr parentForWritingSuggestions = nodeBeforeWritingSuggestionsTextRenderer->parent();
+    WeakPtr parentForWritingSuggestions = nodeBeforeWritingSuggestionsTextRenderer->parent();
     if (!parentForWritingSuggestions) {
         destroyWritingSuggestionsIfNeeded();
         return;
@@ -351,13 +351,18 @@ void RenderTreeUpdater::GeneratedContent::updateWritingSuggestionsRenderer(Rende
         auto newWritingSuggestionsRenderer = WebCore::createRenderer<RenderInline>(RenderObject::Type::Inline, renderer.document(), WTFMove(newStyle));
         newWritingSuggestionsRenderer->initializeStyle();
 
-        CheckedPtr rendererAfterWritingSuggestions = nodeBeforeWritingSuggestionsTextRenderer->nextSibling();
+        WeakPtr rendererAfterWritingSuggestions = nodeBeforeWritingSuggestionsTextRenderer->nextSibling();
 
         auto writingSuggestionsText = WebCore::createRenderer<RenderText>(RenderObject::Type::Text, renderer.document(), writingSuggestionData->content());
         m_updater.m_builder.attach(*newWritingSuggestionsRenderer, WTFMove(writingSuggestionsText));
 
         editor.setWritingSuggestionRenderer(*newWritingSuggestionsRenderer.get());
         m_updater.m_builder.attach(*parentForWritingSuggestions, WTFMove(newWritingSuggestionsRenderer), rendererAfterWritingSuggestions.get());
+
+        if (!parentForWritingSuggestions) {
+            destroyWritingSuggestionsIfNeeded();
+            return;
+        }
 
         auto* prefixNode = nodeBeforeWritingSuggestionsTextRenderer->textNode();
         if (!prefixNode) {


### PR DESCRIPTION
#### cf817ce46fd4faa5382882e69f75bcd49b8a1956
<pre>
[macOS] Crash when inserting writing suggestions in an editable `display: grid` container
<a href="https://bugs.webkit.org/show_bug.cgi?id=275426">https://bugs.webkit.org/show_bug.cgi?id=275426</a>
<a href="https://rdar.apple.com/129366300">rdar://129366300</a>

Reviewed by Richard Robinson and Abrar Protyasha.

Make writing suggestions robust in the case where the process of attaching the suggestions renderer
to its parent in the render tree causes the parent to become destroyed. This can happen if, for
instance, the renderer is being inserted underneath an anonymous renderer inside of a grid
container like so:

```
&lt;body&gt;
    &lt;div style=&quot;display: grid;&quot; contenteditable&gt;&lt;/div&gt;
&lt;/body&gt;
```

...with render tree:

```
RenderBlock {HTML} at (0,0)
  RenderBody {BODY} at (8,8)
    RenderGrid {DIV} at (0,0)
      RenderBlock (anonymous) at (0,0)
        RenderText {#text} at (0,0) // &lt;----- text before suggestion
```

As a result of inserting the renderer, `removeLeftoverAnonymousBlock()` will replace the parent
renderer, which currently leads to a crash since we hold a `CheckedPtr` to it on the stack. Instead,
gracefully handle this (and similar) scenarios by deploying `WeakPtr`, and clean up the writing
suggestions renderer and return early in the case where the parent is destroyed after insertion.

Test: editing/input/mac/inline-prediction-in-grid-container.html

* LayoutTests/editing/input/mac/inline-prediction-in-grid-container-expected.txt: Added.
* LayoutTests/editing/input/mac/inline-prediction-in-grid-container.html: Added.
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(WebCore::RenderTreeUpdater::GeneratedContent::updateWritingSuggestionsRenderer):

Canonical link: <a href="https://commits.webkit.org/279986@main">https://commits.webkit.org/279986@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c55e393651d71c143adf696eed2ecd72e16c214

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58420 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5866 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57559 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42373 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6055 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44639 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4013 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32662 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47769 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25767 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29447 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5097 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4010 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51383 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60010 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52069 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31667 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47839 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51534 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12265 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32748 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31416 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->