### PR TITLE
[Writing Tools] Upstream support for Writing Tools API integration

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.h
@@ -661,9 +661,10 @@ The uniform type identifier kUTTypeWebArchive can be used get the related pasteb
 */
 @property (nonatomic, getter=isInspectable) BOOL inspectable NS_SWIFT_NAME(isInspectable) WK_API_AVAILABLE(macos(13.3), ios(16.4));
 
-#if 0 // API_WEBKIT_ADDITIONS_REPLACEMENT
-#import <WebKitAdditions/WKWebViewAdditions.h>
-#endif
+/*! @abstract A Boolean value indicating whether Writing Tools is active for the view.
+ @discussion @link WKWebView @/link is key-value observing (KVO) compliant for this property.
+ */
+@property (nonatomic, readonly, getter=isWritingToolsActive) BOOL writingToolsActive WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA)) WK_API_UNAVAILABLE(visionos);
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.h
@@ -221,8 +221,22 @@ on the system setting.
  */
 - (nullable id <WKURLSchemeHandler>)urlSchemeHandlerForURLScheme:(NSString *)urlScheme WK_API_AVAILABLE(macos(10.13), ios(11.0));
 
-#if 0 // API_WEBKIT_ADDITIONS_REPLACEMENT
-#import <WebKitAdditions/WKWebViewConfigurationAdditions.h>
+/*! @abstract A Boolean value indicating whether insertion of adaptive image glyphs is allowed.
+    @discussion The default value is `NO`. If `NO`, adaptive image glyphs are inserted as regular
+    images. If `YES`, they are inserted with the full adaptive sizing behavior.
+    */
+@property (nonatomic) BOOL supportsAdaptiveImageGlyph WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
+#if (TARGET_OS_IOS && !TARGET_OS_VISION) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 180000
+/*! @abstract The preferred behavior of Writing Tools.
+    @discussion The default behavior is equivalent to `UIWritingToolsBehaviorLimited`.
+    */
+@property (nonatomic) UIWritingToolsBehavior writingToolsBehavior WK_API_AVAILABLE(ios(WK_IOS_TBA));
+#elif TARGET_OS_OSX && __MAC_OS_X_VERSION_MIN_REQUIRED >= 150000
+/*! @abstract The preferred behavior of Writing Tools.
+    @discussion The default behavior is equivalent to `NSWritingToolsBehaviorLimited`.
+    */
+@property (nonatomic) NSWritingToolsBehavior writingToolsBehavior WK_API_AVAILABLE(macos(WK_MAC_TBA));
 #endif
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -602,9 +602,113 @@ static NSString *defaultApplicationNameForUserAgent()
 }
 #endif
 
