### PR TITLE
Navigation loads that go through a service worker should finish in case of service worker termination

### DIFF
--- a/LayoutTests/http/wpt/service-workers/navigation-fetch-worker-terminate-worker.js
+++ b/LayoutTests/http/wpt/service-workers/navigation-fetch-worker-terminate-worker.js
@@ -1,0 +1,8 @@
+function doTest(event)
+{
+    event.respondWith(new Response("<html><body>PASS</body></html>", { status: 200, headers: [["Content-Type", "text/html"]] }));
+    if (self.internals)
+        setTimeout(() => internals.terminate(), 0);
+}
+
+self.addEventListener("fetch", doTest);

--- a/LayoutTests/http/wpt/service-workers/navigation-fetch-worker-terminate.https-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/navigation-fetch-worker-terminate.https-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Setup worker
+PASS Make sure a navigation load answered by a synthetic response succeeds even if worker terminates
+

--- a/LayoutTests/http/wpt/service-workers/navigation-fetch-worker-terminate.https.html
+++ b/LayoutTests/http/wpt/service-workers/navigation-fetch-worker-terminate.https.html
@@ -1,0 +1,32 @@
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+</head>
+<body>
+<script>
+var scope = "resources";
+var activeWorker;
+
+promise_test(async (test) => {
+    var registration = await navigator.serviceWorker.register("navigation-fetch-worker-terminate-worker.js", { scope : scope });
+    activeWorker = registration.active;
+    if (activeWorker)
+        return;
+    activeWorker = registration.installing;
+    return new Promise(resolve => {
+        activeWorker.addEventListener('statechange', () => {
+            if (activeWorker.state === "activated")
+                resolve();
+        });
+    });
+}, "Setup worker");
+
+promise_test(async (test) => {
+    const iframe = await with_iframe(scope);
+    assert_equals(iframe.contentWindow.document.body.innerHTML, "PASS");
+}, "Make sure a navigation load answered by a synthetic response succeeds even if worker terminates");
+</script>
+</body>
+</html>

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
@@ -178,7 +178,10 @@ void ServiceWorkerGlobalScope::prepareForDestruction()
     // Make sure we destroy fetch events objects before the VM goes away, since their
     // destructor may access the VM.
     m_extendedEvents.clear();
-    m_ongoingFetchTasks.clear();
+
+    auto ongoingFetchTasks = std::exchange(m_ongoingFetchTasks, { });
+    for (auto& task : ongoingFetchTasks.values())
+        task.client->contextIsStopping();
 
     WorkerGlobalScope::prepareForDestruction();
 }

--- a/Source/WebCore/workers/service/context/SWContextManager.cpp
+++ b/Source/WebCore/workers/service/context/SWContextManager.cpp
@@ -337,4 +337,13 @@ void SWContextManager::setRegistrationUpdateViaCache(ServiceWorkerRegistrationId
     });
 }
 
