### PR TITLE
Reject SharedArrayBuffer serialization when forStorage is true

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/serialize-sharedarraybuffer-throws.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/serialize-sharedarraybuffer-throws.https-expected.txt
@@ -1,5 +1,3 @@
 
-FAIL IndexedDB: Attempting to serialize a SharedArrayBuffer should throw assert_throws_dom: function "() => {
-            rq = objStore.put({sab: sab}, 'key');
-        }" threw object "DataError: Failed to store record in an IDBObjectStore: The object store uses in-line keys and the key parameter was provided." that is not a DOMException DataCloneError: property "code" is equal to 0, expected 25
+PASS IndexedDB: Attempting to serialize a SharedArrayBuffer should throw
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/serialization-via-history.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/serialization-via-history.https-expected.txt
@@ -1,22 +1,6 @@
 
-FAIL history.pushState(): simple case assert_throws_dom: function "() => {
-      history[method](new SharedArrayBuffer(), "dummy title");
-    }" did not throw
-FAIL history.pushState(): is interleaved correctly assert_throws_dom: function "() => {
-      history[method]([
-        { get x() { getter1Called = true; return 5; } },
-        new SharedArrayBuffer(),
-        { get x() { getter2Called = true; return 5; } }
-      ], "dummy title");
-    }" did not throw
-FAIL history.replaceState(): simple case assert_throws_dom: function "() => {
-      history[method](new SharedArrayBuffer(), "dummy title");
-    }" did not throw
-FAIL history.replaceState(): is interleaved correctly assert_throws_dom: function "() => {
-      history[method]([
-        { get x() { getter1Called = true; return 5; } },
-        new SharedArrayBuffer(),
-        { get x() { getter2Called = true; return 5; } }
-      ], "dummy title");
-    }" did not throw
+PASS history.pushState(): simple case
+PASS history.pushState(): is interleaved correctly
+PASS history.replaceState(): simple case
+PASS history.replaceState(): is interleaved correctly
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/serialization-via-idb.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/serialization-via-idb.any-expected.txt
@@ -1,12 +1,4 @@
 
-FAIL SharedArrayBuffer cloning via IndexedDB: basic case assert_throws_dom: function "() => {
-      store.put({ key: 1, property: sab });
-    }" did not throw
-FAIL SharedArrayBuffer cloning via the IndexedDB: is interleaved correctly assert_throws_dom: function "() => {
-      store.put({ key: 1, property: [
-        { get x() { getter1Called = true; return 5; } },
-        sab,
-        { get x() { getter2Called = true; return 5; } }
-      ]});
-    }" did not throw
+PASS SharedArrayBuffer cloning via IndexedDB: basic case
+PASS SharedArrayBuffer cloning via the IndexedDB: is interleaved correctly
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/serialization-via-idb.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/serialization-via-idb.any.worker-expected.txt
@@ -1,12 +1,4 @@
 
-FAIL SharedArrayBuffer cloning via IndexedDB: basic case assert_throws_dom: function "() => {
-      store.put({ key: 1, property: sab });
-    }" did not throw
-FAIL SharedArrayBuffer cloning via the IndexedDB: is interleaved correctly assert_throws_dom: function "() => {
-      store.put({ key: 1, property: [
-        { get x() { getter1Called = true; return 5; } },
-        sab,
-        { get x() { getter2Called = true; return 5; } }
-      ]});
-    }" did not throw
+PASS SharedArrayBuffer cloning via IndexedDB: basic case
+PASS SharedArrayBuffer cloning via the IndexedDB: is interleaved correctly
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-unserializable-state-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-unserializable-state-expected.txt
@@ -1,4 +1,4 @@
 
 PASS navigate() with an unserializable state (WritableStream)
-FAIL navigate() with an unserializable state (SharedArrayBuffer) assert_unreached: committed must not fulfill Reached unreachable code
+PASS navigate() with an unserializable state (SharedArrayBuffer)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-unserializable-state-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-unserializable-state-expected.txt
@@ -1,3 +1,4 @@
-FAIL: Timed out waiting for notifyDone to be called
 
+PASS reload() with an unserializable state (WritableStream)
+PASS reload() with an unserializable state (SharedArrayBuffer)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/unserializable-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/unserializable-expected.txt
@@ -1,7 +1,5 @@
 
 
 PASS updateCurrentEntry() must throw if state is unserializable (WritableStream)
-FAIL updateCurrentEntry() must throw if state is unserializable (SharedArrayBuffer) assert_throws_dom: function "() => {
-      iframe.contentWindow.navigation.updateCurrentEntry({ state: buffer });
-    }" did not throw
+PASS updateCurrentEntry() must throw if state is unserializable (SharedArrayBuffer)
 

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -1961,9 +1961,9 @@ private:
                 if (!addToObjectPoolIfNotDupe<ArrayBufferTag, ResizableArrayBufferTag, SharedArrayBufferTag>(obj))
                     return true;
                 
-                if (arrayBuffer->isShared() && m_context == SerializationContext::WorkerPostMessage) {
+                if (arrayBuffer->isShared() && (m_context == SerializationContext::WorkerPostMessage || m_forStorage == SerializationForStorage::Yes)) {
                     // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal
-                    if (!JSC::Options::useSharedArrayBuffer()) {
+                    if (!JSC::Options::useSharedArrayBuffer() || m_forStorage == SerializationForStorage::Yes) {
                         code = SerializationReturnCode::DataCloneError;
                         return true;
                     }


### PR DESCRIPTION
#### 1a5ede6d46809b13b5c8aca1230990b26d3d20c8
<pre>
Reject SharedArrayBuffer serialization when forStorage is true
<a href="https://bugs.webkit.org/show_bug.cgi?id=248331">https://bugs.webkit.org/show_bug.cgi?id=248331</a>
<a href="https://rdar.apple.com/102656648">rdar://102656648</a>

Reviewed by Yusuke Suzuki.

When serializing SharedArrayBuffers, throw DataCloneError if forStorage is true. [1]

[1] <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal</a> (Step 12.1.2)

* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/serialize-sharedarraybuffer-throws.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/serialization-via-history.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/serialization-via-idb.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/serialization-via-idb.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-unserializable-state-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-unserializable-state-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/updateCurrentEntry-method/unserializable-expected.txt:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpIfTerminal):

Canonical link: <a href="https://commits.webkit.org/280194@main">https://commits.webkit.org/280194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aeb49e001534e0a3f55228d30a471382fe3528df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55740 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58724 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6171 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57866 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42685 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6369 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44888 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4246 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57769 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32964 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48052 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26020 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29751 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5381 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4314 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51722 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5650 "Found 1 new test failure: workers/wasm-hashset-many.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60315 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5773 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52316 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51812 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12403 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30894 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31979 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33060 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31726 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->