### PR TITLE
[Writing Tools] Refactor Writing Tools type conversion methods to be in their own file

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/WritingToolsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/WritingToolsSPI.h
@@ -32,10 +32,44 @@
 #import <WritingTools/WTSession_Private.h>
 #import <WritingTools/WritingTools.h>
 
+#if PLATFORM(MAC)
+
+using PlatformWritingToolsBehavior = NSWritingToolsBehavior;
+
+constexpr auto PlatformWritingToolsBehaviorNone = NSWritingToolsBehaviorNone;
+constexpr auto PlatformWritingToolsBehaviorDefault = NSWritingToolsBehaviorDefault;
+constexpr auto PlatformWritingToolsBehaviorLimited = NSWritingToolsBehaviorLimited;
+constexpr auto PlatformWritingToolsBehaviorComplete = NSWritingToolsBehaviorComplete;
+
+using PlatformWritingToolsAllowedInputOptions = NSWritingToolsAllowedInputOptions;
+
+constexpr auto PlatformWritingToolsAllowedInputOptionsPlainText = NSWritingToolsAllowedInputOptionsPlainText;
+constexpr auto PlatformWritingToolsAllowedInputOptionsRichText = NSWritingToolsAllowedInputOptionsRichText;
+constexpr auto PlatformWritingToolsAllowedInputOptionsList = NSWritingToolsAllowedInputOptionsList;
+constexpr auto PlatformWritingToolsAllowedInputOptionsTable = NSWritingToolsAllowedInputOptionsTable;
+
+#else
+
+using PlatformWritingToolsBehavior = UIWritingToolsBehavior;
+
+constexpr auto PlatformWritingToolsBehaviorNone = UIWritingToolsBehaviorNone;
+constexpr auto PlatformWritingToolsBehaviorDefault = UIWritingToolsBehaviorDefault;
+constexpr auto PlatformWritingToolsBehaviorLimited = UIWritingToolsBehaviorLimited;
+constexpr auto PlatformWritingToolsBehaviorComplete = UIWritingToolsBehaviorComplete;
+
+using PlatformWritingToolsAllowedInputOptions = UIWritingToolsAllowedInputOptions;
+
+constexpr auto PlatformWritingToolsAllowedInputOptionsPlainText = UIWritingToolsAllowedInputOptionsPlainText;
+constexpr auto PlatformWritingToolsAllowedInputOptionsRichText = UIWritingToolsAllowedInputOptionsRichText;
+constexpr auto PlatformWritingToolsAllowedInputOptionsList = UIWritingToolsAllowedInputOptionsList;
+constexpr auto PlatformWritingToolsAllowedInputOptionsTable = UIWritingToolsAllowedInputOptionsTable;
+
+#endif
+
 #else
 
 #error Symbols must be forward declared once used with non-internal SDKS.
 
-#endif
+#endif // USE(APPLE_INTERNAL_SDK)
 
 #endif // ENABLE(WRITING_TOOLS)

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -408,6 +408,7 @@ UIProcess/Cocoa/MediaPermissionUtilities.mm
 UIProcess/Cocoa/ModelElementControllerCocoa.mm
 UIProcess/Cocoa/NavigationState.mm
 UIProcess/Cocoa/PageClientImplCocoa.mm
+UIProcess/Cocoa/PlatformWritingToolsUtilities.mm
 UIProcess/Cocoa/PlatformXRCoordinator.mm
 UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
 UIProcess/Cocoa/ProcessAssertionCocoa.mm

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -28,6 +28,7 @@
 
 #import "APIPageConfiguration.h"
 #import "CSPExtensionUtilities.h"
+#import "PlatformWritingToolsUtilities.h"
 #import "WKDataDetectorTypesInternal.h"
 #import "WKPreferencesInternal.h"
 #import "WKProcessPoolInternal.h"
