### PR TITLE
[WPE][GTK] Web process cache suspend/resume does not work, WebProcessProxy::processIdentifier is not the pid of the actual web process

### DIFF
--- a/Source/WebKit/Platform/IPC/IPCUtilities.h
+++ b/Source/WebKit/Platform/IPC/IPCUtilities.h
@@ -56,9 +56,17 @@ struct SocketPair {
 enum PlatformConnectionOptions {
     SetCloexecOnClient = 1 << 0,
     SetCloexecOnServer = 1 << 1,
+#if USE(GLIB) && OS(LINUX)
+    SetPasscredOnServer = 1 << 2
+#endif
 };
 
 SocketPair createPlatformConnection(unsigned options = SetCloexecOnClient | SetCloexecOnServer);
+
+#if USE(GLIB) && OS(LINUX)
+void sendPIDToPeer(int socket);
+pid_t readPIDFromPeer(int socket);
+#endif
 #endif
 
 #if OS(WINDOWS)

--- a/Source/WebKit/Shared/unix/AuxiliaryProcessMain.cpp
+++ b/Source/WebKit/Shared/unix/AuxiliaryProcessMain.cpp
@@ -26,11 +26,13 @@
 #include "config.h"
 #include "AuxiliaryProcessMain.h"
 
+#include "IPCUtilities.h"
 #include <JavaScriptCore/Options.h>
 #include <WebCore/ProcessIdentifier.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>
+#include <wtf/text/StringToIntegerConversion.h>
 
 #if ENABLE(BREAKPAD)
 #include "unix/BreakpadExceptionHandler.h"
@@ -45,18 +47,52 @@ AuxiliaryProcessMainCommon::AuxiliaryProcessMainCommon()
 #endif
 }
 
+// The command line is constructed in ProcessLauncher::launchProcess.
 bool AuxiliaryProcessMainCommon::parseCommandLine(int argc, char** argv)
 {
-    ASSERT(argc >= 3);
-    if (argc < 3)
+#if USE(GLIB) && OS(LINUX)
+    int minimumNumArgs = 4;
+#else
+    int minimumNumArgs = 3;
+#endif
+
+#if USE(LIBWPE) && !ENABLE(BUBBLEWRAP_SANDBOX)
+    if (ProcessProviderLibWPE::singleton().isEnabled())
+        minimumNumArgs = 3;
+#endif
+
+    if (argc < minimumNumArgs)
         return false;
 
-    m_parameters.processIdentifier = ObjectIdentifier<WebCore::ProcessIdentifierType>(atoll(argv[1]));
-    m_parameters.connectionIdentifier = IPC::Connection::Identifier { atoi(argv[2]) };
+    if (auto processIdentifier = parseInteger<uint64_t>(span(argv[1])))
+        m_parameters.processIdentifier = ObjectIdentifier<WebCore::ProcessIdentifierType>(*processIdentifier);
+    else
+        return false;
+
+    if (auto connectionIdentifier = parseInteger<int>(span(argv[2])))
+        m_parameters.connectionIdentifier = IPC::Connection::Identifier { *connectionIdentifier };
+    else
+        return false;
+
+    if (!m_parameters.processIdentifier->toRawValue() || m_parameters.connectionIdentifier.handle <= 0)
+        return false;
+
+#if USE(GLIB) && OS(LINUX)
+    if (minimumNumArgs == 4) {
+        auto pidSocket = parseInteger<int>(span(argv[3]));
+        if (!pidSocket || *pidSocket < 0)
+            return false;
+
+        IPC::sendPIDToPeer(*pidSocket);
+        RELEASE_ASSERT(!close(*pidSocket));
+    }
+#endif
+
 #if ENABLE(DEVELOPER_MODE)
-    if (argc > 3 && argv[3] && !strcmp(argv[3], "--configure-jsc-for-testing"))
+    if (argc > minimumNumArgs && argv[minimumNumArgs] && !strcmp(argv[minimumNumArgs], "--configure-jsc-for-testing"))
         JSC::Config::configureForTesting();
 #endif
+
     return true;
 }
 

