### PR TITLE
[WebGPU] IPC copies too much data leading to jetsams on iOS

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.cpp
@@ -213,7 +213,7 @@ void GPUBuffer::internalUnmap(ScriptExecutionContext& scriptExecutionContext)
     for (auto& arrayBufferAndOffset : m_arrayBuffers) {
         auto& arrayBuffer = arrayBufferAndOffset.buffer;
         if (arrayBuffer && arrayBuffer->data() && arrayBuffer->byteLength()) {
-            m_backing->copy(arrayBuffer->toVector(), arrayBufferAndOffset.offset);
+            m_backing->copy(arrayBuffer->span(), arrayBufferAndOffset.offset);
             JSC::ArrayBufferContents emptyBuffer;
             arrayBuffer->unpin();
             arrayBuffer->transferTo(scriptExecutionContext.vm(), emptyBuffer);

--- a/Source/WebCore/Modules/WebGPU/GPUTexture.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUTexture.cpp
@@ -156,4 +156,395 @@ GPUFlagsConstant GPUTexture::usage() const
     return m_usage;
 }
 
+static GPUTextureFormat depthSpecificFormat(GPUTextureFormat textureFormat)
+{
+    // https://gpuweb.github.io/gpuweb/#aspect-specific-format
+
+    switch (textureFormat) {
+    case GPUTextureFormat::Depth24plusStencil8:
+        return GPUTextureFormat::Depth24plus;
+    case GPUTextureFormat::Depth32floatStencil8:
+        return GPUTextureFormat::Depth32float;
+    default:
+        return textureFormat;
+    }
+}
+
+static GPUTextureFormat stencilSpecificFormat(GPUTextureFormat textureFormat)
+{
+    // https://gpuweb.github.io/gpuweb/#aspect-specific-format
+
+    switch (textureFormat) {
+    case GPUTextureFormat::Depth24plusStencil8:
+        return GPUTextureFormat::Stencil8;
+    case GPUTextureFormat::Depth32floatStencil8:
+        return GPUTextureFormat::Stencil8;
+    default:
+        return textureFormat;
+    }
+}
+
+GPUTextureFormat GPUTexture::aspectSpecificFormat(GPUTextureFormat format, GPUTextureAspect aspect)
+{
+    switch (aspect) {
+    case GPUTextureAspect::All:
+        return format;
+    case GPUTextureAspect::StencilOnly:
+        return stencilSpecificFormat(format);
+    case GPUTextureAspect::DepthOnly:
+        return depthSpecificFormat(format);
+    }
+    return format;
+}
+uint32_t GPUTexture::texelBlockSize(GPUTextureFormat format)
+{
+    switch (format) {
+    case GPUTextureFormat::R8unorm:
+    case GPUTextureFormat::R8snorm:
+    case GPUTextureFormat::R8uint:
+    case GPUTextureFormat::R8sint:
+        return 1;
+    case GPUTextureFormat::R16uint:
+    case GPUTextureFormat::R16sint:
+    case GPUTextureFormat::R16float:
+    case GPUTextureFormat::Rg8unorm:
+    case GPUTextureFormat::Rg8snorm:
+    case GPUTextureFormat::Rg8uint:
+    case GPUTextureFormat::Rg8sint:
+        return 2;
+    case GPUTextureFormat::R32float:
+    case GPUTextureFormat::R32uint:
+    case GPUTextureFormat::R32sint:
+    case GPUTextureFormat::Rg16uint:
+    case GPUTextureFormat::Rg16sint:
+    case GPUTextureFormat::Rg16float:
+    case GPUTextureFormat::Rgba8unorm:
+    case GPUTextureFormat::Rgba8unormSRGB:
+    case GPUTextureFormat::Rgba8snorm:
+    case GPUTextureFormat::Rgba8uint:
+    case GPUTextureFormat::Rgba8sint:
+    case GPUTextureFormat::Bgra8unorm:
+    case GPUTextureFormat::Bgra8unormSRGB:
+    case GPUTextureFormat::Rgb10a2unorm:
+    case GPUTextureFormat::Rg11b10ufloat:
+    case GPUTextureFormat::Rgb9e5ufloat:
+    case GPUTextureFormat::Rgb10a2uint:
+        return 4;
+    case GPUTextureFormat::Rg32float:
+    case GPUTextureFormat::Rg32uint:
+    case GPUTextureFormat::Rg32sint:
+    case GPUTextureFormat::Rgba16uint:
+    case GPUTextureFormat::Rgba16sint:
+    case GPUTextureFormat::Rgba16float:
+        return 8;
+    case GPUTextureFormat::Rgba32float:
+    case GPUTextureFormat::Rgba32uint:
+    case GPUTextureFormat::Rgba32sint:
+        return 16;
+    case GPUTextureFormat::Stencil8:
+        return 1;
+    case GPUTextureFormat::Depth16unorm:
+        return 2;
+    case GPUTextureFormat::Depth24plus:
+        return 4;
+    case GPUTextureFormat::Depth24plusStencil8:
+        ASSERT_NOT_REACHED();
+        return 0;
+    case GPUTextureFormat::Depth32float:
+        return 4;
+    case GPUTextureFormat::Depth32floatStencil8:
+        ASSERT_NOT_REACHED();
+        return 0;
+    case GPUTextureFormat::Bc1RgbaUnorm:
+    case GPUTextureFormat::Bc1RgbaUnormSRGB:
+        return 8;
+    case GPUTextureFormat::Bc2RgbaUnorm:
+    case GPUTextureFormat::Bc2RgbaUnormSRGB:
+        return 16;
+    case GPUTextureFormat::Bc3RgbaUnorm:
+    case GPUTextureFormat::Bc3RgbaUnormSRGB:
+        return 16;
+    case GPUTextureFormat::Bc4RUnorm:
+    case GPUTextureFormat::Bc4RSnorm:
+        return 8;
+    case GPUTextureFormat::Bc5RgUnorm:
+    case GPUTextureFormat::Bc5RgSnorm:
+        return 16;
+    case GPUTextureFormat::Bc6hRgbUfloat:
+    case GPUTextureFormat::Bc6hRgbFloat:
+        return 16;
+    case GPUTextureFormat::Bc7RgbaUnorm:
+    case GPUTextureFormat::Bc7RgbaUnormSRGB:
+        return 16;
+    case GPUTextureFormat::Etc2Rgb8unorm:
+    case GPUTextureFormat::Etc2Rgb8unormSRGB:
+    case GPUTextureFormat::Etc2Rgb8a1unorm:
+    case GPUTextureFormat::Etc2Rgb8a1unormSRGB:
+        return 8;
+    case GPUTextureFormat::EacR11unorm:
+    case GPUTextureFormat::EacR11snorm:
+        return 8;
+    case GPUTextureFormat::Etc2Rgba8unorm:
+    case GPUTextureFormat::Etc2Rgba8unormSRGB:
+    case GPUTextureFormat::EacRg11unorm:
+    case GPUTextureFormat::EacRg11snorm:
+        return 16;
+    case GPUTextureFormat::Astc4x4Unorm:
+    case GPUTextureFormat::Astc4x4UnormSRGB:
+    case GPUTextureFormat::Astc5x4Unorm:
+    case GPUTextureFormat::Astc5x4UnormSRGB:
+    case GPUTextureFormat::Astc5x5Unorm:
+    case GPUTextureFormat::Astc5x5UnormSRGB:
+    case GPUTextureFormat::Astc6x5Unorm:
+    case GPUTextureFormat::Astc6x5UnormSRGB:
+    case GPUTextureFormat::Astc6x6Unorm:
+    case GPUTextureFormat::Astc6x6UnormSRGB:
+    case GPUTextureFormat::Astc8x5Unorm:
+    case GPUTextureFormat::Astc8x5UnormSRGB:
+    case GPUTextureFormat::Astc8x6Unorm:
+    case GPUTextureFormat::Astc8x6UnormSRGB:
+    case GPUTextureFormat::Astc8x8Unorm:
+    case GPUTextureFormat::Astc8x8UnormSRGB:
+    case GPUTextureFormat::Astc10x5Unorm:
+    case GPUTextureFormat::Astc10x5UnormSRGB:
+    case GPUTextureFormat::Astc10x6Unorm:
+    case GPUTextureFormat::Astc10x6UnormSRGB:
+    case GPUTextureFormat::Astc10x8Unorm:
+    case GPUTextureFormat::Astc10x8UnormSRGB:
+    case GPUTextureFormat::Astc10x10Unorm:
+    case GPUTextureFormat::Astc10x10UnormSRGB:
+    case GPUTextureFormat::Astc12x10Unorm:
+    case GPUTextureFormat::Astc12x10UnormSRGB:
+    case GPUTextureFormat::Astc12x12Unorm:
+    case GPUTextureFormat::Astc12x12UnormSRGB:
+        return 16;
+    }
+    return 0;
+}
+uint32_t GPUTexture::texelBlockWidth(GPUTextureFormat format)
+{
+    switch (format) {
+    case GPUTextureFormat::Bc1RgbaUnorm:
+    case GPUTextureFormat::Bc1RgbaUnormSRGB:
+    case GPUTextureFormat::Bc2RgbaUnorm:
+    case GPUTextureFormat::Bc2RgbaUnormSRGB:
+    case GPUTextureFormat::Bc3RgbaUnorm:
+    case GPUTextureFormat::Bc3RgbaUnormSRGB:
+    case GPUTextureFormat::Bc4RUnorm:
+    case GPUTextureFormat::Bc4RSnorm:
+    case GPUTextureFormat::Bc5RgUnorm:
+    case GPUTextureFormat::Bc5RgSnorm:
+    case GPUTextureFormat::Bc6hRgbUfloat:
+    case GPUTextureFormat::Bc6hRgbFloat:
+    case GPUTextureFormat::Bc7RgbaUnorm:
+    case GPUTextureFormat::Bc7RgbaUnormSRGB:
+        return 4;
+    case GPUTextureFormat::Etc2Rgb8unorm:
+    case GPUTextureFormat::Etc2Rgb8unormSRGB:
+    case GPUTextureFormat::Etc2Rgb8a1unorm:
+    case GPUTextureFormat::Etc2Rgb8a1unormSRGB:
+    case GPUTextureFormat::Etc2Rgba8unorm:
+    case GPUTextureFormat::Etc2Rgba8unormSRGB:
+    case GPUTextureFormat::EacR11unorm:
+    case GPUTextureFormat::EacR11snorm:
+    case GPUTextureFormat::EacRg11unorm:
+    case GPUTextureFormat::EacRg11snorm:
+        return 4;
+    case GPUTextureFormat::Astc4x4Unorm:
+    case GPUTextureFormat::Astc4x4UnormSRGB:
+        return 4;
+    case GPUTextureFormat::Astc5x4Unorm:
+    case GPUTextureFormat::Astc5x4UnormSRGB:
+    case GPUTextureFormat::Astc5x5Unorm:
+    case GPUTextureFormat::Astc5x5UnormSRGB:
+        return 5;
+    case GPUTextureFormat::Astc6x5Unorm:
+    case GPUTextureFormat::Astc6x5UnormSRGB:
+    case GPUTextureFormat::Astc6x6Unorm:
+    case GPUTextureFormat::Astc6x6UnormSRGB:
+        return 6;
+    case GPUTextureFormat::Astc8x5Unorm:
+    case GPUTextureFormat::Astc8x5UnormSRGB:
+    case GPUTextureFormat::Astc8x6Unorm:
+    case GPUTextureFormat::Astc8x6UnormSRGB:
+    case GPUTextureFormat::Astc8x8Unorm:
+    case GPUTextureFormat::Astc8x8UnormSRGB:
+        return 8;
+    case GPUTextureFormat::Astc10x5Unorm:
+    case GPUTextureFormat::Astc10x5UnormSRGB:
+    case GPUTextureFormat::Astc10x6Unorm:
+    case GPUTextureFormat::Astc10x6UnormSRGB:
+    case GPUTextureFormat::Astc10x8Unorm:
+    case GPUTextureFormat::Astc10x8UnormSRGB:
+    case GPUTextureFormat::Astc10x10Unorm:
+    case GPUTextureFormat::Astc10x10UnormSRGB:
+        return 10;
+    case GPUTextureFormat::Astc12x10Unorm:
+    case GPUTextureFormat::Astc12x10UnormSRGB:
+    case GPUTextureFormat::Astc12x12Unorm:
+    case GPUTextureFormat::Astc12x12UnormSRGB:
+        return 12;
+    case GPUTextureFormat::R8unorm:
+    case GPUTextureFormat::R8snorm:
+    case GPUTextureFormat::R8uint:
+    case GPUTextureFormat::R8sint:
+    case GPUTextureFormat::R16uint:
+    case GPUTextureFormat::R16sint:
+    case GPUTextureFormat::R16float:
+    case GPUTextureFormat::Rg8unorm:
+    case GPUTextureFormat::Rg8snorm:
+    case GPUTextureFormat::Rg8uint:
+    case GPUTextureFormat::Rg8sint:
+    case GPUTextureFormat::R32float:
+    case GPUTextureFormat::R32uint:
+    case GPUTextureFormat::R32sint:
+    case GPUTextureFormat::Rg16uint:
+    case GPUTextureFormat::Rg16sint:
+    case GPUTextureFormat::Rg16float:
+    case GPUTextureFormat::Rgba8unorm:
+    case GPUTextureFormat::Rgba8unormSRGB:
+    case GPUTextureFormat::Rgba8snorm:
+    case GPUTextureFormat::Rgba8uint:
+    case GPUTextureFormat::Rgba8sint:
+    case GPUTextureFormat::Bgra8unorm:
+    case GPUTextureFormat::Bgra8unormSRGB:
+    case GPUTextureFormat::Rgb10a2unorm:
+    case GPUTextureFormat::Rg11b10ufloat:
+    case GPUTextureFormat::Rgb9e5ufloat:
+    case GPUTextureFormat::Rgb10a2uint:
+    case GPUTextureFormat::Rg32float:
+    case GPUTextureFormat::Rg32uint:
+    case GPUTextureFormat::Rg32sint:
+    case GPUTextureFormat::Rgba16uint:
+    case GPUTextureFormat::Rgba16sint:
+    case GPUTextureFormat::Rgba16float:
+    case GPUTextureFormat::Rgba32float:
+    case GPUTextureFormat::Rgba32uint:
+    case GPUTextureFormat::Rgba32sint:
+    case GPUTextureFormat::Stencil8:
+    case GPUTextureFormat::Depth16unorm:
+    case GPUTextureFormat::Depth24plus:
+    case GPUTextureFormat::Depth24plusStencil8:
+    case GPUTextureFormat::Depth32float:
+    case GPUTextureFormat::Depth32floatStencil8:
+        return 1;
+    }
+    return 0;
+}
+uint32_t GPUTexture::texelBlockHeight(GPUTextureFormat format)
+{
+    switch (format) {
+    case GPUTextureFormat::Bc1RgbaUnorm:
+    case GPUTextureFormat::Bc1RgbaUnormSRGB:
+    case GPUTextureFormat::Bc2RgbaUnorm:
+    case GPUTextureFormat::Bc2RgbaUnormSRGB:
+    case GPUTextureFormat::Bc3RgbaUnorm:
+    case GPUTextureFormat::Bc3RgbaUnormSRGB:
+    case GPUTextureFormat::Bc4RUnorm:
+    case GPUTextureFormat::Bc4RSnorm:
+    case GPUTextureFormat::Bc5RgUnorm:
+    case GPUTextureFormat::Bc5RgSnorm:
+    case GPUTextureFormat::Bc6hRgbUfloat:
+    case GPUTextureFormat::Bc6hRgbFloat:
+    case GPUTextureFormat::Bc7RgbaUnorm:
+    case GPUTextureFormat::Bc7RgbaUnormSRGB:
+        return 4;
+    case GPUTextureFormat::Etc2Rgb8unorm:
+    case GPUTextureFormat::Etc2Rgb8unormSRGB:
+    case GPUTextureFormat::Etc2Rgb8a1unorm:
+    case GPUTextureFormat::Etc2Rgb8a1unormSRGB:
+    case GPUTextureFormat::Etc2Rgba8unorm:
+    case GPUTextureFormat::Etc2Rgba8unormSRGB:
+    case GPUTextureFormat::EacR11unorm:
+    case GPUTextureFormat::EacR11snorm:
+    case GPUTextureFormat::EacRg11unorm:
+    case GPUTextureFormat::EacRg11snorm:
+        return 4;
+    case GPUTextureFormat::Astc4x4Unorm:
+    case GPUTextureFormat::Astc4x4UnormSRGB:
+    case GPUTextureFormat::Astc5x4Unorm:
+    case GPUTextureFormat::Astc5x4UnormSRGB:
+        return 4;
+    case GPUTextureFormat::Astc5x5Unorm:
+    case GPUTextureFormat::Astc5x5UnormSRGB:
+    case GPUTextureFormat::Astc6x5Unorm:
+    case GPUTextureFormat::Astc6x5UnormSRGB:
+        return 5;
+    case GPUTextureFormat::Astc6x6Unorm:
+    case GPUTextureFormat::Astc6x6UnormSRGB:
+        return 6;
+    case GPUTextureFormat::Astc8x5Unorm:
+    case GPUTextureFormat::Astc8x5UnormSRGB:
+        return 5;
+    case GPUTextureFormat::Astc8x6Unorm:
+    case GPUTextureFormat::Astc8x6UnormSRGB:
+        return 6;
+    case GPUTextureFormat::Astc8x8Unorm:
+    case GPUTextureFormat::Astc8x8UnormSRGB:
+        return 8;
+    case GPUTextureFormat::Astc10x5Unorm:
+    case GPUTextureFormat::Astc10x5UnormSRGB:
+        return 5;
+    case GPUTextureFormat::Astc10x6Unorm:
+    case GPUTextureFormat::Astc10x6UnormSRGB:
+        return 6;
+    case GPUTextureFormat::Astc10x8Unorm:
+    case GPUTextureFormat::Astc10x8UnormSRGB:
+        return 8;
+    case GPUTextureFormat::Astc10x10Unorm:
+    case GPUTextureFormat::Astc10x10UnormSRGB:
+    case GPUTextureFormat::Astc12x10Unorm:
+    case GPUTextureFormat::Astc12x10UnormSRGB:
+        return 10;
+    case GPUTextureFormat::Astc12x12Unorm:
+    case GPUTextureFormat::Astc12x12UnormSRGB:
+        return 12;
+    case GPUTextureFormat::R8unorm:
+    case GPUTextureFormat::R8snorm:
+    case GPUTextureFormat::R8uint:
+    case GPUTextureFormat::R8sint:
+    case GPUTextureFormat::R16uint:
+    case GPUTextureFormat::R16sint:
+    case GPUTextureFormat::R16float:
+    case GPUTextureFormat::Rg8unorm:
+    case GPUTextureFormat::Rg8snorm:
+    case GPUTextureFormat::Rg8uint:
+    case GPUTextureFormat::Rg8sint:
+    case GPUTextureFormat::R32float:
+    case GPUTextureFormat::R32uint:
+    case GPUTextureFormat::R32sint:
+    case GPUTextureFormat::Rg16uint:
+    case GPUTextureFormat::Rg16sint:
+    case GPUTextureFormat::Rg16float:
+    case GPUTextureFormat::Rgba8unorm:
+    case GPUTextureFormat::Rgba8unormSRGB:
+    case GPUTextureFormat::Rgba8snorm:
+    case GPUTextureFormat::Rgba8uint:
+    case GPUTextureFormat::Rgba8sint:
+    case GPUTextureFormat::Bgra8unorm:
+    case GPUTextureFormat::Bgra8unormSRGB:
+    case GPUTextureFormat::Rgb10a2unorm:
+    case GPUTextureFormat::Rg11b10ufloat:
+    case GPUTextureFormat::Rgb9e5ufloat:
+    case GPUTextureFormat::Rgb10a2uint:
+    case GPUTextureFormat::Rg32float:
+    case GPUTextureFormat::Rg32uint:
+    case GPUTextureFormat::Rg32sint:
+    case GPUTextureFormat::Rgba16uint:
+    case GPUTextureFormat::Rgba16sint:
+    case GPUTextureFormat::Rgba16float:
+    case GPUTextureFormat::Rgba32float:
+    case GPUTextureFormat::Rgba32uint:
+    case GPUTextureFormat::Rgba32sint:
+    case GPUTextureFormat::Stencil8:
+    case GPUTextureFormat::Depth16unorm:
+    case GPUTextureFormat::Depth24plus:
+    case GPUTextureFormat::Depth24plusStencil8:
+    case GPUTextureFormat::Depth32float:
+    case GPUTextureFormat::Depth32floatStencil8:
+        return 1;
+    }
+    return 0;
+}
+
 }