@@ -128,60 +129,6 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 - (BOOL)allowsInlinePredictions
 {
     return _pageConfiguration->allowsInlinePredictions();
-}
-
-#if ENABLE(WRITING_TOOLS)
-
-static _WKUnifiedTextReplacementBehavior convertToPlatform(WebCore::UnifiedTextReplacement::ReplacementBehavior behavior)
-{
-    switch (behavior) {
-    case WebCore::UnifiedTextReplacement::ReplacementBehavior::None:
-        return _WKUnifiedTextReplacementBehaviorNone;
-
-    case WebCore::UnifiedTextReplacement::ReplacementBehavior::Default:
-        return _WKUnifiedTextReplacementBehaviorDefault;
-
-    case WebCore::UnifiedTextReplacement::ReplacementBehavior::Limited:
-        return _WKUnifiedTextReplacementBehaviorLimited;
-
-    case WebCore::UnifiedTextReplacement::ReplacementBehavior::Complete:
-        return _WKUnifiedTextReplacementBehaviorComplete;
-    }
-}
-
-static WebCore::UnifiedTextReplacement::ReplacementBehavior convertToWeb(_WKUnifiedTextReplacementBehavior behavior)
-{
-    switch (behavior) {
-    case _WKUnifiedTextReplacementBehaviorNone:
-        return WebCore::UnifiedTextReplacement::ReplacementBehavior::None;
-
-    case _WKUnifiedTextReplacementBehaviorDefault:
-        return WebCore::UnifiedTextReplacement::ReplacementBehavior::Default;
-
-    case _WKUnifiedTextReplacementBehaviorLimited:
-        return WebCore::UnifiedTextReplacement::ReplacementBehavior::Limited;
-
-    case _WKUnifiedTextReplacementBehaviorComplete:
-        return WebCore::UnifiedTextReplacement::ReplacementBehavior::Complete;
-    }
-}
-
-#endif
-
-- (void)_setUnifiedTextReplacementBehavior:(_WKUnifiedTextReplacementBehavior)behavior
-{
-#if ENABLE(WRITING_TOOLS)
-    _pageConfiguration->setUnifiedTextReplacementBehavior(convertToWeb(behavior));
-#endif
-}
-
-- (_WKUnifiedTextReplacementBehavior)_unifiedTextReplacementBehavior
-{
-#if ENABLE(WRITING_TOOLS)
-    return convertToPlatform(_pageConfiguration->unifiedTextReplacementBehavior());
-#else
-    return _WKUnifiedTextReplacementBehaviorNone;
-#endif
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -614,99 +561,15 @@ static NSString *defaultApplicationNameForUserAgent()
     return [self _multiRepresentationHEICInsertionEnabled];
 }
 
-#if TARGET_OS_IOS && !TARGET_OS_VISION
-
-static _WKUnifiedTextReplacementBehavior convert(UIWritingToolsBehavior behavior)
+- (void)setWritingToolsBehavior:(PlatformWritingToolsBehavior)writingToolsBehavior
 {
-    switch (behavior) {
-    case UIWritingToolsBehaviorNone:
-        return _WKUnifiedTextReplacementBehaviorNone;
-
-    case UIWritingToolsBehaviorDefault:
-        return _WKUnifiedTextReplacementBehaviorDefault;
-
-    case UIWritingToolsBehaviorLimited:
-        return _WKUnifiedTextReplacementBehaviorLimited;
-
-    case UIWritingToolsBehaviorComplete:
-        return _WKUnifiedTextReplacementBehaviorComplete;
-    }
+    _pageConfiguration->setUnifiedTextReplacementBehavior(WebKit::convertToWebWritingToolsBehavior(writingToolsBehavior));
 }
 
-static UIWritingToolsBehavior convert(_WKUnifiedTextReplacementBehavior behavior)
+- (PlatformWritingToolsBehavior)writingToolsBehavior
 {
-    switch (behavior) {
-    case _WKUnifiedTextReplacementBehaviorNone:
-        return UIWritingToolsBehaviorNone;
-
-    case _WKUnifiedTextReplacementBehaviorDefault:
-        return UIWritingToolsBehaviorDefault;
-
-    case _WKUnifiedTextReplacementBehaviorLimited:
-        return UIWritingToolsBehaviorLimited;
-
-    case _WKUnifiedTextReplacementBehaviorComplete:
-        return UIWritingToolsBehaviorComplete;
-    }
+    return WebKit::convertToPlatformWritingToolsBehavior(_pageConfiguration->unifiedTextReplacementBehavior());
 }