+void SWContextManager::removeFetch(ServiceWorkerIdentifier serviceWorkerIdentifier, SWServerConnectionIdentifier serverConnectionIdentifier, FetchIdentifier fetchIdentifier, bool isNavigationFetch)
+{
+    ASSERT(isMainThread());
+    if (auto* proxy = serviceWorkerThreadProxy(serviceWorkerIdentifier))
+        proxy->removeFetch(serverConnectionIdentifier, fetchIdentifier);
+    if (isNavigationFetch && m_connection)
+        m_connection->removeNavigationFetch(serverConnectionIdentifier, fetchIdentifier);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/workers/service/context/SWContextManager.h
+++ b/Source/WebCore/workers/service/context/SWContextManager.h
@@ -90,6 +90,8 @@ public:
 
         bool isClosed() const { return m_isClosed; }
 
+        virtual void removeNavigationFetch(SWServerConnectionIdentifier, FetchIdentifier) = 0;
+
     protected:
         void setAsClosed() { m_isClosed = true; }
 
@@ -133,6 +135,7 @@ public:
     WEBCORE_EXPORT void fireUpdateFoundEvent(ServiceWorkerRegistrationIdentifier);
     WEBCORE_EXPORT void setRegistrationLastUpdateTime(ServiceWorkerRegistrationIdentifier, WallTime);
     WEBCORE_EXPORT void setRegistrationUpdateViaCache(ServiceWorkerRegistrationIdentifier, ServiceWorkerUpdateViaCache);
+    WEBCORE_EXPORT void removeFetch(ServiceWorkerIdentifier, SWServerConnectionIdentifier, FetchIdentifier, bool isNavigationFetch);
 
 private:
     SWContextManager() = default;

--- a/Source/WebCore/workers/service/context/ServiceWorkerFetch.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerFetch.h
@@ -57,9 +57,8 @@ public:
     virtual void didNotHandle() = 0;
     virtual void cancel() = 0;
     virtual void setCancelledCallback(Function<void()>&&) = 0;
-    virtual void continueDidReceiveResponse() = 0;
-    virtual void convertFetchToDownload() = 0;
     virtual void usePreload() = 0;
+    virtual void contextIsStopping() = 0;
 };
 
 void dispatchFetchEvent(Ref<Client>&&, ServiceWorkerGlobalScope&, ResourceRequest&&, String&& referrer, FetchOptions&&, SWServerConnectionIdentifier, FetchIdentifier, bool isServiceWorkerNavigationPreloadEnabled, String&& clientIdentifier, String&& resultingClientIdentifier);

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
@@ -260,18 +260,6 @@ void ServiceWorkerThreadProxy::cancelFetch(SWServerConnectionIdentifier connecti
     }, WorkerRunLoop::defaultMode());
 }
 
