### PR TITLE
Ignore instance times from endElement*() for inactive timed elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/end-element-on-inactive-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/end-element-on-inactive-element-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL endElement() on an inactive element assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS endElement() on an inactive element
 

--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2004, 2005 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2007 Rob Buis <buis@kde.org>
  * Copyright (C) 2007 Eric Seidel <eric@webkit.org>
- * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2009 Cameron McCormack <cam@mcc.id.au>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
  * Copyright (C) 2014 Adobe Systems Incorporated. All rights reserved.
@@ -257,6 +257,8 @@ void SVGAnimationElement::beginElementAt(float offset)
 void SVGAnimationElement::endElementAt(float offset)
 {
     ASSERT(std::isfinite(offset));
+    if (activeState() == Inactive)
+        return;
     addInstanceTime(End, elapsed() + offset, SMILTimeWithOrigin::ScriptOrigin);
 }
 

--- a/Source/WebCore/svg/animation/SVGSMILElement.h
+++ b/Source/WebCore/svg/animation/SVGSMILElement.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2024 Apple Inc. All rights reserved.
  * Copyright (C) 2013 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -109,6 +109,8 @@ public:
     void dispatchPendingEvent(SMILEventSender*, const AtomString& eventType);
 
 protected:
+    enum ActiveState { Inactive, Active, Frozen };
+    ActiveState activeState() const { return m_activeState; }
     void setInactive() { m_activeState = Inactive; }
 
     bool rendererIsNeeded(const RenderStyle&) override { return false; }
@@ -174,7 +176,6 @@ private:
     void addTimeDependent(SVGSMILElement*);
     void removeTimeDependent(SVGSMILElement*);
 
-    enum ActiveState { Inactive, Active, Frozen };
     ActiveState determineActiveState(SMILTime elapsed) const;
     float calculateAnimationPercentAndRepeat(SMILTime elapsed, unsigned& repeat) const;
     SMILTime calculateNextProgressTime(SMILTime elapsed) const;


### PR DESCRIPTION
#### a937e1c8a1a3da0a2f63dd3a1f22c59bcea4b5ad
<pre>
Ignore instance times from endElement*() for inactive timed elements

<a href="https://bugs.webkit.org/show_bug.cgi?id=200259">https://bugs.webkit.org/show_bug.cgi?id=200259</a>

Reviewed by Said Abou-Hallawa.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Inspired by: <a href="https://github.com/chromium/chromium/commit/810144f1502198bb66cd265a2ce9a16ccd106dd2">https://github.com/chromium/chromium/commit/810144f1502198bb66cd265a2ce9a16ccd106dd2</a>

When endElementAt()/endElement() is trying to add a new instance time
and there&apos;s no active interval, just ignore the new instance time.

Spec [1]:

   &quot;While the element is not active, any end specification of the
   event is ignored.&quot;

[1] <a href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#Timing-EventSensitivity">https://www.w3.org/TR/2001/REC-smil-animation-20010904/#Timing-EventSensitivity</a>

* Source/WebCore/svg/SVGAnimationElement.cpp:
(WebCore::SVGAnimationElement::endElementAt):
* Source/WebCore/svg/animation/SVGSMILElement.h:
(WebCore::SVGSMILElement::activeState const):
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/scripted/end-element-on-inactive-element-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/280184@main">https://commits.webkit.org/280184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57e563652ab3884316e5bfb7c21ed5b7403a2ef8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55934 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58933 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6366 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58060 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42879 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6562 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/45042 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4399 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48228 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26180 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29934 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5556 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4509 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5827 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60520 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5947 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52470 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48297 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51987 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12398 "Found 1 new test failure: imported/w3c/web-platform-tests/webrtc/simulcast/getStats.https.html (failure)") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8269 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31087 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32171 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33253 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31919 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->