-#if USE(APPLE_INTERNAL_SDK)
-#import <WebKitAdditions/WKWebViewConfigurationAdditions.mm>
+#if ENABLE(WRITING_TOOLS)
+
+- (void)setSupportsAdaptiveImageGlyph:(BOOL)supportsAdaptiveImageGlyph
+{
+    [self _setMultiRepresentationHEICInsertionEnabled:supportsAdaptiveImageGlyph];
+}
+
+- (BOOL)supportsAdaptiveImageGlyph
+{
+    return [self _multiRepresentationHEICInsertionEnabled];
+}
+
+#if TARGET_OS_IOS && !TARGET_OS_VISION
+
+static _WKUnifiedTextReplacementBehavior convert(UIWritingToolsBehavior behavior)
+{
+    switch (behavior) {
+    case UIWritingToolsBehaviorNone:
+        return _WKUnifiedTextReplacementBehaviorNone;
+
+    case UIWritingToolsBehaviorDefault:
+        return _WKUnifiedTextReplacementBehaviorDefault;
+
+    case UIWritingToolsBehaviorLimited:
+        return _WKUnifiedTextReplacementBehaviorLimited;
+
+    case UIWritingToolsBehaviorComplete:
+        return _WKUnifiedTextReplacementBehaviorComplete;
+    }
+}
+
+static UIWritingToolsBehavior convert(_WKUnifiedTextReplacementBehavior behavior)
+{
+    switch (behavior) {
+    case _WKUnifiedTextReplacementBehaviorNone:
+        return UIWritingToolsBehaviorNone;
+
+    case _WKUnifiedTextReplacementBehaviorDefault:
+        return UIWritingToolsBehaviorDefault;
+
+    case _WKUnifiedTextReplacementBehaviorLimited:
+        return UIWritingToolsBehaviorLimited;
+
+    case _WKUnifiedTextReplacementBehaviorComplete:
+        return UIWritingToolsBehaviorComplete;
+    }
+}
+
+- (void)setWritingToolsBehavior:(UIWritingToolsBehavior)writingToolsBehavior
+{
+    [self _setUnifiedTextReplacementBehavior:convert(writingToolsBehavior)];
+}
+
+- (UIWritingToolsBehavior)writingToolsBehavior
+{
+    return convert([self _unifiedTextReplacementBehavior]);
+}
+
+#elif TARGET_OS_OSX
+
+static _WKUnifiedTextReplacementBehavior convert(NSWritingToolsBehavior behavior)
+{
+    switch (behavior) {
+    case NSWritingToolsBehaviorNone:
+        return _WKUnifiedTextReplacementBehaviorNone;
+
+    case NSWritingToolsBehaviorDefault:
+        return _WKUnifiedTextReplacementBehaviorDefault;
+
+    case NSWritingToolsBehaviorLimited:
+        return _WKUnifiedTextReplacementBehaviorLimited;
+
+    case NSWritingToolsBehaviorComplete:
+        return _WKUnifiedTextReplacementBehaviorComplete;
+    }
+}
+
+static NSWritingToolsBehavior convert(_WKUnifiedTextReplacementBehavior behavior)
+{
+    switch (behavior) {
+    case _WKUnifiedTextReplacementBehaviorNone:
+        return NSWritingToolsBehaviorNone;
+
+    case _WKUnifiedTextReplacementBehaviorDefault:
+        return NSWritingToolsBehaviorDefault;
+
+    case _WKUnifiedTextReplacementBehaviorLimited:
+        return NSWritingToolsBehaviorLimited;
+
+    case _WKUnifiedTextReplacementBehaviorComplete:
+        return NSWritingToolsBehaviorComplete;
+    }
+}
+
+- (void)setWritingToolsBehavior:(NSWritingToolsBehavior)writingToolsBehavior
+{
+    [self _setUnifiedTextReplacementBehavior:convert(writingToolsBehavior)];
+}
+
+- (NSWritingToolsBehavior)writingToolsBehavior
+{
+    return convert([self _unifiedTextReplacementBehavior]);
+}
+
 #endif
+
+#endif // ENABLE(WRITING_TOOLS)
 
 #pragma mark WKObject protocol implementation
 

--- a/Source/WebKit/mac/replace-webkit-additions-includes.py
+++ b/Source/WebKit/mac/replace-webkit-additions-includes.py
@@ -30,7 +30,7 @@ import sys
 
 
 # Enable this if `FeatureNeededForHeaderReplacement` should be taken into account.
-should_restrict_header_replacement_based_on_feature = True
+should_restrict_header_replacement_based_on_feature = False
 
 
 def read_content_from_webkit_additions(built_products_directory, sdk_root_directory, filename):


### PR DESCRIPTION
#### f5d0ae01ded511fa410491b4c9a4616ef7d2e121
<pre>
[Writing Tools] Upstream support for Writing Tools API integration
<a href="https://bugs.webkit.org/show_bug.cgi?id=275550">https://bugs.webkit.org/show_bug.cgi?id=275550</a>
<a href="https://rdar.apple.com/129969033">rdar://129969033</a>

Reviewed by Aditya Keerthi.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration setSupportsAdaptiveImageGlyph:]):
(-[WKWebViewConfiguration supportsAdaptiveImageGlyph]):
(convert):
(-[WKWebViewConfiguration setWritingToolsBehavior:]):
(-[WKWebViewConfiguration writingToolsBehavior]):
* Source/WebKit/mac/replace-webkit-additions-includes.py:

Canonical link: <a href="https://commits.webkit.org/280076@main">https://commits.webkit.org/280076@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b3ee074143b366a4f784b86f694f2fef4badd12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55713 "Failed to checkout and rebase branch from PR 29879") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8180 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/58697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/6144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6342 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/58697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/6144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57742 "Failed to checkout and rebase branch from PR 29879") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/32937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/48023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/58697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/29724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4287 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/5619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60288 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/5750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/48093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/51787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8211 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30867 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31952 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33033 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/31699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->