### PR TITLE
[view-transitions] Implement matching for view transition classes

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7596,16 +7596,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/web-animations-api-pars
 # Test doesn't seem to pass on Chrome Canary.
 imported/w3c/web-platform-tests/css/css-view-transitions/view-transition-types-mutable-no-document-element-crashtest.html [ Skip ]
 
-# View transitions Level 2 - classes.
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-entry.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-exit.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-mismatch-ident.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-mismatch-partial.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-mismatch-wildcard.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-old-with-class-new-without.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/shadow-part-with-class-inside-shadow-important.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-view-transitions/shadow-part-with-class-inside-shadow.html [ ImageOnlyFailure ]
-
 # View transitions Level 2 - cross document transitions.
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/chromium-paint-holding-timeout.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/no-view-transition-with-cross-origin-redirect.sub.html [ ImageOnlyFailure ]

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -26,6 +26,7 @@
 #include "RenderStyleConstants.h"
 #include <wtf/EnumTraits.h>
 #include <wtf/FixedVector.h>
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 
@@ -38,6 +39,11 @@ struct PossiblyQuotedIdentifier {
 
     bool isNull() const { return identifier.isNull(); }
 };
+
+inline WTF::TextStream& operator<<(WTF::TextStream& ts, PossiblyQuotedIdentifier quoted)
+{
+    return ts << quoted.identifier;
+}
 
 enum class SelectorSpecificityIncrement {
     ClassA = 0x10000,

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1273,7 +1273,24 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
 
             // Wildcard always matches.
             auto& argument = selector.argumentList()->first();
-            return argument == starAtom() || argument == checkingContext.pseudoElementNameArgument;
+            if (argument != starAtom() && argument != checkingContext.pseudoElementNameArgument)
+                return false;
+
+            // WTFReportBacktrace();
+            ALWAYS_LOG_WITH_STREAM(stream << "selector argument list: " << *selector.argumentList());
+            ALWAYS_LOG_WITH_STREAM(stream << "nameArgument: " << checkingContext.pseudoElementNameArgument);
+            ALWAYS_LOG_WITH_STREAM(stream << "checking context argument list: " << checkingContext.classList);
+
+            auto result = std::ranges::all_of(
+                selector.argumentList()->begin() + 1, selector.argumentList()->end(),
+                [&](const PossiblyQuotedIdentifier& classSelector) {
+                    return checkingContext.classList.contains(classSelector.identifier);
+                }
+            );
+
+            ALWAYS_LOG_WITH_STREAM(stream << "result: " << result << "\n");
+
+            return result;
         }
 
         default:

--- a/Source/WebCore/css/SelectorChecker.h
+++ b/Source/WebCore/css/SelectorChecker.h
@@ -86,6 +86,7 @@ public:
         PseudoId pseudoId { PseudoId::None };
         AtomString pseudoElementNameArgument;
         std::optional<StyleScrollbarState> scrollbarState;
+        Vector<AtomString> classList;
         RefPtr<const ContainerNode> scope;
         const Element* hasScope { nullptr };
         bool matchesAllHasScopes { false };

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -331,6 +331,22 @@ static ExceptionOr<void> checkDuplicateViewTransitionName(const AtomString& name
     return { };
 }
 
+static Vector<AtomString> effectiveViewTransitionClassList(RenderLayerModelObject& renderer, Element& originatingElement, Style::Scope& documentScope)
+{
+    auto classList = renderer.style().viewTransitionClasses();
+
+    if (classList.isEmpty())
+        return { };
+
+    auto scope = Style::Scope::forOrdinal(originatingElement, classList.first().scopeOrdinal);
+    if (!scope || scope != &documentScope)
+        return { };
+
+    return WTF::map(classList, [&](auto& item) {
+        return item.name;
+    });
+}
+
 static LayoutRect captureOverflowRect(RenderLayerModelObject& renderer)
 {
     if (!renderer.hasLayer())
@@ -465,6 +481,10 @@ ExceptionOr<void> ViewTransition::captureOldState()
             capture.oldImage = snapshotElementVisualOverflowClippedToViewport(*frame, renderer.get(), capture.oldOverflowRect);
         capture.oldLayerToLayoutOffset = layerToLayoutOffset(renderer.get());
 
+        auto styleable = Styleable::fromRenderer(renderer);
+        ASSERT(styleable);
+        capture.classList = effectiveViewTransitionClassList(renderer, styleable->element, document()->styleScope());
+
         auto transitionName = renderer->style().viewTransitionName();
         m_namedElements.add(transitionName->name, capture);
     }
@@ -495,7 +515,9 @@ ExceptionOr<void> ViewTransition::captureNewState()
                     CapturedElement capturedElement;
                     m_namedElements.add(name, capturedElement);
                 }
