### PR TITLE
Web Inspector: remove unnecessary uses of open fields in protocol

### DIFF
--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp
@@ -114,9 +114,9 @@ static T parseBreakpointOptions(Protocol::ErrorString& errorString, RefPtr<JSON:
     size_t ignoreCount = 0;
 
     if (options) {
-        condition = options->getString(Protocol::Debugger::BreakpointOptions::conditionKey);
+        condition = options->getString("condition"_s);
 
-        auto actionsPayload = options->getArray(Protocol::Debugger::BreakpointOptions::actionsKey);
+        auto actionsPayload = options->getArray("actions"_s);
         if (auto count = actionsPayload ? actionsPayload->length() : 0) {
             actions.reserveInitialCapacity(count);
 
@@ -127,7 +127,7 @@ static T parseBreakpointOptions(Protocol::ErrorString& errorString, RefPtr<JSON:
                     return { };
                 }
 
-                auto actionTypeString = actionObject->getString(Protocol::Debugger::BreakpointAction::typeKey);
+                auto actionTypeString = actionObject->getString("type"_s);
                 if (!actionTypeString) {
                     errorString = "Missing type for item in given actions"_s;
                     return { };
@@ -139,20 +139,20 @@ static T parseBreakpointOptions(Protocol::ErrorString& errorString, RefPtr<JSON:
 
                 JSC::Breakpoint::Action action(*actionType);
 
-                action.data = actionObject->getString(Protocol::Debugger::BreakpointAction::dataKey);
+                action.data = actionObject->getString("data"_s);
 
                 // Specifying an identifier is optional. They are used to correlate probe samples
                 // in the frontend across multiple backend probe actions and segregate object groups.
-                action.id = actionObject->getInteger(Protocol::Debugger::BreakpointAction::idKey).value_or(JSC::noBreakpointActionID);
+                action.id = actionObject->getInteger("id"_s).value_or(JSC::noBreakpointActionID);
 
-                action.emulateUserGesture = actionObject->getBoolean(Protocol::Debugger::BreakpointAction::emulateUserGestureKey).value_or(false);
+                action.emulateUserGesture = actionObject->getBoolean("emulateUserGesture"_s).value_or(false);
 
                 actions.append(WTFMove(action));
             }
         }
 
-        autoContinue = options->getBoolean(Protocol::Debugger::BreakpointOptions::autoContinueKey).value_or(false);
-        ignoreCount = options->getInteger(Protocol::Debugger::BreakpointOptions::ignoreCountKey).value_or(0);
+        autoContinue = options->getBoolean("autoContinue"_s).value_or(false);
+        ignoreCount = options->getInteger("ignoreCount"_s).value_or(0);
     }
 
     return callback(condition, WTFMove(actions), autoContinue, ignoreCount);
@@ -538,7 +538,7 @@ static Ref<Protocol::Debugger::Location> buildDebuggerLocation(const JSC::Breakp
 
 static bool parseLocation(Protocol::ErrorString& errorString, const JSON::Object& location, JSC::SourceID& sourceID, unsigned& lineNumber, unsigned& columnNumber)
 {
-    auto lineNumberValue = location.getInteger(Protocol::Debugger::Location::lineNumberKey);
+    auto lineNumberValue = location.getInteger("lineNumber"_s);
     if (!lineNumberValue) {
         errorString = "Unexpected non-integer lineNumber in given location"_s;
         sourceID = JSC::noSourceID;
@@ -547,7 +547,7 @@ static bool parseLocation(Protocol::ErrorString& errorString, const JSON::Object
 
     lineNumber = *lineNumberValue;
 
-    auto scriptIDStr = location.getString(Protocol::Debugger::Location::scriptIdKey);
+    auto scriptIDStr = location.getString("scriptId"_s);
     if (!scriptIDStr) {
         sourceID = JSC::noSourceID;
         errorString = "Unexepcted non-string scriptId in given location"_s;
@@ -555,7 +555,7 @@ static bool parseLocation(Protocol::ErrorString& errorString, const JSON::Object
     }
 
     sourceID = parseIntegerAllowingTrailingJunk<JSC::SourceID>(scriptIDStr).value_or(0);
-    columnNumber = location.getInteger(Protocol::Debugger::Location::columnNumberKey).value_or(0);
+    columnNumber = location.getInteger("columnNumber"_s).value_or(0);
     return true;
 }
 

--- a/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp
@@ -348,7 +348,7 @@ Protocol::ErrorStringOr<std::optional<int> /* saveResultIndex */> InspectorRunti
 
     InjectedScript injectedScript;
 
-    auto objectId = callArgument->getString(Protocol::Runtime::CallArgument::objectIdKey);
+    auto objectId = callArgument->getString("objectId"_s);
     if (!objectId) {
         injectedScript = injectedScriptForEval(errorString, WTFMove(executionContextId));
         if (injectedScript.hasNoValue())
@@ -409,9 +409,9 @@ Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::Runtime::TypeDescription>>> 
         if (!location)
             return makeUnexpected("Unexpected non-object item in locations"_s);
 
-        auto descriptor = location->getInteger(Protocol::Runtime::TypeLocation::typeInformationDescriptorKey).value_or(TypeProfilerSearchDescriptorNormal);
-        auto sourceIDString = location->getString(Protocol::Runtime::TypeLocation::sourceIDKey);
-        auto divot = location->getInteger(Protocol::Runtime::TypeLocation::divotKey).value_or(0);
+        auto descriptor = location->getInteger("typeInformationDescriptor"_s).value_or(TypeProfilerSearchDescriptorNormal);
+        auto sourceIDString = location->getString("sourceID"_s);
+        auto divot = location->getInteger("divot"_s).value_or(0);
 
         auto typeLocation = m_vm.typeProfiler()->findLocation(divot, parseInteger<uintptr_t>(sourceIDString).value(), static_cast<TypeProfilerSearchDescriptor>(descriptor), m_vm);
 

--- a/Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_protocol_types_header.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_protocol_types_header.py
@@ -269,14 +269,6 @@ class CppProtocolTypesHeaderGenerator(CppGenerator):
         for member in optional_members:
             lines.append(self._generate_unchecked_setter_for_member(member, domain))
 
-        if Generator.type_has_open_fields(type_declaration.type):
-            lines.append('')
-            lines.append('    // Property names for type generated as open.')
-            open_members = Generator.open_fields(type_declaration)
-            for type_member in open_members:
-                export_macro = self.model().framework.setting('export_macro', None)
-                lines.append('    %s static const ASCIILiteral %sKey;' % (export_macro, type_member.member_name))
-
         lines.append('};')
         return self.wrap_with_guard_for_condition(type_declaration.condition, '\n'.join(lines))
 

--- a/Source/JavaScriptCore/inspector/scripts/codegen/generator.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/generator.py
@@ -93,23 +93,12 @@ _TYPES_NEEDING_RUNTIME_CASTS = set([
 ])
 
 # FIXME: This should be converted into a property in JSON.
+# These exist for ONLY for legacy code.
+# DO NOT ADD TO THIS LIST!!!
 _TYPES_WITH_OPEN_FIELDS = {
     "Timeline.TimelineEvent": [],
     "CSS.CSSProperty": ["priority", "parsedOk", "status"],
-    "DOM.HighlightConfig": [],
-    "DOM.GridOverlayConfig": [],
-    "DOM.FlexOverlayConfig": [],
-    "DOM.RGBAColor": [],
-    "DOMStorage.StorageId": [],
-    "Debugger.BreakpointAction": [],
-    "Debugger.BreakpointOptions": [],
-    "Debugger.Location": [],
-    "IndexedDB.Key": [],
-    "IndexedDB.KeyRange": [],
     "Network.Response": ["status", "statusText", "mimeType", "source"],
-    "Page.Cookie": [],
-    "Runtime.CallArgument": ["objectId"],
-    "Runtime.TypeLocation": [],
     # For testing purposes only.
     "Test.OpenParameters": ["alpha"],
 }

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/command-targetType-matching-domain-debuggableType.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/command-targetType-matching-domain-debuggableType.json-result
@@ -458,8 +458,6 @@ namespace Inspector {
 
 namespace Protocol {
 
-
-
 } // namespace Protocol
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result
@@ -781,8 +781,6 @@ template<> std::optional<Protocol::Database::PrimaryColors> parseEnumValueFromSt
 
 } // namespace TestHelpers
 
-
-
 } // namespace Protocol
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result
@@ -694,8 +694,6 @@ template<> std::optional<Protocol::Database::PrimaryColors> parseEnumValueFromSt
 
 } // namespace TestHelpers
 
-
-
 } // namespace Protocol
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/definitions-with-mac-platform.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/definitions-with-mac-platform.json-result
@@ -576,8 +576,6 @@ namespace Inspector {
 
 namespace Protocol {
 
-
-
 } // namespace Protocol
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-debuggableTypes.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-debuggableTypes.json-result
@@ -458,8 +458,6 @@ namespace Inspector {
 
 namespace Protocol {
 
-
-
 } // namespace Protocol
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetType-matching-domain-debuggableType.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetType-matching-domain-debuggableType.json-result
@@ -458,8 +458,6 @@ namespace Inspector {
 
 namespace Protocol {
 
-
-
 } // namespace Protocol
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetTypes.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetTypes.json-result
@@ -458,8 +458,6 @@ namespace Inspector {
 
 namespace Protocol {
 
-
-
 } // namespace Protocol
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domains-with-varying-command-sizes.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domains-with-varying-command-sizes.json-result
@@ -684,8 +684,6 @@ namespace Inspector {
 
 namespace Protocol {
 
-
-
 } // namespace Protocol
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result
@@ -599,8 +599,6 @@ template<> std::optional<Protocol::TypeDomain::Enum> parseEnumValueFromString<Pr
 
 } // namespace TestHelpers
 
-
-
 } // namespace Protocol
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/event-targetType-matching-domain-debuggableType.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/event-targetType-matching-domain-debuggableType.json-result
@@ -458,8 +458,6 @@ namespace Inspector {
 
 namespace Protocol {
 
-
-
 } // namespace Protocol
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/events-with-optional-parameters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/events-with-optional-parameters.json-result
@@ -504,8 +504,6 @@ namespace Inspector {
 
 namespace Protocol {
 
-
-
 } // namespace Protocol
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/generate-domains-with-feature-guards.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/generate-domains-with-feature-guards.json-result
@@ -536,8 +536,6 @@ namespace Inspector {
 
 namespace Protocol {
 
-
-
 } // namespace Protocol
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/same-type-id-different-domain.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/same-type-id-different-domain.json-result
@@ -368,8 +368,6 @@ namespace Inspector {
 
 namespace Protocol {
 
-
-
 } // namespace Protocol
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/shadowed-optional-type-setters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/shadowed-optional-type-setters.json-result
@@ -493,8 +493,6 @@ template<> std::optional<Protocol::Runtime::KeyPath::Type> parseEnumValueFromStr
 
 } // namespace TestHelpers
 
-
-
 } // namespace Protocol
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/should-strip-comments.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/should-strip-comments.json-result
@@ -358,8 +358,6 @@ namespace Inspector {
 
 namespace Protocol {
 
-
-
 } // namespace Protocol
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-aliased-primitive-type.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-aliased-primitive-type.json-result
@@ -363,8 +363,6 @@ namespace Inspector {
 
 namespace Protocol {
 
-
-
 } // namespace Protocol
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-array-type.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-array-type.json-result
@@ -453,8 +453,6 @@ template<> std::optional<Protocol::Debugger::Reason> parseEnumValueFromString<Pr
 
 } // namespace TestHelpers
 
-
-
 } // namespace Protocol
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-enum-type.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-enum-type.json-result
@@ -474,8 +474,6 @@ template<> std::optional<Protocol::Runtime::TwoLeggedAnimals> parseEnumValueFrom
 
 } // namespace TestHelpers
 
-
-
 } // namespace Protocol
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result
@@ -1078,8 +1078,6 @@ template<> std::optional<Protocol::Test::ParameterBundle::Directionality> parseE
 
 } // namespace TestHelpers
 
-
-
 } // namespace Protocol
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result
@@ -691,8 +691,6 @@ template<> std::optional<Protocol::Test::CastedAnimals> parseEnumValueFromString
 
 } // namespace TestHelpers
 
-
-
 void BindingTraits<Protocol::Test::CastedAnimals>::assertValueHasExpectedType(JSON::Value* value)
 {
     ASSERT_UNUSED(value, value);

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-with-open-parameters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-with-open-parameters.json-result
@@ -448,9 +448,6 @@ public:
     {
         return Builder<NoFieldsSet>(JSON::Object::create());
     }
-
-    // Property names for type generated as open.
-    None static const ASCIILiteral alphaKey;
 };
 
 } // Test
@@ -500,8 +497,6 @@ public:
 namespace Inspector {
 
 namespace Protocol {
-
-const ASCIILiteral Protocol::Test::OpenParameters::alphaKey = "alpha"_s;
 
 } // namespace Protocol
 

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/version.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/version.json-result
@@ -368,8 +368,6 @@ namespace Inspector {
 
 namespace Protocol {
 
-
-
 } // namespace Protocol
 
 } // namespace Inspector

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -884,11 +884,11 @@ Ref<Inspector::Protocol::CSS::CSSStyle> InspectorStyle::styleWithProperties() co
                 HashMap<String, RefPtr<Inspector::Protocol::CSS::CSSProperty>>::iterator activeIt = propertyNameToPreviousActiveProperty.find(canonicalPropertyName);
                 if (activeIt != propertyNameToPreviousActiveProperty.end()) {
                     if (propertyEntry.parsedOk) {
-                        auto newPriority = activeIt->value->getString(Inspector::Protocol::CSS::CSSProperty::priorityKey);
+                        auto newPriority = activeIt->value->getString("priority"_s);
                         if (!!newPriority)
                             previousPriority = newPriority;
 
-                        auto newStatus = activeIt->value->getString(Inspector::Protocol::CSS::CSSProperty::statusKey);
+                        auto newStatus = activeIt->value->getString("status"_s);
                         if (!!newStatus) {
                             previousStatus = newStatus;
                             if (previousStatus != Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::CSS::CSSPropertyStatus::Inactive)) {
@@ -901,7 +901,7 @@ Ref<Inspector::Protocol::CSS::CSSStyle> InspectorStyle::styleWithProperties() co
                             }
                         }
                     } else {
-                        auto previousParsedOk = activeIt->value->getBoolean(Inspector::Protocol::CSS::CSSProperty::parsedOkKey);
+                        auto previousParsedOk = activeIt->value->getBoolean("parsedOk"_s);
                         if (previousParsedOk && !previousParsedOk)
                             shouldInactivate = true;
                     }

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -150,13 +150,13 @@ static std::optional<Color> parseColor(RefPtr<JSON::Object>&& colorObject)
     if (!colorObject)
         return std::nullopt;
 
-    auto r = colorObject->getInteger(Inspector::Protocol::DOM::RGBAColor::rKey);
-    auto g = colorObject->getInteger(Inspector::Protocol::DOM::RGBAColor::gKey);
-    auto b = colorObject->getInteger(Inspector::Protocol::DOM::RGBAColor::bKey);
+    auto r = colorObject->getInteger("r"_s);
+    auto g = colorObject->getInteger("g"_s);
+    auto b = colorObject->getInteger("b"_s);
     if (!r || !g || !b)
         return std::nullopt;
 
-    auto a = colorObject->getDouble(Inspector::Protocol::DOM::RGBAColor::aKey);
+    auto a = colorObject->getDouble("a"_s);
     if (!a)
         return { makeFromComponentsClamping<SRGBA<uint8_t>>(*r, *g, *b) };
     return { makeFromComponentsClampingExceptAlpha<SRGBA<uint8_t>>(*r, *g, *b, convertFloatAlphaTo<uint8_t>(*a)) };
@@ -1321,11 +1321,11 @@ std::unique_ptr<InspectorOverlay::Highlight::Config> InspectorDOMAgent::highligh
     }
 
     auto highlightConfig = makeUnique<InspectorOverlay::Highlight::Config>();
-    highlightConfig->showInfo = highlightInspectorObject->getBoolean(Inspector::Protocol::DOM::HighlightConfig::showInfoKey).value_or(false);
-    highlightConfig->content = parseOptionalConfigColor(Inspector::Protocol::DOM::HighlightConfig::contentColorKey, *highlightInspectorObject);
-    highlightConfig->padding = parseOptionalConfigColor(Inspector::Protocol::DOM::HighlightConfig::paddingColorKey, *highlightInspectorObject);
-    highlightConfig->border = parseOptionalConfigColor(Inspector::Protocol::DOM::HighlightConfig::borderColorKey, *highlightInspectorObject);
-    highlightConfig->margin = parseOptionalConfigColor(Inspector::Protocol::DOM::HighlightConfig::marginColorKey, *highlightInspectorObject);
+    highlightConfig->showInfo = highlightInspectorObject->getBoolean("showInfo"_s).value_or(false);
+    highlightConfig->content = parseOptionalConfigColor("contentColor"_s, *highlightInspectorObject);
+    highlightConfig->padding = parseOptionalConfigColor("paddingColor"_s, *highlightInspectorObject);
+    highlightConfig->border = parseOptionalConfigColor("borderColor"_s, *highlightInspectorObject);
+    highlightConfig->margin = parseOptionalConfigColor("marginColor"_s, *highlightInspectorObject);
     return highlightConfig;
 }
 
@@ -1334,7 +1334,7 @@ std::optional<InspectorOverlay::Grid::Config> InspectorDOMAgent::gridOverlayConf
     if (!gridOverlayInspectorObject)
         return std::nullopt;
 
-    auto gridColor = parseRequiredConfigColor(Inspector::Protocol::DOM::GridOverlayConfig::gridColorKey, *gridOverlayInspectorObject);
+    auto gridColor = parseRequiredConfigColor("gridColor"_s, *gridOverlayInspectorObject);
     if (!gridColor) {
         errorString = "Internal error: grid color property of grid overlay configuration parameter is missing"_s;
         return std::nullopt;
@@ -1342,11 +1342,11 @@ std::optional<InspectorOverlay::Grid::Config> InspectorDOMAgent::gridOverlayConf
 
     InspectorOverlay::Grid::Config gridOverlayConfig;
     gridOverlayConfig.gridColor = *gridColor;
-    gridOverlayConfig.showLineNames = gridOverlayInspectorObject->getBoolean(Inspector::Protocol::DOM::GridOverlayConfig::showLineNamesKey).value_or(false);
-    gridOverlayConfig.showLineNumbers = gridOverlayInspectorObject->getBoolean(Inspector::Protocol::DOM::GridOverlayConfig::showLineNumbersKey).value_or(false);
-    gridOverlayConfig.showExtendedGridLines = gridOverlayInspectorObject->getBoolean(Inspector::Protocol::DOM::GridOverlayConfig::showExtendedGridLinesKey).value_or(false);
-    gridOverlayConfig.showTrackSizes = gridOverlayInspectorObject->getBoolean(Inspector::Protocol::DOM::GridOverlayConfig::showTrackSizesKey).value_or(false);
-    gridOverlayConfig.showAreaNames = gridOverlayInspectorObject->getBoolean(Inspector::Protocol::DOM::GridOverlayConfig::showAreaNamesKey).value_or(false);
+    gridOverlayConfig.showLineNames = gridOverlayInspectorObject->getBoolean("showLineNames"_s).value_or(false);
+    gridOverlayConfig.showLineNumbers = gridOverlayInspectorObject->getBoolean("showLineNumbers"_s).value_or(false);
+    gridOverlayConfig.showExtendedGridLines = gridOverlayInspectorObject->getBoolean("showExtendedGridLines"_s).value_or(false);
+    gridOverlayConfig.showTrackSizes = gridOverlayInspectorObject->getBoolean("showTrackSizes"_s).value_or(false);
+    gridOverlayConfig.showAreaNames = gridOverlayInspectorObject->getBoolean("showAreaNames"_s).value_or(false);
     return gridOverlayConfig;
 }
 
@@ -1355,7 +1355,7 @@ std::optional<InspectorOverlay::Flex::Config> InspectorDOMAgent::flexOverlayConf
     if (!flexOverlayInspectorObject)
         return std::nullopt;
 
-    auto flexColor = parseRequiredConfigColor(Inspector::Protocol::DOM::FlexOverlayConfig::flexColorKey, *flexOverlayInspectorObject);
+    auto flexColor = parseRequiredConfigColor("flexColor"_s, *flexOverlayInspectorObject);
     if (!flexColor) {
         errorString = "Internal error: flex color property of flex overlay configuration parameter is missing"_s;
         return std::nullopt;
@@ -1363,7 +1363,7 @@ std::optional<InspectorOverlay::Flex::Config> InspectorDOMAgent::flexOverlayConf
 
     InspectorOverlay::Flex::Config flexOverlayConfig;
     flexOverlayConfig.flexColor = *flexColor;
-    flexOverlayConfig.showOrderNumbers = flexOverlayInspectorObject->getBoolean(Inspector::Protocol::DOM::FlexOverlayConfig::showOrderNumbersKey).value_or(false);
+    flexOverlayConfig.showOrderNumbers = flexOverlayInspectorObject->getBoolean("showOrderNumbers"_s).value_or(false);
     return flexOverlayConfig;
 }
 

--- a/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp
@@ -195,13 +195,13 @@ void InspectorDOMStorageAgent::didDispatchDOMStorageEvent(const String& key, con
 
 RefPtr<StorageArea> InspectorDOMStorageAgent::findStorageArea(Inspector::Protocol::ErrorString& errorString, Ref<JSON::Object>&& storageId, LocalFrame*& targetFrame)
 {
-    auto securityOrigin = storageId->getString(Inspector::Protocol::DOMStorage::StorageId::securityOriginKey);
+    auto securityOrigin = storageId->getString("securityOrigin"_s);
     if (!securityOrigin) {
         errorString = "Missing securityOrigin in given storageId"_s;
         return nullptr;
     }
 
-    auto isLocalStorage = storageId->getBoolean(Inspector::Protocol::DOMStorage::StorageId::isLocalStorageKey);
+    auto isLocalStorage = storageId->getBoolean("isLocalStorage"_s);
     if (!isLocalStorage) {
         errorString = "Missing isLocalStorage in given storageId"_s;
         return nullptr;

--- a/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp
@@ -250,7 +250,7 @@ private:
 
 static RefPtr<IDBKey> idbKeyFromInspectorObject(Ref<JSON::Object>&& key)
 {
-    auto typeString = key->getString(Inspector::Protocol::IndexedDB::Key::typeKey);
+    auto typeString = key->getString("type"_s);
     if (!typeString)
         return nullptr;
 
@@ -260,28 +260,28 @@ static RefPtr<IDBKey> idbKeyFromInspectorObject(Ref<JSON::Object>&& key)
 
     switch (*type) {
     case Inspector::Protocol::IndexedDB::Key::Type::Number: {
-        auto number = key->getDouble(Inspector::Protocol::IndexedDB::Key::numberKey);
+        auto number = key->getDouble("number"_s);
         if (!number)
             return nullptr;
         return IDBKey::createNumber(*number);
     }
 
     case Inspector::Protocol::IndexedDB::Key::Type::String: {
-        auto string = key->getString(Inspector::Protocol::IndexedDB::Key::stringKey);
+        auto string = key->getString("string"_s);
         if (!string)
             return nullptr;
         return IDBKey::createString(string);
     }
 
     case Inspector::Protocol::IndexedDB::Key::Type::Date: {
-        auto date = key->getDouble(Inspector::Protocol::IndexedDB::Key::dateKey);
+        auto date = key->getDouble("date"_s);
         if (!date)
             return nullptr;
         return IDBKey::createDate(*date);
     }
 
     case Inspector::Protocol::IndexedDB::Key::Type::Array: {
-        auto array = key->getArray(Inspector::Protocol::IndexedDB::Key::arrayKey);
+        auto array = key->getArray("array"_s);
         if (!array)
             return nullptr;
 
@@ -303,24 +303,24 @@ static RefPtr<IDBKey> idbKeyFromInspectorObject(Ref<JSON::Object>&& key)
 static RefPtr<IDBKeyRange> idbKeyRangeFromKeyRange(JSON::Object& keyRange)
 {
     RefPtr<IDBKey> idbLower;
-    if (auto lower = keyRange.getObject(Inspector::Protocol::IndexedDB::KeyRange::lowerKey)) {
+    if (auto lower = keyRange.getObject("lower"_s)) {
         idbLower = idbKeyFromInspectorObject(lower.releaseNonNull());
         if (!idbLower)
             return nullptr;
     }
 
     RefPtr<IDBKey> idbUpper;
-    if (auto upper = keyRange.getObject(Inspector::Protocol::IndexedDB::KeyRange::upperKey)) {
+    if (auto upper = keyRange.getObject("upper"_s)) {
         idbUpper = idbKeyFromInspectorObject(upper.releaseNonNull());
         if (!idbUpper)
             return nullptr;
     }
 
-    auto lowerOpen = keyRange.getBoolean(Inspector::Protocol::IndexedDB::KeyRange::lowerOpenKey);
+    auto lowerOpen = keyRange.getBoolean("lowerOpen"_s);
     if (!lowerOpen)
         return nullptr;
 
-    auto upperOpen = keyRange.getBoolean(Inspector::Protocol::IndexedDB::KeyRange::upperOpenKey);
+    auto upperOpen = keyRange.getBoolean("upperOpen"_s);
     if (!upperOpen)
         return nullptr;
 

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -573,7 +573,7 @@ void InspectorNetworkAgent::didReceiveResponse(ResourceLoaderIdentifier identifi
     if (cachedResource) {
         // Use mime type from cached resource in case the one in response is empty.
         if (resourceResponse && response.mimeType().isEmpty())
-            resourceResponse->setString(Inspector::Protocol::Network::Response::mimeTypeKey, cachedResource->response().mimeType());
+            resourceResponse->setString("mimeType"_s, cachedResource->response().mimeType());
         m_resourcesData->addCachedResource(requestId, cachedResource);
     }
 
@@ -596,12 +596,12 @@ void InspectorNetworkAgent::didReceiveResponse(ResourceLoaderIdentifier identifi
                 });
             }
             
-            resourceResponse->setString(Inspector::Protocol::Network::Response::mimeTypeKey, previousResourceData->mimeType());
+            resourceResponse->setString("mimeType"_s, previousResourceData->mimeType());
             
-            resourceResponse->setInteger(Inspector::Protocol::Network::Response::statusKey, previousResourceData->httpStatusCode());
-            resourceResponse->setString(Inspector::Protocol::Network::Response::statusTextKey, previousResourceData->httpStatusText());
+            resourceResponse->setInteger("status"_s, previousResourceData->httpStatusCode());
+            resourceResponse->setString("statusText"_s, previousResourceData->httpStatusText());
             
-            resourceResponse->setString(Inspector::Protocol::Network::Response::sourceKey, Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::Network::Response::Source::DiskCache));
+            resourceResponse->setString("source"_s, Inspector::Protocol::Helpers::getEnumConstantValue(Inspector::Protocol::Network::Response::Source::DiskCache));
         }
     }
 

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -646,31 +646,31 @@ static std::optional<Cookie> parseCookieObject(Inspector::Protocol::ErrorString&
 {
     Cookie cookie;
 
-    cookie.name = cookieObject->getString(Inspector::Protocol::Page::Cookie::nameKey);
+    cookie.name = cookieObject->getString("name"_s);
     if (!cookie.name) {
         errorString = "Invalid value for key name in given cookie"_s;
         return std::nullopt;
     }
 
-    cookie.value = cookieObject->getString(Inspector::Protocol::Page::Cookie::valueKey);
+    cookie.value = cookieObject->getString("value"_s);
     if (!cookie.value) {
         errorString = "Invalid value for key value in given cookie"_s;
         return std::nullopt;
     }
 
-    cookie.domain = cookieObject->getString(Inspector::Protocol::Page::Cookie::domainKey);
+    cookie.domain = cookieObject->getString("domain"_s);
     if (!cookie.domain) {
         errorString = "Invalid value for key domain in given cookie"_s;
         return std::nullopt;
     }
 
-    cookie.path = cookieObject->getString(Inspector::Protocol::Page::Cookie::pathKey);
+    cookie.path = cookieObject->getString("path"_s);
     if (!cookie.path) {
         errorString = "Invalid value for key path in given cookie"_s;
         return std::nullopt;
     }
 
-    auto httpOnly = cookieObject->getBoolean(Inspector::Protocol::Page::Cookie::httpOnlyKey);
+    auto httpOnly = cookieObject->getBoolean("httpOnly"_s);
     if (!httpOnly) {
         errorString = "Invalid value for key httpOnly in given cookie"_s;
         return std::nullopt;
@@ -678,7 +678,7 @@ static std::optional<Cookie> parseCookieObject(Inspector::Protocol::ErrorString&
 
     cookie.httpOnly = *httpOnly;
 
-    auto secure = cookieObject->getBoolean(Inspector::Protocol::Page::Cookie::secureKey);
+    auto secure = cookieObject->getBoolean("secure"_s);
     if (!secure) {
         errorString = "Invalid value for key secure in given cookie"_s;
         return std::nullopt;
@@ -686,8 +686,8 @@ static std::optional<Cookie> parseCookieObject(Inspector::Protocol::ErrorString&
 
     cookie.secure = *secure;
 
-    auto session = cookieObject->getBoolean(Inspector::Protocol::Page::Cookie::sessionKey);
-    cookie.expires = cookieObject->getDouble(Inspector::Protocol::Page::Cookie::expiresKey);
+    auto session = cookieObject->getBoolean("session"_s);
+    cookie.expires = cookieObject->getDouble("expires"_s);
     if (!session && !cookie.expires) {
         errorString = "Invalid value for key expires in given cookie"_s;
         return std::nullopt;
@@ -695,7 +695,7 @@ static std::optional<Cookie> parseCookieObject(Inspector::Protocol::ErrorString&
 
     cookie.session = *session;
 
-    auto sameSiteString = cookieObject->getString(Inspector::Protocol::Page::Cookie::sameSiteKey);
+    auto sameSiteString = cookieObject->getString("sameSite"_s);
     if (!sameSiteString) {
         errorString = "Invalid value for key sameSite in given cookie"_s;
         return std::nullopt;

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
@@ -781,7 +781,7 @@ static Inspector::Protocol::Timeline::EventType toProtocol(TimelineRecordType ty
 
 void InspectorTimelineAgent::addRecordToTimeline(Ref<JSON::Object>&& record, TimelineRecordType type)
 {
-    record->setString(Inspector::Protocol::Timeline::TimelineEvent::typeKey, Inspector::Protocol::Helpers::getEnumConstantValue(toProtocol(type)));
+    record->setString("type"_s, Inspector::Protocol::Helpers::getEnumConstantValue(toProtocol(type)));
 
     if (m_recordStack.isEmpty()) {
         // FIXME: runtimeCast is a hack. We do it because we can't build TimelineEvent directly now.
@@ -811,9 +811,9 @@ void InspectorTimelineAgent::setFrameIdentifier(JSON::Object* record, LocalFrame
 
 void InspectorTimelineAgent::didCompleteRecordEntry(const TimelineRecordEntry& entry)
 {
-    entry.record->setObject(Inspector::Protocol::Timeline::TimelineEvent::dataKey, entry.data.copyRef());
+    entry.record->setObject("data"_s, entry.data.copyRef());
     if (entry.children)
-        entry.record->setArray(Inspector::Protocol::Timeline::TimelineEvent::childrenKey, *entry.children);
+        entry.record->setArray("children"_s, *entry.children);
     entry.record->setDouble("endTime"_s, timestamp());
     addRecordToTimeline(entry.record.copyRef(), entry.type);
 }
@@ -838,7 +838,7 @@ void InspectorTimelineAgent::didCompleteCurrentRecord(TimelineRecordType type)
 void InspectorTimelineAgent::appendRecord(Ref<JSON::Object>&& data, TimelineRecordType type, bool captureCallStack, LocalFrame* frame, std::optional<double> startTime)
 {
     Ref<JSON::Object> record = TimelineRecordFactory::createGenericRecord(startTime.value_or(timestamp()), captureCallStack ? m_maxCallStackDepth : 0);
-    record->setObject(Inspector::Protocol::Timeline::TimelineEvent::dataKey, WTFMove(data));
+    record->setObject("data"_s, WTFMove(data));
     setFrameIdentifier(&record.get(), frame);
     addRecordToTimeline(WTFMove(record), type);
 }


### PR DESCRIPTION
#### 85caa2d31dc1dbec7186471bd2442b73be14d380
<pre>
Web Inspector: remove unnecessary uses of open fields in protocol
<a href="https://bugs.webkit.org/show_bug.cgi?id=275551">https://bugs.webkit.org/show_bug.cgi?id=275551</a>

Reviewed by Timothy Hatcher.

Most of the uses of `Domain::Type::propertyKey` are unnecessary since `String` is super efficient with `ASCIILiteral`.

* Source/JavaScriptCore/inspector/scripts/codegen/generator.py:
* Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_protocol_types_header.py:
(CppProtocolTypesHeaderGenerator._generate_class_for_object_declaration): Deleted.
* Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_protocol_types_implementation.py:
(CppProtocolTypesImplementationGenerator.generate_output):
(CppProtocolTypesImplementationGenerator._generate_assertion_for_object_declaration):
(CppProtocolTypesImplementationGenerator._generate_open_field_names): Deleted.

* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp:
(Inspector::parseBreakpointOptions):
(Inspector::parseLocation):
* Source/JavaScriptCore/inspector/agents/InspectorRuntimeAgent.cpp:
(Inspector::InspectorRuntimeAgent::getRuntimeTypesForVariablesAtOffsets):
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::InspectorStyle::styleWithProperties const):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::parseColor):
(WebCore::InspectorDOMAgent::highlightConfigFromInspectorObject):
(WebCore::InspectorDOMAgent::gridOverlayConfigFromInspectorObject):
(WebCore::InspectorDOMAgent::flexOverlayConfigFromInspectorObject):
* Source/WebCore/inspector/agents/InspectorDOMStorageAgent.cpp:
(WebCore::InspectorDOMStorageAgent::findStorageArea):
* Source/WebCore/inspector/agents/InspectorIndexedDBAgent.cpp:
(WebCore::Inspector::idbKeyFromInspectorObject):
(WebCore::Inspector::idbKeyRangeFromKeyRange):
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::didReceiveResponse):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::parseCookieObject):
* Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp:
(WebCore::InspectorTimelineAgent::addRecordToTimeline):
(WebCore::InspectorTimelineAgent::didCompleteRecordEntry):
(WebCore::InspectorTimelineAgent::appendRecord):

* Source/JavaScriptCore/inspector/scripts/tests/expected/command-targetType-matching-domain-debuggableType.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/definitions-with-mac-platform.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/domain-debuggableTypes.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetType-matching-domain-debuggableType.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/domain-targetTypes.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/domains-with-varying-command-sizes.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/event-targetType-matching-domain-debuggableType.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/events-with-optional-parameters.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/generate-domains-with-feature-guards.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/same-type-id-different-domain.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/shadowed-optional-type-setters.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/should-strip-comments.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-aliased-primitive-type.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-array-type.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-enum-type.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-with-open-parameters.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/version.json-result:

Canonical link: <a href="https://commits.webkit.org/280146@main">https://commits.webkit.org/280146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/266dd23f3965a3fd798a6dd086cabfd9317267a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34987 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58648 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6094 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57790 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42609 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6293 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44826 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4192 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32888 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47978 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25959 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29675 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5307 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4238 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/48741 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51648 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5574 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60239 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/54901 "Built successfully and passed tests") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5702 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52257 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48048 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51745 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12378 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/76662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30818 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/76662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31903 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32984 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31650 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->