### PR TITLE
[visionOS wk2] pointerevents/ios/inputmode-change-update-keyboard-after-pointerup.html is a constant text failure

### DIFF
--- a/LayoutTests/platform/visionos/pointerevents/ios/inputmode-change-update-keyboard-after-pointerup-expected.txt
+++ b/LayoutTests/platform/visionos/pointerevents/ios/inputmode-change-update-keyboard-after-pointerup-expected.txt
@@ -1,0 +1,17 @@
+This tests updating inputmode of an input element from "none" to "text". The software keyboard should be brought up after pointerup.
+To manually test, tap on the input element below. The software keyboard should be brought up
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS textHeight = keyboardRect.height; keyboardRect.height == 0 is true
+PASS logs.length is 2
+PASS logs[0].event.type is "pointerdown"
+PASS logs[0].visualViewportHeight is originalVisualViewportHeight
+PASS logs[1].event.type is "pointerup"
+PASS logs[1].visualViewportHeight is originalVisualViewportHeight
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/pointerevents/ios/inputmode-change-update-keyboard-after-pointerup.html
+++ b/LayoutTests/pointerevents/ios/inputmode-change-update-keyboard-after-pointerup.html
@@ -38,7 +38,10 @@ async function runTest() {
     if (window.testRunner) {
         await UIHelper.activateFormControl(input);
         window.keyboardRect = await UIHelper.inputViewBounds();
-        shouldBeTrue('textHeight = keyboardRect.height; keyboardRect.height > 0');
+        if (window.testRunner.keyboardAppearsOverContent)
+            shouldBeTrue('textHeight = keyboardRect.height; keyboardRect.height == 0');
+        else
+            shouldBeTrue('textHeight = keyboardRect.height; keyboardRect.height > 0');
     } else {
         await new Promise((resolve) => { didResize = resolve; });
         shouldBeTrue('textHeight = document.documentElement.clientHeight - visualViewport.height; document.documentElement.clientHeight - visualViewport.height < 100');

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -28,6 +28,7 @@ interface TestRunner {
     readonly attribute boolean isIOSFamily;
     readonly attribute boolean isMac;
     readonly attribute boolean isKeyboardImmediatelyAvailable;
+    readonly attribute boolean keyboardAppearsOverContent;
 
     // The basics.
     undefined dumpAsText(boolean dumpPixels);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -66,6 +66,15 @@ public:
 #endif
     }
 
+    bool keyboardAppearsOverContent() const
+    {
+#if PLATFORM(VISION)
+        return true;
+#else
+        return false;
+#endif
+    }
+
     bool isKeyboardImmediatelyAvailable()
     {
 #if PLATFORM(VISION)


### PR DESCRIPTION
#### 3874c14356c5115b70484aafb84e5a5db39c3702
<pre>
[visionOS wk2] pointerevents/ios/inputmode-change-update-keyboard-after-pointerup.html is a constant text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=275432">https://bugs.webkit.org/show_bug.cgi?id=275432</a>
<a href="https://rdar.apple.com/129786718">rdar://129786718</a>

Reviewed by Wenson Hsieh.

The test in question was previously expecting the keyboard rect to have
a positive height on form control activation. This does not make sense
on visionOS since keyboard rects should have zero size in said platform.

This patch updates the test to have different expectations across
visionOS and iOS. To do so, we introduce the `keyboardAppearsOverContent`
property on the test runner. The property is named to reflect how it is
consulted in this test.

We also add a new baseline for visionOS.

* LayoutTests/platform/visionos/pointerevents/ios/inputmode-change-update-keyboard-after-pointerup-expected.txt: Added.
* LayoutTests/pointerevents/ios/inputmode-change-update-keyboard-after-pointerup.html:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
(WTR::TestRunner::keyboardAppearsOverContent const):

Canonical link: <a href="https://commits.webkit.org/279990@main">https://commits.webkit.org/279990@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a4248ce3bb46de498bb5114da298c0f876be178

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58437 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5883 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57578 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42394 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6077 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44651 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4024 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57478 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47783 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25779 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29471 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5111 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4027 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5379 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60027 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30603 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5508 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52081 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/31687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47853 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51545 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/12273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32770 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/31435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->