### PR TITLE
Assertion failure in adjustContentForPagination

### DIFF
--- a/LayoutTests/fast/multicol/empty-line-assert-expected.txt
+++ b/LayoutTests/fast/multicol/empty-line-assert-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/multicol/empty-line-assert.html
+++ b/LayoutTests/fast/multicol/empty-line-assert.html
@@ -1,0 +1,14 @@
+<style>
+body { writing-mode: vertical-lr }
+.c { direction: rtl; columns: 10px; widows: 100; }
+.f { float: left; min-block-size: 1000px; shape-outside: border-box; border-top-style: solid; }
+label { border-top-style: solid };
+</style>
+<div class=c>
+<label>
+<div class=f>This test passes if it doesn't crash.</div>
+</div>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>

--- a/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.cpp
@@ -230,7 +230,8 @@ static const InlineDisplay::Box* leadingContentDisplayForLineIndex(size_t lineIn
 
     for (auto firstContentDisplayBoxIndex = rootInlineBoxIndexOnLine() + 1; firstContentDisplayBoxIndex < displayBoxes.size(); ++firstContentDisplayBoxIndex) {
         auto& displayBox = displayBoxes[firstContentDisplayBoxIndex];
-        ASSERT(!displayBox.isRootInlineBox());
+        if (displayBox.isRootInlineBox())
+            return nullptr;
         if (!displayBox.isNonRootInlineBox() || displayBox.isFirstForLayoutBox())
             return &displayBox;
     }


### PR DESCRIPTION
#### ef29e9a60de2f1424951f77038c5ee9dd18cc345
<pre>
Assertion failure in adjustContentForPagination
<a href="https://bugs.webkit.org/show_bug.cgi?id=275605">https://bugs.webkit.org/show_bug.cgi?id=275605</a>
<a href="https://rdar.apple.com/124213853">rdar://124213853</a>

Reviewed by Alan Baradlay.

* LayoutTests/fast/multicol/empty-line-assert-expected.txt: Added.
* LayoutTests/fast/multicol/empty-line-assert.html: Added.
* Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.cpp:
(WebCore::Layout::leadingContentDisplayForLineIndex):

The code assumed we can&apos;t have two subsequent root inline boxes in InlineDisplay. There
are cases that generate empty lines where we get this structure.

Canonical link: <a href="https://commits.webkit.org/280118@main">https://commits.webkit.org/280118@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b046d375ee4a03468923005cb27b6cf8abb75b2c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8258 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58778 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6222 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57917 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44933 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4294 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57820 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33012 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48094 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26065 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29798 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5423 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4365 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51770 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60369 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5821 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52360 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51857 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12363 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30945 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32030 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33111 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31777 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->