### PR TITLE
Backdrop filter isn't rendered when the element changes to a non-zero size.

### DIFF
--- a/LayoutTests/css3/filters/backdrop/resource-use-add-more-layers.html
+++ b/LayoutTests/css3/filters/backdrop/resource-use-add-more-layers.html
@@ -6,7 +6,7 @@
 <div></div>
 <!-- then add a bunch via script, as children to the first div, eventually pushing us over the limit -->
 <script>
-const doNotAutomaticallyCallLayerTree = true;
+window.doNotAutomaticallyCallLayerTree = true;
 
 window.addEventListener("load", () => {
     const firstDiv = document.querySelector("div");

--- a/LayoutTests/css3/filters/backdrop/resource-use-change-size-from-zero-expected.txt
+++ b/LayoutTests/css3/filters/backdrop/resource-use-change-size-from-zero-expected.txt
@@ -1,0 +1,24 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 200.00 200.00)
+          (structural layer
+            (position 100.00 100.00)
+            (bounds 200.00 200.00)
+          )
+          (backdrop layer
+            (position 0.00 0.00)
+            (bounds 200.00 200.00)
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/css3/filters/backdrop/resource-use-change-size-from-zero.html
+++ b/LayoutTests/css3/filters/backdrop/resource-use-change-size-from-zero.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<style>
+div {
+  -webkit-backdrop-filter: blur(1px);
+  width: 200px;
+  height: 0px;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+</style>
+<!-- start with a zero height div so that the backdrop layer is omitted -->
+<div id="div"></div>
+<!-- then change the height and confirm that the resource use checks then allow the layer -->
+<script>
+window.doNotAutomaticallyCallLayerTree = true;
+
+window.addEventListener("load", () => {
+    setTimeout(() => {
+        document.getElementById("div").style.height = "200px";
+
+        setTimeout(() => {
+            addLayerTreeAndFinish();
+        }, 0);
+    }, 0);
+}, false);
+</script>
+<script src="layer-tree-as-text.js"></script>

--- a/LayoutTests/css3/filters/backdrop/resource-use-remove-some-layers.html
+++ b/LayoutTests/css3/filters/backdrop/resource-use-remove-some-layers.html
@@ -20,7 +20,7 @@
 <div></div>
 <!-- then remove some from the start, getting us back under the limit -->
 <script>
-const doNotAutomaticallyCallLayerTree = true;
+window.doNotAutomaticallyCallLayerTree = true;
 
 window.addEventListener("load", () => {
     for (let i = 0; i < 10; i++) {

--- a/LayoutTests/platform/glib/css3/filters/backdrop/resource-use-change-size-from-zero-expected.txt
+++ b/LayoutTests/platform/glib/css3/filters/backdrop/resource-use-change-size-from-zero-expected.txt
@@ -1,0 +1,17 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (bounds 200.00 200.00)
+          (backdrop layer 0.00, 0.00 200.00 x 200.00)
+        )
+      )
+    )
+  )
+)
+

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -2534,10 +2534,9 @@ void GraphicsLayerCA::updateBackdropFilters(CommitState& commitState)
     }
 
     // If nothing actually changed, no need to touch the layer properties.
-    if (!(m_uncommittedChanges & BackdropFiltersChanged)) {
+    if (!(m_uncommittedChanges & BackdropFiltersChanged) && m_backdropLayer) {
         // Opaque state depends on ancestor state, and is cheap to set, so just unconditionally update it.
-        if (m_backdropLayer)
-            m_backdropLayer->setBackdropRootIsOpaque(commitState.backdropRootIsOpaque);
+        m_backdropLayer->setBackdropRootIsOpaque(commitState.backdropRootIsOpaque);
         return;
     }
 


### PR DESCRIPTION
#### 460af2b82edfe5b54cab363c86bffd9d8d8f9b1f
<pre>
Backdrop filter isn&apos;t rendered when the element changes to a non-zero size.
<a href="https://bugs.webkit.org/show_bug.cgi?id=275266">https://bugs.webkit.org/show_bug.cgi?id=275266</a>
&lt;<a href="https://rdar.apple.com/129517679">rdar://129517679</a>&gt;

Reviewed by Simon Fraser.

If the backdrop filter area has changed, and canHaveBackdropFilter is newly true because of it,
we need to ensure the backdrop layer is created even if none of the filter properties are different.

* LayoutTests/css3/filters/backdrop/resource-use-add-more-layers.html:
* LayoutTests/css3/filters/backdrop/resource-use-change-size-from-zero-expected.txt: Added.
* LayoutTests/css3/filters/backdrop/resource-use-change-size-from-zero.html: Added.
* LayoutTests/css3/filters/backdrop/resource-use-remove-some-layers.html:
* LayoutTests/platform/glib/css3/filters/backdrop/resource-use-change-size-from-zero-expected.txt: Added.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::updateBackdropFilters):

Canonical link: <a href="https://commits.webkit.org/280403@main">https://commits.webkit.org/280403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c00e5cb47ac5746e22f84bd6e67456520457c44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35856 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60140 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6970 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58656 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43479 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7161 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/45794 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/4868 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58559 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33715 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48788 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26649 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30496 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6116 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5973 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61823 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/439 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6499 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53052 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/441 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48844 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/52966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12511 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/379 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/31683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32770 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33854 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32516 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->