### PR TITLE
[WebGL] Use shmem for getBufferSubData over 64 KB

### DIFF
--- a/LayoutTests/fast/canvas/webgl/webgl2-large-getbuffersubdata-expected.txt
+++ b/LayoutTests/fast/canvas/webgl/webgl2-large-getbuffersubdata-expected.txt
@@ -1,0 +1,21 @@
+Make sure that reading large buffers with getBufferData works as expected.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS gl.getError() is gl.NO_ERROR
+PASS gl.getError() is gl.NO_ERROR
+PASS gl.getError() is gl.NO_ERROR
+PASS gl.getError() is gl.NO_ERROR
+PASS gl.getError() is gl.NO_ERROR
+PASS gl.getError() is gl.NO_ERROR
+PASS gl.getError() is gl.NO_ERROR
+PASS gl.getError() is gl.NO_ERROR
+PASS gl.getError() is gl.NO_ERROR
+PASS gl.getError() is gl.NO_ERROR
+PASS gl.getError() is gl.NO_ERROR
+PASS gl.getError() is gl.NO_ERROR
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/webgl/webgl2-large-getbuffersubdata.html
+++ b/LayoutTests/fast/canvas/webgl/webgl2-large-getbuffersubdata.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<canvas id="canvas" width="128" height="128"></canvas>
+<script>
+  description("Make sure that reading large buffers with getBufferData works as expected.");
+
+  var canvas = document.getElementById("canvas");
+  var gl = canvas.getContext("webgl2");
+
+  runTests(4096, 1);
+  runTests(32*1024, 8);
+  runTests(1024*1024, 256);
+  runTests(27*1024*1024, 6192);
+
+  var bufferData;
+
+  function runTests(dim, skip) {
+      bufferData = new Float32Array(dim);
+      for (var i = 0; i < dim; ++i)
+          bufferData[i] = i % 256;
+      var buffer = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+      gl.bufferData(gl.ARRAY_BUFFER, bufferData, gl.STATIC_DRAW);
+      shouldBe("gl.getError()", "gl.NO_ERROR");
+
+      bufferData.fill(512);
+
+      gl.getBufferSubData(gl.ARRAY_BUFFER, 0, bufferData);
+      shouldBe("gl.getError()", "gl.NO_ERROR");
+
+      for (var i = 0; i < dim; i += skip) {
+          shouldBe(`bufferData[${i}]`, (i%256).toString(), true);
+      }
+
+      gl.deleteBuffer(buffer);
+      shouldBe("gl.getError()", "gl.NO_ERROR");
+  }
+</script>
+<script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -352,6 +352,9 @@ public:
 
     virtual void withBufferAsNativeImage(SurfaceBuffer, Function<void(NativeImage&)>);
 
+    // Returns the span of valid data read on success.
+    bool getBufferSubDataWithStatus(GCGLenum target, GCGLintptr offset, std::span<uint8_t> data);
+
     // Reads pixels from positive pixel coordinates with tight packing.
     // Returns columns, rows of executed read on success.
     std::optional<IntSize> readPixelsWithStatus(IntRect, GCGLenum format, GCGLenum type, std::span<uint8_t> data);
@@ -383,6 +386,7 @@ protected:
     void validateDepthStencil(ASCIILiteral packedDepthStencilExtension);
     void validateAttributes();
 
+    bool getBufferSubDataImpl(GCGLenum target, GCGLintptr offset, std::span<uint8_t> data);
     std::optional<IntSize> readPixelsImpl(IntRect, GCGLenum format, GCGLenum type, GCGLsizei bufSize, uint8_t* data, bool readingToPixelBufferObject);
 
     // Did the most recent drawing operation leave the GPU in an acceptable state?

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -131,6 +131,8 @@ protected:
     void setSharedVideoFrameMemory(WebCore::SharedMemory::Handle&&);
 #endif
     void simulateEventForTesting(WebCore::GraphicsContextGL::SimulatedEventForTesting);
