### PR TITLE
[WPE] WPE Platform: wayland text input manager object should be released before the display

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
@@ -182,14 +182,6 @@ static void wpeDisplayWaylandDispose(GObject* object)
         auto monitor = priv->monitors.takeLast();
         wpe_monitor_invalidate(monitor.get());
     }
-#if USE(LIBDRM)
-    g_clear_pointer(&priv->dmabufFeedback, zwp_linux_dmabuf_feedback_v1_destroy);
-#endif
-    g_clear_pointer(&priv->linuxDMABuf, zwp_linux_dmabuf_v1_destroy);
-    g_clear_pointer(&priv->wlSHM, wl_shm_destroy);
-    g_clear_pointer(&priv->xdgWMBase, xdg_wm_base_destroy);
-    g_clear_pointer(&priv->wlCompositor, wl_compositor_destroy);
-    g_clear_pointer(&priv->wlDisplay, wl_display_disconnect);
     if (priv->textInputManagerV1) {
         g_clear_pointer(&priv->textInputV1, zwp_text_input_v1_destroy);
         g_clear_pointer(&priv->textInputManagerV1, zwp_text_input_manager_v1_destroy);
@@ -198,6 +190,15 @@ static void wpeDisplayWaylandDispose(GObject* object)
         g_clear_pointer(&priv->textInputV3, zwp_text_input_v3_destroy);
         g_clear_pointer(&priv->textInputManagerV3, zwp_text_input_manager_v3_destroy);
     }
+#if USE(LIBDRM)
+    g_clear_pointer(&priv->dmabufFeedback, zwp_linux_dmabuf_feedback_v1_destroy);
+#endif
+    g_clear_pointer(&priv->linuxDMABuf, zwp_linux_dmabuf_v1_destroy);
+    g_clear_pointer(&priv->wlSHM, wl_shm_destroy);
+    g_clear_pointer(&priv->xdgWMBase, xdg_wm_base_destroy);
+    g_clear_pointer(&priv->wlCompositor, wl_compositor_destroy);
+    g_clear_pointer(&priv->wlDisplay, wl_display_disconnect);
+
     G_OBJECT_CLASS(wpe_display_wayland_parent_class)->dispose(object);
 }
 


### PR DESCRIPTION
#### 6a0df11413dbc84f4136ca05ecb9f5f6cef43fe8
<pre>
[WPE] WPE Platform: wayland text input manager object should be released before the display
<a href="https://bugs.webkit.org/show_bug.cgi?id=275483">https://bugs.webkit.org/show_bug.cgi?id=275483</a>

Reviewed by Nikolas Zimmermann.

It crashes otherwise, since the text input manager depends on the display.

* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp:
(wpeDisplayWaylandDispose):

Canonical link: <a href="https://commits.webkit.org/280117@main">https://commits.webkit.org/280117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/895637f4e8c715cf503482518ce35ed2ee0395f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55517 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/7984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58502 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5948 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6146 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44708 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4084 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32748 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47847 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25836 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29532 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4092 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51466 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5443 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60093 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30671 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5566 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52143 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31756 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47917 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51618 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32837 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8231 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31503 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->