-
-void ServiceWorkerThreadProxy::convertFetchToDownload(SWServerConnectionIdentifier connectionIdentifier, FetchIdentifier fetchIdentifier)
-{
-    RELEASE_LOG(ServiceWorker, "ServiceWorkerThreadProxy::convertFetchToDownload %" PRIu64, fetchIdentifier.toUInt64());
-    ASSERT(!isMainThread());
-
-    postTaskForModeToWorkerOrWorkletGlobalScope([connectionIdentifier, fetchIdentifier] (auto& context) {
-        if (auto client = downcast<ServiceWorkerGlobalScope>(context).takeFetchTask({ connectionIdentifier, fetchIdentifier }))
-            client->convertFetchToDownload();
-    }, WorkerRunLoop::defaultMode());
-}
-
 void ServiceWorkerThreadProxy::navigationPreloadIsReady(SWServerConnectionIdentifier connectionIdentifier, FetchIdentifier fetchIdentifier, ResourceResponse&& response)
 {
     ASSERT(!isMainThread());
@@ -285,16 +273,6 @@ void ServiceWorkerThreadProxy::navigationPreloadFailed(SWServerConnectionIdentif
     ASSERT(!isMainThread());
     postTaskForModeToWorkerOrWorkletGlobalScope([connectionIdentifier, fetchIdentifier, error = WTFMove(error).isolatedCopy()] (auto& context) mutable {
         downcast<ServiceWorkerGlobalScope>(context).navigationPreloadFailed({ connectionIdentifier, fetchIdentifier }, WTFMove(error));
-    }, WorkerRunLoop::defaultMode());
-}
-
-void ServiceWorkerThreadProxy::continueDidReceiveFetchResponse(SWServerConnectionIdentifier connectionIdentifier, FetchIdentifier fetchIdentifier)
-{
-    ASSERT(!isMainThread());
-
-    postTaskForModeToWorkerOrWorkletGlobalScope([connectionIdentifier, fetchIdentifier] (auto& context) {
-        if (auto client = downcast<ServiceWorkerGlobalScope>(context).fetchTask({ connectionIdentifier, fetchIdentifier }))
-            client->continueDidReceiveResponse();
     }, WorkerRunLoop::defaultMode());
 }
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
@@ -76,8 +76,6 @@ public:
 
     WEBCORE_EXPORT void startFetch(SWServerConnectionIdentifier, FetchIdentifier, Ref<ServiceWorkerFetch::Client>&&, ResourceRequest&&, String&& referrer, FetchOptions&&, bool isServiceWorkerNavigationPreloadEnabled, String&& clientIdentifier, String&& resultingClientIdentifier);
     WEBCORE_EXPORT void cancelFetch(SWServerConnectionIdentifier, FetchIdentifier);
-    WEBCORE_EXPORT void convertFetchToDownload(SWServerConnectionIdentifier, FetchIdentifier);
-    WEBCORE_EXPORT void continueDidReceiveFetchResponse(SWServerConnectionIdentifier, FetchIdentifier);
     WEBCORE_EXPORT void removeFetch(SWServerConnectionIdentifier, FetchIdentifier);
     WEBCORE_EXPORT void navigationPreloadIsReady(SWServerConnectionIdentifier, FetchIdentifier, ResourceResponse&&);
     WEBCORE_EXPORT void navigationPreloadFailed(SWServerConnectionIdentifier, FetchIdentifier, ResourceError&&);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.messages.in
@@ -29,4 +29,5 @@ messages -> ServiceWorkerFetchTask NotRefCounted {
     DidReceiveFormData(IPC::FormDataReference data)
     DidFinish(WebCore::NetworkLoadMetrics metrics)
     UsePreload()
+    ContextClosed()
 }

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp
@@ -248,14 +248,15 @@ void WebSWContextManagerConnection::cancelFetch(SWServerConnectionIdentifier ser
 
     if (auto serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxyFromBackgroundThread(serviceWorkerIdentifier))
         serviceWorkerThreadProxy->cancelFetch(serverConnectionIdentifier, fetchIdentifier);
+    m_ongoingNavigationFetchTasks.remove({ serverConnectionIdentifier, fetchIdentifier });
 }
 
 void WebSWContextManagerConnection::continueDidReceiveFetchResponse(SWServerConnectionIdentifier serverConnectionIdentifier, ServiceWorkerIdentifier serviceWorkerIdentifier, FetchIdentifier fetchIdentifier)
 {
     assertIsCurrent(m_queue.get());
 
-    if (auto serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxyFromBackgroundThread(serviceWorkerIdentifier))
-        serviceWorkerThreadProxy->continueDidReceiveFetchResponse(serverConnectionIdentifier, fetchIdentifier);
+    if (auto task = m_ongoingNavigationFetchTasks.take({ serverConnectionIdentifier, fetchIdentifier }))
+        task->continueDidReceiveResponse();
 }
 
 void WebSWContextManagerConnection::startFetch(SWServerConnectionIdentifier serverConnectionIdentifier, ServiceWorkerIdentifier serviceWorkerIdentifier, FetchIdentifier fetchIdentifier, ResourceRequest&& request, FetchOptions&& options, IPC::FormDataReference&& formData, String&& referrer, bool isServiceWorkerNavigationPreloadEnabled, String&& clientIdentifier, String&& resultingClientIdentifier)
@@ -272,7 +273,10 @@ void WebSWContextManagerConnection::startFetch(SWServerConnectionIdentifier serv
         serviceWorkerThreadProxy->setLastNavigationWasAppInitiated(isAppInitiated);
     });
 
-    auto client = WebServiceWorkerFetchTaskClient::create(m_connectionToNetworkProcess.copyRef(), serviceWorkerIdentifier, serverConnectionIdentifier, fetchIdentifier, request.requester() == ResourceRequestRequester::Main);
+    bool needsContinueDidReceiveResponseMessage = request.requester() == ResourceRequestRequester::Main;
+    auto client = WebServiceWorkerFetchTaskClient::create(m_connectionToNetworkProcess.copyRef(), serviceWorkerIdentifier, serverConnectionIdentifier, fetchIdentifier, needsContinueDidReceiveResponseMessage);
+    if (needsContinueDidReceiveResponseMessage)
+        m_ongoingNavigationFetchTasks.add({ serverConnectionIdentifier, fetchIdentifier }, Ref { client });
 
     request.setHTTPBody(formData.takeData());
     serviceWorkerThreadProxy->startFetch(serverConnectionIdentifier, fetchIdentifier, WTFMove(client), WTFMove(request), WTFMove(referrer), WTFMove(options), isServiceWorkerNavigationPreloadEnabled, WTFMove(clientIdentifier), WTFMove(resultingClientIdentifier));