-
-- (void)setWritingToolsBehavior:(UIWritingToolsBehavior)writingToolsBehavior
-{
-    [self _setUnifiedTextReplacementBehavior:convert(writingToolsBehavior)];
-}
-
-- (UIWritingToolsBehavior)writingToolsBehavior
-{
-    return convert([self _unifiedTextReplacementBehavior]);
-}
-
-#elif TARGET_OS_OSX
-
-static _WKUnifiedTextReplacementBehavior convert(NSWritingToolsBehavior behavior)
-{
-    switch (behavior) {
-    case NSWritingToolsBehaviorNone:
-        return _WKUnifiedTextReplacementBehaviorNone;
-
-    case NSWritingToolsBehaviorDefault:
-        return _WKUnifiedTextReplacementBehaviorDefault;
-
-    case NSWritingToolsBehaviorLimited:
-        return _WKUnifiedTextReplacementBehaviorLimited;
-
-    case NSWritingToolsBehaviorComplete:
-        return _WKUnifiedTextReplacementBehaviorComplete;
-    }
-}
-
-static NSWritingToolsBehavior convert(_WKUnifiedTextReplacementBehavior behavior)
-{
-    switch (behavior) {
-    case _WKUnifiedTextReplacementBehaviorNone:
-        return NSWritingToolsBehaviorNone;
-
-    case _WKUnifiedTextReplacementBehaviorDefault:
-        return NSWritingToolsBehaviorDefault;
-
-    case _WKUnifiedTextReplacementBehaviorLimited:
-        return NSWritingToolsBehaviorLimited;
-
-    case _WKUnifiedTextReplacementBehaviorComplete:
-        return NSWritingToolsBehaviorComplete;
-    }
-}
-
-- (void)setWritingToolsBehavior:(NSWritingToolsBehavior)writingToolsBehavior
-{
-    [self _setUnifiedTextReplacementBehavior:convert(writingToolsBehavior)];
-}
-
-- (NSWritingToolsBehavior)writingToolsBehavior
-{
-    return convert([self _unifiedTextReplacementBehavior]);
-}
-
-#endif
 
 #endif // ENABLE(WRITING_TOOLS)
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
@@ -182,8 +182,6 @@ typedef NS_ENUM(NSUInteger, _WKUnifiedTextReplacementBehavior) {
 
 @property (nonatomic, setter=_setScrollToTextFragmentMarkingEnabled:) BOOL _scrollToTextFragmentMarkingEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
-@property (nonatomic, setter=_setUnifiedTextReplacementBehavior:) _WKUnifiedTextReplacementBehavior _unifiedTextReplacementBehavior WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
-
 @end
 
 #if TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -412,8 +412,6 @@ struct PerWebProcessState {
 - (UIWritingToolsAllowedInputOptions)writingToolsAllowedInputOptions;
 #endif
 
-- (BOOL)_wantsCompleteUnifiedTextReplacementBehavior;
-
 #endif // ENABLE(WRITING_TOOLS)
 
 #if ENABLE(WRITING_TOOLS_UI)

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1235,7 +1235,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if ENABLE(WRITING_TOOLS)
 - (BOOL)_web_wantsCompleteUnifiedTextReplacementBehavior
 {
-    return [self _wantsCompleteUnifiedTextReplacementBehavior];
+    return [self wantsWritingToolsInlineEditing];
 }
 #endif
 

--- a/Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WRITING_TOOLS)
+
+#import <pal/spi/cocoa/WritingToolsSPI.h>
+#import <wtf/RetainPtr.h>
+
+namespace WebCore {
+
+namespace UnifiedTextReplacement {
+enum class EditAction : uint8_t;
+enum class ReplacementBehavior : uint8_t;
+enum class ReplacementState : uint8_t;
+enum class SessionCorrectionType : uint8_t;
+enum class SessionReplacementType : uint8_t;
+
+struct Context;
+struct Replacement;
+struct Session;
+}
+
+}
+
+namespace WebKit {
+
+#pragma mark - Conversions from web types to platform types.
+
+PlatformWritingToolsBehavior convertToPlatformWritingToolsBehavior(WebCore::UnifiedTextReplacement::ReplacementBehavior);
+
+WTTextSuggestionState convertToPlatformTextSuggestionState(WebCore::UnifiedTextReplacement::ReplacementState);
+
+RetainPtr<WTContext> convertToPlatformContext(const WebCore::UnifiedTextReplacement::Context&);
+
+#pragma mark - Conversions from platform types to web types.
+
+WebCore::UnifiedTextReplacement::ReplacementBehavior convertToWebWritingToolsBehavior(PlatformWritingToolsBehavior);
+
+WebCore::UnifiedTextReplacement::ReplacementState convertToWebTextSuggestionState(WTTextSuggestionState);
+
+WebCore::UnifiedTextReplacement::EditAction convertToWebAction(WTAction);
+
+WebCore::UnifiedTextReplacement::SessionReplacementType convertToWebSessionType(WTSessionType);
+
+WebCore::UnifiedTextReplacement::SessionCorrectionType convertToWebCompositionSessionType(WTCompositionSessionType);
+
+std::optional<WebCore::UnifiedTextReplacement::Context> convertToWebContext(WTContext *);
+
+std::optional<WebCore::UnifiedTextReplacement::Session> convertToWebSession(WTSession *);
+
+std::optional<WebCore::UnifiedTextReplacement::Replacement> convertToWebTextSuggestion(WTTextSuggestion *);
+
+} // namespace WebKit
+
+#endif

