### PR TITLE
Guard balanceRangeWithLineRequirement against empty/invalid ranges

### DIFF
--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-empty-range-crash-expected.html
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-empty-range-crash-expected.html
@@ -1,0 +1,12 @@
+<style>
+.clamp {
+    width: 50px;
+    -webkit-box-orient: vertical;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+}
+</style>
+<p>This test passes if it doesn't crash.</p>
+<div class=clamp>
+    <div style="overflow-wrap: anywhere">This&nbsptest&nbsppasses&nbspif&nbspit&nbspdoesn't&nbsp crash.</div>
+</div>

--- a/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-empty-range-crash.html
+++ b/LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-empty-range-crash.html
@@ -1,0 +1,13 @@
+<style>
+.clampAndBalance {
+    text-wrap: balance;
+    width: 50px;
+    -webkit-box-orient: vertical;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+}
+</style>
+<p>This test passes if it doesn't crash.</p>
+<div class=clampAndBalance>
+    <div style="overflow-wrap: anywhere">This&nbsptest&nbsppasses&nbspif&nbspit&nbspdoesn't&nbsp crash.</div>
+</div>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.cpp
@@ -190,16 +190,19 @@ std::optional<Vector<LayoutUnit>> InlineContentBalancer::computeBalanceConstrain
     for (auto chunkSize : chunkSizes) {
         bool isFirstChunk = !startLine;
         auto rangeToBalance = InlineItemRange { m_originalLineInlineItemRanges[startLine].startIndex(), m_originalLineInlineItemRanges[startLine + chunkSize - 1].endIndex() };
-        InlineLayoutUnit totalWidth = 0;
-        for (size_t i = 0; i < chunkSize; i++)
-            totalWidth += m_originalLineWidths[startLine + i];
-        InlineLayoutUnit idealLineWidth = totalWidth / chunkSize;
-
         std::optional<Vector<LayoutUnit>> balancedLineWidthsForChunk;
-        if (m_numberOfLinesInOriginalLayout <= maximumLinesToBalanceWithLineRequirement)
-            balancedLineWidthsForChunk = balanceRangeWithLineRequirement(rangeToBalance, idealLineWidth, chunkSize, isFirstChunk);
-        else
-            balancedLineWidthsForChunk = balanceRangeWithNoLineRequirement(rangeToBalance, idealLineWidth, isFirstChunk);
+
+        if (rangeToBalance.startIndex() < rangeToBalance.endIndex()) {
+            InlineLayoutUnit totalWidth = 0;
+            for (size_t i = 0; i < chunkSize; i++)
+                totalWidth += m_originalLineWidths[startLine + i];
+            InlineLayoutUnit idealLineWidth = totalWidth / chunkSize;
+
+            if (m_numberOfLinesInOriginalLayout <= maximumLinesToBalanceWithLineRequirement)
+                balancedLineWidthsForChunk = balanceRangeWithLineRequirement(rangeToBalance, idealLineWidth, chunkSize, isFirstChunk);
+            else
+                balancedLineWidthsForChunk = balanceRangeWithNoLineRequirement(rangeToBalance, idealLineWidth, isFirstChunk);
+        }
 
         if (!balancedLineWidthsForChunk) {
             for (size_t i = 0; i < chunkSize; i++)
@@ -217,6 +220,8 @@ std::optional<Vector<LayoutUnit>> InlineContentBalancer::computeBalanceConstrain
 
 std::optional<Vector<LayoutUnit>> InlineContentBalancer::balanceRangeWithLineRequirement(InlineItemRange range, InlineLayoutUnit idealLineWidth, size_t numberOfLines, bool isFirstChunk)
 {
+    ASSERT(range.startIndex() < range.endIndex());
+
     // breakOpportunities holds the indices i such that a line break can occur before m_inlineItemList[i].
     auto breakOpportunities = computeBreakOpportunities(range);
 
@@ -318,6 +323,8 @@ std::optional<Vector<LayoutUnit>> InlineContentBalancer::balanceRangeWithLineReq
 
 std::optional<Vector<LayoutUnit>> InlineContentBalancer::balanceRangeWithNoLineRequirement(InlineItemRange range, InlineLayoutUnit idealLineWidth, bool isFirstChunk)
 {
+    ASSERT(range.startIndex() < range.endIndex());
+
     // breakOpportunities holds the indices i such that a line break can occur before m_inlineItemList[i].
     auto breakOpportunities = computeBreakOpportunities(range);
 


### PR DESCRIPTION
#### 11e29ebcb6900ae431165666030a5daf157d77e3
<pre>
Guard balanceRangeWithLineRequirement against empty/invalid ranges
<a href="https://rdar.apple.com/126011869">rdar://126011869</a>

Reviewed by Brent Fulgham.

InlineItemRange is used for calculating the
number of line break opportunities (NLBO),

We always insert at least 1 dummy item to the Vector
tracking line break opportunities for algorithm purposes,
so NLBO is never zero. However, when initializing
SlidingWidth, balanceRangeWithLineRequirement starts
counting line break opportunities from startIndex = 1,
assuming that the received range had at least 1 item.

We should consider that an empty or invalid range
can be received and guard against it.

* LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-empty-range-crash-expected.html: Added.
* LayoutTests/fast/css3-text/css3-text-wrap/text-wrap-balance-empty-range-crash.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineContentBalancer.cpp:
(WebCore::Layout::InlineContentBalancer::computeBalanceConstraints):
(WebCore::Layout::InlineContentBalancer::balanceRangeWithLineRequirement):
(WebCore::Layout::InlineContentBalancer::balanceRangeWithNoLineRequirement):

Originally-landed-as: 272448.926@safari-7618-branch (a76aaa768a18). <a href="https://rdar.apple.com/129792267">rdar://129792267</a>
Canonical link: <a href="https://commits.webkit.org/279988@main">https://commits.webkit.org/279988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ceecd134ccfad16453a8c492aa25ca0d79a74f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55440 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7904 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58426 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5872 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57567 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6066 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44643 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4016 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57467 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32672 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47775 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25771 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29457 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5103 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4016 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51392 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5371 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60016 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5497 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52073 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31675 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47845 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51537 "Found 1 new API test failure: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/non-editable (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32758 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8166 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31424 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->