### PR TITLE
Prefer '=default' and implicit constructor fore more classes at Source/WebCore

### DIFF
--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -218,7 +218,7 @@ public:
     Vector<std::unique_ptr<MutationObserverRegistration>> registry;
     WeakHashSet<MutationObserverRegistration> transientRegistry;
 
-    NodeMutationObserverData() { }
+    NodeMutationObserverData() = default;
 };
 
 DECLARE_COMPACT_ALLOCATOR_WITH_HEAP_IDENTIFIER(NodeRareData);

--- a/Source/WebCore/dom/SlotAssignment.h
+++ b/Source/WebCore/dom/SlotAssignment.h
@@ -107,8 +107,6 @@ private:
     struct Slot {
         WTF_MAKE_FAST_ALLOCATED;
     public:
-        Slot() { }
-
         bool hasSlotElements() { return !!elementCount; }
         bool hasDuplicatedSlotElements() { return elementCount > 1; }
         bool shouldResolveSlotElement() { return !element && elementCount; }

--- a/Source/WebCore/dom/TextEncoder.h
+++ b/Source/WebCore/dom/TextEncoder.h
@@ -45,7 +45,7 @@ public:
     RefPtr<Uint8Array> encode(String&&) const;
     EncodeIntoResult encodeInto(String&&, Ref<Uint8Array>&& destination);
 private:
-    TextEncoder() { };
+    TextEncoder() = default;
 };
 
 }

