### PR TITLE
REGRESSION(279854@main): [GStreamer][WebRTC] webrtc/video-stats.html is crashing

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
@@ -38,122 +38,113 @@ GST_DEBUG_CATEGORY_EXTERN(webkit_webrtc_endpoint_debug);
 
 namespace WebCore {
 
-static inline void fillRTCStats(RTCStatsReport::Stats& stats, const GstStructure* structure)
+RTCStatsReport::Stats::Stats(Type type, const GstStructure* structure)
+    : type(type)
+    , id(String::fromLatin1(gst_structure_get_string(structure, "id")))
 {
-    double timestamp;
-    if (gst_structure_get_double(structure, "timestamp", &timestamp))
-        stats.timestamp = timestamp;
-    stats.id = String::fromLatin1(gst_structure_get_string(structure, "id"));
+    double gstTimestamp;
+    if (gst_structure_get_double(structure, "timestamp", &gstTimestamp))
+        timestamp = gstTimestamp;
 }
 
-static inline void fillRTCRTPStreamStats(RTCStatsReport::RtpStreamStats& stats, const GstStructure* structure)
+RTCStatsReport::RtpStreamStats::RtpStreamStats(Type type, const GstStructure* structure)
+    : Stats(type, structure)
 {
-    fillRTCStats(stats, structure);
+    transportId = String::fromLatin1(gst_structure_get_string(structure, "transport-id"));
+    codecId = String::fromLatin1(gst_structure_get_string(structure, "codec-id"));
 
-    stats.transportId = String::fromLatin1(gst_structure_get_string(structure, "transport-id"));
-    stats.codecId = String::fromLatin1(gst_structure_get_string(structure, "codec-id"));
+    unsigned gstSsrc;
+    if (gst_structure_get_uint(structure, "ssrc", &gstSsrc))
+        ssrc = gstSsrc;
 
-    unsigned value;
-    if (gst_structure_get_uint(structure, "ssrc", &value))
-        stats.ssrc = value;
-
-    if (const char* kind = gst_structure_get_string(structure, "kind"))
-        stats.kind = String::fromLatin1(kind);
+    if (const char* gstKind = gst_structure_get_string(structure, "kind"))
+        kind = String::fromLatin1(gstKind);
 }
 
-static inline void fillSentRTPStreamStats(RTCStatsReport::SentRtpStreamStats& stats, const GstStructure* structure)
+RTCStatsReport::SentRtpStreamStats::SentRtpStreamStats(Type type, const GstStructure* structure)
+    : RtpStreamStats(type, structure)
 {
-    fillRTCRTPStreamStats(stats, structure);
-
     uint64_t value;
     if (gst_structure_get_uint64(structure, "packets-sent", &value))
-        stats.packetsSent = value;
+        packetsSent = value;
     if (gst_structure_get_uint64(structure, "bytes-sent", &value))
-        stats.bytesSent = value;
+        bytesSent = value;
 }
 
-static inline void fillRTCCodecStats(RTCStatsReport::CodecStats& stats, const GstStructure* structure)
+RTCStatsReport::CodecStats::CodecStats(const GstStructure* structure)
+    : Stats(Type::Codec, structure)
 {
-    fillRTCStats(stats, structure);
-
     unsigned value;
     if (gst_structure_get_uint(structure, "payload-type", &value))
-        stats.payloadType = value;
+        payloadType = value;
     if (gst_structure_get_uint(structure, "clock-rate", &value))
-        stats.clockRate = value;
+        clockRate = value;
     if (gst_structure_get_uint(structure, "channels", &value))
-        stats.channels = value;
+        channels = value;
 
-    if (const char* sdpFmtpLine = gst_structure_get_string(structure, "sdp-fmtp-line"))
-        stats.sdpFmtpLine = String::fromLatin1(sdpFmtpLine);
+    if (const char* gstSdpFmtpLine = gst_structure_get_string(structure, "sdp-fmtp-line"))
+        sdpFmtpLine = String::fromLatin1(gstSdpFmtpLine);
 
-    if (const char* mimeType = gst_structure_get_string(structure, "mime-type"))
-        stats.mimeType = String::fromLatin1(mimeType);
+    if (const char* gstMIMEType = gst_structure_get_string(structure, "mime-type"))
+        mimeType = String::fromLatin1(gstMIMEType);
 
     // FIXME:
     // stats.implementation =
 }
 
-static inline void fillReceivedRTPStreamStats(RTCStatsReport::ReceivedRtpStreamStats& stats, const GstStructure* structure)
+RTCStatsReport::ReceivedRtpStreamStats::ReceivedRtpStreamStats(Type type, const GstStructure* structure)
+    : RtpStreamStats(type, structure)
 {
-    fillRTCRTPStreamStats(stats, structure);
-
     GstStructure* rtpSourceStats;
     gst_structure_get(structure, "gst-rtpsource-stats", GST_TYPE_STRUCTURE, &rtpSourceStats, nullptr);
 
-    uint64_t packetsReceived;
-    if (gst_structure_get_uint64(rtpSourceStats, "packets-received", &packetsReceived))
-        stats.packetsReceived = packetsReceived;
+    uint64_t gstPacketsReceived;
+    if (gst_structure_get_uint64(rtpSourceStats, "packets-received", &gstPacketsReceived))
+        packetsReceived = gstPacketsReceived;
 
 #if GST_CHECK_VERSION(1, 22, 0)
-    int64_t packetsLost;
-    if (gst_structure_get_int64(structure, "packets-lost", &packetsLost))
-        stats.packetsLost = packetsLost;
+    int64_t gstPacketsLost;
+    if (gst_structure_get_int64(structure, "packets-lost", &gstPacketsLost))
+        packetsLost = gstPacketsLost;
 #else
-    unsigned packetsLost;
-    if (gst_structure_get_uint(structure, "packets-lost", &packetsLost))
-        stats.packetsLost = packetsLost;
+    unsigned gstPacketsLost;
+    if (gst_structure_get_uint(structure, "packets-lost", &gstPacketsLost))
+        packetsLost = gstPacketsLost;
 #endif
 
-    double jitter;
-    if (gst_structure_get_double(structure, "jitter", &jitter))
-        stats.jitter = jitter;
+    double gstJitter;
+    if (gst_structure_get_double(structure, "jitter", &gstJitter))
+        jitter = gstJitter;
 }
 
-static inline void fillRemoteInboundRTPStreamStats(RTCStatsReport::RemoteInboundRtpStreamStats& stats, const GstStructure* structure, const GstStructure* additionalStats)
+RTCStatsReport::RemoteInboundRtpStreamStats::RemoteInboundRtpStreamStats(const GstStructure* structure)
+    : ReceivedRtpStreamStats(Type::RemoteInboundRtp, structure)
 {
-    fillReceivedRTPStreamStats(stats, structure);
+    double gstRoundTripTime;
+    if (gst_structure_get_double(structure, "round-trip-time", &gstRoundTripTime))
+        roundTripTime = gstRoundTripTime;
 
-    UNUSED_PARAM(additionalStats);
+    if (const char* gstLocalId = gst_structure_get_string(structure, "local-id"))
+        localId = String::fromLatin1(gstLocalId);
 
-    double roundTripTime;
-    if (gst_structure_get_double(structure, "round-trip-time", &roundTripTime))
-        stats.roundTripTime = roundTripTime;
-
-    if (const char* localId = gst_structure_get_string(structure, "local-id"))
-        stats.localId = String::fromLatin1(localId);
-
-    double fractionLost;
-    if (gst_structure_get_double(structure, "fraction-lost", &fractionLost))
-        stats.fractionLost = fractionLost;
+    double gstFractionLost;
+    if (gst_structure_get_double(structure, "fraction-lost", &gstFractionLost))
+        fractionLost = gstFractionLost;
 
     // FIXME:
     // stats.reportsReceived
     // stats.roundTripTimeMeasurements
 }
 
-static inline void fillRemoteOutboundRTPStreamStats(RTCStatsReport::RemoteOutboundRtpStreamStats& stats, const GstStructure* structure, const GstStructure* additionalStats)
+RTCStatsReport::RemoteOutboundRtpStreamStats::RemoteOutboundRtpStreamStats(const GstStructure* structure)
+    : SentRtpStreamStats(Type::RemoteOutboundRtp, structure)
 {
-    UNUSED_PARAM(additionalStats);
-
-    fillSentRTPStreamStats(stats, structure);
-
     double value;
     if (gst_structure_get_double(structure, "remote-timestamp", &value))
-        stats.remoteTimestamp = value;
+        remoteTimestamp = value;
 
-    if (const char* localId = gst_structure_get_string(structure, "local-id"))
-        stats.localId = String::fromLatin1(localId);
+    if (const char* gstLocalId = gst_structure_get_string(structure, "local-id"))
+        localId = String::fromLatin1(gstLocalId);
 
     // FIXME:
     // stats.roundTripTime
@@ -162,53 +153,53 @@ static inline void fillRemoteOutboundRTPStreamStats(RTCStatsReport::RemoteOutbou
     // stats.roundTripTimeMeasurements
 }
 
-static inline void fillInboundRTPStreamStats(RTCStatsReport::InboundRtpStreamStats& stats, const GstStructure* structure, const GstStructure* additionalStats)
+RTCStatsReport::InboundRtpStreamStats::InboundRtpStreamStats(const GstStructure* structure, const GstStructure* additionalStats)
+    : ReceivedRtpStreamStats(Type::InboundRtp, structure)
 {
-    fillReceivedRTPStreamStats(stats, structure);
-
     uint64_t value;
     if (gst_structure_get_uint64(structure, "bytes-received", &value))
-        stats.bytesReceived = value;
+        bytesReceived = value;
 
     if (gst_structure_get_uint64(structure, "packets-discarded", &value))
-        stats.packetsDiscarded = value;
+        packetsDiscarded = value;
 
     if (gst_structure_get_uint64(structure, "packets-duplicated", &value))
-        stats.packetsDuplicated = value;
+        packetsDuplicated = value;
 
-    unsigned firCount;
-    if (gst_structure_get_uint(structure, "fir-count", &firCount))
-        stats.firCount = firCount;
+    unsigned gstFirCount;
+    if (gst_structure_get_uint(structure, "fir-count", &gstFirCount))
+        firCount = gstFirCount;
 
-    unsigned pliCount;
-    if (gst_structure_get_uint(structure, "pli-count", &pliCount))
-        stats.pliCount = pliCount;
+    unsigned gstPliCount;
+    if (gst_structure_get_uint(structure, "pli-count", &gstPliCount))
+        pliCount = gstPliCount;
 
-    unsigned nackCount;
-    if (gst_structure_get_uint(structure, "nack-count", &nackCount))
-        stats.nackCount = nackCount;
+    unsigned gstNackCount;
+    if (gst_structure_get_uint(structure, "nack-count", &gstNackCount))
+        nackCount = gstNackCount;
 
-    uint64_t bytesReceived;
-    if (gst_structure_get_uint64(structure, "bytes-received", &bytesReceived))
-        stats.bytesReceived = bytesReceived;
+    uint64_t gstBytesReceived;
+    if (gst_structure_get_uint64(structure, "bytes-received", &gstBytesReceived))
+        bytesReceived = gstBytesReceived;
 
-    stats.decoderImplementation = "GStreamer"_s;
+    decoderImplementation = "GStreamer"_s;
 
     if (!additionalStats)
         return;
 
-    if (gst_structure_get_uint64(additionalStats, "frames-decoded", &value))
-        stats.framesDecoded = value;
+    uint64_t frames;
+    if (gst_structure_get_uint64(additionalStats, "frames-decoded", &frames))
+        framesDecoded = frames;
 
-    if (gst_structure_get_uint64(additionalStats, "frames-dropped", &value))
-        stats.framesDropped = value;
+    if (gst_structure_get_uint64(additionalStats, "frames-dropped", &frames))
+        framesDropped = frames;
 
     unsigned size;
     if (gst_structure_get_uint(additionalStats, "frame-width", &size))
-        stats.frameWidth = size;
+        frameWidth = size;
 
     if (gst_structure_get_uint(additionalStats, "frame-height", &size))
-        stats.frameHeight = size;
+        frameHeight = size;
 
     // FIXME:
     // stats.fractionLost =
@@ -222,59 +213,56 @@ static inline void fillInboundRTPStreamStats(RTCStatsReport::InboundRtpStreamSta
     // stats.gapDiscardRate =
 }
 
-static inline void fillOutboundRTPStreamStats(RTCStatsReport::OutboundRtpStreamStats& stats, const GstStructure* structure, const GstStructure* additionalStats)
+RTCStatsReport::OutboundRtpStreamStats::OutboundRtpStreamStats(const GstStructure* structure, const GstStructure* additionalStats)
+    : SentRtpStreamStats(Type::OutboundRtp, structure)
 {
-    fillSentRTPStreamStats(stats, structure);
+    unsigned gstFirCount;
+    if (gst_structure_get_uint(structure, "fir-count", &gstFirCount))
+        firCount = gstFirCount;
 
-    unsigned firCount;
-    if (gst_structure_get_uint(structure, "fir-count", &firCount))
-        stats.firCount = firCount;
+    unsigned gstPliCount;
+    if (gst_structure_get_uint(structure, "pli-count", &gstPliCount))
+        pliCount = gstPliCount;
 
-    unsigned pliCount;
-    if (gst_structure_get_uint(structure, "pli-count", &pliCount))
-        stats.pliCount = pliCount;
+    unsigned gstNackCount;
+    if (gst_structure_get_uint(structure, "nack-count", &gstNackCount))
+        nackCount = gstNackCount;
 
-    unsigned nackCount;
-    if (gst_structure_get_uint(structure, "nack-count", &nackCount))
-        stats.nackCount = nackCount;
-
-    if (const char* remoteId = gst_structure_get_string(structure, "remote-id"))
-        stats.remoteId = String::fromLatin1(remoteId);
+    if (const char* gstRemoteId = gst_structure_get_string(structure, "remote-id"))
+        remoteId = String::fromLatin1(gstRemoteId);
 
     if (!additionalStats)
         return;
 
     uint64_t value;
     if (gst_structure_get_uint64(additionalStats, "frames-sent", &value))
-        stats.framesSent = value;
+        framesSent = value;
     if (gst_structure_get_uint64(additionalStats, "frames-encoded", &value))
-        stats.framesEncoded = value;
+        framesEncoded = value;
 
     double bitrate;
     if (gst_structure_get_double(additionalStats, "bitrate", &bitrate))
-        stats.targetBitrate = bitrate;
+        targetBitrate = bitrate;
 }
 
-static inline void fillRTCPeerConnectionStats(RTCStatsReport::PeerConnectionStats& stats, const GstStructure* structure)
+RTCStatsReport::PeerConnectionStats::PeerConnectionStats(const GstStructure* structure)
+    : Stats(Type::PeerConnection, structure)
 {
-    fillRTCStats(stats, structure);
-
     int value;
     if (gst_structure_get_int(structure, "data-channels-opened", &value))
-        stats.dataChannelsOpened = value;
+        dataChannelsOpened = value;
     if (gst_structure_get_int(structure, "data-channels-closed", &value))
-        stats.dataChannelsClosed = value;
+        dataChannelsClosed = value;
 }
 
-static inline void fillRTCTransportStats(RTCStatsReport::TransportStats& stats, const GstStructure* structure)
+RTCStatsReport::TransportStats::TransportStats(const GstStructure* structure)
+    : Stats(Type::Transport, structure)
 {
-    fillRTCStats(stats, structure);
-
-    if (const char* selectedCandidatePairId = gst_structure_get_string(structure, "selected-candidate-pair-id"))
-        stats.selectedCandidatePairId = String::fromLatin1(selectedCandidatePairId);
+    if (const char* gstSelectedCandidatePairId = gst_structure_get_string(structure, "selected-candidate-pair-id"))
+        selectedCandidatePairId = String::fromLatin1(gstSelectedCandidatePairId);
 
     // FIXME: This field is required, GstWebRTC doesn't provide it, so hard-code a value here.
-    stats.dtlsState = RTCDtlsTransportState::Connected;
+    dtlsState = RTCDtlsTransportState::Connected;
 
     // FIXME
     // stats.bytesSent =
@@ -301,39 +289,35 @@ static inline RTCIceCandidateType iceCandidateType(const String& type)
     return RTCIceCandidateType::Host;
 }
 
-static inline void fillRTCCandidateStats(RTCStatsReport::IceCandidateStats& stats, GstWebRTCStatsType statsType, const GstStructure* structure)
+RTCStatsReport::IceCandidateStats::IceCandidateStats(GstWebRTCStatsType statsType, const GstStructure* structure)
+    : Stats(statsType == GST_WEBRTC_STATS_REMOTE_CANDIDATE ? Type::RemoteCandidate : Type::LocalCandidate, structure)
 {
-    stats.type = statsType == GST_WEBRTC_STATS_REMOTE_CANDIDATE ? RTCStatsReport::Type::RemoteCandidate : RTCStatsReport::Type::LocalCandidate;
+    transportId = String::fromLatin1(gst_structure_get_string(structure, "transport-id"));
+    address = String::fromLatin1(gst_structure_get_string(structure, "address"));
+    protocol = String::fromLatin1(gst_structure_get_string(structure, "protocol"));
+    url = String::fromLatin1(gst_structure_get_string(structure, "url"));
 
-    fillRTCStats(stats, structure);
+    unsigned gstPort;
+    if (gst_structure_get_uint(structure, "port", &gstPort))
+        port = gstPort;
 
-    stats.transportId = String::fromLatin1(gst_structure_get_string(structure, "transport-id"));
-    stats.address = String::fromLatin1(gst_structure_get_string(structure, "address"));
-    stats.protocol = String::fromLatin1(gst_structure_get_string(structure, "protocol"));
-    stats.url = String::fromLatin1(gst_structure_get_string(structure, "url"));
+    unsigned gstPriority;
+    if (gst_structure_get_uint(structure, "priority", &gstPriority))
+        priority = gstPriority;
 
-    unsigned port;
-    if (gst_structure_get_uint(structure, "port", &port))
-        stats.port = port;
-
-    unsigned priority;
-    if (gst_structure_get_uint(structure, "priority", &priority))
-        stats.priority = priority;
-
-    auto candidateType = String::fromLatin1(gst_structure_get_string(structure, "candidate-type"));
-    stats.candidateType = iceCandidateType(candidateType);
+    auto gstIceCandidateType = String::fromLatin1(gst_structure_get_string(structure, "candidate-type"));
+    candidateType = iceCandidateType(gstIceCandidateType);
 }
 
-static inline void fillRTCCandidatePairStats(RTCStatsReport::IceCandidatePairStats& stats, const GstStructure* structure)
+RTCStatsReport::IceCandidatePairStats::IceCandidatePairStats(const GstStructure* structure)
+    : Stats(Type::CandidatePair, structure)
 {
-    fillRTCStats(stats, structure);
-
-    stats.localCandidateId = String::fromLatin1(gst_structure_get_string(structure, "local-candidate-id"));
-    stats.remoteCandidateId = String::fromLatin1(gst_structure_get_string(structure, "remote-candidate-id"));
+    localCandidateId = String::fromLatin1(gst_structure_get_string(structure, "local-candidate-id"));
+    remoteCandidateId = String::fromLatin1(gst_structure_get_string(structure, "remote-candidate-id"));
 
     // FIXME
     // stats.transportId =
-    stats.state = RTCStatsReport::IceCandidatePairState::Succeeded;
+    state = RTCStatsReport::IceCandidatePairState::Succeeded;
     // stats.priority =
     // stats.nominated =
     // stats.writable =
@@ -384,32 +368,27 @@ static gboolean fillReportCallback(GQuark, const GValue* value, gpointer userDat
 
     switch (statsType) {
     case GST_WEBRTC_STATS_CODEC: {
-        RTCStatsReport::CodecStats stats;
-        fillRTCCodecStats(stats, structure);
+        RTCStatsReport::CodecStats stats(structure);
         report.set<IDLDOMString, IDLDictionary<RTCStatsReport::CodecStats>>(stats.id, WTFMove(stats));
         break;
     }
     case GST_WEBRTC_STATS_INBOUND_RTP: {
-        RTCStatsReport::InboundRtpStreamStats stats;
-        fillInboundRTPStreamStats(stats, structure, additionalStats);
+        RTCStatsReport::InboundRtpStreamStats stats(structure, additionalStats);
         report.set<IDLDOMString, IDLDictionary<RTCStatsReport::InboundRtpStreamStats>>(stats.id, WTFMove(stats));
         break;
     }
     case GST_WEBRTC_STATS_OUTBOUND_RTP: {
-        RTCStatsReport::OutboundRtpStreamStats stats;
-        fillOutboundRTPStreamStats(stats, structure, additionalStats);
+        RTCStatsReport::OutboundRtpStreamStats stats(structure, additionalStats);
         report.set<IDLDOMString, IDLDictionary<RTCStatsReport::OutboundRtpStreamStats>>(stats.id, WTFMove(stats));
         break;
     }
     case GST_WEBRTC_STATS_REMOTE_INBOUND_RTP: {
-        RTCStatsReport::RemoteInboundRtpStreamStats stats;
-        fillRemoteInboundRTPStreamStats(stats, structure, additionalStats);
+        RTCStatsReport::RemoteInboundRtpStreamStats stats(structure);
         report.set<IDLDOMString, IDLDictionary<RTCStatsReport::RemoteInboundRtpStreamStats>>(stats.id, WTFMove(stats));
         break;
     }
     case GST_WEBRTC_STATS_REMOTE_OUTBOUND_RTP: {
-        RTCStatsReport::RemoteOutboundRtpStreamStats stats;
-        fillRemoteOutboundRTPStreamStats(stats, structure, additionalStats);
+        RTCStatsReport::RemoteOutboundRtpStreamStats stats(structure);
         report.set<IDLDOMString, IDLDictionary<RTCStatsReport::RemoteOutboundRtpStreamStats>>(stats.id, WTFMove(stats));
         break;
     }
@@ -417,14 +396,12 @@ static gboolean fillReportCallback(GQuark, const GValue* value, gpointer userDat
         // Deprecated stats: csrc.
         break;
     case GST_WEBRTC_STATS_PEER_CONNECTION: {
-        RTCStatsReport::PeerConnectionStats stats;
-        fillRTCPeerConnectionStats(stats, structure);
+        RTCStatsReport::PeerConnectionStats stats(structure);
         report.set<IDLDOMString, IDLDictionary<RTCStatsReport::PeerConnectionStats>>(stats.id, WTFMove(stats));
         break;
     }
     case GST_WEBRTC_STATS_TRANSPORT: {
-        RTCStatsReport::TransportStats stats;
-        fillRTCTransportStats(stats, structure);
+        RTCStatsReport::TransportStats stats(structure);
         report.set<IDLDOMString, IDLDictionary<RTCStatsReport::TransportStats>>(stats.id, WTFMove(stats));
         break;
     }
@@ -437,15 +414,13 @@ static gboolean fillReportCallback(GQuark, const GValue* value, gpointer userDat
     case GST_WEBRTC_STATS_LOCAL_CANDIDATE:
     case GST_WEBRTC_STATS_REMOTE_CANDIDATE:
         if (webkitGstCheckVersion(1, 22, 0)) {
-            RTCStatsReport::IceCandidateStats stats;
-            fillRTCCandidateStats(stats, statsType, structure);
+            RTCStatsReport::IceCandidateStats stats(statsType, structure);
             report.set<IDLDOMString, IDLDictionary<RTCStatsReport::IceCandidateStats>>(stats.id, WTFMove(stats));
         }
         break;
     case GST_WEBRTC_STATS_CANDIDATE_PAIR:
         if (webkitGstCheckVersion(1, 22, 0)) {
-            RTCStatsReport::IceCandidatePairStats stats;
-            fillRTCCandidatePairStats(stats, structure);
+            RTCStatsReport::IceCandidatePairStats stats(structure);
             report.set<IDLDOMString, IDLDictionary<RTCStatsReport::IceCandidatePairStats>>(stats.id, WTFMove(stats));
         }
         break;


### PR DESCRIPTION
#### 150ac45afe34c2f57289bb7d2aea319bdee92ddc
<pre>
REGRESSION(279854@main): [GStreamer][WebRTC] webrtc/video-stats.html is crashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=275570">https://bugs.webkit.org/show_bug.cgi?id=275570</a>

Reviewed by Philippe Normand.

With 279854@main, the default constructors for Stats structs were
removed if USE(LIBWEBRTC). However, without USE(LIBWEBRTC) we still have
the implicit default constructors declared, which don&apos;t set the type
field as before, so it is left uninitialized and causes a crash in
webrtc/video-stats.html.

Fix the issue by implementing the counterpart to 279854@main in
GStreamerStatsCollector.cpp and add corresponding constructors in
RTCStatsReport classes. Additionally, add static_assert&apos;s to ensure
there are no default constructors at compile time.

* Source/WebCore/Modules/mediastream/RTCStatsReport.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
(WebCore::RTCStatsReport::Stats::Stats):
(WebCore::RTCStatsReport::RtpStreamStats::RtpStreamStats):
(WebCore::RTCStatsReport::SentRtpStreamStats::SentRtpStreamStats):
(WebCore::RTCStatsReport::CodecStats::CodecStats):
(WebCore::RTCStatsReport::ReceivedRtpStreamStats::ReceivedRtpStreamStats):
(WebCore::RTCStatsReport::RemoteInboundRtpStreamStats::RemoteInboundRtpStreamStats):
(WebCore::RTCStatsReport::RemoteOutboundRtpStreamStats::RemoteOutboundRtpStreamStats):
(WebCore::RTCStatsReport::InboundRtpStreamStats::InboundRtpStreamStats):
(WebCore::RTCStatsReport::OutboundRtpStreamStats::OutboundRtpStreamStats):
(WebCore::RTCStatsReport::PeerConnectionStats::PeerConnectionStats):
(WebCore::RTCStatsReport::TransportStats::TransportStats):
(WebCore::RTCStatsReport::IceCandidateStats::IceCandidateStats):
(WebCore::RTCStatsReport::IceCandidatePairStats::IceCandidatePairStats):
(WebCore::fillReportCallback):
(WebCore::fillRTCStats): Deleted.
(WebCore::fillRTCRTPStreamStats): Deleted.
(WebCore::fillSentRTPStreamStats): Deleted.
(WebCore::fillRTCCodecStats): Deleted.
(WebCore::fillReceivedRTPStreamStats): Deleted.
(WebCore::fillRemoteInboundRTPStreamStats): Deleted.
(WebCore::fillRemoteOutboundRTPStreamStats): Deleted.
(WebCore::fillInboundRTPStreamStats): Deleted.
(WebCore::fillOutboundRTPStreamStats): Deleted.
(WebCore::fillRTCPeerConnectionStats): Deleted.
(WebCore::fillRTCTransportStats): Deleted.
(WebCore::fillRTCCandidateStats): Deleted.
(WebCore::fillRTCCandidatePairStats): Deleted.

Canonical link: <a href="https://commits.webkit.org/280132@main">https://commits.webkit.org/280132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecb272fbe98157b533e36dc325f10be28f7d341a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55785 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58776 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6216 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57911 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42730 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44932 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4284 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48087 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26064 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29791 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5416 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4359 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51761 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5685 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60367 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5815 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52359 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48158 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51856 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12373 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30939 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32024 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33105 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31771 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->