### PR TITLE
[WPE] WPE Platform: add none IM context implementation as fallback

### DIFF
--- a/Source/WebKit/WPEPlatform/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/CMakeLists.txt
@@ -22,6 +22,7 @@ set(WPEPlatform_SOURCES
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEEGLError.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEExtensions.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEInputMethodContext.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEInputMethodContextNone.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeyUnicode.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeymap.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeymapXKB.cpp

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp
@@ -29,6 +29,7 @@
 #include "WPEDisplayPrivate.h"
 #include "WPEEGLError.h"
 #include "WPEExtensions.h"
+#include "WPEInputMethodContextNone.h"
 #include <epoxy/egl.h>
 #include <gio/gio.h>
 #include <mutex>
@@ -141,7 +142,7 @@ static void wpe_display_class_init(WPEDisplayClass* displayClass)
 WPEView* wpeDisplayCreateView(WPEDisplay* display)
 {
     auto* wpeDisplayClass = WPE_DISPLAY_GET_CLASS(display);
-    return wpeDisplayClass->create_view ? wpeDisplayClass->create_view(display) : nullptr;
+    return wpeDisplayClass->create_view(display);
 }
 
 bool wpeDisplayCheckEGLExtension(WPEDisplay* display, const char* extensionName)
@@ -151,6 +152,12 @@ bool wpeDisplayCheckEGLExtension(WPEDisplay* display, const char* extensionName)
         return eglDisplay ? epoxy_has_egl_extension(eglDisplay, extensionName) : false;
     });
     return addResult.iterator->value;
+}
+
+WPEInputMethodContext* wpeDisplayCreateInputMethodContext(WPEDisplay* display)
+{
+    auto* wpeDisplayClass = WPE_DISPLAY_GET_CLASS(display);
+    return wpeDisplayClass->create_input_method_context ? wpeDisplayClass->create_input_method_context(display) : wpeInputMethodContextNoneNew();
 }
 
 /**
@@ -524,8 +531,3 @@ const char* wpe_display_get_drm_render_node(WPEDisplay* display)
     return wpeDisplayClass->get_drm_render_node ? wpeDisplayClass->get_drm_render_node(display) : nullptr;
 }
 
-WPEInputMethodContext* wpeDisplayCreateInputMethodContext(WPEDisplay* display)
-{
-    auto* wpeDisplayClass = WPE_DISPLAY_GET_CLASS(display);
-    return wpeDisplayClass->create_input_method_context ? wpeDisplayClass->create_input_method_context(display) : nullptr;
-}

--- a/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.cpp
@@ -346,7 +346,7 @@ static void wpe_input_method_context_class_init(WPEInputMethodContextClass* klas
  *
  * Create a new #WPEInputMethodContext for @view
  *
- * Returns: (transfer full) (nullable): a #WPEInputMethodContext, or %NULL
+ * Returns: (transfer full): a #WPEInputMethodContext
  */
 WPEInputMethodContext* wpe_input_method_context_new(WPEView* view)
 {

--- a/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContextNone.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContextNone.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEInputMethodContextNone.h"
+
+#include <wtf/glib/WTFGType.h>
+
+struct _WPEInputMethodContextNonePrivate {
+};
+
+WEBKIT_DEFINE_FINAL_TYPE(WPEInputMethodContextNone, wpe_input_method_context_none, WPE_TYPE_INPUT_METHOD_CONTEXT, WPEInputMethodContext)
+
+static void wpeInputMethodContextNoneGetPreeditString(WPEInputMethodContext*, char** text, GList** underlines, guint* cursorOffset)
+{
+    if (text)
+        *text = g_strdup("");
+    if (underlines)
+        *underlines = nullptr;
+    if (cursorOffset)
+        *cursorOffset = 0;
+}
+
+static void wpe_input_method_context_none_class_init(WPEInputMethodContextNoneClass* klass)
+{
+    WPEInputMethodContextClass* imContextClass = WPE_INPUT_METHOD_CONTEXT_CLASS(klass);
+    imContextClass->get_preedit_string = wpeInputMethodContextNoneGetPreeditString;
+}
+
+WPEInputMethodContext* wpeInputMethodContextNoneNew()
+{
+    return WPE_INPUT_METHOD_CONTEXT(g_object_new(WPE_TYPE_INPUT_METHOD_CONTEXT_NONE, nullptr));
+}

--- a/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContextNone.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContextNone.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <glib-object.h>
+#include <wpe/wpe-platform.h>
+
+G_BEGIN_DECLS
+
+#define WPE_TYPE_INPUT_METHOD_CONTEXT_NONE (wpe_input_method_context_none_get_type())
+G_DECLARE_FINAL_TYPE(WPEInputMethodContextNone, wpe_input_method_context_none, WPE, INPUT_METHOD_CONTEXT_NONE, WPEInputMethodContext)
+
+WPEInputMethodContext* wpeInputMethodContextNoneNew();
+
+G_END_DECLS

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -386,7 +386,7 @@ static void wpe_view_class_init(WPEViewClass* viewClass)
  *
  * Create a new #WPEView for @display
  *
- * Returns: (transfer full) (nullable): a #WPEView, or %NULL
+ * Returns: (transfer full): a #WPEView
  */
 WPEView* wpe_view_new(WPEDisplay* display)
 {


### PR DESCRIPTION
#### 635b3690eaea76a04a790a5ca8b8eb99d7191f0d
<pre>
[WPE] WPE Platform: add none IM context implementation as fallback
<a href="https://bugs.webkit.org/show_bug.cgi?id=275480">https://bugs.webkit.org/show_bug.cgi?id=275480</a>

Reviewed by Nikolas Zimmermann.

We don&apos;t want object new methods that can return nullptr, so better
have a None implementation used as fallback for platforms not implementing IME.
Also make create_view mandatory for the same reason, but in this case
all platform implementations are expected to implement WPEView.

* Source/WebKit/WPEPlatform/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp:
(wpeDisplayCreateView):
(wpeDisplayCreateInputMethodContext):
* Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.cpp:
* Source/WebKit/WPEPlatform/wpe/WPEInputMethodContextNone.cpp: Added.
(wpeInputMethodContextNoneGetPreeditString):
(wpe_input_method_context_none_class_init):
(wpeInputMethodContextNoneNew):
* Source/WebKit/WPEPlatform/wpe/WPEInputMethodContextNone.h: Added.
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:

Canonical link: <a href="https://commits.webkit.org/280009@main">https://commits.webkit.org/280009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d846128b0dc4553fe1221bfbb86093a357139a9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7976 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58494 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5940 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6138 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44701 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4076 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47839 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25829 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29524 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4084 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51458 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5435 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60085 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30663 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5558 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52137 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31748 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47909 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51606 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32829 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8179 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31495 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->