### PR TITLE
Sec-Fetch-Destination is invalid for service worker intercepted loads

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/navigation-headers.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/navigation-headers.https-expected.txt
@@ -41,13 +41,13 @@ PASS POST Navigation, same-origin with cross-site redirect, same-origin redirect
 PASS POST Navigation, same-origin with cross-site redirect, same-origin redirect, and change-request service worker sets correct origin and referer headers.
 PASS GET Navigation, same-origin with no service worker sets correct sec-fetch headers.
 PASS POST Navigation, same-origin with no service worker sets correct sec-fetch headers.
-FAIL GET Navigation, same-origin with passthrough service worker sets correct sec-fetch headers. assert_equals: sec-fetch-dest header expected "empty" but got "iframe"
-FAIL POST Navigation, same-origin with passthrough service worker sets correct sec-fetch headers. assert_equals: sec-fetch-dest header expected "empty" but got "iframe"
+PASS GET Navigation, same-origin with passthrough service worker sets correct sec-fetch headers.
+PASS POST Navigation, same-origin with passthrough service worker sets correct sec-fetch headers.
 PASS GET Navigation, same-origin with fallback service worker sets correct sec-fetch headers.
 PASS POST Navigation, same-origin with fallback service worker sets correct sec-fetch headers.
 PASS GET Navigation, same-origin with navpreload service worker sets correct sec-fetch headers.
-FAIL GET Navigation, same-origin with service worker that changes the request sets correct sec-fetch headers. assert_equals: sec-fetch-dest header expected "empty" but got "iframe"
-FAIL POST Navigation, same-origin with service worker that changes the request sets correct sec-fetch headers. assert_equals: sec-fetch-dest header expected "empty" but got "iframe"
+PASS GET Navigation, same-origin with service worker that changes the request sets correct sec-fetch headers.
+PASS POST Navigation, same-origin with service worker that changes the request sets correct sec-fetch headers.
 FAIL GET Navigation, same-site with no service worker sets correct sec-fetch headers. assert_equals: sec-fetch-site header expected "same-site" but got "cross-site"
 FAIL POST Navigation, same-site with no service worker sets correct sec-fetch headers. assert_equals: sec-fetch-site header expected "same-site" but got "cross-site"
 FAIL GET Navigation, same-site with passthrough service worker sets correct sec-fetch headers. assert_equals: sec-fetch-site header expected "same-site" but got "same-origin"
@@ -55,8 +55,8 @@ FAIL POST Navigation, same-site with passthrough service worker sets correct sec
 FAIL GET Navigation, same-site with fallback service worker sets correct sec-fetch headers. assert_equals: sec-fetch-site header expected "same-site" but got "cross-site"
 FAIL POST Navigation, same-site with fallback service worker sets correct sec-fetch headers. assert_equals: sec-fetch-site header expected "same-site" but got "cross-site"
 FAIL GET Navigation, same-site with navpreload service worker sets correct sec-fetch headers. assert_equals: sec-fetch-site header expected "same-site" but got "cross-site"
-FAIL GET Navigation, same-site with service worker that changes the request sets correct sec-fetch headers. assert_equals: sec-fetch-dest header expected "empty" but got "iframe"
-FAIL POST Navigation, same-site with service worker that changes the request sets correct sec-fetch headers. assert_equals: sec-fetch-dest header expected "empty" but got "iframe"
+PASS GET Navigation, same-site with service worker that changes the request sets correct sec-fetch headers.
+PASS POST Navigation, same-site with service worker that changes the request sets correct sec-fetch headers.
 PASS GET Navigation, cross-site with no service worker sets correct sec-fetch headers.
 PASS POST Navigation, cross-site with no service worker sets correct sec-fetch headers.
 FAIL GET Navigation, cross-site with passthrough service worker sets correct sec-fetch headers. assert_equals: sec-fetch-site header expected "cross-site" but got "same-origin"
@@ -64,22 +64,22 @@ FAIL POST Navigation, cross-site with passthrough service worker sets correct se
 PASS GET Navigation, cross-site with fallback service worker sets correct sec-fetch headers.
 PASS POST Navigation, cross-site with fallback service worker sets correct sec-fetch headers.
 PASS GET Navigation, cross-site with navpreload service worker sets correct sec-fetch headers.
