### PR TITLE
2 fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download*.html tests have redundant baselines.

### DIFF
--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-async-delegate-expected.txt
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-async-delegate-expected.txt
@@ -1,5 +1,5 @@
 Download started.
-Downloading URL with suggested filename "Unknown"
+Downloading URL with suggested filename "Unknown.otf"
 Download completed.
 The download should succeed.
 

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-expected.txt
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-expected.txt
@@ -1,5 +1,5 @@
 Download started.
-Downloading URL with suggested filename "Unknown"
+Downloading URL with suggested filename "Unknown.otf"
 Download completed.
 The download should succeed.
 

--- a/LayoutTests/platform/ios/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-async-delegate-expected.txt
+++ b/LayoutTests/platform/ios/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-async-delegate-expected.txt
@@ -1,6 +1,0 @@
-Download started.
-Downloading URL with suggested filename "Unknown.otf"
-Download completed.
-The download should succeed.
-
-File backed blob URL

--- a/LayoutTests/platform/ios/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-expected.txt
+++ b/LayoutTests/platform/ios/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-expected.txt
@@ -1,6 +1,0 @@
-Download started.
-Downloading URL with suggested filename "Unknown.otf"
-Download completed.
-The download should succeed.
-
-File backed blob URL

--- a/LayoutTests/platform/mac-wk2/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-async-delegate-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-async-delegate-expected.txt
@@ -1,6 +1,0 @@
-Download started.
-Downloading URL with suggested filename "Unknown.otf"
-Download completed.
-The download should succeed.
-
-File backed blob URL

--- a/LayoutTests/platform/mac-wk2/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-expected.txt
@@ -1,6 +1,0 @@
-Download started.
-Downloading URL with suggested filename "Unknown.otf"
-Download completed.
-The download should succeed.
-
-File backed blob URL


### PR DESCRIPTION
#### e7b92661b45177cc3d6fa36aad5bf6ca7b5050cf
<pre>
2 fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download*.html tests have redundant baselines.
<a href="https://bugs.webkit.org/show_bug.cgi?id=275462">https://bugs.webkit.org/show_bug.cgi?id=275462</a>
<a href="https://rdar.apple.com/129810738">rdar://129810738</a>

Unreviewed test gardening.

Removing redundant baselines for two tests.

* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-async-delegate-expected.txt:
* LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-expected.txt:
* LayoutTests/platform/ios/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-async-delegate-expected.txt: Removed.
* LayoutTests/platform/ios/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-expected.txt: Removed.
* LayoutTests/platform/mac-wk2/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-async-delegate-expected.txt: Removed.
* LayoutTests/platform/mac-wk2/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-expected.txt: Removed.

Canonical link: <a href="https://commits.webkit.org/279994@main">https://commits.webkit.org/279994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c40d06ccbbd9afd8bdbfd9f92723c5920074eef8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55470 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7935 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58456 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5902 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42413 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6096 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/4042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/57497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/32700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/47800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/25793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/29485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/5128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4046 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/5396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60046 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/30623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/5520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/31708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/47870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/32790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8170 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/31456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->