### PR TITLE
[JSC] Fix `Intl.DurationFormat` for `numeric` and `2-digit`

### DIFF
--- a/JSTests/stress/intl-durationformat-numeric-auto-and-zero.js
+++ b/JSTests/stress/intl-durationformat-numeric-auto-and-zero.js
@@ -1,0 +1,26 @@
+//@ requireOptions("--useIntlDurationFormat=1")
+
+function assertSameValue(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected "${expected}" but got "${actual}"`)
+}
+
+const durations = [
+  [{hours: 0, minutes: 0, seconds: 0}, "0"],
+  [{hours: 0, minutes: 0, seconds: 1}, "0:00:01"],
+  [{hours: 0, minutes: 1, seconds: 0}, "0:01"],
+  [{hours: 0, minutes: 1, seconds: 1}, "0:01:01"],
+  [{hours: 1, minutes: 0, seconds: 0}, "1"],
+  [{hours: 1, minutes: 0, seconds: 1}, "1:00:01"],
+  [{hours: 1, minutes: 1, seconds: 0}, "1:01"],
+  [{hours: 1, minutes: 1, seconds: 1}, "1:01:01"],
+  [{hours: 1, minutes: 0, seconds: 0, milliseconds: 1}, "1:00:00.001"],
+  [{hours: 1, minutes: 0, seconds: 0, microseconds: 1}, "1:00:00.000001"],
+  [{hours: 1, minutes: 0, seconds: 0, nanoseconds: 1}, "1:00:00.000000001"],
+];
+
+const df = new Intl.DurationFormat("en", { hours: "numeric", minutesDisplay: "auto", secondsDisplay: "auto" });
+
+for (const [duration, expected] of durations) {
+  assertSameValue(df.format(duration), expected);
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -922,15 +922,6 @@ test/intl402/DateTimeFormat/timezone-legacy-non-iana.js:
 test/intl402/DateTimeFormat/timezone-not-canonicalized.js:
   default: 'Test262Error: Expected SameValue(«Asia/Calcutta», «Asia/Kolkata») to be true'
   strict mode: 'Test262Error: Expected SameValue(«Asia/Calcutta», «Asia/Kolkata») to be true'
-test/intl402/DurationFormat/prototype/format/numeric-hour-with-zero-minutes-and-non-zero-seconds-with-auto-display-and-zero-fractional.js:
-  default: 'Test262Error: Duration is {"hours":0,"minutes":0,"seconds":1} Expected SameValue(«0, 01», «0:00:01») to be true'
-  strict mode: 'Test262Error: Duration is {"hours":0,"minutes":0,"seconds":1} Expected SameValue(«0, 01», «0:00:01») to be true'
-test/intl402/DurationFormat/prototype/format/numeric-hour-with-zero-minutes-and-non-zero-seconds-with-auto-display.js:
-  default: 'Test262Error: Duration is {"hours":0,"minutes":0,"seconds":1} Expected SameValue(«0, 01», «0:00:01») to be true'
-  strict mode: 'Test262Error: Duration is {"hours":0,"minutes":0,"seconds":1} Expected SameValue(«0, 01», «0:00:01») to be true'
-test/intl402/DurationFormat/prototype/format/numeric-hour-with-zero-minutes-and-non-zero-seconds.js:
-  default: 'Test262Error: Duration is {"hours":0,"minutes":0,"seconds":1} Expected SameValue(«0, 01», «0:00:01») to be true'
-  strict mode: 'Test262Error: Duration is {"hours":0,"minutes":0,"seconds":1} Expected SameValue(«0, 01», «0:00:01») to be true'
 test/intl402/DurationFormat/prototype/format/precision-exact-mathematical-values.js:
   default: 'Test262Error: Duration is {"seconds":10000000,"nanoseconds":1} Expected SameValue(«0:00:10,000,000.000000002», «0:00:10,000,000.000000001») to be true'
   strict mode: 'Test262Error: Duration is {"seconds":10000000,"nanoseconds":1} Expected SameValue(«0:00:10,000,000.000000002», «0:00:10,000,000.000000001») to be true'


### PR DESCRIPTION
#### 471838036efeaf4fd8203d543bdc8c707248606d
<pre>
[JSC] Fix `Intl.DurationFormat` for `numeric` and `2-digit`
<a href="https://bugs.webkit.org/show_bug.cgi?id=275489">https://bugs.webkit.org/show_bug.cgi?id=275489</a>

Reviewed by Ross Kirsling and Yusuke Suzuki.

In the current JSC `Intl.DurationFormat` implementation, only units with a value that is not 0 or a
display setting that is not `auto` are formatted. However, this behavior is incorrect according to
the current spec[1]. When a unit&apos;s style is `numeric` or `2-digit` (i.e., the unit is `hours`,
`minutes`, or `seconds`), it needs to be formatted even if its value is 0 and its display is set to
auto. For example, consider the following code:

```
const df = new Intl.DurationFormat(&quot;en&quot;, { hours: &quot;numeric&quot;, minutesDisplay: &quot;auto&quot;, secondsDisplay: &quot;auto&quot; });
print(df.format({ hours: 0, minutes: 0, seconds: 1 }));
```

This code is expected to output `0:00:01`, but the current JSC outputs `0, 01`. Only the hours and
seconds are displayed, while the minutes are not. Additionally, the separator `:` is not used; instead,
`,` is outputted.

This patch fixes this behavior and includes refactoring.

[1]: <a href="https://tc39.es/proposal-intl-duration-format/#sec-partitiondurationformatpattern">https://tc39.es/proposal-intl-duration-format/#sec-partitiondurationformatpattern</a>

* JSTests/stress/intl-durationformat-numeric-auto-and-zero.js: Added.
(assertSameValue):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/runtime/IntlDurationFormat.cpp:
(JSC::collectElements):

Canonical link: <a href="https://commits.webkit.org/280460@main">https://commits.webkit.org/280460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93d0368d06dd2ca5ef28c0108cfd4a3b0d7c4bf1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59652 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6480 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6674 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45203 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4482 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33266 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48333 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26266 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30047 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5662 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5484 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/49122 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52016 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5934 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61329 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/55281 "Built successfully and passed tests") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6060 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52617 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48400 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52305 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/77041 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8432 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31197 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12780 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32283 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33366 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32030 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->