### PR TITLE
REGRESSION(273818@main): [GTK] Eclipse crashes when rendering tooltips: gdk_window_create_gl_context: assertion 'GDK_IS_WINDOW (window)' failed in WebKit::AcceleratedBackingStoreDMABuf::ensureGLContext

### DIFF
--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
@@ -544,12 +544,6 @@ void AcceleratedBackingStoreDMABuf::frame(uint64_t bufferID, const std::optional
         return;
     }
 
-    if (buffer->type() == Buffer::Type::EglImage) {
-        ensureGLContext();
-        gdk_gl_context_make_current(m_gdkGLContext.get());
-    }
-    buffer->didUpdateContents();
-
     m_pendingBuffer = buffer;
     gtk_widget_queue_draw(m_webPage.viewWidget());
 }
@@ -613,10 +607,13 @@ void AcceleratedBackingStoreDMABuf::update(const LayerTreeContext& context)
 
 bool AcceleratedBackingStoreDMABuf::prepareForRendering()
 {
-    if (m_gdkGLContext)
-        gdk_gl_context_make_current(m_gdkGLContext.get());
-
     if (m_pendingBuffer) {
+        if (m_pendingBuffer->type() == Buffer::Type::EglImage) {
+            ensureGLContext();
+            gdk_gl_context_make_current(m_gdkGLContext.get());
+        }
+        m_pendingBuffer->didUpdateContents();
+
         if (m_committedBuffer)
             m_webPage.legacyMainFrameProcess().send(Messages::AcceleratedSurfaceDMABuf::ReleaseBuffer(m_committedBuffer->id()), m_surfaceID);
         m_committedBuffer = WTFMove(m_pendingBuffer);


### PR DESCRIPTION
#### 847b2a717cfba4a0672d5e62e366349632799b9d
<pre>
REGRESSION(273818@main): [GTK] Eclipse crashes when rendering tooltips: gdk_window_create_gl_context: assertion &apos;GDK_IS_WINDOW (window)&apos; failed in WebKit::AcceleratedBackingStoreDMABuf::ensureGLContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=271477">https://bugs.webkit.org/show_bug.cgi?id=271477</a>

Reviewed by Adrian Perez de Castro.

Update the buffer contents on prepareForRendering to make sure the view
is already realized, which is required to create the gl context.

* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::frame):
(WebKit::AcceleratedBackingStoreDMABuf::prepareForRendering):

Canonical link: <a href="https://commits.webkit.org/280197@main">https://commits.webkit.org/280197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ec05c63ec38d19773c074f60eb2f9406e298b47

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55499 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58484 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5930 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6127 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44689 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4065 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57528 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32729 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47829 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25817 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29513 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4074 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51445 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5425 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60075 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30653 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5547 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52124 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31738 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51589 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32819 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8277 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31485 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->