### PR TITLE
Disable chronod when booting simulated devices for testing.

### DIFF
--- a/Tools/Scripts/webkitpy/xcode/simulated_device.py
+++ b/Tools/Scripts/webkitpy/xcode/simulated_device.py
@@ -56,6 +56,7 @@ class DeviceRequest(object):
 class SimulatedDeviceManager(object):
     class Runtime(object):
         def __init__(self, runtime_dict):
+            self.root = runtime_dict['runtimeRoot']
             self.build_version = runtime_dict['buildversion']
             self.os_variant = runtime_dict['name'].split(' ')[0]
             self.version = Version.from_string(runtime_dict['version'])
@@ -124,6 +125,7 @@ class SimulatedDeviceManager(object):
             host=host,
             device_type=device_type,
             build_version=runtime.build_version,
+            runtime_root=runtime.root,
         ))
         SimulatedDeviceManager.AVAILABLE_DEVICES.append(result)
         return result
@@ -537,20 +539,23 @@ class SimulatedDevice(object):
         'watchOS': 'com.apple.NanoSettings',
     }
 
-    def __init__(self, name, udid, host, device_type, build_version):
+    def __init__(self, name, udid, host, device_type, build_version, runtime_root):
         assert device_type.software_version
 
         self.name = name
         self.udid = udid
         self.device_type = device_type
         self.build_version = build_version
+        self.runtime_root = runtime_root
         self._state = SimulatedDevice.DeviceState.SHUTTING_DOWN
 
         self.executive = host.executive
         self.filesystem = host.filesystem
         self.platform = host.platform
 
-        self.environment_extras = []
+        self.environment_extras = [
+            [SimulatedDeviceManager.xcrun, 'simctl', 'spawn', self.udid, 'launchctl', 'unload', '-w', f'{runtime_root}/System/Library/LaunchDaemons/com.apple.chronod.plist'],  # FIXME: rdar://129075664
+        ]
 
         if apple_additions():
             self.environment_extras.extend(apple_additions().environment_extras(udid))

--- a/Tools/Scripts/webkitpy/xcode/simulated_device_unittest.py
+++ b/Tools/Scripts/webkitpy/xcode/simulated_device_unittest.py
@@ -164,6 +164,7 @@ simctl_json_output = """{
  ],
  "runtimes" : [
    {
+     "runtimeRoot" : "/path/to/RuntimeRoot",
      "buildversion" : "13E233",
      "availability" : "(available)",
      "name" : "iOS 9.3",
@@ -171,6 +172,7 @@ simctl_json_output = """{
      "version" : "9.3"
    },
    {
+     "runtimeRoot" : "/path/to/RuntimeRoot",
      "buildversion" : "15A8401",
      "availability" : "(available)",
      "name" : "iOS 11.0",
@@ -178,6 +180,7 @@ simctl_json_output = """{
      "version" : "11.0.1"
    },
    {
+     "runtimeRoot" : "/path/to/RuntimeRoot",
      "buildversion" : "15J380",
      "availability" : "(available)",
      "name" : "tvOS 11.0",
@@ -185,6 +188,7 @@ simctl_json_output = """{
      "version" : "11.0"
    },
    {
+     "runtimeRoot" : "/path/to/RuntimeRoot",
      "buildversion" : "15R372",
      "availability" : "(available)",
      "name" : "watchOS 4.0",
@@ -192,6 +196,7 @@ simctl_json_output = """{
      "version" : "4.0"
    },
    {
+     "runtimeRoot" : "/path/to/RuntimeRoot",
      "buildversion" : "16A367",
      "isAvailable" : "YES",
      "name" : "iOS 12.0",


### PR DESCRIPTION
#### 72c9c0bd54a86cce02e64a1b9fe8b6c3e57851b4
<pre>
Disable chronod when booting simulated devices for testing.
<a href="https://rdar.apple.com/130111123">rdar://130111123</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=275623">https://bugs.webkit.org/show_bug.cgi?id=275623</a>

Reviewed by Elliott Williams.

We&apos;re observing abnormally large memory usage from widgets-related processes on the
iOS simulator. To combat this during investigation, we should unload `chronod` at
simulator startup.

* Tools/Scripts/webkitpy/xcode/simulated_device.py:
(SimulatedDeviceManager.Runtime.__init__): Add runtime.root (path to simulator runtime root).
(SimulatedDeviceManager._create_device_with_runtime): Pass runtime root path to device init method.
(SimulatedDevice.__init__): Add device.runtime_root (path to simulator runtime root).
* Tools/Scripts/webkitpy/xcode/simulated_device_unittest.py: Update mock data to include runtimeRoot.

Canonical link: <a href="https://commits.webkit.org/280818@main">https://commits.webkit.org/280818@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6f99b3e62391fcc883cee502158b2a0cafd9562

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57741 "Failed to checkout and rebase branch from PR 29939") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37069 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61363 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8186 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59869 "Failed to checkout and rebase branch from PR 29939") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8374 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/46784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/5805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59771 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/34764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/49895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/27609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/57267 "Failed to checkout and rebase branch from PR 29939") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/31534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/7187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7190 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/53486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/7458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/63045 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1655 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/7531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/63045 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1661 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49906 "Build is in progress. Recent messages:") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/63045 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/1400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8605 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32898 "Built successfully") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33984 "Failed to checkout and rebase branch from PR 29939") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35068 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33729 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->