### PR TITLE
[ANGLE] Protect from faulty GPU drivers, reporting nullptr as GL_EXTENSION string

### DIFF
--- a/Source/ThirdParty/ANGLE/changes.diff
+++ b/Source/ThirdParty/ANGLE/changes.diff
@@ -682,6 +682,20 @@ index 503cae9acc842efc57c740021b5b8b16f5df6578..69f2f96ff53d0cf7fc674efaa2c88a94
    protected:
      const gl::State &mState;
      gl::MemoryProgramCache *mMemoryProgramCache;
+diff --git a/src/libANGLE/renderer/gl/FunctionsGL.cpp b/src/libANGLE/renderer/gl/FunctionsGL.cpp
+index 737e8d073f23729c602ebf52e6096601d589743e..c5a3c76d9019fec43f0f922b9a0cd767dc601f15 100644
+--- a/src/libANGLE/renderer/gl/FunctionsGL.cpp
++++ b/src/libANGLE/renderer/gl/FunctionsGL.cpp
+@@ -53,7 +53,8 @@ static std::vector<std::string> GetIndexedExtensions(PFNGLGETINTEGERVPROC getInt
+ 
+     for (GLint i = 0; i < numExtensions; i++)
+     {
+-        result.push_back(reinterpret_cast<const char *>(getStringIFunction(GL_EXTENSIONS, i)));
++        if (const char* extensionString = reinterpret_cast<const char *>(getStringIFunction(GL_EXTENSIONS, i)))
++            result.push_back(extensionString);
+     }
+ 
+     return result;
 diff --git a/src/libANGLE/renderer/gl/StateManagerGL.cpp b/src/libANGLE/renderer/gl/StateManagerGL.cpp
 index ab17e3e33ad04625c0e0d42a6212d8dc5187180e..2793d806faa5408fc64a33871d400f2a3976920a 100644
 --- a/src/libANGLE/renderer/gl/StateManagerGL.cpp

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/FunctionsGL.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/FunctionsGL.cpp
@@ -53,7 +53,8 @@ static std::vector<std::string> GetIndexedExtensions(PFNGLGETINTEGERVPROC getInt
 
     for (GLint i = 0; i < numExtensions; i++)
     {
-        result.push_back(reinterpret_cast<const char *>(getStringIFunction(GL_EXTENSIONS, i)));
+        if (const char* extensionString = reinterpret_cast<const char *>(getStringIFunction(GL_EXTENSIONS, i)))
+            result.push_back(extensionString);
     }
 
     return result;


### PR DESCRIPTION
#### 86c1918fdd79715f17cf6bbf161cdda598882198
<pre>
[ANGLE] Protect from faulty GPU drivers, reporting nullptr as GL_EXTENSION string
<a href="https://bugs.webkit.org/show_bug.cgi?id=275481">https://bugs.webkit.org/show_bug.cgi?id=275481</a>

Reviewed by Kimmo Kinnunen and Adrian Perez de Castro.

On a particular i.MX8 board any WebGL demo crashes in ANGLE initialization,
reporting a nullptr instead of a proper null-terminated string, when calling
getStringIFunction(GL_EXTENSIONS, i) in libANGLEs GetIndexExtensions() method
in renderer/gl/FunctionsGL.cpp. Null-check the string before trying to
wrap it in a std::string.

Covered by any WebGL test/demo on a certain i.MX8 board.

* Source/ThirdParty/ANGLE/changes.diff:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/FunctionsGL.cpp:
(rx::GetIndexedExtensions):

Canonical link: <a href="https://commits.webkit.org/280016@main">https://commits.webkit.org/280016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa7c68f1ed8bffd64c9786b4f3ca81fefb4aa4cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34836 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58498 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5944 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42459 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6142 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44705 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4080 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57542 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32744 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47843 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25833 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29528 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5171 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4088 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51461 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5439 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60089 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30667 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5562 "layout-tests (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52139 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31752 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47913 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51609 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12295 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32833 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31499 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->