### PR TITLE
Further reduce use of legacyMainFrameProcess

### DIFF
--- a/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.h
+++ b/Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.h
@@ -34,14 +34,12 @@
 
 OBJC_CLASS _WKRemoteObjectRegistry;
 
-namespace IPC {
-class MessageSender;
-}
-
 namespace WebKit {
 
 class RemoteObjectInvocation;
 class UserData;
+class WebPage;
+class WebProcessProxy;
 
 class RemoteObjectRegistry : public IPC::MessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
@@ -54,11 +52,12 @@ public:
 
 protected:
     explicit RemoteObjectRegistry(_WKRemoteObjectRegistry *);
-    
+    using MessageSender = std::variant<std::reference_wrapper<WebProcessProxy>, std::reference_wrapper<WebPage>>;
 private:
     virtual std::unique_ptr<ProcessThrottler::BackgroundActivity> backgroundActivity(ASCIILiteral) { return nullptr; }
-    virtual IPC::MessageSender& messageSender() = 0;
+    virtual MessageSender messageSender() = 0;
     virtual uint64_t messageDestinationID() = 0;
+    template<typename M> void send(M&&);
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;

--- a/Source/WebKit/Shared/API/Cocoa/WKBrowsingContextHandle.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKBrowsingContextHandle.mm
@@ -34,7 +34,7 @@
 
 - (id)_initWithPageProxy:(NakedRef<WebKit::WebPageProxy>)page
 {
-    return [self _initWithPageProxyID:page->identifier() andWebPageID:page->webPageID()];
+    return [self _initWithPageProxyID:page->identifier() andWebPageID:page->webPageIDInMainFrameProcess()];
 }
 
 - (id)_initWithPage:(NakedRef<WebKit::WebPage>)page

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -1315,7 +1315,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         milestones.add(WebCore::LayoutMilestone::DidFirstVisuallyNonEmptyLayout);
 
     if (milestones)
-        webPageProxy->send(Messages::WebPage::ListenForLayoutMilestones(milestones));
+        webPageProxy->legacyMainFrameProcess().send(Messages::WebPage::ListenForLayoutMilestones(milestones), webPageProxy->webPageIDInMainFrameProcess());
 
     webPageProxy->setLoaderClient(WTFMove(loaderClient));
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm
@@ -56,7 +56,7 @@
 
     WebKit::InitializeWebKit2();
 
-    API::Object::constructInWrapper<API::UserStyleSheet>(self, WebCore::UserStyleSheet { source, baseURL, makeVector<String>(includeMatchPatternStrings), makeVector<String>(excludeMatchPatternStrings), forMainFrameOnly ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames, API::toWebCoreUserStyleLevel(level), webView ? std::optional<WebCore::PageIdentifier>([webView _page]->webPageID()) : std::nullopt }, contentWorld ? *contentWorld->_contentWorld : API::ContentWorld::pageContentWorld());
+    API::Object::constructInWrapper<API::UserStyleSheet>(self, WebCore::UserStyleSheet { source, baseURL, makeVector<String>(includeMatchPatternStrings), makeVector<String>(excludeMatchPatternStrings), forMainFrameOnly ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames, API::toWebCoreUserStyleLevel(level), webView ? std::optional<WebCore::PageIdentifier>([webView _page]->webPageIDInMainFrameProcess()) : std::nullopt }, contentWorld ? *contentWorld->_contentWorld : API::ContentWorld::pageContentWorld());
 
     return self;
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -3463,7 +3463,7 @@ guint64 webkit_web_view_get_page_id(WebKitWebView* webView)
 {
     g_return_val_if_fail(WEBKIT_IS_WEB_VIEW(webView), 0);
 
-    return getPage(webView).webPageID().toUInt64();
+    return getPage(webView).webPageIDInMainFrameProcess().toUInt64();
 }
 
 /**
@@ -5256,7 +5256,7 @@ void webkit_web_view_send_message_to_page(WebKitWebView* webView, WebKitUserMess
     GRefPtr<WebKitUserMessage> adoptedMessage = message;
     Ref page = getPage(webView);
     if (!callback) {
-        page->ensureRunningProcess().send(Messages::WebPage::SendMessageToWebProcessExtension(webkitUserMessageGetMessage(message)), page->webPageID().toUInt64());
+        page->ensureRunningProcess().send(Messages::WebPage::SendMessageToWebProcessExtension(webkitUserMessageGetMessage(message)), page->webPageIDInMainFrameProcess().toUInt64());
         return;
     }
 
@@ -5275,7 +5275,7 @@ void webkit_web_view_send_message_to_page(WebKitWebView* webView, WebKitUserMess
         }
     };
     page->ensureRunningProcess().sendWithAsyncReply(Messages::WebPage::SendMessageToWebProcessExtensionWithReply(webkitUserMessageGetMessage(message)),
-        WTFMove(completionHandler), page->webPageID().toUInt64());
+        WTFMove(completionHandler), page->webPageIDInMainFrameProcess().toUInt64());
 }
 
 /**

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -972,7 +972,7 @@ void WebAutomationSession::evaluateJavaScriptFunction(const Inspector::Protocol:
     uint64_t callbackID = m_nextEvaluateJavaScriptCallbackID++;
     m_evaluateJavaScriptFunctionCallbacks.set(callbackID, WTFMove(callback));
 
-    page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::EvaluateJavaScriptFunction(page->webPageID(), frameID, function, argumentsVector, expectsImplicitCallbackArgument.value_or(false), WTFMove(callbackTimeout), callbackID));
+    page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::EvaluateJavaScriptFunction(page->webPageIDInMainFrameProcess(), frameID, function, argumentsVector, expectsImplicitCallbackArgument.value_or(false), WTFMove(callbackTimeout), callbackID));
 }
 
 void WebAutomationSession::didEvaluateJavaScriptFunction(uint64_t callbackID, const String& result, const String& errorType)
@@ -1011,17 +1011,17 @@ void WebAutomationSession::resolveChildFrameHandle(const Inspector::Protocol::Au
     };
 
     if (!!optionalNodeHandle) {
-        page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::ResolveChildFrameWithNodeHandle(page->webPageID(), frameID, optionalNodeHandle), WTFMove(completionHandler));
+        page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::ResolveChildFrameWithNodeHandle(page->webPageIDInMainFrameProcess(), frameID, optionalNodeHandle), WTFMove(completionHandler));
         return;
     }
 
     if (!!optionalName) {
-        page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::ResolveChildFrameWithName(page->webPageID(), frameID, optionalName), WTFMove(completionHandler));
+        page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::ResolveChildFrameWithName(page->webPageIDInMainFrameProcess(), frameID, optionalName), WTFMove(completionHandler));
         return;
     }
 
     if (optionalOrdinal) {
-        page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::ResolveChildFrameWithOrdinal(page->webPageID(), frameID, *optionalOrdinal), WTFMove(completionHandler));
+        page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::ResolveChildFrameWithOrdinal(page->webPageIDInMainFrameProcess(), frameID, *optionalOrdinal), WTFMove(completionHandler));
         return;
     }
 
@@ -1048,7 +1048,7 @@ void WebAutomationSession::resolveParentFrameHandle(const Inspector::Protocol::A
         callback->sendSuccess(handleForWebFrameID(frameID));
     };
 
-    page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::ResolveParentFrame(page->webPageID(), frameID), WTFMove(completionHandler));
+    page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::ResolveParentFrame(page->webPageIDInMainFrameProcess(), frameID), WTFMove(completionHandler));
 }
 
 static std::optional<CoordinateSystem> protocolStringToCoordinateSystem(Inspector::Protocol::Automation::CoordinateSystem coordinateSystem)
@@ -1116,7 +1116,7 @@ void WebAutomationSession::computeElementLayout(const Inspector::Protocol::Autom
     };
 
     bool scrollIntoViewIfNeeded = optionalScrollIntoViewIfNeeded ? *optionalScrollIntoViewIfNeeded : false;
-    page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::ComputeElementLayout(page->webPageID(), frameID, nodeHandle, scrollIntoViewIfNeeded, coordinateSystem.value()), WTFMove(completionHandler));
+    page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::ComputeElementLayout(page->webPageIDInMainFrameProcess(), frameID, nodeHandle, scrollIntoViewIfNeeded, coordinateSystem.value()), WTFMove(completionHandler));
 }
 
 void WebAutomationSession::getComputedRole(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, const Inspector::Protocol::Automation::NodeHandle& nodeHandle, Ref<GetComputedRoleCallback>&& callback)
@@ -1139,7 +1139,7 @@ void WebAutomationSession::getComputedRole(const Inspector::Protocol::Automation
         callback->sendSuccess(*role);
     };
 
-    page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::GetComputedRole(page->webPageID(), frameID, nodeHandle), WTFMove(completionHandler));
+    page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::GetComputedRole(page->webPageIDInMainFrameProcess(), frameID, nodeHandle), WTFMove(completionHandler));
 }
 
 void WebAutomationSession::getComputedLabel(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, const Inspector::Protocol::Automation::NodeHandle& nodeHandle, Ref<GetComputedLabelCallback>&& callback)
@@ -1162,7 +1162,7 @@ void WebAutomationSession::getComputedLabel(const Inspector::Protocol::Automatio
         callback->sendSuccess(*label);
     };
 
-    page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::GetComputedLabel(page->webPageID(), frameID, nodeHandle), WTFMove(completionHandler));
+    page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::GetComputedLabel(page->webPageIDInMainFrameProcess(), frameID, nodeHandle), WTFMove(completionHandler));
 }
 
 void WebAutomationSession::selectOptionElement(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, const Inspector::Protocol::Automation::NodeHandle& nodeHandle, Ref<SelectOptionElementCallback>&& callback)
@@ -1185,7 +1185,7 @@ void WebAutomationSession::selectOptionElement(const Inspector::Protocol::Automa
         callback->sendSuccess();
     };
 
-    page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::SelectOptionElement(page->webPageID(), frameID, nodeHandle), WTFMove(completionHandler));
+    page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::SelectOptionElement(page->webPageIDInMainFrameProcess(), frameID, nodeHandle), WTFMove(completionHandler));
 }
 
 Inspector::Protocol::ErrorStringOr<bool> WebAutomationSession::isShowingJavaScriptDialog(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle)
@@ -1353,7 +1353,7 @@ void WebAutomationSession::setFilesForInputFileUpload(const Inspector::Protocol:
         callback->sendSuccess();
     };
 
-    page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::SetFilesForInputFileUpload(page->webPageID(), frameID, nodeHandle, WTFMove(newFileList)), WTFMove(completionHandler));
+    page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::SetFilesForInputFileUpload(page->webPageIDInMainFrameProcess(), frameID, nodeHandle, WTFMove(newFileList)), WTFMove(completionHandler));
 }
 
 static inline Inspector::Protocol::Automation::CookieSameSitePolicy toProtocolSameSitePolicy(WebCore::Cookie::SameSitePolicy policy)
@@ -1423,7 +1423,7 @@ void WebAutomationSession::getAllCookies(const Inspector::Protocol::Automation::
         callback->sendSuccess(buildArrayForCookies(cookies));
     };
 
-    page->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebAutomationSessionProxy::GetCookiesForFrame(page->webPageID(), std::nullopt), WTFMove(completionHandler));
+    page->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebAutomationSessionProxy::GetCookiesForFrame(page->webPageIDInMainFrameProcess(), std::nullopt), WTFMove(completionHandler));
 }
 
 void WebAutomationSession::deleteSingleCookie(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const String& cookieName, Ref<DeleteSingleCookieCallback>&& callback)
@@ -1441,7 +1441,7 @@ void WebAutomationSession::deleteSingleCookie(const Inspector::Protocol::Automat
         callback->sendSuccess();
     };
 
-    page->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebAutomationSessionProxy::DeleteCookie(page->webPageID(), std::nullopt, cookieName), WTFMove(completionHandler));
+    page->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebAutomationSessionProxy::DeleteCookie(page->webPageIDInMainFrameProcess(), std::nullopt, cookieName), WTFMove(completionHandler));
 }
 
 static String domainByAddingDotPrefixIfNeeded(String domain)
@@ -1748,7 +1748,7 @@ void WebAutomationSession::viewportInViewCenterPointOfElement(WebPageProxy& page
         completionHandler(inViewCenterPoint, std::nullopt);
     };
 
-    page.sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::ComputeElementLayout(page.webPageID(), frameID, nodeHandle, false, CoordinateSystem::LayoutViewport), WTFMove(didComputeElementLayoutHandler));
+    page.sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::ComputeElementLayout(page.webPageIDInMainFrameProcess(), frameID, nodeHandle, false, CoordinateSystem::LayoutViewport), WTFMove(didComputeElementLayoutHandler));
 }
 
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
@@ -2393,7 +2393,7 @@ void WebAutomationSession::takeScreenshot(const Inspector::Protocol::Automation:
         uint64_t callbackID = m_nextScreenshotCallbackID++;
         m_screenshotCallbacks.set(callbackID, WTFMove(callback));
 
-        page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::TakeScreenshot(page->webPageID(), frameID, nodeHandle, scrollIntoViewIfNeeded, clipToViewport, callbackID));
+        page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::TakeScreenshot(page->webPageIDInMainFrameProcess(), frameID, nodeHandle, scrollIntoViewIfNeeded, clipToViewport, callbackID));
         return;
     }
 #endif
@@ -2426,12 +2426,12 @@ void WebAutomationSession::takeScreenshot(const Inspector::Protocol::Automation:
         takeViewSnapsot(page.get(), WTFMove(rect), WTFMove(callback));
     };
 
-    page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::SnapshotRectForScreenshot(page->webPageID(), frameID, nodeHandle, scrollIntoViewIfNeeded, clipToViewport), WTFMove(completionHandler));
+    page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::SnapshotRectForScreenshot(page->webPageIDInMainFrameProcess(), frameID, nodeHandle, scrollIntoViewIfNeeded, clipToViewport), WTFMove(completionHandler));
 #else
     uint64_t callbackID = m_nextScreenshotCallbackID++;
     m_screenshotCallbacks.set(callbackID, WTFMove(callback));
 
-    page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::TakeScreenshot(page->webPageID(), frameID, nodeHandle, scrollIntoViewIfNeeded, clipToViewport, callbackID));
+    page->sendToProcessContainingFrame(frameID, Messages::WebAutomationSessionProxy::TakeScreenshot(page->webPageIDInMainFrameProcess(), frameID, nodeHandle, scrollIntoViewIfNeeded, clipToViewport, callbackID));
 #endif
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -493,7 +493,7 @@ PlaybackSessionManagerProxy::PlaybackSessionManagerProxy(WebPageProxy& page)
 #endif
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    m_page->legacyMainFrameProcess().addMessageReceiver(Messages::PlaybackSessionManagerProxy::messageReceiverName(), m_page->webPageID(), *this);
+    m_page->legacyMainFrameProcess().addMessageReceiver(Messages::PlaybackSessionManagerProxy::messageReceiverName(), m_page->webPageIDInMainFrameProcess(), *this);
 }
 
 PlaybackSessionManagerProxy::~PlaybackSessionManagerProxy()
@@ -507,7 +507,7 @@ PlaybackSessionManagerProxy::~PlaybackSessionManagerProxy()
 void PlaybackSessionManagerProxy::invalidate()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    m_page->legacyMainFrameProcess().removeMessageReceiver(Messages::PlaybackSessionManagerProxy::messageReceiverName(), m_page->webPageID());
+    m_page->legacyMainFrameProcess().removeMessageReceiver(Messages::PlaybackSessionManagerProxy::messageReceiverName(), m_page->webPageIDInMainFrameProcess());
     m_page = nullptr;
 
     auto contextMap = WTFMove(m_contextMap);
@@ -720,119 +720,119 @@ void PlaybackSessionManagerProxy::handleControlledElementIDResponse(PlaybackSess
 
 void PlaybackSessionManagerProxy::play(PlaybackSessionContextIdentifier contextId)
 {
-    m_page->send(Messages::PlaybackSessionManager::Play(contextId));
+    m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::Play(contextId), m_page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::pause(PlaybackSessionContextIdentifier contextId)
 {
-    m_page->send(Messages::PlaybackSessionManager::Pause(contextId));
+    m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::Pause(contextId), m_page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::togglePlayState(PlaybackSessionContextIdentifier contextId)
 {
-    m_page->send(Messages::PlaybackSessionManager::TogglePlayState(contextId));
+    m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::TogglePlayState(contextId), m_page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::beginScrubbing(PlaybackSessionContextIdentifier contextId)
 {
-    m_page->send(Messages::PlaybackSessionManager::BeginScrubbing(contextId));
+    m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::BeginScrubbing(contextId), m_page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::endScrubbing(PlaybackSessionContextIdentifier contextId)
 {
-    m_page->send(Messages::PlaybackSessionManager::EndScrubbing(contextId));
+    m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::EndScrubbing(contextId), m_page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::seekToTime(PlaybackSessionContextIdentifier contextId, double time, double toleranceBefore, double toleranceAfter)
 {
-    m_page->send(Messages::PlaybackSessionManager::SeekToTime(contextId, time, toleranceBefore, toleranceAfter));
+    m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::SeekToTime(contextId, time, toleranceBefore, toleranceAfter), m_page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::fastSeek(PlaybackSessionContextIdentifier contextId, double time)
 {
-    m_page->send(Messages::PlaybackSessionManager::FastSeek(contextId, time));
+    m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::FastSeek(contextId, time), m_page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::beginScanningForward(PlaybackSessionContextIdentifier contextId)
 {
-    m_page->send(Messages::PlaybackSessionManager::BeginScanningForward(contextId));
+    m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::BeginScanningForward(contextId), m_page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::beginScanningBackward(PlaybackSessionContextIdentifier contextId)
 {
-    m_page->send(Messages::PlaybackSessionManager::BeginScanningBackward(contextId));
+    m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::BeginScanningBackward(contextId), m_page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::endScanning(PlaybackSessionContextIdentifier contextId)
 {
-    m_page->send(Messages::PlaybackSessionManager::EndScanning(contextId));
+    m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::EndScanning(contextId), m_page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::setDefaultPlaybackRate(PlaybackSessionContextIdentifier contextId, double defaultPlaybackRate)
 {
-    m_page->send(Messages::PlaybackSessionManager::SetDefaultPlaybackRate(contextId, defaultPlaybackRate));
+    m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::SetDefaultPlaybackRate(contextId, defaultPlaybackRate), m_page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::setPlaybackRate(PlaybackSessionContextIdentifier contextId, double playbackRate)
 {
-    m_page->send(Messages::PlaybackSessionManager::SetPlaybackRate(contextId, playbackRate));
+    m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::SetPlaybackRate(contextId, playbackRate), m_page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::selectAudioMediaOption(PlaybackSessionContextIdentifier contextId, uint64_t index)
 {
-    m_page->send(Messages::PlaybackSessionManager::SelectAudioMediaOption(contextId, index));
+    m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::SelectAudioMediaOption(contextId, index), m_page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::selectLegibleMediaOption(PlaybackSessionContextIdentifier contextId, uint64_t index)
 {
-    m_page->send(Messages::PlaybackSessionManager::SelectLegibleMediaOption(contextId, index));
+    m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::SelectLegibleMediaOption(contextId, index), m_page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::togglePictureInPicture(PlaybackSessionContextIdentifier contextId)
 {
-    m_page->send(Messages::PlaybackSessionManager::TogglePictureInPicture(contextId));
+    m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::TogglePictureInPicture(contextId), m_page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::enterFullscreen(PlaybackSessionContextIdentifier contextId)
 {
-    m_page->send(Messages::PlaybackSessionManager::EnterFullscreen(contextId));
+    m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::EnterFullscreen(contextId), m_page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::exitFullscreen(PlaybackSessionContextIdentifier contextId)
 {
-    m_page->send(Messages::PlaybackSessionManager::ExitFullscreen(contextId));
+    m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::ExitFullscreen(contextId), m_page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::toggleInWindow(PlaybackSessionContextIdentifier contextId)
 {
-    m_page->send(Messages::PlaybackSessionManager::ToggleInWindow(contextId));
+    m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::ToggleInWindow(contextId), m_page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::toggleMuted(PlaybackSessionContextIdentifier contextId)
 {
-    m_page->send(Messages::PlaybackSessionManager::ToggleMuted(contextId));
+    m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::ToggleMuted(contextId), m_page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::setMuted(PlaybackSessionContextIdentifier contextId, bool muted)
 {
-    m_page->send(Messages::PlaybackSessionManager::SetMuted(contextId, muted));
+    m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::SetMuted(contextId, muted), m_page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::setVolume(PlaybackSessionContextIdentifier contextId, double volume)
 {
-    m_page->send(Messages::PlaybackSessionManager::SetVolume(contextId, volume));
+    m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::SetVolume(contextId, volume), m_page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::setPlayingOnSecondScreen(PlaybackSessionContextIdentifier contextId, bool value)
 {
     if (m_page)
-        m_page->send(Messages::PlaybackSessionManager::SetPlayingOnSecondScreen(contextId, value));
+        m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::SetPlayingOnSecondScreen(contextId, value), m_page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::sendRemoteCommand(PlaybackSessionContextIdentifier contextId, WebCore::PlatformMediaSession::RemoteControlCommandType command, const WebCore::PlatformMediaSession::RemoteCommandArgument& argument)
 {
     if (m_page)
-        m_page->send(Messages::PlaybackSessionManager::SendRemoteCommand(contextId, command, argument));
+        m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::SendRemoteCommand(contextId, command, argument), m_page->webPageIDInMainFrameProcess());
 }
 
 void PlaybackSessionManagerProxy::setVideoReceiverEndpoint(PlaybackSessionContextIdentifier contextId, const WebCore::VideoReceiverEndpoint& endpoint)
@@ -905,7 +905,7 @@ void PlaybackSessionManagerProxy::uncacheVideoReceiverEndpoint(PlaybackSessionCo
 void PlaybackSessionManagerProxy::setSpatialTrackingLabel(PlaybackSessionContextIdentifier contextId, const String& label)
 {
     if (m_page)
-        m_page->send(Messages::PlaybackSessionManager::SetSpatialTrackingLabel(contextId, label));
+        m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::SetSpatialTrackingLabel(contextId, label), m_page->webPageIDInMainFrameProcess());
 }
 #endif
 
@@ -924,7 +924,7 @@ void PlaybackSessionManagerProxy::removeNowPlayingMetadataObserver(PlaybackSessi
 void PlaybackSessionManagerProxy::setSoundStageSize(PlaybackSessionContextIdentifier contextId, WebCore::AudioSessionSoundStageSize size)
 {
     if (m_page)
-        m_page->send(Messages::PlaybackSessionManager::SetSoundStageSize(contextId, size));
+        m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::SetSoundStageSize(contextId, size), m_page->webPageIDInMainFrameProcess());
 }
 
 bool PlaybackSessionManagerProxy::wirelessVideoPlaybackDisabled()
@@ -939,7 +939,7 @@ bool PlaybackSessionManagerProxy::wirelessVideoPlaybackDisabled()
 void PlaybackSessionManagerProxy::requestControlledElementID()
 {
     if (m_controlsManagerContextId)
-        m_page->send(Messages::PlaybackSessionManager::HandleControlledElementIDRequest(m_controlsManagerContextId));
+        m_page->legacyMainFrameProcess().send(Messages::PlaybackSessionManager::HandleControlledElementIDRequest(m_controlsManagerContextId), m_page->webPageIDInMainFrameProcess());
 }
 
 PlatformPlaybackSessionInterface* PlaybackSessionManagerProxy::controlsManagerInterface()

--- a/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp
@@ -57,14 +57,14 @@ void UIRemoteObjectRegistry::sendInvocation(const RemoteObjectInvocation& invoca
     RemoteObjectRegistry::sendInvocation(invocation);
 }
 
-IPC::MessageSender& UIRemoteObjectRegistry::messageSender()
+auto UIRemoteObjectRegistry::messageSender() -> MessageSender
 {
-    return m_page.get();
+    return m_page->legacyMainFrameProcess();
 }
 
 uint64_t UIRemoteObjectRegistry::messageDestinationID()
 {
-    return protectedPage()->webPageID().toUInt64();
+    return protectedPage()->webPageIDInMainFrameProcess().toUInt64();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.h
@@ -41,7 +41,7 @@ public:
 
 private:
     Ref<WebPageProxy> protectedPage();
-    IPC::MessageSender& messageSender() final;
+    MessageSender messageSender() final;
     uint64_t messageDestinationID() final;
     std::unique_ptr<ProcessThrottler::BackgroundActivity> backgroundActivity(ASCIILiteral) final;
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -122,10 +122,10 @@ SOFT_LINK_PRIVATE_FRAMEWORK_OPTIONAL(AppleMediaServicesUI)
 SOFT_LINK_CLASS_OPTIONAL(AppleMediaServicesUI, AMSUIEngagementTask)
 #endif
 
-#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, legacyMainFrameProcess().connection())
-#define MESSAGE_CHECK_COMPLETION(assertion, completion) MESSAGE_CHECK_COMPLETION_BASE(assertion, legacyMainFrameProcess().connection(), completion)
+#define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, &connection)
+#define MESSAGE_CHECK_COMPLETION(assertion, completion) MESSAGE_CHECK_COMPLETION_BASE(assertion, &connection, completion)
 
-#define WEBPAGEPROXY_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [pageProxyID=%llu, webPageID=%llu, PID=%i] WebPageProxy::" fmt, this, identifier().toUInt64(), webPageID().toUInt64(), m_legacyMainFrameProcess->processID(), ##__VA_ARGS__)
+#define WEBPAGEPROXY_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [pageProxyID=%llu, webPageID=%llu, PID=%i] WebPageProxy::" fmt, this, identifier().toUInt64(), webPageIDInMainFrameProcess().toUInt64(), m_legacyMainFrameProcess->processID(), ##__VA_ARGS__)
 
 namespace WebKit {
 using namespace WebCore;
@@ -181,14 +181,14 @@ void WebPageProxy::handleClickForDataDetectionResult(const DataDetectorElementIn
 
 #endif
 
-void WebPageProxy::saveRecentSearches(const String& name, const Vector<WebCore::RecentSearch>& searchItems)
+void WebPageProxy::saveRecentSearches(IPC::Connection& connection, const String& name, const Vector<WebCore::RecentSearch>& searchItems)
 {
     MESSAGE_CHECK(!name.isNull());
 
     m_websiteDataStore->saveRecentSearches(name, searchItems);
 }
 
-void WebPageProxy::loadRecentSearches(const String& name, CompletionHandler<void(Vector<WebCore::RecentSearch>&&)>&& completionHandler)
+void WebPageProxy::loadRecentSearches(IPC::Connection& connection, const String& name, CompletionHandler<void(Vector<WebCore::RecentSearch>&&)>&& completionHandler)
 {
     MESSAGE_CHECK_COMPLETION(!name.isNull(), completionHandler({ }));
 
@@ -366,7 +366,7 @@ void WebPageProxy::performDictionaryLookupAtLocation(const WebCore::FloatPoint& 
     if (!hasRunningProcess())
         return;
     
-    send(Messages::WebPage::PerformDictionaryLookupAtLocation(point));
+    legacyMainFrameProcess().send(Messages::WebPage::PerformDictionaryLookupAtLocation(point), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::performDictionaryLookupOfCurrentSelection()
@@ -374,7 +374,7 @@ void WebPageProxy::performDictionaryLookupOfCurrentSelection()
     if (!hasRunningProcess())
         return;
     
-    send(Messages::WebPage::PerformDictionaryLookupOfCurrentSelection());
+    legacyMainFrameProcess().send(Messages::WebPage::PerformDictionaryLookupOfCurrentSelection(), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::insertDictatedTextAsync(const String& text, const EditingRange& replacementRange, const Vector<TextAlternativeWithRange>& dictationAlternativesWithRange, InsertTextOptions&& options)
@@ -393,7 +393,7 @@ void WebPageProxy::insertDictatedTextAsync(const String& text, const EditingRang
         return;
     }
 
-    send(Messages::WebPage::InsertDictatedTextAsync { text, replacementRange, dictationAlternatives, WTFMove(options) });
+    legacyMainFrameProcess().send(Messages::WebPage::InsertDictatedTextAsync { text, replacementRange, dictationAlternatives, WTFMove(options) }, webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::addDictationAlternative(TextAlternativeWithRange&& alternative)
@@ -403,10 +403,10 @@ void WebPageProxy::addDictationAlternative(TextAlternativeWithRange&& alternativ
 
     auto nsAlternatives = alternative.alternatives.get();
     auto context = protectedPageClient()->addDictationAlternatives(nsAlternatives);
-    sendWithAsyncReply(Messages::WebPage::AddDictationAlternative { nsAlternatives.primaryString, context }, [context, weakThis = WeakPtr { *this }](bool success) {
+    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::AddDictationAlternative { nsAlternatives.primaryString, context }, [context, weakThis = WeakPtr { *this }](bool success) {
         if (RefPtr protectedThis = weakThis.get(); protectedThis && !success)
             protectedThis->removeDictationAlternatives(context);
-    });
+    }, webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::dictationAlternativesAtSelection(CompletionHandler<void(Vector<DictationContext>&&)>&& completion)
@@ -416,7 +416,7 @@ void WebPageProxy::dictationAlternativesAtSelection(CompletionHandler<void(Vecto
         return;
     }
 
-    sendWithAsyncReply(Messages::WebPage::DictationAlternativesAtSelection(), WTFMove(completion));
+    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::DictationAlternativesAtSelection(), WTFMove(completion), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::clearDictationAlternatives(Vector<DictationContext>&& alternativesToClear)
@@ -424,7 +424,7 @@ void WebPageProxy::clearDictationAlternatives(Vector<DictationContext>&& alterna
     if (!hasRunningProcess() || alternativesToClear.isEmpty())
         return;
 
-    send(Messages::WebPage::ClearDictationAlternatives(WTFMove(alternativesToClear)));
+    legacyMainFrameProcess().send(Messages::WebPage::ClearDictationAlternatives(WTFMove(alternativesToClear)), webPageIDInMainFrameProcess());
 }
 
 #if USE(DICTATION_ALTERNATIVES)
@@ -445,7 +445,7 @@ ResourceError WebPageProxy::errorForUnpermittedAppBoundDomainNavigation(const UR
 
 IPC::Connection* WebPageProxy::Internals::paymentCoordinatorConnection(const WebPaymentCoordinatorProxy&)
 {
-    return page.messageSenderConnection();
+    return page.legacyMainFrameProcess().connection();
 }
 
 const String& WebPageProxy::Internals::paymentCoordinatorBoundInterfaceIdentifier(const WebPaymentCoordinatorProxy&)
@@ -508,17 +508,17 @@ void WebPageProxy::Internals::didResumeSpeaking(WebCore::PlatformSpeechSynthesis
 
 void WebPageProxy::Internals::speakingErrorOccurred(WebCore::PlatformSpeechSynthesisUtterance&)
 {
-    page.send(Messages::WebPage::SpeakingErrorOccurred());
+    page.legacyMainFrameProcess().send(Messages::WebPage::SpeakingErrorOccurred(), page.webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::Internals::boundaryEventOccurred(WebCore::PlatformSpeechSynthesisUtterance&, WebCore::SpeechBoundary speechBoundary, unsigned charIndex, unsigned charLength)
 {
-    page.send(Messages::WebPage::BoundaryEventOccurred(speechBoundary == WebCore::SpeechBoundary::SpeechWordBoundary, charIndex, charLength));
+    page.legacyMainFrameProcess().send(Messages::WebPage::BoundaryEventOccurred(speechBoundary == WebCore::SpeechBoundary::SpeechWordBoundary, charIndex, charLength), page.webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::Internals::voicesDidChange()
 {
-    page.send(Messages::WebPage::VoicesDidChange());
+    page.legacyMainFrameProcess().send(Messages::WebPage::VoicesDidChange(), page.webPageIDInMainFrameProcess());
 }
 
 #endif // ENABLE(SPEECH_SYNTHESIS)
@@ -677,7 +677,7 @@ bool WebPageProxy::updateIconForDirectory(NSFileWrapper *fileWrapper, const Stri
     auto handle = convertedImage->createHandle();
     if (!handle)
         return false;
-    send(Messages::WebPage::UpdateAttachmentIcon(identifier, WTFMove(handle), iconSize));
+    legacyMainFrameProcess().send(Messages::WebPage::UpdateAttachmentIcon(identifier, WTFMove(handle), iconSize), webPageIDInMainFrameProcess());
     return true;
 }
 
@@ -740,10 +740,11 @@ void WebPageProxy::createAppHighlightInSelectedRange(WebCore::CreateNewGroupForH
     setUpHighlightsObserver();
 
     auto completionHandler = [this, protectedThis = Ref { *this }] (WebCore::AppHighlight&& highlight) {
-        MESSAGE_CHECK(!highlight.highlight->isEmpty());
+        // FIXME: Make a way to get the IPC::Connection that sent the reply in the CompletionHandler.
+        MESSAGE_CHECK_BASE(!highlight.highlight->isEmpty(), legacyMainFrameProcess().connection());
         protectedPageClient()->storeAppHighlight(highlight);
     };
-    sendWithAsyncReply(Messages::WebPage::CreateAppHighlightInSelectedRange(createNewGroup, requestOriginatedInApp), WTFMove(completionHandler));
+    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::CreateAppHighlightInSelectedRange(createNewGroup, requestOriginatedInApp), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::restoreAppHighlightsAndScrollToIndex(const Vector<Ref<SharedMemory>>& highlights, const std::optional<unsigned> index)
@@ -757,7 +758,7 @@ void WebPageProxy::restoreAppHighlightsAndScrollToIndex(const Vector<Ref<SharedM
     
     setUpHighlightsObserver();
 
-    send(Messages::WebPage::RestoreAppHighlightsAndScrollToIndex(WTFMove(memoryHandles), index));
+    legacyMainFrameProcess().send(Messages::WebPage::RestoreAppHighlightsAndScrollToIndex(WTFMove(memoryHandles), index), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::setAppHighlightsVisibility(WebCore::HighlightVisibility appHighlightsVisibility)
@@ -767,7 +768,7 @@ void WebPageProxy::setAppHighlightsVisibility(WebCore::HighlightVisibility appHi
     if (!hasRunningProcess())
         return;
 
-    send(Messages::WebPage::SetAppHighlightsVisibility(appHighlightsVisibility));
+    legacyMainFrameProcess().send(Messages::WebPage::SetAppHighlightsVisibility(appHighlightsVisibility), webPageIDInMainFrameProcess());
 }
 
 bool WebPageProxy::appHighlightsVisibility()
@@ -879,7 +880,7 @@ void WebPageProxy::handleContextMenuWritingTools(WebCore::IntRect selectionBound
 
 void WebPageProxy::requestActiveNowPlayingSessionInfo(CompletionHandler<void(bool, WebCore::NowPlayingInfo&&)>&& callback)
 {
-    sendWithAsyncReply(Messages::WebPage::RequestActiveNowPlayingSessionInfo(), WTFMove(callback));
+    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::RequestActiveNowPlayingSessionInfo(), WTFMove(callback), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::setLastNavigationWasAppInitiated(ResourceRequest& request)
@@ -896,7 +897,7 @@ void WebPageProxy::setLastNavigationWasAppInitiated(ResourceRequest& request)
 
 void WebPageProxy::lastNavigationWasAppInitiated(CompletionHandler<void(bool)>&& completionHandler)
 {
-    sendWithAsyncReply(Messages::WebPage::LastNavigationWasAppInitiated(), WTFMove(completionHandler));
+    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::LastNavigationWasAppInitiated(), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::grantAccessToAssetServices()
@@ -966,14 +967,14 @@ bool WebPageProxy::isQuarantinedAndNotUserApproved(const String& fileURLString)
 
 void WebPageProxy::insertMultiRepresentationHEIC(NSData *data, NSString *altText)
 {
-    send(Messages::WebPage::InsertMultiRepresentationHEIC(span(data), altText));
+    legacyMainFrameProcess().send(Messages::WebPage::InsertMultiRepresentationHEIC(span(data), altText), webPageIDInMainFrameProcess());
 }
 
 #endif
 
 void WebPageProxy::replaceSelectionWithPasteboardData(const Vector<String>& types, std::span<const uint8_t> data)
 {
-    send(Messages::WebPage::ReplaceSelectionWithPasteboardData(types, data));
+    legacyMainFrameProcess().send(Messages::WebPage::ReplaceSelectionWithPasteboardData(types, data), webPageIDInMainFrameProcess());
 }
 
 RetainPtr<WKWebView> WebPageProxy::cocoaView()
@@ -990,7 +991,7 @@ void WebPageProxy::setCocoaView(WKWebView *view)
 
 void WebPageProxy::replaceImageForRemoveBackground(const ElementContext& elementContext, const Vector<String>& types, std::span<const uint8_t> data)
 {
-    send(Messages::WebPage::ReplaceImageForRemoveBackground(elementContext, types, data));
+    legacyMainFrameProcess().send(Messages::WebPage::ReplaceImageForRemoveBackground(elementContext, types, data), webPageIDInMainFrameProcess());
 }
 
 #endif
@@ -1062,12 +1063,12 @@ void WebPageProxy::setMediaCapability(std::optional<MediaCapability>&& capabilit
 
     if (!internals().mediaCapability) {
         WEBPAGEPROXY_RELEASE_LOG(ProcessCapabilities, "setMediaCapability: clearing media capability");
-        send(Messages::WebPage::SetMediaEnvironment({ }));
+        legacyMainFrameProcess().send(Messages::WebPage::SetMediaEnvironment({ }), webPageIDInMainFrameProcess());
         return;
     }
 
     WEBPAGEPROXY_RELEASE_LOG(ProcessCapabilities, "setMediaCapability: creating (envID=%{public}s) for URL '%{sensitive}s'", internals().mediaCapability->environmentIdentifier().utf8().data(), internals().mediaCapability->webPageURL().string().utf8().data());
-    send(Messages::WebPage::SetMediaEnvironment(internals().mediaCapability->environmentIdentifier()));
+    legacyMainFrameProcess().send(Messages::WebPage::SetMediaEnvironment(internals().mediaCapability->environmentIdentifier()), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::deactivateMediaCapability(MediaCapability& capability)
@@ -1161,37 +1162,37 @@ void WebPageProxy::setWritingToolsActive(bool active)
 
 void WebPageProxy::willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>& session, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&& completionHandler)
 {
-    sendWithAsyncReply(Messages::WebPage::WillBeginWritingToolsSession(session), WTFMove(completionHandler));
+    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::WillBeginWritingToolsSession(session), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::didBeginWritingToolsSession(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::Context>& contexts)
 {
-    send(Messages::WebPage::DidBeginWritingToolsSession(session, contexts));
+    legacyMainFrameProcess().send(Messages::WebPage::DidBeginWritingToolsSession(session, contexts), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::proofreadingSessionDidReceiveSuggestions(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::TextSuggestion>& suggestions, const WebCore::WritingTools::Context& context, bool finished)
 {
-    send(Messages::WebPage::ProofreadingSessionDidReceiveSuggestions(session, suggestions, context, finished));
+    legacyMainFrameProcess().send(Messages::WebPage::ProofreadingSessionDidReceiveSuggestions(session, suggestions, context, finished), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::proofreadingSessionDidUpdateStateForSuggestion(const WebCore::WritingTools::Session& session, WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion& suggestion, const WebCore::WritingTools::Context& context)
 {
-    send(Messages::WebPage::ProofreadingSessionDidUpdateStateForSuggestion(session, state, suggestion, context));
+    legacyMainFrameProcess().send(Messages::WebPage::ProofreadingSessionDidUpdateStateForSuggestion(session, state, suggestion, context), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::didEndWritingToolsSession(const WebCore::WritingTools::Session& session, bool accepted)
 {
-    send(Messages::WebPage::DidEndWritingToolsSession(session, accepted));
+    legacyMainFrameProcess().send(Messages::WebPage::DidEndWritingToolsSession(session, accepted), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::compositionSessionDidReceiveTextWithReplacementRange(const WebCore::WritingTools::Session& session, const WebCore::AttributedString& attributedText, const WebCore::CharacterRange& range, const WebCore::WritingTools::Context& context, bool finished)
 {
-    send(Messages::WebPage::CompositionSessionDidReceiveTextWithReplacementRange(session, attributedText, range, context, finished));
+    legacyMainFrameProcess().send(Messages::WebPage::CompositionSessionDidReceiveTextWithReplacementRange(session, attributedText, range, context, finished), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::writingToolsSessionDidReceiveAction(const WebCore::WritingTools::Session& session, WebCore::WritingTools::Action action)
 {
-    send(Messages::WebPage::WritingToolsSessionDidReceiveAction(session, action));
+    legacyMainFrameProcess().send(Messages::WebPage::WritingToolsSessionDidReceiveAction(session, action), webPageIDInMainFrameProcess());
 }
 
 #endif // ENABLE(WRITING_TOOLS)
@@ -1203,7 +1204,7 @@ void WebPageProxy::enableSourceTextAnimationAfterElementWithID(const String& ele
     if (!hasRunningProcess())
         return;
 
-    send(Messages::WebPage::enableSourceTextAnimationAfterElementWithID(elementID, uuid));
+    legacyMainFrameProcess().send(Messages::WebPage::enableSourceTextAnimationAfterElementWithID(elementID, uuid), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::enableTextAnimationTypeForElementWithID(const String& elementID, const WTF::UUID& uuid)
@@ -1211,10 +1212,10 @@ void WebPageProxy::enableTextAnimationTypeForElementWithID(const String& element
     if (!hasRunningProcess())
         return;
 
-    send(Messages::WebPage::EnableTextAnimationTypeForElementWithID(elementID, uuid));
+    legacyMainFrameProcess().send(Messages::WebPage::EnableTextAnimationTypeForElementWithID(elementID, uuid), webPageIDInMainFrameProcess());
 }
 
-void WebPageProxy::addTextAnimationTypeForID(const WTF::UUID& uuid, const TextAnimationData& styleData, const WebCore::TextIndicatorData& indicatorData)
+void WebPageProxy::addTextAnimationTypeForID(IPC::Connection& connection, const WTF::UUID& uuid, const TextAnimationData& styleData, const WebCore::TextIndicatorData& indicatorData)
 {
     MESSAGE_CHECK(uuid.isValid());
 
@@ -1237,7 +1238,7 @@ void WebPageProxy::getTextIndicatorForID(const WTF::UUID& uuid, CompletionHandle
         return;
     }
 
-    sendWithAsyncReply(Messages::WebPage::createTextIndicatorForTextAnimationID(uuid), WTFMove(completionHandler));
+    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::createTextIndicatorForTextAnimationID(uuid), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::updateUnderlyingTextVisibilityForTextAnimationID(const WTF::UUID& uuid, bool visible, CompletionHandler<void()>&& completionHandler)
@@ -1247,10 +1248,10 @@ void WebPageProxy::updateUnderlyingTextVisibilityForTextAnimationID(const WTF::U
         return;
     }
 
-    sendWithAsyncReply(Messages::WebPage::updateUnderlyingTextVisibilityForTextAnimationID(uuid, visible), WTFMove(completionHandler));
+    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::updateUnderlyingTextVisibilityForTextAnimationID(uuid, visible), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
-void WebPageProxy::removeTextAnimationForID(const WTF::UUID& uuid)
+void WebPageProxy::removeTextAnimationForID(IPC::Connection& connection, const WTF::UUID& uuid)
 {
     MESSAGE_CHECK(uuid.isValid());
 
@@ -1261,14 +1262,14 @@ void WebPageProxy::removeTextAnimationForID(const WTF::UUID& uuid)
 
 #if ENABLE(WRITING_TOOLS)
 
-void WebPageProxy::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::Session::ID& sessionID, const WebCore::WritingTools::TextSuggestion::ID& replacementID, WebCore::IntRect selectionBoundsInRootView)
+void WebPageProxy::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(IPC::Connection& connection, const WebCore::WritingTools::Session::ID& sessionID, const WebCore::WritingTools::TextSuggestion::ID& replacementID, WebCore::IntRect selectionBoundsInRootView)
 {
     MESSAGE_CHECK(sessionID.isValid());
 
     protectedPageClient()->proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(sessionID, replacementID, selectionBoundsInRootView);
 }
 
-void WebPageProxy::proofreadingSessionUpdateStateForSuggestionWithID(const WebCore::WritingTools::Session::ID& sessionID, WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion::ID& replacementID)
+void WebPageProxy::proofreadingSessionUpdateStateForSuggestionWithID(IPC::Connection& connection, const WebCore::WritingTools::Session::ID& sessionID, WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion::ID& replacementID)
 {
     MESSAGE_CHECK(sessionID.isValid());
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
@@ -643,7 +643,7 @@ std::optional<DataOwnerType> WebPasteboardProxy::determineDataOwner(IPC::Connect
 
     std::optional<DataOwnerType> result;
     for (Ref page : process->pages()) {
-        if (page->webPageID() == *pageID) {
+        if (page->webPageIDInMainFrameProcess() == *pageID) {
             result = page->dataOwnerForPasteboard(intent);
             break;
         }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -165,7 +165,7 @@ void executeScript(const SourcePairs& scriptPairs, WKWebView *webView, API::Cont
 void injectStyleSheets(const SourcePairs& styleSheetPairs, WKWebView *webView, API::ContentWorld& executionWorld, WebCore::UserStyleLevel styleLevel, WebCore::UserContentInjectedFrames injectedFrames, WebExtensionContext& context)
 {
     auto page = webView._page;
-    auto pageID = page->webPageID();
+    auto pageID = page->webPageIDInMainFrameProcess();
 
     for (auto& styleSheet : styleSheetPairs) {
         auto userStyleSheet = API::UserStyleSheet::create(WebCore::UserStyleSheet { styleSheet.first, styleSheet.second, Vector<String> { }, Vector<String> { }, injectedFrames, styleLevel, pageID }, executionWorld);

--- a/Source/WebKit/UIProcess/FindStringCallbackAggregator.cpp
+++ b/Source/WebKit/UIProcess/FindStringCallbackAggregator.cpp
@@ -108,7 +108,7 @@ FindStringCallbackAggregator::~FindStringCallbackAggregator()
     };
 
     Ref targetFrame = frameContainingMatch ? *frameContainingMatch : *focusedFrame;
-    targetFrame->protectedProcess()->sendWithAsyncReply(WTFMove(message), WTFMove(completionHandler), protectedPage->webPageID());
+    targetFrame->protectedProcess()->sendWithAsyncReply(WTFMove(message), WTFMove(completionHandler), protectedPage->webPageIDInMainFrameProcess());
     if (frameContainingMatch && focusedFrame && focusedFrame->process() != frameContainingMatch->process())
         protectedPage->clearSelection(focusedFrame->frameID());
 }

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -720,7 +720,7 @@ void GPUProcessProxy::didCreateContextForVisibilityPropagation(WebPageProxyIdent
         RELEASE_LOG(Process, "GPUProcessProxy::didCreateContextForVisibilityPropagation() No WebPageProxy with this identifier");
         return;
     }
-    if (page->webPageID() == pageID) {
+    if (page->webPageIDInMainFrameProcess() == pageID) {
         page->didCreateContextInGPUProcessForVisibilityPropagation(contextID);
         return;
     }

--- a/Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.cpp
@@ -68,7 +68,7 @@ void GeolocationPermissionRequestManagerProxy::didReceiveGeolocationPermissionDe
     if (!authorizationToken.isNull())
         m_validAuthorizationTokens.add(authorizationToken);
     if (RefPtr process = it->value->process())
-        process->send(Messages::WebPage::DidReceiveGeolocationPermissionDecision(geolocationID, authorizationToken), m_page.webPageID());
+        process->send(Messages::WebPage::DidReceiveGeolocationPermissionDecision(geolocationID, authorizationToken), m_page.webPageIDInMainFrameProcess());
 #else
     UNUSED_PARAM(allowed);
 #endif

--- a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
@@ -66,7 +66,7 @@ void InspectorTargetProxy::connect(Inspector::FrontendChannel::ConnectionType co
     }
 
     if (m_page.hasRunningProcess())
-        m_page.send(Messages::WebPage::ConnectInspector(identifier(), connectionType));
+        m_page.legacyMainFrameProcess().send(Messages::WebPage::ConnectInspector(identifier(), connectionType), m_page.webPageIDInMainFrameProcess());
 }
 
 void InspectorTargetProxy::disconnect()
@@ -80,7 +80,7 @@ void InspectorTargetProxy::disconnect()
     }
 
     if (m_page.hasRunningProcess())
-        m_page.send(Messages::WebPage::DisconnectInspector(identifier()));
+        m_page.legacyMainFrameProcess().send(Messages::WebPage::DisconnectInspector(identifier()), m_page.webPageIDInMainFrameProcess());
 }
 
 void InspectorTargetProxy::sendMessageToTargetBackend(const String& message)
@@ -91,7 +91,7 @@ void InspectorTargetProxy::sendMessageToTargetBackend(const String& message)
     }
 
     if (m_page.hasRunningProcess())
-        m_page.send(Messages::WebPage::SendMessageToTargetBackend(identifier(), message));
+        m_page.legacyMainFrameProcess().send(Messages::WebPage::SendMessageToTargetBackend(identifier(), message), m_page.webPageIDInMainFrameProcess());
 }
 
 void InspectorTargetProxy::didCommitProvisionalTarget()

--- a/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp
@@ -67,7 +67,8 @@ void RemoteWebInspectorUIProxy::invalidate()
 void RemoteWebInspectorUIProxy::setDiagnosticLoggingAvailable(bool available)
 {
 #if ENABLE(INSPECTOR_TELEMETRY)
-    protectedInspectorPage()->send(Messages::RemoteWebInspectorUI::SetDiagnosticLoggingAvailable(available));
+    if (RefPtr page = protectedInspectorPage())
+        page->legacyMainFrameProcess().send(Messages::RemoteWebInspectorUI::SetDiagnosticLoggingAvailable(available), page->webPageIDInMainFrameProcess());
 #else
     UNUSED_PARAM(available);
 #endif
@@ -81,7 +82,7 @@ void RemoteWebInspectorUIProxy::initialize(Ref<API::DebuggableInfo>&& debuggable
     createFrontendPageAndWindow();
 
     auto inspectorPage = protectedInspectorPage();
-    inspectorPage->send(Messages::RemoteWebInspectorUI::Initialize(m_debuggableInfo->debuggableInfoData(), backendCommandsURL));
+    inspectorPage->legacyMainFrameProcess().send(Messages::RemoteWebInspectorUI::Initialize(m_debuggableInfo->debuggableInfoData(), backendCommandsURL), m_inspectorPage->webPageIDInMainFrameProcess());
     inspectorPage->loadRequest(URL { WebInspectorUIProxy::inspectorPageURL() });
 }
 
@@ -103,17 +104,20 @@ void RemoteWebInspectorUIProxy::show()
 
 void RemoteWebInspectorUIProxy::showConsole()
 {
-    protectedInspectorPage()->send(Messages::RemoteWebInspectorUI::ShowConsole { });
+    if (RefPtr page = protectedInspectorPage())
+        page->legacyMainFrameProcess().send(Messages::RemoteWebInspectorUI::ShowConsole { }, page->webPageIDInMainFrameProcess());
 }
 
 void RemoteWebInspectorUIProxy::showResources()
 {
-    protectedInspectorPage()->send(Messages::RemoteWebInspectorUI::ShowResources { });
+    if (RefPtr page = protectedInspectorPage())
+        page->legacyMainFrameProcess().send(Messages::RemoteWebInspectorUI::ShowResources { }, page->webPageIDInMainFrameProcess());
 }
 
 void RemoteWebInspectorUIProxy::sendMessageToFrontend(const String& message)
 {
-    protectedInspectorPage()->send(Messages::RemoteWebInspectorUI::SendMessageToFrontend(message));
+    if (RefPtr page = protectedInspectorPage())
+        page->legacyMainFrameProcess().send(Messages::RemoteWebInspectorUI::SendMessageToFrontend(message), page->webPageIDInMainFrameProcess());
 }
 
 void RemoteWebInspectorUIProxy::frontendLoaded()
@@ -221,7 +225,7 @@ void RemoteWebInspectorUIProxy::createFrontendPageAndWindow()
 
     trackInspectorPage(inspectorPage.get(), nullptr);
 
-    inspectorPage->legacyMainFrameProcess().addMessageReceiver(Messages::RemoteWebInspectorUIProxy::messageReceiverName(), inspectorPage->webPageID(), *this);
+    inspectorPage->legacyMainFrameProcess().addMessageReceiver(Messages::RemoteWebInspectorUIProxy::messageReceiverName(), inspectorPage->webPageIDInMainFrameProcess(), *this);
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     m_extensionController = WebInspectorUIExtensionControllerProxy::create(*inspectorPage);
@@ -234,7 +238,7 @@ void RemoteWebInspectorUIProxy::closeFrontendPageAndWindow()
     if (!inspectorPage)
         return;
 
-    inspectorPage->legacyMainFrameProcess().removeMessageReceiver(Messages::RemoteWebInspectorUIProxy::messageReceiverName(), inspectorPage->webPageID());
+    inspectorPage->legacyMainFrameProcess().removeMessageReceiver(Messages::RemoteWebInspectorUIProxy::messageReceiverName(), inspectorPage->webPageIDInMainFrameProcess());
 
     untrackInspectorPage(inspectorPage.get());
 

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
@@ -42,7 +42,7 @@ namespace WebKit {
 WebInspectorUIExtensionControllerProxy::WebInspectorUIExtensionControllerProxy(WebPageProxy& inspectorPage)
     : m_inspectorPage(inspectorPage)
 {
-    m_inspectorPage->legacyMainFrameProcess().addMessageReceiver(Messages::WebInspectorUIExtensionControllerProxy::messageReceiverName(), m_inspectorPage->webPageID(), *this);
+    m_inspectorPage->legacyMainFrameProcess().addMessageReceiver(Messages::WebInspectorUIExtensionControllerProxy::messageReceiverName(), m_inspectorPage->webPageIDInMainFrameProcess(), *this);
 }
 
 WebInspectorUIExtensionControllerProxy::~WebInspectorUIExtensionControllerProxy()
@@ -86,7 +86,7 @@ void WebInspectorUIExtensionControllerProxy::inspectorFrontendWillClose()
     if (!m_inspectorPage)
         return;
 
-    m_inspectorPage->legacyMainFrameProcess().removeMessageReceiver(Messages::WebInspectorUIExtensionControllerProxy::messageReceiverName(), m_inspectorPage->webPageID());
+    m_inspectorPage->legacyMainFrameProcess().removeMessageReceiver(Messages::WebInspectorUIExtensionControllerProxy::messageReceiverName(), m_inspectorPage->webPageIDInMainFrameProcess());
     m_inspectorPage = nullptr;
 
     m_extensionAPIObjectMap.clear();
@@ -102,7 +102,7 @@ void WebInspectorUIExtensionControllerProxy::registerExtension(const Inspector::
             return;
         }
 
-        weakThis->m_inspectorPage->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::RegisterExtension { extensionID, extensionBundleIdentifier, displayName }, [protectedThis = Ref { *weakThis.get() }, extensionID, completionHandler = WTFMove(completionHandler)](Expected<void, Inspector::ExtensionError> result) mutable {
+        weakThis->m_inspectorPage->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebInspectorUIExtensionController::RegisterExtension { extensionID, extensionBundleIdentifier, displayName }, [protectedThis = Ref { *weakThis.get() }, extensionID, completionHandler = WTFMove(completionHandler)](Expected<void, Inspector::ExtensionError> result) mutable {
             if (!result) {
                 completionHandler(makeUnexpected(Inspector::ExtensionError::RegistrationFailed));
                 return;
@@ -117,7 +117,7 @@ void WebInspectorUIExtensionControllerProxy::registerExtension(const Inspector::
             protectedThis->m_extensionAPIObjectMap.set(extensionID, extensionAPIObject.copyRef());
 
             completionHandler(WTFMove(extensionAPIObject));
-        });
+        }, weakThis->m_inspectorPage->webPageIDInMainFrameProcess());
     });
 }
 
@@ -129,7 +129,7 @@ void WebInspectorUIExtensionControllerProxy::unregisterExtension(const Inspector
             return;
         }
 
-        weakThis->m_inspectorPage->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::UnregisterExtension { extensionID }, [protectedThis = Ref { *weakThis.get() }, extensionID, completionHandler = WTFMove(completionHandler)](Expected<void, Inspector::ExtensionError> result) mutable {
+        weakThis->m_inspectorPage->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebInspectorUIExtensionController::UnregisterExtension { extensionID }, [protectedThis = Ref { *weakThis.get() }, extensionID, completionHandler = WTFMove(completionHandler)](Expected<void, Inspector::ExtensionError> result) mutable {
             if (!result) {
                 completionHandler(makeUnexpected(Inspector::ExtensionError::InvalidRequest));
                 return;
@@ -143,7 +143,7 @@ void WebInspectorUIExtensionControllerProxy::unregisterExtension(const Inspector
             protectedThis->m_extensionAPIObjectMap.take(extensionID);
 
             completionHandler(WTFMove(result));
-        });
+        }, weakThis->m_inspectorPage->webPageIDInMainFrameProcess());
     });
 }
 
@@ -155,7 +155,7 @@ void WebInspectorUIExtensionControllerProxy::createTabForExtension(const Inspect
             return;
         }
 
-        weakThis->m_inspectorPage->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::CreateTabForExtension { extensionID, tabName, tabIconURL, sourceURL }, WTFMove(completionHandler));
+        weakThis->m_inspectorPage->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebInspectorUIExtensionController::CreateTabForExtension { extensionID, tabName, tabIconURL, sourceURL }, WTFMove(completionHandler), weakThis->m_inspectorPage->webPageIDInMainFrameProcess());
     });
 }
 
@@ -167,7 +167,7 @@ void WebInspectorUIExtensionControllerProxy::evaluateScriptForExtension(const In
             return;
         }
 
-        weakThis->m_inspectorPage->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::EvaluateScriptForExtension { extensionID, scriptSource, frameURL, contextSecurityOrigin, useContentScriptContext }, [completionHandler = WTFMove(completionHandler)](std::span<const uint8_t> dataReference, const std::optional<WebCore::ExceptionDetails>& details, const std::optional<Inspector::ExtensionError> error) mutable {
+        weakThis->m_inspectorPage->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebInspectorUIExtensionController::EvaluateScriptForExtension { extensionID, scriptSource, frameURL, contextSecurityOrigin, useContentScriptContext }, [completionHandler = WTFMove(completionHandler)](std::span<const uint8_t> dataReference, const std::optional<WebCore::ExceptionDetails>& details, const std::optional<Inspector::ExtensionError> error) mutable {
             if (error) {
                 completionHandler(makeUnexpected(error.value()));
                 return;
@@ -180,7 +180,7 @@ void WebInspectorUIExtensionControllerProxy::evaluateScriptForExtension(const In
             }
 
             completionHandler({ API::SerializedScriptValue::createFromWireBytes(dataReference) });
-        });
+        }, weakThis->m_inspectorPage->webPageIDInMainFrameProcess());
     });
 }
 
@@ -192,14 +192,14 @@ void WebInspectorUIExtensionControllerProxy::reloadForExtension(const Inspector:
             return;
         }
 
-        weakThis->m_inspectorPage->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::ReloadForExtension {extensionID, ignoreCache, userAgent, injectedScript}, [completionHandler = WTFMove(completionHandler)](const std::optional<Inspector::ExtensionError> error) mutable {
+        weakThis->m_inspectorPage->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebInspectorUIExtensionController::ReloadForExtension { extensionID, ignoreCache, userAgent, injectedScript }, [completionHandler = WTFMove(completionHandler)] (const std::optional<Inspector::ExtensionError> error) mutable {
             if (error) {
                 completionHandler(makeUnexpected(error.value()));
                 return;
             }
 
             completionHandler({ });
-        });
+        }, weakThis->m_inspectorPage->webPageIDInMainFrameProcess());
     });
 }
 
@@ -211,7 +211,7 @@ void WebInspectorUIExtensionControllerProxy::showExtensionTab(const Inspector::E
             return;
         }
 
-        weakThis->m_inspectorPage->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::ShowExtensionTab { extensionTabIdentifier }, WTFMove(completionHandler));
+        weakThis->m_inspectorPage->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebInspectorUIExtensionController::ShowExtensionTab { extensionTabIdentifier }, WTFMove(completionHandler), weakThis->m_inspectorPage->webPageIDInMainFrameProcess());
     });
 }
 
@@ -223,7 +223,7 @@ void WebInspectorUIExtensionControllerProxy::navigateTabForExtension(const Inspe
             return;
         }
 
-        weakThis->m_inspectorPage->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::NavigateTabForExtension { extensionTabIdentifier, sourceURL }, WTFMove(completionHandler));
+        weakThis->m_inspectorPage->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebInspectorUIExtensionController::NavigateTabForExtension { extensionTabIdentifier, sourceURL }, WTFMove(completionHandler), weakThis->m_inspectorPage->webPageIDInMainFrameProcess());
     });
 }
 
@@ -237,7 +237,7 @@ void WebInspectorUIExtensionControllerProxy::evaluateScriptInExtensionTab(const 
             return;
         }
 
-        weakThis->m_inspectorPage->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::EvaluateScriptInExtensionTab { extensionTabID, scriptSource }, [completionHandler = WTFMove(completionHandler)](std::span<const uint8_t> dataReference, const std::optional<WebCore::ExceptionDetails>& details, const std::optional<Inspector::ExtensionError>& error) mutable {
+        weakThis->m_inspectorPage->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebInspectorUIExtensionController::EvaluateScriptInExtensionTab { extensionTabID, scriptSource }, [completionHandler = WTFMove(completionHandler)](std::span<const uint8_t> dataReference, const std::optional<WebCore::ExceptionDetails>& details, const std::optional<Inspector::ExtensionError>& error) mutable {
             if (error) {
                 completionHandler(makeUnexpected(error.value()));
                 return;
@@ -250,7 +250,7 @@ void WebInspectorUIExtensionControllerProxy::evaluateScriptInExtensionTab(const 
             }
 
             completionHandler({ API::SerializedScriptValue::createFromWireBytes(dataReference) });
-        });
+        }, weakThis->m_inspectorPage->webPageIDInMainFrameProcess());
     });
 }
 

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
@@ -66,7 +66,7 @@ Ref<WebPageProxy> WebPageInspectorController::protectedInspectedPage()
 
 void WebPageInspectorController::init()
 {
-    String pageTargetId = WebPageInspectorTarget::toTargetID(m_inspectedPage->webPageID());
+    String pageTargetId = WebPageInspectorTarget::toTargetID(m_inspectedPage->webPageIDInMainFrameProcess());
     createInspectorTarget(pageTargetId, Inspector::InspectorTargetType::Page);
 }
 

--- a/Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
@@ -100,7 +100,7 @@ WKWebView *RemoteWebInspectorUIProxy::webView() const
 
 void RemoteWebInspectorUIProxy::didBecomeActive()
 {
-    m_inspectorPage->send(Messages::RemoteWebInspectorUI::UpdateFindString(WebKit::stringForFind()));
+    m_inspectorPage->legacyMainFrameProcess().send(Messages::RemoteWebInspectorUI::UpdateFindString(WebKit::stringForFind()), m_inspectorPage->webPageIDInMainFrameProcess());
 }
 
 WebPageProxy* RemoteWebInspectorUIProxy::platformCreateFrontendPageAndWindow()

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -313,7 +313,7 @@ using namespace WebCore;
 
 void WebInspectorUIProxy::didBecomeActive()
 {
-    m_inspectorPage->send(Messages::WebInspectorUI::UpdateFindString(WebKit::stringForFind()));
+    m_inspectorPage->legacyMainFrameProcess().send(Messages::WebInspectorUI::UpdateFindString(WebKit::stringForFind()), m_inspectorPage->webPageIDInMainFrameProcess());
 }
 
 void WebInspectorUIProxy::attachmentViewDidChange(NSView *oldView, NSView *newView)

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp
@@ -61,12 +61,12 @@ RemoteMediaSessionCoordinatorProxy::RemoteMediaSessionCoordinatorProxy(WebPagePr
 #endif
 {
     m_privateCoordinator->setClient(*this);
-    m_webPageProxy.legacyMainFrameProcess().addMessageReceiver(Messages::RemoteMediaSessionCoordinatorProxy::messageReceiverName(), m_webPageProxy.webPageID(), *this);
+    m_webPageProxy.legacyMainFrameProcess().addMessageReceiver(Messages::RemoteMediaSessionCoordinatorProxy::messageReceiverName(), m_webPageProxy.webPageIDInMainFrameProcess(), *this);
 }
 
 RemoteMediaSessionCoordinatorProxy::~RemoteMediaSessionCoordinatorProxy()
 {
-    m_webPageProxy.legacyMainFrameProcess().removeMessageReceiver(Messages::RemoteMediaSessionCoordinatorProxy::messageReceiverName(), m_webPageProxy.webPageID());
+    m_webPageProxy.legacyMainFrameProcess().removeMessageReceiver(Messages::RemoteMediaSessionCoordinatorProxy::messageReceiverName(), m_webPageProxy.webPageIDInMainFrameProcess());
 }
 
 void RemoteMediaSessionCoordinatorProxy::join(MediaSessionCommandCompletionHandler&& completionHandler)
@@ -157,27 +157,27 @@ void RemoteMediaSessionCoordinatorProxy::trackIdentifierChanged(const String& id
 
 void RemoteMediaSessionCoordinatorProxy::seekSessionToTime(double time, CompletionHandler<void(bool)>&& callback)
 {
-    m_webPageProxy.sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::SeekSessionToTime { time }, callback);
+    m_webPageProxy.legacyMainFrameProcess().sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::SeekSessionToTime { time }, callback, m_webPageProxy.webPageIDInMainFrameProcess());
 }
 
 void RemoteMediaSessionCoordinatorProxy::playSession(std::optional<double> atTime, std::optional<MonotonicTime> hostTime, CompletionHandler<void(bool)>&& callback)
 {
-    m_webPageProxy.sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::PlaySession { WTFMove(atTime), WTFMove(hostTime) }, callback);
+    m_webPageProxy.legacyMainFrameProcess().sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::PlaySession { WTFMove(atTime), WTFMove(hostTime) }, callback, m_webPageProxy.webPageIDInMainFrameProcess());
 }
 
 void RemoteMediaSessionCoordinatorProxy::pauseSession(CompletionHandler<void(bool)>&& callback)
 {
-    m_webPageProxy.sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::PauseSession { }, callback);
+    m_webPageProxy.legacyMainFrameProcess().sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::PauseSession { }, callback, m_webPageProxy.webPageIDInMainFrameProcess());
 }
 
 void RemoteMediaSessionCoordinatorProxy::setSessionTrack(const String& trackId, CompletionHandler<void(bool)>&& callback)
 {
-    m_webPageProxy.sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::SetSessionTrack { trackId }, callback);
+    m_webPageProxy.legacyMainFrameProcess().sendWithAsyncReply(Messages::RemoteMediaSessionCoordinator::SetSessionTrack { trackId }, callback, m_webPageProxy.webPageIDInMainFrameProcess());
 }
 
 void RemoteMediaSessionCoordinatorProxy::coordinatorStateChanged(WebCore::MediaSessionCoordinatorState state)
 {
-    m_webPageProxy.send(Messages::RemoteMediaSessionCoordinator::CoordinatorStateChanged { state });
+    m_webPageProxy.legacyMainFrameProcess().send(Messages::RemoteMediaSessionCoordinator::CoordinatorStateChanged { state }, m_webPageProxy.webPageIDInMainFrameProcess());
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
@@ -91,7 +91,7 @@ void MediaKeySystemPermissionRequestManagerProxy::denyRequest(MediaKeySystemPerm
     ALWAYS_LOG(LOGIDENTIFIER, request.mediaKeySystemID().toUInt64(), ", reason: ", message);
 
 #if ENABLE(ENCRYPTED_MEDIA)
-    m_page.send(Messages::WebPage::MediaKeySystemWasDenied(request.mediaKeySystemID(), message));
+    m_page.legacyMainFrameProcess().send(Messages::WebPage::MediaKeySystemWasDenied(request.mediaKeySystemID(), message), m_page.webPageIDInMainFrameProcess());
 #else
     UNUSED_PARAM(message);
 #endif
@@ -105,7 +105,7 @@ void MediaKeySystemPermissionRequestManagerProxy::grantRequest(MediaKeySystemPer
 #if ENABLE(ENCRYPTED_MEDIA)
     ALWAYS_LOG(LOGIDENTIFIER, request.mediaKeySystemID().toUInt64(), ", keySystem: ", request.keySystem());
 
-    m_page.send(Messages::WebPage::MediaKeySystemWasGranted { request.mediaKeySystemID() });
+    m_page.legacyMainFrameProcess().send(Messages::WebPage::MediaKeySystemWasGranted { request.mediaKeySystemID() }, m_page.webPageIDInMainFrameProcess());
 #else
     UNUSED_PARAM(request);
 #endif

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
@@ -276,7 +276,7 @@ void ModelProcessProxy::didCreateContextForVisibilityPropagation(WebPageProxyIde
         RELEASE_LOG(Process, "ModelProcessProxy::didCreateContextForVisibilityPropagation() No WebPageProxy with this identifier");
         return;
     }
-    if (page->webPageID() == pageID) {
+    if (page->webPageIDInMainFrameProcess() == pageID) {
         page->didCreateContextInModelProcessForVisibilityPropagation(contextID);
         return;
     }

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1689,7 +1689,7 @@ void NetworkProcessProxy::testProcessIncomingSyncMessagesWhenWaitingForSyncReply
     if (!page)
         return reply(false);
 
-    auto syncResult = page->sendSync(Messages::WebPage::TestProcessIncomingSyncMessagesWhenWaitingForSyncReply(), Seconds::infinity(), IPC::SendSyncOption::ForceDispatchWhenDestinationIsWaitingForUnboundedSyncReply);
+    auto syncResult = page->legacyMainFrameProcess().sendSync(Messages::WebPage::TestProcessIncomingSyncMessagesWhenWaitingForSyncReply(), page->webPageIDInMainFrameProcess(), Seconds::infinity(), IPC::SendSyncOption::ForceDispatchWhenDestinationIsWaitingForUnboundedSyncReply);
     auto [handled] = syncResult.takeReplyOr(false);
     reply(handled);
 }

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -407,7 +407,7 @@ void ProvisionalPageProxy::didCommitLoadForFrame(IPC::Connection& connection, Fr
             Site openerSite(openerFrame->url());
             Site openedSite(request.url());
             if (openerSite != openedSite) {
-                page->send(Messages::WebPage::LoadDidCommitInAnotherProcess(page->mainFrame()->frameID(), std::nullopt));
+                page->legacyMainFrameProcess().send(Messages::WebPage::LoadDidCommitInAnotherProcess(page->mainFrame()->frameID(), std::nullopt), page->webPageIDInMainFrameProcess());
                 m_browsingContextGroup->transitionPageToRemotePage(page, openerSite);
             }
         }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -162,7 +162,7 @@ void RemoteScrollingCoordinatorProxy::applyScrollingTreeLayerPositionsAfterCommi
 
 void RemoteScrollingCoordinatorProxy::currentSnapPointIndicesDidChange(WebCore::ScrollingNodeID nodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical)
 {
-    m_webPageProxy.send(Messages::RemoteScrollingCoordinator::CurrentSnapPointIndicesChangedForNode(nodeID, horizontal, vertical));
+    m_webPageProxy.legacyMainFrameProcess().send(Messages::RemoteScrollingCoordinator::CurrentSnapPointIndicesChangedForNode(nodeID, horizontal, vertical), m_webPageProxy.webPageIDInMainFrameProcess());
 }
 
 // This comes from the scrolling tree.
@@ -230,7 +230,7 @@ void RemoteScrollingCoordinatorProxy::receivedLastScrollingTreeNodeDidScrollRepl
 
 void RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidStopAnimatedScroll(ScrollingNodeID scrolledNodeID)
 {
-    m_webPageProxy.send(Messages::RemoteScrollingCoordinator::AnimatedScrollDidEndForNode(scrolledNodeID));
+    m_webPageProxy.legacyMainFrameProcess().send(Messages::RemoteScrollingCoordinator::AnimatedScrollDidEndForNode(scrolledNodeID), m_webPageProxy.webPageIDInMainFrameProcess());
 }
 
 bool RemoteScrollingCoordinatorProxy::scrollingTreeNodeRequestsScroll(ScrollingNodeID scrolledNodeID, const RequestedScrollData& request)
@@ -342,7 +342,7 @@ void RemoteScrollingCoordinatorProxy::sendUIStateChangedIfNecessary()
     if (!m_uiState.changes())
         return;
 
-    m_webPageProxy.send(Messages::RemoteScrollingCoordinator::ScrollingStateInUIProcessChanged(m_uiState));
+    m_webPageProxy.legacyMainFrameProcess().send(Messages::RemoteScrollingCoordinator::ScrollingStateInUIProcessChanged(m_uiState), m_webPageProxy.webPageIDInMainFrameProcess());
     m_uiState.clearChanges();
 }
 
@@ -370,19 +370,19 @@ void RemoteScrollingCoordinatorProxy::reportSynchronousScrollingReasonsChanged(M
 
 void RemoteScrollingCoordinatorProxy::receivedWheelEventWithPhases(PlatformWheelEventPhase phase, PlatformWheelEventPhase momentumPhase)
 {
-    m_webPageProxy.send(Messages::RemoteScrollingCoordinator::ReceivedWheelEventWithPhases(phase, momentumPhase));
+    m_webPageProxy.legacyMainFrameProcess().send(Messages::RemoteScrollingCoordinator::ReceivedWheelEventWithPhases(phase, momentumPhase), m_webPageProxy.webPageIDInMainFrameProcess());
 }
 
 void RemoteScrollingCoordinatorProxy::deferWheelEventTestCompletionForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
 {
     if (isMonitoringWheelEvents() && nodeID)
-        m_webPageProxy.send(Messages::RemoteScrollingCoordinator::StartDeferringScrollingTestCompletionForNode(nodeID, reason));
+        m_webPageProxy.legacyMainFrameProcess().send(Messages::RemoteScrollingCoordinator::StartDeferringScrollingTestCompletionForNode(nodeID, reason), m_webPageProxy.webPageIDInMainFrameProcess());
 }
 
 void RemoteScrollingCoordinatorProxy::removeWheelEventTestCompletionDeferralForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
 {
     if (isMonitoringWheelEvents() && nodeID)
-        m_webPageProxy.send(Messages::RemoteScrollingCoordinator::StopDeferringScrollingTestCompletionForNode(nodeID, reason));
+        m_webPageProxy.legacyMainFrameProcess().send(Messages::RemoteScrollingCoordinator::StopDeferringScrollingTestCompletionForNode(nodeID, reason), m_webPageProxy.webPageIDInMainFrameProcess());
 }
 
 void RemoteScrollingCoordinatorProxy::viewWillStartLiveResize()

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -50,7 +50,7 @@ using namespace WebCore;
 RemoteScrollingCoordinatorProxyMac::RemoteScrollingCoordinatorProxyMac(WebPageProxy& webPageProxy)
     : RemoteScrollingCoordinatorProxy(webPageProxy)
 #if ENABLE(SCROLLING_THREAD)
-    , m_eventDispatcher(RemoteLayerTreeEventDispatcher::create(*this, webPageProxy.webPageID()))
+    , m_eventDispatcher(RemoteLayerTreeEventDispatcher::create(*this, webPageProxy.webPageIDInMainFrameProcess()))
 #endif
 {
     m_eventDispatcher->setScrollingTree(scrollingTree());

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -48,7 +48,7 @@
 namespace WebKit {
 
 RemotePageProxy::RemotePageProxy(WebPageProxy& page, WebProcessProxy& process, const Site& site, WebPageProxyMessageReceiverRegistration* registrationToTransfer)
-    : m_webPageID(page.webPageID())
+    : m_webPageID(page.webPageIDInMainFrameProcess()) // FIXME: We should generate a new identifier so that it will be more obvious when we get things wrong.
     , m_process(process)
     , m_page(page)
     , m_site(site)
@@ -157,7 +157,7 @@ void RemotePageProxy::decidePolicyForResponse(FrameInfoData&& frameInfo, uint64_
 {
     if (!m_page)
         return completionHandler({ });
-    m_page->decidePolicyForResponseShared(m_process.copyRef(), m_page->webPageID(), WTFMove(frameInfo), navigationID, response, request, canShowMIMEType, downloadAttribute, isShowingInitialAboutBlank, activeDocumentCOOPValue, WTFMove(completionHandler));
+    m_page->decidePolicyForResponseShared(m_process.copyRef(), m_page->webPageIDInMainFrameProcess(), WTFMove(frameInfo), navigationID, response, request, canShowMIMEType, downloadAttribute, isShowingInitialAboutBlank, activeDocumentCOOPValue, WTFMove(completionHandler));
 }
 
 void RemotePageProxy::didCommitLoadForFrame(IPC::Connection& connection, WebCore::FrameIdentifier frameID, FrameInfoData&& frameInfo, WebCore::ResourceRequest&& request, uint64_t navigationID, const String& mimeType, bool frameHasCustomContentProvider, WebCore::FrameLoadType frameLoadType, const WebCore::CertificateInfo& certificateInfo, bool usedLegacyTLS, bool privateRelayed, bool containsPluginDocument, WebCore::HasInsecureContent hasInsecureContent, WebCore::MouseEventPolicy mouseEventPolicy, const UserData& userData)

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -84,11 +84,6 @@ public:
     WebPageProxy* page() const;
     RefPtr<WebPageProxy> protectedPage() const;
 
-    template<typename M> void send(M&&);
-    template<typename M> IPC::ConnectionSendSyncResult<M> sendSync(M&& message);
-    template<typename M, typename C> void sendWithAsyncReply(M&&, C&&);
-    template<typename M, typename C, typename RawValue> void sendWithAsyncReply(M&&, C&&, const ObjectIdentifierGenericBase<RawValue>&);
-
     void injectPageIntoNewProcess();
     void processDidTerminate(WebCore::ProcessIdentifier);
 
@@ -96,7 +91,9 @@ public:
 
     WebProcessProxy& process() { return m_process.get(); }
     Ref<WebProcessProxy> protectedProcess() const;
-    WebCore::PageIdentifier pageID() const { return m_webPageID; }
+    WebProcessProxy& siteIsolatedProcess() const { return m_process.get(); }
+    WebCore::PageIdentifier pageID() const { return m_webPageID; } // FIXME: Remove this in favor of identifierInSiteIsolatedProcess.
+    WebCore::PageIdentifier identifierInSiteIsolatedProcess() const { return m_webPageID; }
     const Site& site() const { return m_site; }
 
 private:
@@ -119,26 +116,5 @@ private:
     std::unique_ptr<RemotePageVisitedLinkStoreRegistration> m_visitedLinkStoreRegistration;
     WebPageProxyMessageReceiverRegistration m_messageReceiverRegistration;
 };
-
-template<typename M> void RemotePageProxy::send(M&& message)
-{
-    m_process->send(std::forward<M>(message), m_webPageID, { });
-}
-
-template<typename M>
-IPC::ConnectionSendSyncResult<M> RemotePageProxy::sendSync(M&& message)
-{
-    return m_process->sendSync(std::forward<M>(message), m_webPageID);
-}
-
-template<typename M, typename C> void RemotePageProxy::sendWithAsyncReply(M&& message, C&& completionHandler)
-{
-    sendWithAsyncReply(std::forward<M>(message), std::forward<C>(completionHandler), m_webPageID);
-}
-
-template<typename M, typename C, typename RawValue> void RemotePageProxy::sendWithAsyncReply(M&& message, C&& completionHandler, const ObjectIdentifierGenericBase<RawValue>& destinationID)
-{
-    m_process->sendWithAsyncReply(std::forward<M>(message), std::forward<C>(completionHandler), destinationID.toUInt64());
-}
 
 }

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -106,7 +106,7 @@ static const MessageNameSet& messageNamesToIgnoreWhileSuspended()
 
 SuspendedPageProxy::SuspendedPageProxy(WebPageProxy& page, Ref<WebProcessProxy>&& process, Ref<WebFrameProxy>&& mainFrame, Ref<BrowsingContextGroup>&& browsingContextGroup, ShouldDelayClosingUntilFirstLayerFlush shouldDelayClosingUntilFirstLayerFlush)
     : m_page(page)
-    , m_webPageID(page.webPageID())
+    , m_webPageID(page.webPageIDInMainFrameProcess())
     , m_process(WTFMove(process))
     , m_mainFrame(WTFMove(mainFrame))
     , m_browsingContextGroup(WTFMove(browsingContextGroup))

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp
@@ -453,7 +453,7 @@ void AuthenticatorManager::runPanel()
     auto* page = m_pendingRequestData.page.get();
     if (!page)
         return;
-    ASSERT(m_pendingRequestData.globalFrameID && page->webPageID() == m_pendingRequestData.globalFrameID->pageID);
+    ASSERT(m_pendingRequestData.globalFrameID && page->webPageIDInMainFrameProcess() == m_pendingRequestData.globalFrameID->pageID);
     auto* frame = WebFrameProxy::webFrame(m_pendingRequestData.globalFrameID->frameID);
     if (!frame)
         return;

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp
@@ -50,7 +50,7 @@ using namespace WebCore;
 WebAuthenticatorCoordinatorProxy::WebAuthenticatorCoordinatorProxy(WebPageProxy& webPageProxy)
     : m_webPageProxy(webPageProxy)
 {
-    m_webPageProxy.legacyMainFrameProcess().addMessageReceiver(Messages::WebAuthenticatorCoordinatorProxy::messageReceiverName(), m_webPageProxy.webPageID(), *this);
+    m_webPageProxy.legacyMainFrameProcess().addMessageReceiver(Messages::WebAuthenticatorCoordinatorProxy::messageReceiverName(), m_webPageProxy.webPageIDInMainFrameProcess(), *this);
 }
 
 WebAuthenticatorCoordinatorProxy::~WebAuthenticatorCoordinatorProxy()
@@ -58,17 +58,17 @@ WebAuthenticatorCoordinatorProxy::~WebAuthenticatorCoordinatorProxy()
 #if HAVE(UNIFIED_ASC_AUTH_UI)
     cancel([]() { });
 #endif // HAVE(UNIFIED_ASC_AUTH_UI)
-    m_webPageProxy.legacyMainFrameProcess().removeMessageReceiver(Messages::WebAuthenticatorCoordinatorProxy::messageReceiverName(), m_webPageProxy.webPageID());
+    m_webPageProxy.legacyMainFrameProcess().removeMessageReceiver(Messages::WebAuthenticatorCoordinatorProxy::messageReceiverName(), m_webPageProxy.webPageIDInMainFrameProcess());
 }
 
 void WebAuthenticatorCoordinatorProxy::makeCredential(FrameIdentifier frameId, FrameInfoData&& frameInfo, PublicKeyCredentialCreationOptions&& options, MediationRequirement mediation, RequestCompletionHandler&& handler)
 {
-    handleRequest({ { }, WTFMove(options), m_webPageProxy, WebAuthenticationPanelResult::Unavailable, nullptr, GlobalFrameIdentifier { m_webPageProxy.webPageID(), frameId }, WTFMove(frameInfo), String(), nullptr, mediation, std::nullopt }, WTFMove(handler));
+    handleRequest({ { }, WTFMove(options), m_webPageProxy, WebAuthenticationPanelResult::Unavailable, nullptr, GlobalFrameIdentifier { m_webPageProxy.webPageIDInMainFrameProcess(), frameId }, WTFMove(frameInfo), String(), nullptr, mediation, std::nullopt }, WTFMove(handler));
 }
 
 void WebAuthenticatorCoordinatorProxy::getAssertion(FrameIdentifier frameId, FrameInfoData&& frameInfo, PublicKeyCredentialRequestOptions&& options, MediationRequirement mediation, std::optional<WebCore::SecurityOriginData> parentOrigin, RequestCompletionHandler&& handler)
 {
-    handleRequest({ { }, WTFMove(options), m_webPageProxy, WebAuthenticationPanelResult::Unavailable, nullptr, GlobalFrameIdentifier { m_webPageProxy.webPageID(), frameId }, WTFMove(frameInfo), String(), nullptr, mediation, parentOrigin }, WTFMove(handler));
+    handleRequest({ { }, WTFMove(options), m_webPageProxy, WebAuthenticationPanelResult::Unavailable, nullptr, GlobalFrameIdentifier { m_webPageProxy.webPageIDInMainFrameProcess(), frameId }, WTFMove(frameInfo), String(), nullptr, mediation, parentOrigin }, WTFMove(handler));
 }
 
 void WebAuthenticatorCoordinatorProxy::handleRequest(WebAuthenticationRequestData&& data, RequestCompletionHandler&& handler)

--- a/Source/WebKit/UIProcess/WebEditCommandProxy.cpp
+++ b/Source/WebKit/UIProcess/WebEditCommandProxy.cpp
@@ -56,7 +56,7 @@ void WebEditCommandProxy::unapply()
     if (!m_page || !m_page->hasRunningProcess())
         return;
 
-    m_page->send(Messages::WebPage::UnapplyEditCommand(m_commandID), IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
+    m_page->legacyMainFrameProcess().send(Messages::WebPage::UnapplyEditCommand(m_commandID), m_page->webPageIDInMainFrameProcess(), IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
     m_page->registerEditCommand(*this, UndoOrRedo::Redo);
 }
 
@@ -65,7 +65,7 @@ void WebEditCommandProxy::reapply()
     if (!m_page || !m_page->hasRunningProcess())
         return;
 
-    m_page->send(Messages::WebPage::ReapplyEditCommand(m_commandID), IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
+    m_page->legacyMainFrameProcess().send(Messages::WebPage::ReapplyEditCommand(m_commandID), m_page->webPageIDInMainFrameProcess(), IPC::SendOption::DispatchMessageEvenWhenWaitingForSyncReply);
     m_page->registerEditCommand(*this, UndoOrRedo::Undo);
 }
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -176,7 +176,7 @@ std::optional<PageIdentifier> WebFrameProxy::pageIdentifier() const
 {
     if (!m_page)
         return { };
-    return m_page->webPageID();
+    return m_page->webPageIDInMainFrameProcess();
 }
 
 void WebFrameProxy::navigateServiceWorkerClient(WebCore::ScriptExecutionContextIdentifier documentIdentifier, const URL& url, CompletionHandler<void(std::optional<PageIdentifier>, std::optional<FrameIdentifier>)>&& callback)
@@ -186,7 +186,7 @@ void WebFrameProxy::navigateServiceWorkerClient(WebCore::ScriptExecutionContextI
         return;
     }
 
-    protectedPage()->sendWithAsyncReply(Messages::WebPage::NavigateServiceWorkerClient { documentIdentifier, url }, [this, protectedThis = Ref { *this }, url, callback = WTFMove(callback)](auto result) mutable {
+    protectedPage()->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::NavigateServiceWorkerClient { documentIdentifier, url }, [this, protectedThis = Ref { *this }, url, callback = WTFMove(callback)](auto result) mutable {
         switch (result) {
         case WebCore::ScheduleLocationChangeResult::Stopped:
             callback({ }, { });
@@ -206,7 +206,7 @@ void WebFrameProxy::navigateServiceWorkerClient(WebCore::ScriptExecutionContextI
             m_navigateCallback = WTFMove(callback);
             return;
         }
-    });
+    }, protectedPage()->webPageIDInMainFrameProcess());
 }
 
 void WebFrameProxy::bindAccessibilityFrameWithData(std::span<const uint8_t> data)
@@ -214,20 +214,20 @@ void WebFrameProxy::bindAccessibilityFrameWithData(std::span<const uint8_t> data
     if (!m_page)
         return;
 
-    m_page->send(Messages::WebProcess::BindAccessibilityFrameWithData(m_frameID, data));
+    m_page->legacyMainFrameProcess().send(Messages::WebProcess::BindAccessibilityFrameWithData(m_frameID, data), m_page->webPageIDInMainFrameProcess());
 }
 
 void WebFrameProxy::loadURL(const URL& url, const String& referrer)
 {
     if (RefPtr page = m_page.get())
-        page->send(Messages::WebPage::LoadURLInFrame(url, referrer, m_frameID));
+        page->legacyMainFrameProcess().send(Messages::WebPage::LoadURLInFrame(url, referrer, m_frameID), page->webPageIDInMainFrameProcess());
 }
 
 void WebFrameProxy::loadData(std::span<const uint8_t> data, const String& type, const String& encodingName, const URL& baseURL)
 {
     ASSERT(!isMainFrame());
     if (RefPtr page = m_page.get())
-        page->send(Messages::WebPage::LoadDataInFrame(data, type, encodingName, baseURL, m_frameID));
+        page->legacyMainFrameProcess().send(Messages::WebPage::LoadDataInFrame(data, type, encodingName, baseURL, m_frameID), page->webPageIDInMainFrameProcess());
 }
     
 bool WebFrameProxy::canProvideSource() const
@@ -393,7 +393,7 @@ bool WebFrameProxy::didHandleContentFilterUnblockNavigation(const ResourceReques
 void WebFrameProxy::collapseSelection()
 {
     if (RefPtr page = m_page.get())
-        page->send(Messages::WebPage::CollapseSelectionInFrame(m_frameID));
+        page->legacyMainFrameProcess().send(Messages::WebPage::CollapseSelectionInFrame(m_frameID), page->webPageIDInMainFrameProcess());
 }
 #endif
 
@@ -442,11 +442,11 @@ void WebFrameProxy::commitProvisionalFrame(IPC::Connection& connection, FrameIde
 {
     ASSERT(m_page);
     if (m_provisionalFrame) {
-        protectedProcess()->send(Messages::WebPage::LoadDidCommitInAnotherProcess(frameID, m_layerHostingContextIdentifier), m_page->webPageID());
+        protectedProcess()->send(Messages::WebPage::LoadDidCommitInAnotherProcess(frameID, m_layerHostingContextIdentifier), m_page->webPageIDInMainFrameProcess());
         if (RefPtr process = std::exchange(m_provisionalFrame, nullptr)->takeFrameProcess()) {
             m_frameProcess = process.releaseNonNull();
             if (m_remoteFrameSize)
-                protectedProcess()->send(Messages::WebPage::UpdateFrameSize(frameID, *m_remoteFrameSize), m_page->webPageID());
+                protectedProcess()->send(Messages::WebPage::UpdateFrameSize(frameID, *m_remoteFrameSize), m_page->webPageIDInMainFrameProcess());
         }
     }
     protectedPage()->didCommitLoadForFrame(connection, frameID, WTFMove(frameInfo), WTFMove(request), navigationID, mimeType, frameHasCustomContentProvider, frameLoadType, certificateInfo, usedLegacyTLS, privateRelayed, containsPluginDocument, hasInsecureContent, mouseEventPolicy, userData);
@@ -486,7 +486,7 @@ void WebFrameProxy::getFrameInfo(CompletionHandler<void(FrameTreeNodeData&&)>&& 
     protectedProcess()->sendWithAsyncReply(Messages::WebPage::GetFrameInfo(m_frameID), [aggregator] (std::optional<FrameInfoData>&& info) {
         if (info)
             aggregator->setCurrentFrameData(WTFMove(*info));
-    }, m_page->webPageID());
+    }, m_page->webPageIDInMainFrameProcess());
 
     bool isSiteIsolationEnabled = page() && page()->preferences().siteIsolationEnabled();
     size_t index = 0;
@@ -563,7 +563,7 @@ void WebFrameProxy::notifyParentOfLoadCompletion(WebProcessProxy& childFrameProc
 std::optional<WebCore::PageIdentifier> WebFrameProxy::webPageIDInCurrentProcess()
 {
     if (m_page)
-        return m_page->webPageID();
+        return m_page->webPageIDInMainFrameProcess();
     return std::nullopt;
 }
 

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -61,12 +61,12 @@ WebFullScreenManagerProxy::WebFullScreenManagerProxy(WebPageProxy& page, WebFull
     , m_logIdentifier(page.logIdentifier())
 #endif
 {
-    m_page.legacyMainFrameProcess().addMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), m_page.webPageID(), *this);
+    m_page.legacyMainFrameProcess().addMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), m_page.webPageIDInMainFrameProcess(), *this);
 }
 
 WebFullScreenManagerProxy::~WebFullScreenManagerProxy()
 {
-    m_page.legacyMainFrameProcess().removeMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), m_page.webPageID());
+    m_page.legacyMainFrameProcess().removeMessageReceiver(Messages::WebFullScreenManagerProxy::messageReceiverName(), m_page.webPageIDInMainFrameProcess());
     m_client.closeFullScreenManager();
     callCloseCompletionHandlers();
 }
@@ -76,7 +76,7 @@ void WebFullScreenManagerProxy::willEnterFullScreen(WebCore::HTMLMediaElementEnu
     ALWAYS_LOG(LOGIDENTIFIER);
     m_fullscreenState = FullscreenState::EnteringFullscreen;
     m_page.fullscreenClient().willEnterFullscreen(&m_page);
-    m_page.send(Messages::WebFullScreenManager::WillEnterFullScreen(mode));
+    m_page.legacyMainFrameProcess().send(Messages::WebFullScreenManager::WillEnterFullScreen(mode), m_page.webPageIDInMainFrameProcess());
 }
 
 void WebFullScreenManagerProxy::didEnterFullScreen()
@@ -84,7 +84,7 @@ void WebFullScreenManagerProxy::didEnterFullScreen()
     ALWAYS_LOG(LOGIDENTIFIER);
     m_fullscreenState = FullscreenState::InFullscreen;
     m_page.fullscreenClient().didEnterFullscreen(&m_page);
-    m_page.send(Messages::WebFullScreenManager::DidEnterFullScreen());
+    m_page.legacyMainFrameProcess().send(Messages::WebFullScreenManager::DidEnterFullScreen(), m_page.webPageIDInMainFrameProcess());
 
     if (m_page.isControlledByAutomation()) {
         if (WebAutomationSession* automationSession = m_page.configuration().processPool().automationSession())
@@ -97,7 +97,7 @@ void WebFullScreenManagerProxy::willExitFullScreen()
     ALWAYS_LOG(LOGIDENTIFIER);
     m_fullscreenState = FullscreenState::ExitingFullscreen;
     m_page.fullscreenClient().willExitFullscreen(&m_page);
-    m_page.send(Messages::WebFullScreenManager::WillExitFullScreen());
+    m_page.legacyMainFrameProcess().send(Messages::WebFullScreenManager::WillExitFullScreen(), m_page.webPageIDInMainFrameProcess());
 }
 
 void WebFullScreenManagerProxy::callCloseCompletionHandlers()
@@ -118,7 +118,7 @@ void WebFullScreenManagerProxy::didExitFullScreen()
     ALWAYS_LOG(LOGIDENTIFIER);
     m_fullscreenState = FullscreenState::NotInFullscreen;
     m_page.fullscreenClient().didExitFullscreen(&m_page);
-    m_page.send(Messages::WebFullScreenManager::DidExitFullScreen());
+    m_page.legacyMainFrameProcess().send(Messages::WebFullScreenManager::DidExitFullScreen(), m_page.webPageIDInMainFrameProcess());
     
     if (m_page.isControlledByAutomation()) {
         if (WebAutomationSession* automationSession = m_page.configuration().processPool().automationSession())
@@ -129,19 +129,19 @@ void WebFullScreenManagerProxy::didExitFullScreen()
 
 void WebFullScreenManagerProxy::setAnimatingFullScreen(bool animating)
 {
-    m_page.send(Messages::WebFullScreenManager::SetAnimatingFullScreen(animating));
+    m_page.legacyMainFrameProcess().send(Messages::WebFullScreenManager::SetAnimatingFullScreen(animating), m_page.webPageIDInMainFrameProcess());
 }
 
 void WebFullScreenManagerProxy::requestRestoreFullScreen(CompletionHandler<void(bool)>&& completionHandler)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    m_page.sendWithAsyncReply(Messages::WebFullScreenManager::RequestRestoreFullScreen(), WTFMove(completionHandler));
+    m_page.legacyMainFrameProcess().sendWithAsyncReply(Messages::WebFullScreenManager::RequestRestoreFullScreen(), WTFMove(completionHandler), m_page.webPageIDInMainFrameProcess());
 }
 
 void WebFullScreenManagerProxy::requestExitFullScreen()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    m_page.send(Messages::WebFullScreenManager::RequestExitFullScreen());
+    m_page.legacyMainFrameProcess().send(Messages::WebFullScreenManager::RequestExitFullScreen(), m_page.webPageIDInMainFrameProcess());
 }
 
 void WebFullScreenManagerProxy::supportsFullScreen(bool withKeyboard, CompletionHandler<void(bool)>&& completionHandler)
@@ -155,22 +155,22 @@ void WebFullScreenManagerProxy::supportsFullScreen(bool withKeyboard, Completion
 
 void WebFullScreenManagerProxy::saveScrollPosition()
 {
-    m_page.send(Messages::WebFullScreenManager::SaveScrollPosition());
+    m_page.legacyMainFrameProcess().send(Messages::WebFullScreenManager::SaveScrollPosition(), m_page.webPageIDInMainFrameProcess());
 }
 
 void WebFullScreenManagerProxy::restoreScrollPosition()
 {
-    m_page.send(Messages::WebFullScreenManager::RestoreScrollPosition());
+    m_page.legacyMainFrameProcess().send(Messages::WebFullScreenManager::RestoreScrollPosition(), m_page.webPageIDInMainFrameProcess());
 }
 
 void WebFullScreenManagerProxy::setFullscreenInsets(const WebCore::FloatBoxExtent& insets)
 {
-    m_page.send(Messages::WebFullScreenManager::SetFullscreenInsets(insets));
+    m_page.legacyMainFrameProcess().send(Messages::WebFullScreenManager::SetFullscreenInsets(insets), m_page.webPageIDInMainFrameProcess());
 }
 
 void WebFullScreenManagerProxy::setFullscreenAutoHideDuration(Seconds duration)
 {
-    m_page.send(Messages::WebFullScreenManager::SetFullscreenAutoHideDuration(duration));
+    m_page.legacyMainFrameProcess().send(Messages::WebFullScreenManager::SetFullscreenAutoHideDuration(duration), m_page.webPageIDInMainFrameProcess());
 }
 
 void WebFullScreenManagerProxy::close()

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -811,7 +811,7 @@ bool WebProcessProxy::shouldDropNearSuspendedAssertionAfterDelay() const
 
 void WebProcessProxy::addExistingWebPage(WebPageProxy& webPage, BeginsUsingDataStore beginsUsingDataStore)
 {
-    WEBPROCESSPROXY_RELEASE_LOG(Process, "addExistingWebPage: webPage=%p, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64, &webPage, webPage.identifier().toUInt64(), webPage.webPageID().toUInt64());
+    WEBPROCESSPROXY_RELEASE_LOG(Process, "addExistingWebPage: webPage=%p, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64, &webPage, webPage.identifier().toUInt64(), webPage.webPageIDInMainFrameProcess().toUInt64());
 
     ASSERT(!m_pageMap.contains(webPage.identifier()));
     ASSERT(!globalPageMap().contains(webPage.identifier()));
@@ -865,7 +865,7 @@ void WebProcessProxy::markIsNoLongerInPrewarmedPool()
 
 void WebProcessProxy::removeWebPage(WebPageProxy& webPage, EndsUsingDataStore endsUsingDataStore)
 {
-    WEBPROCESSPROXY_RELEASE_LOG(Process, "removeWebPage: webPage=%p, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64, &webPage, webPage.identifier().toUInt64(), webPage.webPageID().toUInt64());
+    WEBPROCESSPROXY_RELEASE_LOG(Process, "removeWebPage: webPage=%p, pageProxyID=%" PRIu64 ", webPageID=%" PRIu64, &webPage, webPage.identifier().toUInt64(), webPage.webPageIDInMainFrameProcess().toUInt64());
     RefPtr removedPage = m_pageMap.take(webPage.identifier()).get();
     ASSERT_UNUSED(removedPage, removedPage == &webPage);
     removedPage = globalPageMap().take(webPage.identifier()).get();
@@ -1736,7 +1736,7 @@ RefPtr<API::Object> WebProcessProxy::transformObjectsToHandles(API::Object* obje
                 return API::FrameHandle::createAutoconverting(static_cast<const WebFrameProxy&>(object).frameID());
 
             case API::Object::Type::Page:
-                return API::PageHandle::createAutoconverting(static_cast<const WebPageProxy&>(object).identifier(), static_cast<const WebPageProxy&>(object).webPageID());
+                return API::PageHandle::createAutoconverting(static_cast<const WebPageProxy&>(object).identifier(), static_cast<const WebPageProxy&>(object).webPageIDInMainFrameProcess());
 
             default:
                 return &object;
@@ -2195,7 +2195,7 @@ void WebProcessProxy::createSpeechRecognitionServer(SpeechRecognitionServerIdent
 {
     RefPtr<WebPageProxy> targetPage;
     for (Ref page : pages()) {
-        if (page->webPageID() == identifier) {
+        if (page->webPageIDInMainFrameProcess() == identifier) {
             targetPage = WTFMove(page);
             break;
         }
@@ -2255,7 +2255,7 @@ void WebProcessProxy::muteCaptureInPagesExcept(WebCore::PageIdentifier pageID)
 {
 #if PLATFORM(COCOA)
     for (Ref page : globalPages()) {
-        if (page->webPageID() != pageID)
+        if (page->webPageIDInMainFrameProcess() != pageID)
             page->setMediaStreamCaptureMuted(true);
     }
 #else

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
@@ -42,14 +42,14 @@ WebScreenOrientationManagerProxy::WebScreenOrientationManagerProxy(WebPageProxy&
     : m_page(page)
     , m_currentOrientation(orientation)
 {
-    m_page.legacyMainFrameProcess().addMessageReceiver(Messages::WebScreenOrientationManagerProxy::messageReceiverName(), m_page.webPageID(), *this);
+    m_page.legacyMainFrameProcess().addMessageReceiver(Messages::WebScreenOrientationManagerProxy::messageReceiverName(), m_page.webPageIDInMainFrameProcess(), *this);
 }
 
 WebScreenOrientationManagerProxy::~WebScreenOrientationManagerProxy()
 {
     unlockIfNecessary();
 
-    m_page.legacyMainFrameProcess().removeMessageReceiver(Messages::WebScreenOrientationManagerProxy::messageReceiverName(), m_page.webPageID());
+    m_page.legacyMainFrameProcess().removeMessageReceiver(Messages::WebScreenOrientationManagerProxy::messageReceiverName(), m_page.webPageIDInMainFrameProcess());
 }
 
 void WebScreenOrientationManagerProxy::currentOrientation(CompletionHandler<void(WebCore::ScreenOrientationType)>&& completionHandler)
@@ -66,7 +66,7 @@ void WebScreenOrientationManagerProxy::setCurrentOrientation(WebCore::ScreenOrie
     if (!m_shouldSendChangeNotifications)
         return;
 
-    m_page.send(Messages::WebScreenOrientationManager::OrientationDidChange(orientation));
+    m_page.legacyMainFrameProcess().send(Messages::WebScreenOrientationManager::OrientationDidChange(orientation), m_page.webPageIDInMainFrameProcess());
     if (m_currentLockRequest)
         m_currentLockRequest(std::nullopt);
 }

--- a/Source/WebKit/UIProcess/WebURLSchemeTask.cpp
+++ b/Source/WebKit/UIProcess/WebURLSchemeTask.cpp
@@ -107,7 +107,7 @@ auto WebURLSchemeTask::willPerformRedirection(ResourceResponse&& response, Resou
             completionHandler(WTFMove(request));
     };
 
-    page->sendWithAsyncReply(Messages::WebPage::URLSchemeTaskWillPerformRedirection(m_urlSchemeHandler->identifier(), m_resourceLoaderID, response, request), WTFMove(innerCompletionHandler));
+    page->legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::URLSchemeTaskWillPerformRedirection(m_urlSchemeHandler->identifier(), m_resourceLoaderID, response, request), WTFMove(innerCompletionHandler), page->webPageIDInMainFrameProcess());
 
     return ExceptionType::None;
 }

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
@@ -42,12 +42,12 @@ namespace WebKit {
 PlatformXRSystem::PlatformXRSystem(WebPageProxy& page)
     : m_page(page)
 {
-    m_page.legacyMainFrameProcess().addMessageReceiver(Messages::PlatformXRSystem::messageReceiverName(), m_page.webPageID(), *this);
+    m_page.legacyMainFrameProcess().addMessageReceiver(Messages::PlatformXRSystem::messageReceiverName(), m_page.webPageIDInMainFrameProcess(), *this);
 }
 
 PlatformXRSystem::~PlatformXRSystem()
 {
-    m_page.legacyMainFrameProcess().removeMessageReceiver(Messages::PlatformXRSystem::messageReceiverName(), m_page.webPageID());
+    m_page.legacyMainFrameProcess().removeMessageReceiver(Messages::PlatformXRSystem::messageReceiverName(), m_page.webPageIDInMainFrameProcess());
 }
 
 void PlatformXRSystem::invalidate()
@@ -194,7 +194,7 @@ void PlatformXRSystem::sessionDidEnd(XRDeviceIdentifier deviceIdentifier)
         if (!protectedThis)
             return;
 
-        protectedThis->m_page.send(Messages::PlatformXRSystemProxy::SessionDidEnd(deviceIdentifier));
+        protectedThis->m_page.legacyMainFrameProcess().send(Messages::PlatformXRSystemProxy::SessionDidEnd(deviceIdentifier), protectedThis->m_page.webPageIDInMainFrameProcess());
         protectedThis->m_immersiveSessionActivity = nullptr;
         protectedThis->invalidateImmersiveSessionState();
     });
@@ -207,7 +207,7 @@ void PlatformXRSystem::sessionDidUpdateVisibilityState(XRDeviceIdentifier device
         if (!protectedThis)
             return;
 
-        protectedThis->m_page.send(Messages::PlatformXRSystemProxy::SessionDidUpdateVisibilityState(deviceIdentifier, visibilityState));
+        protectedThis->m_page.legacyMainFrameProcess().send(Messages::PlatformXRSystemProxy::SessionDidUpdateVisibilityState(deviceIdentifier, visibilityState), protectedThis->m_page.webPageIDInMainFrameProcess());
     });
 }
 

--- a/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
+++ b/Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm
@@ -135,7 +135,7 @@ void ARKitCoordinator::startSession(WebPageProxy& page, WeakPtr<SessionEventClie
 
             m_state = Active {
                 .sessionEventClient = WTFMove(sessionEventClient),
-                .pageIdentifier = page.webPageID(),
+                .pageIdentifier = page.webPageIDInMainFrameProcess(),
                 .renderState = renderState,
                 .renderThread = Thread::create("ARKitCoordinator session renderer"_s, [this, renderState] { renderLoop(renderState); }),
             };
@@ -183,7 +183,7 @@ void ARKitCoordinator::endSessionIfExists(std::optional<WebCore::PageIdentifier>
 
 void ARKitCoordinator::endSessionIfExists(WebPageProxy& page)
 {
-    endSessionIfExists(page.webPageID());
+    endSessionIfExists(page.webPageIDInMainFrameProcess());
 }
 
 void ARKitCoordinator::scheduleAnimationFrame(WebPageProxy& page, PlatformXR::Device::RequestFrameCallback&& onFrameUpdateCallback)
@@ -195,7 +195,7 @@ void ARKitCoordinator::scheduleAnimationFrame(WebPageProxy& page, PlatformXR::De
             onFrameUpdateCallback({ });
         },
         [&](Active& active) {
-            if (active.pageIdentifier != page.webPageID()) {
+            if (active.pageIdentifier != page.webPageIDInMainFrameProcess()) {
                 RELEASE_LOG(XR, "ARKitCoordinator: trying to schedule frame update for session owned by another page");
                 return;
             }
@@ -218,7 +218,7 @@ void ARKitCoordinator::submitFrame(WebPageProxy& page)
             RELEASE_LOG(XR, "ARKitCoordinator: trying to submit frame update for an inactive session");
         },
         [&](Active& active) {
-            if (active.pageIdentifier != page.webPageID()) {
+            if (active.pageIdentifier != page.webPageIDInMainFrameProcess()) {
                 RELEASE_LOG(XR, "ARKitCoordinator: trying to submit frame update for session owned by another page");
                 return;
             }

--- a/Source/WebKit/UIProcess/glib/WebPageProxyGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebPageProxyGLib.cpp
@@ -50,12 +50,12 @@ String WebPageProxy::standardUserAgent(const String& applicationNameForUserAgent
     return WebCore::standardUserAgent(applicationNameForUserAgent);
 }
 
-void WebPageProxy::saveRecentSearches(const String&, const Vector<WebCore::RecentSearch>&)
+void WebPageProxy::saveRecentSearches(IPC::Connection&, const String&, const Vector<WebCore::RecentSearch>&)
 {
     notImplemented();
 }
 
-void WebPageProxy::loadRecentSearches(const String&, CompletionHandler<void(Vector<WebCore::RecentSearch>&&)>&& completionHandler)
+void WebPageProxy::loadRecentSearches(IPC::Connection&, const String&, CompletionHandler<void(Vector<WebCore::RecentSearch>&&)>&& completionHandler)
 {
     notImplemented();
     completionHandler({ });

--- a/Source/WebKit/UIProcess/gstreamer/WebPageProxyGStreamer.cpp
+++ b/Source/WebKit/UIProcess/gstreamer/WebPageProxyGStreamer.cpp
@@ -60,17 +60,17 @@ void WebPageProxy::Internals::didResumeSpeaking(WebCore::PlatformSpeechSynthesis
 
 void WebPageProxy::Internals::speakingErrorOccurred(WebCore::PlatformSpeechSynthesisUtterance&)
 {
-    page.send(Messages::WebPage::SpeakingErrorOccurred());
+    page.legacyMainFrameProcess().send(Messages::WebPage::SpeakingErrorOccurred(), page.webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::Internals::boundaryEventOccurred(WebCore::PlatformSpeechSynthesisUtterance&, WebCore::SpeechBoundary speechBoundary, unsigned charIndex, unsigned charLength)
 {
-    page.send(Messages::WebPage::BoundaryEventOccurred(speechBoundary == WebCore::SpeechBoundary::SpeechWordBoundary, charIndex, charLength));
+    page.legacyMainFrameProcess().send(Messages::WebPage::BoundaryEventOccurred(speechBoundary == WebCore::SpeechBoundary::SpeechWordBoundary, charIndex, charLength), page.webPageIDInMainFrameProcess());
 }
 
 void WebPageProxy::Internals::voicesDidChange()
 {
-    page.send(Messages::WebPage::VoicesDidChange());
+    page.legacyMainFrameProcess().send(Messages::WebPage::VoicesDidChange(), page.webPageIDInMainFrameProcess());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebPageProxyGtk.cpp
@@ -112,7 +112,7 @@ void WebPageProxy::accentColorDidChange()
 
     WebCore::Color accentColor = pageClient().accentColor();
 
-    send(Messages::WebPage::SetAccentColor(accentColor));
+    legacyMainFrameProcess().send(Messages::WebPage::SetAccentColor(accentColor), webPageIDInMainFrameProcess());
 }
 
 OptionSet<WebCore::PlatformEvent::Modifier> WebPageProxy::currentStateOfModifierKeys()

--- a/Source/WebKit/UIProcess/ios/SmartMagnificationController.mm
+++ b/Source/WebKit/UIProcess/ios/SmartMagnificationController.mm
@@ -54,17 +54,17 @@ SmartMagnificationController::SmartMagnificationController(WKContentView *conten
     : m_webPageProxy(*contentView.page)
     , m_contentView(contentView)
 {
-    m_webPageProxy.legacyMainFrameProcess().addMessageReceiver(Messages::SmartMagnificationController::messageReceiverName(), m_webPageProxy.webPageID(), *this);
+    m_webPageProxy.legacyMainFrameProcess().addMessageReceiver(Messages::SmartMagnificationController::messageReceiverName(), m_webPageProxy.webPageIDInMainFrameProcess(), *this);
 }
 
 SmartMagnificationController::~SmartMagnificationController()
 {
-    m_webPageProxy.legacyMainFrameProcess().removeMessageReceiver(Messages::SmartMagnificationController::messageReceiverName(), m_webPageProxy.webPageID());
+    m_webPageProxy.legacyMainFrameProcess().removeMessageReceiver(Messages::SmartMagnificationController::messageReceiverName(), m_webPageProxy.webPageIDInMainFrameProcess());
 }
 
 void SmartMagnificationController::handleSmartMagnificationGesture(FloatPoint origin)
 {
-    m_webPageProxy.send(Messages::ViewGestureGeometryCollector::CollectGeometryForSmartMagnificationGesture(origin));
+    m_webPageProxy.legacyMainFrameProcess().send(Messages::ViewGestureGeometryCollector::CollectGeometryForSmartMagnificationGesture(origin), m_webPageProxy.webPageIDInMainFrameProcess());
 }
 
 void SmartMagnificationController::handleResetMagnificationGesture(FloatPoint origin)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -3103,7 +3103,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _isWaitingOnPositionInformation = YES;
     if (![self _hasValidOutstandingPositionInformationRequest:request])
         [self requestAsynchronousPositionInformationUpdate:request];
-    bool receivedResponse = connection->waitForAndDispatchImmediately<Messages::WebPageProxy::DidReceivePositionInformation>(_page->webPageID(), 1_s, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives) == IPC::Error::NoError;
+    bool receivedResponse = connection->waitForAndDispatchImmediately<Messages::WebPageProxy::DidReceivePositionInformation>(_page->webPageIDInMainFrameProcess(), 1_s, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives) == IPC::Error::NoError;
     _hasValidPositionInformation = receivedResponse && _positionInformation.canBeValid;
     return _hasValidPositionInformation;
 }
@@ -5678,7 +5678,7 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
     _pendingAutocorrectionContextHandler = WTFMove(completionHandler);
     _page->requestAutocorrectionContext();
 
-    if (_page->legacyMainFrameProcess().connection()->waitForAndDispatchImmediately<Messages::WebPageProxy::HandleAutocorrectionContext>(_page->webPageID(), 1_s, IPC::WaitForOption::DispatchIncomingSyncMessagesWhileWaiting) != IPC::Error::NoError)
+    if (_page->legacyMainFrameProcess().connection()->waitForAndDispatchImmediately<Messages::WebPageProxy::HandleAutocorrectionContext>(_page->webPageIDInMainFrameProcess(), 1_s, IPC::WaitForOption::DispatchIncomingSyncMessagesWhileWaiting) != IPC::Error::NoError)
         RELEASE_LOG(TextInput, "Timed out while waiting for autocorrection context.");
 
     if (_autocorrectionContextNeedsUpdate)
@@ -9951,7 +9951,7 @@ static std::optional<WebCore::DragOperation> coreDragOperationForUIDropOperation
         dragOperationMask,
         { },
         WebKit::coreDragDestinationActionMask(dragDestinationAction),
-        _page->webPageID()
+        _page->webPageIDInMainFrameProcess()
     };
 }
 
@@ -10756,7 +10756,7 @@ static Vector<WebCore::IntSize> sizesOfPlaceholderElementsToInsertWhenDroppingIt
         context.get()[@"_WebViewURL"] = platformURL;
 
     if (_focusedElementInformation.nonAutofillCredentialType == WebCore::NonAutofillCredentialType::WebAuthn) {
-        context.get()[@"_page_id"] = [NSNumber numberWithUnsignedLong:_page->webPageID().toUInt64()];
+        context.get()[@"_page_id"] = [NSNumber numberWithUnsignedLong:_page->webPageIDInMainFrameProcess().toUInt64()];
         context.get()[@"_frame_id"] = [NSNumber numberWithUnsignedLong:_focusedElementInformation.frameID.object().toUInt64()];
         context.get()[@"_credential_type"] = WebCore::nonAutofillCredentialTypeString(_focusedElementInformation.nonAutofillCredentialType);
     }
@@ -11549,7 +11549,7 @@ static BOOL applicationIsKnownToIgnoreMouseEvents(const char* &warningVersion)
     if (![textInputContext isKindOfClass:_WKTextInputContext.class])
         return nil;
     auto elementContext = textInputContext._textInputContext;
-    if (elementContext.webPageIdentifier != _page->webPageID())
+    if (elementContext.webPageIdentifier != _page->webPageIDInMainFrameProcess())
         return nil;
     return textInputContext;
 }

--- a/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm
+++ b/Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm
@@ -40,12 +40,12 @@ namespace WebKit {
 WebDeviceOrientationUpdateProviderProxy::WebDeviceOrientationUpdateProviderProxy(WebPageProxy& page)
     : m_page(page)
 {
-    m_page.legacyMainFrameProcess().addMessageReceiver(Messages::WebDeviceOrientationUpdateProviderProxy::messageReceiverName(), m_page.webPageID(), *this);
+    m_page.legacyMainFrameProcess().addMessageReceiver(Messages::WebDeviceOrientationUpdateProviderProxy::messageReceiverName(), m_page.webPageIDInMainFrameProcess(), *this);
 }
 
 WebDeviceOrientationUpdateProviderProxy::~WebDeviceOrientationUpdateProviderProxy()
 {
-    m_page.legacyMainFrameProcess().removeMessageReceiver(Messages::WebDeviceOrientationUpdateProviderProxy::messageReceiverName(), m_page.webPageID());
+    m_page.legacyMainFrameProcess().removeMessageReceiver(Messages::WebDeviceOrientationUpdateProviderProxy::messageReceiverName(), m_page.webPageIDInMainFrameProcess());
 }
 
 void WebDeviceOrientationUpdateProviderProxy::startUpdatingDeviceOrientation()
@@ -70,12 +70,12 @@ void WebDeviceOrientationUpdateProviderProxy::stopUpdatingDeviceMotion()
 
 void WebDeviceOrientationUpdateProviderProxy::orientationChanged(double alpha, double beta, double gamma, double compassHeading, double compassAccuracy)
 {
-    m_page.send(Messages::WebDeviceOrientationUpdateProvider::DeviceOrientationChanged(alpha, beta, gamma, compassHeading, compassAccuracy));
+    m_page.legacyMainFrameProcess().send(Messages::WebDeviceOrientationUpdateProvider::DeviceOrientationChanged(alpha, beta, gamma, compassHeading, compassAccuracy), m_page.webPageIDInMainFrameProcess());
 }
 
 void WebDeviceOrientationUpdateProviderProxy::motionChanged(double xAcceleration, double yAcceleration, double zAcceleration, double xAccelerationIncludingGravity, double yAccelerationIncludingGravity, double zAccelerationIncludingGravity, std::optional<double> xRotationRate, std::optional<double> yRotationRate, std::optional<double> zRotationRate)
 {
-    m_page.send(Messages::WebDeviceOrientationUpdateProvider::DeviceMotionChanged(xAcceleration, yAcceleration, zAcceleration, xAccelerationIncludingGravity, yAccelerationIncludingGravity, zAccelerationIncludingGravity, xRotationRate, yRotationRate, zRotationRate));
+    m_page.legacyMainFrameProcess().send(Messages::WebDeviceOrientationUpdateProvider::DeviceMotionChanged(xAcceleration, yAcceleration, zAcceleration, xAccelerationIncludingGravity, yAccelerationIncludingGravity, zAccelerationIncludingGravity, xRotationRate, yRotationRate, zRotationRate), m_page.webPageIDInMainFrameProcess());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
@@ -135,7 +135,7 @@ void TiledCoreAnimationDrawingAreaProxy::didUpdateGeometry()
 void TiledCoreAnimationDrawingAreaProxy::waitForDidUpdateActivityState(ActivityStateChangeID, WebProcessProxy& process)
 {
     Seconds activityStateUpdateTimeout = Seconds::fromMilliseconds(250);
-    process.connection()->waitForAndDispatchImmediately<Messages::WebPageProxy::DidUpdateActivityState>(protectedWebPageProxy()->webPageID(), activityStateUpdateTimeout, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives);
+    process.connection()->waitForAndDispatchImmediately<Messages::WebPageProxy::DidUpdateActivityState>(protectedWebPageProxy()->webPageIDInMainFrameProcess(), activityStateUpdateTimeout, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives);
 }
 
 void TiledCoreAnimationDrawingAreaProxy::willSendUpdateGeometry()

--- a/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
+++ b/Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm
@@ -162,7 +162,7 @@ void ViewGestureController::handleSmartMagnificationGesture(FloatPoint gestureLo
 
     LOG_WITH_STREAM(ViewGestures, stream << "ViewGestureController::handleSmartMagnificationGesture - gesture location " << gestureLocationInViewCoordinates);
 
-    m_webPageProxy.send(Messages::ViewGestureGeometryCollector::CollectGeometryForSmartMagnificationGesture(gestureLocationInViewCoordinates));
+    m_webPageProxy.legacyMainFrameProcess().send(Messages::ViewGestureGeometryCollector::CollectGeometryForSmartMagnificationGesture(gestureLocationInViewCoordinates), m_webPageProxy.webPageIDInMainFrameProcess());
 }
 
 static float maximumRectangleComponentDelta(FloatRect a, FloatRect b)

--- a/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
+++ b/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
@@ -195,7 +195,7 @@
     // FIXME: Connection can be null if the process is closed; we should clean up better in that case.
     if (_state == WebKit::ImmediateActionState::Pending) {
         if (auto* connection = RefPtr { _page.get() }->legacyMainFrameProcess().connection()) {
-            bool receivedReply = connection->waitForAndDispatchImmediately<Messages::WebPageProxy::DidPerformImmediateActionHitTest>(RefPtr { _page.get() }->webPageID(), 500_ms) == IPC::Error::NoError;
+            bool receivedReply = connection->waitForAndDispatchImmediately<Messages::WebPageProxy::DidPerformImmediateActionHitTest>(RefPtr { _page.get() }->webPageIDInMainFrameProcess(), 500_ms) == IPC::Error::NoError;
             if (!receivedReply)
                 _state = WebKit::ImmediateActionState::TimedOut;
         }
@@ -426,13 +426,13 @@
     RefPtr<WebKit::WebPageProxy> page = _page.get();
     WebCore::PageOverlay::PageOverlayID overlayID = _hitTestResultData.platformData.detectedDataOriginatingPageOverlay;
     _currentActionContext = (WKDDActionContext *)[actionContext contextForView:_view altMode:YES interactionStartedHandler:^() {
-        page->send(Messages::WebPage::DataDetectorsDidPresentUI(overlayID));
+        page->legacyMainFrameProcess().send(Messages::WebPage::DataDetectorsDidPresentUI(overlayID), page->webPageIDInMainFrameProcess());
     } interactionChangedHandler:^() {
         if (_hitTestResultData.platformData.detectedDataTextIndicator)
             page->setTextIndicator(_hitTestResultData.platformData.detectedDataTextIndicator->data());
-        page->send(Messages::WebPage::DataDetectorsDidChangeUI(overlayID));
+        page->legacyMainFrameProcess().send(Messages::WebPage::DataDetectorsDidChangeUI(overlayID), page->webPageIDInMainFrameProcess());
     } interactionStoppedHandler:^() {
-        page->send(Messages::WebPage::DataDetectorsDidHideUI(overlayID));
+        page->legacyMainFrameProcess().send(Messages::WebPage::DataDetectorsDidHideUI(overlayID), page->webPageIDInMainFrameProcess());
         [self _clearImmediateActionState];
     }];
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4005,7 +4005,7 @@ NSDragOperation WebViewImpl::draggingEntered(id <NSDraggingInfo> draggingInfo)
     WebCore::IntPoint global(WebCore::globalPoint(draggingInfo.draggingLocation, [m_view window]));
     auto dragDestinationActionMask = coreDragDestinationActionMask([m_view _web_dragDestinationActionForDraggingInfo:draggingInfo]);
     auto dragOperationMask = coreDragOperationMask(draggingInfo.draggingSourceOperationMask);
-    WebCore::DragData dragData(draggingInfo, client, global, dragOperationMask, applicationFlagsForDrag(m_view.getAutoreleased(), draggingInfo), dragDestinationActionMask, m_page->webPageID());
+    WebCore::DragData dragData(draggingInfo, client, global, dragOperationMask, applicationFlagsForDrag(m_view.getAutoreleased(), draggingInfo), dragDestinationActionMask, m_page->webPageIDInMainFrameProcess());
 
     m_page->resetCurrentDragInformation();
     m_page->dragEntered(dragData, draggingInfo.draggingPasteboard.name);
@@ -4043,7 +4043,7 @@ NSDragOperation WebViewImpl::draggingUpdated(id <NSDraggingInfo> draggingInfo)
     WebCore::IntPoint global(WebCore::globalPoint(draggingInfo.draggingLocation, [m_view window]));
     auto dragDestinationActionMask = coreDragDestinationActionMask([m_view _web_dragDestinationActionForDraggingInfo:draggingInfo]);
     auto dragOperationMask = coreDragOperationMask(draggingInfo.draggingSourceOperationMask);
-    WebCore::DragData dragData(draggingInfo, client, global, dragOperationMask, applicationFlagsForDrag(m_view.getAutoreleased(), draggingInfo), dragDestinationActionMask, m_page->webPageID());
+    WebCore::DragData dragData(draggingInfo, client, global, dragOperationMask, applicationFlagsForDrag(m_view.getAutoreleased(), draggingInfo), dragDestinationActionMask, m_page->webPageIDInMainFrameProcess());
     m_page->dragUpdated(dragData, draggingInfo.draggingPasteboard.name);
 
     NSInteger numberOfValidItemsForDrop = m_page->currentDragNumberOfFilesToBeAccepted();
@@ -4067,7 +4067,7 @@ void WebViewImpl::draggingExited(id <NSDraggingInfo> draggingInfo)
 {
     WebCore::IntPoint client([m_view convertPoint:draggingInfo.draggingLocation fromView:nil]);
     WebCore::IntPoint global(WebCore::globalPoint(draggingInfo.draggingLocation, [m_view window]));
-    WebCore::DragData dragData(draggingInfo, client, global, coreDragOperationMask(draggingInfo.draggingSourceOperationMask), applicationFlagsForDrag(m_view.getAutoreleased(), draggingInfo), WebCore::anyDragDestinationAction(), m_page->webPageID());
+    WebCore::DragData dragData(draggingInfo, client, global, coreDragOperationMask(draggingInfo.draggingSourceOperationMask), applicationFlagsForDrag(m_view.getAutoreleased(), draggingInfo), WebCore::anyDragDestinationAction(), m_page->webPageIDInMainFrameProcess());
     m_page->dragExited(dragData);
     m_page->resetCurrentDragInformation();
     draggingInfo.numberOfValidItemsForDrop = m_initialNumberOfValidItemsForDrop;
@@ -4083,7 +4083,7 @@ bool WebViewImpl::performDragOperation(id <NSDraggingInfo> draggingInfo)
 {
     WebCore::IntPoint client([m_view convertPoint:draggingInfo.draggingLocation fromView:nil]);
     WebCore::IntPoint global(WebCore::globalPoint(draggingInfo.draggingLocation, [m_view window]));
-    auto dragData = Box<WebCore::DragData>::create(draggingInfo, client, global, coreDragOperationMask(draggingInfo.draggingSourceOperationMask), applicationFlagsForDrag(m_view.getAutoreleased(), draggingInfo), WebCore::anyDragDestinationAction(), m_page->webPageID());
+    auto dragData = Box<WebCore::DragData>::create(draggingInfo, client, global, coreDragOperationMask(draggingInfo.draggingSourceOperationMask), applicationFlagsForDrag(m_view.getAutoreleased(), draggingInfo), WebCore::anyDragDestinationAction(), m_page->webPageIDInMainFrameProcess());
 
     NSArray *types = draggingInfo.draggingPasteboard.types;
     SandboxExtension::Handle sandboxExtensionHandle;

--- a/Source/WebKit/UIProcess/playstation/WebPageProxyPlayStation.cpp
+++ b/Source/WebKit/UIProcess/playstation/WebPageProxyPlayStation.cpp
@@ -58,12 +58,12 @@ String WebPageProxy::standardUserAgent(const String& applicationNameForUserAgent
     return WebCore::standardUserAgent(applicationNameForUserAgent);
 }
 
-void WebPageProxy::saveRecentSearches(const String&, const Vector<WebCore::RecentSearch>&)
+void WebPageProxy::saveRecentSearches(IPC::Connection&, const String&, const Vector<WebCore::RecentSearch>&)
 {
     notImplemented();
 }
 
-void WebPageProxy::loadRecentSearches(const String&, CompletionHandler<void(Vector<WebCore::RecentSearch>&&)>&& completionHandler)
+void WebPageProxy::loadRecentSearches(IPC::Connection&, const String&, CompletionHandler<void(Vector<WebCore::RecentSearch>&&)>&& completionHandler)
 {
     notImplemented();
     completionHandler({ });

--- a/Source/WebKit/UIProcess/win/WebPageProxyWin.cpp
+++ b/Source/WebKit/UIProcess/win/WebPageProxyWin.cpp
@@ -49,7 +49,7 @@ String WebPageProxy::standardUserAgent(const String& applicationNameForUserAgent
     return WebCore::standardUserAgent(applicationNameForUserAgent);
 }
 
-void WebPageProxy::saveRecentSearches(const String& name, const Vector<WebCore::RecentSearch>& searchItems)
+void WebPageProxy::saveRecentSearches(IPC::Connection&, const String& name, const Vector<WebCore::RecentSearch>& searchItems)
 {
     if (!name)
         return;
@@ -57,7 +57,7 @@ void WebPageProxy::saveRecentSearches(const String& name, const Vector<WebCore::
     return WebCore::SearchPopupMenuDB::singleton().saveRecentSearches(name, searchItems);
 }
 
-void WebPageProxy::loadRecentSearches(const String& name, CompletionHandler<void(Vector<WebCore::RecentSearch>&&)>&& completionHandler)
+void WebPageProxy::loadRecentSearches(IPC::Connection&, const String& name, CompletionHandler<void(Vector<WebCore::RecentSearch>&&)>&& completionHandler)
 {
     if (!name)
         return completionHandler({ });

--- a/Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp
@@ -29,6 +29,7 @@
 #include "EditorState.h"
 #include "InputMethodState.h"
 #include "PageClientImpl.h"
+#include "WebProcessProxy.h"
 #include <WebCore/PlatformEvent.h>
 
 #if USE(ATK)
@@ -157,7 +158,7 @@ void WebPageProxy::preferredBufferFormatsDidChange()
     if (!view)
         return;
 
-    send(Messages::WebPage::PreferredBufferFormatsDidChange(preferredBufferFormats()));
+    legacyMainFrameProcess().send(Messages::WebPage::PreferredBufferFormatsDidChange(preferredBufferFormats()), webPageIDInMainFrameProcess());
 }
 #endif
 #endif

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebRemoteObjectRegistry.cpp
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebRemoteObjectRegistry.cpp
@@ -54,7 +54,7 @@ void WebRemoteObjectRegistry::close()
     }
 }
 
-IPC::MessageSender& WebRemoteObjectRegistry::messageSender()
+auto WebRemoteObjectRegistry::messageSender() -> MessageSender
 {
     return m_page.get();
 }

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebRemoteObjectRegistry.h
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebRemoteObjectRegistry.h
@@ -49,7 +49,7 @@ public:
     void close();
     
 private:
-    IPC::MessageSender& messageSender() final;
+    MessageSender messageSender() final;
     uint64_t messageDestinationID() final;
 
     WeakRef<WebPage> m_page;


### PR DESCRIPTION
#### 85ca0b3686dca416aad8618a5f23558e49dc432a
<pre>
Further reduce use of legacyMainFrameProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=275591">https://bugs.webkit.org/show_bug.cgi?id=275591</a>
<a href="https://rdar.apple.com/130034699">rdar://130034699</a>

Reviewed by Charlie Wolfe.

This may look like it increases use of legacyMainFrameProcess, but it removes an important central use of it.
WebPageProxy can&apos;t be a MessageSender with site isolation because instead of just sending a message to its
web content process, we now need to answer the question, &quot;which web content process?&quot;.  To help us keep track
of places we haven&apos;t answered this question and to prevent adding more without thinking about it, I&apos;ve renamed
a few functions like webPageID to webPageIDInMainFrameProcess.

Instead of calling WebPageProxy::send and having it find the process and identifier, I explicitly write out
which process to use and what identifier to use in all call sites except the ones in WebPageProxy.cpp to make
this PR smaller.

* Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.h:
* Source/WebKit/Shared/API/Cocoa/RemoteObjectRegistry.mm:
(WebKit::RemoteObjectRegistry::send):
(WebKit::RemoteObjectRegistry::sendInvocation):
(WebKit::RemoteObjectRegistry::sendReplyBlock):
(WebKit::RemoteObjectRegistry::sendUnusedReply):
(WebKit::RemoteObjectRegistry::~RemoteObjectRegistry): Deleted.
* Source/WebKit/Shared/API/Cocoa/WKBrowsingContextHandle.mm:
(-[WKBrowsingContextHandle _initWithPageProxy:]):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetPageLoaderClient):
* Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm:
(-[_WKUserStyleSheet initWithSource:forWKWebView:forMainFrameOnly:includeMatchPatternStrings:excludeMatchPatternStrings:baseURL:level:contentWorld:]):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::evaluateJavaScriptFunction):
(WebKit::WebAutomationSession::resolveChildFrameHandle):
(WebKit::WebAutomationSession::resolveParentFrameHandle):
(WebKit::WebAutomationSession::computeElementLayout):
(WebKit::WebAutomationSession::getComputedRole):
(WebKit::WebAutomationSession::getComputedLabel):
(WebKit::WebAutomationSession::selectOptionElement):
(WebKit::WebAutomationSession::setFilesForInputFileUpload):
(WebKit::WebAutomationSession::getAllCookies):
(WebKit::WebAutomationSession::deleteSingleCookie):
(WebKit::WebAutomationSession::viewportInViewCenterPointOfElement):
(WebKit::WebAutomationSession::takeScreenshot):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionManagerProxy::PlaybackSessionManagerProxy):
(WebKit::PlaybackSessionManagerProxy::invalidate):
(WebKit::PlaybackSessionManagerProxy::play):
(WebKit::PlaybackSessionManagerProxy::pause):
(WebKit::PlaybackSessionManagerProxy::togglePlayState):
(WebKit::PlaybackSessionManagerProxy::beginScrubbing):
(WebKit::PlaybackSessionManagerProxy::endScrubbing):
(WebKit::PlaybackSessionManagerProxy::seekToTime):
(WebKit::PlaybackSessionManagerProxy::fastSeek):
(WebKit::PlaybackSessionManagerProxy::beginScanningForward):
(WebKit::PlaybackSessionManagerProxy::beginScanningBackward):
(WebKit::PlaybackSessionManagerProxy::endScanning):
(WebKit::PlaybackSessionManagerProxy::setDefaultPlaybackRate):
(WebKit::PlaybackSessionManagerProxy::setPlaybackRate):
(WebKit::PlaybackSessionManagerProxy::selectAudioMediaOption):
(WebKit::PlaybackSessionManagerProxy::selectLegibleMediaOption):
(WebKit::PlaybackSessionManagerProxy::togglePictureInPicture):
(WebKit::PlaybackSessionManagerProxy::enterFullscreen):
(WebKit::PlaybackSessionManagerProxy::exitFullscreen):
(WebKit::PlaybackSessionManagerProxy::toggleInWindow):
(WebKit::PlaybackSessionManagerProxy::toggleMuted):
(WebKit::PlaybackSessionManagerProxy::setMuted):
(WebKit::PlaybackSessionManagerProxy::setVolume):
(WebKit::PlaybackSessionManagerProxy::setPlayingOnSecondScreen):
(WebKit::PlaybackSessionManagerProxy::sendRemoteCommand):
(WebKit::PlaybackSessionManagerProxy::setSpatialTrackingLabel):
(WebKit::PlaybackSessionManagerProxy::setSoundStageSize):
(WebKit::PlaybackSessionManagerProxy::requestControlledElementID):
* Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.cpp:
(WebKit::UIRemoteObjectRegistry::messageSender):
(WebKit::UIRemoteObjectRegistry::messageDestinationID):
* Source/WebKit/UIProcess/Cocoa/UIRemoteObjectRegistry.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::VideoPresentationManagerProxy):
(WebKit::VideoPresentationManagerProxy::invalidate):
(WebKit::VideoPresentationManagerProxy::requestRouteSharingPolicyAndContextUID):
(WebKit::VideoPresentationManagerProxy::createLayerWithID):
(WebKit::VideoPresentationManagerProxy::createViewWithID):
(WebKit::VideoPresentationManagerProxy::setRequiresTextTrackRepresentation):
(WebKit::VideoPresentationManagerProxy::setTextTrackRepresentationBounds):
(WebKit::VideoPresentationManagerProxy::requestFullscreenMode):
(WebKit::VideoPresentationManagerProxy::requestUpdateInlineRect):
(WebKit::VideoPresentationManagerProxy::requestVideoContentLayer):
(WebKit::VideoPresentationManagerProxy::returnVideoContentLayer):
(WebKit::VideoPresentationManagerProxy::didSetupFullscreen):
(WebKit::VideoPresentationManagerProxy::willExitFullscreen):
(WebKit::VideoPresentationManagerProxy::didExitFullscreen):
(WebKit::VideoPresentationManagerProxy::didEnterFullscreen):
(WebKit::VideoPresentationManagerProxy::failedToEnterFullscreen):
(WebKit::VideoPresentationManagerProxy::didCleanupFullscreen):
(WebKit::VideoPresentationManagerProxy::setVideoLayerFrame):
(WebKit::VideoPresentationManagerProxy::setVideoLayerGravity):
(WebKit::VideoPresentationManagerProxy::setVideoFullscreenFrame):
(WebKit::VideoPresentationManagerProxy::fullscreenModeChanged):
(WebKit::VideoPresentationManagerProxy::fullscreenMayReturnToInline):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::saveRecentSearches):
(WebKit::WebPageProxy::loadRecentSearches):
(WebKit::WebPageProxy::performDictionaryLookupAtLocation):
(WebKit::WebPageProxy::performDictionaryLookupOfCurrentSelection):
(WebKit::WebPageProxy::insertDictatedTextAsync):
(WebKit::WebPageProxy::addDictationAlternative):
(WebKit::WebPageProxy::Internals::paymentCoordinatorConnection):
(WebKit::WebPageProxy::Internals::speakingErrorOccurred):
(WebKit::WebPageProxy::Internals::boundaryEventOccurred):
(WebKit::WebPageProxy::Internals::voicesDidChange):
(WebKit::WebPageProxy::createAppHighlightInSelectedRange):
(WebKit::WebPageProxy::restoreAppHighlightsAndScrollToIndex):
(WebKit::WebPageProxy::setAppHighlightsVisibility):
(WebKit::WebPageProxy::requestActiveNowPlayingSessionInfo):
(WebKit::WebPageProxy::lastNavigationWasAppInitiated):
(WebKit::WebPageProxy::insertMultiRepresentationHEIC):
(WebKit::WebPageProxy::replaceSelectionWithPasteboardData):
(WebKit::WebPageProxy::replaceImageForRemoveBackground):
(WebKit::WebPageProxy::willBeginWritingToolsSession):
(WebKit::WebPageProxy::didBeginWritingToolsSession):
(WebKit::WebPageProxy::proofreadingSessionDidReceiveSuggestions):
(WebKit::WebPageProxy::proofreadingSessionDidUpdateStateForSuggestion):
(WebKit::WebPageProxy::didEndWritingToolsSession):
(WebKit::WebPageProxy::compositionSessionDidReceiveTextWithReplacementRange):
(WebKit::WebPageProxy::writingToolsSessionDidReceiveAction):
(WebKit::WebPageProxy::enableSourceTextAnimationAfterElementWithID):
(WebKit::WebPageProxy::enableTextAnimationTypeForElementWithID):
(WebKit::WebPageProxy::addTextAnimationTypeForID):
(WebKit::WebPageProxy::getTextIndicatorForID):
(WebKit::WebPageProxy::updateUnderlyingTextVisibilityForTextAnimationID):
(WebKit::WebPageProxy::removeTextAnimationForID):
(WebKit::WebPageProxy::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect):
(WebKit::WebPageProxy::proofreadingSessionUpdateStateForSuggestionWithID):
* Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm:
(WebKit::WebPasteboardProxy::determineDataOwner const):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::didCommitLoadForFrame):
(WebKit::WebExtensionContext::backgroundPageIdentifier const):
(WebKit::WebExtensionContext::inspectorBackgroundPageIdentifiers const):
(WebKit::WebExtensionContext::inspectorPageIdentifiers const):
(WebKit::WebExtensionContext::popupPageIdentifiers const):
(WebKit::WebExtensionContext::tabPageIdentifiers const):
(WebKit::WebExtensionContext::addPopupPage):
(WebKit::WebExtensionContext::addExtensionTabPage):
(WebKit::WebExtensionContext::loadBackgroundWebView):
(WebKit::WebExtensionContext::loadInspectorBackgroundPage):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::injectStyleSheets):
* Source/WebKit/UIProcess/FindStringCallbackAggregator.cpp:
(WebKit::FindStringCallbackAggregator::~FindStringCallbackAggregator):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::didCreateContextForVisibilityPropagation):
* Source/WebKit/UIProcess/GeolocationPermissionRequestManagerProxy.cpp:
(WebKit::GeolocationPermissionRequestManagerProxy::didReceiveGeolocationPermissionDecision):
* Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp:
(WebKit::InspectorTargetProxy::connect):
(WebKit::InspectorTargetProxy::disconnect):
(WebKit::InspectorTargetProxy::sendMessageToTargetBackend):
* Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp:
(WebKit::RemoteWebInspectorUIProxy::setDiagnosticLoggingAvailable):
(WebKit::RemoteWebInspectorUIProxy::initialize):
(WebKit::RemoteWebInspectorUIProxy::showConsole):
(WebKit::RemoteWebInspectorUIProxy::showResources):
(WebKit::RemoteWebInspectorUIProxy::sendMessageToFrontend):
(WebKit::RemoteWebInspectorUIProxy::createFrontendPageAndWindow):
(WebKit::RemoteWebInspectorUIProxy::closeFrontendPageAndWindow):
* Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp:
(WebKit::WebInspectorUIExtensionControllerProxy::WebInspectorUIExtensionControllerProxy):
(WebKit::WebInspectorUIExtensionControllerProxy::inspectorFrontendWillClose):
(WebKit::WebInspectorUIExtensionControllerProxy::registerExtension):
(WebKit::WebInspectorUIExtensionControllerProxy::unregisterExtension):
(WebKit::WebInspectorUIExtensionControllerProxy::createTabForExtension):
(WebKit::WebInspectorUIExtensionControllerProxy::evaluateScriptForExtension):
(WebKit::WebInspectorUIExtensionControllerProxy::reloadForExtension):
(WebKit::WebInspectorUIExtensionControllerProxy::showExtensionTab):
(WebKit::WebInspectorUIExtensionControllerProxy::navigateTabForExtension):
(WebKit::WebInspectorUIExtensionControllerProxy::evaluateScriptInExtensionTab):
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp:
(WebKit::WebInspectorUIProxy::WebInspectorUIProxy):
(WebKit::WebInspectorUIProxy::sendMessageToFrontend):
(WebKit::WebInspectorUIProxy::connect):
(WebKit::WebInspectorUIProxy::close):
(WebKit::WebInspectorUIProxy::reset):
(WebKit::WebInspectorUIProxy::updateForNewPageProcess):
(WebKit::WebInspectorUIProxy::setFrontendConnection):
(WebKit::WebInspectorUIProxy::showConsole):
(WebKit::WebInspectorUIProxy::showResources):
(WebKit::WebInspectorUIProxy::showMainResourceForFrame):
(WebKit::WebInspectorUIProxy::attach):
(WebKit::WebInspectorUIProxy::detach):
(WebKit::WebInspectorUIProxy::togglePageProfiling):
(WebKit::WebInspectorUIProxy::toggleElementSelection):
(WebKit::WebInspectorUIProxy::openLocalInspectorFrontend):
(WebKit::WebInspectorUIProxy::open):
(WebKit::WebInspectorUIProxy::closeFrontendPageAndWindow):
(WebKit::WebInspectorUIProxy::attachAvailabilityChanged):
(WebKit::WebInspectorUIProxy::setDiagnosticLoggingAvailable):
(WebKit::WebInspectorUIProxy::evaluateInFrontendForTesting):
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp:
(WebKit::WebPageInspectorController::init):
* Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm:
(WebKit::RemoteWebInspectorUIProxy::didBecomeActive):
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(WebKit::WebInspectorUIProxy::didBecomeActive):
* Source/WebKit/UIProcess/Media/RemoteMediaSessionCoordinatorProxy.cpp:
(WebKit::RemoteMediaSessionCoordinatorProxy::RemoteMediaSessionCoordinatorProxy):
(WebKit::RemoteMediaSessionCoordinatorProxy::~RemoteMediaSessionCoordinatorProxy):
(WebKit::RemoteMediaSessionCoordinatorProxy::seekSessionToTime):
(WebKit::RemoteMediaSessionCoordinatorProxy::playSession):
(WebKit::RemoteMediaSessionCoordinatorProxy::pauseSession):
(WebKit::RemoteMediaSessionCoordinatorProxy::setSessionTrack):
(WebKit::RemoteMediaSessionCoordinatorProxy::coordinatorStateChanged):
* Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp:
(WebKit::MediaKeySystemPermissionRequestManagerProxy::denyRequest):
(WebKit::MediaKeySystemPermissionRequestManagerProxy::grantRequest):
* Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp:
(WebKit::ModelProcessProxy::didCreateContextForVisibilityPropagation):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::testProcessIncomingSyncMessagesWhenWaitingForSyncReply):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::didCommitLoadForFrame):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::currentSnapPointIndicesDidChange):
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidStopAnimatedScroll):
(WebKit::RemoteScrollingCoordinatorProxy::sendUIStateChangedIfNecessary):
(WebKit::RemoteScrollingCoordinatorProxy::receivedWheelEventWithPhases):
(WebKit::RemoteScrollingCoordinatorProxy::deferWheelEventTestCompletionForReason):
(WebKit::RemoteScrollingCoordinatorProxy::removeWheelEventTestCompletionDeferralForReason):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::RemoteScrollingCoordinatorProxyMac):
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::RemotePageProxy):
(WebKit::RemotePageProxy::decidePolicyForResponse):
* Source/WebKit/UIProcess/RemotePageProxy.h:
(WebKit::RemotePageProxy::siteIsolatedProcess const):
(WebKit::RemotePageProxy::pageID const):
(WebKit::RemotePageProxy::identifierInSiteIsolatedProcess const):
(WebKit::RemotePageProxy::send): Deleted.
(WebKit::RemotePageProxy::sendSync): Deleted.
(WebKit::RemotePageProxy::sendWithAsyncReply): Deleted.
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::SuspendedPageProxy):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::~UserMediaPermissionRequestManagerProxy):
(WebKit::UserMediaPermissionRequestManagerProxy::captureDevicesChanged):
(WebKit::UserMediaPermissionRequestManagerProxy::denyRequest):
(WebKit::UserMediaPermissionRequestManagerProxy::finishGrantingRequest):
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::ViewGestureController::disconnectFromProcess):
(WebKit::ViewGestureController::connectToProcess):
(WebKit::ViewGestureController::requestRenderTreeSizeNotificationIfNeeded):
(WebKit::ViewGestureController::prepareMagnificationGesture):
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp:
(WebKit::AuthenticatorManager::runPanel):
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.cpp:
(WebKit::WebAuthenticatorCoordinatorProxy::WebAuthenticatorCoordinatorProxy):
(WebKit::WebAuthenticatorCoordinatorProxy::~WebAuthenticatorCoordinatorProxy):
(WebKit::WebAuthenticatorCoordinatorProxy::makeCredential):
(WebKit::WebAuthenticatorCoordinatorProxy::getAssertion):
* Source/WebKit/UIProcess/WebEditCommandProxy.cpp:
(WebKit::WebEditCommandProxy::unapply):
(WebKit::WebEditCommandProxy::reapply):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::pageIdentifier const):
(WebKit::WebFrameProxy::navigateServiceWorkerClient):
(WebKit::WebFrameProxy::bindAccessibilityFrameWithData):
(WebKit::WebFrameProxy::loadURL):
(WebKit::WebFrameProxy::loadData):
(WebKit::WebFrameProxy::commitProvisionalFrame):
(WebKit::WebFrameProxy::getFrameInfo):
(WebKit::WebFrameProxy::webPageIDInCurrentProcess):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::WebFullScreenManagerProxy):
(WebKit::WebFullScreenManagerProxy::~WebFullScreenManagerProxy):
(WebKit::WebFullScreenManagerProxy::willEnterFullScreen):
(WebKit::WebFullScreenManagerProxy::didEnterFullScreen):
(WebKit::WebFullScreenManagerProxy::willExitFullScreen):
(WebKit::WebFullScreenManagerProxy::didExitFullScreen):
(WebKit::WebFullScreenManagerProxy::setAnimatingFullScreen):
(WebKit::WebFullScreenManagerProxy::requestRestoreFullScreen):
(WebKit::WebFullScreenManagerProxy::requestExitFullScreen):
(WebKit::WebFullScreenManagerProxy::saveScrollPosition):
(WebKit::WebFullScreenManagerProxy::restoreScrollPosition):
(WebKit::WebFullScreenManagerProxy::setFullscreenInsets):
(WebKit::WebFullScreenManagerProxy::setFullscreenAutoHideDuration):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::send):
(WebKit::WebPageProxy::sendWithAsyncReply):
(WebKit::WebPageProxy::initializeWebPage):
(WebKit::WebPageProxy::close):
(WebKit::WebPageProxy::goToBackForwardItem):
(WebKit::WebPageProxy::sendMouseEvent):
(WebKit::WebPageProxy::sendWheelEvent):
(WebKit::WebPageProxy::sendWheelEventScrollingAccelerationCurveIfNecessary):
(WebKit::WebPageProxy::sendKeyEvent):
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
(WebKit::WebPageProxy::didDestroyFrame):
(WebKit::WebPageProxy::preconnectTo):
(WebKit::WebPageProxy::callLoadCompletionHandlersIfNecessary):
(WebKit::WebPageProxy::forEachWebContentProcess):
(WebKit::WebPageProxy::createNewPage):
(WebKit::WebPageProxy::didChooseFilesForOpenPanel):
(WebKit::WebPageProxy::didCancelForOpenPanel):
(WebKit::WebPageProxy::isJITEnabled):
(WebKit::WebPageProxy::beginPrinting):
(WebKit::WebPageProxy::endPrinting):
(WebKit::WebPageProxy::computePagesForPrinting):
(WebKit::WebPageProxy::drawRectToImage):
(WebKit::WebPageProxy::drawPagesToPDF):
(WebKit::WebPageProxy::setOverlayScrollbarStyle):
(WebKit::WebPageProxy::webPageIDInMainFrameProcess const):
(WebKit::WebPageProxy::didCreateSleepDisabler):
(WebKit::WebPageProxy::sendToProcessContainingFrame):
(WebKit::WebPageProxy::sendSyncToProcessContainingFrame):
(WebKit::WebPageProxy::sendMessage): Deleted.
(WebKit::WebPageProxy::sendMessageWithAsyncReply): Deleted.
(WebKit::WebPageProxy::messageSenderConnection const): Deleted.
(WebKit::WebPageProxy::messageSenderDestinationID const): Deleted.
(WebKit::WebPageProxy::webPageID const): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::addExistingWebPage):
(WebKit::WebProcessProxy::removeWebPage):
(WebKit::WebProcessProxy::transformObjectsToHandles):
(WebKit::WebProcessProxy::createSpeechRecognitionServer):
(WebKit::WebProcessProxy::muteCaptureInPagesExcept):
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp:
(WebKit::WebScreenOrientationManagerProxy::WebScreenOrientationManagerProxy):
(WebKit::WebScreenOrientationManagerProxy::~WebScreenOrientationManagerProxy):
(WebKit::WebScreenOrientationManagerProxy::setCurrentOrientation):
* Source/WebKit/UIProcess/WebURLSchemeTask.cpp:
(WebKit::WebURLSchemeTask::willPerformRedirection):
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::PlatformXRSystem):
(WebKit::PlatformXRSystem::~PlatformXRSystem):
* Source/WebKit/UIProcess/XR/ios/PlatformXRARKit.mm:
(WebKit::ARKitCoordinator::startSession):
(WebKit::ARKitCoordinator::endSessionIfExists):
(WebKit::ARKitCoordinator::scheduleAnimationFrame):
(WebKit::ARKitCoordinator::submitFrame):
* Source/WebKit/UIProcess/ios/SmartMagnificationController.mm:
(WebKit::SmartMagnificationController::SmartMagnificationController):
(WebKit::SmartMagnificationController::~SmartMagnificationController):
(WebKit::SmartMagnificationController::handleSmartMagnificationGesture):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView ensurePositionInformationIsUpToDate:]):
(-[WKContentView _internalRequestAutocorrectionContextWithCompletionHandler:]):
(-[WKContentView dragDataForDropSession:dragDestinationAction:]):
(-[WKContentView _autofillContext]):
(-[WKContentView _textInputContextByScribbleIdentifier:]):
* Source/WebKit/UIProcess/ios/WebDeviceOrientationUpdateProviderProxy.mm:
(WebKit::WebDeviceOrientationUpdateProviderProxy::WebDeviceOrientationUpdateProviderProxy):
(WebKit::WebDeviceOrientationUpdateProviderProxy::~WebDeviceOrientationUpdateProviderProxy):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::generateDisplayIDFromPageID const):
(WebKit::WebPageProxy::updateVisibleContentRects):
(WebKit::WebPageProxy::resendLastVisibleContentRects):
(WebKit::WebPageProxy::dynamicViewportSizeUpdate):
(WebKit::WebPageProxy::setViewportConfigurationViewLayoutSize):
(WebKit::WebPageProxy::setSceneIdentifier):
(WebKit::WebPageProxy::setForceAlwaysUserScalable):
(WebKit::WebPageProxy::setDeviceOrientation):
(WebKit::WebPageProxy::setOverrideViewportArguments):
(WebKit::WebPageProxy::willInsertFinalDictationResult):
(WebKit::WebPageProxy::didInsertFinalDictationResult):
(WebKit::WebPageProxy::replaceDictatedText):
(WebKit::WebPageProxy::replaceSelectedText):
(WebKit::WebPageProxy::applyAutocorrection):
(WebKit::WebPageProxy::requestAutocorrectionContext):
(WebKit::WebPageProxy::requestPositionInformation):
(WebKit::WebPageProxy::startInteractionWithPositionInformation):
(WebKit::WebPageProxy::stopInteraction):
(WebKit::WebPageProxy::performActionOnElements):
(WebKit::WebPageProxy::applicationDidEnterBackground):
(WebKit::WebPageProxy::applicationDidFinishSnapshottingAfterEnteringBackground):
(WebKit::WebPageProxy::applicationWillEnterForeground):
(WebKit::WebPageProxy::applicationWillResignActive):
(WebKit::WebPageProxy::applicationDidEnterBackgroundForMedia):
(WebKit::WebPageProxy::applicationWillEnterForegroundForMedia):
(WebKit::WebPageProxy::applicationDidBecomeActive):
(WebKit::WebPageProxy::selectWordBackward):
(WebKit::WebPageProxy::storeSelectionForAccessibility):
(WebKit::WebPageProxy::startAutoscrollAtPosition):
(WebKit::WebPageProxy::cancelAutoscroll):
(WebKit::WebPageProxy::autofillLoginCredentials):
(WebKit::WebPageProxy::hardwareKeyboardAvailabilityChanged):
(WebKit::WebPageProxy::requestDragStart):
(WebKit::WebPageProxy::requestAdditionalItemsForDragSession):
(WebKit::WebPageProxy::didConcludeDrop):
* Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm:
(WebKit::TiledCoreAnimationDrawingAreaProxy::waitForDidUpdateActivityState):
* Source/WebKit/UIProcess/mac/ViewGestureControllerMac.mm:
(WebKit::ViewGestureController::handleSmartMagnificationGesture):
* Source/WebKit/UIProcess/mac/WKImmediateActionController.mm:
(-[WKImmediateActionController immediateActionRecognizerWillBeginAnimation:]):
(-[WKImmediateActionController _animationControllerForDataDetectedText]):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::windowAndViewFramesChanged):
(WebKit::WebPageProxy::setMainFrameIsScrollable):
(WebKit::WebPageProxy::attributedSubstringForCharacterRangeAsync):
(WebKit::WebPageProxy::stringSelectionForPasteboard):
(WebKit::WebPageProxy::dataSelectionForPasteboard):
(WebKit::WebPageProxy::readSelectionFromPasteboard):
(WebKit::WebPageProxy::uppercaseWord):
(WebKit::WebPageProxy::lowercaseWord):
(WebKit::WebPageProxy::capitalizeWord):
(WebKit::WebPageProxy::setSmartInsertDeleteEnabled):
(WebKit::WebPageProxy::registerWebProcessAccessibilityToken):
(WebKit::WebPageProxy::semanticContextDidChange):
(WebKit::WebPageProxy::registerUIProcessAccessibilityTokens):
(WebKit::WebPageProxy::shouldDelayWindowOrderingForEvent):
(WebKit::WebPageProxy::acceptsFirstMouse):
(WebKit::WebPageProxy::pdfZoomIn):
(WebKit::WebPageProxy::pdfZoomOut):
(WebKit::WebPageProxy::pdfSaveToPDF):
(WebKit::WebPageProxy::pdfOpenWithPreview):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::draggingEntered):
(WebKit::WebViewImpl::draggingUpdated):
(WebKit::WebViewImpl::draggingExited):
(WebKit::WebViewImpl::performDragOperation):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebRemoteObjectRegistry.cpp:
(WebKit::WebRemoteObjectRegistry::messageSender):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebRemoteObjectRegistry.h:

Canonical link: <a href="https://commits.webkit.org/280258@main">https://commits.webkit.org/280258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c246a2a8186c9c26340fd59407501a709e9c992e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35433 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8579 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59713 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6543 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6737 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/45247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4530 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58136 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33323 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48392 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26298 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30104 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5547 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52074 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5993 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61395 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/15 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/6119 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/15 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48459 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/52350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/13 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8320 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31260 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32346 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33429 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32093 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->