### PR TITLE
REGRESSION(279372@main): Blank space and offset clicks after running a view transition on a scrolled page

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/reset-state-after-scrolled-view-transition-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/reset-state-after-scrolled-view-transition-expected.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+    <title>Reference: Finishing a View Transition on a scrolled page should properly reset state</title>
+    <style>
+        html {
+            background: lightblue;
+        }
+        body {
+            background-color: lightgreen;
+        }
+    </style>
+</head>
+<body>
+    <p>Start</p>
+    <div style="height: 200vh"></div>
+    <p>End</p>
+
+    <script>
+        function scrollBy(y) {
+            return new Promise(resolve => {
+                addEventListener("scroll", () => {
+                    requestAnimationFrame(() => {
+                        requestAnimationFrame(resolve);
+                    });
+                }, { once: true, capture: true });
+                document.documentElement.scrollBy({
+                    top: y,
+                    behavior: "instant"
+                });
+            });
+        }
+        addEventListener("load", async () => {
+            await scrollBy(document.documentElement.scrollHeight);
+            document.documentElement.classList.remove("reftest-wait");
+        });
+    </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/reset-state-after-scrolled-view-transition-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/reset-state-after-scrolled-view-transition-ref.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+    <title>Reference: Finishing a View Transition on a scrolled page should properly reset state</title>
+    <style>
+        html {
+            background: lightblue;
+        }
+        body {
+            background-color: lightgreen;
+        }
+    </style>
+</head>
+<body>
+    <p>Start</p>
+    <div style="height: 200vh"></div>
+    <p>End</p>
+
+    <script>
+        function scrollBy(y) {
+            return new Promise(resolve => {
+                addEventListener("scroll", () => {
+                    requestAnimationFrame(() => {
+                        requestAnimationFrame(resolve);
+                    });
+                }, { once: true, capture: true });
+                document.documentElement.scrollBy({
+                    top: y,
+                    behavior: "instant"
+                });
+            });
+        }
+        addEventListener("load", async () => {
+            await scrollBy(document.documentElement.scrollHeight);
+            document.documentElement.classList.remove("reftest-wait");
+        });
+    </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/reset-state-after-scrolled-view-transition.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/reset-state-after-scrolled-view-transition.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+    <title>Finishing a View Transition on a scrolled page should properly reset state</title>
+    <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+    <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+    <link rel="match" href="reset-state-after-scrolled-view-transition-ref.html">
+    <style>
+        html {
+            background: lightblue;
+        }
+        body {
+            background-color: lightgreen;
+        }
+        ::view-transition-group(*) {
+            animation-duration: 2s;
+        }
+    </style>
+</head>
+<body>
+    <p>Start</p>
+    <div id="block" style="height: 150vh"></div>
+    <p>End</p>
+
+    <script>
+        function scrollBy(y) {
+            return new Promise(resolve => {
+                addEventListener("scroll", () => {
+                    requestAnimationFrame(() => {
+                        requestAnimationFrame(resolve);
+                    });
+                }, { once: true, capture: true });
+                document.documentElement.scrollBy({
+                    top: y,
+                    behavior: "instant"
+                });
+            });
+        }
+        addEventListener("load", async () => {
+            await scrollBy(document.documentElement.scrollHeight / 2);
+            const transition = document.startViewTransition(() => { block.style.height = '200vh' });
+            await transition.ready;
+            scrollBy(document.documentElement.scrollHeight / 2);
+            await transition.finished;
+            document.documentElement.classList.remove("reftest-wait");
+        });
+    </script>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1807,9 +1807,12 @@ void RenderObject::setCapturedInViewTransition(bool captured)
 {
     if (capturedInViewTransition() != captured) {
         m_stateBitfields.setFlag(StateFlag::CapturedInViewTransition, captured);
-        if (isDocumentElementRenderer())
+        if (isDocumentElementRenderer()) {
             view().layer()->setNeedsPostLayoutCompositingUpdate();
-        else if (hasLayer())
+
+            // Invalidate transform applied by `RenderLayerBacking::updateTransform`.
+            view().layer()->setNeedsCompositingGeometryUpdate();
+        } else if (hasLayer())
             downcast<RenderLayerModelObject>(*this).layer()->setNeedsPostLayoutCompositingUpdate();
     }
 }


### PR DESCRIPTION
#### 98bf925cf7976055188f853dfc9b5ef10c3e013f
<pre>
REGRESSION(279372@main): Blank space and offset clicks after running a view transition on a scrolled page
<a href="https://bugs.webkit.org/show_bug.cgi?id=275335">https://bugs.webkit.org/show_bug.cgi?id=275335</a>
<a href="https://rdar.apple.com/129528943">rdar://129528943</a>

Reviewed by Alan Baradlay.

`RenderLayerBacking::updateTransform` adds a transform on the RenderView graphics layer when a view transition is running.

We however forget to clean it up when the transition ends. This requires a geometry update. Call `view().layer()-&gt;setNeedsCompositingGeometryUpdate()` to notify that one is needed.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/reset-state-after-scrolled-view-transition-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/reset-state-after-scrolled-view-transition-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/reset-state-after-scrolled-view-transition.html: Added.
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::setCapturedInViewTransition):

Canonical link: <a href="https://commits.webkit.org/280017@main">https://commits.webkit.org/280017@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2950510c557f89214b49e7215d4ce8ef1f4fbf1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55515 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7982 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58500 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5946 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57641 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6144 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44709 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4081 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57544 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47844 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25837 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29529 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5172 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4090 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51463 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5440 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60091 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30669 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52140 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31754 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47914 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51610 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12299 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32835 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31501 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->