--- a/Source/WebKit/UIProcess/Launcher/glib/FlatpakLauncher.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/FlatpakLauncher.cpp
@@ -33,7 +33,7 @@
 
 namespace WebKit {
 
-GRefPtr<GSubprocess> flatpakSpawn(GSubprocessLauncher* launcher, const WebKit::ProcessLauncher::LaunchOptions& launchOptions, char** argv, int childProcessSocket, GError** error)
+GRefPtr<GSubprocess> flatpakSpawn(GSubprocessLauncher* launcher, const WebKit::ProcessLauncher::LaunchOptions& launchOptions, char** argv, int childProcessSocket, int pidSocket, GError** error)
 {
     ASSERT(launcher);
 
@@ -41,10 +41,13 @@ GRefPtr<GSubprocess> flatpakSpawn(GSubprocessLauncher* launcher, const WebKit::P
     // bubblewrap sandbox we do outside but flatpak offers the ability to create new sandboxes
     // for us using flatpak-spawn.
 
-    GUniquePtr<gchar> childProcessSocketArg(g_strdup_printf("--forward-fd=%d", childProcessSocket));
+    GUniquePtr<char> childProcessSocketArg(g_strdup_printf("--forward-fd=%d", childProcessSocket));
+    GUniquePtr<char> pidSocketArg(g_strdup_printf("--forward-fd=%d", pidSocket));
     Vector<CString> flatpakArgs = {
         "flatpak-spawn",
         childProcessSocketArg.get(),
+        pidSocketArg.get(),
+        "--expose-pids",
         "--watch-bus"
     };
 

--- a/Source/WebKit/UIProcess/Launcher/glib/FlatpakLauncher.h
+++ b/Source/WebKit/UIProcess/Launcher/glib/FlatpakLauncher.h
@@ -36,7 +36,7 @@ typedef struct _GSubprocessLauncher GSubprocessLauncher;
 
 namespace WebKit {
 
-GRefPtr<GSubprocess> flatpakSpawn(GSubprocessLauncher*, const WebKit::ProcessLauncher::LaunchOptions&, char** argv, int childProcessSocket, GError**);
+GRefPtr<GSubprocess> flatpakSpawn(GSubprocessLauncher*, const WebKit::ProcessLauncher::LaunchOptions&, char** argv, int childProcessSocket, int pidSocket, GError**);
 
 };
 

--- a/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
@@ -125,10 +125,12 @@ static bool isSandboxEnabled(const ProcessLauncher::LaunchOptions& launchOptions
 
 void ProcessLauncher::launchProcess()
 {
-    IPC::SocketPair socketPair = IPC::createPlatformConnection(connectionOptions());
+    RELEASE_ASSERT(m_launchOptions.processType != ProcessLauncher::ProcessType::DBusProxy);
 
     GUniquePtr<gchar> processIdentifier(g_strdup_printf("%" PRIu64, m_launchOptions.processIdentifier.toUInt64()));
-    GUniquePtr<gchar> webkitSocket(g_strdup_printf("%d", socketPair.client));
+
+    IPC::SocketPair webkitSocketPair = IPC::createPlatformConnection(connectionOptions());
+    GUniquePtr<gchar> webkitSocket(g_strdup_printf("%d", webkitSocketPair.client));
 
 #if USE(LIBWPE) && !ENABLE(BUBBLEWRAP_SANDBOX)
     if (ProcessProviderLibWPE::singleton().isEnabled()) {
@@ -139,17 +141,22 @@ void ProcessLauncher::launchProcess()
         argv[i++] = webkitSocket.get();
         argv[i++] = nullptr;
 
-        m_processID = ProcessProviderLibWPE::singleton().launchProcess(m_launchOptions, argv, socketPair.client);
+        m_processID = ProcessProviderLibWPE::singleton().launchProcess(m_launchOptions, argv, webkitSocketPair.client);
         if (m_processID <= -1)
             g_error("Unable to spawn a new child process");
 
         // We've finished launching the process, message back to the main run loop.
-        RunLoop::main().dispatch([protectedThis = Ref { *this }, this, serverSocket = socketPair.server] {
+        RunLoop::main().dispatch([protectedThis = Ref { *this }, this, serverSocket = webkitSocketPair.server] {
             didFinishLaunchingProcess(m_processID, IPC::Connection::Identifier { serverSocket });
         });
 
         return;
     }
+#endif
+
+#if OS(LINUX)
+    IPC::SocketPair pidSocketPair = IPC::createPlatformConnection(IPC::PlatformConnectionOptions::SetCloexecOnClient | IPC::PlatformConnectionOptions::SetCloexecOnServer | IPC::PlatformConnectionOptions::SetPasscredOnServer);
+    GUniquePtr<gchar> pidSocket(g_strdup_printf("%d", pidSocketPair.client));
 #endif
 
     String executablePath;
@@ -172,7 +179,7 @@ void ProcessLauncher::launchProcess()
     }
 
     realExecutablePath = FileSystem::fileSystemRepresentation(executablePath);
-    unsigned nargs = 4; // size of the argv array for g_spawn_async()
+    unsigned nargs = 5; // size of the argv array for g_spawn_async()
 
 #if ENABLE(DEVELOPER_MODE)
     Vector<CString> prefixArgs;
@@ -199,6 +206,7 @@ void ProcessLauncher::launchProcess()
     argv[i++] = const_cast<char*>(realExecutablePath.data());
     argv[i++] = processIdentifier.get();
     argv[i++] = webkitSocket.get();
+    argv[i++] = pidSocket.get();
 #if ENABLE(DEVELOPER_MODE)
     if (configureJSCForTesting)
         argv[i++] = const_cast<char*>("--configure-jsc-for-testing");
@@ -215,7 +223,10 @@ void ProcessLauncher::launchProcess()
     //
     // Please keep this comment in sync with the duplicate comment in XDGDBusProxy::launch.
     GRefPtr<GSubprocessLauncher> launcher = adoptGRef(g_subprocess_launcher_new(G_SUBPROCESS_FLAGS_INHERIT_FDS));
-    g_subprocess_launcher_take_fd(launcher.get(), socketPair.client, socketPair.client);
+    g_subprocess_launcher_take_fd(launcher.get(), webkitSocketPair.client, webkitSocketPair.client);
+#if OS(LINUX)
+    g_subprocess_launcher_take_fd(launcher.get(), pidSocketPair.client, pidSocketPair.client);
+#endif
 
 #if USE(SYSPROF_CAPTURE)
     UnixFileDescriptor sysprofFd;
@@ -238,7 +249,7 @@ void ProcessLauncher::launchProcess()
     bool sandboxEnabled = isSandboxEnabled(m_launchOptions);
 
     if (sandboxEnabled && isFlatpakSpawnUsable())
-        process = flatpakSpawn(launcher.get(), m_launchOptions, argv, socketPair.client, &error.outPtr());
+        process = flatpakSpawn(launcher.get(), m_launchOptions, argv, webkitSocketPair.client, pidSocketPair.client, &error.outPtr());
 #if ENABLE(BUBBLEWRAP_SANDBOX)
     // You cannot use bubblewrap within Flatpak or some containers so lets ensure it never happens.
     // Snap can allow it but has its own limitations that require workarounds.
@@ -252,15 +263,20 @@ void ProcessLauncher::launchProcess()
     if (!process.get())
         g_error("Unable to spawn a new child process: %s", error->message);
 
+#if OS(LINUX)
+    m_processID = IPC::readPIDFromPeer(pidSocketPair.server);
+    RELEASE_ASSERT(!close(pidSocketPair.server));
+#else
     const char* processIdStr = g_subprocess_get_identifier(process.get());
     if (!processIdStr)
         g_error("Spawned process died immediately. This should not happen.");
 
     m_processID = g_ascii_strtoll(processIdStr, nullptr, 0);
     RELEASE_ASSERT(m_processID);
+#endif
 
     // We've finished launching the process, message back to the main run loop.
-    RunLoop::main().dispatch([protectedThis = Ref { *this }, this, serverSocket = socketPair.server] {
+    RunLoop::main().dispatch([protectedThis = Ref { *this }, this, serverSocket = webkitSocketPair.server] {
         didFinishLaunchingProcess(m_processID, IPC::Connection::Identifier { serverSocket });
     });
 }


### PR DESCRIPTION
#### c3c75352f0eef0734daa4946af7a5b60ce045ccd
<pre>
[WPE][GTK] Web process cache suspend/resume does not work, WebProcessProxy::processIdentifier is not the pid of the actual web process
<a href="https://bugs.webkit.org/show_bug.cgi?id=262794">https://bugs.webkit.org/show_bug.cgi?id=262794</a>

Reviewed by Carlos Garcia Campos.

We&apos;ll use Unix credentials to send the actual pid of the child process
to the parent process.

This could be done using the WebKit IPC connection, but the code is
much simpler if we create a separate socket for this.

* Source/WebKit/Platform/IPC/IPCUtilities.h:
* Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp:
(IPC::createPlatformConnection):
(IPC::sendPIDToPeer):
(IPC::readPIDFromPeer):
* Source/WebKit/Shared/unix/AuxiliaryProcessMain.cpp:
(WebKit::AuxiliaryProcessMainCommon::parseCommandLine):
* Source/WebKit/UIProcess/Launcher/glib/FlatpakLauncher.cpp:
(WebKit::flatpakSpawn):
* Source/WebKit/UIProcess/Launcher/glib/FlatpakLauncher.h:
* Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp:
(WebKit::ProcessLauncher::launchProcess):

Canonical link: <a href="https://commits.webkit.org/281488@main">https://commits.webkit.org/281488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e56985f4e931717f4c5ccae6eca52c854bd8d64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/59820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/39167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/12349 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/63737 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/10344 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/46819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/10515 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/48513 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7239 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/61850 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/36532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/51795 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29357 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/33240 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/9267 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55171 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/9312 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/65467 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/3748 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/9185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/55852 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/3759 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/51774 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/55992 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13319 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3114 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/34979 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/36062 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/37148 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/35807 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->