### PR TITLE
Web Inspector: REGRESSION(?): Canvas: cannot scroll list of WebGL shader programs

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/CanvasSidebarPanel.css
+++ b/Source/WebInspectorUI/UserInterface/Views/CanvasSidebarPanel.css
@@ -30,9 +30,17 @@
     overflow-y: hidden;
 }
 
+.sidebar > .panel.navigation.canvas:not(.showing-recording) > .content {
+    bottom: 0;
+}
+
 .sidebar > .panel.navigation.canvas > .navigation-bar > .item.record-start-stop.disabled > .glyph {
     filter: grayscale();
     opacity: 0.5;
+}
+
+.sidebar > .panel.navigation.canvas > .content > .tree-outline.canvas {
+    overflow-y: auto;
 }
 
 .sidebar > .panel.navigation.canvas > .content > .tree-outline .item.canvas:is(.canvas-2d, .bitmaprenderer) .icon {
@@ -47,6 +55,10 @@
     border-top: 1px solid var(--border-color);
 }
 
+.sidebar > .panel.navigation.canvas:not(.showing-recording) > .content > .navigation-bar {
+    border-bottom: none;
+}
+
 .sidebar > .panel.navigation.canvas.has-recordings > .content > .recording-content {
     flex-grow: 1;
     overflow-y: auto;
@@ -56,10 +68,9 @@
     flex-shrink: 0;
     height: fit-content;
     max-height: 110px;
-    overflow-y: auto;
 }
 
-.sidebar > .panel.navigation.canvas:not(.has-recordings) > .filter-bar,
+.sidebar > .panel.navigation.canvas:not(.showing-recording) > :is(.filter-bar, .overflow-shadow),
 .sidebar > .panel.navigation.canvas:not(.has-recordings) > .content > :is(.navigation-bar, .recording-content) {
     display: none;
 }


### PR DESCRIPTION
#### 7336e06e94b0e9a8c4711a24a941ba0ce3c83cf0
<pre>
Web Inspector: REGRESSION(?): Canvas: cannot scroll list of WebGL shader programs
<a href="https://bugs.webkit.org/show_bug.cgi?id=275540">https://bugs.webkit.org/show_bug.cgi?id=275540</a>

Reviewed by Timothy Hatcher.

* Source/WebInspectorUI/UserInterface/Views/CanvasSidebarPanel.css:
(.sidebar &gt; .panel.navigation.canvas:not(.showing-recording) &gt; .content): Added.
(.sidebar &gt; .panel.navigation.canvas &gt; .content &gt; .tree-outline.canvas): Added.
(.sidebar &gt; .panel.navigation.canvas:not(.showing-recording) &gt; .content &gt; .navigation-bar): Added.
(.sidebar &gt; .panel.navigation.canvas.showing-recording &gt; .content &gt; .tree-outline.canvas):
(.sidebar &gt; .panel.navigation.canvas:not(.showing-recording) &gt; :is(.filter-bar, .overflow-shadow), .sidebar &gt; .panel.navigation.canvas:not(.has-recordings) &gt; .content &gt; :is(.navigation-bar, .recording-content)): Added.
(.sidebar &gt; .panel.navigation.canvas:not(.has-recordings) &gt; .filter-bar, .sidebar &gt; .panel.navigation.canvas:not(.has-recordings) &gt; .content &gt; :is(.navigation-bar, .recording-content)): Deleted.
Move the `overflow-y: auto;` to always apply instead of only when a recording is selected.
Also ensure that the recording scope bar is always visible if there are recordings.

Drive-by: prevent the overflow shadow and filter bar from being shown when a recording is not selected.
Canonical link: <a href="https://commits.webkit.org/280145@main">https://commits.webkit.org/280145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb5e70165bd5a9c9dd0258c2ca6546a672b46e3c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58624 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6070 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42585 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44805 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4169 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32865 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47957 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25937 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29651 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5286 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4214 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51593 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60215 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30794 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5679 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52236 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48027 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51723 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12376 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32960 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31626 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->