--- a/Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.mm
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if ENABLE(WRITING_TOOLS)
+
+#import "config.h"
+#import "PlatformWritingToolsUtilities.h"
+
+#import <WebCore/UnifiedTextReplacementTypes.h>
+
+namespace WebKit {
+
+#pragma mark - Conversions from web types to platform types.
+
+PlatformWritingToolsBehavior convertToPlatformWritingToolsBehavior(WebCore::UnifiedTextReplacement::ReplacementBehavior behavior)
+{
+    switch (behavior) {
+    case WebCore::UnifiedTextReplacement::ReplacementBehavior::None:
+        return PlatformWritingToolsBehaviorNone;
+
+    case WebCore::UnifiedTextReplacement::ReplacementBehavior::Default:
+        return PlatformWritingToolsBehaviorDefault;
+
+    case WebCore::UnifiedTextReplacement::ReplacementBehavior::Limited:
+        return PlatformWritingToolsBehaviorLimited;
+
+    case WebCore::UnifiedTextReplacement::ReplacementBehavior::Complete:
+        return PlatformWritingToolsBehaviorComplete;
+    }
+}
+
+WTTextSuggestionState convertToPlatformTextSuggestionState(WebCore::UnifiedTextReplacement::Replacement::State state)
+{
+    switch (state) {
+    case WebCore::UnifiedTextReplacement::Replacement::State::Pending:
+        return WTTextSuggestionStatePending;
+    case WebCore::UnifiedTextReplacement::Replacement::State::Active:
+        return WTTextSuggestionStateReviewing;
+    case WebCore::UnifiedTextReplacement::Replacement::State::Reverted:
+        return WTTextSuggestionStateRejected;
+    case WebCore::UnifiedTextReplacement::Replacement::State::Invalid:
+        return WTTextSuggestionStateInvalid;
+    }
+}
+
+RetainPtr<WTContext> convertToPlatformContext(const WebCore::UnifiedTextReplacement::Context& contextData)
+{
+    return adoptNS([[WTContext alloc] initWithAttributedText:contextData.attributedText.nsAttributedString().get() range:NSMakeRange(contextData.range.location, contextData.range.length)]);
+}
+
+#pragma mark - Conversions from platform types to web types.
+
+WebCore::UnifiedTextReplacement::ReplacementBehavior convertToWebWritingToolsBehavior(PlatformWritingToolsBehavior behavior)
+{
+    switch (behavior) {
+    case PlatformWritingToolsBehaviorNone:
+        return WebCore::UnifiedTextReplacement::ReplacementBehavior::None;
+
+    case PlatformWritingToolsBehaviorDefault:
+        return WebCore::UnifiedTextReplacement::ReplacementBehavior::Default;
+
+    case PlatformWritingToolsBehaviorLimited:
+        return WebCore::UnifiedTextReplacement::ReplacementBehavior::Limited;
+
+    case PlatformWritingToolsBehaviorComplete:
+        return WebCore::UnifiedTextReplacement::ReplacementBehavior::Complete;
+    }
+}
+
+WebCore::UnifiedTextReplacement::Replacement::State convertToWebTextSuggestionState(WTTextSuggestionState state)
+{
+    switch (state) {
+    case WTTextSuggestionStatePending:
+        return WebCore::UnifiedTextReplacement::Replacement::State::Pending;
+    case WTTextSuggestionStateReviewing:
+        return WebCore::UnifiedTextReplacement::Replacement::State::Active;
+    case WTTextSuggestionStateRejected:
+        return WebCore::UnifiedTextReplacement::Replacement::State::Reverted;
+    case WTTextSuggestionStateInvalid:
+        return WebCore::UnifiedTextReplacement::Replacement::State::Invalid;
+
+    // FIXME: Remove this default case once the WTTextSuggestionStateAccepted case is no longer in the build.
+    default:
+        ASSERT_NOT_REACHED();
+        return WebCore::UnifiedTextReplacement::Replacement::State::Invalid;
+    }
+}
+
+WebCore::UnifiedTextReplacement::EditAction convertToWebAction(WTAction action)
+{
+    switch (action) {
+    case WTActionShowOriginal:
+        return WebCore::UnifiedTextReplacement::EditAction::Undo;
+    case WTActionShowRewritten:
+        return WebCore::UnifiedTextReplacement::EditAction::Redo;
+    case WTActionCompositionRestart:
+        return WebCore::UnifiedTextReplacement::EditAction::UndoAll;
+    }
+}
+
+WebCore::UnifiedTextReplacement::Session::ReplacementType convertToWebSessionType(WTSessionType type)
+{
+    switch (type) {
+    case WTSessionTypeProofreading:
+        return WebCore::UnifiedTextReplacement::Session::ReplacementType::PlainText;
+    case WTSessionTypeComposition:
+        return WebCore::UnifiedTextReplacement::Session::ReplacementType::RichText;
+    }
+}
+
+WebCore::UnifiedTextReplacement::Session::CorrectionType convertToWebCompositionSessionType(WTCompositionSessionType type)
+{
+    switch (type) {
+    case WTCompositionSessionTypeNone:
+        return WebCore::UnifiedTextReplacement::Session::CorrectionType::None;
+
+    // FIXME: Map these to specific `CorrectionType` types post-upstreaming.
+    case WTCompositionSessionTypeMagic:
+    case WTCompositionSessionTypeConcise:
+    case WTCompositionSessionTypeFriendly:
+    case WTCompositionSessionTypeProfessional:
+    case WTCompositionSessionTypeOpenEnded:
+    case WTCompositionSessionTypeSummary:
+    case WTCompositionSessionTypeKeyPoints:
+    case WTCompositionSessionTypeList:
+    case WTCompositionSessionTypeTable:
+    case WTCompositionSessionTypeCompose:
+        return WebCore::UnifiedTextReplacement::Session::CorrectionType::Grammar;
+
+    case WTCompositionSessionTypeSmartReply:
+        return WebCore::UnifiedTextReplacement::Session::CorrectionType::Spelling;
+
+    default:
+        return WebCore::UnifiedTextReplacement::Session::CorrectionType::Grammar;
+    }
+}
+
+std::optional<WebCore::UnifiedTextReplacement::Context> convertToWebContext(WTContext *context)
+{
+    auto contextUUID = WTF::UUID::fromNSUUID(context.uuid);
+    if (!contextUUID)
+        return std::nullopt;
+
+    return { { *contextUUID, WebCore::AttributedString::fromNSAttributedString(context.attributedText), { context.range } } };
+}
+
+std::optional<WebCore::UnifiedTextReplacement::Session> convertToWebSession(WTSession *session)
+{
+    auto sessionUUID = WTF::UUID::fromNSUUID(session.uuid);
+    if (!sessionUUID)
+        return std::nullopt;
+
+    return { { *sessionUUID, convertToWebSessionType(session.type), convertToWebCompositionSessionType(session.compositionSessionType) } };
+}
+
+std::optional<WebCore::UnifiedTextReplacement::Replacement> convertToWebTextSuggestion(WTTextSuggestion *suggestion)
+{
+    auto suggestionUUID = WTF::UUID::fromNSUUID(suggestion.uuid);
+    if (!suggestionUUID)
+        return std::nullopt;
+
+    return { { *suggestionUUID, { suggestion.originalRange }, { suggestion.replacement }, convertToWebTextSuggestionState(suggestion.state) } };
+}
+
+} // namespace WebKit
+
+#endif

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -39,6 +39,7 @@
 #import "NativeWebTouchEvent.h"
 #import "PageClient.h"
 #import "PickerDismissalReason.h"