+    void getBufferSubDataInline(uint32_t target, uint64_t offset, size_t dataSize, CompletionHandler<void(std::span<const uint8_t>)>&&);
+    void getBufferSubDataSharedMemory(uint32_t target, uint64_t offset, size_t dataSize, WebCore::SharedMemory::Handle, CompletionHandler<void(bool)>&&);
     void readPixelsInline(WebCore::IntRect, uint32_t format, uint32_t type, CompletionHandler<void(std::optional<WebCore::IntSize>, std::span<const uint8_t>)>&&);
     void readPixelsSharedMemory(WebCore::IntRect, uint32_t format, uint32_t type, WebCore::SharedMemory::Handle, CompletionHandler<void(std::optional<WebCore::IntSize>)>&&);
     void multiDrawArraysANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t>&& firstsAndCounts);

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in
@@ -50,6 +50,8 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void SetSharedVideoFrameMemory(WebCore::SharedMemory::Handle storageHandle) NotStreamEncodable
 #endif
     void SimulateEventForTesting(enum:uint8_t WebCore::GraphicsContextGLSimulatedEventForTesting event)
+    void GetBufferSubDataInline(uint32_t target, uint64_t offset, size_t dataSize) -> (std::span<const uint8_t> data) Synchronous
+    void GetBufferSubDataSharedMemory(uint32_t target, uint64_t offset, size_t dataSize, WebCore::SharedMemory::Handle handle) -> (bool valid) Synchronous NotStreamEncodable
     void ReadPixelsInline(WebCore::IntRect rect, uint32_t format, uint32_t type) -> (std::optional<WebCore::IntSize> readArea, std::span<const uint8_t> data) Synchronous
     void ReadPixelsSharedMemory(WebCore::IntRect rect, uint32_t format, uint32_t type, WebCore::SharedMemory::Handle handle) -> (std::optional<WebCore::IntSize> readArea) Synchronous NotStreamEncodable
     void MultiDrawArraysANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t> firstsAndCounts)
@@ -210,7 +212,6 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {
     void IsVertexArray(uint32_t arg0) -> (bool returnValue) Synchronous
     void BindVertexArray(uint32_t arg0)
     void CopyBufferSubData(uint32_t readTarget, uint32_t writeTarget, uint64_t readOffset, uint64_t writeOffset, uint64_t arg4)
-    void GetBufferSubData(uint32_t target, uint64_t offset, size_t dataSize) -> (std::span<const uint8_t> data) Synchronous
     void BlitFramebuffer(int32_t srcX0, int32_t srcY0, int32_t srcX1, int32_t srcY1, int32_t dstX0, int32_t dstY0, int32_t dstX1, int32_t dstY1, uint32_t mask, uint32_t filter)
     void FramebufferTextureLayer(uint32_t target, uint32_t attachment, uint32_t texture, int32_t level, int32_t layer)
     void InvalidateFramebuffer(uint32_t target, std::span<const uint32_t> attachments)

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h
@@ -960,13 +960,6 @@
         assertIsCurrent(workQueue());
         m_context->copyBufferSubData(readTarget, writeTarget, static_cast<GCGLintptr>(readOffset), static_cast<GCGLintptr>(writeOffset), static_cast<GCGLsizeiptr>(arg4));
     }
-    void getBufferSubData(uint32_t target, uint64_t offset, size_t dataSize, CompletionHandler<void(std::span<const uint8_t>)>&& completionHandler)
-    {
-        assertIsCurrent(workQueue());
-        Vector<uint8_t, 4> data(dataSize, 0);
-        m_context->getBufferSubData(target, static_cast<GCGLintptr>(offset), data);
-        completionHandler(byteCast<uint8_t>(data.span()));
-    }
     void blitFramebuffer(int32_t srcX0, int32_t srcY0, int32_t srcX1, int32_t srcY1, int32_t dstX0, int32_t dstY0, int32_t dstX1, int32_t dstY1, uint32_t mask, uint32_t filter)
     {
         assertIsCurrent(workQueue());

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -289,6 +289,58 @@ void RemoteGraphicsContextGLProxy::simulateEventForTesting(SimulatedEventForTest
     }
 }
 
