### PR TITLE
IPC decoding fails for some extension API message replies

### DIFF
--- a/Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h
@@ -101,7 +101,11 @@ inline bool matchesFrame(const WebExtensionFrameIdentifier& identifier, const We
 inline WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(WebCore::FrameIdentifier frameIdentifier)
 {
     WebExtensionFrameIdentifier result { frameIdentifier.object().toUInt64() };
-    ASSERT(result.isValid());
+    if (!result.isValid()) {
+        ASSERT_NOT_REACHED();
+        return WebExtensionFrameConstants::NoneIdentifier;
+    }
+
     return result;
 }
 
@@ -136,7 +140,11 @@ inline WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(WKFrameInfo *fr
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     WebExtensionFrameIdentifier result { frameInfo._handle.frameID };
 ALLOW_DEPRECATED_DECLARATIONS_END
-    ASSERT(result.isValid());
+    if (!result.isValid()) {
+        ASSERT_NOT_REACHED();
+        return WebExtensionFrameConstants::NoneIdentifier;
+    }
+
     return result;
 }
 #endif // __OBJC__

--- a/Source/WebKit/Shared/Extensions/WebExtensionTabIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionTabIdentifier.h
@@ -70,7 +70,11 @@ inline std::optional<WebExtensionTabIdentifier> toWebExtensionTabIdentifier(doub
     }
 
     WebExtensionTabIdentifier result { static_cast<uint64_t>(identifier) };
-    ASSERT(result.isValid());
+    if (!result.isValid()) {
+        ASSERT_NOT_REACHED();
+        return WebExtensionTabConstants::NoneIdentifier;
+    }
+
     return result;
 }
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionWindowIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionWindowIdentifier.h
@@ -86,7 +86,11 @@ inline std::optional<WebExtensionWindowIdentifier> toWebExtensionWindowIdentifie
     }
 
     WebExtensionWindowIdentifier result { static_cast<uint64_t>(identifier) };
-    ASSERT(result.isValid());
+    if (!result.isValid()) {
+        ASSERT_NOT_REACHED();
+        return WebExtensionWindowConstants::NoneIdentifier;
+    }
+
     return result;
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -125,6 +125,12 @@ void executeScript(std::optional<SourcePairs> scriptPairs, WKWebView *webView, A
     });
 
     [webView _frames:makeBlockPtr([webView = RetainPtr { webView }, tab = Ref { tab }, context = Ref { context }, scriptPairs, executionWorld = Ref { executionWorld }, injectionResults, aggregator, parameters](_WKFrameTreeNode *mainFrame) mutable {
+        if (!mainFrame.info.isMainFrame) {
+            RELEASE_LOG_INFO(Extensions, "Not executing script because the mainFrame is nil");
+            injectionResults->results.append(toInjectionResultParameters(nil, nil, @"Failed to execute script."));
+            return;
+        }
+
         WKContentWorld *world = executionWorld->wrapper();
         Vector<RetainPtr<_WKFrameTreeNode>> frames = getFrames(mainFrame, parameters.frameIDs);
 


### PR DESCRIPTION
#### 1ec49c531096be196d67726d6bb20bf0ce7d3ceb
<pre>
IPC decoding fails for some extension API message replies
<a href="https://bugs.webkit.org/show_bug.cgi?id=275516">https://bugs.webkit.org/show_bug.cgi?id=275516</a>
<a href="https://rdar.apple.com/129546020">rdar://129546020</a>

Reviewed by Timothy Hatcher, Charlie Wolfe and Brian Weinstein.

If we get a nil mainFrame back from `WebKit::WKWebView:_frames:`, we can get
into a bad state where we create an invalid WebExtensionFrameIdentifier and
pass it back to the completion handler, causing the IPC decoding to fail.
To fix this, we should return early if the mainFrame is nil.

In addition, we should update WebExtensionFrameIdentifier::toWebExtensionFrameIdentifier()
to return WebExtensionFrameConstants::NoneIdentifier for invalid results to prevent an
invalid identifier from being returned.

Testing:
Verified that the WKWebExtensionWebNavigation.GetAllFrames test doesn&apos;t crash in
WebKit::WebExtensionContext::didReceiveMessage if an empty main frame object is passed
back from WebPageProxy::getAllFrames().

* Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h:
(WebKit::toWebExtensionFrameIdentifier):
* Source/WebKit/Shared/Extensions/WebExtensionTabIdentifier.h:
(WebKit::toWebExtensionTabIdentifier):
* Source/WebKit/Shared/Extensions/WebExtensionWindowIdentifier.h:
(WebKit::toWebExtensionWindowIdentifier):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWebNavigationCocoa.mm:
(WebKit::WebExtensionContext::webNavigationGetFrame):
(WebKit::WebExtensionContext::webNavigationGetAllFrames):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::executeScript):

Canonical link: <a href="https://commits.webkit.org/280048@main">https://commits.webkit.org/280048@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f01160329f2a2afea4e6f7ccdb37f54403699fdd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8056 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58573 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6019 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6218 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44762 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/4131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32813 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47911 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25889 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29599 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4163 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5507 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60164 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30743 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5632 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52193 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/31828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47981 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32909 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8199 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/31575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->