### PR TITLE
[Navigation] Reset navigation API state when using History.replaceState

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/history-replaceState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/history-replaceState-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL entry.getState() after history.replaceState() assert_equals: expected (undefined) undefined but got (object) object "[object Object]"
+PASS entry.getState() after history.replaceState()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/history-replaceState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/history-replaceState-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL entry.getState() after history.replaceState() assert_equals: expected (undefined) undefined but got (object) object "[object Object]"
+PASS entry.getState() after history.replaceState()
 

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -971,8 +971,10 @@ void HistoryController::replaceState(RefPtr<SerializedScriptValue>&& stateObject
     addVisitedLink(*page, URL({ }, urlString));
     frame->checkedLoader()->client().updateGlobalHistory();
 
-    if (RefPtr document = frame->document(); document && document->settings().navigationAPIEnabled())
+    if (RefPtr document = frame->document(); document && document->settings().navigationAPIEnabled()) {
+        currentItem->setNavigationAPIStateObject(nullptr);
         document->protectedWindow()->navigation().updateForNavigation(*currentItem, NavigationNavigationType::Replace);
+    }
 }
 
 void HistoryController::replaceCurrentItem(RefPtr<HistoryItem>&& item)


### PR DESCRIPTION
#### a3d83f83abe551d565be879c9f6cfafe963b428b
<pre>
[Navigation] Reset navigation API state when using History.replaceState
<a href="https://bugs.webkit.org/show_bug.cgi?id=275547">https://bugs.webkit.org/show_bug.cgi?id=275547</a>

Reviewed by Alex Christensen.

Reset navigation API state when using History.replaceState.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/history-replaceState-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/history-replaceState-expected.txt:
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::replaceState):

Canonical link: <a href="https://commits.webkit.org/280083@main">https://commits.webkit.org/280083@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c7a96ebe5ca9e80e9c101125c114b99c5fc4f4b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58634 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6080 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6279 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44814 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4180 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57679 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47967 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25947 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5296 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4224 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51622 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60225 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30804 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5691 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52245 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31889 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51733 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12337 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32970 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31636 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->