@@ -386,8 +390,8 @@ void WebSWContextManagerConnection::convertFetchToDownload(SWServerConnectionIde
 {
     assertIsCurrent(m_queue.get());
 
-    if (auto serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxyFromBackgroundThread(serviceWorkerIdentifier))
-        serviceWorkerThreadProxy->convertFetchToDownload(serverConnectionIdentifier, fetchIdentifier);
+    if (auto task = m_ongoingNavigationFetchTasks.take({ serverConnectionIdentifier, fetchIdentifier }))
+        task->convertFetchToDownload();
 }
 
 void WebSWContextManagerConnection::navigationPreloadIsReady(SWServerConnectionIdentifier serverConnectionIdentifier, ServiceWorkerIdentifier serviceWorkerIdentifier, FetchIdentifier fetchIdentifier, ResourceResponse&& response)
@@ -605,6 +609,14 @@ void WebSWContextManagerConnection::setAsInspected(WebCore::ServiceWorkerIdentif
 void WebSWContextManagerConnection::reportConsoleMessage(WebCore::ServiceWorkerIdentifier identifier, MessageSource source, MessageLevel level, const String& message, unsigned long requestIdentifier)
 {
     m_connectionToNetworkProcess->send(Messages::WebSWServerToContextConnection::ReportConsoleMessage { identifier, source, level, message, requestIdentifier }, 0);
+}
+
+void WebSWContextManagerConnection::removeNavigationFetch(WebCore::SWServerConnectionIdentifier serverConnectionIdentifier, WebCore::FetchIdentifier fetchIdentifier)
+{
+    m_queue->dispatch([protectedThis = Ref { *this }, serverConnectionIdentifier, fetchIdentifier] {
+        assertIsCurrent(protectedThis->m_queue.get());
+        protectedThis->m_ongoingNavigationFetchTasks.remove({ serverConnectionIdentifier, fetchIdentifier });
+    });
 }
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
@@ -56,6 +56,7 @@ struct ServiceWorkerContextData;
 namespace WebKit {
 
 class RemoteWorkerFrameLoaderClient;
+class WebServiceWorkerFetchTaskClient;
 class WebUserContentController;
 struct RemoteWorkerInitializationData;
 
@@ -94,6 +95,7 @@ private:
     void openWindow(WebCore::ServiceWorkerIdentifier, const URL&, OpenWindowCallback&&) final;
     void stop() final;
     void reportConsoleMessage(WebCore::ServiceWorkerIdentifier, MessageSource, MessageLevel, const String& message, unsigned long requestIdentifier) final;
+    void removeNavigationFetch(WebCore::SWServerConnectionIdentifier, WebCore::FetchIdentifier) final;
 
     // IPC messages.
     void updatePreferencesStore(WebPreferencesStore&&);
@@ -148,6 +150,9 @@ private:
     Ref<WebUserContentController> m_userContentController;
     std::optional<WebPreferencesStore> m_preferencesStore;
     Ref<WorkQueue> m_queue;
+
+    using FetchKey = std::pair<WebCore::SWServerConnectionIdentifier, WebCore::FetchIdentifier>;
+    HashMap<FetchKey, Ref<WebServiceWorkerFetchTaskClient>> m_ongoingNavigationFetchTasks WTF_GUARDED_BY_CAPABILITY(m_queue.get());
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp
@@ -53,8 +53,12 @@ WebServiceWorkerFetchTaskClient::WebServiceWorkerFetchTaskClient(Ref<IPC::Connec
 
 void WebServiceWorkerFetchTaskClient::didReceiveRedirection(const WebCore::ResourceResponse& response)
 {
+    Locker lock(m_connectionLock);
+
     if (!m_connection)
         return;
+
+    m_didSendResponse = true;
     m_connection->send(Messages::ServiceWorkerFetchTask::DidReceiveRedirectResponse { response }, m_fetchIdentifier);
 
     cleanup();
@@ -62,9 +66,12 @@ void WebServiceWorkerFetchTaskClient::didReceiveRedirection(const WebCore::Resou
 
 void WebServiceWorkerFetchTaskClient::didReceiveResponse(const ResourceResponse& response)
 {
+    Locker lock(m_connectionLock);
+
     if (!m_connection)
         return;
 
+    m_didSendResponse = true;
     if (m_needsContinueDidReceiveResponseMessage)
         m_waitingForContinueDidReceiveResponseMessage = true;
 
@@ -72,6 +79,12 @@ void WebServiceWorkerFetchTaskClient::didReceiveResponse(const ResourceResponse&
 }
 
 void WebServiceWorkerFetchTaskClient::didReceiveData(const SharedBuffer& buffer)
+{
+    Locker lock(m_connectionLock);
+    didReceiveDataInternal(buffer);
+}
+
+void WebServiceWorkerFetchTaskClient::didReceiveDataInternal(const SharedBuffer& buffer)
 {
     if (!m_connection)
         return;
@@ -91,9 +104,15 @@ void WebServiceWorkerFetchTaskClient::didReceiveData(const SharedBuffer& buffer)
 
 void WebServiceWorkerFetchTaskClient::didReceiveFormDataAndFinish(Ref<FormData>&& formData)
 {
+    Locker lock(m_connectionLock);
+    didReceiveFormDataAndFinishInternal(WTFMove(formData));
+}
+
+void WebServiceWorkerFetchTaskClient::didReceiveFormDataAndFinishInternal(Ref<FormData>&& formData)
+{
     if (auto sharedBuffer = formData->asSharedBuffer()) {
-        didReceiveData(sharedBuffer.releaseNonNull());
-        didFinish({ });
+        didReceiveDataInternal(sharedBuffer.releaseNonNull());
+        didFinishInternal({ });
         return;
     }
 
@@ -137,6 +156,7 @@ void WebServiceWorkerFetchTaskClient::didReceiveFormDataAndFinish(Ref<FormData>&
 
 void WebServiceWorkerFetchTaskClient::didReceiveBlobChunk(const SharedBuffer& buffer)
 {
+    Locker lock(m_connectionLock);
     if (!m_connection)
         return;
 
@@ -154,6 +174,12 @@ void WebServiceWorkerFetchTaskClient::didFinishBlobLoading()
 }
 
 void WebServiceWorkerFetchTaskClient::didFail(const ResourceError& error)
+{
+    Locker lock(m_connectionLock);
+    didFailInternal(error);
+}
+
+void WebServiceWorkerFetchTaskClient::didFailInternal(const ResourceError& error)
 {
     if (!m_connection)
         return;
@@ -174,6 +200,12 @@ void WebServiceWorkerFetchTaskClient::didFail(const ResourceError& error)
 }
 
 void WebServiceWorkerFetchTaskClient::didFinish(const NetworkLoadMetrics& metrics)
+{
+    Locker lock(m_connectionLock);
+    didFinishInternal(metrics);
+}
+
+void WebServiceWorkerFetchTaskClient::didFinishInternal(const NetworkLoadMetrics& metrics)
 {
     if (!m_connection)
         return;
@@ -196,6 +228,12 @@ void WebServiceWorkerFetchTaskClient::didFinish(const NetworkLoadMetrics& metric
 
 void WebServiceWorkerFetchTaskClient::didNotHandle()
 {
+    Locker lock(m_connectionLock);
+    didNotHandleInternal();
+}
+
+void WebServiceWorkerFetchTaskClient::didNotHandleInternal()
+{
     if (!m_connection)
         return;
 
@@ -206,6 +244,8 @@ void WebServiceWorkerFetchTaskClient::didNotHandle()
 
 void WebServiceWorkerFetchTaskClient::cancel()
 {
+    Locker lock(m_connectionLock);
+
     ASSERT(!isMainRunLoop());
     m_connection = nullptr;
     if (m_cancelledCallback)
@@ -226,6 +266,8 @@ void WebServiceWorkerFetchTaskClient::setCancelledCallback(Function<void()>&& ca
 
 void WebServiceWorkerFetchTaskClient::usePreload()
 {
+    Locker lock(m_connectionLock);
+
     if (!m_connection)
         return;
 
@@ -236,7 +278,9 @@ void WebServiceWorkerFetchTaskClient::usePreload()
 
 void WebServiceWorkerFetchTaskClient::continueDidReceiveResponse()
 {
-    RELEASE_LOG(ServiceWorker, "ServiceWorkerFrameLoaderClient::continueDidReceiveResponse, has connection %d, didFinish %d, response type %ld", !!m_connection, m_didFinish, static_cast<long>(m_responseData.index()));
+    Locker lock(m_connectionLock);
+
+    RELEASE_LOG(ServiceWorker, "ServiceWorkerFrameLoaderClient::continueDidReceiveResponse, has connection %d, didFinish %d, response type %ld", !!m_connection, !!m_didFinish, static_cast<long>(m_responseData.index()));
 
     if (!m_connection)
         return;
@@ -244,16 +288,20 @@ void WebServiceWorkerFetchTaskClient::continueDidReceiveResponse()
     m_waitingForContinueDidReceiveResponseMessage = false;
 
     switchOn(m_responseData, [this](std::nullptr_t&) {
+        assertIsHeld(m_connectionLock);
         if (m_didFinish)
-            didFinish(m_networkLoadMetrics);
+            didFinishInternal(m_networkLoadMetrics);
     }, [this](const SharedBufferBuilder& buffer) {
-        didReceiveData(buffer.copy()->makeContiguous());
+        assertIsHeld(m_connectionLock);
+        didReceiveDataInternal(buffer.copy()->makeContiguous());
         if (m_didFinish)
-            didFinish(m_networkLoadMetrics);
+            didFinishInternal(m_networkLoadMetrics);
     }, [this](Ref<FormData>& formData) {
-        didReceiveFormDataAndFinish(WTFMove(formData));
+        assertIsHeld(m_connectionLock);
+        didReceiveFormDataAndFinishInternal(WTFMove(formData));
     }, [this](UniqueRef<ResourceError>& error) {
-        didFail(error.get());
+        assertIsHeld(m_connectionLock);
+        didFailInternal(error.get());
     });
     m_responseData = nullptr;
 }
@@ -261,10 +309,30 @@ void WebServiceWorkerFetchTaskClient::continueDidReceiveResponse()
 void WebServiceWorkerFetchTaskClient::cleanup()
 {
     m_connection = nullptr;
-    ensureOnMainRunLoop([serviceWorkerIdentifier = m_serviceWorkerIdentifier, serverConnectionIdentifier = m_serverConnectionIdentifier, fetchIdentifier = m_fetchIdentifier] {
-        if (auto* proxy = SWContextManager::singleton().serviceWorkerThreadProxy(serviceWorkerIdentifier))
-            proxy->removeFetch(serverConnectionIdentifier, fetchIdentifier);
+    ensureOnMainRunLoop([serviceWorkerIdentifier = m_serviceWorkerIdentifier, serverConnectionIdentifier = m_serverConnectionIdentifier, fetchIdentifier = m_fetchIdentifier, needsContinueDidReceiveResponseMessage = m_needsContinueDidReceiveResponseMessage] {
+        SWContextManager::singleton().removeFetch(serviceWorkerIdentifier, serverConnectionIdentifier, fetchIdentifier, needsContinueDidReceiveResponseMessage);
     });
+}
+
+void WebServiceWorkerFetchTaskClient::contextIsStopping()
+{
+    Locker lock(m_connectionLock);
+
+    if (!m_connection)
+        return;
+
+    if (!m_didSendResponse) {
+        didNotHandleInternal();
+        return;
+    }
+
+    if (m_didFinish) {
+        ASSERT(m_needsContinueDidReceiveResponseMessage);
+        return;
+    }
+
+    m_connection->send(Messages::ServiceWorkerFetchTask::ContextClosed { }, m_fetchIdentifier);
+    cleanup();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.h
+++ b/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.h
@@ -33,6 +33,7 @@
 #include <WebCore/ServiceWorkerFetch.h>
 #include <WebCore/ServiceWorkerTypes.h>
 #include <WebCore/SharedBuffer.h>
+#include <wtf/Lock.h>
 #include <wtf/UniqueRef.h>
 
 namespace WebKit {
@@ -43,6 +44,9 @@ public:
     {
         return adoptRef(*new WebServiceWorkerFetchTaskClient(WTFMove(connection), serviceWorkerIdentifier, serverConnectionIdentifier, fetchTaskIdentifier, needsContinueDidReceiveResponseMessage));
     }
+
+    void continueDidReceiveResponse();
+    void convertFetchToDownload();
 
 private:
     WebServiceWorkerFetchTaskClient(Ref<IPC::Connection>&&, WebCore::ServiceWorkerIdentifier, WebCore::SWServerConnectionIdentifier, WebCore::FetchIdentifier, bool needsContinueDidReceiveResponseMessage);
@@ -55,12 +59,17 @@ private:
     void didFinish(const WebCore::NetworkLoadMetrics&) final;
     void didNotHandle() final;
     void cancel() final;
-    void continueDidReceiveResponse() final;
-    void convertFetchToDownload() final;
     void setCancelledCallback(Function<void()>&&) final;
     void usePreload() final;
+    void contextIsStopping() final;
 
-    void cleanup();
+    void didReceiveDataInternal(const WebCore::SharedBuffer&) WTF_REQUIRES_LOCK(m_connectionLock);
+    void didReceiveFormDataAndFinishInternal(Ref<WebCore::FormData>&&) WTF_REQUIRES_LOCK(m_connectionLock);
+    void didFailInternal(const WebCore::ResourceError&) WTF_REQUIRES_LOCK(m_connectionLock);
+    void didFinishInternal(const WebCore::NetworkLoadMetrics&) WTF_REQUIRES_LOCK(m_connectionLock);
+    void didNotHandleInternal() WTF_REQUIRES_LOCK(m_connectionLock);
+
+    void cleanup() WTF_REQUIRES_LOCK(m_connectionLock);
 
     void didReceiveBlobChunk(const WebCore::SharedBuffer&);
     void didFinishBlobLoading();
@@ -78,7 +87,8 @@ private:
         std::unique_ptr<WebCore::FetchLoader> loader;
     };
 
-    RefPtr<IPC::Connection> m_connection;
+    Lock m_connectionLock;
+    RefPtr<IPC::Connection> m_connection WTF_GUARDED_BY_LOCK(m_connectionLock);
     WebCore::SWServerConnectionIdentifier m_serverConnectionIdentifier;
     WebCore::ServiceWorkerIdentifier m_serviceWorkerIdentifier;
     WebCore::FetchIdentifier m_fetchIdentifier;
@@ -89,6 +99,7 @@ private:
     WebCore::NetworkLoadMetrics m_networkLoadMetrics;
     bool m_didFinish { false };
     bool m_isDownload { false };
+    bool m_didSendResponse { false };
     Function<void()> m_cancelledCallback;
 };
 


### PR DESCRIPTION
#### 3830822c935e6fa0e851781b1cf7def6d3f66f66
<pre>
Navigation loads that go through a service worker should finish in case of service worker termination
<a href="https://rdar.apple.com/130079675">rdar://130079675</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=275613">https://bugs.webkit.org/show_bug.cgi?id=275613</a>

Reviewed by Chris Dumez.

We now store navigation fetch tasks in WebSWContextManagerConnection.
This allows to directly ask them to continueDidReceiveFetchResponse or convertFetchToDownload without hopping to the worker thread.
This is useful as the worker thread may be dead by the time we hop to it, which will prevent the load to finish or fail.

Since we are now calling continueDidReceiveFetchResponse or convertFetchToDownload from WebSWContextManagerConnection queue, we add a connection lock to WebServiceWorkerFetchTaskClient.

When a service worker gets stopped, we are now explicitly cancelling the ongoing fetch tasks by calling WebServiceWorkerFetchTaskClient::contextIsStopping.
It will cancel the load except if the load is already terminated but waiting to proceed (which happens for navigation loads waiting for a response check).

* LayoutTests/http/wpt/service-workers/navigation-fetch-worker-terminate-worker.js: Added.
(doTest):
* LayoutTests/http/wpt/service-workers/navigation-fetch-worker-terminate.https-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/navigation-fetch-worker-terminate.https.html: Added.
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp:
(WebCore::ServiceWorkerGlobalScope::prepareForDestruction):
* Source/WebCore/workers/service/context/SWContextManager.cpp:
(WebCore::SWContextManager::removeFetch):
* Source/WebCore/workers/service/context/SWContextManager.h:
* Source/WebCore/workers/service/context/ServiceWorkerFetch.h:
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::ServiceWorkerThreadProxy::cancelFetch):
(WebCore::ServiceWorkerThreadProxy::convertFetchToDownload): Deleted.
(WebCore::ServiceWorkerThreadProxy::continueDidReceiveFetchResponse): Deleted.
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.messages.in:
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.cpp:
(WebKit::WebSWContextManagerConnection::cancelFetch):
(WebKit::WebSWContextManagerConnection::continueDidReceiveFetchResponse):
(WebKit::WebSWContextManagerConnection::startFetch):
(WebKit::WebSWContextManagerConnection::convertFetchToDownload):
(WebKit::WebSWContextManagerConnection::removeNavigationFetch):
* Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h:
* Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp:
(WebKit::WebServiceWorkerFetchTaskClient::didReceiveRedirection):
(WebKit::WebServiceWorkerFetchTaskClient::didReceiveResponse):
(WebKit::WebServiceWorkerFetchTaskClient::didReceiveData):
(WebKit::WebServiceWorkerFetchTaskClient::didReceiveDataInternal):
(WebKit::WebServiceWorkerFetchTaskClient::didReceiveFormDataAndFinish):
(WebKit::WebServiceWorkerFetchTaskClient::didReceiveFormDataAndFinishInternal):
(WebKit::WebServiceWorkerFetchTaskClient::didReceiveBlobChunk):
(WebKit::WebServiceWorkerFetchTaskClient::didFail):
(WebKit::WebServiceWorkerFetchTaskClient::didFailInternal):
(WebKit::WebServiceWorkerFetchTaskClient::didFinish):
(WebKit::WebServiceWorkerFetchTaskClient::didFinishInternal):
(WebKit::WebServiceWorkerFetchTaskClient::didNotHandle):
(WebKit::WebServiceWorkerFetchTaskClient::didNotHandleInternal):
(WebKit::WebServiceWorkerFetchTaskClient::cancel):
(WebKit::WebServiceWorkerFetchTaskClient::usePreload):
(WebKit::WebServiceWorkerFetchTaskClient::continueDidReceiveResponse):
(WebKit::WebServiceWorkerFetchTaskClient::cleanup):
(WebKit::WebServiceWorkerFetchTaskClient::contextIsStopping):
* Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.h:

Canonical link: <a href="https://commits.webkit.org/280246@main">https://commits.webkit.org/280246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/331bd5df6664f05f2cc54c2b9e6281c4c272e055

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56059 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8531 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/59665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6495 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58185 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43007 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6689 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/59665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4495 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58088 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33280 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48348 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/59665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30061 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5678 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/5499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52030 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5949 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/61344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6076 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/61344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48415 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/61344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12424 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31212 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32298 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33381 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32045 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->