### PR TITLE
fast/forms/ios/focus-input-via-button.html needs baselines tidied.

### DIFF
--- a/LayoutTests/fast/forms/ios/focus-input-via-button-expected.txt
+++ b/LayoutTests/fast/forms/ios/focus-input-via-button-expected.txt
@@ -2,6 +2,6 @@ Tests zooming into a text input on tap.
 
 Click to focus input
 
-tap location	{ x: 20.000, y: 62.000 }
+tap location	{ x: 18.000, y: 62.000 }
 scale	1.455
-visibleRect	{ left: 0.000, top: 711.837, width: 219.979, height: 376.713 }
+visibleRect	{ left: 0.000, top: 624.229, width: 268.018, height: 547.718 }

--- a/LayoutTests/platform/ios/fast/forms/ios/focus-input-via-button-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/ios/focus-input-via-button-expected.txt
@@ -1,7 +1,0 @@
-Tests zooming into a text input on tap.
-
-Click to focus input
-
-tap location	{ x: 18.000, y: 62.000 }
-scale	1.455
-visibleRect	{ left: 0.000, top: 624.229, width: 268.018, height: 547.718 }

--- a/LayoutTests/platform/ios/platform/ipad/fast/forms/focus-input-via-button-expected.txt
+++ b/LayoutTests/platform/ios/platform/ipad/fast/forms/focus-input-via-button-expected.txt
@@ -1,7 +1,0 @@
-Tests zooming into a text input on tap.
-
-Click to focus input
-
-tap location	{ x: 20.000, y: 62.000 }
-scale	1.500
-visibleRect	{ left: 0.000, top: 568.667, width: 512.000, height: 669.333 }


### PR DESCRIPTION
#### 2a9760bb77c85520560e04483022b28cbd127f78
<pre>
fast/forms/ios/focus-input-via-button.html needs baselines tidied.
<a href="https://bugs.webkit.org/show_bug.cgi?id=275504">https://bugs.webkit.org/show_bug.cgi?id=275504</a>
<a href="https://rdar.apple.com/129866027">rdar://129866027</a>

Unreviewed test re-baseline.

Tidying baselines for this test.

* LayoutTests/fast/forms/ios/focus-input-via-button-expected.txt:
* LayoutTests/platform/ios/fast/forms/ios/focus-input-via-button-expected.txt: Removed.
* LayoutTests/platform/ios/platform/ipad/fast/forms/focus-input-via-button-expected.txt: Removed.

Canonical link: <a href="https://commits.webkit.org/280030@main">https://commits.webkit.org/280030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2dc8cf5de1402a706fe430309145547f088659b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55558 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8025 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58542 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/5988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42503 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6187 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/5988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57587 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/32785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/47883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/25866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/29569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/5212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4132 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/5479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/60133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/30712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/5605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/60133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/31797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/47953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/60133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/32878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8188 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/31544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->