+#import "PlatformWritingToolsUtilities.h"
 #import "RemoteLayerTreeDrawingAreaProxy.h"
 #import "RemoteLayerTreeViews.h"
 #import "RemoteScrollingCoordinatorProxyIOS.h"
@@ -13241,24 +13242,9 @@ inline static NSString *extendSelectionCommand(UITextLayoutDirection direction)
     [_webView writingToolsSession:session didReceiveAction:action];
 }
 
-static UIWritingToolsBehavior convert(WebCore::UnifiedTextReplacement::ReplacementBehavior behavior)
-{
-    switch (behavior) {
-    case WebCore::UnifiedTextReplacement::ReplacementBehavior::None:
-        return UIWritingToolsBehaviorNone;
-
-    case WebCore::UnifiedTextReplacement::ReplacementBehavior::Default:
-    case WebCore::UnifiedTextReplacement::ReplacementBehavior::Limited:
-        return UIWritingToolsBehaviorLimited;
-
-    case WebCore::UnifiedTextReplacement::ReplacementBehavior::Complete:
-        return UIWritingToolsBehaviorComplete;
-    }
-}
-
 - (void)_updateTextInputTraitsForUnifiedTextReplacement:(id<UITextInputTraits>)traits
 {
-    UIWritingToolsBehavior behavior = convert([self unifiedTextReplacementBehavior]);
+    auto behavior = WebKit::convertToPlatformWritingToolsBehavior([self unifiedTextReplacementBehavior]);
     [traits setWritingToolsBehavior:behavior];
 }
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -135,6 +135,7 @@
 		0792314C239CBCB8009598E2 /* RemoteMediaPlayerManagerProxyMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 07923146239CBCB7009598E2 /* RemoteMediaPlayerManagerProxyMessages.h */; };
 		079D1D9A26960CD300883577 /* SystemStatusSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 079D1D9926960CD300883577 /* SystemStatusSPI.h */; };
 		07A5EBBC1C7BA43E00B9CA69 /* WKFrameHandleRef.h in Headers */ = {isa = PBXBuildFile; fileRef = 07A5EBBA1C7BA43E00B9CA69 /* WKFrameHandleRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		07CF2D512C2147A50064DF23 /* PlatformWritingToolsUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 07CA7FE92C20FAAA00798167 /* PlatformWritingToolsUtilities.h */; };
 		07E19EFB23D401F10094FFB4 /* MediaPlayerPrivateRemoteMessageReceiver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 07E19EF823D401F00094FFB4 /* MediaPlayerPrivateRemoteMessageReceiver.cpp */; };
 		07E19EFC23D401F10094FFB4 /* MediaPlayerPrivateRemoteMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 07E19EF923D401F00094FFB4 /* MediaPlayerPrivateRemoteMessages.h */; };
 		07E4BDC72A3A7089000D5509 /* _WKWebViewTextInputNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 07E4BDC52A3A7089000D5509 /* _WKWebViewTextInputNotifications.h */; };
