### PR TITLE
Fix a specific crash where a WebPageProxy outlives its PageClient

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -881,6 +881,7 @@ public:
 
     PageClient& pageClient() const;
     Ref<PageClient> protectedPageClient() const;
+    RefPtr<PageClient> optionalProtectedPageClient() const;
 
     void setViewNeedsDisplay(const WebCore::Region&);
     void requestScroll(const WebCore::FloatPoint& scrollPosition, const WebCore::IntPoint& scrollOrigin, WebCore::ScrollIsAnimated);


### PR DESCRIPTION
#### 927f3f7dfde6e87358894dd55b3a583f4964c36e
<pre>
Fix a specific crash where a WebPageProxy outlives its PageClient
<a href="https://rdar.apple.com/129558032">rdar://129558032</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=275508">https://bugs.webkit.org/show_bug.cgi?id=275508</a>

Reviewed by Youenn Fablet.

It&apos;s known that WebPageProxy objects can outlive their client view object (WKContentView or WebViewImpl)
And since the client view object owns the PageClient, WebPageProxy objects can exist without a PageClient.

The WebPageProxy::pageClient() accessor acknowledges this with a debug-only ASSERT.

The gamepad access hysteresis skips some of the other &quot;close() or process crashed&quot; cleanup that other
member objects perform, such as timers. So it&apos;s very possible that simply cancelling the hysteresis when
those events occur is good enough.

This patch does that, but also explicitly closes the hazard of assuming the PageClient is non-null.

I believe there&apos;s still a submarine risk of many other &quot;protectedPageClient()&quot; calls happening on a null
page client, driven by racey IPC timing. A followup will apply null checking more widely.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::optionalProtectedPageClient const):
(WebKit::WebPageProxy::close):
(WebKit::WebPageProxy::resetStateAfterProcessExited):
(WebKit::WebPageProxy::recentGamepadAccessStateChanged):
* Source/WebKit/UIProcess/WebPageProxy.h:

Canonical link: <a href="https://commits.webkit.org/280131@main">https://commits.webkit.org/280131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0c8b27a69a65cc56f3afbf53e0e2a041e7af07a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55800 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8267 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58791 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6235 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6429 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44938 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4301 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57829 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48102 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26071 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29807 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4374 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51790 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5701 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60381 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5829 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52371 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48171 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51865 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12370 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30954 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32039 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33121 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31786 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->