### PR TITLE
Web Inspector: introduce some additional protocol GenericTypes

### DIFF
--- a/LayoutTests/inspector/css/add-rule.html
+++ b/LayoutTests/inspector/css/add-rule.html
@@ -11,8 +11,8 @@ function test() {
 
     let mainFrame = WI.networkManager.mainFrame;
 
-    function stringify(range) {
-        return `${range.startLine}:${range.startColumn},${range.endLine}:${range.endColumn}`;
+    function stringify(sourceRange) {
+        return `${sourceRange.start.line}:${sourceRange.start.column},${sourceRange.end.line}:${sourceRange.end.column}`;
     }
 
     suite.addTestCase({
@@ -26,7 +26,7 @@ function test() {
                 }
 
                 InspectorTest.expectEqual(rulePayload.selectorList.text, "body", `Rule selector should be "body"`);
-                InspectorTest.expectEqual(stringify(rulePayload.selectorList.range), "0:0,0:4", `Rule range should be [0:0,0:4]`);
+                InspectorTest.expectEqual(stringify(rulePayload.selectorList.sourceRange), "0:0,0:4", `Rule range should be [0:0,0:4]`);
                 InspectorTest.expectEqual(rulePayload.origin, "inspector", `Rule origin should be "inspector"`);
 
                 resolve();
@@ -58,7 +58,7 @@ function test() {
                 }
 
                 InspectorTest.expectEqual(rulePayload.selectorList.text, "div", `Rule selector should be "div"`);
-                InspectorTest.expectEqual(stringify(rulePayload.selectorList.range), "1:0,1:3", `Rule range should be [1:0,1:3]`);
+                InspectorTest.expectEqual(stringify(rulePayload.selectorList.sourceRange), "1:0,1:3", `Rule range should be [1:0,1:3]`);
                 InspectorTest.expectEqual(rulePayload.origin, "inspector", `Rule origin should be "inspector"`);
 
                 resolve();
@@ -94,7 +94,7 @@ function test() {
                 }
 
                 InspectorTest.expectEqual(rulePayload.selectorList.text, "div", `Rule selector should be "div"`);
-                InspectorTest.expectEqual(stringify(rulePayload.selectorList.range), "2:0,2:3", `Rule range should be [2:0,2:3]`);
+                InspectorTest.expectEqual(stringify(rulePayload.selectorList.sourceRange), "2:0,2:3", `Rule range should be [2:0,2:3]`);
                 InspectorTest.expectEqual(rulePayload.origin, "author", `Rule origin should be "author"`);
 
                 resolve();

--- a/LayoutTests/inspector/css/getMatchedStylesForNode-expected.txt
+++ b/LayoutTests/inspector/css/getMatchedStylesForNode-expected.txt
@@ -163,7 +163,7 @@ Matched:
           }
         ],
         "text": "div",
-        "range": "<filtered>"
+        "sourceRange": "<filtered>"
       },
       "sourceLine": "<filtered>",
       "origin": "author",
@@ -173,7 +173,7 @@ Matched:
             "name": "z-index",
             "value": "300",
             "text": "z-index: 300;",
-            "range": "<filtered>",
+            "sourceRange": "<filtered>",
             "implicit": false,
             "status": "active"
           }
@@ -182,7 +182,7 @@ Matched:
         "styleId": "<filtered>",
         "width": "",
         "height": "",
-        "range": "<filtered>",
+        "sourceRange": "<filtered>",
         "cssText": " z-index: 300; "
       },
       "sourceURL": "<filtered>",
@@ -207,7 +207,7 @@ Matched:
           }
         ],
         "text": "#x",
-        "range": "<filtered>"
+        "sourceRange": "<filtered>"
       },
       "sourceLine": "<filtered>",
       "origin": "author",
@@ -217,7 +217,7 @@ Matched:
             "name": "z-index",
             "value": "200",
             "text": "z-index: 200;",
-            "range": "<filtered>",
+            "sourceRange": "<filtered>",
             "implicit": false,
             "status": "active"
           }
@@ -226,7 +226,7 @@ Matched:
         "styleId": "<filtered>",
         "width": "",
         "height": "",
-        "range": "<filtered>",
+        "sourceRange": "<filtered>",
         "cssText": " z-index: 200; "
       },
       "sourceURL": "<filtered>",
@@ -251,7 +251,7 @@ Matched:
           }
         ],
         "text": "div#x",
-        "range": "<filtered>"
+        "sourceRange": "<filtered>"
       },
       "sourceLine": "<filtered>",
       "origin": "author",
@@ -261,7 +261,7 @@ Matched:
             "name": "z-index",
             "value": "100",
             "text": "z-index: 100;",
-            "range": "<filtered>",
+            "sourceRange": "<filtered>",
             "implicit": false,
             "status": "active"
           }
@@ -270,7 +270,7 @@ Matched:
         "styleId": "<filtered>",
         "width": "",
         "height": "",
-        "range": "<filtered>",
+        "sourceRange": "<filtered>",
         "cssText": " z-index: 100; "
       },
       "sourceURL": "<filtered>",
@@ -302,7 +302,7 @@ Pseudo:
               }
             ],
             "text": "div::first-line",
-            "range": "<filtered>"
+            "sourceRange": "<filtered>"
           },
           "sourceLine": "<filtered>",
           "origin": "author",
@@ -312,7 +312,7 @@ Pseudo:
                 "name": "z-index",
                 "value": "1",
                 "text": "z-index: 1;",
-                "range": "<filtered>",
+                "sourceRange": "<filtered>",
                 "implicit": false,
                 "status": "active"
               }
@@ -321,7 +321,7 @@ Pseudo:
             "styleId": "<filtered>",
             "width": "",
             "height": "",
-            "range": "<filtered>",
+            "sourceRange": "<filtered>",
             "cssText": " z-index: 1; "
           },
           "sourceURL": "<filtered>",
@@ -351,7 +351,7 @@ Pseudo:
               }
             ],
             "text": "div::first-letter",
-            "range": "<filtered>"
+            "sourceRange": "<filtered>"
           },
           "sourceLine": "<filtered>",
           "origin": "author",
