### PR TITLE
[WTF] reorganize `Base64DecodeMode` into flags for more extensibility

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -1599,7 +1599,7 @@ JSC_DEFINE_HOST_FUNCTION(functionAtob, (JSGlobalObject* globalObject, CallFrame*
     if (encodedString.isNull())
         return JSValue::encode(jsEmptyString(vm));
 
-    auto decodedString = base64DecodeToString(encodedString, Base64DecodeMode::DefaultValidatePaddingAndIgnoreWhitespace);
+    auto decodedString = base64DecodeToString(encodedString, { Base64DecodeOption::ValidatePadding, Base64DecodeOption::IgnoreWhitespace });
     if (decodedString.isNull())
         return JSValue::encode(throwException(globalObject, scope, createError(globalObject, "Invalid character in argument for atob."_s)));
 
@@ -1644,7 +1644,7 @@ JSC_DEFINE_HOST_FUNCTION(functionDisassembleBase64, (JSGlobalObject* globalObjec
     if (encodedString.isNull())
         return JSValue::encode(jsEmptyString(vm));
 
-    std::optional<Vector<uint8_t>> decodedVector = base64Decode(encodedString, Base64DecodeMode::DefaultValidatePaddingAndIgnoreWhitespace);
+    std::optional<Vector<uint8_t>> decodedVector = base64Decode(encodedString, { Base64DecodeOption::ValidatePadding, Base64DecodeOption::IgnoreWhitespace });
     if (!decodedVector)
         return JSValue::encode(throwException(globalObject, scope, createError(globalObject, "Invalid character in base64 string argument."_s)));
 

--- a/Source/WebCore/page/Base64Utilities.cpp
+++ b/Source/WebCore/page/Base64Utilities.cpp
@@ -46,7 +46,7 @@ ExceptionOr<String> Base64Utilities::atob(const String& encodedString)
     if (encodedString.isNull())
         return String();
 
-    auto decodedData = base64DecodeToString(encodedString, Base64DecodeMode::DefaultValidatePaddingAndIgnoreWhitespace);
+    auto decodedData = base64DecodeToString(encodedString, { Base64DecodeOption::ValidatePadding, Base64DecodeOption::IgnoreWhitespace });
     if (decodedData.isNull())
         return Exception { ExceptionCode::InvalidCharacterError };
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2433,7 +2433,7 @@ void Page::userStyleSheetLocationChanged()
     if (url.protocolIsData() && url.string().startsWith("data:text/css;charset=utf-8;base64,"_s)) {
         m_didLoadUserStyleSheet = true;
 
-        String styleSheetAsBase64 = base64DecodeToString(PAL::decodeURLEscapeSequences(StringView(url.string()).substring(35)), Base64DecodeMode::DefaultValidatePaddingAndIgnoreWhitespace);
+        String styleSheetAsBase64 = base64DecodeToString(PAL::decodeURLEscapeSequences(StringView(url.string()).substring(35)), { Base64DecodeOption::ValidatePadding, Base64DecodeOption::IgnoreWhitespace });
         if (!styleSheetAsBase64.isNull())
             m_userStyleSheet = styleSheetAsBase64;
     }

--- a/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
@@ -111,7 +111,7 @@ static Vector<Ref<SharedBuffer>> extractSinfData(const SharedBuffer& buffer)
         if (!keyID)
             return nullptr;
 
-        auto sinfData = base64Decode(keyID, Base64DecodeMode::DefaultValidatePaddingAndIgnoreWhitespace);
+        auto sinfData = base64Decode(keyID, { Base64DecodeOption::ValidatePadding, Base64DecodeOption::IgnoreWhitespace });
         if (!sinfData)
             return nullptr;
 

--- a/Source/WebCore/platform/network/DataURLDecoder.cpp
+++ b/Source/WebCore/platform/network/DataURLDecoder.cpp
@@ -156,8 +156,10 @@ static std::optional<Result> decodeSynchronously(DecodeTask& task)
         return std::nullopt;
 
     if (task.isBase64) {
-        auto mode = task.shouldValidatePadding == ShouldValidatePadding::Yes ? Base64DecodeMode::DefaultValidatePaddingAndIgnoreWhitespace : Base64DecodeMode::DefaultIgnoreWhitespaceForQuirk;
-        auto decodedData = base64Decode(PAL::decodeURLEscapeSequences(task.encodedData), mode);
+        OptionSet<Base64DecodeOption> options = { Base64DecodeOption::IgnoreWhitespace };
+        if (task.shouldValidatePadding == ShouldValidatePadding::Yes)
+            options.add(Base64DecodeOption::ValidatePadding);
+        auto decodedData = base64Decode(PAL::decodeURLEscapeSequences(task.encodedData), options);
         if (!decodedData)
             return std::nullopt;
         task.result.data = WTFMove(*decodedData);

--- a/Source/WebKit/UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp
@@ -145,7 +145,7 @@ void RemoteWebInspectorUIProxy::platformSave(Vector<InspectorFrontendClient::Sav
     Vector<uint8_t> dataVector;
     CString dataString;
     if (saveDatas[0].base64Encoded) {
-        auto decodedData = base64Decode(saveDatas[0].content, Base64DecodeMode::DefaultValidatePadding);
+        auto decodedData = base64Decode(saveDatas[0].content, { Base64DecodeOption::ValidatePadding });
         if (!decodedData)
             return;
         decodedData->shrinkToFit();

--- a/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp
@@ -527,7 +527,7 @@ void WebInspectorUIProxy::platformSave(Vector<WebCore::InspectorFrontendClient::
     Vector<uint8_t> dataVector;
     CString dataString;
     if (saveDatas[0].base64Encoded) {
-        auto decodedData = base64Decode(saveDatas[0].content, Base64DecodeMode::DefaultValidatePadding);
+        auto decodedData = base64Decode(saveDatas[0].content, { Base64DecodeOption::ValidatePadding });
         if (!decodedData)
             return;
         decodedData->shrinkToFit();

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -403,7 +403,7 @@ void WebInspectorUIProxy::showSavePanel(NSWindow *frontendWindow, NSURL *platfor
 
         if ([controller base64Encoded]) {
             String contentString = [controller content];
-            auto decodedData = base64Decode(contentString, Base64DecodeMode::DefaultValidatePadding);
+            auto decodedData = base64Decode(contentString, { Base64DecodeOption::ValidatePadding });
             if (!decodedData)
                 return;
             auto dataContent = adoptNS([[NSData alloc] initWithBytes:decodedData->data() length:decodedData->size()]);

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
@@ -423,7 +423,7 @@ void WebInspectorFrontendClient::save(Vector<InspectorFrontendClient::SaveData>&
         m_suggestedToActualURLMap.set(suggestedURLCopy, actualURL);
 
         if (base64Encoded) {
-            auto decodedData = base64Decode(contentCopy, Base64DecodeMode::DefaultValidatePadding);
+            auto decodedData = base64Decode(contentCopy, { Base64DecodeOption::ValidatePadding });
             if (!decodedData)
                 return;
             RetainPtr<NSData> dataContent = adoptNS([[NSData alloc] initWithBytes:decodedData->data() length:decodedData->size()]);

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -26,6 +26,7 @@ set(TestWTF_SOURCES
     Utilities.cpp
 
     Tests/WTF/AtomString.cpp
+    Tests/WTF/Base64.cpp
     Tests/WTF/BitSet.cpp
     Tests/WTF/BloomFilter.cpp
     Tests/WTF/BoxPtr.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -824,6 +824,7 @@
 		83F22C6420B355F80034277E /* NoPolicyDelegateResponse.mm in Sources */ = {isa = PBXBuildFile; fileRef = 83F22C6320B355EB0034277E /* NoPolicyDelegateResponse.mm */; };
 		8C10AF98206467920018FD90 /* localstorage-empty-string-value.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 8C10AF97206467830018FD90 /* localstorage-empty-string-value.html */; };
 		8E4A85371E1D1AB200F53B0F /* GridPosition.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8E4A85361E1D1AA100F53B0F /* GridPosition.cpp */; };
+		919B50762C177055009FE7B0 /* Base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 919B506E2C177055009FE7B0 /* Base64.cpp */; };
 		930AD402150698D00067970F /* lots-of-text.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 930AD401150698B30067970F /* lots-of-text.html */; };
 		9310CD381EF708FB0050FFE0 /* Function.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9310CD361EF708FB0050FFE0 /* Function.cpp */; };
 		931C281E22BC579A001D98C4 /* opendatabase-always-exists.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 931C281B22BC5583001D98C4 /* opendatabase-always-exists.html */; };
@@ -2991,6 +2992,7 @@
 		8C10AF97206467830018FD90 /* localstorage-empty-string-value.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "localstorage-empty-string-value.html"; sourceTree = "<group>"; };
 		8DD76FA10486AA7600D96B5E /* TestWebKitAPI */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = TestWebKitAPI; sourceTree = BUILT_PRODUCTS_DIR; };
 		8E4A85361E1D1AA100F53B0F /* GridPosition.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GridPosition.cpp; sourceTree = "<group>"; };
+		919B506E2C177055009FE7B0 /* Base64.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Base64.cpp; sourceTree = "<group>"; };
 		930AD401150698B30067970F /* lots-of-text.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "lots-of-text.html"; sourceTree = "<group>"; };
 		9310CD361EF708FB0050FFE0 /* Function.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Function.cpp; sourceTree = "<group>"; };
 		931C281B22BC5583001D98C4 /* opendatabase-always-exists.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "opendatabase-always-exists.html"; sourceTree = "<group>"; };
@@ -5374,6 +5376,7 @@
 				BC029B1A1486B23800817DA9 /* ns */,
 				FF25942A2834B7A7006892D6 /* AlignedRefLogger.h */,
 				26F1B44215CA434F00D1E4BF /* AtomString.cpp */,
+				919B506E2C177055009FE7B0 /* Base64.cpp */,
 				FE2D9473245EB2DF00E48135 /* BitSet.cpp */,
 				E40019301ACE9B5C001B0A2A /* BloomFilter.cpp */,
 				93A427AE180DA60F00CD24D7 /* BoxPtr.cpp */,
@@ -6367,6 +6370,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7C83DE991D0A590C00FEBCF3 /* AtomString.cpp in Sources */,
+				919B50762C177055009FE7B0 /* Base64.cpp in Sources */,
 				FE2D9474245EB2F400E48135 /* BitSet.cpp in Sources */,
 				1ADAD1501D77A9F600212586 /* BlockPtr.mm in Sources */,
 				7C83DE9C1D0A590C00FEBCF3 /* BloomFilter.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/Base64.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Base64.cpp
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2024 Devin Rousso <webkit@devinrousso.com>. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <wtf/text/Base64.h>
+
+namespace TestWebKitAPI {
+
+#define EXPECT_DECODE(expected, input) EXPECT_STREQ(expected, base64DecodeToString(input, options).utf8().data())
+
+TEST(Base64, Decode)
+{
+    static constexpr OptionSet<Base64DecodeOption> options;
+
+    EXPECT_DECODE("", "==="_s);
+    EXPECT_DECODE("f", "Zg==="_s);
+    EXPECT_DECODE("fo", "Zm8==="_s);
+    EXPECT_DECODE("foo", "Zm9v==="_s);
+    EXPECT_DECODE("foob", "Zm9vYg==="_s);
+    EXPECT_DECODE("fooba", "Zm9vYmE==="_s);
+    EXPECT_DECODE("foobar", "Zm9vYmFy==="_s);
+
+    EXPECT_TRUE(Vector<uint8_t>({ 0 }) == base64Decode("AA==="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 1 }) == base64Decode("AQ==="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 128 }) == base64Decode("gA==="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 254 }) == base64Decode("/g==="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 255 }) == base64Decode("/w==="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 0, 1 }) == base64Decode("AAE==="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 254, 255 }) == base64Decode("/v8==="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 0, 1, 128, 254, 255 }) == base64Decode("AAGA/v8==="_s, options));
+}
+
+TEST(Base64, DecodeValidatePadding)
+{
+    static constexpr OptionSet<Base64DecodeOption> options = { Base64DecodeOption::ValidatePadding };
+
+    EXPECT_DECODE("", ""_s);
+    EXPECT_DECODE("f", "Zg=="_s);
+    EXPECT_DECODE("fo", "Zm8="_s);
+    EXPECT_DECODE("foo", "Zm9v"_s);
+    EXPECT_DECODE("foob", "Zm9vYg=="_s);
+    EXPECT_DECODE("fooba", "Zm9vYmE="_s);
+    EXPECT_DECODE("foobar", "Zm9vYmFy"_s);
+
+    EXPECT_TRUE(Vector<uint8_t>({ 0 }) == base64Decode("AA=="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 1 }) == base64Decode("AQ=="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 128 }) == base64Decode("gA=="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 254 }) == base64Decode("/g=="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 255 }) == base64Decode("/w=="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 0, 1 }) == base64Decode("AAE="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 254, 255 }) == base64Decode("/v8="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 0, 1, 128, 254, 255 }) == base64Decode("AAGA/v8="_s, options));
+}
+
+TEST(Base64, DecodeIgnoreWhitespace)
+{
+    static constexpr OptionSet<Base64DecodeOption> options = { Base64DecodeOption::IgnoreWhitespace };
+
+    EXPECT_DECODE("", " = = = "_s);
+    EXPECT_DECODE("f", " Z g = = = "_s);
+    EXPECT_DECODE("fo", " Z m 8 = = = "_s);
+    EXPECT_DECODE("foo", " Z m 9 v = = = "_s);
+    EXPECT_DECODE("foob", " Z m 9 v Y g = = = "_s);
+    EXPECT_DECODE("fooba", " Z m 9 v Y m E = = = "_s);
+    EXPECT_DECODE("foobar", " Z m 9 v Y m F y = = = "_s);
+
+    EXPECT_TRUE(Vector<uint8_t>({ 0 }) == base64Decode(" A A = = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 1 }) == base64Decode(" A Q = = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 128 }) == base64Decode(" g A = = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 254 }) == base64Decode(" / g = = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 255 }) == base64Decode(" / w = = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 0, 1 }) == base64Decode(" A A E = = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 254, 255 }) == base64Decode(" / v 8 = = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 0, 1, 128, 254, 255 }) == base64Decode(" A A G A / v 8 = = = "_s, options));
+}
+
+TEST(Base64, DecodeValidatePaddingIgnoreWhitespace)
+{
+    static constexpr OptionSet<Base64DecodeOption> options = { Base64DecodeOption::ValidatePadding, Base64DecodeOption::IgnoreWhitespace };
+
+    EXPECT_DECODE("", " "_s);
+    EXPECT_DECODE("f", " Z g = = "_s);
+    EXPECT_DECODE("fo", " Z m 8 = "_s);
+    EXPECT_DECODE("foo", " Z m 9 v "_s);
+    EXPECT_DECODE("foob", " Z m 9 v Y g = = "_s);
+    EXPECT_DECODE("fooba", " Z m 9 v Y m E = "_s);
+    EXPECT_DECODE("foobar", " Z m 9 v Y m F y "_s);
+
+    EXPECT_TRUE(Vector<uint8_t>({ 0 }) == base64Decode(" A A = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 1 }) == base64Decode(" A Q = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 128 }) == base64Decode(" g A = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 254 }) == base64Decode(" / g = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 255 }) == base64Decode(" / w = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 0, 1 }) == base64Decode(" A A E = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 254, 255 }) == base64Decode(" / v 8 = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 0, 1, 128, 254, 255 }) == base64Decode(" A A G A / v 8 = "_s, options));
+}
+
+TEST(Base64, DecodeURL)
+{
+    static constexpr OptionSet<Base64DecodeOption> options = { Base64DecodeOption::URL };
+
+    EXPECT_DECODE("", "==="_s);
+    EXPECT_DECODE("f", "Zg==="_s);
+    EXPECT_DECODE("fo", "Zm8==="_s);
+    EXPECT_DECODE("foo", "Zm9v==="_s);
+    EXPECT_DECODE("foob", "Zm9vYg==="_s);
+    EXPECT_DECODE("fooba", "Zm9vYmE==="_s);
+    EXPECT_DECODE("foobar", "Zm9vYmFy==="_s);
+
+    EXPECT_TRUE(Vector<uint8_t>({ 0 }) == base64Decode("AA==="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 1 }) == base64Decode("AQ==="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 128 }) == base64Decode("gA==="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 254 }) == base64Decode("_g==="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 255 }) == base64Decode("_w==="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 0, 1 }) == base64Decode("AAE==="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 254, 255 }) == base64Decode("_v8==="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 0, 1, 128, 254, 255 }) == base64Decode("AAGA_v8==="_s, options));
+}
+
+TEST(Base64, DecodeURLValidatePadding)
+{
+    static constexpr OptionSet<Base64DecodeOption> options = { Base64DecodeOption::URL, Base64DecodeOption::ValidatePadding };
+
+    EXPECT_DECODE("", ""_s);
+    EXPECT_DECODE("f", "Zg=="_s);
+    EXPECT_DECODE("fo", "Zm8="_s);
+    EXPECT_DECODE("foo", "Zm9v"_s);
+    EXPECT_DECODE("foob", "Zm9vYg=="_s);
+    EXPECT_DECODE("fooba", "Zm9vYmE="_s);
+    EXPECT_DECODE("foobar", "Zm9vYmFy"_s);
+
+    EXPECT_TRUE(Vector<uint8_t>({ 0 }) == base64Decode("AA=="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 1 }) == base64Decode("AQ=="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 128 }) == base64Decode("gA=="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 254 }) == base64Decode("_g=="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 255 }) == base64Decode("_w=="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 0, 1 }) == base64Decode("AAE="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 254, 255 }) == base64Decode("_v8="_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 0, 1, 128, 254, 255 }) == base64Decode("AAGA_v8="_s, options));
+}
+
+TEST(Base64, DecodeURLIgnoreWhitespace)
+{
+    static constexpr OptionSet<Base64DecodeOption> options = { Base64DecodeOption::URL, Base64DecodeOption::IgnoreWhitespace };
+
+    EXPECT_DECODE("", " = = = "_s);
+    EXPECT_DECODE("f", " Z g = = = "_s);
+    EXPECT_DECODE("fo", " Z m 8 = = = "_s);
+    EXPECT_DECODE("foo", " Z m 9 v = = = "_s);
+    EXPECT_DECODE("foob", " Z m 9 v Y g = = = "_s);
+    EXPECT_DECODE("fooba", " Z m 9 v Y m E = = = "_s);
+    EXPECT_DECODE("foobar", " Z m 9 v Y m F y = = = "_s);
+
+    EXPECT_TRUE(Vector<uint8_t>({ 0 }) == base64Decode(" A A = = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 1 }) == base64Decode(" A Q = = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 128 }) == base64Decode(" g A = = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 254 }) == base64Decode(" _ g = = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 255 }) == base64Decode(" _ w = = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 0, 1 }) == base64Decode(" A A E = = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 254, 255 }) == base64Decode(" _ v 8 = = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 0, 1, 128, 254, 255 }) == base64Decode(" A A G A _ v 8 = = = "_s, options));
+}
+
+TEST(Base64, DecodeURLValidatePaddingIgnoreWhitespace)
+{
+    static constexpr OptionSet<Base64DecodeOption> options = { Base64DecodeOption::URL, Base64DecodeOption::ValidatePadding, Base64DecodeOption::IgnoreWhitespace };
+
+    EXPECT_DECODE("", " "_s);
+    EXPECT_DECODE("f", " Z g = = "_s);
+    EXPECT_DECODE("fo", " Z m 8 = "_s);
+    EXPECT_DECODE("foo", " Z m 9 v "_s);
+    EXPECT_DECODE("foob", " Z m 9 v Y g = = "_s);
+    EXPECT_DECODE("fooba", " Z m 9 v Y m E = "_s);
+    EXPECT_DECODE("foobar", " Z m 9 v Y m F y "_s);
+
+    EXPECT_TRUE(Vector<uint8_t>({ 0 }) == base64Decode(" A A = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 1 }) == base64Decode(" A Q = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 128 }) == base64Decode(" g A = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 254 }) == base64Decode(" _ g = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 255 }) == base64Decode(" _ w = = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 0, 1 }) == base64Decode(" A A E = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 254, 255 }) == base64Decode(" _ v 8 = "_s, options));
+    EXPECT_TRUE(Vector<uint8_t>({ 0, 1, 128, 254, 255 }) == base64Decode(" A A G A _ v 8 = "_s, options));
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### a4e626a2b14f7600fd7f65c2aa2d09bb4dd76583
<pre>
[WTF] reorganize `Base64DecodeMode` into flags for more extensibility
<a href="https://bugs.webkit.org/show_bug.cgi?id=275558">https://bugs.webkit.org/show_bug.cgi?id=275558</a>

Reviewed by Darin Adler.

This will assist with implementing `Uint8Array.fromBase64` since that has a couple of other extra behavior modes when decoding base64 content &lt;<a href="https://webkit.org/b/275593">https://webkit.org/b/275593</a>&gt;.

* Source/WTF/wtf/text/Base64.h:
(WTF::base64Decode):
(WTF::base64URLDecode):
* Source/WTF/wtf/text/Base64.cpp:
(WTF::base64DecodeInternal):
(WTF::base64Decode):
(WTF::base64DecodeToString):
Introduce a `Base64DecodeOption` that&apos;s wrapped in an `OptionSet` (for future extensibility) as a parameter for adjusting base64 decoding.

* Source/JavaScriptCore/jsc.cpp:
(functionAtob):
(functionDisassembleBase64):
* Source/WebCore/page/Base64Utilities.cpp:
(WebCore::Base64Utilities::atob):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::userStyleSheetLocationChanged):
* Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp:
(WebCore::extractSinfData):
* Source/WebCore/platform/network/DataURLDecoder.cpp:
(WebCore::DataURLDecoder::decodeSynchronously):
* Source/WebKit/UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp:
(WebKit::RemoteWebInspectorUIProxy::platformSave):
* Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp:
(WebKit::WebInspectorUIProxy::platformSave):
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(WebKit::WebInspectorUIProxy::showSavePanel):
* Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm:
(WebInspectorFrontendClient::save):
Replace `Base64EncodeMode::DefaultIgnorePadding` with no options (i.e. default behavior).
Replace `Base64EncodeMode::DefaultValidatePadding` with `Base64EncodeOption::ValidatePadding`.
Replace `Base64EncodeMode::DefaultValidatePaddingAndIgnoreWhitespace` with `Base64EncodeOption::ValidatePadding` and `Base64EncodeOption::IgnoreWhitespace`.
Replace `Base64EncodeMode::DefaultIgnoreWhitespaceForQuirk` with `Base64EncodeOption::IgnoreWhitespace`.
Replace `Base64EncodeMode::URL` with `Base64EncodeOption::URL`.

* Tools/TestWebKitAPI/Tests/WTF/Base64.cpp: Added.
(TestWebKitAPI::TEST(Base64, Decode)):
(TestWebKitAPI::TEST(Base64, DecodeValidatePadding)):
(TestWebKitAPI::TEST(Base64, DecodeIgnoreWhitespace)):
(TestWebKitAPI::TEST(Base64, DecodeValidatePaddingIgnoreWhitespace)):
(TestWebKitAPI::TEST(Base64, DecodeURL)):
(TestWebKitAPI::TEST(Base64, DecodeURLValidatePadding)):
(TestWebKitAPI::TEST(Base64, DecodeURLIgnoreWhitespace)):
(TestWebKitAPI::TEST(Base64, DecodeURLValidatePaddingIgnoreWhitespace)):

* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/280108@main">https://commits.webkit.org/280108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99553dbf06f38e089c819667f76cd8c30510ab3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55773 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8240 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58757 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6204 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57899 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6402 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44920 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4273 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57802 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32996 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48077 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26054 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29782 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5406 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4347 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/48850 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51749 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60348 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/55010 "Built successfully and passed tests") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5804 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52344 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48148 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51841 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12353 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/76772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30927 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/76772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32012 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33093 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31759 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->