### PR TITLE
[JSC] Always use Handler IC on Baseline JIT

### DIFF
--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
@@ -377,7 +377,7 @@ private:
     CallSiteIndex callSiteIndexForExceptionHandlingOrOriginal();
     const ScalarRegisterSet& liveRegistersToPreserveAtExceptionHandlingCallSite();
 
-    AccessGenerationResult compileOneAccessCaseHandler(CodeBlock*, AccessCase&, Vector<WatchpointSet*, 8>&&);
+    AccessGenerationResult compileOneAccessCaseHandler(PolymorphicAccess&, CodeBlock*, AccessCase&, Vector<WatchpointSet*, 8>&&);
 
     void emitDOMJITGetter(JSGlobalObject*, const DOMJIT::GetterSetter*, GPRReg baseForGetGPR);
     void emitModuleNamespaceLoad(ModuleNamespaceAccessCase&, MacroAssembler::JumpList& fallThrough);

--- a/Source/JavaScriptCore/bytecode/SharedJITStubSet.h
+++ b/Source/JavaScriptCore/bytecode/SharedJITStubSet.h
@@ -94,31 +94,27 @@ public:
             static bool equal(const Hash::Key a, const Searcher& b)
             {
                 if (a.m_stubInfoKey == b.m_stubInfoKey && Hash::hash(a) == b.m_hash) {
-                    // FIXME: The ordering of cases does not matter for sharing capabilities.
-                    // We can potentially increase success rate by making this comparison / hashing non ordering sensitive.
-                    const auto& aCases = a.m_wrapped->cases();
-                    const auto& bCases = b.m_cases;
-                    if (aCases.size() != bCases.size())
+                    if (a.m_wrapped->cases().size() != 1)
                         return false;
-                    for (unsigned index = 0; index < bCases.size(); ++index) {
-                        if (!AccessCase::canBeShared(aCases[index].get(), bCases[index].get()))
-                            return false;
-                    }
+                    const auto& aCase = a.m_wrapped->cases()[0];
+                    const auto& bCase = b.m_accessCase;
+                    if (!AccessCase::canBeShared(aCase.get(), bCase.get()))
+                        return false;
                     return true;
                 }
                 return false;
             }
         };
 
-        Searcher(StructureStubInfoKey&& stubInfoKey, std::span<const Ref<AccessCase>>&& span)
+        Searcher(StructureStubInfoKey&& stubInfoKey, Ref<AccessCase>&& accessCase)
             : m_stubInfoKey(WTFMove(stubInfoKey))
-            , m_cases(WTFMove(span))
-            , m_hash(PolymorphicAccessJITStubRoutine::computeHash(m_cases))
+            , m_accessCase(WTFMove(accessCase))
+            , m_hash(m_accessCase->hash())
         {
         }
 
         StructureStubInfoKey m_stubInfoKey;
-        std::span<const Ref<AccessCase>> m_cases;
+        Ref<AccessCase> m_accessCase;
         unsigned m_hash { 0 };
     };
 

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp
@@ -141,6 +141,9 @@ void PolymorphicAccessJITStubRoutine::invalidate()
 
 unsigned PolymorphicAccessJITStubRoutine::computeHash(std::span<const Ref<AccessCase>> cases)
 {
+    if (cases.size() == 1)
+        return cases.front()->hash();
+
     Hasher hasher;
     for (auto& key : cases)
         WTF::add(hasher, key->hash());


### PR DESCRIPTION
#### db4158a3355bbe0540eda12699f081660adc879a
<pre>
[JSC] Always use Handler IC on Baseline JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=275573">https://bugs.webkit.org/show_bug.cgi?id=275573</a>
<a href="https://rdar.apple.com/130016303">rdar://130016303</a>

Reviewed by Yijia Huang.

This patch enables Handler IC for ByVal ICs. We already emitted Int32 / String / Symbol checks inside handler when it is necessary.
So we can simply enable Handler IC for ByVal ICs. As a result, Handler IC always use InlineCacheCompiler::compileHandler, and InlineCacheCompiler::compile
is not longer used for Handler IC. So we remove Handler IC specific code from InlineCacheCompiler::compile.

* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::compile):
(JSC::InlineCacheCompiler::compileOneAccessCaseHandler):
* Source/JavaScriptCore/bytecode/SharedJITStubSet.h:
(JSC::SharedJITStubSet::Searcher::Translator::equal):
(JSC::SharedJITStubSet::Searcher::Searcher):
* Source/JavaScriptCore/bytecode/StructureStubInfo.cpp:
(JSC::StructureStubInfo::addAccessCase):
(JSC::StructureStubInfo::callLinkInfoAt):
(JSC::StructureStubInfo::resetStubAsJumpInAccess):
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp:
(JSC::PolymorphicAccessJITStubRoutine::computeHash):

Canonical link: <a href="https://commits.webkit.org/280098@main">https://commits.webkit.org/280098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4f7b4aa10e55c6b8596a651ee6371e7ae7b7db1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35046 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58707 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6154 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44877 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4234 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32944 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48031 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26009 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29731 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5360 "Found 1 new test failure: imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4297 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/48800 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51707 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60298 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/54960 "Built successfully and passed tests") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5759 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52302 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51795 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/76722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8223 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30877 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/76722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31962 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33043 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31709 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->