### PR TITLE
Web Inspector: REGRESSION(252630@main): Canvas: clicking on trace call frame doesn't jump to source

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/Recording.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Recording.js
@@ -515,7 +515,7 @@ WI.Recording = class Recording extends WI.Object
                     let promises = [];
 
                     // callFrames
-                    promises.push(Promise.all(array[0].map((item) => this.swizzle(item, WI.Recording.Swizzle.CallFrame))));
+                    promises.push(Promise.all(array[0].map((item) => this.swizzle(item, WI.Recording.Swizzle.CallFramePayload))));
 
                     // topCallFrameIsBoundary
                     if (array.length > 1)
@@ -534,18 +534,18 @@ WI.Recording = class Recording extends WI.Object
                     break;
                 }
 
-                case WI.Recording.Swizzle.CallFrame: {
+                case WI.Recording.Swizzle.CallFramePayload: {
                     let array = await this.swizzle(data, WI.Recording.Swizzle.Array);
                     let [functionName, url] = await Promise.all([
                         this.swizzle(array[0], WI.Recording.Swizzle.String),
                         this.swizzle(array[1], WI.Recording.Swizzle.String),
                     ]);
-                    this._swizzle[index][type] = WI.CallFrame.fromPayload(WI.assumingMainTarget(), {
+                    this._swizzle[index][type] = {
                         functionName,
                         url,
                         lineNumber: array[2],
                         columnNumber: array[3],
-                    });
+                    };
                     break;
                 }
                 }
@@ -1031,5 +1031,5 @@ WI.Recording.Swizzle = {
 
     // Special frontend-only swizzle types.
     CallStack: Symbol("CallStack"),
-    CallFrame: Symbol("CallFrame"),
+    CallFramePayload: Symbol("CallFramePayload"),
 };

--- a/Source/WebInspectorUI/UserInterface/Models/RecordingAction.js
+++ b/Source/WebInspectorUI/UserInterface/Models/RecordingAction.js
@@ -360,8 +360,8 @@ WI.RecordingAction = class RecordingAction extends WI.Object
             swizzlePromises.push(recording.swizzle(this._payloadStackTrace, WI.Recording.Swizzle.CallStack));
         else {
             // COMPATIBILITY (iOS 12.1): "stackTrace" was sent as an array of call frames instead of a single call stack
-            let stackTracePromise = Promise.all(this._payloadStackTrace.map((item) => recording.swizzle(item, WI.Recording.Swizzle.CallFrame)))
-                .then((callFrames) => WI.StackTrace.fromPayload(WI.assumingMainTarget(), callFrames));
+            let stackTracePromise = Promise.all(this._payloadStackTrace.map((item) => recording.swizzle(item, WI.Recording.Swizzle.CallFramePayload)))
+                .then((callFrames) => WI.StackTrace.fromPayload(WI.assumingMainTarget(), {callFrames}));
             swizzlePromises.push(stackTracePromise);
         }
 


### PR DESCRIPTION
#### cba08d5a8e69b7a5c58e0df3f1fd867ccb14cac1
<pre>
Web Inspector: REGRESSION(252630@main): Canvas: clicking on trace call frame doesn&apos;t jump to source
<a href="https://bugs.webkit.org/show_bug.cgi?id=275539">https://bugs.webkit.org/show_bug.cgi?id=275539</a>

Reviewed by Timothy Hatcher.

`WI.StackTrace.fromPayload` expects that the `callFrames` property in the `payload` parameter are protocol payloads, not actual `WI.CallFrame` objects.

* Source/WebInspectorUI/UserInterface/Models/Recording.js:
(WI.Recording.prototype.async swizzle):
* Source/WebInspectorUI/UserInterface/Models/RecordingAction.js:
(WI.RecordingAction.prototype.async swizzle):

Canonical link: <a href="https://commits.webkit.org/280147@main">https://commits.webkit.org/280147@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/507fb43451efd7d878358e4122a7b68319264323

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34966 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8110 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58627 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6073 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42588 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6272 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44808 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4173 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57672 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32869 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47960 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25941 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29655 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5289 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4217 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51602 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5556 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60218 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30797 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5683 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52239 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31882 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48030 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51727 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12377 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32963 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31629 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->