### PR TITLE
[JSC] Split large Handler IC into per AccessCase handlers

### DIFF
--- a/Source/JavaScriptCore/bytecode/GetByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.cpp
@@ -276,7 +276,7 @@ GetByStatus GetByStatus::computeForStubInfoWithoutExitSiteFeedback(const Concurr
                 auto& accessCase = access.as<ProxyObjectAccessCase>();
                 auto status = GetByStatus(accessCase);
                 auto callLinkStatus = makeUnique<CallLinkStatus>();
-                if (CallLinkInfo* callLinkInfo = stubInfo->callLinkInfoAt(locker, 0))
+                if (CallLinkInfo* callLinkInfo = stubInfo->callLinkInfoAt(locker, 0, access))
                     *callLinkStatus = CallLinkStatus::computeFor(locker, profiledBlock, *callLinkInfo, callExitSiteData);
                 status.appendVariant(GetByVariant(accessCase.identifier(), { }, invalidOffset, { }, WTFMove(callLinkStatus)));
                 return status;
@@ -390,7 +390,7 @@ GetByStatus GetByStatus::computeForStubInfoWithoutExitSiteFeedback(const Concurr
                     }
                     case AccessCase::Getter: {
                         callLinkStatus = makeUnique<CallLinkStatus>();
-                        if (CallLinkInfo* callLinkInfo = stubInfo->callLinkInfoAt(locker, listIndex))
+                        if (CallLinkInfo* callLinkInfo = stubInfo->callLinkInfoAt(locker, listIndex, access))
                             *callLinkStatus = CallLinkStatus::computeFor(locker, profiledBlock, *callLinkInfo, callExitSiteData);
                         break;
                     }

--- a/Source/JavaScriptCore/bytecode/PutByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/PutByStatus.cpp
@@ -292,7 +292,7 @@ PutByStatus PutByStatus::computeForStubInfo(const ConcurrentJSLocker& locker, Co
 
                 case ComplexGetStatus::Inlineable: {
                     auto callLinkStatus = makeUnique<CallLinkStatus>();
-                    if (CallLinkInfo* callLinkInfo = stubInfo->callLinkInfoAt(locker, i))
+                    if (CallLinkInfo* callLinkInfo = stubInfo->callLinkInfoAt(locker, i, access))
                         *callLinkStatus = CallLinkStatus::computeFor(locker, profiledBlock, *callLinkInfo, callExitSiteData);
 
                     auto variant = PutByVariant::setter(access.identifier(), structure, complexGetStatus.offset(), complexGetStatus.conditionSet(), WTFMove(callLinkStatus));
@@ -310,7 +310,7 @@ PutByStatus PutByStatus::computeForStubInfo(const ConcurrentJSLocker& locker, Co
             case AccessCase::ProxyObjectStore: {
                 auto& accessCase = access.as<ProxyObjectAccessCase>();
                 auto callLinkStatus = makeUnique<CallLinkStatus>();
-                if (CallLinkInfo* callLinkInfo = stubInfo->callLinkInfoAt(locker, i))
+                if (CallLinkInfo* callLinkInfo = stubInfo->callLinkInfoAt(locker, i, access))
                     *callLinkStatus = CallLinkStatus::computeFor(locker, profiledBlock, *callLinkInfo, callExitSiteData);
                 auto variant = PutByVariant::proxy(accessCase.identifier(), access.structure(), WTFMove(callLinkStatus));
                 if (!result.appendVariant(variant))

--- a/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.cpp
+++ b/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.cpp
@@ -48,7 +48,7 @@ void StructureStubInfoClearingWatchpoint::fireInternal(VM&, const FireDetail&)
     // That works, because deleting a watchpoint removes it from the set's list, and
     // the set's list traversal for firing is robust against the set changing.
     ConcurrentJSLocker locker(m_owner->m_lock);
-    m_stubInfo->reset(locker, m_owner.get());
+    m_stubInfo.reset(locker, m_owner.get());
 }
 
 void StructureTransitionStructureStubClearingWatchpoint::fireInternal(VM& vm, const FireDetail&)

--- a/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h
+++ b/Source/JavaScriptCore/bytecode/StructureStubClearingWatchpoint.h
@@ -45,7 +45,7 @@ class StructureStubInfoClearingWatchpoint final : public Watchpoint {
     WTF_MAKE_NONCOPYABLE(StructureStubInfoClearingWatchpoint);
     WTF_MAKE_TZONE_ALLOCATED(StructureStubInfoClearingWatchpoint);
 public:
-    StructureStubInfoClearingWatchpoint(CodeBlock* owner, StructureStubInfo* stubInfo)
+    StructureStubInfoClearingWatchpoint(CodeBlock* owner, StructureStubInfo& stubInfo)
         : Watchpoint(Watchpoint::Type::StructureStubInfoClearing)
         , m_owner(owner)
         , m_stubInfo(stubInfo)
@@ -56,7 +56,7 @@ public:
 
 private:
     PackedCellPtr<CodeBlock> m_owner;
-    StructureStubInfo* m_stubInfo { nullptr };
+    StructureStubInfo& m_stubInfo;
 };
 
 class StructureTransitionStructureStubClearingWatchpoint final : public Watchpoint {

--- a/Source/JavaScriptCore/bytecode/StructureStubInfo.h
+++ b/Source/JavaScriptCore/bytecode/StructureStubInfo.h
@@ -238,7 +238,9 @@ public:
         return m_inlineAccessBaseStructureID.get();
     }
 
-    CallLinkInfo* callLinkInfoAt(const ConcurrentJSLocker&, unsigned index);
+    CallLinkInfo* callLinkInfoAt(const ConcurrentJSLocker&, unsigned index, const AccessCase&);
+
+    bool useHandlerIC() const { return useDataIC && Options::useHandlerIC(); }
 
 private:
     ALWAYS_INLINE bool considerRepatchingCacheImpl(VM& vm, CodeBlock* codeBlock, Structure* structure, CacheableIdentifier impl)
@@ -353,6 +355,7 @@ private:
     }
 
     void replaceHandler(CodeBlock*, Ref<InlineCacheHandler>&&);
+    void prependHandler(CodeBlock*, Ref<InlineCacheHandler>&&, bool isMegamorphic);
     void rewireStubAsJumpInAccess(CodeBlock*, InlineCacheHandler&);
 
 public:

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.cpp
@@ -105,7 +105,7 @@ void UnlinkedCodeBlock::visitChildrenImpl(JSCell* cell, Visitor& visitor)
         visitor.append(barrier);
     for (auto& barrier : thisObject->m_functionExprs)
         visitor.append(barrier);
-    visitor.appendValues(thisObject->m_constantRegisters);
+    visitor.appendValues(thisObject->m_constantRegisters.span());
     size_t extraMemory = thisObject->metadataSizeInBytes();
     if (thisObject->m_instructions)
         extraMemory += thisObject->m_instructions->sizeInBytes();

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
@@ -109,7 +109,7 @@ public:
     unsigned hash() const
     {
         if (!m_hash)
-            m_hash = computeHash(m_cases);
+            m_hash = computeHash(m_cases.span());
         return m_hash;
     }
 


### PR DESCRIPTION
#### ad63895f25ec02cf2dd3de7694c801e53f0bb93d
<pre>
[JSC] Split large Handler IC into per AccessCase handlers
<a href="https://bugs.webkit.org/show_bug.cgi?id=275428">https://bugs.webkit.org/show_bug.cgi?id=275428</a>
<a href="https://rdar.apple.com/129733285">rdar://129733285</a>

Reviewed by Keith Miller.

Before this patch, for multiple AccessCases IC, we are still generating sequence of code combining all AccessCases.
This generates very succinct small code, but it makes sharing hard. As a result, we end up generating code frequently.

In this patch, we split this large code. In Handler IC with constant-identifier case (we will eventually remove this limitation),
we generate code only one per AccessCase. And we chain these snippets as a chain of handlers. Each handler has next handler, and
code will jump to the next handler when it does not meet the handler&apos;s requirement. And the last handler holds the code for generic fallback.
By doing so, we can increase cache hit rate significantly. Pre-compiled Handler IC code can be easily reused, and even for code-generated case
can get a cached one easily since we no longer need to consider about the combination of AccessCases.

Because AccessCase code generation becomes super cheap (in most of cases, we no longer generate code), we remove AccessCase buffering in this case.
When a new AccessCase is added, we immediately generate a new Handler and chain it to the existing one. This makes IC setup super fast and it removes
a lot of complexity for IC code generation.

* Source/JavaScriptCore/bytecode/GetByStatus.cpp:
(JSC::GetByStatus::computeForStubInfoWithoutExitSiteFeedback):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::useHandlerIC const):
(JSC::InlineCacheCompiler::succeed):
(JSC::InlineCacheCompiler::calculateLiveRegistersForCallAndExceptionHandling):
(JSC::InlineCacheCompiler::preserveLiveRegistersToStackForCallWithoutExceptions):
(JSC::InlineCacheCompiler::callSiteIndexForExceptionHandlingOrOriginal):
(JSC::InlineCacheCompiler::originalExceptionHandler):
(JSC::InlineCacheCompiler::originalCallSiteIndex const):
(JSC::InlineCacheCompiler::makeDefaultScratchAllocator):
(JSC::InlineCacheCompiler::emitDataICJumpNextHandler):
(JSC::InlineCacheHandler::InlineCacheHandler):
(JSC::m_next):
(JSC::InlineCacheHandler::create):
(JSC::InlineCacheHandler::createPreCompiled):
(JSC::InlineCacheCompiler::generateWithGuard):
(JSC::InlineCacheCompiler::generateWithoutGuard):
(JSC::InlineCacheCompiler::generateAccessCase):
(JSC::InlineCacheCompiler::emitDOMJITGetter):
(JSC::InlineCacheCompiler::emitModuleNamespaceLoad):
(JSC::InlineCacheCompiler::emitProxyObjectAccess):
(JSC::InlineCacheCompiler::emitIntrinsicGetter):
(JSC::InlineCacheCompiler::tryFoldToMegamorphic):
(JSC::InlineCacheCompiler::compile):
(JSC::getByIdLoadHandlerCodeGeneratorImpl):
(JSC::getByIdMissHandlerCodeGenerator):
(JSC::getByIdCustomHandlerImpl):
(JSC::getByIdGetterHandler):
(JSC::getByIdProxyObjectLoadHandler):
(JSC::putByIdReplaceHandlerCodeGenerator):
(JSC::putByIdTransitionHandlerCodeGeneratorImpl):
(JSC::putByIdCustomHandlerImpl):
(JSC::putByIdSetterHandlerImpl):
(JSC::InlineCacheCompiler::compileHandler):
(JSC::InlineCacheCompiler::compileOneAccessCaseHandler):
(JSC::PolymorphicAccess::addCases):
(JSC::m_watchpoint): Deleted.
(JSC::PolymorphicAccess::addCase): Deleted.
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.h:
(JSC::InlineCacheCompiler::InlineCacheCompiler):
* Source/JavaScriptCore/bytecode/PutByStatus.cpp:
(JSC::PutByStatus::computeForStubInfo):
* Source/JavaScriptCore/bytecode/StructureStubInfo.cpp:
(JSC::StructureStubInfo::aboutToDie):
(JSC::StructureStubInfo::addAccessCase):
(JSC::StructureStubInfo::visitWeakReferences):
(JSC::StructureStubInfo::callLinkInfoAt):
(JSC::StructureStubInfo::containsPC const):
(JSC::StructureStubInfo::initializeFromUnlinkedStructureStubInfo):
(JSC::StructureStubInfo::replaceHandler):
(JSC::StructureStubInfo::prependHandler):
(JSC::StructureStubInfo::resetStubAsJumpInAccess):
* Source/JavaScriptCore/bytecode/StructureStubInfo.h:
(JSC::StructureStubInfo::useHandlerIC const):

Canonical link: <a href="https://commits.webkit.org/279991@main">https://commits.webkit.org/279991@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80da20fca4c120364361797018d7444e5f27734e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34752 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58419 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5865 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6054 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44638 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4011 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57458 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32675 "Found 60 new test failures: accessibility/accessibility-node-reparent.html accessibility/ancestor-computation.html accessibility/announcement-notification.html accessibility/aria-braillelabel.html accessibility/aria-brailleroledescription.html accessibility/aria-checked-mixed-value.html accessibility/aria-current-state-changed-notification.html accessibility/aria-current.html accessibility/aria-describedby-on-input.html accessibility/aria-description.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47768 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25766 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29460 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5096 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4009 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/48511 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5364 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60009 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/54671 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30579 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5487 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52068 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31666 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47838 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51531 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32747 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/66934 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8168 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31415 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12758 "Passed tests") | 
<!--EWS-Status-Bubble-End-->