### PR TITLE
Relax privacy for some log messages in LinearMediaPlayer

### DIFF
--- a/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
+++ b/Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift
@@ -204,7 +204,7 @@ enum LinearMediaPlayerErrors: Error {
 
 extension WKSLinearMediaPlayer {
     private func presentationStateChanged(_ presentationState: WKSLinearMediaPresentationState) {
-        Logger.linearMediaPlayer.log("\(#function): \(presentationState)")
+        Logger.linearMediaPlayer.log("\(#function): \(presentationState, privacy: .public)")
 
         switch presentationState {
         case .inline:
@@ -555,12 +555,12 @@ extension WKSLinearMediaPlayer: @retroactive Playable {
     }
 
     public func setCaptionContentInsets(_ insets: UIEdgeInsets) {
-        Logger.linearMediaPlayer.log("\(#function) \(NSCoder.string(for: insets))")
+        Logger.linearMediaPlayer.log("\(#function) \(NSCoder.string(for: insets), privacy: .public)")
         delegate?.linearMediaPlayer?(self, setCaptionContentInsets: insets)
     }
 
     public func updateVideoBounds(_ bounds: CGRect) {
-        Logger.linearMediaPlayer.log("\(#function) \(NSCoder.string(for: bounds))")
+        Logger.linearMediaPlayer.log("\(#function) \(NSCoder.string(for: bounds), privacy: .public)")
         delegate?.linearMediaPlayer?(self, updateVideoBounds: bounds)
     }
 
@@ -576,7 +576,7 @@ extension WKSLinearMediaPlayer: @retroactive Playable {
     }
 
     public func toggleInlineMode() {
-        Logger.linearMediaPlayer.log("\(#function): presentationState=\(self.presentationState)")
+        Logger.linearMediaPlayer.log("\(#function): presentationState=\(self.presentationState, privacy: .public)")
 
         switch presentationState {
         case .inline:
@@ -591,7 +591,7 @@ extension WKSLinearMediaPlayer: @retroactive Playable {
     }
 
     public func willEnterFullscreen() {
-        Logger.linearMediaPlayer.log("\(#function): presentationState=\(self.presentationState)")
+        Logger.linearMediaPlayer.log("\(#function): presentationState=\(self.presentationState, privacy: .public)")
 
         switch presentationState {
         case .inline:
@@ -618,7 +618,7 @@ extension WKSLinearMediaPlayer: @retroactive Playable {
     }
 
     public func willExitFullscreen() {
-        Logger.linearMediaPlayer.log("\(#function): presentationState=\(self.presentationState)")
+        Logger.linearMediaPlayer.log("\(#function): presentationState=\(self.presentationState, privacy: .public)")
 
         switch presentationState {
         case .fullscreen:
@@ -666,7 +666,7 @@ extension WKSLinearMediaPlayer: @retroactive Playable {
     }
 
     public func setThumbnailSize(_ size: CGSize) {
-        Logger.linearMediaPlayer.log("\(#function) \(NSCoder.string(for: size))")
+        Logger.linearMediaPlayer.log("\(#function) \(NSCoder.string(for: size), privacy: .public)")
         delegate?.linearMediaPlayer?(self, setThumbnailSize: size)
     }
 


### PR DESCRIPTION
#### 62a8966b7a0e6ce0a0c19938c0504c08922bdf54
<pre>
Relax privacy for some log messages in LinearMediaPlayer
<a href="https://bugs.webkit.org/show_bug.cgi?id=275505">https://bugs.webkit.org/show_bug.cgi?id=275505</a>
<a href="https://rdar.apple.com/129866471">rdar://129866471</a>

Reviewed by Geoffrey Garen.

For log strings that do not reveal privacy-sensitive information, mark them as publibly visible to
make bug reports more actionable.

* Source/WebKit/WebKitSwift/LinearMediaKit/LinearMediaPlayer.swift:
(WKSLinearMediaPlayer.presentationStateChanged(_:)):
(WKSLinearMediaPlayer.setCaptionContentInsets(_:)):
(WKSLinearMediaPlayer.updateVideoBounds(_:)):
(WKSLinearMediaPlayer.toggleInlineMode):
(WKSLinearMediaPlayer.willEnterFullscreen):
(WKSLinearMediaPlayer.willExitFullscreen):
(WKSLinearMediaPlayer.setThumbnailSize(_:)):

Canonical link: <a href="https://commits.webkit.org/280035@main">https://commits.webkit.org/280035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f3a69599abcff5d41e6692e18ad71b363d23663

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8026 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58543 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/5989 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6188 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44740 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/4112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57588 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32787 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/47886 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25867 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29571 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4133 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60134 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30713 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5604 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52171 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/31798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47956 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12311 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32879 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/31545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->