### PR TITLE
[WPE][Qt6] Make WPE/Qt public API usable

### DIFF
--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -576,6 +576,7 @@ if (ENABLE_WPE_QT_API)
         )
         target_compile_definitions(qtwpe PUBLIC
             QT_NO_KEYWORDS=1
+            QT_WPE_LIBRARY
         )
         target_link_libraries(qtwpe
             PUBLIC

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h
@@ -20,16 +20,21 @@
 
 #pragma once
 
-#include <QQmlEngine>
 #include <QQuickItem>
 #include <QUrl>
-#include <memory>
+
 #include <wpe/webkit.h>
-#include <wtf/glib/GRefPtr.h>
+
+#if defined(QT_WPE_LIBRARY)
+#define QT_WPE_EXPORT Q_DECL_EXPORT
+#else
+#define QT_WPE_EXPORT Q_DECL_IMPORT
+#endif
 
 class WPEQtViewLoadRequest;
+class WPEQtViewPrivate;
 
-class Q_DECL_EXPORT WPEQtView : public QQuickItem {
+class QT_WPE_EXPORT WPEQtView : public QQuickItem {
     Q_OBJECT
     Q_DISABLE_COPY(WPEQtView)
     Q_PROPERTY(QUrl url READ url WRITE setUrl NOTIFY urlChanged)
@@ -49,7 +54,7 @@ public:
     };
 
     WPEQtView(QQuickItem* parent = nullptr);
-    ~WPEQtView();
+    virtual ~WPEQtView();
 
     void triggerUpdateScene() { QMetaObject::invokeMethod(this, "update", Qt::QueuedConnection); };
     void triggerDidUpdateScene() { QMetaObject::invokeMethod(this, "didUpdateScene", Qt::QueuedConnection); };
@@ -80,9 +85,10 @@ Q_SIGNALS:
     void loadProgressChanged();
 
 protected:
-    bool errorOccured() const { return m_errorOccured; };
-    void setErrorOccured(bool errorOccured) { m_errorOccured = errorOccured; };
+    bool errorOccured() const;
+    void setErrorOccured(bool);
 
+    bool event(QEvent*) override;
     void geometryChange(const QRectF&, const QRectF&) override;
 
     void hoverEnterEvent(QHoverEvent*) override;
@@ -113,10 +119,6 @@ private:
     static void notifyLoadChangedCallback(WebKitWebView*, WebKitLoadEvent, WPEQtView*);
     static void notifyLoadFailedCallback(WebKitWebView*, WebKitLoadEvent, const gchar* failingURI, GError*, WPEQtView*);
 
-    GRefPtr<WebKitWebView> m_webView;
-    QUrl m_url;
-    QString m_html;
-    QUrl m_baseUrl;
-    QSize m_size;
-    bool m_errorOccured { false };
+    Q_DECLARE_PRIVATE(WPEQtView)
+    QScopedPointer<WPEQtViewPrivate> d_ptr;
 };

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewLoadRequest.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewLoadRequest.cpp
@@ -35,15 +35,18 @@
 
   \sa {WPEView::loadingChanged()}{WPEView.loadingChanged()}
 */
-WPEQtViewLoadRequest::WPEQtViewLoadRequest(const WPEQtViewLoadRequestPrivate& d)
-    : d_ptr(new WPEQtViewLoadRequestPrivate(d))
+WPEQtViewLoadRequest::WPEQtViewLoadRequest(const QUrl& url, WPEQtView::LoadStatus loadStatus, const QString& errorString)
+    : d_ptr(new WPEQtViewLoadRequestPrivate(url, loadStatus, errorString))
 {
-
 }
 
 WPEQtViewLoadRequest::~WPEQtViewLoadRequest()
 {
+}
 
+bool WPEQtViewLoadRequest::event(QEvent* ev)
+{
+    return QObject::event(ev);
 }
 
 /*!

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewLoadRequestPrivate.h
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewLoadRequestPrivate.h
@@ -26,13 +26,16 @@
 
 class WPEQtViewLoadRequestPrivate {
 public:
-    WPEQtViewLoadRequestPrivate() { }
-    WPEQtViewLoadRequestPrivate(const QUrl& url, WPEQtView::LoadStatus status, const QString& errorString)
+    explicit WPEQtViewLoadRequestPrivate(const QUrl& url, WPEQtView::LoadStatus status, const QString& errorString)
         : m_url(url)
         , m_status(status)
         , m_errorString(errorString)
-    { }
-    ~WPEQtViewLoadRequestPrivate() { }
+    {
+    }
+
+    ~WPEQtViewLoadRequestPrivate()
+    {
+    }
 
     QUrl m_url;
     WPEQtView::LoadStatus m_status;

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewPrivate.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2018, 2019, 2024 Igalia S.L
- * Copyright (C) 2018, 2019 Zodiac Inflight Innovations
+ * Copyright (C) 2024 Igalia S.L
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -20,28 +19,22 @@
 
 #pragma once
 
-#include "WPEQtView.h"
+#include <QSize>
+#include <QUrl>
+#include <wpe/webkit.h>
+#include <wtf/glib/GRefPtr.h>
 
-class WPEQtViewLoadRequestPrivate;
-
-class QT_WPE_EXPORT WPEQtViewLoadRequest : public QObject {
-    Q_OBJECT
-    Q_PROPERTY(QUrl url READ url)
-    Q_PROPERTY(WPEQtView::LoadStatus status READ status)
-    Q_PROPERTY(QString errorString READ errorString)
-
+class WPEQtViewPrivate {
 public:
-    explicit WPEQtViewLoadRequest(const QUrl&, WPEQtView::LoadStatus, const QString& errorString);
-    virtual ~WPEQtViewLoadRequest();
+    WPEQtViewPrivate() { }
+    ~WPEQtViewPrivate() { }
 
-    QUrl url() const;
-    WPEQtView::LoadStatus status() const;
-    QString errorString() const;
-
-protected:
-    bool event(QEvent*) override;
-
-private:
-    Q_DECLARE_PRIVATE(WPEQtViewLoadRequest)
-    QScopedPointer<WPEQtViewLoadRequestPrivate> d_ptr;
+    GRefPtr<WebKitWebView> m_webView;
+    QUrl m_url;
+    QString m_html;
+    QUrl m_baseUrl;
+    QSize m_size;
+    bool m_errorOccured { false };
 };
+
+Q_DECLARE_METATYPE(WPEQtViewPrivate)

--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -157,7 +157,10 @@ _PATH_RULES_SPECIFIER = [
     ([
         # The WPEQtViewLoadRequest class uses Qt naming conventions (d_ptr).
         os.path.join('Source', 'WebKit', 'UIProcess', 'API', 'wpe', 'qt5', 'WPEQtViewLoadRequest.h'),
-        os.path.join('Source', 'WebKit', 'UIProcess', 'API', 'wpe', 'qt6', 'WPEQtViewLoadRequest.h')],
+        os.path.join('Source', 'WebKit', 'UIProcess', 'API', 'wpe', 'qt6', 'WPEQtViewLoadRequest.h'),
+
+        # The WPEQtView class uses Qt naming conventions (d_ptr).
+        os.path.join('Source', 'WebKit', 'UIProcess', 'API', 'wpe', 'qt6', 'WPEQtView.h')],
      ["-readability/naming/underscores"]),
 
     ([


### PR DESCRIPTION
#### 5e7ce03dc5feb90ffcefde7489844d8d74086310
<pre>
[WPE][Qt6] Make WPE/Qt public API usable
<a href="https://bugs.webkit.org/show_bug.cgi?id=275475">https://bugs.webkit.org/show_bug.cgi?id=275475</a>

Reviewed by Michael Catanzaro and Adrian Perez de Castro.

- Introduce WPEQtViewPrivate, similar to WPEQtViewLoadRequestPrivate.
  Move all members from WPEQtView to WPEQtViewPrivate and make use of
  Qts d-ptr mechanism, to provide a stable ABI. This allows us to
  continue using GRefPtr to manage the web view lifetime -- prior to
  this patch it was impossible to include WPEQtView.h in projects using
  WPE/Qt6, since the WTF headers are not installed along libqtwpe.so.

- Provide non-inline virtual destructors for WPEQtView &amp;
  WPEQtViewLoadRequest

- Assure all constructors are non-inline, for public API classes.

- Reimplement event() in QObject-derived classes, such as WPEQtView &amp;
  WPEQtViewLoadRequest - folllowing the KDE ABI guidelines.

- Correct d-ptr usage in WPEQtViewLoadRequest. Previously one had to
  create WPEQtViewLoadRequestPrivate objects and pass them to
  WPEQtViewLoadRequest - which defeats the purpose of the d-ptr
  mechanism. No external class (except those inheriting from
  WPEQtViewLoadRequest, which we don&apos;t have) should need to construct
  d-ptr objects, since it&apos;s a private implementatil detail.

- Do not mark WPEQtView &amp; friends with Q_DECL_EXPORT, but instead follow
  the Qt recommendation, of introducing a QT_WPE_EXPORT definition, that
  either resolves to Q_DECL_EXPORT or Q_DECL_IMPORT, depending on if we
  are building libqtwpe.so, or if we&apos;re using it externally.

  #if defined(QT_WPE_LIBRARY)
  #define QT_WPE_EXPORT Q_DECL_EXPORT
  #else
  #define QT_WPE_EXPORT Q_DECL_IMPORT
  #endif

Tested successfully on both desktop + yocto builds.

* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp:
(WPEQtView::WPEQtView):
(WPEQtView::~WPEQtView):
(WPEQtView::event):
(WPEQtView::geometryChange):
(WPEQtView::createWebView):
(WPEQtView::notifyLoadChangedCallback):
(WPEQtView::notifyLoadFailedCallback):
(WPEQtView::didUpdateScene):
(WPEQtView::updatePaintNode):
(WPEQtView::url const):
(WPEQtView::setUrl):
(WPEQtView::loadProgress const):
(WPEQtView::title const):
(WPEQtView::canGoBack const):
(WPEQtView::isLoading const):
(WPEQtView::canGoForward const):
(WPEQtView::goBack):
(WPEQtView::goForward):
(WPEQtView::reload):
(WPEQtView::stop):
(WPEQtView::loadHtml):
(WPEQtView::runJavaScript):
(WPEQtView::mousePressEvent):
(WPEQtView::mouseMoveEvent):
(WPEQtView::mouseReleaseEvent):
(WPEQtView::hoverEnterEvent):
(WPEQtView::hoverLeaveEvent):
(WPEQtView::hoverMoveEvent):
(WPEQtView::wheelEvent):
(WPEQtView::keyPressEvent):
(WPEQtView::keyReleaseEvent):
(WPEQtView::touchEvent):
(WPEQtView::webView const):
(WPEQtView::errorOccured const):
(WPEQtView::setErrorOccured):
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h:
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewLoadRequest.cpp:
(WPEQtViewLoadRequest::WPEQtViewLoadRequest):
(WPEQtViewLoadRequest::~WPEQtViewLoadRequest):
(WPEQtViewLoadRequest::event):
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewLoadRequest.h:
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewLoadRequestPrivate.h:
(WPEQtViewLoadRequestPrivate::WPEQtViewLoadRequestPrivate):
(WPEQtViewLoadRequestPrivate::~WPEQtViewLoadRequestPrivate):
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewPrivate.h: Copied from Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewLoadRequestPrivate.h.
(WPEQtViewPrivate::WPEQtViewPrivate):
(WPEQtViewPrivate::~WPEQtViewPrivate):
* Tools/Scripts/webkitpy/style/checker.py:

Canonical link: <a href="https://commits.webkit.org/280220@main">https://commits.webkit.org/280220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/864f39a362d39380f480e518b9cb678c0ba8f494

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55792 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8259 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58779 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6223 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57918 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6421 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44934 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4295 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57821 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33013 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48095 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26066 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/55320 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29799 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5424 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4366 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51774 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5693 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60370 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5822 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52361 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48166 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51858 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12414 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30946 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32031 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33112 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31778 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->