@@ -3202,6 +3203,8 @@
 		07B93FF523AF0CB80036F8EA /* RemoteMediaPlayerConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteMediaPlayerConfiguration.h; sourceTree = "<group>"; };
 		07BAF35623A2CC170044257E /* RemoteMediaPlayerProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteMediaPlayerProxy.h; sourceTree = "<group>"; };
 		07BAF35723A2CC190044257E /* RemoteMediaPlayerProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteMediaPlayerProxy.cpp; sourceTree = "<group>"; };
+		07CA7FE92C20FAAA00798167 /* PlatformWritingToolsUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PlatformWritingToolsUtilities.h; sourceTree = "<group>"; };
+		07CA7FEA2C20FAAA00798167 /* PlatformWritingToolsUtilities.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PlatformWritingToolsUtilities.mm; sourceTree = "<group>"; };
 		07E19EF823D401F00094FFB4 /* MediaPlayerPrivateRemoteMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MediaPlayerPrivateRemoteMessageReceiver.cpp; sourceTree = "<group>"; };
 		07E19EF923D401F00094FFB4 /* MediaPlayerPrivateRemoteMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MediaPlayerPrivateRemoteMessages.h; sourceTree = "<group>"; };
 		07E19F0523D4DC880094FFB4 /* TextTrackPrivateRemoteConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextTrackPrivateRemoteConfiguration.h; sourceTree = "<group>"; };
@@ -9451,6 +9454,8 @@
 				5C6CE6D31F59EA350007C6CB /* PageClientImplCocoa.h */,
 				5C6CE6D01F59BC460007C6CB /* PageClientImplCocoa.mm */,
 				E5AF80FC2BB4F00A00726F63 /* PickerDismissalReason.h */,
