### PR TITLE
[JSC] Use WeakHashSet for the DeferredWorkTimer::Ticket's stored in JSGlobalObject

### DIFF
--- a/Source/JavaScriptCore/runtime/DeferredWorkTimer.h
+++ b/Source/JavaScriptCore/runtime/DeferredWorkTimer.h
@@ -31,6 +31,8 @@
 #include <wtf/Deque.h>
 #include <wtf/FixedVector.h>
 #include <wtf/HashSet.h>
+#include <wtf/RefPtr.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Vector.h>
 
 namespace JSC {
@@ -44,24 +46,28 @@ class DeferredWorkTimer final : public JSRunLoopTimer {
 public:
     using Base = JSRunLoopTimer;
 
-    struct TicketData {
+    class TicketData : public CanMakeWeakPtr<TicketData>, public ThreadSafeRefCounted<TicketData>  {
     private:
         WTF_MAKE_TZONE_ALLOCATED(TicketData);
         WTF_MAKE_NONCOPYABLE(TicketData);
     public:
         inline TicketData(JSGlobalObject*, JSObject* scriptExecutionOwner, Vector<Weak<JSCell>>&& dependencies);
-        inline ~TicketData();
+        inline static Ref<TicketData> create(JSGlobalObject*, JSObject* scriptExecutionOwner, Vector<Weak<JSCell>>&& dependencies);
 
         inline VM& vm();
         JSObject* target();
+        inline bool hasValidTarget() const;
+        inline FixedVector<Weak<JSCell>>& dependencies();
+        inline JSObject* scriptExecutionOwner();
+        inline JSGlobalObject* globalObject();
 
-        void clearGlobalObject();
         inline void cancel();
-        bool isCancelled() const { return !scriptExecutionOwner.get() || !globalObject.get(); }
+        bool isCancelled() const { return !m_scriptExecutionOwner.get() || !m_globalObject.get() || !hasValidTarget(); }
 
-        FixedVector<Weak<JSCell>> dependencies;
-        Weak<JSObject> scriptExecutionOwner;
-        Weak<JSGlobalObject> globalObject;
+    private:
+        FixedVector<Weak<JSCell>> m_dependencies;
+        Weak<JSObject> m_scriptExecutionOwner;
+        Weak<JSGlobalObject> m_globalObject;
     };
 
     using Ticket = TicketData*;
@@ -96,13 +102,36 @@ private:
     bool m_shouldStopRunLoopWhenAllTicketsFinish { false };
     bool m_currentlyRunningTask { false };
     Deque<std::tuple<Ticket, Task>> m_tasks WTF_GUARDED_BY_LOCK(m_taskLock);
-    HashSet<std::unique_ptr<TicketData>> m_pendingTickets;
+    HashSet<Ref<TicketData>> m_pendingTickets;
 };
 
 inline JSObject* DeferredWorkTimer::TicketData::target()
 {
     ASSERT(!isCancelled());
-    return jsCast<JSObject*>(dependencies.last().get());
+    return jsCast<JSObject*>(m_dependencies.last().get());
+}
+
+inline bool DeferredWorkTimer::TicketData::hasValidTarget() const
+{
+    return !m_dependencies.isEmpty() && !!m_dependencies.last().get();
+}
+
+inline FixedVector<Weak<JSCell>>& DeferredWorkTimer::TicketData::dependencies()
+{
+    ASSERT(!isCancelled());
+    return m_dependencies;
+}
+
+inline JSObject* DeferredWorkTimer::TicketData::scriptExecutionOwner()
+{
+    ASSERT(!isCancelled());
+    return m_scriptExecutionOwner.get();
+}
+
+inline JSGlobalObject* DeferredWorkTimer::TicketData::globalObject()
+{
+    ASSERT(!isCancelled());
+    return m_globalObject.get();
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -280,6 +280,7 @@
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/FixedVector.h>
 #include <wtf/SystemTracing.h>
+#include <wtf/WeakHashSet.h>
 
 #if ENABLE(REMOTE_INSPECTOR)
 #include "JSGlobalObjectDebuggable.h"
@@ -709,7 +710,7 @@ JSGlobalObject::JSGlobalObject(VM& vm, Structure* structure, const GlobalObjectM
 
 JSGlobalObject::~JSGlobalObject()
 {
-    clearObjectsForTicket();
+    clearWeakTickets();
 #if ENABLE(REMOTE_INSPECTOR)
     m_inspectorController->globalObjectDestroyed();
 #endif
@@ -2645,11 +2646,14 @@ void JSGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     thisObject->m_regExpGlobalData.visitAggregate(visitor);
 
     {
-        if (thisObject->m_objectsForTicket) {
+        if (thisObject->m_weakTickets) {
             Locker locker { thisObject->cellLock() };
-            for (auto& entry : *thisObject->m_objectsForTicket) {
-                for (auto& cell : entry.value)
-                    visitor.append(cell);
+            for (Ref<DeferredWorkTimer::TicketData> ticket : *thisObject->m_weakTickets) {
+                if (ticket->isCancelled())
+                    continue;
+                visitor.appendUnbarriered(ticket->scriptExecutionOwner());
+                for (auto& dependency : ticket->dependencies())
+                    visitor.append(dependency);
             }
         }
     }
@@ -3288,28 +3292,20 @@ void JSGlobalObject::setWrapperMap(std::unique_ptr<WrapperMap>&& map)
 }
 #endif
 
-void JSGlobalObject::addObjectsForTicket(DeferredWorkTimer::Ticket ticket, JSObject* scriptExecutionOwner, FixedVector<Weak<JSCell>>& dependencies)
+void JSGlobalObject::addWeakTicket(DeferredWorkTimer::Ticket ticket)
 {
     Locker locker { cellLock() };
-    if (!m_objectsForTicket)
-        m_objectsForTicket = makeUnique<HashMap<DeferredWorkTimer::Ticket, FixedVector<WriteBarrier<JSCell>>>>();
-
-    FixedVector<WriteBarrier<JSCell>> value(dependencies.size() + 1, WriteBarrier<JSCell>());
-    auto addResult = m_objectsForTicket->add(ticket, WTFMove(value));
-
-    unsigned i = 0;
-    for (auto& dependency : dependencies)
-        addResult.iterator->value.at(i++).set(vm(), this, dependency.get());
-    addResult.iterator->value.at(i).set(vm(), this, scriptExecutionOwner);
+    if (!m_weakTickets) {
+        auto weakTickets = makeUnique<WeakHashSet<DeferredWorkTimer::TicketData>>();
+        WTF::storeStoreFence();
+        m_weakTickets = WTFMove(weakTickets);
+    }
+    m_weakTickets->add(*ticket);
+    vm().writeBarrier(this);
 }
-void JSGlobalObject::removeObjectsForTicket(DeferredWorkTimer::Ticket ticket)
+void JSGlobalObject::clearWeakTickets()
 {
-    Locker locker { cellLock() };
-    m_objectsForTicket->remove(ticket);
-}
-void JSGlobalObject::clearObjectsForTicket()
-{
-    if (!m_objectsForTicket)
+    if (!m_weakTickets)
         return;
 
     WaiterListManager::singleton().unregister(this);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -506,10 +506,9 @@ public:
 #undef DECLARE_TYPED_ARRAY_TYPE_WATCHPOINT
     Vector<std::unique_ptr<ObjectAdaptiveStructureWatchpoint>> m_missWatchpoints;
 
-    void addObjectsForTicket(DeferredWorkTimer::Ticket, JSObject* scriptExecutionOwner, FixedVector<Weak<JSCell>>& dependencies);
-    void removeObjectsForTicket(DeferredWorkTimer::Ticket);
-    void clearObjectsForTicket();
-    std::unique_ptr<HashMap<DeferredWorkTimer::Ticket, FixedVector<WriteBarrier<JSCell>>>> m_objectsForTicket;
+    void addWeakTicket(DeferredWorkTimer::Ticket);
+    void clearWeakTickets();
+    std::unique_ptr<WeakHashSet<DeferredWorkTimer::TicketData>> m_weakTickets;
 
     inline std::unique_ptr<ObjectAdaptiveStructureWatchpoint>& typedArrayConstructorSpeciesAbsenceWatchpoint(TypedArrayType);
     inline std::unique_ptr<ObjectAdaptiveStructureWatchpoint>& typedArrayPrototypeSymbolIteratorAbsenceWatchpoint(TypedArrayType);

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
@@ -141,7 +141,7 @@ void StreamingCompiler::didComplete()
     case CompilerMode::Validation: {
         m_vm.deferredWorkTimer->scheduleWorkSoon(ticket, [result = WTFMove(result)](DeferredWorkTimer::Ticket ticket) mutable {
             JSPromise* promise = jsCast<JSPromise*>(ticket->target());
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(ticket->dependencies[0].get());
+            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(ticket->dependencies()[0].get());
             VM& vm = globalObject->vm();
             auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -162,8 +162,8 @@ void StreamingCompiler::didComplete()
     case CompilerMode::FullCompile: {
         m_vm.deferredWorkTimer->scheduleWorkSoon(ticket, [result = WTFMove(result)](DeferredWorkTimer::Ticket ticket) mutable {
             JSPromise* promise = jsCast<JSPromise*>(ticket->target());
-            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(ticket->dependencies[0].get());
-            JSObject* importObject = jsCast<JSObject*>(ticket->dependencies[1].get());
+            JSGlobalObject* globalObject = jsCast<JSGlobalObject*>(ticket->dependencies()[0].get());
+            JSObject* importObject = jsCast<JSObject*>(ticket->dependencies()[1].get());
             VM& vm = globalObject->vm();
             auto scope = DECLARE_THROW_SCOPE(vm);
 


### PR DESCRIPTION
#### 2aa59a0d48ddd9684584ccbbb6db8207d1a62733
<pre>
[JSC] Use WeakHashSet for the DeferredWorkTimer::Ticket&apos;s stored in JSGlobalObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=275518">https://bugs.webkit.org/show_bug.cgi?id=275518</a>
<a href="https://rdar.apple.com/129879654">rdar://129879654</a>

Reviewed by Yusuke Suzuki.

Use WeakHashSet for managing the TicketData&apos;s stored in JSGlobalObject
to avoid the manual unregistration in the destruction of TicketData.

* Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp:
(JSC::DeferredWorkTimer::TicketData::TicketData):
(JSC::DeferredWorkTimer::TicketData::create):
(JSC::DeferredWorkTimer::TicketData::cancel):
(JSC::DeferredWorkTimer::TicketData::globalObject):
(JSC::DeferredWorkTimer::doWork):
(JSC::DeferredWorkTimer::addPendingWork):
(JSC::DeferredWorkTimer::cancelPendingWorkSafe):
(JSC::DeferredWorkTimer::TicketData::~TicketData): Deleted.
(JSC::DeferredWorkTimer::TicketData::clearGlobalObject): Deleted.
* Source/JavaScriptCore/runtime/DeferredWorkTimer.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::~JSGlobalObject):
(JSC::JSGlobalObject::visitChildrenImpl):
(JSC::JSGlobalObject::addTicket):
(JSC::JSGlobalObject::clearTickets):
(JSC::JSGlobalObject::addObjectsForTicket): Deleted.
(JSC::JSGlobalObject::removeObjectsForTicket): Deleted.
(JSC::JSGlobalObject::clearObjectsForTicket): Deleted.
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/WaiterListManager.cpp:
(JSC::WaiterListManager::notifyWaiterImpl):
(JSC::WaiterListManager::unregister):
(JSC::Waiter::dump const):

Canonical link: <a href="https://commits.webkit.org/280180@main">https://commits.webkit.org/280180@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1e9b0b431354a377f0031064f4d368b3a329b7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58884 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6320 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6516 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45000 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4360 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57917 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33104 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48183 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26136 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29888 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5511 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4463 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/48964 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51857 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5782 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60473 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/55124 "Built successfully and passed tests") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5904 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52430 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48252 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51939 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12396 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/76885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31041 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/76885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32125 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33207 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31873 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->