### PR TITLE
Use actual version numbers for Fall 2024 OS releases.

### DIFF
--- a/Source/WebKit/WebKitSwift/GroupActivities/GroupSession.swift
+++ b/Source/WebKit/WebKitSwift/GroupActivities/GroupSession.swift
@@ -28,7 +28,7 @@ import Combine
 @_spi(Safari) import GroupActivities
 import Foundation
 
-@available(macOS 9999.0, iOS 9999.0, tvOS 9999.0, *)
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, *)
 @objc(WKGroupSessionState)
 public enum GroupSessionState : Int {
     case waiting = 0
@@ -36,7 +36,7 @@ public enum GroupSessionState : Int {
     case invalidated = 2
 }
 
-@available(macOS 9999.0, iOS 9999.0, tvOS 9999.0, *)
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, *)
 @objc(WKURLActivity)
 public final class URLActivityWrapper : NSObject {
     private var urlActivity: URLActivity
@@ -50,7 +50,7 @@ public final class URLActivityWrapper : NSObject {
     }
 }
 
-@available(macOS 9999.0, iOS 9999.0, tvOS 9999.0, *)
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, *)
 @objc(WKGroupSession)
 public final class GroupSessionWrapper : NSObject {
     private var groupSession: GroupSession<URLActivity>
@@ -128,7 +128,7 @@ public final class GroupSessionWrapper : NSObject {
     }
 }
 
-@available(macOS 9999.0, iOS 9999.0, tvOS 9999.0, *)
+@available(macOS 15.0, iOS 18.0, tvOS 18.0, *)
 @objc(WKGroupSessionObserver)
 public class GroupSessionObserver : NSObject {
     @objc public var newSessionCallback: ((GroupSessionWrapper) -> Void)?


### PR DESCRIPTION
#### 9a5672cee350242fc097767027e9fd8feaa638f9
<pre>
Use actual version numbers for Fall 2024 OS releases.
<a href="https://bugs.webkit.org/show_bug.cgi?id=275439">https://bugs.webkit.org/show_bug.cgi?id=275439</a>
<a href="https://rdar.apple.com/125427383">rdar://125427383</a>

Reviewed by Elliott Williams.

Use the newly announced version numbers for API availability annotations.
They are now public as per announcements at WWDC 24&apos;.
So we can safely remove the future value that is 9999.0 as these APIs need to be marked available.

* Source/WebKit/WebKitSwift/GroupActivities/GroupSession.swift:

Canonical link: <a href="https://commits.webkit.org/282676@main">https://commits.webkit.org/282676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13d48c1866024a90c971db6f5640dc0b064e2b7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67913 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14499 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51473 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/10023 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/40051 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55313 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32089 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36729 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13372 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/58693 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/13025 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69609 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7838 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/12557 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/58795 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7871 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55410 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/58941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6509 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/9663 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/39068 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/40147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/41330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39890 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->