@@ -361,7 +361,7 @@ Pseudo:
                 "name": "z-index",
                 "value": "2",
                 "text": "z-index: 2;",
-                "range": "<filtered>",
+                "sourceRange": "<filtered>",
                 "implicit": false,
                 "status": "active"
               }
@@ -370,7 +370,7 @@ Pseudo:
             "styleId": "<filtered>",
             "width": "",
             "height": "",
-            "range": "<filtered>",
+            "sourceRange": "<filtered>",
             "cssText": " z-index: 2; "
           },
           "sourceURL": "<filtered>",
@@ -400,7 +400,7 @@ Pseudo:
               }
             ],
             "text": "div::before",
-            "range": "<filtered>"
+            "sourceRange": "<filtered>"
           },
           "sourceLine": "<filtered>",
           "origin": "author",
@@ -410,7 +410,7 @@ Pseudo:
                 "name": "z-index",
                 "value": "4",
                 "text": "z-index: 4;",
-                "range": "<filtered>",
+                "sourceRange": "<filtered>",
                 "implicit": false,
                 "status": "active"
               }
@@ -419,7 +419,7 @@ Pseudo:
             "styleId": "<filtered>",
             "width": "",
             "height": "",
-            "range": "<filtered>",
+            "sourceRange": "<filtered>",
             "cssText": " z-index: 4; "
           },
           "sourceURL": "<filtered>",
@@ -449,7 +449,7 @@ Pseudo:
               }
             ],
             "text": "div::after",
-            "range": "<filtered>"
+            "sourceRange": "<filtered>"
           },
           "sourceLine": "<filtered>",
           "origin": "author",
@@ -459,7 +459,7 @@ Pseudo:
                 "name": "z-index",
                 "value": "5",
                 "text": "z-index: 5;",
-                "range": "<filtered>",
+                "sourceRange": "<filtered>",
                 "implicit": false,
                 "status": "active"
               }
@@ -468,7 +468,7 @@ Pseudo:
             "styleId": "<filtered>",
             "width": "",
             "height": "",
-            "range": "<filtered>",
+            "sourceRange": "<filtered>",
             "cssText": " z-index: 5; "
           },
           "sourceURL": "<filtered>",
@@ -498,7 +498,7 @@ Pseudo:
               }
             ],
             "text": "div::selection",
-            "range": "<filtered>"
+            "sourceRange": "<filtered>"
           },
           "sourceLine": "<filtered>",
           "origin": "author",
@@ -508,7 +508,7 @@ Pseudo:
                 "name": "z-index",
                 "value": "6",
                 "text": "z-index: 6;",
-                "range": "<filtered>",
+                "sourceRange": "<filtered>",
                 "implicit": false,
                 "status": "active"
               }
@@ -517,7 +517,7 @@ Pseudo:
             "styleId": "<filtered>",
             "width": "",
             "height": "",
-            "range": "<filtered>",
+            "sourceRange": "<filtered>",
             "cssText": " z-index: 6; "
           },
           "sourceURL": "<filtered>",
@@ -547,7 +547,7 @@ Pseudo:
               }
             ],
             "text": "div::-webkit-scrollbar",
-            "range": "<filtered>"
+            "sourceRange": "<filtered>"
           },
           "sourceLine": "<filtered>",
           "origin": "author",
@@ -557,7 +557,7 @@ Pseudo:
                 "name": "z-index",
                 "value": "7",
                 "text": "z-index: 7;",
-                "range": "<filtered>",
+                "sourceRange": "<filtered>",
                 "implicit": false,
                 "status": "active"
               }
@@ -566,7 +566,7 @@ Pseudo:
             "styleId": "<filtered>",
             "width": "",
             "height": "",
-            "range": "<filtered>",
+            "sourceRange": "<filtered>",
             "cssText": " z-index: 7; "
           },
           "sourceURL": "<filtered>",
@@ -596,7 +596,7 @@ Pseudo:
               }
             ],
             "text": "div::-webkit-scrollbar-thumb",
-            "range": "<filtered>"
+            "sourceRange": "<filtered>"
           },
           "sourceLine": "<filtered>",
           "origin": "author",
@@ -606,7 +606,7 @@ Pseudo:
                 "name": "z-index",
                 "value": "8",
                 "text": "z-index: 8;",
-                "range": "<filtered>",
+                "sourceRange": "<filtered>",
                 "implicit": false,
                 "status": "active"
               }
@@ -615,7 +615,7 @@ Pseudo:
             "styleId": "<filtered>",
             "width": "",
             "height": "",
-            "range": "<filtered>",
+            "sourceRange": "<filtered>",
             "cssText": " z-index: 8; "
           },
           "sourceURL": "<filtered>",
@@ -645,7 +645,7 @@ Pseudo:
               }
             ],
             "text": "div::-webkit-scrollbar-button",
-            "range": "<filtered>"
+            "sourceRange": "<filtered>"
           },
           "sourceLine": "<filtered>",
           "origin": "author",
@@ -655,7 +655,7 @@ Pseudo:
                 "name": "z-index",
                 "value": "9",
                 "text": "z-index: 9;",
-                "range": "<filtered>",
+                "sourceRange": "<filtered>",
                 "implicit": false,
                 "status": "active"
               }
@@ -664,7 +664,7 @@ Pseudo:
             "styleId": "<filtered>",
             "width": "",
             "height": "",
-            "range": "<filtered>",
+            "sourceRange": "<filtered>",
             "cssText": " z-index: 9; "
           },
           "sourceURL": "<filtered>",
@@ -694,7 +694,7 @@ Pseudo:
               }
             ],
             "text": "div::-webkit-scrollbar-track",
-            "range": "<filtered>"
+            "sourceRange": "<filtered>"
           },
           "sourceLine": "<filtered>",
           "origin": "author",
@@ -704,7 +704,7 @@ Pseudo:
                 "name": "z-index",
                 "value": "10",
                 "text": "z-index: 10;",
-                "range": "<filtered>",
+                "sourceRange": "<filtered>",
                 "implicit": false,
                 "status": "active"
               }
