### PR TITLE
Web Inspector: Debugger: inline breakpoints aren't shown for comma sub-expressions

### DIFF
--- a/LayoutTests/inspector/debugger/breakpoints/resolved-dump-all-pause-locations-expected.txt
+++ b/LayoutTests/inspector/debugger/breakpoints/resolved-dump-all-pause-locations-expected.txt
@@ -1437,11 +1437,41 @@ PAUSES AT: 217:0
     220        a(),
 
 INSERTING AT: 217:1
+PAUSES AT: 217:9
+    214    b(),
+    215    c();
+    216
+-=> 217    t#rue && (|a(), b(), c()) && true;
+    218
+    219    true && (
+    220        a(),
+
+INSERTING AT: 217:10
+PAUSES AT: 217:14
+    214    b(),
+    215    c();
+    216
+-=> 217    true && (a#(), |b(), c()) && true;
+    218
+    219    true && (
+    220        a(),
+
+INSERTING AT: 217:15
+PAUSES AT: 217:19
+    214    b(),
+    215    c();
+    216
+-=> 217    true && (a(), b#(), |c()) && true;
+    218
+    219    true && (
+    220        a(),
+
+INSERTING AT: 217:20
 PAUSES AT: 219:0
     214    b(),
     215    c();
     216
- -> 217    t#rue && (a(), b(), c()) && true;
+ -> 217    true && (a(), b(), c#()) && true;
     218
  => 219    |true && (
     220        a(),
@@ -1449,14 +1479,44 @@ PAUSES AT: 219:0
     222        c()
 
 INSERTING AT: 219:1
-PAUSES AT: 226:4
+PAUSES AT: 220:4
     216
     217    true && (a(), b(), c()) && true;
     218
  -> 219    t#rue && (
-    220        a(),
+ => 220        |a(),
     221        b(),
     222        c()
+    223    ) && true;
+
+INSERTING AT: 220:5
+PAUSES AT: 221:4
+    217    true && (a(), b(), c()) && true;
+    218
+    219    true && (
+ -> 220        a#(),
+ => 221        |b(),
+    222        c()
+    223    ) && true;
+    224
+
+INSERTING AT: 221:5
+PAUSES AT: 222:4
+    218
+    219    true && (
+    220        a(),
+ -> 221        b#(),
+ => 222        |c()
+    223    ) && true;
+    224
+    225    try {
+
+INSERTING AT: 222:5
+PAUSES AT: 226:4
+    219    true && (
+    220        a(),
+    221        b(),
+ -> 222        c#()
     223    ) && true;
     224
     225    try {

--- a/LayoutTests/inspector/debugger/breakpoints/resolved-dump-each-line-expected.txt
+++ b/LayoutTests/inspector/debugger/breakpoints/resolved-dump-each-line-expected.txt
@@ -3346,7 +3346,7 @@ PAUSES AT: 217:0
     219    true && (
     220        a(),
 LOCATIONS FROM 217:0 to 217:32
-    217    |true && (a(), b(), c()) && true;
+    217    |true && (|a(), |b(), |c()) && true;
 
 INSERTING AT: 218:0
 PAUSES AT: 219:0
@@ -3374,55 +3374,40 @@ LOCATIONS FROM 219:0 to 219:9
     219    |true && (
 
 INSERTING AT: 220:0
-PAUSES AT: 226:4
+PAUSES AT: 220:4
     217    true && (a(), b(), c()) && true;
     218
     219    true && (
- -> 220    #    a(),
+-=> 220    #    |a(),
     221        b(),
     222        c()
     223    ) && true;
-    224
-    225    try {
- => 226        |throw a(), b(), c();
-    227    } catch { }
-    228
-    229    try {
 LOCATIONS FROM 220:0 to 220:8
-    220    #    a(),
+    220    #    |a(),
 
 INSERTING AT: 221:0
-PAUSES AT: 226:4
+PAUSES AT: 221:4
     218
     219    true && (
     220        a(),
- -> 221    #    b(),
+-=> 221    #    |b(),
     222        c()
     223    ) && true;
     224
-    225    try {
- => 226        |throw a(), b(), c();
-    227    } catch { }
-    228
-    229    try {
 LOCATIONS FROM 221:0 to 221:8
-    221    #    b(),
+    221    #    |b(),
 
 INSERTING AT: 222:0
-PAUSES AT: 226:4
+PAUSES AT: 222:4
     219    true && (
     220        a(),
     221        b(),
- -> 222    #    c()
+-=> 222    #    |c()
     223    ) && true;
     224
     225    try {
- => 226        |throw a(), b(), c();
-    227    } catch { }
-    228
-    229    try {
 LOCATIONS FROM 222:0 to 222:7
-    222    #    c()
+    222    #    |c()
 
 INSERTING AT: 223:0
 PAUSES AT: 226:4

--- a/LayoutTests/inspector/debugger/stepping/stepInto-expected.txt
+++ b/LayoutTests/inspector/debugger/stepping/stepInto-expected.txt
@@ -341,6 +341,15 @@ PAUSE AT testCommas:45:5
      46
      47    function testChainedExpressions() {
 
+PAUSE AT testCommas:45:14
+     41            y = 2,
+     42            z = 3;
+     43        a(), b(), c();
+ ->  44        true && (|a(), b(), c()) && true;
+     45    }
+     46
+     47    function testChainedExpressions() {
+
 PAUSE AT a:7:16
       3    <script src="../../../http/tests/inspector/resources/inspector-test.js"></script>
       4    <script src="../resources/log-pause-location.js"></script>

--- a/LayoutTests/inspector/debugger/stepping/stepNext-expected.txt
+++ b/LayoutTests/inspector/debugger/stepping/stepNext-expected.txt
@@ -263,6 +263,15 @@ PAUSE AT testCommas:45:5
      46
      47    function testChainedExpressions() {
 
+PAUSE AT testCommas:45:14
+     41            y = 2,
+     42            z = 3;
+     43        a(), b(), c();
+ ->  44        true && (|a(), b(), c()) && true;
+     45    }
+     46
+     47    function testChainedExpressions() {
+
 PAUSE AT testCommas:45:19
      41            y = 2,
      42            z = 3;

--- a/LayoutTests/inspector/debugger/stepping/stepOver-expected.txt
+++ b/LayoutTests/inspector/debugger/stepping/stepOver-expected.txt
@@ -263,6 +263,33 @@ PAUSE AT testCommas:45:5
      46
      47    function testChainedExpressions() {
 
+PAUSE AT testCommas:45:14
+     41            y = 2,
+     42            z = 3;
+     43        a(), b(), c();
+ ->  44        true && (|a(), b(), c()) && true;
+     45    }
+     46
+     47    function testChainedExpressions() {
+
+PAUSE AT testCommas:45:19
+     41            y = 2,
+     42            z = 3;
+     43        a(), b(), c();
+ ->  44        true && (a(), |b(), c()) && true;
+     45    }
+     46
+     47    function testChainedExpressions() {
+
+PAUSE AT testCommas:45:24
+     41            y = 2,
+     42            z = 3;
+     43        a(), b(), c();
+ ->  44        true && (a(), b(), |c()) && true;
+     45    }
+     46
+     47    function testChainedExpressions() {
+
 PAUSE AT testCommas:46:2
      42            z = 3;
      43        a(), b(), c();

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -4046,14 +4046,9 @@ RegisterID* ShortCircuitReadModifyBracketNode::emitBytecode(BytecodeGenerator& g
 
 RegisterID* CommaNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
 {
-    DebugHookType debugHookType = isOnlyChildOfStatement() ? WillExecuteStatement : WillExecuteExpression;
-
     CommaNode* node = this;
-    for (; node->next(); node = node->next()) {
-        generator.emitDebugHook(debugHookType, node->m_expr->position());
+    for (; node->next(); node = node->next())
         generator.emitNodeInIgnoreResultPosition(node->m_expr);
-    }
-    generator.emitDebugHook(debugHookType, node->m_expr->position());
     return generator.emitNodeInTailPosition(dst, node->m_expr);
 }
 

--- a/Source/JavaScriptCore/parser/ASTBuilder.h
+++ b/Source/JavaScriptCore/parser/ASTBuilder.h
@@ -882,7 +882,7 @@ public:
         return new (m_parserArena) CommaNode(location, node);
     }
 
-    CommaNode* appendToCommaExpr(const JSTokenLocation& location, ExpressionNode*, ExpressionNode* tail, ExpressionNode* next)
+    CommaNode* appendToCommaExpr(const JSTokenLocation& location, ExpressionNode* tail, ExpressionNode* next)
     {
         ASSERT(tail->isCommaNode());
         ASSERT(next);

--- a/Source/JavaScriptCore/parser/NodeConstructors.h
+++ b/Source/JavaScriptCore/parser/NodeConstructors.h
@@ -853,14 +853,12 @@ namespace JSC {
         : StatementNode(location)
         , m_expr(expr)
     {
-        m_expr->setIsOnlyChildOfStatement();
     }
 
     inline DeclarationStatement::DeclarationStatement(const JSTokenLocation& location, ExpressionNode* expr)
         : StatementNode(location)
         , m_expr(expr)
     {
-        m_expr->setIsOnlyChildOfStatement();
     }
 
     inline ModuleDeclarationNode::ModuleDeclarationNode(const JSTokenLocation& location)
@@ -986,8 +984,6 @@ namespace JSC {
         : StatementNode(location)
         , m_value(value)
     {
-        if (m_value)
-            m_value->setIsOnlyChildOfStatement();
     }
 
     inline WithNode::WithNode(const JSTokenLocation& location, ExpressionNode* expr, StatementNode* statement, const JSTextPosition& divot, uint32_t expressionLength)
@@ -1010,7 +1006,6 @@ namespace JSC {
         : StatementNode(location)
         , m_expr(expr)
     {
-        m_expr->setIsOnlyChildOfStatement();
     }
 
     inline TryNode::TryNode(const JSTokenLocation& location, StatementNode* tryBlock, DestructuringPatternNode* catchPattern, StatementNode* catchBlock, VariableEnvironment&& catchEnvironment, StatementNode* finallyBlock)

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -226,15 +226,11 @@ namespace JSC {
 
         ResultType resultDescriptor() const { return m_resultType; }
 
-        bool isOnlyChildOfStatement() const { return m_isOnlyChildOfStatement; }
-        void setIsOnlyChildOfStatement() { m_isOnlyChildOfStatement = true; }
-
         bool isOptionalChainBase() const { return m_isOptionalChainBase; }
         void setIsOptionalChainBase() { m_isOptionalChainBase = true; }
 
     private:
         ResultType m_resultType;
-        bool m_isOnlyChildOfStatement { false };
         bool m_isOptionalChainBase { false };
     };
 

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -984,11 +984,11 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseVariableDecl
                 headLocation = location;
             } else {
                 if (!tail) {
-                    head = tail = context.createCommaExpr(headLocation, head);
                     recordPauseLocation(context.breakpointLocation(head));
+                    head = tail = context.createCommaExpr(headLocation, head);
                 }
-                tail = context.appendToCommaExpr(location, head, tail, node);
-                recordPauseLocation(context.breakpointLocation(tail));
+                recordPauseLocation(context.breakpointLocation(node));
+                tail = context.appendToCommaExpr(location, tail, node);
             }
         }
     } while (match(COMMA));
@@ -1711,7 +1711,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseReturnStateme
 
     if (autoSemiColon())
         return context.createReturnStatement(location, 0, start, end);
-    TreeExpression expr = parseExpression(context, IsOnlyChildOfStatement::Yes);
+    TreeExpression expr = parseExpression(context);
     failIfFalse(expr, "Cannot parse the return expression");
     end = lastTokenEndPosition();
     if (match(SEMICOLON))
@@ -1731,7 +1731,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseThrowStatemen
     failIfTrue(match(SEMICOLON), "Expected expression after 'throw'");
     semanticFailIfTrue(autoSemiColon(), "Cannot have a newline after 'throw'");
     
-    TreeExpression expr = parseExpression(context, IsOnlyChildOfStatement::Yes);
+    TreeExpression expr = parseExpression(context);
     failIfFalse(expr, "Cannot parse expression for throw statement");
     JSTextPosition end = lastTokenEndPosition();
     failIfFalse(autoSemiColon(), "Expected a ';' after a throw statement");
@@ -3477,7 +3477,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseExpressionSta
 
     JSTextPosition start = tokenStartPosition();
     JSTokenLocation location(tokenLocation());
-    TreeExpression expression = parseExpression(context, IsOnlyChildOfStatement::Yes);
+    TreeExpression expression = parseExpression(context);
     failIfFalse(expression, "Cannot parse expression statement");
     if (!autoSemiColon())
         failDueToUnexpectedToken();
@@ -4088,7 +4088,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseExportDeclara
 }
 
 template <typename LexerType>
-template <class TreeBuilder> TreeExpression Parser<LexerType>::parseExpression(TreeBuilder& context, IsOnlyChildOfStatement isStatement)
+template <class TreeBuilder> TreeExpression Parser<LexerType>::parseExpression(TreeBuilder& context)
 {
     failIfStackOverflow();
     JSTokenLocation headLocation(tokenLocation());
@@ -4097,28 +4097,25 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseExpression(T
     context.setEndOffset(node, m_lastTokenEndPosition.offset);
     if (!match(COMMA))
         return node;
+    recordPauseLocation(context.breakpointLocation(node));
     next();
     m_parserState.nonTrivialExpressionCount++;
     m_parserState.nonLHSCount++;
     JSTokenLocation tailLocation(tokenLocation());
     TreeExpression right = parseAssignmentExpression(context);
     failIfFalse(right, "Cannot parse expression in a comma expression");
+    recordPauseLocation(context.breakpointLocation(right));
     context.setEndOffset(right, m_lastTokenEndPosition.offset);
     typename TreeBuilder::Comma head = context.createCommaExpr(headLocation, node);
-    if (isStatement == IsOnlyChildOfStatement::Yes)
-        recordPauseLocation(context.breakpointLocation(head));
-    typename TreeBuilder::Comma tail = context.appendToCommaExpr(tailLocation, head, head, right);
-    if (isStatement == IsOnlyChildOfStatement::Yes)
-        recordPauseLocation(context.breakpointLocation(tail));
+    typename TreeBuilder::Comma tail = context.appendToCommaExpr(tailLocation, head, right);
     while (match(COMMA)) {
         next(TreeBuilder::DontBuildStrings);
         tailLocation = tokenLocation();
         right = parseAssignmentExpression(context);
         failIfFalse(right, "Cannot parse expression in a comma expression");
         context.setEndOffset(right, m_lastTokenEndPosition.offset);
-        tail = context.appendToCommaExpr(tailLocation, head, tail, right);
-        if (isStatement == IsOnlyChildOfStatement::Yes)
-            recordPauseLocation(context.breakpointLocation(tail));
+        recordPauseLocation(context.breakpointLocation(right));
+        tail = context.appendToCommaExpr(tailLocation, tail, right);
     }
     context.setEndOffset(head, m_lastTokenEndPosition.offset);
     return head;

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -1818,10 +1818,7 @@ private:
     template <class TreeBuilder> TreeStatement parseIfStatement(TreeBuilder&);
     enum class BlockType : uint8_t { Normal, CatchBlock, StaticBlock };
     template <class TreeBuilder> TreeStatement parseBlockStatement(TreeBuilder&, BlockType = BlockType::Normal);
-
-    enum class IsOnlyChildOfStatement : bool { No, Yes };
-    template <class TreeBuilder> TreeExpression parseExpression(TreeBuilder&, IsOnlyChildOfStatement = IsOnlyChildOfStatement::No);
-
+    template <class TreeBuilder> TreeExpression parseExpression(TreeBuilder&);
     template <class TreeBuilder> TreeExpression parseAssignmentExpression(TreeBuilder&, ExpressionErrorClassifier&);
     template <class TreeBuilder> TreeExpression parseAssignmentExpression(TreeBuilder&);
     template <class TreeBuilder> TreeExpression parseAssignmentExpressionOrPropagateErrorClass(TreeBuilder&);

--- a/Source/JavaScriptCore/parser/SyntaxChecker.h
+++ b/Source/JavaScriptCore/parser/SyntaxChecker.h
@@ -153,7 +153,7 @@ public:
     ExpressionType makeStaticBlockFunctionCallNode(const JSTokenLocation&, ExpressionType, int, int, int) { return CallExpr; }
     ExpressionType makeFunctionCallNode(const JSTokenLocation&, ExpressionType, bool, int, int, int, int, size_t, bool) { return CallExpr; }
     ExpressionType createCommaExpr(const JSTokenLocation&, ExpressionType) { return CommaExpr; }
-    ExpressionType appendToCommaExpr(const JSTokenLocation&, ExpressionType, ExpressionType, ExpressionType) { return CommaExpr; }
+    ExpressionType appendToCommaExpr(const JSTokenLocation&, ExpressionType, ExpressionType) { return CommaExpr; }
     ExpressionType makeAssignNode(const JSTokenLocation&, ExpressionType, Operator, ExpressionType, bool, bool, int, int, int) { return AssignmentExpr; }
     ExpressionType makePrefixNode(const JSTokenLocation&, ExpressionType, Operator, int, int, int) { return PreExpr; }
     ExpressionType makePostfixNode(const JSTokenLocation&, ExpressionType, Operator, int, int, int) { return PostExpr; }


### PR DESCRIPTION
#### 1ccd70cd2ef4cd369cebe0d5dabe775b406a31aa
<pre>
Web Inspector: Debugger: inline breakpoints aren&apos;t shown for comma sub-expressions
<a href="https://bugs.webkit.org/show_bug.cgi?id=275440">https://bugs.webkit.org/show_bug.cgi?id=275440</a>

Reviewed by Justin Michaud.

The ability to treat comma sub-expressions as statements was originally added in &lt;<a href="https://webkit.org/b/209998">https://webkit.org/b/209998</a>&gt;.

It was later restricted to only top-level sub-expressions (i.e. statements) in &lt;<a href="https://webkit.org/b/210588">https://webkit.org/b/210588</a>&gt;.

It&apos;s extremely common for minifiers to convert code like this

```js
if (foo) {
    a();
    b();
    c();
}
```

into code like this

```js
foo &amp;&amp; (a(), b(), c())
```

meaning that if we continue to restrict to only top-level sub-expressions then there will be no pause positions on that line.

In order to have better parity to extremely similar code like this

```js
a(), b(), c();
```

we should just remove this restriction.

* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::CommaNode::emitBytecode):
Instead of manually emitting debugger hooks for each `CommaNode`, let the contained `ExpressionNode` do it.
This way, multiple debugger hooks won&apos;t be emitted if the `ExpressionNode` was already going to.

* Source/JavaScriptCore/parser/Parser.h:
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseVariableDeclarationList):
(JSC::Parser&lt;LexerType&gt;::parseReturnStatement):
(JSC::Parser&lt;LexerType&gt;::parseThrowStatement):
(JSC::Parser&lt;LexerType&gt;::parseExpressionStatement):
(JSC::Parser&lt;LexerType&gt;::parseExpression):
* Source/JavaScriptCore/parser/ASTBuilder.h:
(JSC::ASTBuilder::appendToCommaExpr):
* Source/JavaScriptCore/parser/SyntaxChecker.h:
(JSC::SyntaxChecker::appendToCommaExpr):
Mark the `ExpressionNode` contained by each `CommaNode` as needing a debugger hook.
Remove `IsOnlyChildOfStatement` now that Web Inspector treats all comma expressions as statements.

* Source/JavaScriptCore/parser/Nodes.h:
(JSC::ExpressionNode::isOnlyChildOfStatement const): Deleted.
(JSC::ExpressionNode::setIsOnlyChildOfStatement): Deleted.
* Source/JavaScriptCore/parser/NodeConstructors.h:
(JSC::ExprStatementNode::ExprStatementNode):
(JSC::DeclarationStatement::DeclarationStatement):
(JSC::ReturnNode::ReturnNode):
(JSC::ThrowNode::ThrowNode):
Remove `isOnlyChildOfStatement` now that Web Inspector treats all comma expressions as statements.

* LayoutTests/inspector/debugger/breakpoints/resolved-dump-all-pause-locations-expected.txt:
* LayoutTests/inspector/debugger/breakpoints/resolved-dump-each-line-expected.txt:
* LayoutTests/inspector/debugger/stepping/stepInto-expected.txt:
* LayoutTests/inspector/debugger/stepping/stepNext-expected.txt:
* LayoutTests/inspector/debugger/stepping/stepOver-expected.txt:

Canonical link: <a href="https://commits.webkit.org/280099@main">https://commits.webkit.org/280099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/782e6178b191bdb7621dc3f6a0cfbf63e5e7a2e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58587 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6033 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6232 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44775 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4140 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57632 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47923 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25907 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29612 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5252 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4177 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/48680 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51539 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5519 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60178 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/54840 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30757 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5790 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52207 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31842 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51689 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12351 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32923 "Built successfully") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/72428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31589 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/72428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->