+void RemoteGraphicsContextGLProxy::getBufferSubData(GCGLenum target, GCGLintptr offset, std::span<uint8_t> data)
+{
+    if (isContextLost())
+        return;
+
+    if (data.empty())
+        return;
+
+    static constexpr size_t getBufferSubDataInlineSizeLimit = 64 * KB; // NOTE: when changing, change the value in RemoteGraphicsContextGL too.
+    static constexpr size_t getBufferSubDataSharedMemorySizeLimit = 100 * MB;
+
+    if (data.size() > getBufferSubDataInlineSizeLimit) {
+        RefPtr<SharedMemory> replyBuffer = SharedMemory::allocate(std::min(data.size(), getBufferSubDataSharedMemorySizeLimit));
+        if (!replyBuffer)
+            goto inlineCase;
+        while (!data.empty()) {
+            auto handle = replyBuffer->createHandle(SharedMemory::Protection::ReadWrite);
+            if (!handle)
+                goto inlineCase;
+            auto transferSize = std::min(data.size(), getBufferSubDataSharedMemorySizeLimit);
+            auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetBufferSubDataSharedMemory(target, offset, transferSize, WTFMove(*handle)));
+            if (!sendResult.succeeded()) {
+                markContextLost();
+                return;
+            }
+            auto [valid] = sendResult.takeReply();
+            if (!valid)
+                return;
+            std::ranges::copy(replyBuffer->span().subspan(0, transferSize), data.begin());
+            data = data.subspan(transferSize);
+            offset += transferSize;
+        }
+        return;
+    }
+inlineCase:
+    while (data.size()) {
+        auto transferSize = std::min(data.size(), getBufferSubDataInlineSizeLimit);
+        auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetBufferSubDataInline(target, offset, transferSize));
+        if (!sendResult.succeeded()) {
+            markContextLost();
+            return;
+        }
+        auto [inlineBuffer] = sendResult.takeReply();
+        if (inlineBuffer.empty())
+            return;
+        RELEASE_ASSERT(transferSize == inlineBuffer.size());
+        std::ranges::copy(inlineBuffer, data.begin());
+        data = data.subspan(transferSize);
+        offset += transferSize;
+    }
+}
+
 void RemoteGraphicsContextGLProxy::readPixels(IntRect rect, GCGLenum format, GCGLenum type, std::span<uint8_t> dataStore, GCGLint alignment, GCGLint rowLength)
 {
     if (isContextLost())

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -88,6 +88,7 @@ public:
 #endif
 
     void simulateEventForTesting(WebCore::GraphicsContextGLSimulatedEventForTesting) final;
+    void getBufferSubData(GCGLenum target, GCGLintptr offset, std::span<uint8_t> data) final;
     void readPixels(WebCore::IntRect, GCGLenum format, GCGLenum type, std::span<uint8_t> data, GCGLint alignment, GCGLint rowLength) final;
     void multiDrawArraysANGLE(GCGLenum mode, GCGLSpanTuple<const GCGLint, const GCGLsizei> firstsAndCounts) final;
     void multiDrawArraysInstancedANGLE(GCGLenum mode, GCGLSpanTuple<const GCGLint, const GCGLsizei, const GCGLsizei> firstsCountsAndInstanceCounts) final;
@@ -248,7 +249,6 @@ public:
     GCGLboolean isVertexArray(PlatformGLObject arg0) final;
     void bindVertexArray(PlatformGLObject arg0) final;
     void copyBufferSubData(GCGLenum readTarget, GCGLenum writeTarget, GCGLintptr readOffset, GCGLintptr writeOffset, GCGLsizeiptr) final;
-    void getBufferSubData(GCGLenum target, GCGLintptr offset, std::span<uint8_t> data) final;
     void blitFramebuffer(GCGLint srcX0, GCGLint srcY0, GCGLint srcX1, GCGLint srcY1, GCGLint dstX0, GCGLint dstY0, GCGLint dstX1, GCGLint dstY1, GCGLbitfield mask, GCGLenum filter) final;
     void framebufferTextureLayer(GCGLenum target, GCGLenum attachment, PlatformGLObject texture, GCGLint level, GCGLint layer) final;
     void invalidateFramebuffer(GCGLenum target, std::span<const GCGLenum> attachments) final;
@@ -405,8 +405,6 @@ private:
     void wasCreated(IPC::Semaphore&&, IPC::Semaphore&&, std::optional<RemoteGraphicsContextGLInitializationState>&&);
     void wasLost();
     void addDebugMessage(GCGLenum, GCGLenum, GCGLenum, String&&);
-
-    void readPixelsSharedMemory(WebCore::IntRect, GCGLenum format, GCGLenum type, std::span<uint8_t> data);
 
     void initialize(const RemoteGraphicsContextGLInitializationState&);
     void waitUntilInitialized();

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp
@@ -1779,19 +1779,6 @@ void RemoteGraphicsContextGLProxy::copyBufferSubData(GCGLenum readTarget, GCGLen
     }
 }
 
