### PR TITLE
Crash under WebCore::ScrollableArea::availableContentSizeChanged

### DIFF
--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbars-controller-crash-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbars-controller-crash-expected.txt
@@ -1,0 +1,2 @@
+Test passes if there is no assertion or crash.
+

--- a/LayoutTests/fast/scrolling/mac/scrollbars/scrollbars-controller-crash.html
+++ b/LayoutTests/fast/scrolling/mac/scrollbars/scrollbars-controller-crash.html
@@ -1,0 +1,17 @@
+Test passes if there is no assertion or crash.
+
+<script>
+function freememory() {
+}
+function eventhandler2() {
+try { document.write("1");; } catch(e) { }
+}
+</script>
+<details open="true" ontoggle="eventhandler2()">
+<iframe max="0.11504264281756393"></iframe>
+<iframe srcdoc="94?+2r" class="class3"></iframe>
+
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+</script>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -5605,8 +5605,10 @@ void LocalFrameView::setScrollingPerformanceTestingEnabled(bool scrollingPerform
 void LocalFrameView::createScrollbarsController()
 {
     auto* page = m_frame->page();
-    if (!page)
+    if (!page) {
+        ScrollView::createScrollbarsController();
         return;
+    }
 
     page->chrome().client().ensureScrollbarsController(*page, *this);
 }

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -88,7 +88,7 @@ ScrollbarsController& ScrollableArea::scrollbarsController() const
 {
     if (!m_scrollbarsController)
         const_cast<ScrollableArea&>(*this).internalCreateScrollbarsController();
-
+    RELEASE_ASSERT(m_scrollbarsController);
     return *m_scrollbarsController.get();
 }
 


### PR DESCRIPTION
#### 7ce8caf68469c9210478f4ceb968ce758a789f55
<pre>
Crash under WebCore::ScrollableArea::availableContentSizeChanged
<a href="https://bugs.webkit.org/show_bug.cgi?id=275458">https://bugs.webkit.org/show_bug.cgi?id=275458</a>
<a href="https://rdar.apple.com/129621091">rdar://129621091</a>

Reviewed by Tim Horton.

Add a call to the default scrollbars creator if page is null in
LocalFrameView::createScrollbarsController. Also add a release assert to
catch any cases of this in the future.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::createScrollbarsController):
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::scrollbarsController const):

Canonical link: <a href="https://commits.webkit.org/280256@main">https://commits.webkit.org/280256@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f60c3f4a160fa74f461da1c547daa49e95b5fe28

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56094 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59700 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6530 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58220 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6724 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/45237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4518 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33309 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48378 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26286 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30090 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5708 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5534 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52064 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61382 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6106 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48445 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/52347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12432 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31247 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32333 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33416 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32080 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->