-                m_namedElements.find(name)->newElement = *styleable;
+                auto namedElement = m_namedElements.find(name);
+                namedElement->classList = effectiveViewTransitionClassList(renderer, styleable->element, document()->styleScope());
+                namedElement->newElement = *styleable;
             }
             return { };
         }, *view->layer());

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -66,6 +66,7 @@ public:
     LayoutSize oldSize;
     RefPtr<MutableStyleProperties> oldProperties;
     WeakStyleable newElement;
+    Vector<AtomString> classList;
 
     RefPtr<MutableStyleProperties> groupStyleProperties;
 };

--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -114,7 +114,7 @@ Vector<MarkedText> MarkedText::collectForHighlights(const RenderText& renderer, 
         auto& parentStyle = parentRenderer.style();
         if (auto highlightRegistry = renderer.document().highlightRegistryIfExists()) {
             for (auto& highlightName : highlightRegistry->highlightNames()) {
-                auto renderStyle = parentRenderer.getUncachedPseudoStyle({ PseudoId::Highlight, highlightName }, &parentStyle);
+                auto renderStyle = parentRenderer.getUncachedPseudoStyle(Style::PseudoElementIdentifier { PseudoId::Highlight, highlightName }, &parentStyle);
                 if (!renderStyle)
                     continue;
                 if (renderStyle->textDecorationsInEffect().isEmpty() && phase == PaintPhase::Decoration)

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -84,7 +84,7 @@ static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, 
         break;
     }
     case MarkedText::Type::Highlight: {
-        auto renderStyle = renderer.parent()->getUncachedPseudoStyle({ PseudoId::Highlight, markedText.highlightName }, &renderer.style());
+        auto renderStyle = renderer.parent()->getUncachedPseudoStyle(Style::PseudoElementIdentifier { PseudoId::Highlight, markedText.highlightName }, &renderer.style());
         computeStyleForPseudoElementStyle(style, renderStyle.get(), paintInfo);
         break;
     }

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.h
@@ -40,8 +40,8 @@ public:
 
     void updatePseudoElementTree(RenderElement&, StyleDifference minimalStyleDifference);
 private:
-    void buildPseudoElementGroup(const AtomString&, RenderElement&, RenderObject* = nullptr);
-    void updatePseudoElementGroup(const RenderStyle&, RenderElement&, RenderElement&, StyleDifference minimalStyleDifference);
+    void buildPseudoElementGroup(const AtomString&, const Vector<AtomString>&, RenderElement&, RenderObject* = nullptr);
+    void updatePseudoElementGroup(const RenderStyle&, RenderElement&, RenderElement&, const Vector<AtomString>&, StyleDifference minimalStyleDifference);
     RenderTreeUpdater& m_updater;
 };
 

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -508,6 +508,7 @@ inline bool ElementRuleCollector::ruleMatches(const RuleData& ruleData, unsigned
         context.pseudoId = m_pseudoElementRequest->pseudoId();
         context.pseudoElementNameArgument = m_pseudoElementRequest->nameArgument();
         context.scrollbarState = m_pseudoElementRequest->scrollbarState();
+        context.classList = m_pseudoElementRequest->classList();
     }
     context.styleScopeOrdinal = styleScopeOrdinal;
     context.selectorMatchingState = m_selectorMatchingState;

--- a/Source/WebCore/style/PseudoElementRequest.h
+++ b/Source/WebCore/style/PseudoElementRequest.h
@@ -41,25 +41,29 @@ public:
         ASSERT(pseudoId != PseudoId::None);
     }
 
-    PseudoElementRequest(PseudoId pseudoId, const AtomString& nameArgument)
-        : m_identifier({ pseudoId, nameArgument })
-    {
-        ASSERT(pseudoId == PseudoId::Highlight || pseudoId == PseudoId::ViewTransitionGroup || pseudoId == PseudoId::ViewTransitionImagePair || pseudoId == PseudoId::ViewTransitionOld || pseudoId == PseudoId::ViewTransitionNew);
-    }
-
     PseudoElementRequest(const PseudoElementIdentifier& pseudoElementIdentifier)
         : m_identifier(pseudoElementIdentifier)
     {
         ASSERT(pseudoElementIdentifier.pseudoId != PseudoId::None);
     }
 
+    PseudoElementRequest(const PseudoElementIdentifier& pseudoElementIdentifier, Vector<AtomString> classList)
+        : m_identifier(pseudoElementIdentifier)
+        , m_classList(classList)
+    {
+        auto pseudoId = pseudoElementIdentifier.pseudoId;
+        ASSERT(pseudoId == PseudoId::ViewTransitionGroup || pseudoId == PseudoId::ViewTransitionImagePair || pseudoId == PseudoId::ViewTransitionOld || pseudoId == PseudoId::ViewTransitionNew);
+    }
+
     const PseudoElementIdentifier& identifier() const { return m_identifier; }
     PseudoId pseudoId() const { return m_identifier.pseudoId; }
     const AtomString& nameArgument() const { return m_identifier.nameArgument; }