@@ -713,7 +713,7 @@ Pseudo:
             "styleId": "<filtered>",
             "width": "",
             "height": "",
-            "range": "<filtered>",
+            "sourceRange": "<filtered>",
             "cssText": " z-index: 10; "
           },
           "sourceURL": "<filtered>",
@@ -743,7 +743,7 @@ Pseudo:
               }
             ],
             "text": "div::-webkit-scrollbar-track-piece",
-            "range": "<filtered>"
+            "sourceRange": "<filtered>"
           },
           "sourceLine": "<filtered>",
           "origin": "author",
@@ -753,7 +753,7 @@ Pseudo:
                 "name": "z-index",
                 "value": "11",
                 "text": "z-index: 11;",
-                "range": "<filtered>",
+                "sourceRange": "<filtered>",
                 "implicit": false,
                 "status": "active"
               }
@@ -762,7 +762,7 @@ Pseudo:
             "styleId": "<filtered>",
             "width": "",
             "height": "",
-            "range": "<filtered>",
+            "sourceRange": "<filtered>",
             "cssText": " z-index: 11; "
           },
           "sourceURL": "<filtered>",
@@ -792,7 +792,7 @@ Pseudo:
               }
             ],
             "text": "div::-webkit-scrollbar-corner",
-            "range": "<filtered>"
+            "sourceRange": "<filtered>"
           },
           "sourceLine": "<filtered>",
           "origin": "author",
@@ -802,7 +802,7 @@ Pseudo:
                 "name": "z-index",
                 "value": "12",
                 "text": "z-index: 12;",
-                "range": "<filtered>",
+                "sourceRange": "<filtered>",
                 "implicit": false,
                 "status": "active"
               }
@@ -811,7 +811,7 @@ Pseudo:
             "styleId": "<filtered>",
             "width": "",
             "height": "",
-            "range": "<filtered>",
+            "sourceRange": "<filtered>",
             "cssText": " z-index: 12; "
           },
           "sourceURL": "<filtered>",
@@ -841,7 +841,7 @@ Pseudo:
               }
             ],
             "text": "div::-webkit-resizer",
-            "range": "<filtered>"
+            "sourceRange": "<filtered>"
           },
           "sourceLine": "<filtered>",
           "origin": "author",
@@ -851,7 +851,7 @@ Pseudo:
                 "name": "z-index",
                 "value": "13",
                 "text": "z-index: 13;",
-                "range": "<filtered>",
+                "sourceRange": "<filtered>",
                 "implicit": false,
                 "status": "active"
               }
@@ -860,7 +860,7 @@ Pseudo:
             "styleId": "<filtered>",
             "width": "",
             "height": "",
-            "range": "<filtered>",
+            "sourceRange": "<filtered>",
             "cssText": " z-index: 13; "
           },
           "sourceURL": "<filtered>",
@@ -893,7 +893,7 @@ Inherited:
               }
             ],
             "text": "body",
-            "range": "<filtered>"
+            "sourceRange": "<filtered>"
           },
           "sourceLine": "<filtered>",
           "origin": "author",
@@ -903,7 +903,7 @@ Inherited:
                 "name": "color",
                 "value": "red",
                 "text": "color: red;",
-                "range": "<filtered>",
+                "sourceRange": "<filtered>",
                 "implicit": false,
                 "status": "active"
               }
@@ -912,7 +912,7 @@ Inherited:
             "styleId": "<filtered>",
             "width": "",
             "height": "",
-            "range": "<filtered>",
+            "sourceRange": "<filtered>",
             "cssText": " color: red; "
           },
           "sourceURL": "<filtered>",
@@ -944,7 +944,7 @@ Inherited:
               }
             ],
             "text": "body",
-            "range": "<filtered>"
+            "sourceRange": "<filtered>"
           },
           "sourceLine": "<filtered>",
           "origin": "author",
@@ -954,7 +954,7 @@ Inherited:
                 "name": "color",
                 "value": "red",
                 "text": "color: red;",
-                "range": "<filtered>",
+                "sourceRange": "<filtered>",
                 "implicit": false,
                 "status": "active"
               }
@@ -963,7 +963,7 @@ Inherited:
             "styleId": "<filtered>",
             "width": "",
             "height": "",
-            "range": "<filtered>",
+            "sourceRange": "<filtered>",
             "cssText": " color: red; "
           },
           "sourceURL": "<filtered>",
@@ -988,7 +988,7 @@ Inherited:
               }
             ],
             "text": "body",
-            "range": "<filtered>"
+            "sourceRange": "<filtered>"
           },
           "sourceLine": "<filtered>",
           "origin": "author",
@@ -998,7 +998,7 @@ Inherited:
                 "name": "color",
                 "value": "red",
                 "text": "color: red;",
-                "range": "<filtered>",
+                "sourceRange": "<filtered>",
                 "implicit": false,
                 "status": "active"
               }
@@ -1007,7 +1007,7 @@ Inherited:
             "styleId": "<filtered>",
             "width": "",
             "height": "",
-            "range": "<filtered>",
+            "sourceRange": "<filtered>",
             "cssText": " color: red; "
           },
           "sourceURL": "<filtered>",
@@ -1017,7 +1017,7 @@ Inherited:
               "type": "media-rule",
               "ruleId": "<filtered>",
               "text": "(min-width: 1px)",
-              "range": "<filtered>",
+              "sourceRange": "<filtered>",
               "sourceURL": "<filtered>"
             }
           ],
@@ -1041,7 +1041,7 @@ Inherited:
               }
             ],
             "text": "body",
-            "range": "<filtered>"
+            "sourceRange": "<filtered>"
           },
           "sourceLine": "<filtered>",
           "origin": "author",
@@ -1051,7 +1051,7 @@ Inherited:
                 "name": "color",
                 "value": "red",
                 "text": "color: red;",
-                "range": "<filtered>",
+                "sourceRange": "<filtered>",
                 "implicit": false,
                 "status": "active"
               }
@@ -1060,7 +1060,7 @@ Inherited:
             "styleId": "<filtered>",
             "width": "",
             "height": "",