--- a/Source/WebCore/Modules/WebGPU/GPUTexture.h
+++ b/Source/WebCore/Modules/WebGPU/GPUTexture.h
@@ -27,6 +27,7 @@
 
 #include "ExceptionOr.h"
 #include "GPUIntegralTypes.h"
+#include "GPUTextureAspect.h"
 #include "GPUTextureDimension.h"
 #include "GPUTextureFormat.h"
 #include "WebGPUTexture.h"
@@ -70,6 +71,11 @@ public:
     GPUSize32Out sampleCount() const;
     GPUTextureDimension dimension() const;
     GPUFlagsConstant usage() const;
+
+    static GPUTextureFormat aspectSpecificFormat(GPUTextureFormat, GPUTextureAspect);
+    static uint32_t texelBlockSize(GPUTextureFormat);
+    static uint32_t texelBlockWidth(GPUTextureFormat);
+    static uint32_t texelBlockHeight(GPUTextureFormat);
 
     virtual ~GPUTexture();
 private:

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.cpp
@@ -93,7 +93,7 @@ auto BufferImpl::getBufferContents() -> MappedRange
     return { static_cast<uint8_t*>(pointer), static_cast<size_t>(bufferSize) };
 }
 
-void BufferImpl::copy(Vector<uint8_t>&&, size_t)
+void BufferImpl::copy(std::span<const uint8_t>, size_t)
 {
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.h
@@ -62,7 +62,7 @@ private:
     void getMappedRange(Size64 offset, std::optional<Size64>, Function<void(MappedRange)>&&) final;
     MappedRange getBufferContents() final;
     void unmap() final;
-    void copy(Vector<uint8_t>&&, size_t) final;
+    void copy(std::span<const uint8_t>, size_t offset) final;
 
     void destroy() final;
 

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h
@@ -59,7 +59,7 @@ public:
 
     virtual void destroy() = 0;
     virtual MappedRange getBufferContents() = 0;
-    virtual void copy(Vector<uint8_t>&&, size_t offset) = 0;
+    virtual void copy(std::span<const uint8_t>, size_t offset) = 0;
 protected:
     Buffer() = default;
 

--- a/Source/WebCore/platform/SharedMemory.cpp
+++ b/Source/WebCore/platform/SharedMemory.cpp
@@ -56,6 +56,21 @@ RefPtr<SharedMemory> SharedMemory::copyBuffer(const FragmentedSharedBuffer& buff
     return sharedMemory;
 }
 
+RefPtr<SharedMemory> SharedMemory::copySpan(std::span<const uint8_t> span)
+{
+    if (!span.size())
+        return nullptr;
+
+    auto sharedMemory = allocate(span.size());
+    if (!sharedMemory)
+        return nullptr;
+
+    auto destination = sharedMemory->mutableSpan();
+    memcpySpan(destination, span);
+
+    return sharedMemory;
+}
+
 Ref<SharedBuffer> SharedMemory::createSharedBuffer(size_t dataSize) const
 {
     ASSERT(dataSize <= size());

--- a/Source/WebCore/platform/SharedMemory.h
+++ b/Source/WebCore/platform/SharedMemory.h
@@ -99,6 +99,7 @@ public:
     // FIXME: Change these factory functions to return Ref<SharedMemory> and crash on failure.
     WEBCORE_EXPORT static RefPtr<SharedMemory> allocate(size_t);
     WEBCORE_EXPORT static RefPtr<SharedMemory> copyBuffer(const WebCore::FragmentedSharedBuffer&);
+    WEBCORE_EXPORT static RefPtr<SharedMemory> copySpan(std::span<const uint8_t>);
     WEBCORE_EXPORT static RefPtr<SharedMemory> map(Handle&&, Protection);
 #if USE(UNIX_DOMAIN_SOCKETS)
     WEBCORE_EXPORT static RefPtr<SharedMemory> wrapMap(void*, size_t, int fileDescriptor);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
@@ -38,6 +38,10 @@
 #include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
+namespace WebCore {
+class SharedMemoryHandle;
+}
+
 namespace WebCore::WebGPU {
 class Buffer;
 }
@@ -80,7 +84,7 @@ private:
 
     void getMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> sizeForMap, CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);
     void mapAsync(WebCore::WebGPU::MapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> sizeForMap, CompletionHandler<void(bool)>&&);
-    void copy(Vector<uint8_t>&&, size_t offset);
+    void copy(std::optional<WebCore::SharedMemoryHandle>&&, size_t offset, CompletionHandler<void(bool)>&&);
     void unmap();
 
     void destroy();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.messages.in
@@ -26,7 +26,7 @@
 messages -> RemoteBuffer NotRefCounted Stream {
     void GetMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size) -> (std::optional<Vector<uint8_t>> data) Synchronous
     void MapAsync(WebCore::WebGPU::MapModeFlags mapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size) -> (bool success)
-    void Copy(Vector<uint8_t> data, size_t offset)
+    void Copy(std::optional<WebCore::SharedMemory::Handle> data, size_t offset) -> (bool success) NotStreamEncodable
     void Unmap()
     void Destroy()
     void Destruct()

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
@@ -31,6 +31,7 @@
 #include "RemoteQueueMessages.h"
 #include "StreamServerConnection.h"
 #include "WebGPUObjectHeap.h"
+#include <WebCore/SharedMemory.h>
 #include <WebCore/WebGPUQueue.h>
 
 namespace WebKit {
@@ -80,32 +81,42 @@ void RemoteQueue::onSubmittedWorkDone(CompletionHandler<void()>&& callback)
 void RemoteQueue::writeBuffer(
     WebGPUIdentifier buffer,
     WebCore::WebGPU::Size64 bufferOffset,
-    Vector<uint8_t>&& data)
+    std::optional<WebCore::SharedMemoryHandle>&& dataHandle,
+    CompletionHandler<void(bool)>&& completionHandler)
 {
+    auto data = dataHandle ? WebCore::SharedMemory::map(WTFMove(*dataHandle), WebCore::SharedMemory::Protection::ReadOnly) : nullptr;
     auto convertedBuffer = m_objectHeap->convertBufferFromBacking(buffer);
     ASSERT(convertedBuffer);
-    if (!convertedBuffer)
+    if (!convertedBuffer) {
+        completionHandler(false);
         return;
+    }
 
-    m_backing->writeBufferNoCopy(*convertedBuffer, bufferOffset, data.mutableSpan(), 0, std::nullopt);
+    m_backing->writeBufferNoCopy(*convertedBuffer, bufferOffset, data ? data->mutableSpan() : std::span<uint8_t> { }, 0, std::nullopt);
+    completionHandler(true);
 }
 
 void RemoteQueue::writeTexture(
     const WebGPU::ImageCopyTexture& destination,
-    Vector<uint8_t>&& data,
+    std::optional<WebCore::SharedMemoryHandle>&& dataHandle,
     const WebGPU::ImageDataLayout& dataLayout,
-    const WebGPU::Extent3D& size)
+    const WebGPU::Extent3D& size,
+    CompletionHandler<void(bool)>&& completionHandler)
 {
+    auto data = dataHandle ? WebCore::SharedMemory::map(WTFMove(*dataHandle), WebCore::SharedMemory::Protection::ReadOnly) : nullptr;
     auto convertedDestination = m_objectHeap->convertFromBacking(destination);
     ASSERT(convertedDestination);
     auto convertedDataLayout = m_objectHeap->convertFromBacking(dataLayout);
     ASSERT(convertedDestination);
     auto convertedSize = m_objectHeap->convertFromBacking(size);
     ASSERT(convertedSize);
-    if (!convertedDestination || !convertedDestination || !convertedSize)
+    if (!convertedDestination || !convertedDestination || !convertedSize) {
+        completionHandler(false);
         return;
+    }
 
-    m_backing->writeTexture(*convertedDestination, data.mutableSpan(), *convertedDataLayout, *convertedSize);
+    m_backing->writeTexture(*convertedDestination, data ? data->mutableSpan() : std::span<uint8_t> { }, *convertedDataLayout, *convertedSize);
+    completionHandler(true);
 }
 
 void RemoteQueue::copyExternalImageToTexture(

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
@@ -38,6 +38,10 @@
 #include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
+namespace WebCore {
+class SharedMemoryHandle;
+}
+
 namespace WebCore::WebGPU {
 class Queue;
 }
@@ -89,13 +93,15 @@ private:
     void writeBuffer(
         WebGPUIdentifier,
         WebCore::WebGPU::Size64 bufferOffset,
-        Vector<uint8_t>&&);
+        std::optional<WebCore::SharedMemoryHandle>&&,
+        CompletionHandler<void(bool)>&&);
 
     void writeTexture(
         const WebGPU::ImageCopyTexture& destination,
-        Vector<uint8_t>&&,
+        std::optional<WebCore::SharedMemoryHandle>&&,
         const WebGPU::ImageDataLayout&,
-        const WebGPU::Extent3D& size);
+        const WebGPU::Extent3D& size,
+        CompletionHandler<void(bool)>&&);
 
     void copyExternalImageToTexture(
         const WebGPU::ImageCopyExternalImage& source,

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.messages.in
@@ -27,8 +27,8 @@ messages -> RemoteQueue NotRefCounted Stream {
     void Destruct()
     void Submit(Vector<WebKit::WebGPUIdentifier> commandBuffers)
     void OnSubmittedWorkDone() -> ()
-    void WriteBuffer(WebKit::WebGPUIdentifier identifier, WebCore::WebGPU::Size64 bufferOffset, Vector<uint8_t> data)
-    void WriteTexture(WebKit::WebGPU::ImageCopyTexture destination, Vector<uint8_t> data, WebKit::WebGPU::ImageDataLayout imageDataLayout, WebKit::WebGPU::Extent3D size)
+    void WriteBuffer(WebKit::WebGPUIdentifier identifier, WebCore::WebGPU::Size64 bufferOffset, std::optional<WebCore::SharedMemory::Handle> data) -> (bool success) NotStreamEncodable
+    void WriteTexture(WebKit::WebGPU::ImageCopyTexture destination, std::optional<WebCore::SharedMemory::Handle> dataHandle, WebKit::WebGPU::ImageDataLayout imageDataLayout, WebKit::WebGPU::Extent3D size) -> (bool success) NotStreamEncodable
     void CopyExternalImageToTexture(WebKit::WebGPU::ImageCopyExternalImage source, WebKit::WebGPU::ImageCopyTextureTagged destination, WebKit::WebGPU::Extent3D copySize)
     void SetLabel(String label)
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
@@ -82,7 +82,7 @@ private:
     void getMappedRange(WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64>, Function<void(MappedRange)>&&) final;
     MappedRange getBufferContents() final;
     void unmap() final;
-    void copy(Vector<uint8_t>&&, size_t offset) final;
+    void copy(std::span<const uint8_t>, size_t offset) final;
 
     void destroy() final;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
@@ -80,7 +80,13 @@ void RemoteQueueProxy::writeBuffer(
     if (!convertedBuffer)
         return;
 
-    auto sendResult = send(Messages::RemoteQueue::WriteBuffer(convertedBuffer, bufferOffset, source.subspan(dataOffset, static_cast<size_t>(size.value_or(source.size() - dataOffset)))));
+    auto sharedMemory = WebCore::SharedMemory::copySpan(source.subspan(dataOffset, static_cast<size_t>(size.value_or(source.size() - dataOffset))));
+    std::optional<WebCore::SharedMemoryHandle> handle;
+    if (sharedMemory)
+        handle = sharedMemory->createHandle(WebCore::SharedMemory::Protection::ReadOnly);
+    auto sendResult = sendWithAsyncReply(Messages::RemoteQueue::WriteBuffer(convertedBuffer, bufferOffset, WTFMove(handle)), [sharedMemory = sharedMemory.copyRef(), handleHasValue = handle.has_value()](auto) mutable {
+        RELEASE_ASSERT(sharedMemory.get() || !handleHasValue);
+    });
     UNUSED_VARIABLE(sendResult);
 }
 
@@ -99,7 +105,13 @@ void RemoteQueueProxy::writeTexture(
     if (!convertedDestination || !convertedDataLayout || !convertedSize)
         return;
 
-    auto sendResult = send(Messages::RemoteQueue::WriteTexture(*convertedDestination, Vector(source), *convertedDataLayout, *convertedSize));
+    auto sharedMemory = WebCore::SharedMemory::copySpan(source);
+    std::optional<WebCore::SharedMemoryHandle> handle;
+    if (sharedMemory)
+        handle = sharedMemory->createHandle(WebCore::SharedMemory::Protection::ReadOnly);
+    auto sendResult = sendWithAsyncReply(Messages::RemoteQueue::WriteTexture(*convertedDestination, WTFMove(handle), *convertedDataLayout, *convertedSize), [sharedMemory = sharedMemory.copyRef(), handleHasValue = handle.has_value()](auto) mutable {
+        RELEASE_ASSERT(sharedMemory.get() || !handleHasValue);
+    });
     UNUSED_VARIABLE(sendResult);
 }
 


### PR DESCRIPTION
#### bdf8fc7b595b4fc47022346a7fb7befd0f5dc694
<pre>
[WebGPU] IPC copies too much data leading to jetsams on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=275422">https://bugs.webkit.org/show_bug.cgi?id=275422</a>
&lt;radar://129714560&gt;

Reviewed by Tadeu Zagallo.

GPUQueue.writeTexture and GPUQueue.writeBuffer can pass a large
BufferSource but only end up copying a small number of bytes. We
were copying the entire BufferSource and passing it as a Vector
across IPC.

On iOS, this quickly led to jetsams on more complex examples.

Pass only the required data across shared memory to avoid large
copies and additional memory usage in the GPU process.

* Source/WebCore/Modules/WebGPU/GPUBuffer.cpp:
(WebCore::GPUBuffer::internalUnmap):
* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::GPUQueue::writeBuffer):
(WebCore::getExtentDimension):
(WebCore::width):
(WebCore::height):
(WebCore::depth):
(WebCore::requiredBytesInCopy):
(WebCore::GPUQueue::writeTexture):
* Source/WebCore/Modules/WebGPU/GPUTexture.cpp:
(WebCore::depthSpecificFormat):
(WebCore::stencilSpecificFormat):
(WebCore::GPUTexture::aspectSpecificFormat):
(WebCore::GPUTexture::texelBlockSize):
(WebCore::GPUTexture::texelBlockWidth):
(WebCore::GPUTexture::texelBlockHeight):
* Source/WebCore/Modules/WebGPU/GPUTexture.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.cpp:
(WebCore::WebGPU::BufferImpl::copy):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUBufferImpl.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPUBuffer.h:
* Source/WebCore/platform/SharedMemory.cpp:
(WebCore::SharedMemory::copySpan):
* Source/WebCore/platform/SharedMemory.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp:
(WebKit::RemoteBuffer::copy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.messages.in:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp:
(WebKit::RemoteQueue::writeBuffer):
(WebKit::RemoteQueue::writeTexture):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp:
(WebKit::WebGPU::RemoteBufferProxy::copy):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp:
(WebKit::WebGPU::RemoteQueueProxy::writeBuffer):
(WebKit::WebGPU::RemoteQueueProxy::writeTexture):

Canonical link: <a href="https://commits.webkit.org/280124@main">https://commits.webkit.org/280124@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9a9fe120d6011f6b7d7e982e5fdb287c27bc1d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55787 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8254 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/58802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6218 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57913 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42732 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6416 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/58802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4288 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48090 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/58802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29794 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5419 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4361 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51764 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5688 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60362 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5817 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52369 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48161 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51863 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12368 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30941 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32026 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33107 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31773 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->