-void RemoteGraphicsContextGLProxy::getBufferSubData(GCGLenum target, GCGLintptr offset, std::span<uint8_t> data)
-{
-    if (isContextLost())
-        return;
-    auto sendResult = sendSync(Messages::RemoteGraphicsContextGL::GetBufferSubData(target, static_cast<uint64_t>(offset), data.size()));
-    if (!sendResult.succeeded()) {
-        markContextLost();
-        return;
-    }
-    auto& [dataReply] = sendResult.reply();
-    memcpy(data.data(), dataReply.data(), data.size() * sizeof(const uint8_t));
-}
-
 void RemoteGraphicsContextGLProxy::blitFramebuffer(GCGLint srcX0, GCGLint srcY0, GCGLint srcX1, GCGLint srcY1, GCGLint dstX0, GCGLint dstY0, GCGLint dstX1, GCGLint dstY1, GCGLbitfield mask, GCGLenum filter)
 {
     if (isContextLost())

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -112,6 +112,8 @@ messages -> RemoteGraphicsContextGL NotRefCounted Stream {{
     void SetSharedVideoFrameMemory(WebCore::SharedMemory::Handle storageHandle) NotStreamEncodable
 #endif
     void SimulateEventForTesting(enum:uint8_t WebCore::GraphicsContextGLSimulatedEventForTesting event)
+    void GetBufferSubDataInline(uint32_t target, uint64_t offset, size_t dataSize) -> (std::span<const uint8_t> data) Synchronous
+    void GetBufferSubDataSharedMemory(uint32_t target, uint64_t offset, size_t dataSize, WebCore::SharedMemory::Handle handle) -> (bool valid) Synchronous NotStreamEncodable
     void ReadPixelsInline(WebCore::IntRect rect, uint32_t format, uint32_t type) -> (std::optional<WebCore::IntSize> readArea, std::span<const uint8_t> data) Synchronous
     void ReadPixelsSharedMemory(WebCore::IntRect rect, uint32_t format, uint32_t type, WebCore::SharedMemory::Handle handle) -> (std::optional<WebCore::IntSize> readArea) Synchronous NotStreamEncodable
     void MultiDrawArraysANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t> firstsAndCounts)


### PR DESCRIPTION
#### 13571d41220ab567f2f19ebf40c417f4d1b26e06
<pre>
[WebGL] Use shmem for getBufferSubData over 64 KB
<a href="https://bugs.webkit.org/show_bug.cgi?id=275472">https://bugs.webkit.org/show_bug.cgi?id=275472</a>
<a href="https://rdar.apple.com/129831454">rdar://129831454</a>

Reviewed by Kimmo Kinnunen.

RemoteGraphicsContextGLProxy::readPixels is optimized to return data transfers
over 64 KB via shared memory. This change implements the same behavior for
RemoteGraphicsContextGLProxy::getBufferSubData, which is a companion to
readPixels, used to transfer texture data via pixel pack buffers.

Tested by webgl2-large-getbuffersubdata.html which exercises fragmented and
unfragmented transfer for both inline and shared memory transfers.

* LayoutTests/fast/canvas/webgl/webgl2-large-getbuffersubdata-expected.txt: Added.
* LayoutTests/fast/canvas/webgl/webgl2-large-getbuffersubdata.html: Added.
* Source/WebCore/platform/SharedMemory.h:
(WebCore::SharedMemory::subspan const):
(WebCore::SharedMemory::mutableSubspan const):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::getBufferSubDataImpl):
(WebCore::GraphicsContextGLANGLE::getBufferSubData):
(WebCore::GraphicsContextGLANGLE::getBufferSubDataWithStatus):
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::getBufferSubDataInline):
(WebKit::RemoteGraphicsContextGL::getBufferSubDataSharedMemory):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.h:
(copyBufferSubData):
(getBufferSubData): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::getBufferSubData):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxyFunctionsGenerated.cpp:
(WebKit::RemoteGraphicsContextGLProxy::getBufferSubData): Deleted.
* Tools/Scripts/generate-gpup-webgl:

Canonical link: <a href="https://commits.webkit.org/280157@main">https://commits.webkit.org/280157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8403ce8aa27a281fe069714da66189569cb6944c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8349 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58877 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6313 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58007 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42826 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6509 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44994 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4352 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57910 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48176 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26130 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29882 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5504 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4456 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60466 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5898 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52425 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48245 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51925 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8255 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31034 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32118 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33200 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31866 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->