### PR TITLE
[results.webkit.org] ⌘F should not override system find-in-page if the search panel is collapsed

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/drawer.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/drawer.js
@@ -123,10 +123,15 @@ function CommitSearchBar(onSearchAction = null) {
         }
     });
     const searchHotKeyFunction = (e) => {
-        if (e.key == "f" && ( e.ctrlKey || e.metaKey )) {
-            e.preventDefault();
-            searchInputRef.element.focus();
-        }
+        if (e.key !== "f" || !( e.ctrlKey || e.metaKey ))
+            return;
+
+        const element = searchInputRef.element;
+        if (element.disabled)
+            return;
+
+        e.preventDefault();
+        element.focus();
     };
     const searchInputEventStream = searchInputRef.fromEvent("keyup");
     searchInputEventStream.action((e) => {
@@ -138,8 +143,8 @@ function CommitSearchBar(onSearchAction = null) {
     });
     
     const searchButtonRef = REF.createRef({});
-    const searchButtonClikEventStream = searchButtonRef.fromEvent("click");
-    searchButtonClikEventStream.action((e) => {
+    const searchButtonClickEventStream = searchButtonRef.fromEvent("click");
+    searchButtonClickEventStream.action((e) => {
         const searchValue = searchInputRef.element.value;
         if (onSearchAction)
             onSearchAction(searchValue);


### PR DESCRIPTION
#### 3fecce8a9b38374458fabf95582d6be8074fe357
<pre>
[results.webkit.org] ⌘F should not override system find-in-page if the search panel is collapsed
<a href="https://bugs.webkit.org/show_bug.cgi?id=275531">https://bugs.webkit.org/show_bug.cgi?id=275531</a>

Reviewed by BJ Burg.

Avoid preventing default and attempting to focus the search field when the user presses ⌘F, if the
search field is disabled (and therefore cannot be edited in the first place). The existing logic
makes it difficult to invoke the browser&apos;s built-in find-in-page functionality at all in
results.webkit.org, which can be useful in some cases (e.g. when searching for specific trains, OS
build versions, etc.).

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/drawer.js:

Also drive-by-fix a typo in a nearby local variable.

Canonical link: <a href="https://commits.webkit.org/280092@main">https://commits.webkit.org/280092@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c949f14fa8d5e8a985f85dfa32c9149097eee47

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58612 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6058 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57754 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6257 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44794 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4159 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32852 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47945 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25926 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/55156 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29638 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5274 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4202 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51574 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60203 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30782 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5667 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52225 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/55322 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31867 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48015 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51710 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12343 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32948 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31614 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->