-FAIL GET Navigation, cross-site with service worker that changes the request sets correct sec-fetch headers. assert_equals: sec-fetch-dest header expected "empty" but got "iframe"
-FAIL POST Navigation, cross-site with service worker that changes the request sets correct sec-fetch headers. assert_equals: sec-fetch-dest header expected "empty" but got "iframe"
+PASS GET Navigation, cross-site with service worker that changes the request sets correct sec-fetch headers.
+PASS POST Navigation, cross-site with service worker that changes the request sets correct sec-fetch headers.
 FAIL GET Navigation, same-origin with same-site redirect and no service worker sets correct sec-fetch headers. assert_equals: sec-fetch-site header expected "same-site" but got "cross-site"
 FAIL GET Navigation, same-origin with same-site redirect and passthrough service worker sets correct sec-fetch headers. assert_equals: sec-fetch-site header expected "same-site" but got "same-origin"
 FAIL GET Navigation, same-origin with same-site redirect and fallback service worker sets correct sec-fetch headers. assert_equals: sec-fetch-site header expected "same-site" but got "cross-site"
 FAIL GET Navigation, same-origin with same-site redirect and navpreload service worker sets correct sec-fetch headers. assert_equals: sec-fetch-site header expected "same-site" but got "cross-site"
-FAIL GET Navigation, same-origin with same-site redirect and change-request service worker sets correct sec-fetch headers. assert_equals: sec-fetch-dest header expected "empty" but got "iframe"
+PASS GET Navigation, same-origin with same-site redirect and change-request service worker sets correct sec-fetch headers.
 PASS GET Navigation, same-origin with cross-site redirect and no service worker sets correct sec-fetch headers.
 FAIL GET Navigation, same-origin with cross-site redirect and passthrough service worker sets correct sec-fetch headers. assert_equals: sec-fetch-site header expected "cross-site" but got "same-origin"
 PASS GET Navigation, same-origin with cross-site redirect and fallback service worker sets correct sec-fetch headers.
 PASS GET Navigation, same-origin with cross-site redirect and navpreload service worker sets correct sec-fetch headers.
-FAIL GET Navigation, same-origin with cross-site redirect and change-request service worker sets correct sec-fetch headers. assert_equals: sec-fetch-dest header expected "empty" but got "iframe"
+PASS GET Navigation, same-origin with cross-site redirect and change-request service worker sets correct sec-fetch headers.
 PASS GET Navigation, same-origin with cross-site redirect, same-origin redirect, and no service worker sets correct sec-fetch headers.
 FAIL GET Navigation, same-origin with cross-site redirect, same-origin redirect, and passthrough service worker sets correct sec-fetch headers. assert_equals: sec-fetch-site header expected "cross-site" but got "same-origin"
 PASS GET Navigation, same-origin with cross-site redirect, same-origin redirect, and fallback service worker sets correct sec-fetch headers.
 PASS GET Navigation, same-origin with cross-site redirect, same-origin redirect, and navpreload service worker sets correct sec-fetch headers.
