### PR TITLE
[JSC] Cache DOMJIT code in Handler IC

### DIFF
--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
@@ -373,7 +373,7 @@ private:
 
     AccessGenerationResult compileOneAccessCaseHandler(CodeBlock*, AccessCase&, Vector<WatchpointSet*, 8>&&);
 
-    void emitDOMJITGetter(GetterSetterAccessCase&, const DOMJIT::GetterSetter*, GPRReg baseForGetGPR);
+    void emitDOMJITGetter(JSGlobalObject*, const DOMJIT::GetterSetter*, GPRReg baseForGetGPR);
     void emitModuleNamespaceLoad(ModuleNamespaceAccessCase&, MacroAssembler::JumpList& fallThrough);
     void emitProxyObjectAccess(unsigned index, ProxyObjectAccessCase&, MacroAssembler::JumpList& fallThrough);
     void emitIntrinsicGetter(IntrinsicGetterAccessCase&);
@@ -381,6 +381,7 @@ private:
     void generateWithConditionChecks(unsigned index, AccessCase&);
     void generateAccessCase(unsigned index, AccessCase&);
 
+    MacroAssemblerCodeRef<JITStubRoutinePtrTag> compileGetByIdDOMJITHandler(CodeBlock*, const DOMJIT::GetterSetter*);
     RefPtr<AccessCase> tryFoldToMegamorphic(CodeBlock*, std::span<const Ref<AccessCase>>);
 
     VM& m_vm;

--- a/Source/JavaScriptCore/bytecode/SharedJITStubSet.cpp
+++ b/Source/JavaScriptCore/bytecode/SharedJITStubSet.cpp
@@ -46,6 +46,16 @@ void SharedJITStubSet::setStatelessStub(StatelessCacheKey key, Ref<PolymorphicAc
     m_statelessStubs.add(key, WTFMove(stub));
 }
 
+MacroAssemblerCodeRef<JITStubRoutinePtrTag> SharedJITStubSet::getDOMJITCode(DOMJITCacheKey key) const
+{
+    return m_domJITCodes.get(key);
+}
+
+void SharedJITStubSet::setDOMJITCode(DOMJITCacheKey key, MacroAssemblerCodeRef<JITStubRoutinePtrTag> code)
+{
+    m_domJITCodes.add(key, WTFMove(code));
+}
+
 RefPtr<InlineCacheHandler> SharedJITStubSet::getSlowPathHandler(AccessType type) const
 {
     return m_slowPathHandlers[static_cast<unsigned>(type)];

--- a/Source/JavaScriptCore/bytecode/SharedJITStubSet.h
+++ b/Source/JavaScriptCore/bytecode/SharedJITStubSet.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "DOMJITGetterSetter.h"
 #include "StructureStubInfo.h"
 
 namespace JSC {
@@ -38,6 +39,7 @@ public:
 
     using StructureStubInfoKey = std::tuple<AccessType, bool, bool, bool, bool>;
     using StatelessCacheKey = std::tuple<StructureStubInfoKey, AccessCase::AccessType>;
+    using DOMJITCacheKey = std::tuple<StructureStubInfoKey, const DOMJIT::GetterSetter*>;
 
     static StructureStubInfoKey stubInfoKey(const StructureStubInfo& stubInfo)
     {
@@ -155,12 +157,16 @@ public:
     RefPtr<PolymorphicAccessJITStubRoutine> getStatelessStub(StatelessCacheKey) const;
     void setStatelessStub(StatelessCacheKey, Ref<PolymorphicAccessJITStubRoutine>);
 
+    MacroAssemblerCodeRef<JITStubRoutinePtrTag> getDOMJITCode(DOMJITCacheKey) const;
+    void setDOMJITCode(DOMJITCacheKey, MacroAssemblerCodeRef<JITStubRoutinePtrTag>);
+
     RefPtr<InlineCacheHandler> getSlowPathHandler(AccessType) const;
     void setSlowPathHandler(AccessType, Ref<InlineCacheHandler>);
 
 private:
     HashSet<Hash::Key, Hash, Hash::KeyTraits> m_stubs;
     HashMap<StatelessCacheKey, Ref<PolymorphicAccessJITStubRoutine>> m_statelessStubs;
+    HashMap<DOMJITCacheKey, MacroAssemblerCodeRef<JITStubRoutinePtrTag>> m_domJITCodes;
     std::array<RefPtr<InlineCacheHandler>, numberOfAccessTypes> m_fallbackHandlers { };
     std::array<RefPtr<InlineCacheHandler>, numberOfAccessTypes> m_slowPathHandlers { };
 };


### PR DESCRIPTION
#### a2259003b12d057f7c0697b4db63df105fe213e4
<pre>
[JSC] Cache DOMJIT code in Handler IC
<a href="https://bugs.webkit.org/show_bug.cgi?id=275525">https://bugs.webkit.org/show_bug.cgi?id=275525</a>
<a href="https://rdar.apple.com/129897956">rdar://129897956</a>

Reviewed by Yijia Huang.

This patch tweaks DOMJIT code generation so that we generate cached Handler IC for DOMJIT.
We cache them in SharedJITStubSet. And InlineCacheHandler holds JSGlobalObject etc. for DOMJIT so that
we can just use shared code for DOMJIT code too in Handler IC.

* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::generateAccessCase):
(JSC::InlineCacheCompiler::emitDOMJITGetter):
(JSC::InlineCacheCompiler::emitProxyObjectAccess):
(JSC::getByIdCustomHandlerImpl):
(JSC::putByIdCustomHandlerImpl):
(JSC::InlineCacheCompiler::compileOneAccessCaseHandler):
(JSC::InlineCacheCompiler::compileGetByIdDOMJITHandler):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.h:
* Source/JavaScriptCore/bytecode/SharedJITStubSet.cpp:
(JSC::SharedJITStubSet::getDOMJITCode const):
(JSC::SharedJITStubSet::setDOMJITCode):
* Source/JavaScriptCore/bytecode/SharedJITStubSet.h:

Canonical link: <a href="https://commits.webkit.org/280063@main">https://commits.webkit.org/280063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/216bf6baac53b58ec58c4b568d1e78cb85fb687b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55620 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58604 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6050 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6249 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44787 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4155 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57649 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47937 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25919 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29628 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5266 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4194 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/48697 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51560 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5533 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60195 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/54857 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30774 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5660 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52218 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31859 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51703 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32940 "Built successfully") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/72464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8206 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31606 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/72464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->