### PR TITLE
[Writing Tools] Upstream support for Writing Tools integration (macOS)

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -132,6 +132,8 @@
 #import <pal/spi/cocoa/NSAccessibilitySPI.h>
 #import <pal/spi/cocoa/NSTouchBarSPI.h>
 #import <pal/spi/cocoa/VisionKitCoreSPI.h>
+#import <pal/spi/cocoa/WritingToolsSPI.h>
+#import <pal/spi/cocoa/WritingToolsUISPI.h>
 #import <pal/spi/mac/LookupSPI.h>
 #import <pal/spi/mac/NSAppearanceSPI.h>
 #import <pal/spi/mac/NSApplicationSPI.h>
@@ -167,6 +169,14 @@
 #import <pal/cocoa/VisionKitCoreSoftLink.h>
 #import <pal/cocoa/TranslationUIServicesSoftLink.h>
 #import <pal/mac/DataDetectorsSoftLink.h>
+
+#if ENABLE(WRITING_TOOLS_UI)
+namespace WebKit {
+void showSwapCharactersViewRelativeToRectOfView(NSRect positioningRect, NSView *positioningView);
+void scheduleShowSwapCharactersViewForSelectionRectOfView(NSRect positioningRect, NSView *positioningView);
+bool webViewCanHandleSwapCharacters();
+}
+#endif
 
 #if HAVE(TOUCH_BAR) && ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
 SOFT_LINK_FRAMEWORK(AVKit)
@@ -6697,8 +6707,24 @@ Ref<WebPageProxy> WebViewImpl::protectedPage() const
     return m_page.get();
 }
 
-#if USE(APPLE_INTERNAL_SDK)
-#import <WebKitAdditions/WebViewImplAdditionsAfter.mm>
+#if ENABLE(WRITING_TOOLS_UI)
+
+void showSwapCharactersViewRelativeToRectOfView(NSRect positioningRect, NSView *positioningView)
+{
+    [WTWritingTools.sharedInstance showPanelForSelectionRect:positioningRect ofView:positioningView forDelegate:(NSObject<WTWritingToolsDelegate> *)positioningView];
+}
+
+void scheduleShowSwapCharactersViewForSelectionRectOfView(NSRect positioningRect, NSView *positioningView)
+{
+    // The affordance will only show up if the selected range consists of >= 50 characters.
+    [WTWritingTools.sharedInstance scheduleShowAffordanceForSelectionRect:positioningRect ofView:positioningView forDelegate:(NSObject<WTWritingToolsDelegate> *)positioningView];
+}
+
+bool webViewCanHandleSwapCharacters()
+{
+    return WTWritingToolsViewController.isAvailable;
+}
+
 #endif
 
 } // namespace WebKit


### PR DESCRIPTION
#### 143df8292a067bf288283ecb733b269fbc060736
<pre>
[Writing Tools] Upstream support for Writing Tools integration (macOS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=275549">https://bugs.webkit.org/show_bug.cgi?id=275549</a>
<a href="https://rdar.apple.com/129963667">rdar://129963667</a>

Reviewed by Alex Christensen.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(convert):
(-[WKWebView isWritingToolsActive]):
(-[WKWebView writingToolsAllowedInputOptions]):
(-[WKWebView _wantsCompleteUnifiedTextReplacementBehavior]):
(-[WKWebView wantsWritingToolsInlineEditing]):
(-[WKWebView willBeginWritingToolsSession:requestContexts:]):
(-[WKWebView didBeginWritingToolsSession:contexts:]):
(-[WKWebView proofreadingSession:didReceiveSuggestions:processedRange:inContext:finished:]):
(-[WKWebView proofreadingSession:didUpdateState:forSuggestionWithUUID:inContext:]):
(-[WKWebView didEndWritingToolsSession:accepted:]):
(-[WKWebView compositionSession:didReceiveText:replacementRange:inContext:finished:]):
(-[WKWebView writingToolsSession:didReceiveAction:]):
(-[WKWebView _textReplacementSession:showInformationForReplacementWithUUID:relativeToRect:]):
(-[WKWebView _textReplacementSession:updateState:forReplacementWithUUID:]):
(-[WKWebView beginWritingToolsAnimationForSessionWithUUID:]):
(-[WKWebView endWritingToolsAnimationForSessionWithUUID:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::showSwapCharactersViewRelativeToRectOfView):
(WebKit::scheduleShowSwapCharactersViewForSelectionRectOfView):
(WebKit::webViewCanHandleSwapCharacters):

Canonical link: <a href="https://commits.webkit.org/280078@main">https://commits.webkit.org/280078@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2831dfab19861b659f3efe1e05ca9f539ccd1d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55716 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58700 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6147 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6345 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44866 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/4230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57745 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/32939 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25999 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29726 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4290 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5620 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60291 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/5752 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52295 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48094 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51788 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8212 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30870 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31955 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33036 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31702 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->