+    const Vector<AtomString>& classList() const { return m_classList; }
     const std::optional<StyleScrollbarState>& scrollbarState() const { return m_scrollbarState; }
 
 private:
     PseudoElementIdentifier m_identifier;
+    Vector<AtomString> m_classList;
     std::optional<StyleScrollbarState> m_scrollbarState;
 };
 

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -84,7 +84,7 @@ private:
     std::unique_ptr<RenderStyle> resolveStartingStyle(const ResolvedStyle&, const Styleable&, const ResolutionContext&) const;
     HashSet<AnimatableCSSProperty> applyCascadeAfterAnimation(RenderStyle&, const HashSet<AnimatableCSSProperty>&, bool isTransition, const MatchResult&, const Element&, const ResolutionContext&);
 
-    std::optional<ElementUpdate> resolvePseudoElement(Element&, const PseudoElementIdentifier&, const ElementUpdate&, IsInDisplayNoneTree);
+    std::optional<ElementUpdate> resolvePseudoElement(Element&, const PseudoElementRequest&, const ElementUpdate&, IsInDisplayNoneTree);
     std::optional<ElementUpdate> resolveAncestorPseudoElement(Element&, const PseudoElementIdentifier&, const ElementUpdate&);
     std::optional<ResolvedStyle> resolveAncestorFirstLinePseudoElement(Element&, const ElementUpdate&);
     std::optional<ResolvedStyle> resolveAncestorFirstLetterPseudoElement(Element&, const ElementUpdate&, ResolutionContext&);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -6801,7 +6801,7 @@ String Internals::highlightPseudoElementColor(const AtomString& highlightName, E
     if (!parentStyle)
         return { };
 
-    auto resolvedStyle = styleResolver.styleForPseudoElement(element, { PseudoId::Highlight, highlightName }, { parentStyle });
+    auto resolvedStyle = styleResolver.styleForPseudoElement(element, Style::PseudoElementIdentifier { PseudoId::Highlight, highlightName }, { parentStyle });
     if (!resolvedStyle)
         return { };
 


### PR DESCRIPTION
#### 690d7e24a09f97351dbef983253ba235c9ace830
<pre>
[view-transitions] Implement matching for view transition classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=278223">https://bugs.webkit.org/show_bug.cgi?id=278223</a>
<a href="https://rdar.apple.com/134020027">rdar://134020027</a>

Reviewed by NOBODY (OOPS!).

* LayoutTests/TestExpectations:
* Source/WebCore/css/CSSSelector.h:
(WebCore::operator&lt;&lt;):
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/SelectorChecker.h:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::captureOldState):
(WebCore::ViewTransition::captureNewState):
* Source/WebCore/dom/ViewTransition.h:
* Source/WebCore/rendering/MarkedText.cpp:
(WebCore::MarkedText::collectForHighlights):
* Source/WebCore/rendering/StyledMarkedText.cpp:
(WebCore::resolveStyleForMarkedText):
* Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.cpp:
(WebCore::namedPseudoElementStyle):
(WebCore::RenderTreeUpdater::ViewTransition::updatePseudoElementTree):
(WebCore::createRendererIfNeeded):
(WebCore::RenderTreeUpdater::ViewTransition::buildPseudoElementGroup):
(WebCore::RenderTreeUpdater::ViewTransition::updatePseudoElementGroup):
* Source/WebCore/rendering/updating/RenderTreeUpdaterViewTransition.h:
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::ruleMatches):
* Source/WebCore/style/PseudoElementRequest.h:
(WebCore::Style::PseudoElementRequest::PseudoElementRequest):
(WebCore::Style::PseudoElementRequest::classList const):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveElement):
(WebCore::Style::TreeResolver::resolvePseudoElement):
* Source/WebCore/style/StyleTreeResolver.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::highlightPseudoElementColor):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/690d7e24a09f97351dbef983253ba235c9ace830

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/62965 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/48/builds/42321 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/15561 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/66986 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/13569 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/65085 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/49/builds/50008 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/61/builds/13853 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/66986 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/13569 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/66034 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/49/builds/50008 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/15561 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/66986 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/49/builds/50008 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/15561 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/12445 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/49/builds/50008 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/15561 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/68681 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/87/builds/6911 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/61/builds/13853 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/68681 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/86/builds/6943 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/15561 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/68681 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/38141 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/39221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/40332 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/38963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->