+				07CA7FE92C20FAAA00798167 /* PlatformWritingToolsUtilities.h */,
+				07CA7FEA2C20FAAA00798167 /* PlatformWritingToolsUtilities.mm */,
 				1185025E2673B0A700A6425E /* PlatformXRCoordinator.mm */,
 				CDA29A1E1CBEB5FB00901CCF /* PlaybackSessionManagerProxy.h */,
 				CDA29A221CBEB61A00901CCF /* PlaybackSessionManagerProxy.messages.in */,
@@ -16467,6 +16472,7 @@
 				2D8949F1182044F600E898AA /* PlatformCALayerRemoteTiledBacking.h in Headers */,
 				BCE81D8D1319F7EF00241910 /* PlatformFontInfo.h in Headers */,
 				BCC43ABB127B95DC00317F16 /* PlatformPopupMenuData.h in Headers */,
+				07CF2D512C2147A50064DF23 /* PlatformWritingToolsUtilities.h in Headers */,
 				F4BE0D7727AAE1CB005F0323 /* PlaybackSessionContextIdentifier.h in Headers */,
 				1F6B9EF92B7AA2160051676F /* PlaybackSessionInterfaceLMK.h in Headers */,
 				CDA29A1B1CBDBF4100901CCF /* PlaybackSessionManager.h in Headers */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedTextReplacement.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedTextReplacement.mm
@@ -50,33 +50,6 @@
 
 #if PLATFORM(MAC)
 
-#define PlatformWritingToolsBehavior NSWritingToolsBehavior
-#define PlatformWritingToolsBehaviorNone NSWritingToolsBehaviorNone
-#define PlatformWritingToolsBehaviorDefault NSWritingToolsBehaviorDefault
-#define PlatformWritingToolsBehaviorLimited NSWritingToolsBehaviorLimited
-#define PlatformWritingToolsBehaviorComplete NSWritingToolsBehaviorComplete
-
-#define PlatformWritingToolsAllowedInputOptions NSWritingToolsAllowedInputOptions
-
-#else
-
-#define PlatformWritingToolsBehavior UIWritingToolsBehavior
-#define PlatformWritingToolsBehaviorNone UIWritingToolsBehaviorNone
-#define PlatformWritingToolsBehaviorDefault UIWritingToolsBehaviorDefault
-#define PlatformWritingToolsBehaviorLimited UIWritingToolsBehaviorLimited
-#define PlatformWritingToolsBehaviorComplete UIWritingToolsBehaviorComplete
-
-#define PlatformWritingToolsAllowedInputOptions UIWritingToolsAllowedInputOptions
-
-#endif
-
-#define PlatformWritingToolsAllowedInputOptionsPlainText ((PlatformWritingToolsAllowedInputOptions)(1 << 0))
-#define PlatformWritingToolsAllowedInputOptionsRichText ((PlatformWritingToolsAllowedInputOptions)(1 << 1))
-#define PlatformWritingToolsAllowedInputOptionsList ((PlatformWritingToolsAllowedInputOptions)(1 << 2))
-#define PlatformWritingToolsAllowedInputOptionsTable ((PlatformWritingToolsAllowedInputOptions)(1 << 3))
-
-#if PLATFORM(MAC)
-
 @interface NSMenu (Extras)
 - (NSMenuItem *)itemWithIdentifier:(NSString *)identifier;
 @end


