### PR TITLE
Crash at com.apple.WebKit: -[_WKWebExtensionMessagePort sendMessage:completionHandler:].

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.h
@@ -82,7 +82,7 @@ NS_SWIFT_NAME(_WKWebExtension.MessagePort)
  @param message The message that needs to be sent, which must be JSON-serializable.
  @param completionHandler An optional block to be invoked after the message is sent, taking a boolean and an optional error object as parameters.
  */
-- (void)sendMessage:(id)message completionHandler:(void (^ _Nullable)(BOOL success, NSError * _Nullable error))completionHandler WK_SWIFT_ASYNC_THROWS_ON_FALSE(1);
+- (void)sendMessage:(nullable id)message completionHandler:(void (^ _Nullable)(BOOL success, NSError * _Nullable error))completionHandler WK_SWIFT_ASYNC_THROWS_ON_FALSE(1);
 
 /*!
  @abstract Disconnects the port, terminating all further messages.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.mm
@@ -68,8 +68,6 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(_WKWebExtensionMessagePort, WebExtensionMe
 
 - (void)sendMessage:(id)message completionHandler:(void (^)(BOOL success, NSError *))completionHandler
 {
-    NSParameterAssert(message);
-
     if (!completionHandler)
         completionHandler = ^(BOOL, NSError *) { };
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm
@@ -128,7 +128,7 @@ void WebExtensionMessagePort::sendMessage(id message, CompletionHandler<void(Err
         return;
     }
 
-    if (!isValidJSONObject(message, JSONOptions::FragmentsAllowed)) {
+    if (message && !isValidJSONObject(message, JSONOptions::FragmentsAllowed)) {
         completionHandler({ { ErrorType::MessageInvalid, std::nullopt } });
         return;
     }


### PR DESCRIPTION
#### f1994d68f985424f788a88fe4f01cd2e45ed3f5d
<pre>
Crash at com.apple.WebKit: -[_WKWebExtensionMessagePort sendMessage:completionHandler:].
<a href="https://webkit.org/b/275589">https://webkit.org/b/275589</a>
<a href="https://rdar.apple.com/129687779">rdar://129687779</a>

Reviewed by Brian Weinstein.

We need to allow `nil` to be sent to `_WKWebExtensionMessagePort`, which will be delivered as `undefined`.
This was the behavior in Safari 17, so we need to match to avoid breaking extensions.

* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.h: Added nullable to sendMessage:completionHandler:.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionMessagePort.mm:
(-[_WKWebExtensionMessagePort sendMessage:completionHandler:]): Removed NSParameterAssert.
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionMessagePortCocoa.mm:
(WebKit::WebExtensionMessagePort::sendMessage): Only call isValidJSONObject if message is not null.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, ConnectNative)): Removed nullable attributes.
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, ConnectNativeWithInvalidMessage)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, ConnectNativeWithUndefinedMessage)): Added.

Canonical link: <a href="https://commits.webkit.org/280107@main">https://commits.webkit.org/280107@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00813247a1585377d0af91091542286b539e798b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55759 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35082 "Build is in progress. Recent messages:OS: Sonoma (14.4.1), Xcode: 15.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58743 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6190 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57885 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42704 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6388 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44904 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4260 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32980 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48060 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26038 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29766 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5389 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4333 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5658 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60334 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5791 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52332 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48131 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51830 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8227 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30913 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/31998 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33079 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31745 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->