### PR TITLE
REGRESSION(272822@main): IPC sync replies might use freed data

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -156,29 +156,33 @@ class WorkQueueMessageReceiver;
 struct AsyncReplyIDType;
 using AsyncReplyID = AtomicObjectIdentifier<AsyncReplyIDType>;
 
-template<typename T> struct ConnectionSendSyncResult {
-    Expected<typename T::ReplyArguments, Error> value;
-
+// Sync message sender is expected to hold this instance alive as long as the reply() is being
+// accessed. View type data types in replies, such as std::span, refer to data stored in
+// ConnectionSendSyncResult.
+template<typename T> class ConnectionSendSyncResult {
+public:
     ConnectionSendSyncResult(Error error)
         : value(makeUnexpected(error))
     {
         ASSERT(value.error() != Error::NoError);
     }
 
-    ConnectionSendSyncResult(typename T::ReplyArguments&& replyArguments)
-        : value(WTFMove(replyArguments)) { }
+    ConnectionSendSyncResult(UniqueRef<Decoder>&& decoder, typename T::ReplyArguments&& replyArguments)
+        : value({ WTFMove(decoder), WTFMove(replyArguments) })
+    {
+    }
 
     bool succeeded() const { return value.has_value(); }
     Error error() const { return value.has_value() ? Error::NoError : value.error(); }
 
     typename T::ReplyArguments& reply()
     {
-        return value.value();
+        return value.value().reply;
     }
 
     typename T::ReplyArguments takeReply()
     {
-        return WTFMove(value.value());
+        return WTFMove(value.value().reply);
     }
 
     template<typename... U>
@@ -188,6 +192,12 @@ template<typename T> struct ConnectionSendSyncResult {
             return { std::forward<U>(defaultValues)... };
         return takeReply();
     }
+private:
+    struct ReplyData {
+        UniqueRef<Decoder> decoder; // Owns the memory for reply.
+        typename T::ReplyArguments reply;
+    };
+    Expected<ReplyData, Error> value;
 };
 
 struct ConnectionAsyncReplyHandler {
@@ -759,7 +769,7 @@ template<typename T> Connection::SendSyncResult<T> Connection::sendSync(T&& mess
     if (!replyArguments)
         return { Error::FailedToDecodeReplyArguments };
 
-    return { WTFMove(*replyArguments) };
+    return SendSyncResult<T> { WTFMove(replyDecoderOrError.value()), WTFMove(*replyArguments) };
 }
 
 template<typename T> Error Connection::waitForAndDispatchImmediately(uint64_t destinationID, Timeout timeout, OptionSet<WaitForOption> waitForOptions)

--- a/Source/WebKit/Platform/IPC/MessageSender.h
+++ b/Source/WebKit/Platform/IPC/MessageSender.h
@@ -37,7 +37,7 @@ enum class SendOption : uint8_t;
 enum class SendSyncOption : uint8_t;
 struct AsyncReplyIDType;
 struct ConnectionAsyncReplyHandler;
-template<typename> struct ConnectionSendSyncResult;
+template<typename> class ConnectionSendSyncResult;
 using AsyncReplyID = AtomicObjectIdentifier<AsyncReplyIDType>;
 
 class MessageSender {

--- a/Source/WebKit/Platform/IPC/StreamClientConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnection.h
@@ -309,7 +309,7 @@ std::optional<StreamClientConnection::SendSyncResult<T>> StreamClientConnection:
         auto& decoder = decoderResult->value();
         *decoder >> replyArguments;
         if (replyArguments)
-            return { { WTFMove(*replyArguments) } };
+            return { { WTFMove(decoderResult->value()), WTFMove(*replyArguments) } };
         return { Error::FailedToDecodeReplyArguments };
     }
     return { decoderResult->error() };

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -47,7 +47,7 @@ namespace IPC {
 class Connection;
 class Decoder;
 class Encoder;
-template<typename> struct ConnectionSendSyncResult;
+template<typename> class ConnectionSendSyncResult;
 }
 
 namespace WebCore {

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -84,7 +84,7 @@ namespace IPC {
 class Decoder;
 class FormDataReference;
 class SharedBufferReference;
-template<typename> struct ConnectionSendSyncResult;
+template<typename> class ConnectionSendSyncResult;
 }
 
 namespace JSC {

--- a/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
@@ -67,6 +67,24 @@ struct MockTestSyncMessage {
     std::tuple<> m_arguments;
 };
 
+struct MockTestSyncMessageWithDataReply {
+    static constexpr bool isSync = true;
+    static constexpr bool canDispatchOutOfOrder = false;
+    static constexpr bool replyCanDispatchOutOfOrder = false;
+    static constexpr IPC::MessageName name()  { return  IPC::MessageName::IPCTester_SyncPing; } // Needs to be sync.
+    using ReplyArguments = std::tuple<std::span<const uint8_t>>;
+    auto&& arguments()
+    {
+        return WTFMove(m_arguments);
+    }
+
+    MockTestSyncMessageWithDataReply()
+    {
+    }
+
+    std::tuple<> m_arguments;
+};
+
 namespace {
 class SimpleConnectionTest : public testing::Test {
 public:
@@ -1024,6 +1042,35 @@ TEST_P(ConnectionRunLoopTest, RunLoopWaitForAndDispatchImmediately)
         b()->invalidate();
     });
 
+    localReferenceBarrier();
+}
+
+TEST_P(ConnectionRunLoopTest, SendLocalSyncMessageWithDataReply)
+{
+    constexpr int iterations = 10;
+    constexpr size_t dataSize = 1e8; // 100 MB.
+    ASSERT_TRUE(openA());
+    auto runLoop = createRunLoop(RUN_LOOP_NAME);
+    runLoop->dispatch([&] {
+        bClient().setSyncMessageHandler([&](IPC::Decoder& decoder, UniqueRef<IPC::Encoder>& encoder) -> bool {
+            Vector<uint8_t> data(dataSize);
+            for (size_t i = 0; i < dataSize; ++i)
+                data[i] = static_cast<uint8_t>(i);
+            encoder.get() << data;
+            return false;
+        });
+        ASSERT_TRUE(openB());
+    });
+    for (int i = 0; i < iterations; ++i) {
+        auto sendResult = a()->sendSync(MockTestSyncMessageWithDataReply { }, i, IPC::Timeout::infinity());
+        ASSERT_TRUE(sendResult.succeeded());
+        auto& [replyData] = sendResult.reply();
+        for (size_t i = 0; i < replyData.size(); ++i)
+            ASSERT_EQ(static_cast<uint8_t>(i), replyData[i]);
+    }
+    runLoop->dispatch([&] {
+        b()->invalidate();
+    });
     localReferenceBarrier();
 }
 


### PR DESCRIPTION
#### 83b7d1094b341c9fef824c58e88fcb5ebcf41141
<pre>
REGRESSION(272822@main): IPC sync replies might use freed data
<a href="https://bugs.webkit.org/show_bug.cgi?id=275434">https://bugs.webkit.org/show_bug.cgi?id=275434</a>
<a href="https://rdar.apple.com/125071066">rdar://125071066</a>

Reviewed by Cameron McCormack.

The commit 272822@main would remove IPC::Decoder from the
ConnectionSendSyncResult. The decoder owns the data pointed by the
data references. This change results in sender reading freed memory
when reading the reply data references.

Fix by ensuring ConnectionSendSyncResult stores the IPC::Decoder that
owns the data referenced by the reply.

Using data references, e.g. std::spans, in IPC messages means that the
data is stored in the IPC message. Contrast this with messages transferring
Vectors: the Vectors store the data.

* Source/WebKit/Platform/IPC/Connection.h:
(IPC::ConnectionSendSyncResult::ConnectionSendSyncResult):
(IPC::ConnectionSendSyncResult::reply):
(IPC::ConnectionSendSyncResult::takeReply):
(IPC::Connection::sendSync):
* Source/WebKit/Platform/IPC/MessageSender.h:
* Source/WebKit/Platform/IPC/StreamClientConnection.h:
(IPC::StreamClientConnection::trySendSyncStream):
* Source/WebKit/UIProcess/RemotePageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp:
(TestWebKitAPI::MockTestSyncMessageWithDataReply::name):
(TestWebKitAPI::MockTestSyncMessageWithDataReply::arguments):
(TestWebKitAPI::MockTestSyncMessageWithDataReply::MockTestSyncMessageWithDataReply):
(TestWebKitAPI::TEST_P):
* Tools/TestWebKitAPI/Tests/IPC/IPCTestUtilities.h:

Canonical link: <a href="https://commits.webkit.org/280004@main">https://commits.webkit.org/280004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5eb702f723056c6a5982f119da505cfbc144f30d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58476 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5922 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57617 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6117 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44685 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4060 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57518 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32721 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47821 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25812 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29506 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5149 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4066 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51436 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5417 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60066 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30644 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5541 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52118 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31728 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47891 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51580 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12288 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32811 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31477 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->