### PR TITLE
[Win] PopupMenu should support RTL contents

### DIFF
--- a/Source/WebKit/Shared/PlatformPopupMenuData.h
+++ b/Source/WebKit/Shared/PlatformPopupMenuData.h
@@ -45,6 +45,7 @@ struct PlatformPopupMenuData {
     int m_clientInsetRight { 0 };
     int m_popupWidth { 0 };
     float m_itemHeight { 0 };
+    bool m_isRTL { false };
     RefPtr<WebCore::ShareableBitmap> m_notSelectedBackingStore;
     RefPtr<WebCore::ShareableBitmap> m_selectedBackingStore;
 #endif

--- a/Source/WebKit/Shared/PlatformPopupMenuData.serialization.in
+++ b/Source/WebKit/Shared/PlatformPopupMenuData.serialization.in
@@ -34,6 +34,7 @@ struct WebKit::PlatformPopupMenuData {
     int m_clientInsetRight;
     int m_popupWidth;
     float m_itemHeight;
+    bool m_isRTL
     RefPtr<WebCore::ShareableBitmap> m_notSelectedBackingStore;
     RefPtr<WebCore::ShareableBitmap> m_selectedBackingStore;
 #endif

--- a/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.h
+++ b/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.h
@@ -79,7 +79,7 @@ private:
     WebCore::IntSize visibleSize() const override;
     WebCore::IntSize contentsSize() const override;
     WebCore::IntRect scrollableAreaBoundingBox(bool* = nullptr) const override;
-    bool shouldPlaceVerticalScrollbarOnLeft() const override { return false; }
+    bool shouldPlaceVerticalScrollbarOnLeft() const override;
     bool forceUpdateScrollbarsOnMainThreadForPerformanceTesting() const override { return false; }
     bool isScrollableOrRubberbandable() override { return true; }
     bool hasScrollableOrRubberbandableAncestor() override { return true; }


### PR DESCRIPTION
#### 2051bf7c1fc3f29a4418320b3ba4e44e2d4a22c3
<pre>
[Win] PopupMenu should support RTL contents
<a href="https://bugs.webkit.org/show_bug.cgi?id=275390">https://bugs.webkit.org/show_bug.cgi?id=275390</a>

Reviewed by Fujii Hironori.

WebPopupMenuWin cannot display correctly a HTML having
&lt;select&gt; elements with dir=&quot;rtl&quot;.
When device scale factor is set other than 1,
texts on PopupMenu drop out.
When PopupMenu needs Scrollbar, scrollbar is always
displayed on the right side and overlaps texts.

To fix these, WebPopupMenuWin sets correct width of
PopupMenu to backingStore and Scrollbar is displayed
on the right side by default or on the left side
when &lt;select&gt; has dir=&quot;rtl&quot;.

* Source/WebKit/Shared/PlatformPopupMenuData.h:
* Source/WebKit/Shared/PlatformPopupMenuData.serialization.in:
* Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp:
* Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.h:
* Source/WebKit/WebProcess/WebCoreSupport/win/WebPopupMenuWin.cpp:

Canonical link: <a href="https://commits.webkit.org/279998@main">https://commits.webkit.org/279998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d273bc293867d031137592796b4fd641079f1e64

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55476 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58462 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5908 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6102 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44674 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4046 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57503 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32706 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/47806 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25801 "Found 1 new API test failure: /WPE/TestMultiprocess:/webkit/WebKitWebView/multiprocess-create-ready-close (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29491 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4052 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51424 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60052 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30629 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5526 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52103 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31714 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47876 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51565 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32796 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8173 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31462 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->