-            "range": "<filtered>",
+            "sourceRange": "<filtered>",
             "cssText": " color: red; "
           },
           "sourceURL": "<filtered>",
@@ -1070,14 +1070,14 @@ Inherited:
               "type": "supports-rule",
               "ruleId": "<filtered>",
               "text": "(display: block)",
-              "range": "<filtered>",
+              "sourceRange": "<filtered>",
               "sourceURL": "<filtered>"
             },
             {
               "type": "media-rule",
               "ruleId": "<filtered>",
               "text": "(min-width: 2px)",
-              "range": "<filtered>",
+              "sourceRange": "<filtered>",
               "sourceURL": "<filtered>"
             }
           ],
@@ -1101,7 +1101,7 @@ Inherited:
               }
             ],
             "text": "body",
-            "range": "<filtered>"
+            "sourceRange": "<filtered>"
           },
           "sourceLine": "<filtered>",
           "origin": "author",
@@ -1111,7 +1111,7 @@ Inherited:
                 "name": "color",
                 "value": "red",
                 "text": "color: red;",
-                "range": "<filtered>",
+                "sourceRange": "<filtered>",
                 "implicit": false,
                 "status": "active"
               }
@@ -1120,7 +1120,7 @@ Inherited:
             "styleId": "<filtered>",
             "width": "",
             "height": "",
-            "range": "<filtered>",
+            "sourceRange": "<filtered>",
             "cssText": " color: red;"
           },
           "sourceURL": "<filtered>",
@@ -1152,7 +1152,7 @@ Inherited:
               }
             ],
             "text": "body",
-            "range": "<filtered>"
+            "sourceRange": "<filtered>"
           },
           "sourceLine": "<filtered>",
           "origin": "author",
@@ -1162,7 +1162,7 @@ Inherited:
                 "name": "color",
                 "value": "red",
                 "text": "color: red;",
-                "range": "<filtered>",
+                "sourceRange": "<filtered>",
                 "implicit": false,
                 "status": "active"
               }
@@ -1171,7 +1171,7 @@ Inherited:
             "styleId": "<filtered>",
             "width": "",
             "height": "",
-            "range": "<filtered>",
+            "sourceRange": "<filtered>",
             "cssText": " color: red; "
           },
           "sourceURL": "<filtered>",

--- a/LayoutTests/inspector/css/getMatchedStylesForNode.html
+++ b/LayoutTests/inspector/css/getMatchedStylesForNode.html
@@ -85,7 +85,7 @@ function test()
         }
 
         function replacer(key, value) {
-            if (key === "ruleId" || key === "styleId" || key === "range" || key === "sourceLine" || key === "sourceURL")
+            if (key === "ruleId" || key === "styleId" || key === "sourceRange" || key === "sourceLine" || key === "sourceURL")
                 return "<filtered>";
             return value;
         }

--- a/LayoutTests/inspector/debugger/breakpoints/resources/dump.js
+++ b/LayoutTests/inspector/debugger/breakpoints/resources/dump.js
@@ -126,19 +126,21 @@ TestPage.registerInitializer(() => {
                                 let inputLocation = {lineNumber: line, columnNumber: 0};
                                 let resolvedLocation = script.createSourceCodeLocation(payload.lineNumber, payload.columnNumber);
                                 InspectorTest.log(`INSERTING AT: ${inputLocation.lineNumber}:${inputLocation.columnNumber}`);
-                                InspectorTest.log(`PAUSES AT: ${payload.lineNumber}:${payload.columnNumber}`);                                
+                                InspectorTest.log(`PAUSES AT: ${payload.lineNumber}:${payload.columnNumber}`);
                                 window.logResolvedBreakpointLinesWithContext(inputLocation, resolvedLocation, 3);
                             }
                         });
 
