### PR TITLE
WebCore::BackgroundFetchOptions fails to initialize instance variables due to missing constructors

### DIFF
--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchOptions.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchOptions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,7 +33,7 @@ namespace WebCore {
 struct BackgroundFetchOptions : BackgroundFetchUIOptions {
     BackgroundFetchOptions() = default;
     BackgroundFetchOptions(Vector<ImageResource>&& icons, String title, uint64_t downloadTotal)
-        : BackgroundFetchUIOptions { WTFMove(icons), WTFMove(title) }
+        : BackgroundFetchUIOptions(WTFMove(icons), WTFMove(title))
         , downloadTotal(downloadTotal)
     {
     }

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchUIOptions.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchUIOptions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,13 @@
 namespace WebCore {
 
 struct BackgroundFetchUIOptions {
+    BackgroundFetchUIOptions() = default;
+    BackgroundFetchUIOptions(Vector<ImageResource>&& icons, String&& title)
+        : icons(WTFMove(icons))
+        , title(WTFMove(title))
+    {
+    }
+
     Vector<ImageResource> icons;
     String title;
 };


### PR DESCRIPTION
#### 449783290701f2b61dd9854e55a148121daf86a4
<pre>
WebCore::BackgroundFetchOptions fails to initialize instance variables due to missing constructors
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=275532">https://bugs.webkit.org/show_bug.cgi?id=275532</a>&gt;
&lt;<a href="https://rdar.apple.com/129924024">rdar://129924024</a>&gt;

Reviewed by Sam Weinig.

* Source/WebCore/workers/service/background-fetch/BackgroundFetchOptions.h:
(WebCore::BackgroundFetchOptions::BackgroundFetchOptions):
- Change constructor to call the base class constructor.
* Source/WebCore/workers/service/background-fetch/BackgroundFetchUIOptions.h:
(WebCore::BackgroundFetchUIOptions::BackgroundFetchUIOptions): Add.
- Add constructors so instance variables are initialized.

Canonical link: <a href="https://commits.webkit.org/280056@main">https://commits.webkit.org/280056@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30dd5c84ac8a11f9d86aa3bb12f1aaa944896c7d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55629 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58613 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6059 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57755 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42574 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44795 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4163 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57658 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32854 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47946 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25927 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29640 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5275 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4203 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51580 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60204 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30783 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5668 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52227 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31868 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51712 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32949 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8204 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31615 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->