### PR TITLE
Fix notifyd notification forwarding in the simulator

### DIFF
--- a/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.entitlements
+++ b/Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.entitlements
@@ -8,6 +8,8 @@
 	<true/>
 	<key>com.apple.developer.web-browser-engine.webcontent</key>
 	<true/>
+	<key>com.apple.developer.web-browser-engine.restrict.notifyd</key>
+	<true/>
 	<key>com.apple.private.extensionkit.host-requirement-exemption</key>
 	<true/>
 </dict>


### PR DESCRIPTION
#### b72eb4d87c98048be3b3258132e6d23586c19998
<pre>
Fix notifyd notification forwarding in the simulator
<a href="https://bugs.webkit.org/show_bug.cgi?id=275521">https://bugs.webkit.org/show_bug.cgi?id=275521</a>
<a href="https://rdar.apple.com/129884765">rdar://129884765</a>

Reviewed by Per Arne Vollan.

279416@main adds an entitlement check before forwarding notifyd notifications from the UIProcess to
the WebProcess. But the simulator&apos;s WebProcess is missing that entitlement so it always fails that
entitlement check. Add that entitlement here.

* Source/WebKit/Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.entitlements:

Canonical link: <a href="https://commits.webkit.org/280084@main">https://commits.webkit.org/280084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbad28c1a659a954d079b4f3e514278fd0b7d9c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55596 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8063 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58580 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6026 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44768 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4132 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57625 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32819 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47917 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25898 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29605 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4170 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51532 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5513 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60171 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30750 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5638 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52197 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31835 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/47987 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51679 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12338 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32916 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31582 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->