-                        let start = createLocation(script, line, 0);
-                        let end = createLocation(script, line, lines[line].length);
-                        DebuggerAgent.getBreakpointLocations(start, end, (error, locations) => {
-                            InspectorTest.log(`LOCATIONS FROM ${start.lineNumber}:${start.columnNumber} to ${end.lineNumber}:${end.columnNumber}`);
+                        let range = {
+                            start: {line, column: 0},
+                            end: {line, column: lines[line].length},
+                        };
+                        DebuggerAgent.getBreakpointSourcePositions(script.id, range, (error, locations) => {
+                            InspectorTest.log(`LOCATIONS FROM ${range.start.line}:${range.start.column} to ${range.end.line}:${range.end.column}`);
                             if (error)
                                 InspectorTest.log(`PRODUCES: ${error}`);
                             else
-                                window.logResolvedBreakpointLocationsInRange(start, end, locations.map((location) => script.createSourceCodeLocation(location.lineNumber, location.columnNumber)));
+                                window.logResolvedBreakpointLocationsInRange(range, locations.map(({line, column}) => script.createSourceCodeLocation(line, column)));
                         });
 
                         // Clear the breakpoint we just set without knowing its breakpoint identifier.

--- a/LayoutTests/inspector/debugger/resources/log-pause-location.js
+++ b/LayoutTests/inspector/debugger/resources/log-pause-location.js
@@ -106,23 +106,23 @@ TestPage.registerInitializer(() => {
         }
     }
 
-    window.logResolvedBreakpointLocationsInRange = function(start, end, resolvedLocations) {
-        InspectorTest.assert(!resolvedLocations.length || start.lineNumber < resolvedLocations.firstValue.lineNumber || start.columnNumber <= resolvedLocations.firstValue.columnNumber, "Start position should always come before first resolved location position.");
-        InspectorTest.assert(!resolvedLocations.length || end.lineNumber > resolvedLocations.lastValue.lineNumber || end.columnNumber > resolvedLocations.lastValue.columnNumber, "End position should always come after last resolved position.");
+    window.logResolvedBreakpointLocationsInRange = function(range, resolvedLocations) {
+        InspectorTest.assert(!resolvedLocations.length || range.start.line < resolvedLocations.firstValue.lineNumber || range.start.column <= resolvedLocations.firstValue.columnNumber, "Start position should always come before first resolved location position.");
+        InspectorTest.assert(!resolvedLocations.length || range.end.line > resolvedLocations.lastValue.lineNumber || range.end.column > resolvedLocations.lastValue.columnNumber, "End position should always come after last resolved position.");
 
         const inputCaret = "#";
         const resolvedCaret = "|";
 
-        for (let lineNumber = start.lineNumber; lineNumber <= end.lineNumber; ++lineNumber) {
+        for (let lineNumber = range.start.line; lineNumber <= range.end.line; ++lineNumber) {
             let lineContent = lines[lineNumber];
             if (typeof lineContent !== "string")
                 continue;
 
-            if (lineNumber === start.lineNumber)
-                lineContent = " ".repeat(start.columnNumber) + lineContent.slice(start.columnNumber);
+            if (lineNumber === range.start.line)
+                lineContent = " ".repeat(range.start.column) + lineContent.slice(range.start.column);
 
-            if (lineNumber === end.lineNumber)
-                lineContent = lineContent.slice(0, end.columnNumber)
+            if (lineNumber === range.end.line)
+                lineContent = lineContent.slice(0, range.end.column)
 
             for (let i = resolvedLocations.length - 1; i >= 0; --i) {
                 let resolvedLocation = resolvedLocations[i];

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -809,6 +809,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     inspector/InspectorProtocolTypes.h
     inspector/InspectorTarget.h
     inspector/PerGlobalObjectWrapperWorld.h
+    inspector/ProtocolUtilities.h
     inspector/ScriptArguments.h
     inspector/ScriptCallFrame.h
     inspector/ScriptCallStack.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1431,6 +1431,7 @@
 		9177A1DC22F958D500B34CA2 /* HeapAnalyzer.h in Headers */ = {isa = PBXBuildFile; fileRef = 9177A1DB22F958D300B34CA2 /* HeapAnalyzer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		918E15C12447B22700447A56 /* AggregateErrorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 918E15BD2447B22600447A56 /* AggregateErrorPrototype.h */; };
 		918E15C32447B22700447A56 /* AggregateErrorConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 918E15BF2447B22700447A56 /* AggregateErrorConstructor.h */; };
+		91DF80BB2C1FB21700BD3657 /* ProtocolUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 91DF80B92C1FB20900BD3657 /* ProtocolUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		93052C350FB792190048FDC3 /* ParserArena.h in Headers */ = {isa = PBXBuildFile; fileRef = 93052C330FB792190048FDC3 /* ParserArena.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		932F5BDD0822A1C700736975 /* jsc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 45E12D8806A49B0F00E9DF84 /* jsc.cpp */; };
 		933040040E6A749400786E6A /* SmallStrings.h in Headers */ = {isa = PBXBuildFile; fileRef = 93303FEA0E6A72C000786E6A /* SmallStrings.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -4728,6 +4729,8 @@
 		918E15BE2447B22700447A56 /* AggregateErrorPrototype.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AggregateErrorPrototype.cpp; sourceTree = "<group>"; };
 		918E15BF2447B22700447A56 /* AggregateErrorConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AggregateErrorConstructor.h; sourceTree = "<group>"; };
 		91D1578C24E0BE35001F4CED /* Breakpoint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Breakpoint.cpp; sourceTree = "<group>"; };
+		91DF80B82C1FB20900BD3657 /* ProtocolUtilities.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ProtocolUtilities.cpp; sourceTree = "<group>"; };
+		91DF80B92C1FB20900BD3657 /* ProtocolUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProtocolUtilities.h; sourceTree = "<group>"; };
 		91F548A52A4CF448007292DE /* MapConstructor.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = MapConstructor.js; sourceTree = "<group>"; };
 		91FD55322A4CF52100F5D482 /* MapConstructor.lut.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MapConstructor.lut.h; sourceTree = "<group>"; };
 		93052C320FB792190048FDC3 /* ParserArena.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ParserArena.cpp; sourceTree = "<group>"; };
@@ -9768,6 +9771,8 @@
 				A503FA18188E0FB000110F14 /* JSJavaScriptCallFramePrototype.h */,
 				A5AB49DA1BEC8079007020FB /* PerGlobalObjectWrapperWorld.cpp */,
 				A5AB49DB1BEC8079007020FB /* PerGlobalObjectWrapperWorld.h */,
+				91DF80B82C1FB20900BD3657 /* ProtocolUtilities.cpp */,
+				91DF80B92C1FB20900BD3657 /* ProtocolUtilities.h */,
 				A5FD0065189AFE9C00633231 /* ScriptArguments.cpp */,
 				A5FD0066189AFE9C00633231 /* ScriptArguments.h */,
 				A5FD0069189B00A900633231 /* ScriptCallFrame.cpp */,
@@ -11546,6 +11551,7 @@
 				276B39142A71D2B600252F4E /* PropertyTableInlines.h in Headers */,
 				BC18C4560E16F5CD00B34460 /* Protect.h in Headers */,
 				FE1D6D752362649F007A5C26 /* ProtoCallFrameInlines.h in Headers */,
+				91DF80BB2C1FB21700BD3657 /* ProtocolUtilities.h in Headers */,
 				0F74B93B1F89614800B935D3 /* PrototypeKey.h in Headers */,
 				534E03561E53BEDE00213F64 /* ProxyableAccessCase.h in Headers */,
 				79B00CBD1C6AB07E0088C65D /* ProxyConstructor.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -615,6 +615,7 @@ inspector/JSJavaScriptCallFrame.cpp
 inspector/JSJavaScriptCallFramePrototype.cpp
 inspector/JavaScriptCallFrame.cpp
 inspector/PerGlobalObjectWrapperWorld.cpp
+inspector/ProtocolUtilities.cpp
 inspector/ScriptArguments.cpp
 inspector/ScriptCallFrame.cpp
 inspector/ScriptCallStack.cpp

--- a/Source/JavaScriptCore/inspector/ProtocolUtilities.cpp
+++ b/Source/JavaScriptCore/inspector/ProtocolUtilities.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2024 Devin Rousso <webkit@devinrousso.com>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ProtocolUtilities.h"
+
+#include <wtf/text/TextPosition.h>
+
+namespace Inspector {
+
+namespace Protocol {
+
+ErrorStringOr<TextPosition> parseSourcePosition(Ref<JSON::Object>&& payload)
+{
+    auto lineValue = payload->getInteger("line"_s);
+    if (!lineValue)
+        return makeUnexpected("Unexpected non-integer line"_s);
+
+    auto columnValue = payload->getInteger("column"_s);
+    if (!columnValue)
+        return makeUnexpected("Unexpected non-integer column"_s);
+
+    return { { OrdinalNumber::fromZeroBasedInt(*lineValue), OrdinalNumber::fromZeroBasedInt(*columnValue) } };
+}
+
+Ref<GenericTypes::SourcePosition> buildSourcePosition(const TextPosition& position)
+{
+    return GenericTypes::SourcePosition::create()
+        .setLine(position.m_line.zeroBasedInt())
+        .setColumn(position.m_column.zeroBasedInt())
+        .release();
+}
+
+ErrorStringOr<std::pair<TextPosition, TextPosition>> parseSourceRange(Ref<JSON::Object>&& payload)
+{
+    auto startObject = payload->getObject("start"_s);
+    if (!startObject)
+        return makeUnexpected("Unexpected non-object start"_s);
+
+    auto start = parseSourcePosition(startObject.releaseNonNull());
+    if (!start)
+        return makeUnexpected(start.error());
+
+    auto endObject = payload->getObject("end"_s);
+    if (!endObject)
+        return makeUnexpected("Unexpected non-object end"_s);
+
+    auto end = parseSourcePosition(endObject.releaseNonNull());
+    if (!end)
+        return makeUnexpected(end.error());
+
+    if (*start > *end)
+        return makeUnexpected("Unexpected end before start"_s);
+
+    return { { *start, *end } };
+}
+
+Ref<GenericTypes::SourceRange> buildSourceRange(const std::pair<TextPosition, TextPosition>& range)
+{
+    return GenericTypes::SourceRange::create()
+        .setStart(buildSourcePosition(range.first))
+        .setEnd(buildSourcePosition(range.second))
+        .release();
+}
+
+} // namespace Protocol
+
+} // namespace Inspector

--- a/Source/JavaScriptCore/inspector/ProtocolUtilities.h
+++ b/Source/JavaScriptCore/inspector/ProtocolUtilities.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 Devin Rousso <webkit@devinrousso.com>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "InspectorProtocolObjects.h"
+#include <wtf/Forward.h>
+
+namespace Inspector {
+
+namespace Protocol {
+
+JS_EXPORT_PRIVATE ErrorStringOr<TextPosition> parseSourcePosition(Ref<JSON::Object>&&);
+JS_EXPORT_PRIVATE Ref<GenericTypes::SourcePosition> buildSourcePosition(const TextPosition&);
+
+JS_EXPORT_PRIVATE ErrorStringOr<std::pair<TextPosition, TextPosition>> parseSourceRange(Ref<JSON::Object>&&);
+JS_EXPORT_PRIVATE Ref<GenericTypes::SourceRange> buildSourceRange(const std::pair<TextPosition, TextPosition>&);
+
+} // namespace Protocol
+
+} // namespace Inspector

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
@@ -91,7 +91,7 @@ public:
     Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::GenericTypes::SearchMatch>>> searchInContent(const Protocol::Debugger::ScriptId&, const String& query, std::optional<bool>&& caseSensitive, std::optional<bool>&& isRegex) final;
     Protocol::ErrorStringOr<String> getScriptSource(const Protocol::Debugger::ScriptId&) final;
     Protocol::ErrorStringOr<Ref<Protocol::Debugger::FunctionDetails>> getFunctionDetails(const String& functionId) final;
-    Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::Debugger::Location>>> getBreakpointLocations(Ref<JSON::Object>&& start, Ref<JSON::Object>&& end) final;
+    Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Protocol::GenericTypes::SourcePosition>>> getBreakpointSourcePositions(const Protocol::Debugger::ScriptId&, Ref<JSON::Object>&& sourceRange) final;
     Protocol::ErrorStringOr<void> setPauseOnDebuggerStatements(bool enabled, RefPtr<JSON::Object>&& options) final;
     Protocol::ErrorStringOr<void> setPauseOnExceptions(const String& state, RefPtr<JSON::Object>&& options) final;
     Protocol::ErrorStringOr<void> setPauseOnAssertions(bool enabled, RefPtr<JSON::Object>&& options) final;

--- a/Source/JavaScriptCore/inspector/protocol/CSS.json
+++ b/Source/JavaScriptCore/inspector/protocol/CSS.json
@@ -119,7 +119,7 @@
             "properties": [
                 { "name": "selectors", "type": "array", "items": { "$ref": "CSSSelector" }, "description": "Selectors in the list." },
                 { "name": "text", "type": "string", "description": "Rule selector text." },
-                { "name": "range", "$ref": "SourceRange", "optional": true, "description": "Rule selector range in the underlying resource (if available)." }
+                { "name": "sourceRange", "$ref": "GenericTypes.SourceRange", "optional": true, "description": "Rule selector range in the underlying resource (if available)." }
             ]
         },
         {
@@ -173,17 +173,6 @@
             ]
         },
         {
-            "id": "SourceRange",
-            "type": "object",
-            "description": "Text range within a resource.",
-            "properties": [
-                { "name": "startLine", "type": "integer", "description": "Start line of range." },
-                { "name": "startColumn", "type": "integer", "description": "Start column of range (inclusive)." },
-                { "name": "endLine", "type": "integer", "description": "End line of range" },
-                { "name": "endColumn", "type": "integer", "description": "End column of range (exclusive)." }
-            ]
-        },
-        {
             "id": "ShorthandEntry",
             "type": "object",
             "properties": [
@@ -219,7 +208,7 @@
                 { "name": "cssProperties", "type": "array", "items": { "$ref": "CSSProperty" }, "description": "CSS properties in the style." },
                 { "name": "shorthandEntries", "type": "array", "items": { "$ref": "ShorthandEntry" }, "description": "Computed values for all shorthands found in the style." },
                 { "name": "cssText", "type": "string", "optional": true, "description": "Style declaration text (if available)." },
-                { "name": "range", "$ref": "SourceRange", "optional": true, "description": "Style declaration range in the enclosing stylesheet (if available)." },
+                { "name": "sourceRange", "$ref": "GenericTypes.SourceRange", "optional": true, "description": "Style declaration range in the enclosing stylesheet (if available)." },
                 { "name": "width", "type": "string", "optional": true, "description": "The effective \"width\" property value from this style." },
                 { "name": "height", "type": "string", "optional": true, "description": "The effective \"height\" property value from this style." }
             ]
@@ -242,7 +231,7 @@
                 { "name": "text", "type": "string", "optional": true, "description": "The full property text as specified in the style." },
                 { "name": "parsedOk", "type": "boolean", "optional": true, "description": "Whether the property is understood by the browser (implies <code>true</code> if absent)." },
                 { "name": "status", "$ref": "CSSPropertyStatus", "optional": true, "description": "Whether the property is active or disabled." },
-                { "name": "range", "$ref": "SourceRange", "optional": true, "description": "The entire property range in the enclosing style declaration (if available)." }
+                { "name": "sourceRange", "$ref": "GenericTypes.SourceRange", "optional": true, "description": "The entire property range in the enclosing style declaration (if available)." }
             ]
         },
         {
@@ -254,7 +243,7 @@
                 { "name": "ruleId", "$ref": "CSSRuleId", "optional": true, "description": "The CSS rule identifier for the `@rule` (absent for non-editable grouping rules) or the nesting parent style rule's selector. In CSSOM terms, this is the parent rule of either the previous Grouping for a CSSRule, or of a CSSRule itself."},
                 { "name": "text", "type": "string", "optional": true, "description": "Query text if specified by a @media, @supports, or @container rule. Layer name (or not present for anonymous layers) for @layer rules." },
                 { "name": "sourceURL", "type": "string", "optional": true, "description": "URL of the document containing the CSS grouping." },
-                { "name": "range", "$ref": "SourceRange", "optional": true, "description": "@-rule's header text range in the enclosing stylesheet (if available). This is from the first non-whitespace character after the @ declarartion to the last non-whitespace character before an opening curly bracket or semicolon." }
+                { "name": "sourceRange", "$ref": "GenericTypes.SourceRange", "optional": true, "description": "@-rule's header text range in the enclosing stylesheet (if available). This is from the first non-whitespace character after the @ declarartion to the last non-whitespace character before an opening curly bracket or semicolon." }
             ]
         },
         {

--- a/Source/JavaScriptCore/inspector/protocol/Debugger.json
+++ b/Source/JavaScriptCore/inspector/protocol/Debugger.json
@@ -274,14 +274,14 @@
             ]
         },
         {
-            "name": "getBreakpointLocations",
-            "description": "Returns a list of valid breakpoint locations within the given location range.",
+            "name": "getBreakpointSourcePositions",
+            "description": "Returns a list of valid breakpoint source positions within the given location range.",
             "parameters": [
-                { "name": "start", "$ref": "Location", "description": "Starting location to look for breakpoint locations after (inclusive). Must have same scriptId as end." },
-                { "name": "end", "$ref": "Location", "description": "Ending location to look for breakpoint locations before (exclusive). Must have same scriptId as start." }
+                { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to search." },
+                { "name": "sourceRange", "$ref": "GenericTypes.SourceRange", "description": "Range to look for breakpoint source positions." }
             ],
             "returns": [
-                { "name": "locations", "type": "array", "items": { "$ref": "Location" }, "description": "List of resolved breakpoint locations." }
+                { "name": "sourcePositions", "type": "array", "items": { "$ref": "GenericTypes.SourcePosition" }, "description": "List of resolved breakpoint source positions." }
             ]
         },
         {

--- a/Source/JavaScriptCore/inspector/protocol/GenericTypes.json
+++ b/Source/JavaScriptCore/inspector/protocol/GenericTypes.json
@@ -3,6 +3,22 @@
     "description": "Exposes generic types to be used by any domain.",
     "types": [
         {
+            "id": "SourcePosition",
+            "type": "object",
+            "properties": [
+                { "name": "line", "type": "integer", "description": "Line number (0-based)." },
+                { "name": "column", "type": "integer", "description": "Column number (0-based)." }
+            ]
+        },
+        {
+            "id": "SourceRange",
+            "type": "object",
+            "properties": [
+                { "name": "start", "$ref": "SourcePosition", "description": "Start of range (inclusive)." },
+                { "name": "end", "$ref": "SourcePosition", "description": "End of range (exclusive)." }
+            ]
+        },
+        {
             "id": "SearchMatch",
             "type": "object",
             "description": "Search match in a resource.",

--- a/Source/WTF/wtf/text/OrdinalNumber.h
+++ b/Source/WTF/wtf/text/OrdinalNumber.h
@@ -42,7 +42,7 @@ public:
     int oneBasedInt() const { return m_zeroBasedValue + 1; }
 
     friend bool operator==(OrdinalNumber, OrdinalNumber) = default;
-    bool operator>(OrdinalNumber other) const { return m_zeroBasedValue > other.m_zeroBasedValue; }
+    friend std::strong_ordering operator<=>(OrdinalNumber, OrdinalNumber) = default;
 
 private:
     OrdinalNumber(int zeroBasedInt) : m_zeroBasedValue(zeroBasedInt) { }

--- a/Source/WTF/wtf/text/TextPosition.h
+++ b/Source/WTF/wtf/text/TextPosition.h
@@ -41,6 +41,11 @@ public:
 
     TextPosition() { }
     friend bool operator==(const TextPosition&, const TextPosition&) = default;
+    friend std::strong_ordering operator<=>(const TextPosition& a, const TextPosition& b)
+    {
+        auto lineComparison = a.m_line <=> b.m_line;
+        return lineComparison != std::strong_ordering::equal ? lineComparison : a.m_column <=> b.m_column;
+    }
 
     // A value with line value less than a minimum; used as an impossible position.
     static TextPosition belowRangePosition() { return TextPosition(OrdinalNumber::beforeFirst(), OrdinalNumber::beforeFirst()); }

--- a/Source/WebInspectorUI/UserInterface/Models/CSSRule.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSRule.js
@@ -127,18 +127,22 @@ WI.CSSRule = class CSSRule extends WI.Object
         let selectors = WI.DOMNodeStyles.parseSelectorListPayload(rulePayload.selectorList);
 
         let sourceCodeLocation = null;
-        let sourceRange = rulePayload.selectorList.range;
+        // COMPATIBILITY (macOS X.Y, iOS X.Y): CSS.SourceRange was renamed to GenericTypes.SourceRange.
+        let sourceRange = rulePayload.selectorList.sourceRange ?? rulePayload.selectorList.range;
         if (sourceRange) {
             sourceCodeLocation = WI.DOMNodeStyles.createSourceCodeLocation(rulePayload.sourceURL, {
-                line: sourceRange.startLine,
-                column: sourceRange.startColumn,
+                // COMPATIBILITY (macOS X.Y, iOS X.Y): CSS.SourceRange was renamed to GenericTypes.SourceRange.
+                line: sourceRange.start?.line ?? sourceRange.startLine,
+                column: sourceRange.start?.column ?? sourceRange.startColumn,
                 documentNode: this._nodeStyles.node.ownerDocument,
             });
         }
 
         if (this._ownerStyleSheet) {
-            if (!sourceCodeLocation && sourceRange)
-                sourceCodeLocation = this._ownerStyleSheet.createSourceCodeLocation(sourceRange.startLine, sourceRange.startColumn);
+            if (!sourceCodeLocation && sourceRange) {
+                // COMPATIBILITY (macOS X.Y, iOS X.Y): CSS.SourceRange was renamed to GenericTypes.SourceRange.
+                sourceCodeLocation = this._ownerStyleSheet.createSourceCodeLocation(sourceRange.start?.line ?? sourceRange.startLine, sourceRange.start?.column ?? sourceRange.startColumn);
+            }
             sourceCodeLocation = this._ownerStyleSheet.offsetSourceCodeLocation(sourceCodeLocation);
         }
 


### PR DESCRIPTION
#### 18300722b1a58bf797f504417858a29474ae6049
<pre>
Web Inspector: introduce some additional protocol GenericTypes
<a href="https://bugs.webkit.org/show_bug.cgi?id=275553">https://bugs.webkit.org/show_bug.cgi?id=275553</a>

Reviewed by NOBODY (OOPS!).

This will make it easier to implement things like blackboxing ranges within a file &lt;<a href="https://webkit.org/b/275552">https://webkit.org/b/275552</a>&gt; since now there&apos;s a common understanding of what a &quot;range&quot; is.

* Source/JavaScriptCore/inspector/protocol/GenericTypes.json:
* Source/JavaScriptCore/inspector/protocol/CSS.json:
* Source/JavaScriptCore/inspector/protocol/Debugger.json:
Add `SourcePosition` and move `SourceRange` to `GenericTypes`.

* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h:
* Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.cpp:
(Inspector::InspectorDebuggerAgent::getBreakpointSourcePositions): Added.
(Inspector::InspectorDebuggerAgent::getBreakpointLocations): Deleted.
* Source/WebInspectorUI/UserInterface/Models/Script.js:
(WI.Script.prototype.async breakpointLocations):
* LayoutTests/inspector/debugger/breakpoints/resources/dump.js:
(addDumpEachLinePauseLocationTestCase):
* LayoutTests/inspector/debugger/resources/log-pause-location.js:
(logResolvedBreakpointLocationsInRange):
Use `GenericTypes.SourcePosition` instead of `Debugger.Location` as it doesn&apos;t require providing a `Debugger.ScriptId`.

* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::buildSourceRangeObject):
(WebCore::InspectorStyleSheet::buildObjectForGrouping):
(WebCore::InspectorStyle::buildObjectForStyle const):
(WebCore::InspectorStyle::styleWithProperties const):
(WebCore::InspectorStyleSheet::buildObjectForSelectorList):
* Source/WebInspectorUI/UserInterface/Models/CSSRule.js:
(WI.CSSRule.prototype._selectorResolved):
* Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js:
(WI.DOMNodeStyles.prototype._parseSourceRangePayload):
(WI.DOMNodeStyles.prototype._parseStylePropertyPayload):
(WI.DOMNodeStyles.prototype._parseStyleDeclarationPayload):
(WI.DOMNodeStyles.prototype._parseRulePayload):
* LayoutTests/inspector/css/add-rule.html:
* LayoutTests/inspector/css/getMatchedStylesForNode-expected.txt:
* LayoutTests/inspector/css/getMatchedStylesForNode.html:
Use `GenericTypes.SourceRange` instead of `CSS.SourceRange` as it&apos;s organized more nicely.

* Source/JavaScriptCore/inspector/ProtocolUtilities.h: Added.
* Source/JavaScriptCore/inspector/ProtocolUtilities.cpp: Added.
(Inspector::Protocol::parseSourcePosition):
(Inspector::Protocol::buildSourcePosition):
(Inspector::Protocol::parseSourceRange):
(Inspector::Protocol::buildSourceRange):
Add a utility file for converting to/from protocol objects defined in `GenericTypes`.

* Source/WTF/wtf/text/OrdinalNumber.h:
(WTF::OrdinalNumber::operator&lt;=&gt;): Added.
(WTF::OrdinalNumber::operator&gt; const): Deleted.
* Source/WTF/wtf/text/TextPosition.h:
(WTF::TextPosition::operator&lt;=&gt;): Added.
Add comparison operators to make it easier to reason about source positions within source ranges.

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18300722b1a58bf797f504417858a29474ae6049

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/34993 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58654 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6100 "Hash 18300722 for PR 29881 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57796 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6299 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44831 "Passed tests") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/59/builds/6100 "Hash 18300722 for PR 29881 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57699 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32893 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/47983 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25964 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29680 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5312 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4244 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/48747 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51659 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5579 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60245 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/54907 "Built successfully and passed tests") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5707 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52262 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48053 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51750 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/76668 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30824 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12773 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31909 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/32990 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31656 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->