### PR TITLE
[view-transitions] Misplaced arrows after scrolling then transitioning on https://codepen.io/bramus/full/xxmozvN

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/transformed-element-scroll-transform-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/transformed-element-scroll-transform-expected.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html style="reftest-wait">
+<head>
+    <style>
+        #target {
+            width: 100px;
+            height: 100px;
+            background: green;
+            margin: 300px;
+        }
+    </style>
+</head>
+<body>
+    <div id="target"></div>
+    <div style="height: 1000px"></div>
+    <script>
+        function scrollBy(y) {
+            return new Promise(resolve => {
+                addEventListener("scroll", () => {
+                    requestAnimationFrame(() => {
+                        requestAnimationFrame(resolve);
+                    });
+                }, { once: true, capture: true });
+                document.documentElement.scrollBy({
+                    top: y,
+                    behavior: "instant"
+                });
+            });
+        }
+        addEventListener("load", async () => {
+            await scrollBy(200);
+            document.documentElement.classList.remove("reftest-wait");
+        });
+    </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/transformed-element-scroll-transform-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/transformed-element-scroll-transform-ref.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html style="reftest-wait">
+<head>
+    <style>
+        #target {
+            width: 100px;
+            height: 100px;
+            background: green;
+            margin: 300px;
+        }
+    </style>
+</head>
+<body>
+    <div id="target"></div>
+    <div style="height: 1000px"></div>
+    <script>
+        function scrollBy(y) {
+            return new Promise(resolve => {
+                addEventListener("scroll", () => {
+                    requestAnimationFrame(() => {
+                        requestAnimationFrame(resolve);
+                    });
+                }, { once: true, capture: true });
+                document.documentElement.scrollBy({
+                    top: y,
+                    behavior: "instant"
+                });
+            });
+        }
+        addEventListener("load", async () => {
+            await scrollBy(200);
+            document.documentElement.classList.remove("reftest-wait");
+        });
+    </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/transformed-element-scroll-transform.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/transformed-element-scroll-transform.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html style="reftest-wait">
+<head>
+    <title>Scroll position transform should be the last one to be applied</title>
+    <link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+    <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+    <link rel="match" href="transformed-element-scroll-transform-ref.html">
+    <style>
+        :root {
+            view-transition-name: none;
+        }
+
+        ::view-transition-group(*) {
+            animation-duration: 10s;
+        }
+
+        #target {
+            width: 100px;
+            height: 100px;
+            background: green;
+            margin: 300px;
+            view-transition-name: target;
+            rotate: 90deg;
+        }
+    </style>
+</head>
+<body>
+    <div id="target"></div>
+    <div style="height: 1000px"></div>
+    <script>
+        function scrollBy(y) {
+            return new Promise(resolve => {
+                addEventListener("scroll", () => {
+                    requestAnimationFrame(() => {
+                        requestAnimationFrame(resolve);
+                    });
+                }, { once: true, capture: true });
+                document.documentElement.scrollBy({
+                    top: y,
+                    behavior: "instant"
+                });
+            });
+        }
+        addEventListener("load", async () => {
+            await scrollBy(200);
+            const transition = document.startViewTransition();
+            await transition.ready;
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                    document.documentElement.classList.remove("reftest-wait");
+                });
+            });
+        });
+    </script>
+</body>
+</html>

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -689,7 +689,7 @@ Ref<MutableStyleProperties> ViewTransition::copyElementBaseProperties(RenderLaye
             transform->translate(layoutOffset.x(), layoutOffset.y());
 
             auto offset = -toFloatSize(frameView.visibleContentRect().location());
-            transform->translate(offset.width(), offset.height());
+            transform->translateRight(offset.width(), offset.height());
 
             // Apply the inverse of what will be added by the default value of 'transform-origin',
             // since the computed transform has already included it.


### PR DESCRIPTION
#### 60a6419541bf7f3af43e2df260ccf6d10bf4e68d
<pre>
[view-transitions] Misplaced arrows after scrolling then transitioning on <a href="https://codepen.io/bramus/full/xxmozvN">https://codepen.io/bramus/full/xxmozvN</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=275506">https://bugs.webkit.org/show_bug.cgi?id=275506</a>
<a href="https://rdar.apple.com/129866645">rdar://129866645</a>

Reviewed by Matt Woodrow.

The scroll position translation was being applied before the element rotation, causing the capture to be offset on the wrong axis when scrolled.

Use translateRight() method to make sure the translation is applied last.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/transformed-element-scroll-transform-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/transformed-element-scroll-transform-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/transformed-element-scroll-transform.html: Added.
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::copyElementBaseProperties):

Canonical link: <a href="https://commits.webkit.org/280081@main">https://commits.webkit.org/280081@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8572be6f15c25a856d298a496ccd8672a6724bfe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58696 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6143 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57838 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42657 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6341 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44864 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4227 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57741 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32936 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48022 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25997 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29723 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5351 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4286 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5618 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60287 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5749 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52293 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48092 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51786 "Found 1 new API test failure: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12335 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30866 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31951 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33032 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31698 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->