### PR TITLE
RE-BASELINE: [ iOS ] editing/selection/ios/do-not-hide-selection-in-visible-field.html is constantly failing.

### DIFF
--- a/LayoutTests/editing/selection/ios/do-not-hide-selection-in-visible-field-expected.txt
+++ b/LayoutTests/editing/selection/ios/do-not-hide-selection-in-visible-field-expected.txt
@@ -5,8 +5,8 @@ This test verifies platform selection UI is not incorrectly suppressed when the 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS caretRect.top is 6
-PASS caretRect.left is 34
+PASS caretRect.top is 5
+PASS caretRect.left is 35
 PASS caretRect.width is 2
 PASS caretRect.height is 25
 PASS successfullyParsed is true

--- a/LayoutTests/editing/selection/ios/do-not-hide-selection-in-visible-field.html
+++ b/LayoutTests/editing/selection/ios/do-not-hide-selection-in-visible-field.html
@@ -64,8 +64,8 @@
         while (!caretRect || !caretRect.width || !caretRect.height)
             caretRect = await UIHelper.getUICaretViewRect();
 
-        shouldBe("caretRect.top", "6");
-        shouldBe("caretRect.left", "34");
+        shouldBe("caretRect.top", "5");
+        shouldBe("caretRect.left", "35");
         shouldBe("caretRect.width", "2");
         shouldBe("caretRect.height", "25");
         finishJSTest();

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -6426,10 +6426,6 @@ http/wpt/mediarecorder/video-rotation.html [ Pass Failure ]
 
 webkit.org/b/228604 [ Release ] http/wpt/mediarecorder/set-srcObject-MediaStream-Blob.html [ Pass Failure ]
 
-# These tests currently fail or are flaky in EWS on iOS 14.
-editing/selection/ios/changing-selection-does-not-trigger-autocapitalization.html [ Pass Timeout ]
-editing/selection/ios/do-not-hide-selection-in-visible-field.html [ Failure ]
-
 webkit.org/b/231962 editing/selection/modal-dialog-select-paragraph.html [ Failure ]
 
 # rdar://80393995 ([ iOS15 ] http/tests/media/modern-media-controls/overflow-support/playback-speed-live-broadcast.html is a constant timeout)


### PR DESCRIPTION
#### 07b0e3d97c36a46bbfbc22ed79bc166c3b0bc3af
<pre>
RE-BASELINE: [ iOS ] editing/selection/ios/do-not-hide-selection-in-visible-field.html is constantly failing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=275461">https://bugs.webkit.org/show_bug.cgi?id=275461</a>
<a href="https://rdar.apple.com/129808789">rdar://129808789</a>

Unreviewed test re-baseline.

Re-baselining long-failing test and removed test expectation for test with no bug that was grouped with this test.

* LayoutTests/editing/selection/ios/do-not-hide-selection-in-visible-field-expected.txt:
* LayoutTests/editing/selection/ios/do-not-hide-selection-in-visible-field.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/279993@main">https://commits.webkit.org/279993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4febda2920c41a18fb1fddee097ed18caf09cbc4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34791 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58454 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5900 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6094 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/4040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57495 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/32698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/47797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/25792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/29483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/5125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4044 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/5393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60044 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/30621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/5518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/31706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/47867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/32788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8169 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/31454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->