### PR DESCRIPTION
#### 0af20f269c8d2afd0298c7200ae15b25124a3065
<pre>
[Writing Tools] Refactor Writing Tools type conversion methods to be in their own file
<a href="https://bugs.webkit.org/show_bug.cgi?id=275599">https://bugs.webkit.org/show_bug.cgi?id=275599</a>
<a href="https://rdar.apple.com/130054970">rdar://130054970</a>

Reviewed by Aditya Keerthi.

* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView wantsWritingToolsInlineEditing]):
(-[WKWebView willBeginWritingToolsSession:requestContexts:]):
(-[WKWebView didBeginWritingToolsSession:contexts:]):
(-[WKWebView proofreadingSession:didReceiveSuggestions:processedRange:inContext:finished:]):
(-[WKWebView proofreadingSession:didUpdateState:forSuggestionWithUUID:inContext:]):
(-[WKWebView didEndWritingToolsSession:accepted:]):
(-[WKWebView compositionSession:didReceiveText:replacementRange:inContext:finished:]):
(-[WKWebView writingToolsSession:didReceiveAction:]):
(-[WKWebView _textReplacementSession:updateState:forReplacementWithUUID:]):
(convert): Deleted.
(-[WKWebView _wantsCompleteUnifiedTextReplacementBehavior]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration setWritingToolsBehavior:]):
(-[WKWebViewConfiguration writingToolsBehavior]):
(convertToPlatform): Deleted.
(convertToWeb): Deleted.
(-[WKWebViewConfiguration _setUnifiedTextReplacementBehavior:]): Deleted.
(-[WKWebViewConfiguration _unifiedTextReplacementBehavior]): Deleted.
(convert): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _web_wantsCompleteUnifiedTextReplacementBehavior]):
* Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.h: Added.
* Source/WebKit/UIProcess/Cocoa/PlatformWritingToolsUtilities.mm: Added.
(WebKit::convertToPlatformWritingToolsBehavior):
(WebKit::convertToPlatformTextSuggestionState):
(WebKit::convertToPlatformContext):
(WebKit::convertToWebWritingToolsBehavior):
(WebKit::convertToWebTextSuggestionState):
(WebKit::convertToWebAction):
(WebKit::convertToWebSessionType):
(WebKit::convertToWebCompositionSessionType):
(WebKit::convertToWebContext):
(WebKit::convertToWebSession):
(WebKit::convertToWebTextSuggestion):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::selectionDidChange):
(WebKit::WebViewImpl::canHandleSwapCharacters const):
(WebKit::WebViewImpl::handleContextMenuSwapCharacters):
(WebKit::showSwapCharactersViewRelativeToRectOfView): Deleted.
(WebKit::scheduleShowSwapCharactersViewForSelectionRectOfView): Deleted.
(WebKit::webViewCanHandleSwapCharacters): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/280134@main">https://commits.webkit.org/280134@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d23bb3fbdfc31f4632c4b640cf2f912f2b74d62

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55844 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58840 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/6276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57970 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42789 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6472 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/6276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57873 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/33064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/48141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/26101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29848 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/5469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4419 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/5740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/60429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/5867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/60429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/48210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/60429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8238 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/30997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32081 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/33163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/31829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->