### PR TITLE
[GLib] Some default values for WebKitSettings properties do not match UnifiedWebPreferences.yaml

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2368,6 +2368,7 @@ EncryptedMediaAPIEnabled:
     WebKitLegacy:
       default: false
     WebKit:
+      "PLATFORM(GTK) || PLATFORM(WPE)": false
       default: true
     WebCore:
       default: false
@@ -2668,8 +2669,10 @@ FullScreenEnabled:
     WebKitLegacy:
       default: false
     WebKit:
+      "PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
     WebCore:
+      "PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
 
 FullScreenKeyboardLock:
@@ -3524,7 +3527,7 @@ JavaScriptCanOpenWindowsAutomatically:
       "PLATFORM(IOS_FAMILY)": WebKit::defaultJavaScriptCanOpenWindowsAutomatically()
       default: true
     WebKit:
-      "PLATFORM(IOS_FAMILY)": false
+      "PLATFORM(IOS_FAMILY) || PLATFORM(GTK) || PLATFORM(WPE)": false
       default: true
     WebCore:
       default: false
@@ -4083,6 +4086,7 @@ MediaCapabilitiesEnabled:
     WebKitLegacy:
       default: false
     WebKit:
+      "PLATFORM(GTK) || PLATFORM(WPE)": false
       default: true
     WebCore:
       default: false
@@ -4224,8 +4228,10 @@ MediaDevicesEnabled:
     WebKitLegacy:
       default: false
     WebKit:
+      "PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
     WebCore:
+      "PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
 
 MediaEnabled:
@@ -6110,6 +6116,7 @@ ShouldPrintBackgrounds:
       default: false
     WebKit:
       "PLATFORM(IOS_FAMILY)": WebKit::defaultShouldPrintBackgrounds()
+      "PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
     WebCore:
       default: false
@@ -6122,10 +6129,10 @@ ShouldRespectImageOrientation:
       "PLATFORM(IOS_FAMILY)": true
       default: false
     WebKit:
-      "PLATFORM(IOS_FAMILY)": true
+      "PLATFORM(IOS_FAMILY) || PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
     WebCore:
-      "PLATFORM(IOS_FAMILY)": true
+      "PLATFORM(IOS_FAMILY) || PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
 
 ShouldRestrictBaseURLSchemes:
@@ -6501,7 +6508,7 @@ TabsToLinks:
     WebKitLegacy:
       default: false
     WebKit:
-      "PLATFORM(GTK)": true
+      "PLATFORM(GTK) || PLATFORM(WPE)": true
       default: false
 
 TelephoneNumberParsingEnabled:

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPreferences.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPreferences.cpp
@@ -75,8 +75,13 @@ TEST(WebKit, WKPreferencesDefaults)
     EXPECT_TRUE(WKPreferencesGetJavaScriptEnabled(preference));
     EXPECT_TRUE(WKPreferencesGetLoadsImagesAutomatically(preference));
     EXPECT_TRUE(WKPreferencesGetLocalStorageEnabled(preference));
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    EXPECT_TRUE(WKPreferencesGetShouldPrintBackgrounds(preference));
+    EXPECT_FALSE(WKPreferencesGetJavaScriptCanOpenWindowsAutomatically(preference));
+#else
     EXPECT_FALSE(WKPreferencesGetShouldPrintBackgrounds(preference));
     EXPECT_TRUE(WKPreferencesGetJavaScriptCanOpenWindowsAutomatically(preference));
+#endif
     EXPECT_TRUE(WKPreferencesGetHyperlinkAuditingEnabled(preference));
     EXPECT_WK_STREQ(expectedStandardFontFamily, adoptWK(WKPreferencesCopyStandardFontFamily(preference)));
     EXPECT_WK_STREQ(expectedFixedFontFamily, adoptWK(WKPreferencesCopyFixedFontFamily(preference)));


### PR DESCRIPTION
#### 4ad8749ae961d25f2847fa31db30c5ada9f62cdc
<pre>
[GLib] Some default values for WebKitSettings properties do not match UnifiedWebPreferences.yaml
<a href="https://bugs.webkit.org/show_bug.cgi?id=255779">https://bugs.webkit.org/show_bug.cgi?id=255779</a>

Reviewed by Carlos Garcia Campos.

Make WebKitSettings properties which have a corresponding WebKitFeature
pick their default values from UnifiedWebPreferences.yaml, by means of
the generated DEFAULT_VALUE_FOR_* macros. This way changing the defaults
in the YAML source both the feature flags and WebKitSettings properties
will be initially in sync.

For feature flags that have a corresponding WebKitSettings property
that did not match the value declared in UnifiedWebPreferences.yaml,
move the default values to the YAML file. This makes the YAML source
the canonical source of truth.

Note that this patch does not attempt to keep the values of feature
flags and WebKitSettings properties synchronized at run time. That
would be an additional cghange to be done later on on top of this one.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml: Update
defaults to reflect the WebKitSettings ones for the WPE and GTK ports.
* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
(webKitSettingsConstructed): Remove manually setting feature flag
defaults, relying on the values from UnifiedWebPreferences.yaml instead.
(webkit_settings_class_init): Change property definitions to use default
values from UnifiedWebPreferences.yaml.
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp:
(testWebKitSettings): Adapt to handle the default for WebRTC being
different for USE(GSTREAMER_WEBRTC) and USE(LIBWEBRTC).
(testWebKitFeatures): Remove FIXME in the part of the test case that
checks that initial values match the declared defaults. There are a
couple of feature flags which are skipped in the check, possibly to
be fixed later on.
(testWebKitSettingsApplyFromConfigFile): Adapt to handle the default
for WebRTC being different for USE(GSTREAMER_WEBRTC) and USE(LIBWEBRTC).
* Tools/TestWebKitAPI/Tests/WebKit/WKPreferences.cpp:
(TestWebKitAPI::TEST(WebKit, WKPreferencesDefaults)): Adapt test case
for defaults which are now defined in UnifiedWebPreferences.yaml
differently for the WPE and GTK ports.

Canonical link: <a href="https://commits.webkit.org/280080@main">https://commits.webkit.org/280080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1905ad72e2ce1baeab511757c9cda2e9cead6ae7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58689 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6136 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57831 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6334 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44859 "Found 61 new test failures: fast/dom/navigator-detached-no-crash.html imported/w3c/web-platform-tests/encrypted-media/clearkey-check-encryption-scheme.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-check-initdata-type.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-events-session-closed-event.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-events.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-invalid-license.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-keystatuses-multiple-sessions.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-keystatuses.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-clear-encrypted.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-encrypted-clear.https.html ... (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4222 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57734 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48016 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/25992 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29714 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5345 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4279 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/48782 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5612 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60280 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/54942 "Built successfully and passed tests") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5741 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52287 "Found 63 new test failures: fast/dom/navigator-detached-no-crash.html imported/w3c/web-platform-tests/encrypted-media/clearkey-check-encryption-scheme.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-check-initdata-type.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-events-session-closed-event.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-events.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-invalid-license.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-keystatuses-multiple-sessions.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-keystatuses.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-clear-encrypted.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-encrypted-clear-sources.https.html ... (failure)") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48086 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51780 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/76704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8214 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30859 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/76704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31944 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33025 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31691 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->