### PR TITLE
[Video Viewer] Media control bar not reappear when cursor is moved on Netflix.com

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/auto-hide-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/auto-hide-controller.js
@@ -35,6 +35,7 @@ class AutoHideController
         this._pointerIdentifiersPreventingAutoHide = new Set;
         this._pointerIdentifiersPreventingAutoHideForHover = new Set;
 
+        this._mediaControls.element.addEventListener("mousemove", this);
         this._mediaControls.element.addEventListener("pointermove", this);
         this._mediaControls.element.addEventListener("pointerdown", this);
         this._mediaControls.element.addEventListener("pointerup", this);
@@ -90,6 +91,8 @@ class AutoHideController
             return;
 
         switch (event.type) {
+        case "mousemove":
+                this._mediaControls.faded = false;
         case "pointermove":
             // If the pointer is a mouse (supports hover), immediately show the controls.
             if (event.pointerType === "mouse")


### PR DESCRIPTION
#### d946a12cfb4f55d6f8853b780d5b410a9a60e214
<pre>
[Video Viewer] Media control bar not reappear when cursor is moved on Netflix.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=275520">https://bugs.webkit.org/show_bug.cgi?id=275520</a>
<a href="https://rdar.apple.com/128645397">rdar://128645397</a>

Reviewed by Andy Estes.

Add a mousemove event listener to media controls div. AutoHideController handles this
Event by toggling off the faded class, which controls visibility of the controls.

* Source/WebCore/Modules/modern-media-controls/controls/auto-hide-controller.js:
(AutoHideController):
(AutoHideController.prototype.handleEvent):

Canonical link: <a href="https://commits.webkit.org/280221@main">https://commits.webkit.org/280221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f900086eabc7b257f3b22f7d1fa008346ddb4f50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55817 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58813 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6249 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44951 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4315 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33038 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48116 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26084 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29822 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5444 "Found 1 new test failure: imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4392 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51800 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5715 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60402 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5843 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52386 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48185 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51880 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8293 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/30970 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32054 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33136 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31802 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->