### PR TITLE
Scrolling leaves artifacts at the right side of the window if the window has a left vertical overlay scrollbar in RTL in non-compositing mode

### DIFF
--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -830,11 +830,14 @@ IntRect ScrollView::rectToCopyOnScroll() const
 {
     IntRect scrollViewRect = convertToRootView(IntRect(0, 0, visibleWidth(), visibleHeight()));
     if (hasOverlayScrollbars()) {
-        int verticalScrollbarWidth = (verticalScrollbar() && !hasLayerForVerticalScrollbar()) ? verticalScrollbar()->width() : 0;
-        int horizontalScrollbarHeight = (horizontalScrollbar() && !hasLayerForHorizontalScrollbar()) ? horizontalScrollbar()->height() : 0;
-        
-        scrollViewRect.setWidth(scrollViewRect.width() - verticalScrollbarWidth);
-        scrollViewRect.setHeight(scrollViewRect.height() - horizontalScrollbarHeight);
+        if (verticalScrollbar() && !hasLayerForVerticalScrollbar()) {
+            if (shouldPlaceVerticalScrollbarOnLeft())
+                scrollViewRect.shiftXEdgeBy(verticalScrollbar()->width());
+            else
+                scrollViewRect.shiftMaxXEdgeBy(-verticalScrollbar()->width());
+        }
+        if (horizontalScrollbar() && !hasLayerForHorizontalScrollbar())
+            scrollViewRect.shiftMaxYEdgeBy(-horizontalScrollbar()->height());
     }
     return scrollViewRect;
 }

--- a/Source/WebCore/platform/graphics/IntRect.h
+++ b/Source/WebCore/platform/graphics/IntRect.h
@@ -144,10 +144,20 @@ public:
         setWidth(std::max(0, width() - delta));
     }
 
+    void shiftMaxXEdgeBy(int delta)
+    {
+        setWidth(std::max(0, width() + delta));
+    }
+
     void shiftYEdgeBy(int delta)
     {
         move(0, delta);
         setHeight(std::max(0, height() - delta));
+    }
+
+    void shiftMaxYEdgeBy(int delta)
+    {
+        setHeight(std::max(0, height() + delta));
     }
 
     IntPoint minXMinYCorner() const { return m_location; } // typically topLeft


### PR DESCRIPTION
#### fe975b3d7ff6cace8562ce9f17472dcedfa14e4e
<pre>
Scrolling leaves artifacts at the right side of the window if the window has a left vertical overlay scrollbar in RTL in non-compositing mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=160359">https://bugs.webkit.org/show_bug.cgi?id=160359</a>

Reviewed by Don Olmstead.

ScrollView::rectToCopyOnScroll returns a rect to copy on scroll as the
name implies. However, it didn&apos;t take the left vertical overlay
scrollbar in RTL. It always assumed the vertical scroll bar was at the
right side of the window. As the result, the area of the right
scrollbar wasn&apos;t updated on scrolling even when the vertical scrollbar
was actually at the left.

If a windows has a vertical overlay scrollbar at the left side of the
window in RTL, rectToCopyOnScroll shouldn&apos;t exclude area of the right
scrollbar.

This problem was reprodusible with GTK, Windows and PlayStation ports
which still support non-compositing mode. But with Mac WK1 and WK2.
Mac WK1 is still supporting non-compositing mode, but it shows a
scrollbar always on the right side of the window. So it&apos;s not
reproducible with Mac WK1.

Added shiftMaxXEdgeBy and shiftMaxYEdgeBy methods to IntRect class as
same as FloatRect class has.

* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::rectToCopyOnScroll const):
* WebCore/platform/graphics/IntRect.h
(WebCore::IntRect::shiftMaxXEdgeBy): Added.
(WebCore::IntRect::shiftMaxYEdgeBy): Added.

Canonical link: <a href="https://commits.webkit.org/280155@main">https://commits.webkit.org/280155@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb483b60e87f116504cfbc5a869774db4336e43d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58863 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6299 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57993 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44987 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4347 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33084 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48163 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26121 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29868 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5491 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4442 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5762 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60452 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5886 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52417 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48232 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51914 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8253 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31020 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32104 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33186 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31852 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->