-FAIL GET Navigation, same-origin with cross-site redirect, same-origin redirect, and change-request service worker sets correct sec-fetch headers. assert_equals: sec-fetch-dest header expected "empty" but got "iframe"
+PASS GET Navigation, same-origin with cross-site redirect, same-origin redirect, and change-request service worker sets correct sec-fetch headers.
 PASS Cleanup service worker
 

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -584,6 +584,7 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
 
     if (m_async) {
         ResourceLoaderOptions options = m_options;
+        options.loadedFromFetch = m_options.initiatorType == cachedResourceRequestInitiatorTypes().fetch ? LoadedFromFetch::Yes : LoadedFromFetch::No;
         options.clientCredentialPolicy = m_sameOriginRequest ? ClientCredentialPolicy::MayAskClientForCredentials : ClientCredentialPolicy::CannotAskClientForCredentials;
         options.contentSecurityPolicyImposition = ContentSecurityPolicyImposition::SkipPolicyCheck;
         

--- a/Source/WebCore/loader/ResourceLoaderOptions.h
+++ b/Source/WebCore/loader/ResourceLoaderOptions.h
@@ -160,6 +160,9 @@ static constexpr unsigned bitWidthOfLoadedFromOpaqueSource = 1;
 enum class LoadedFromPluginElement : bool { No, Yes };
 static constexpr unsigned bitWidthOfLoadedFromPluginElement = 1;
 
+enum class LoadedFromFetch : bool { No, Yes };
+static constexpr unsigned bitWidthOfLoadedFromFetch = 1;
+
 struct ResourceLoaderOptions : public FetchOptions {
     ResourceLoaderOptions()
         : ResourceLoaderOptions(FetchOptions())
@@ -187,6 +190,7 @@ struct ResourceLoaderOptions : public FetchOptions {
         , preflightPolicy(PreflightPolicy::Consider)
         , loadedFromOpaqueSource(LoadedFromOpaqueSource::No)
         , loadedFromPluginElement(LoadedFromPluginElement::No)
+        , loadedFromFetch(LoadedFromFetch::No)
         , fetchPriorityHint(RequestPriority::Auto)
         , shouldEnableContentExtensionsCheck(ShouldEnableContentExtensionsCheck::Yes)
     { }
@@ -211,6 +215,7 @@ struct ResourceLoaderOptions : public FetchOptions {
         , preflightPolicy(PreflightPolicy::Consider)
         , loadedFromOpaqueSource(LoadedFromOpaqueSource::No)
         , loadedFromPluginElement(LoadedFromPluginElement::No)
+        , loadedFromFetch(LoadedFromFetch::No)
         , fetchPriorityHint(RequestPriority::Auto)
         , shouldEnableContentExtensionsCheck(ShouldEnableContentExtensionsCheck::Yes)
     {
@@ -244,6 +249,7 @@ struct ResourceLoaderOptions : public FetchOptions {
     PreflightPolicy preflightPolicy : bitWidthOfPreflightPolicy;
     LoadedFromOpaqueSource loadedFromOpaqueSource : bitWidthOfLoadedFromOpaqueSource;
     LoadedFromPluginElement loadedFromPluginElement : bitWidthOfLoadedFromPluginElement;
+    LoadedFromFetch loadedFromFetch : bitWidthOfLoadedFromFetch;
     RequestPriority fetchPriorityHint : bitWidthOfFetchPriorityHint;
     ShouldEnableContentExtensionsCheck shouldEnableContentExtensionsCheck : bitWidthOfShouldEnableContentExtensionsCheck;
 

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -713,7 +713,7 @@ static void updateRequestFetchMetadataHeaders(ResourceRequest& request, const Re
 
     String destinationString;
     // The Fetch IDL documents this as "" while FetchMetadata expects "empty".
-    if (options.destination == FetchOptions::Destination::EmptyString)
+    if (options.destination == FetchOptions::Destination::EmptyString || options.loadedFromFetch == LoadedFromFetch::Yes)
         destinationString = "empty"_s;
     else
         destinationString = convertEnumerationToString(options.destination);


### PR DESCRIPTION
#### f55a27a7a6fa99d9870f187d6b06471991672b5d
<pre>
Sec-Fetch-Destination is invalid for service worker intercepted loads
<a href="https://bugs.webkit.org/show_bug.cgi?id=275474">https://bugs.webkit.org/show_bug.cgi?id=275474</a>
<a href="https://rdar.apple.com/129832604">rdar://129832604</a>

Reviewed by Alex Christensen.

We are updating destination when empty based on the resource type.
We are then using destination to compute sec-fetch-dest which has a specific handling of empty.
To cover the case of mismatch (which happens only for service worker intercepted fetches), we are storing whether the load is a fetch.
In which case, we are using empty string as a the value of sec-fetch-dest.
.
* LayoutTests/imported/w3c/web-platform-tests/service-workers/service-worker/navigation-headers.https-expected.txt:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::updateRequestFetchMetadataHeaders):

Canonical link: <a href="https://commits.webkit.org/280070@main">https://commits.webkit.org/280070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bdd4a45b1ce1efc897ec25dcb3f93c5d201d6a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34826 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58488 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5934 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57629 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44696 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4072 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57532 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32734 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47834 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25824 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29518 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5162 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4078 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51450 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5430 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60079 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30657 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5553 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52132 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31742 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47904 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51601 "Found 3 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12331 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32823 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31489 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->