### PR TITLE
[WPE] WPE Platform: add API to handle visibility

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp
@@ -100,6 +100,7 @@ void WPEQtView::createWebView()
 
     auto* wpeView = webkit_web_view_get_wpe_view(m_webView.get());
     wpe_view_resize(wpeView, m_size.width(), m_size.height());
+    wpe_view_map(wpeView); // FIXME: unmap when appropriate and implement can_be_mapped if needed.
 
     if (!wpe_view_qtquick_initialize_rendering(WPE_VIEW_QTQUICK(wpeView), this, &error.outPtr())) {
         g_warning("Failed to create Web view: %s", error->message);

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.h
@@ -73,6 +73,7 @@ struct _WPEViewClass
     void                    (* set_opaque_rectangles)         (WPEView      *view,
                                                                WPERectangle *rects,
                                                                guint         n_rects);
+    gboolean                (* can_be_mapped)                 (WPEView      *view);
 
     gpointer padding[32];
 };
@@ -119,6 +120,12 @@ WPE_API void                    wpe_view_resized                       (WPEView 
 WPE_API gdouble                 wpe_view_get_scale                     (WPEView      *view);
 WPE_API void                    wpe_view_scale_changed                 (WPEView      *view,
                                                                         gdouble       scale);
+WPE_API gboolean                wpe_view_get_visible                   (WPEView      *view);
+WPE_API void                    wpe_view_set_visible                   (WPEView      *view,
+                                                                        gboolean      visible);
+WPE_API gboolean                wpe_view_get_mapped                    (WPEView      *view);
+WPE_API void                    wpe_view_map                           (WPEView      *view);
+WPE_API void                    wpe_view_unmap                         (WPEView      *view);
 WPE_API void                    wpe_view_set_cursor_from_name          (WPEView      *view,
                                                                         const char   *name);
 WPE_API void                    wpe_view_set_cursor_from_bytes         (WPEView      *view,

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp
@@ -81,6 +81,7 @@ static void wpeViewDRMConstructed(GObject* object)
     wpe_view_resized(wpeView, mode->hdisplay / scale, mode->vdisplay / scale);
     wpe_view_scale_changed(wpeView, scale);
     wpe_view_state_changed(wpeView, WPE_VIEW_STATE_FULLSCREEN);
+    wpe_view_map(wpeView);
 
     priv->refreshDuration = Seconds(1 / (wpe_monitor_get_refresh_rate(monitor) / 1000.));
 

--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.cpp
@@ -62,6 +62,8 @@ static void wpeViewHeadlessConstructed(GObject* object)
 {
     G_OBJECT_CLASS(wpe_view_headless_parent_class)->constructed(object);
 
+    wpe_view_map(WPE_VIEW(object));
+
     auto* priv = WPE_VIEW_HEADLESS(object)->priv;
     priv->frameSource = adoptGRef(g_source_new(&frameSourceFuncs, sizeof(GSource)));
     g_source_set_priority(priv->frameSource.get(), RunLoopSourcePriority::RunLoopTimer);


### PR DESCRIPTION
#### 37eef8a67009b9162a9be622ad4a8c429331982b
<pre>
[WPE] WPE Platform: add API to handle visibility
<a href="https://bugs.webkit.org/show_bug.cgi?id=275482">https://bugs.webkit.org/show_bug.cgi?id=275482</a>

Reviewed by Nikolas Zimmermann.

Users should be able to make a view visible/hidden and platform
implementations should map/unmap the view according to the toplevel
state.

* Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp:
(WKWPE::m_backend):
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp:
(WPEQtView::createWebView):
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpeViewGetProperty):
(wpe_view_class_init):
(wpe_view_get_visible):
(wpe_view_set_visible):
(wpe_view_get_mapped):
(wpe_view_map):
(wpe_view_unmap):
* Source/WebKit/WPEPlatform/wpe/WPEView.h:
* Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp:
(wpeViewDRMConstructed):
* Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.cpp:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:
(wpeViewWaylandConstructed):
(wpeViewWaylandCanBeMapped):
(wpe_view_wayland_class_init):

Canonical link: <a href="https://commits.webkit.org/280113@main">https://commits.webkit.org/280113@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c33ecbb654c5a0af94d3a0394a54ab48bf3dbf7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35006 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58667 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6113 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44844 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4208 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57712 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32905 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47994 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25976 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29692 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4257 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51678 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60258 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5720 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52273 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48064 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51762 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8230 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30837 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31922 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33003 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31669 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->