### PR TITLE
Remove and replace `WKBundleSetWebNotificationPermission`

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -3235,3 +3235,8 @@ bool WKPageIsEditingCommandEnabledForTesting(WKPageRef pageRef, WKStringRef comm
 {
     return toImpl(pageRef)->isEditingCommandEnabledForTesting(toImpl(command)->string());
 }
+
+void WKPageSetPermissionLevelForTesting(WKPageRef pageRef, WKStringRef origin, bool allowed)
+{
+    toImpl(pageRef)->setPermissionLevelForTesting(toImpl(origin)->string(), allowed);
+}

--- a/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
@@ -214,6 +214,7 @@ WK_EXPORT void WKPagePermissionChanged(WKStringRef permissionName, WKStringRef o
 
 WK_EXPORT void WKPageExecuteCommandForTesting(WKPageRef pageRef, WKStringRef command, WKStringRef value);
 WK_EXPORT bool WKPageIsEditingCommandEnabledForTesting(WKPageRef page, WKStringRef command);
+WK_EXPORT void WKPageSetPermissionLevelForTesting(WKPageRef page, WKStringRef origin, bool allowed);
 
 #ifdef __cplusplus
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -14392,6 +14392,13 @@ bool WebPageProxy::isEditingCommandEnabledForTesting(const String& commandName)
     return result;
 }
 
+void WebPageProxy::setPermissionLevelForTesting(const String& origin, bool allowed)
+{
+    forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        webProcess.send(Messages::WebPage::SetPermissionLevelForTesting(origin, allowed), pageID);
+    });
+}
+
 } // namespace WebKit
 
 #undef WEBPAGEPROXY_RELEASE_LOG

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2484,6 +2484,7 @@ public:
     BrowsingContextGroup& browsingContextGroup() const { return m_browsingContextGroup; }
 
     bool isEditingCommandEnabledForTesting(const String&);
+    void setPermissionLevelForTesting(const String& origin, bool allowed);
 
 private:
     std::optional<Vector<uint8_t>> getWebCryptoMasterKey();

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundle.cpp
@@ -186,11 +186,6 @@ void WKBundleSetUserStyleSheetLocationForTesting(WKBundleRef bundleRef, WKString
     WebKit::toImpl(bundleRef)->setUserStyleSheetLocation(WebKit::toWTFString(location));
 }
 
-void WKBundleSetWebNotificationPermission(WKBundleRef bundleRef, WKBundlePageRef pageRef, WKStringRef originStringRef, bool allowed)
-{
-    WebKit::toImpl(bundleRef)->setWebNotificationPermission(WebKit::toImpl(pageRef), WebKit::toWTFString(originStringRef), allowed);
-}
-
 void WKBundleRemoveAllWebNotificationPermissions(WKBundleRef bundleRef, WKBundlePageRef pageRef)
 {
     WebKit::toImpl(bundleRef)->removeAllWebNotificationPermissions(WebKit::toImpl(pageRef));

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePrivate.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePrivate.h
@@ -50,7 +50,6 @@ WK_EXPORT int WKBundlePageNumberForElementById(WKBundleRef bundle, WKBundleFrame
 WK_EXPORT WKStringRef WKBundlePageSizeAndMarginsInPixels(WKBundleRef bundle, WKBundleFrameRef frameRef, int, int, int, int, int, int, int);
 WK_EXPORT bool WKBundleIsPageBoxVisible(WKBundleRef bundle, WKBundleFrameRef frameRef, int);
 WK_EXPORT void WKBundleSetUserStyleSheetLocationForTesting(WKBundleRef bundle, WKStringRef location);
-WK_EXPORT void WKBundleSetWebNotificationPermission(WKBundleRef bundle, WKBundlePageRef page, WKStringRef originStringRef, bool allowed);
 WK_EXPORT void WKBundleRemoveAllWebNotificationPermissions(WKBundleRef bundle, WKBundlePageRef page);
 WK_EXPORT WKDataRef WKBundleCopyWebNotificationID(WKBundleRef bundle, JSContextRef context, JSValueRef notification);
 WK_EXPORT WKDataRef WKBundleCreateWKDataFromUInt8Array(WKBundleRef bundle, JSContextRef context, JSValueRef data);

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
@@ -274,17 +274,6 @@ void InjectedBundle::setUserStyleSheetLocation(const String& location)
     });
 }
 
-void InjectedBundle::setWebNotificationPermission(WebPage* page, const String& originString, bool allowed)
-{
-#if ENABLE(NOTIFICATIONS)
-    page->notificationPermissionRequestManager()->setPermissionLevelForTesting(originString, allowed);
-#else
-    UNUSED_PARAM(page);
-    UNUSED_PARAM(originString);
-    UNUSED_PARAM(allowed);
-#endif
-}
-
 void InjectedBundle::removeAllWebNotificationPermissions(WebPage* page)
 {
 #if ENABLE(NOTIFICATIONS)

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.h
@@ -100,7 +100,6 @@ public:
     String pageSizeAndMarginsInPixels(WebFrame*, int, int, int, int, int, int, int);
     bool isPageBoxVisible(WebFrame*, int);
     void setUserStyleSheetLocation(const String&);
-    void setWebNotificationPermission(WebPage*, const String& originString, bool allowed);
     void removeAllWebNotificationPermissions(WebPage*);
     std::optional<WTF::UUID> webNotificationID(JSContextRef, JSValueRef);
     Ref<API::Data> createWebDataFromUint8Array(JSContextRef, JSValueRef);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9711,6 +9711,16 @@ void WebPage::updateLastNodeBeforeWritingSuggestions(const KeyboardEvent& event)
         m_lastNodeBeforeWritingSuggestions = frame->editor().nodeBeforeWritingSuggestions();
 }
 
