### PR TITLE
Marked some Legacy WebKit notification names as deprecated

### DIFF
--- a/Source/WebKitLegacy/mac/WebView/WebView.h
+++ b/Source/WebKitLegacy/mac/WebView/WebView.h
@@ -600,11 +600,11 @@ WEBKIT_CLASS_DEPRECATED_MAC(10_3, 10_14, "No longer supported; please adopt WKWe
 
 // WebView editing support
 
-extern NSString * const WebViewDidBeginEditingNotification;
-extern NSString * const WebViewDidChangeNotification;
-extern NSString * const WebViewDidEndEditingNotification;
-extern NSString * const WebViewDidChangeTypingStyleNotification;
-extern NSString * const WebViewDidChangeSelectionNotification;
+extern NSString * const WebViewDidBeginEditingNotification WEBKIT_DEPRECATED_MAC(10_3, 10_14);
+extern NSString * const WebViewDidChangeNotification WEBKIT_DEPRECATED_MAC(10_3, 10_14);
+extern NSString * const WebViewDidEndEditingNotification WEBKIT_DEPRECATED_MAC(10_3, 10_14);
+extern NSString * const WebViewDidChangeTypingStyleNotification WEBKIT_DEPRECATED_MAC(10_3, 10_14);
+extern NSString * const WebViewDidChangeSelectionNotification WEBKIT_DEPRECATED_MAC(10_3, 10_14);
 
 @interface WebView (WebViewCSS)
 - (DOMCSSStyleDeclaration *)computedStyleForElement:(DOMElement *)element pseudoElement:(NSString *)pseudoElement;


### PR DESCRIPTION
#### d1499acf0f8633c4673883b62fd05832184f0597
<pre>
Marked some Legacy WebKit notification names as deprecated
<a href="https://bugs.webkit.org/show_bug.cgi?id=275587">https://bugs.webkit.org/show_bug.cgi?id=275587</a>
<a href="https://rdar.apple.com/130033164">rdar://130033164</a>

Reviewed by Brady Eidson.

The rest are already marked as such, but we missed these.

This helps clarify in the SDK why these APIs weren&apos;t updated to use modern
thread safety techniques.

* Source/WebKitLegacy/mac/WebView/WebView.h:

Canonical link: <a href="https://commits.webkit.org/280101@main">https://commits.webkit.org/280101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42fcf186b4f010d552340f483e866ed1c7a6e4be

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8220 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58737 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6184 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6382 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44899 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4254 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57782 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48059 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26033 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29764 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5388 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4327 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60328 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5785 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52327 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48130 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51824 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12345 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30907 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31992 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33073 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31739 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->