### PR TITLE
[WebGPU] Release assertion triggered in RenderPassEncoder::computeMininumVertexInstanceCount

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/poc-275569-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/poc-275569-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/poc-275569.html
+++ b/LayoutTests/fast/webgpu/nocrash/poc-275569.html
@@ -1,0 +1,326 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>WebGPU triangle</title>
+    <script>
+onload = async () => {
+  let adapter = await navigator.gpu.requestAdapter({});
+  let device = await adapter.requestDevice({
+    label: 'dev',
+    requiredFeatures: [
+      'depth-clip-control',
+      'texture-compression-etc2',
+      'texture-compression-astc',
+      'texture-compression-bc',
+      'indirect-first-instance',
+      'shader-f16',
+      'rg11b10ufloat-renderable',
+      'bgra8unorm-storage'
+    ],
+    requiredLimits: {
+      maxColorAttachmentBytesPerSample: 49,
+      maxVertexAttributes: 22,
+      maxVertexBufferArrayStride: 22731,
+      maxStorageTexturesPerShaderStage: 13,
+      maxBindingsPerBindGroup: 2463,
+      maxTextureArrayLayers: 2048,
+      maxTextureDimension1D: 9624,
+      maxTextureDimension2D: 12505,
+      maxVertexBuffers: 12,
+      minUniformBufferOffsetAlignment: 32,
+    },
+  });
+
+  // Clear color for GPURenderPassDescriptor
+  const clearColor = { r: 0.0, g: 0.5, b: 1.0, a: 1.0 };
+
+  // Vertex data for triangle
+  // Each vertex has 8 values representing position and color: X Y Z W R G B A
+
+  const vertices = new Float32Array([
+    0.0,  0.6, 0, 1, 1, 0, 0, 1,
+  -0.5, -0.6, 0, 1, 0, 1, 0, 1,
+    0.5, -0.6, 0, 1, 0, 0, 1, 1
+  ]);
+
+  // Vertex and fragment shaders
+  const shaders = `
+  struct VertexOut {
+    @builtin(position) position : vec4f,
+    @location(0) color : vec4f
+  }
+
+  @vertex
+  fn vertex_main(@location(0) position: vec4f,
+                @location(1) color: vec4f) -> VertexOut
+  {
+    var output : VertexOut;
+    output.position = position;
+    output.color = color;
+    return output;
+  }
+
+  @fragment
+  fn fragment_main(fragData: VertexOut) -> @location(0) vec4f
+  {
+    return fragData.color;
+  }
+  `;
+
+  // 2: Create a shader module from the shaders template literal
+  const shaderModule = device.createShaderModule({
+    code: shaders
+  });
+
+  // 3: Get reference to the canvas to render on
+  const canvas = document.querySelector('#gpuCanvas');
+  const context = canvas.getContext('webgpu');
+
+  context.configure({
+    device: device,
+    format: navigator.gpu.getPreferredCanvasFormat(),
+    alphaMode: 'premultiplied'
+  });
+
+  // 4: Create vertex buffer to contain vertex data
+  const vertexBuffer = device.createBuffer({
+    size: vertices.byteLength, // make it big enough to store vertices in
+    usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+  });
+
+  // Copy the vertex data over to the GPUBuffer using the writeBuffer() utility function
+  device.queue.writeBuffer(vertexBuffer, 0, vertices, 0, vertices.length);
+
+  // 5: Create a GPUVertexBufferLayout and GPURenderPipelineDescriptor to provide a definition of our render pipline
+  const vertexBuffers = [{
+    attributes: [{
+      shaderLocation: 0, // position
+      offset: 0,
+      format: 'float32x4'
+    }, {
+      shaderLocation: 1, // color
+      offset: 16,
+      format: 'float32x4'
+    }],
+    arrayStride: 32,
+    stepMode: 'vertex'
+  }];
+
+  const bindGroupLayout = device.createBindGroupLayout({
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: {
+        type: "uniform",
+        hasDynamicOffset: true,
+      },
+    },
+    {
+      binding: 1,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: {
+        type: "storage",
+        hasDynamicOffset: true,
+      },
+    },
+    {
+      binding: 2,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: {
+        type: "storage",
+        hasDynamicOffset: true,
+      },
+    },
+  ],
+  });
+
+  const bindGroupLayout2 = device.createBindGroupLayout({
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: {
+        type: "uniform",
+        hasDynamicOffset: true,
+      },
+    },
+    {
+      binding: 1,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: {
+        type: "storage",
+        hasDynamicOffset: true,
+        minBindingSize: 0x12,
+      },
+    },
+    {
+      binding: 2,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: {
+        type: "storage",
+        hasDynamicOffset: true,
+      },
+    },
+  ],
+  });
+
+  const pipelineLayout = device.createPipelineLayout({
+    bindGroupLayouts: [bindGroupLayout, bindGroupLayout2],
+  });
+
+  const pipelineDescriptor = {
+    vertex: {
+      module: shaderModule,
+      entryPoint: 'vertex_main',
+      buffers: vertexBuffers
+    },
+    fragment: {
+      module: shaderModule,
+      entryPoint: 'fragment_main',
+      targets: [{
+        format: navigator.gpu.getPreferredCanvasFormat()
+      }]
+    },
+    primitive: {
+      topology: 'triangle-list'
+    },
+    layout: pipelineLayout
+  };
+
+  // 6: Create the actual render pipeline
+
+  const renderPipeline = device.createRenderPipeline(pipelineDescriptor);
+
+  // 7: Create GPUCommandEncoder to issue commands to the GPU
+  // Note: render pass descriptor, command encoder, etc. are destroyed after use, fresh one needed for each frame.
+  let commandEncoder = device.createCommandEncoder();
+
+  // 8: Create GPURenderPassDescriptor to tell WebGPU which texture to draw into, then initiate render pass
+
+  const renderPassDescriptor = {
+    colorAttachments: [{
+      clearValue: clearColor,
+      loadOp: 'clear',
+      storeOp: 'store',
+      view: context.getCurrentTexture().createView()
+    }]
+  };
+
+  const output = device.createBuffer({
+      size: 1024,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC
+    });
+
+  const output2 = device.createBuffer({
+    size: 0x10000000,
+    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC
+  });
+
+  const outputUniform = device.createBuffer({
+      size: 1024,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_SRC
+    });
+
+  const bindGroup = device.createBindGroup({
+    layout: bindGroupLayout,
+    entries: [
+      {
+        binding: 0,
+        resource: {
+          buffer: outputUniform,
+          size: 500
+        },
+      },
+      {
+        binding: 1,
+        resource: {
+          buffer: output2,
+          size: 500
+        },
+      },
+      {
+        binding: 2,
+        resource: {
+          buffer: output,
+          size: 500
+        },
+      },
+    ],
+  });
+
+  const bindGroup2 = device.createBindGroup({
+    layout: bindGroupLayout2,
+    entries: [
+      {
+        binding: 0,
+        resource: {
+          buffer: outputUniform,
+          size: 512
+        },
+      },
+      {
+        binding: 1,
+        resource: {
+          buffer: output,
+          size: 512
+        },
+      },
+      {
+        binding: 2,
+        resource: {
+          buffer: output,
+          size: 512
+        },
+      },
+    ],
+  });
+
+  // 9: Draw the triangle
+
+  let passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+
+  passEncoder.setPipeline(renderPipeline);
+  // passEncoder.setVertexBuffer(0, vertexBuffer);
+  // const dynamicOffsets = new Uint32Array([256, 512, 256, 256, 256]);
+  // passEncoder.setBindGroup(0, bindGroup, dynamicOffsets, 1, 3);
+  // passEncoder.setBindGroup(1, bindGroup2, dynamicOffsets, 1, 3);
+
+  const indexCount = 16;
+  const indexBuffer = device.createBuffer({
+    size: indexCount * Uint16Array.BYTES_PER_ELEMENT,
+    usage: GPUBufferUsage.INDEX,
+    mappedAtCreation: true,
+  });
+  passEncoder.setIndexBuffer(indexBuffer, "uint16");
+
+  const drawValues = device.createBuffer({
+    size: 20,
+    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT,
+  });
+  passEncoder.drawIndexedIndirect(drawValues, 0);
+
+  // passEncoder.draw(3);
+
+  // End the render pass
+  passEncoder.end();
+
+  // 10: End frame by passing array of command buffers to command queue for execution
+  device.queue.submit([commandEncoder.finish()]);
+
+  // commandEncoder = device.createCommandEncoder();
+  // passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+  // passEncoder.setIndexBuffer(indexBuffer, "uint16");
+  // passEncoder.end();
+  // device.queue.submit([commandEncoder.finish()]);
+
+
+};
+  </script>
+</head>
+<body>
+  <h1>WebGPU triangle</h1>
+  <canvas id="gpuCanvas" width="800" height="600"></canvas>
+</body>
+</html>

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -571,10 +571,7 @@ std::pair<uint32_t, uint32_t> RenderBundleEncoder::computeMininumVertexInstanceC
     uint32_t minInstanceCount = invalidVertexInstanceCount;
     auto& requiredBufferIndices = m_pipeline->requiredBufferIndices();
     for (auto& [bufferIndex, bufferData] : requiredBufferIndices) {
-        if (bufferIndex >= m_vertexBuffers.size())
-            continue;
-        auto& vertexBuffer = m_vertexBuffers[bufferIndex];
-        auto bufferSize = vertexBuffer.size;
+        auto bufferSize = bufferIndex < m_vertexBuffers.size() ? m_vertexBuffers[bufferIndex].size : 0;
         auto stride = bufferData.stride;
         auto lastStride = bufferData.lastStride;
         if (!stride)

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -583,8 +583,7 @@ std::pair<uint32_t, uint32_t> RenderPassEncoder::computeMininumVertexInstanceCou
     auto& requiredBufferIndices = m_pipeline->requiredBufferIndices();
     for (auto& [bufferIndex, bufferData] : requiredBufferIndices) {
         auto it = m_vertexBuffers.find(bufferIndex);
-        RELEASE_ASSERT(it != m_vertexBuffers.end());
-        auto bufferSize = it->value.buffer.length;
+        auto bufferSize = it == m_vertexBuffers.end() ? 0 : it->value.buffer.length;
         auto stride = bufferData.stride;
         auto lastStride = bufferData.lastStride;
         if (!stride)


### PR DESCRIPTION
#### 59950b920418413ba9bd7e6bfca147bd599d0514
<pre>
[WebGPU] Release assertion triggered in RenderPassEncoder::computeMininumVertexInstanceCount
<a href="https://bugs.webkit.org/show_bug.cgi?id=275569">https://bugs.webkit.org/show_bug.cgi?id=275569</a>
&lt;radar://129990531&gt;

Reviewed by Tadeu Zagallo.

If the user does not call setVertexBuffer on a buffer which the pipeline
uses, we should treat the buffer&apos;s size as 0.

* LayoutTests/fast/webgpu/nocrash/poc-275569-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/poc-275569.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::computeMininumVertexInstanceCount const):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::computeMininumVertexInstanceCount const):

Canonical link: <a href="https://commits.webkit.org/280310@main">https://commits.webkit.org/280310@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/047f0dfa29993b617b47f042fe1b458a30cad1fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55727 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58711 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6158 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42672 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6356 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44874 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4236 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32951 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48529 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26402 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29738 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5363 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4301 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51710 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5630 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60302 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5762 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52304 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48104 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51797 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12461 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30881 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31966 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33047 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31713 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->