### PR TITLE
Adopt more smart pointers addressing UncountedLocalVarsChecker warning

### DIFF
--- a/Source/WebCore/loader/SubresourceIntegrity.cpp
+++ b/Source/WebCore/loader/SubresourceIntegrity.cpp
@@ -203,7 +203,7 @@ bool matchIntegrityMetadataSlow(const CachedResource& resource, const String& in
 String integrityMismatchDescription(const CachedResource& resource, const String& integrityMetadata)
 {
     auto resourceURL = resource.url().stringCenterEllipsizedToLength();
-    if (auto resourceBuffer = resource.resourceBuffer()) {
+    if (RefPtr resourceBuffer = resource.resourceBuffer()) {
         return makeString(resourceURL, ". Failed integrity metadata check. Content length: "_s, resourceBuffer->size(), ", Expected content length: "_s,
             resource.response().expectedContentLength(), ", Expected metadata: "_s, integrityMetadata);
     }

--- a/Source/WebCore/loader/cocoa/BundleResourceLoader.mm
+++ b/Source/WebCore/loader/cocoa/BundleResourceLoader.mm
@@ -42,8 +42,8 @@ namespace BundleResourceLoader {
 
 static WorkQueue& loadQueue()
 {
-    static auto& queue = WorkQueue::create("org.WebKit.BundleResourceLoader"_s, WorkQueue::QOS::Utility).leakRef();
-    return queue;
+    static NeverDestroyed<Ref<WorkQueue>> queue(WorkQueue::create("org.WebKit.BundleResourceLoader"_s, WorkQueue::QOS::Utility));
+    return queue.get();
 }
 
 void loadResourceFromBundle(ResourceLoader& loader, const String& subdirectory)

--- a/Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.cpp
+++ b/Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.cpp
@@ -72,13 +72,13 @@ void DisplayRefreshMonitorManager::unregisterClient(DisplayRefreshMonitorClient&
 
 void DisplayRefreshMonitorManager::clientPreferredFramesPerSecondChanged(DisplayRefreshMonitorClient& client)
 {
-    if (auto* monitor = monitorForClient(client))
+    if (RefPtr monitor = monitorForClient(client))
         monitor->clientPreferredFramesPerSecondChanged(client);
 }
 
 bool DisplayRefreshMonitorManager::scheduleAnimation(DisplayRefreshMonitorClient& client)
 {
-    if (auto* monitor = monitorForClient(client)) {
+    if (RefPtr monitor = monitorForClient(client)) {
         client.setIsScheduled(true);
         return monitor->requestRefreshCallback();
     }
@@ -103,8 +103,7 @@ void DisplayRefreshMonitorManager::windowScreenDidChange(PlatformDisplayID displ
 
 std::optional<FramesPerSecond> DisplayRefreshMonitorManager::nominalFramesPerSecondForDisplay(PlatformDisplayID displayID, DisplayRefreshMonitorFactory* factory)
 {
-    auto* monitor = ensureMonitorForDisplayID(displayID, factory);
-    if (monitor)
+    if (RefPtr monitor = ensureMonitorForDisplayID(displayID, factory))
         return monitor->displayNominalFramesPerSecond();
 
     return std::nullopt;
@@ -112,8 +111,7 @@ std::optional<FramesPerSecond> DisplayRefreshMonitorManager::nominalFramesPerSec
 
 void DisplayRefreshMonitorManager::displayDidRefresh(PlatformDisplayID displayID, const DisplayUpdate& displayUpdate)
 {
-    auto* monitor = monitorForDisplayID(displayID);
-    if (monitor)
+    if (RefPtr monitor = monitorForDisplayID(displayID))
         monitor->displayLinkFired(displayUpdate);
 }
 
@@ -129,11 +127,11 @@ DisplayRefreshMonitor* DisplayRefreshMonitorManager::monitorForClient(DisplayRef
     if (!client.hasDisplayID())
         return nullptr;
 
-    auto* monitor = ensureMonitorForDisplayID(client.displayID(), client.displayRefreshMonitorFactory());
+    RefPtr monitor = ensureMonitorForDisplayID(client.displayID(), client.displayRefreshMonitorFactory());
     if (monitor)
         monitor->addClient(client);
 
-    return monitor;
+    return monitor.get();
 }
 
 DisplayRefreshMonitor* DisplayRefreshMonitorManager::monitorForDisplayID(PlatformDisplayID displayID) const

--- a/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.cpp
+++ b/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.cpp
@@ -62,7 +62,7 @@ static RefPtr<LibWebRTCAudioModule> audioModuleFromSource(RealtimeMediaSource& s
 std::unique_ptr<AudioMediaStreamTrackRenderer> AudioTrackPrivateMediaStream::createRenderer(AudioTrackPrivateMediaStream& stream)
 {
 #if !RELEASE_LOG_DISABLED
-    auto& track = stream.m_streamTrack.get();
+    auto& track = stream.m_streamTrack;
 #endif
     return AudioMediaStreamTrackRenderer::create(AudioMediaStreamTrackRenderer::Init {
         [stream = WeakPtr { stream }] {
@@ -73,8 +73,8 @@ std::unique_ptr<AudioMediaStreamTrackRenderer> AudioTrackPrivateMediaStream::cre
         , audioModuleFromSource(stream.m_audioSource.get())
 #endif
 #if !RELEASE_LOG_DISABLED
-        , track.logger()
-        , track.logIdentifier()
+        , track->logger()
+        , track->logIdentifier()
 #endif
     });
 }

--- a/Source/WebCore/platform/network/BlobRegistryImpl.cpp
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.cpp
@@ -326,8 +326,8 @@ unsigned long long BlobRegistryImpl::blobSize(const URL& url)
 
 static WorkQueue& blobUtilityQueue()
 {
-    static auto& queue = WorkQueue::create("org.webkit.BlobUtility"_s, WorkQueue::QOS::Utility).leakRef();
-    return queue;
+    static NeverDestroyed<Ref<WorkQueue>> queue(WorkQueue::create("org.webkit.BlobUtility"_s, WorkQueue::QOS::Utility));
+    return queue.get();
 }
 
 bool BlobRegistryImpl::populateBlobsForFileWriting(const Vector<String>& blobURLs, Vector<BlobForFileWriting>& blobsForWriting)

--- a/Source/WebCore/platform/network/DataURLDecoder.cpp
+++ b/Source/WebCore/platform/network/DataURLDecoder.cpp
@@ -63,8 +63,8 @@ static bool shouldRemoveFragmentIdentifier(const String& mediaType)
 
 static WorkQueue& decodeQueue()
 {
-    static auto& queue = WorkQueue::create("org.webkit.DataURLDecoder"_s, WorkQueue::QOS::UserInitiated).leakRef();
-    return queue;
+    static NeverDestroyed<Ref<WorkQueue>> queue(WorkQueue::create("org.webkit.DataURLDecoder"_s, WorkQueue::QOS::UserInitiated));
+    return queue.get();
 }
 
 static Result parseMediaType(const String& mediaType)

--- a/Source/WebCore/rendering/style/ShapeValue.cpp
+++ b/Source/WebCore/rendering/style/ShapeValue.cpp
@@ -59,7 +59,7 @@ bool ShapeValue::canBlend(const ShapeValue& to) const
     if (m_cssBox != to.cssBox())
         return false;
 
-    if (auto* toShape = to.shape())
+    if (RefPtr toShape = to.shape())
         return m_shape && m_shape->canBlend(*toShape);
 
     return false;


### PR DESCRIPTION
#### 087ccacd8055a28188d1b4e372e7e183bed4b4f2
<pre>
Adopt more smart pointers addressing UncountedLocalVarsChecker warning
<a href="https://bugs.webkit.org/show_bug.cgi?id=275614">https://bugs.webkit.org/show_bug.cgi?id=275614</a>

Reviewed by Chris Dumez.

Adopt more smart pointers addressing the
[alpha.webkit.UncountedLocalVarsChecker] warning.

* Source/WebCore/loader/SubresourceIntegrity.cpp:
(WebCore::integrityMismatchDescription):
* Source/WebCore/loader/cocoa/BundleResourceLoader.mm:
(WebCore::BundleResourceLoader::loadQueue):
* Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.cpp:
(WebCore::DisplayRefreshMonitorManager::clientPreferredFramesPerSecondChanged):
(WebCore::DisplayRefreshMonitorManager::scheduleAnimation):
(WebCore::DisplayRefreshMonitorManager::nominalFramesPerSecondForDisplay):
(WebCore::DisplayRefreshMonitorManager::displayDidRefresh):
(WebCore::DisplayRefreshMonitorManager::monitorForClient):
* Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.cpp:
(WebCore::AudioTrackPrivateMediaStream::createRenderer):
* Source/WebCore/platform/network/BlobRegistryImpl.cpp:
(WebCore::blobUtilityQueue):
* Source/WebCore/platform/network/DataURLDecoder.cpp:
(WebCore::DataURLDecoder::decodeQueue):
* Source/WebCore/rendering/style/ShapeValue.cpp:
(WebCore::ShapeValue::canBlend const):

Canonical link: <a href="https://commits.webkit.org/280747@main">https://commits.webkit.org/280747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e62269bccd22e4087d64a5f0ef389e86b233d44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57011 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60631 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7454 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59139 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43962 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7644 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46174 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5242 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59041 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34126 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49207 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27034 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30906 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6538 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6459 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52865 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6809 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62312 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/924 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6915 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53432 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/927 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49262 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53474 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12717 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/785 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32168 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33253 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34338 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32999 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->