### PR TITLE
[Site Isolation] Fix file open panels

### DIFF
--- a/Source/WebKit/UIProcess/WebOpenPanelResultListenerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebOpenPanelResultListenerProxy.cpp
@@ -29,14 +29,16 @@
 #include "APIArray.h"
 #include "APIString.h"
 #include "WebPageProxy.h"
+#include "WebProcessProxy.h"
 #include <wtf/URL.h>
 #include <wtf/Vector.h>
 
 namespace WebKit {
 using namespace WebCore;
 
-WebOpenPanelResultListenerProxy::WebOpenPanelResultListenerProxy(WebPageProxy* page)
+WebOpenPanelResultListenerProxy::WebOpenPanelResultListenerProxy(WebPageProxy* page, WebProcessProxy& process)
     : m_page(page)
+    , m_process(process)
 {
 }
 
@@ -73,6 +75,12 @@ void WebOpenPanelResultListenerProxy::cancel()
 void WebOpenPanelResultListenerProxy::invalidate()
 {
     m_page = nullptr;
+    m_process = nullptr;
+}
+
+WebProcessProxy* WebOpenPanelResultListenerProxy::process() const
+{
+    return m_process.get();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebOpenPanelResultListenerProxy.h
+++ b/Source/WebKit/UIProcess/WebOpenPanelResultListenerProxy.h
@@ -29,6 +29,7 @@
 #include <wtf/Forward.h>
 #include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
 
 namespace API {
 class Array;
@@ -38,12 +39,13 @@ class Data;
 namespace WebKit {
 
 class WebPageProxy;
+class WebProcessProxy;
 
 class WebOpenPanelResultListenerProxy : public API::ObjectImpl<API::Object::Type::FramePolicyListener> {
 public:
-    static Ref<WebOpenPanelResultListenerProxy> create(WebPageProxy* page)
+    static Ref<WebOpenPanelResultListenerProxy> create(WebPageProxy* page, WebProcessProxy& process)
     {
-        return adoptRef(*new WebOpenPanelResultListenerProxy(page));
+        return adoptRef(*new WebOpenPanelResultListenerProxy(page, process));
     }
 
     virtual ~WebOpenPanelResultListenerProxy();
@@ -56,10 +58,13 @@ public:
 
     void invalidate();
 
+    WebProcessProxy* process() const;
+
 private:
-    explicit WebOpenPanelResultListenerProxy(WebPageProxy*);
+    WebOpenPanelResultListenerProxy(WebPageProxy*, WebProcessProxy&);
 
     RefPtr<WebPageProxy> m_page;
+    WeakPtr<WebProcessProxy> m_process;
 };
 
 } // namespace WebKit

--- a/Tools/TestWebKitAPI/cocoa/TestUIDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestUIDelegate.h
@@ -42,6 +42,7 @@
 @property (nonatomic, copy) void (^unfocusWebView)(WKWebView *);
 @property (nonatomic, copy) void (^webViewDidClose)(WKWebView *);
 @property (nonatomic, copy) void (^webViewDidAdjustVisibilityWithSelectors)(WKWebView *, NSArray<NSString *> *);
+@property (nonatomic, copy) void (^runOpenPanelWithParameters)(WKWebView *, WKOpenPanelParameters *, WKFrameInfo *, void (^)(NSArray<NSURL *> *));
 
 - (NSString *)waitForAlert;
 - (NSString *)waitForConfirm;

--- a/Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm
@@ -99,6 +99,13 @@
     if (_unfocusWebView)
         _unfocusWebView(webView);
 }
+
+- (void)webView:(WKWebView *)webView runOpenPanelWithParameters:(WKOpenPanelParameters *)parameters initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(NSArray<NSURL *> *))completionHandler
+{
+    if (_runOpenPanelWithParameters)
+        _runOpenPanelWithParameters(webView, parameters, frame, completionHandler);
+}
+
 #endif // PLATFORM(MAC)
 
 - (void)webViewDidClose:(WKWebView *)webView


### PR DESCRIPTION
#### 267386a0cc1cd17e40151cd460520e37e0bbc118
<pre>
[Site Isolation] Fix file open panels
<a href="https://bugs.webkit.org/show_bug.cgi?id=275465">https://bugs.webkit.org/show_bug.cgi?id=275465</a>
<a href="https://rdar.apple.com/128979437">rdar://128979437</a>

Reviewed by Aditya Keerthi.

When a file panel is opened, the selected file should be sent to the process that opened the panel. Store
a weak pointer to the process that opened the file on `WebOpenPanelResultListenerProxy`.

* Source/WebKit/UIProcess/WebOpenPanelResultListenerProxy.cpp:
(WebKit::WebOpenPanelResultListenerProxy::WebOpenPanelResultListenerProxy):
(WebKit::WebOpenPanelResultListenerProxy::invalidate):
* Source/WebKit/UIProcess/WebOpenPanelResultListenerProxy.h:
(WebKit::WebOpenPanelResultListenerProxy::create):
(WebKit::WebOpenPanelResultListenerProxy::process const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::runOpenPanel):
(WebKit::WebPageProxy::didChooseFilesForOpenPanel):
(WebKit::WebPageProxy::didCancelForOpenPanel):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::siteIsolatedViewAndDelegate):
(TestWebKitAPI::TEST(SiteIsolation, RunOpenPanel)):
(TestWebKitAPI::TEST(SiteIsolation, CancelOpenPanel)):
* Tools/TestWebKitAPI/cocoa/TestUIDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestUIDelegate.mm:
(-[TestUIDelegate webView:runOpenPanelWithParameters:initiatedByFrame:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/280042@main">https://commits.webkit.org/280042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffb7c0c3a3c9b93df3d060a9a9ed76813cae1be4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58550 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5996 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57692 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44746 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4117 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57595 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32794 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47892 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25873 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29578 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5221 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4140 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51511 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5488 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60141 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30720 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5612 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52179 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31805 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47962 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51659 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32886 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8194 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31552 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->