### PR TITLE
[Win] Update intrinsic device scale factor dynamically

### DIFF
--- a/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
+++ b/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
@@ -184,6 +184,11 @@ LRESULT CALLBACK WebInspectorUIProxy::wndProc(HWND hwnd, UINT msg, WPARAM wParam
     case WM_CLOSE:
         inspector->close();
         return 0;
+    case WM_DPICHANGED: {
+        RECT& rect = *reinterpret_cast<RECT*>(lParam);
+        SetWindowPos(hwnd, nullptr, rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top, SWP_NOZORDER | SWP_NOACTIVATE);
+        return 0;
+    }
     default:
         break;
     }

--- a/Source/WebKit/UIProcess/win/WebView.cpp
+++ b/Source/WebKit/UIProcess/win/WebView.cpp
@@ -550,6 +550,8 @@ LRESULT WebView::onPrintClientEvent(HWND hWnd, UINT, WPARAM wParam, LPARAM, bool
 
 LRESULT WebView::onSizeEvent(HWND hwnd, UINT, WPARAM, LPARAM lParam, bool& handled)
 {
+    if (m_page)
+        m_page->setIntrinsicDeviceScaleFactor(deviceScaleFactorForWindow(hwnd));
     // If there are no m_page, use intrinsic device scale factor.
     float deviceScaleFactor = m_page ? m_page->deviceScaleFactor() : deviceScaleFactorForWindow(hwnd);
     m_viewSize = expandedIntSize(FloatSize(LOWORD(lParam), HIWORD(lParam)) / deviceScaleFactor);


### PR DESCRIPTION
#### 50c1741732a33548a144c043375f433523104f47
<pre>
[Win] Update intrinsic device scale factor dynamically
<a href="https://bugs.webkit.org/show_bug.cgi?id=274377">https://bugs.webkit.org/show_bug.cgi?id=274377</a>

Reviewed by Fujii Hironori.

When intrinsic device scale factor dynamically is changed, i.e. moving
between different displays, we need to change intrinsic device scale
factor and repaint contents.
For main web contents, although WebView can&apos;t receive WM_DPICHANGED by
default, it&apos;s sufficient to update on WM_SIZE handler
because MainWindow&apos;s WM_DPICHANGED handling contains resizing window.
Above change also enables WebInspector resize when receiving WM_DPICHANGED,
just as MainWindow does.

    * Source\WebKit\UIProcess\Inspector\win\WebInspectorUIProxyWin.cpp:
    * Source\WebKit\UIProcess\win\WebView.cpp:

Canonical link: <a href="https://commits.webkit.org/280003@main">https://commits.webkit.org/280003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f872c75b84afbf3e3a12d53382c7377adca0ee59

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55497 "Failed to checkout and rebase branch from PR 29810") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34820 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58482 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5928 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6125 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44687 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4064 "Passed tests") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/57526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32728 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/47827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/25815 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29512 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4072 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/5423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60073 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30651 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5546 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52122 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/31736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/47897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51587 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32817 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8177 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31483 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->