+void WebPage::setPermissionLevelForTesting(const String& origin, bool allowed)
+{
+#if ENABLE(NOTIFICATIONS)
+    notificationPermissionRequestManager()->setPermissionLevelForTesting(origin, allowed);
+#else
+    UNUSED_PARAM(origin);
+    UNUSED_PARAM(allowed);
+#endif
+}
+
 } // namespace WebKit
 
 #undef WEBPAGE_RELEASE_LOG

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2313,6 +2313,8 @@ private:
 
     void frameNameWasChangedInAnotherProcess(WebCore::FrameIdentifier, const String& frameName);
 
+    void setPermissionLevelForTesting(const String& origin, bool allowed);
+
     WebCore::PageIdentifier m_identifier;
 
     RefPtr<WebCore::Page> m_page;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -822,4 +822,6 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     FrameNameWasChangedInAnotherProcess(WebCore::FrameIdentifier frameID, String frameName)
 
     IsEditingCommandEnabled(String commandName) -> (bool result) Synchronous
+
+    SetPermissionLevelForTesting(String origin, bool allowed)
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -800,13 +800,11 @@ void TestRunner::setAsynchronousSpellCheckingEnabled(bool enabled)
 
 void TestRunner::grantWebNotificationPermission(JSStringRef origin)
 {
-    WKBundleSetWebNotificationPermission(InjectedBundle::singleton().bundle(), page(), toWK(origin).get(), true);
     postSynchronousPageMessageWithReturnValue("GrantNotificationPermission", toWK(origin));
 }
 
 void TestRunner::denyWebNotificationPermission(JSStringRef origin)
 {
-    WKBundleSetWebNotificationPermission(InjectedBundle::singleton().bundle(), page(), toWK(origin).get(), false);
     postSynchronousPageMessageWithReturnValue("DenyNotificationPermission", toWK(origin));
 }
 

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -942,11 +942,15 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         return adoptWK(WKUInt64Create(count));
     }
 
-    if (WKStringIsEqualToUTF8CString(messageName, "GrantNotificationPermission"))
+    if (WKStringIsEqualToUTF8CString(messageName, "GrantNotificationPermission")) {
+        WKPageSetPermissionLevelForTesting(TestController::singleton().mainWebView()->page(), stringValue(messageBody), true);
         return adoptWK(WKBooleanCreate(TestController::singleton().grantNotificationPermission(stringValue(messageBody))));
+    }
 
-    if (WKStringIsEqualToUTF8CString(messageName, "DenyNotificationPermission"))
+    if (WKStringIsEqualToUTF8CString(messageName, "DenyNotificationPermission")) {
+        WKPageSetPermissionLevelForTesting(TestController::singleton().mainWebView()->page(), stringValue(messageBody), false);
         return adoptWK(WKBooleanCreate(TestController::singleton().denyNotificationPermission(stringValue(messageBody))));
+    }
 
     if (WKStringIsEqualToUTF8CString(messageName, "DenyNotificationPermissionOnPrompt"))
         return adoptWK(WKBooleanCreate(TestController::singleton().denyNotificationPermissionOnPrompt(stringValue(messageBody))));


### PR DESCRIPTION
#### d64835ffdf88f7a0e454c916f869accf0856f622
<pre>
Remove and replace `WKBundleSetWebNotificationPermission`
<a href="https://bugs.webkit.org/show_bug.cgi?id=275597">https://bugs.webkit.org/show_bug.cgi?id=275597</a>
<a href="https://rdar.apple.com/130050804">rdar://130050804</a>

Reviewed by Alex Christensen.

Injected bundle API will not work with site isolation, and this is only used by WKTR.

* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetPermissionLevelForTesting):
* Source/WebKit/UIProcess/API/C/WKPagePrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setPermissionLevelForTesting):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundle.cpp:
(WKBundleSetWebNotificationPermission): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePrivate.h:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp:
(WebKit::InjectedBundle::setWebNotificationPermission): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setPermissionLevelForTesting):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::grantWebNotificationPermission):
(WTR::TestRunner::denyWebNotificationPermission):
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/280136@main">https://commits.webkit.org/280136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab7bc0e6a0110586347613a725bea0dab8309111

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58760 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6207 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57902 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6405 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44918 "Found 1 new test failure: imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-serializable.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4276 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57805 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/32997 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48080 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26052 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29783 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5409 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4350 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51750 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60351 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5807 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52347 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48151 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51844 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8240 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30930 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32015 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33096 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31762 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->