### PR TITLE
Reduce code duplication in SiteIsolation.mm

### DIFF
--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -26,6 +26,7 @@
 #import <WebKit/WebKit.h>
 #import <wtf/RetainPtr.h>
 
+@class _WKFrameTreeNode;
 @class _WKProcessPoolConfiguration;
 
 #if PLATFORM(IOS_FAMILY)
@@ -207,4 +208,11 @@ struct AutocorrectionContext {
 @property (nonatomic) BOOL forceWindowToBecomeKey;
 @end
 #endif
+
+@interface TestWKWebView (SiteIsolation)
+- (_WKFrameTreeNode *)mainFrame;
+- (_WKFrameTreeNode *)firstChildFrame;
+- (void)evaluateJavaScript:(NSString *)string inFrame:(WKFrameInfo *)frame completionHandler:(void(^)(id, NSError *))completionHandler;
+- (WKFindResult *)findStringAndWait:(NSString *)string withConfiguration:(WKFindConfiguration *)configuration;
+@end
 


### PR DESCRIPTION
#### 28e8c9518098caa802fabc81fda8ef46eb1f42a2
<pre>
Reduce code duplication in SiteIsolation.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=275576">https://bugs.webkit.org/show_bug.cgi?id=275576</a>
<a href="https://rdar.apple.com/130018166">rdar://130018166</a>

Reviewed by Alex Christensen.

Site isolation API tests do certain things often, like evaluate JavaScript in an iframe or get the node
for the main frame or its first child frame. We should have helper functions instead of duplicating the
code in tests.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, PreferencesUpdatesToAllProcesses)):
(TestWebKitAPI::TEST(SiteIsolation, ParentOpener)):
(TestWebKitAPI::TEST(SiteIsolation, CloseAfterWindowOpen)):
(TestWebKitAPI::TEST(SiteIsolation, PostMessageWithMessagePorts)):
(TestWebKitAPI::TEST(SiteIsolation, PostMessageWithNotAllowedTargetOrigin)):
(TestWebKitAPI::TEST(SiteIsolation, PostMessageToIFrameWithOpaqueOrigin)):
(TestWebKitAPI::TEST(SiteIsolation, QueryFramesStateAfterNavigating)):
(TestWebKitAPI::TEST(SiteIsolation, NavigatingCrossOriginIframeToSameOrigin)):
(TestWebKitAPI::TEST(SiteIsolation, ParentNavigatingCrossOriginIframeToSameOrigin)):
(TestWebKitAPI::TEST(SiteIsolation, IframeNavigatesSelfWithoutChangingOrigin)):
(TestWebKitAPI::TEST(SiteIsolation, IframeWithConfirm)):
(TestWebKitAPI::TEST(SiteIsolation, IframeWithPrompt)):
(TestWebKitAPI::TEST(SiteIsolation, ChildNavigatingToNewDomain)):
(TestWebKitAPI::TEST(SiteIsolation, ChildNavigatingToMainFrameDomain)):
(TestWebKitAPI::TEST(SiteIsolation, ChildNavigatingToSameDomain)):
(TestWebKitAPI::TEST(SiteIsolation, ChildNavigatingToDomainLoadedOnADifferentPage)):
(TestWebKitAPI::TEST(SiteIsolation, MainFrameWithTwoIFramesInTheSameProcess)):
(TestWebKitAPI::TEST(SiteIsolation, ChildBeingNavigatedToMainFrameDomainByParent)):
(TestWebKitAPI::TEST(SiteIsolation, ChildBeingNavigatedToSameDomainByParent)):
(TestWebKitAPI::TEST(SiteIsolation, CrossOriginOpenerPolicy)):
(TestWebKitAPI::TEST(SiteIsolation, PropagateMouseEventsToSubframe)):
(TestWebKitAPI::TEST(SiteIsolation, RunOpenPanel)):
(TestWebKitAPI::TEST(SiteIsolation, PasteGIF)):
(TestWebKitAPI::TEST(SiteIsolation, OpenerProcessSharing)):
(TestWebKitAPI::TEST(SiteIsolation, SetFocusedFrame)):
(TestWebKitAPI::TEST(SiteIsolation, EvaluateJavaScriptInFrame)):
(TestWebKitAPI::TEST(SiteIsolation, MainFrameURLAfterFragmentNavigation)):
(TestWebKitAPI::TEST(SiteIsolation, FocusOpenedWindow)):
(TestWebKitAPI::TEST(SiteIsolation, FindStringInFrame)):
(TestWebKitAPI::TEST(SiteIsolation, FindStringInNestedFrame)):
(TestWebKitAPI::TEST(SiteIsolation, FindStringSelection)):
(TestWebKitAPI::TEST(SiteIsolation, FindStringSelectionWithEmptyFrames)):
(TestWebKitAPI::TEST(SiteIsolation, FindStringSelectionNoWrap)):
(TestWebKitAPI::TEST(SiteIsolation, FindStringSelectionBackwards)):
(TestWebKitAPI::TEST(SiteIsolation, FindStringSelectionSameOriginFrames)):
(TestWebKitAPI::TEST(SiteIsolation, FindStringSelectionNestedFrames)):
(TestWebKitAPI::TEST(SiteIsolation, FindStringSelectionMultipleMatchesInMainFrame)):
(TestWebKitAPI::TEST(SiteIsolation, FindStringSelectionMultipleMatchesInChildFrame)):
(TestWebKitAPI::TEST(SiteIsolation, FindStringSelectionSameOriginFrameBeforeWrap)):
(TestWebKitAPI::TEST(SiteIsolation, FindStringMatchCount)):
(TestWebKitAPI::TEST(SiteIsolation, CustomUserAgent)):
(TestWebKitAPI::TEST(SiteIsolation, ApplicationNameForUserAgent)):
(TestWebKitAPI::TEST(SiteIsolation, WebsitePoliciesCustomUserAgent)):
(TestWebKitAPI::TEST(SiteIsolation, WebsitePoliciesCustomNavigatorPlatform)):
(TestWebKitAPI::TEST(SiteIsolation, ProvisionalLoadFailureOnCrossSiteRedirect)):
(TestWebKitAPI::TEST(SiteIsolation, SynchronouslyExecuteEditCommandSelectAll)):
(TestWebKitAPI::TEST(SiteIsolation, SelectAll)):
(TestWebKitAPI::TEST(SiteIsolation, TopContentInsetAfterCrossSiteNavigation)):
(TestWebKitAPI::TEST(SiteIsolation, CanGoBackAfterLoadingAndNavigatingFrame)):
(TestWebKitAPI::TEST(SiteIsolation, CanGoBackAfterNavigatingFrameCrossOrigin)):
(TestWebKitAPI::TEST(SiteIsolation, NavigateIframeSameOriginBackForward)):
(TestWebKitAPI::TEST(SiteIsolation, NavigateIframeCrossOriginBackForward)):
(TestWebKitAPI::TEST(SiteIsolation, NavigateNestedIframeSameOriginBackForward)):
(TestWebKitAPI::TEST(SiteIsolation, AdvancedPrivacyProtectionsHideScreenMetricsFromBindings)):
* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[TestWKWebView mainFrame]):
(-[TestWKWebView firstChildFrame]):
(-[TestWKWebView evaluateJavaScript:inFrame:completionHandler:]):
(-[TestWKWebView findStringAndWait:withConfiguration:]):

Canonical link: <a href="https://commits.webkit.org/280137@main">https://commits.webkit.org/280137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/504bf2840e32e75742c022b6f2cc1fefefc116cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55843 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58839 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6275 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57969 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6471 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4331 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57872 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33061 "Found 60 new test failures: accessibility/accessibility-node-reparent.html accessibility/ancestor-computation.html accessibility/announcement-notification.html accessibility/aria-braillelabel.html accessibility/aria-brailleroledescription.html accessibility/aria-checked-mixed-value.html accessibility/aria-current-state-changed-notification.html accessibility/aria-current.html accessibility/aria-describedby-on-input.html accessibility/aria-description.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48142 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26100 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29845 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5470 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4418 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60428 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5866 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48211 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8241 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30996 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32080 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33162 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/31828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->