### PR TITLE
[JSC] Skip test262 tests fails on Ventura

### DIFF
--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -85,8 +85,10 @@ skip:
     - test/intl402/Locale/likely-subtags-grandfathered.js
 
     # ICU 72~ is required
+    - test/intl402/Intl/supportedValuesOf/numberingSystems-with-simple-digit-mappings.js
     - test/intl402/NumberFormat/prototype/format/format-rounding-priority-less-precision.js
     - test/intl402/NumberFormat/prototype/format/format-rounding-priority-more-precision.js
+    - test/intl402/NumberFormat/prototype/format/numbering-systems.js
     - test/intl402/NumberFormat/test-option-roundingPriority-mixed-options.js
 
     # ICU canonicalization bug


### PR DESCRIPTION
#### 3c2157f74be5221a44c97fff75729f16483b2866
<pre>
[JSC] Skip test262 tests fails on Ventura
<a href="https://bugs.webkit.org/show_bug.cgi?id=275530">https://bugs.webkit.org/show_bug.cgi?id=275530</a>

Reviewed by Ross Kirsling.

The build bot for test262 on Ventura[1] is failing due to intl402 tests, likely caused by the ICU
version. According to the failure messages[2] from these tests, it seems the lack of support for
&apos;kawi&apos; is the issue. &apos;kawi&apos; was added in Unicode 15[3], supported from ICU 72[4].

failure messages:
```
FAIL test/intl402/Intl/supportedValuesOf/numberingSystems-with-simple-digit-mappings.js (default)
Full Output:
Exception: Test262Error: kawi with simple digit mappings is supported
FAIL test/intl402/Intl/supportedValuesOf/numberingSystems-with-simple-digit-mappings.js (strict mode)
Full Output:
Exception: Test262Error: kawi with simple digit mappings is supported
FAIL test/intl402/NumberFormat/prototype/format/numbering-systems.js (default)
Full Output:
Exception: Test262Error: numberingSystem: kawi, digit: 0 Expected SameValue(«0», «𑽐») to be true
FAIL test/intl402/NumberFormat/prototype/format/numbering-systems.js (strict mode)
Full Output:
Exception: Test262Error: numberingSystem: kawi, digit: 0 Expected SameValue(«0», «𑽐») to be true
```

This patch updates config.yaml to skip these failing tests.

[1]: <a href="https://build.webkit.org/#/builders/1027">https://build.webkit.org/#/builders/1027</a>
[2]: <a href="https://build.webkit.org/#/builders/1027/builds/1151">https://build.webkit.org/#/builders/1027/builds/1151</a>
[3]: <a href="https://www.unicode.org/versions/Unicode15.0.0/">https://www.unicode.org/versions/Unicode15.0.0/</a>
[4]: <a href="https://github.com/unicode-org/icu/releases/tag/release-72-1">https://github.com/unicode-org/icu/releases/tag/release-72-1</a>

* JSTests/test262/config.yaml:

Canonical link: <a href="https://commits.webkit.org/280156@main">https://commits.webkit.org/280156@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ad3bcd6eb77fe61a523de3552f59ca49eeda7b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58881 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6317 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42830 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6513 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4357 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57914 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/33101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/48181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/26134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/29885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4460 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/48961 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/5780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60470 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/55121 "Built successfully and passed tests") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5901 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/48250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/76882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8254 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/31038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/76882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32122 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33204 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31870 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->