--- a/Source/WebCore/dom/TreeScopeOrderedMap.h
+++ b/Source/WebCore/dom/TreeScopeOrderedMap.h
@@ -75,7 +75,7 @@ private:
     Vector<WeakRef<Element, WeakPtrImplWithEventTargetData>>* getAll(const AtomString&, const TreeScope&, const KeyMatchingFunction&) const;
 
     struct MapEntry {
-        MapEntry() { }
+        MapEntry() = default;
         explicit MapEntry(Element* firstElement)
             : element(firstElement)
             , count(1)

--- a/Source/WebCore/layout/formattingContexts/inline/AvailableLineWidthOverride.h
+++ b/Source/WebCore/layout/formattingContexts/inline/AvailableLineWidthOverride.h
@@ -37,7 +37,7 @@ namespace Layout {
 // the line box dimensions themselves (i.e. this won't change where text is aligned, etc).
 class AvailableLineWidthOverride {
 public:
-    AvailableLineWidthOverride() { }
+    AvailableLineWidthOverride() = default;
     AvailableLineWidthOverride(LayoutUnit globalLineWidthOverride) { m_globalLineWidthOverride = globalLineWidthOverride; }
     AvailableLineWidthOverride(Vector<LayoutUnit> individualLineWidthOverrides) { m_individualLineWidthOverrides = individualLineWidthOverrides; }
     std::optional<LayoutUnit> availableLineWidthOverrideForLine(size_t lineIndex) const

--- a/Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.h
@@ -55,7 +55,7 @@ public:
 
 class InlineBoxIterator : public BoxIterator {
 public:
-    InlineBoxIterator() { }
+    InlineBoxIterator() = default;
     InlineBoxIterator(Box::PathVariant&&);
     InlineBoxIterator(const Box&);
 

--- a/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.h
@@ -60,7 +60,7 @@ public:
 
 class TextBoxIterator : public LeafBoxIterator {
 public:
-    TextBoxIterator() { }
+    TextBoxIterator() = default;
     TextBoxIterator(Box::PathVariant&&);
     TextBoxIterator(const Box&);
 

--- a/Source/WebCore/rendering/AncestorSubgridIterator.cpp
+++ b/Source/WebCore/rendering/AncestorSubgridIterator.cpp
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 
-AncestorSubgridIterator::AncestorSubgridIterator() { }
+AncestorSubgridIterator::AncestorSubgridIterator() = default;
 
 AncestorSubgridIterator::AncestorSubgridIterator(SingleThreadWeakPtr<RenderGrid> firstAncestorSubgrid, GridTrackSizingDirection direction)
     : m_firstAncestorSubgrid(firstAncestorSubgrid)

--- a/Source/WebCore/rendering/TextPaintStyle.h
+++ b/Source/WebCore/rendering/TextPaintStyle.h
@@ -39,7 +39,7 @@ class ShadowData;
 struct PaintInfo;
 
 struct TextPaintStyle {
-    TextPaintStyle() { }
+    TextPaintStyle() = default;
     TextPaintStyle(const Color&);
 
     bool operator==(const TextPaintStyle&) const;

--- a/Source/WebCore/rendering/mathml/MathMLStyle.h
+++ b/Source/WebCore/rendering/mathml/MathMLStyle.h
@@ -34,7 +34,6 @@ namespace WebCore {
 
 class MathMLStyle: public RefCounted<MathMLStyle> {
 public:
-    MathMLStyle() { }
     static Ref<MathMLStyle> create();
 
     MathMLElement::MathVariant mathVariant() const { return m_mathVariant; }

--- a/Source/WebCore/rendering/svg/legacy/SVGResourcesCycleSolver.h
+++ b/Source/WebCore/rendering/svg/legacy/SVGResourcesCycleSolver.h
@@ -35,7 +35,7 @@ public:
     static void resolveCycles(RenderElement&, SVGResources&);
 
 private:
-    SVGResourcesCycleSolver() { }
+    SVGResourcesCycleSolver() = default;
 
     static bool resourceContainsCycles(LegacyRenderSVGResourceContainer&, SingleThreadWeakHashSet<LegacyRenderSVGResourceContainer>& activeResources, SingleThreadWeakHashSet<LegacyRenderSVGResourceContainer>& acyclicResources);
     static void breakCycle(LegacyRenderSVGResourceContainer&, SVGResources&);

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -97,7 +97,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(Resolver);
 
 class Resolver::State {
 public:
-    State() { }
+    State() = default;
     State(const Element& element, const RenderStyle* parentStyle, const RenderStyle* documentElementStyle = nullptr)
         : m_element(&element)
         , m_parentStyle(parentStyle)


### PR DESCRIPTION
#### b6966d585e085d03a2de9f7d1211c03741214a58
<pre>
Prefer &apos;=default&apos; and implicit constructor fore more classes at Source/WebCore
<a href="https://rdar.apple.com/129890943">rdar://129890943</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=275522">https://bugs.webkit.org/show_bug.cgi?id=275522</a>

Reviewed by Sammy Gill.

We prefer to let the compiler generate default constructors
rather than explicitly defining it. When the default
constructor is the only constructor we can omit it instead,
so it is implicitly generated.

* Source/WebCore/dom/NodeRareData.h:
(WebCore::NodeMutationObserverData::NodeMutationObserverData): Deleted.
* Source/WebCore/dom/SlotAssignment.h:
(WebCore::NamedSlotAssignment::Slot::Slot): Deleted.
* Source/WebCore/dom/TextEncoder.h:
(WebCore::TextEncoder::TextEncoder): Deleted.
* Source/WebCore/dom/TreeScopeOrderedMap.h:
* Source/WebCore/layout/formattingContexts/inline/AvailableLineWidthOverride.h:
* Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.h:
(WebCore::InlineIterator::InlineBoxIterator::InlineBoxIterator): Deleted.
* Source/WebCore/layout/integration/inline/InlineIteratorTextBox.h:
(WebCore::InlineIterator::TextBoxIterator::TextBoxIterator): Deleted.
* Source/WebCore/rendering/AncestorSubgridIterator.cpp:
* Source/WebCore/rendering/TextPaintStyle.h:
(WebCore::TextPaintStyle::TextPaintStyle): Deleted.
* Source/WebCore/rendering/mathml/MathMLStyle.h:
* Source/WebCore/rendering/svg/legacy/SVGResourcesCycleSolver.h:
(WebCore::SVGResourcesCycleSolver::SVGResourcesCycleSolver): Deleted.
* Source/WebCore/style/StyleResolver.cpp:

Canonical link: <a href="https://commits.webkit.org/280226@main">https://commits.webkit.org/280226@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59e5ce31cd1d3ef08a9aea5faa0ffb01146b7177

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55730 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35053 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8197 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58714 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6161 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57856 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6359 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44879 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4237 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32956 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48039 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26011 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29743 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5368 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4304 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51715 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5635 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60305 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5767 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52306 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48109 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51799 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12417 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30884 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31969 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33050 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31716 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->