### PR TITLE
Avoid copying for return values from swift

### DIFF
--- a/Source/WebCore/PAL/pal/PALSwift.h
+++ b/Source/WebCore/PAL/pal/PALSwift.h
@@ -34,12 +34,29 @@ using VectorUInt8 = WTF::Vector<uint8_t>;
 using SpanConstUInt8 = std::span<const uint8_t>;
 using OptionalVectorUInt8 = std::optional<WTF::Vector<uint8_t>>;
 
-
-// FIXME: remove when swift support is available rdar://118026392
-inline OptionalVectorUInt8 makeOptional(VectorUInt8 val)
-{
-    return val;
-}
+enum class ErrorCodes: int {
+    Success = 0,
+    WrongTagSize,
+    EncryptionFailed,
+    EncryptionResultNil,
+    InvalidArgument,
+    TooBigArguments,
+    DecryptionFailed,
+    HashingFailed,
+    PublicKeyProvidedToSign,
+    FailedToSign,
+    FailedToVerify,
+    PrivateKeyProvidedForVerification,
+    FailedToImport,
+    FailedToDerive,
+    FailedToExport,
+    DefaultValue,
+    UnsupportedAlgorithm,
+};
+struct CryptoOperationReturnValue {
+    ErrorCodes errorCode = ErrorCodes::DefaultValue;
+    VectorUInt8 result;
+};
 
 } // Cpp
 

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMMac.cpp
@@ -55,9 +55,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 static ExceptionOr<Vector<uint8_t>> encryptCryptoKitAESGCM(const Vector<uint8_t>& iv, const Vector<uint8_t>& key, const Vector<uint8_t>& plainText, const Vector<uint8_t>& additionalData, size_t desiredTagLengthInBytes)
 {
     auto rv = PAL::AesGcm::encrypt(key.span(), iv.span(), additionalData.span(), plainText.span(), desiredTagLengthInBytes);
-    if (!rv.getErrorCode().isSuccess())
+    if (rv.errorCode != Cpp::ErrorCodes::Success)
         return Exception { ExceptionCode::OperationError };
-    return WTFMove(*rv.getCipherText());
+    return WTFMove(rv.result);
 }
 #endif
 

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESKWMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmAESKWMac.cpp
@@ -64,17 +64,17 @@ static ExceptionOr<Vector<uint8_t>> unwrapKeyAESKW(const Vector<uint8_t>& key, c
 static ExceptionOr<Vector<uint8_t>> wrapKeyAESKWCryptoKit(const Vector<uint8_t>& key, const Vector<uint8_t>& data)
 {
     auto rv = PAL::AesKw::wrap(data.span(), key.span());
-    if (!rv.getErrorCode().isSuccess())
+    if (rv.errorCode != Cpp::ErrorCodes::Success)
         return Exception { ExceptionCode::OperationError };
-    return WTFMove(*rv.getResult());
+    return WTFMove(rv.result);
 }
 
 static ExceptionOr<Vector<uint8_t>> unwrapKeyAESKWCryptoKit(const Vector<uint8_t>& key, const Vector<uint8_t>& data)
 {
     auto rv = PAL::AesKw::unwrap(data.span(), key.span());
-    if (!rv.getErrorCode().isSuccess())
+    if (rv.errorCode != Cpp::ErrorCodes::Success)
         return Exception { ExceptionCode::OperationError };
-    return WTFMove(*rv.getResult());
+    return WTFMove(rv.result);
 }
 #endif
 

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDHMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDHMac.cpp
@@ -49,7 +49,7 @@ static std::optional<Vector<uint8_t>> platformDeriveBitsCC(const CryptoKeyEC& ba
 #else
     if (!CCECCryptorComputeSharedSecret(baseKey.platformKey().get(), publicKey.platformKey().get(), derivedKey.data(), &size))
 #endif
-        result = WTFMove(derivedKey);
+        result = std::make_optional(WTFMove(derivedKey));
     return result;
 }
 
@@ -61,9 +61,9 @@ static std::optional<Vector<uint8_t>> platformDeriveBitsCryptoKit(const CryptoKe
     if (!priv || !pub)
         return std::nullopt;
     auto rv = (*priv)->deriveBits(*pub);
-    if (!(rv.getErrorCode().isSuccess() && rv.getKeyBytes()))
+    if (rv.errorCode != Cpp::ErrorCodes::Success)
         return std::nullopt;
-    return rv.getKeyBytes();
+    return std::make_optional(WTFMove(rv.result));
 }
 #endif
 

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp
@@ -46,9 +46,9 @@ static ExceptionOr<Vector<uint8_t>> signECDSACryptoKit(CryptoAlgorithmIdentifier
     if (!isValidHashParameter(hash))
         return Exception { ExceptionCode::OperationError };
     auto rv = (*priv)->sign(data.span(), toCKHashFunction(hash));
-    if (!(rv.getErrorCode().isSuccess() && rv.getSignature()))
+    if (rv.errorCode != Cpp::ErrorCodes::Success)
         return Exception { ExceptionCode::OperationError };
-    return *rv.getSignature();
+    return WTFMove(rv.result);
 }
 
 static ExceptionOr<bool> verifyECDSACryptoKit(CryptoAlgorithmIdentifier hash, const PlatformECKeyContainer& key, const Vector<uint8_t>& signature, const Vector<uint8_t> data)
@@ -58,7 +58,7 @@ static ExceptionOr<bool> verifyECDSACryptoKit(CryptoAlgorithmIdentifier hash, co
         return Exception { ExceptionCode::OperationError };
     if (!isValidHashParameter(hash))
         return Exception { ExceptionCode::OperationError };
-    return (*pub)->verify(data.span(), signature.span(), toCKHashFunction(hash)).getErrorCode().isSuccess();
+    return (*pub)->verify(data.span(), signature.span(), toCKHashFunction(hash)).errorCode == Cpp::ErrorCodes::Success;
 }
 #endif
 

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp
@@ -66,11 +66,9 @@ static ExceptionOr<Vector<uint8_t>> signEd25519CryptoKit(const Vector<uint8_t>&s
     if (sk.size() != ed25519KeySize)
         return Exception { ExceptionCode::OperationError };
     auto rv = PAL::EdKey::sign(PAL::EdSigningAlgorithm::ed25519(), sk.span(), data.span());
-    if (!rv.getErrorCode().isSuccess())
+    if (rv.errorCode != Cpp::ErrorCodes::Success)
         return Exception { ExceptionCode::OperationError };
-    if (!rv.getSignature())
-        return Exception { ExceptionCode::OperationError };
-    return *rv.getSignature();
+    return WTFMove(rv.result);
 }
 
 static ExceptionOr<bool>  verifyEd25519CryptoKit(const Vector<uint8_t>& pubKey, const Vector<uint8_t>& signature, const Vector<uint8_t>& data)
@@ -78,7 +76,7 @@ static ExceptionOr<bool>  verifyEd25519CryptoKit(const Vector<uint8_t>& pubKey, 
     if (pubKey.size() != ed25519KeySize || signature.size() != ed25519SignatureSize)
         return false;
     auto rv = PAL::EdKey::verify(PAL::EdSigningAlgorithm::ed25519(), pubKey.span(), signature.span(), data.span());
-    return rv.getErrorCode().isSuccess();
+    return rv.errorCode == Cpp::ErrorCodes::Success;
 }
 #endif
 

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFMac.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFMac.cpp
@@ -50,9 +50,9 @@ static ExceptionOr<Vector<uint8_t>> platformDeriveBitsCryptoKit(const CryptoAlgo
     if (!isValidHashParameter(parameters.hashIdentifier))
         return Exception { ExceptionCode::OperationError };
     auto rv = PAL::HKDF::deriveBits(key.key().span(), parameters.saltVector().span(), parameters.infoVector().span(), length, toCKHashFunction(parameters.hashIdentifier));
-    if (!rv.getErrorCode().isSuccess() || !rv.getKey())
+    if (rv.errorCode != Cpp::ErrorCodes::Success)
         return Exception { ExceptionCode::OperationError };
-    return *rv.getKey();
+    return WTFMove(rv.result);
 }
 #endif
 

--- a/Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp
+++ b/Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp
@@ -34,11 +34,9 @@ static std::optional<Vector<uint8_t>> deriveBitsCryptoKit(const Vector<uint8_t>&
     if (baseKey.size() != ed25519KeySize || publicKey.size() != ed25519KeySize)
         return std::nullopt;
     auto rv = PAL::EdKey::deriveBits(PAL::EdKeyAgreementAlgorithm::x25519(), baseKey.span(), publicKey.span());
-    if (!rv.getErrorCode().isSuccess())
+    if (rv.errorCode != Cpp::ErrorCodes::Success)
         return std::nullopt;
-    if (!rv.getKeyBytes())
-        return std::nullopt;
-    return *rv.getKeyBytes();
+    return WTFMove(rv.result);
 }
 #endif
 static std::optional<Vector<uint8_t>> deriveBitsCoreCrypto(const Vector<uint8_t>& baseKey, const Vector<uint8_t>& publicKey)


### PR DESCRIPTION
#### 20dee432499d1fd7fa1abcaf3f3a408989a68a95
<pre>
Avoid copying for return values from swift
<a href="https://bugs.webkit.org/show_bug.cgi?id=275619">https://bugs.webkit.org/show_bug.cgi?id=275619</a>
<a href="https://rdar.apple.com/129772363">rdar://129772363</a>

Reviewed by David Kilzer.

In the existing Swift-Cpp interop interface, when C++ tries to extract values out of swift structs, it generates a Copy as swift structs are value types.
Even if we declare the same structure in C++ and construct it on swift side with std::optional in it, and then get the value on C++ side, it still generates a copy. That&apos;s because
`Cpp.makeOptional` that is being removed here cannot take an rvalue reference(no support in swift).

With the current interop features, the best solution for now is to remove optionals and return an empty vector in error scenarios.
This should be a reasonable mitigation as the hot path &quot;should&quot; be success in which case the vector returned actually holds a useful value.
In errors, yes, an empty vector will be returned(adding std::optional was a solution for that problem) but that seems to add extra copies which we
would like to avoid if possible.

* Source/WebCore/PAL/pal/PALSwift.h:
(Cpp::makeOptional): Deleted.
* Source/WebCore/PAL/pal/PALSwift/CryptoKitShim.swift:
(AesKw.wrap(_:using:)):
(AesKw.unwrap(_:using:)):
(ECImportReturnValue.errorCode):
(ECKey.importX963Pub(_:curve:)):
(ECKey.exportX963Pub):
(ECKey.importCompressedPub(_:curve:)):
(ECKey.importX963Private(_:curve:)):
(ECKey.exportX963Private):
(ECKey.sign(_:hashFunction:)):
(ECKey.deriveBits(_:)):
(AesGcmReturnValue.cipherText): Deleted.
(AesGcmReturnValue.errorCode): Deleted.
(AesKwReturnValue.errorCode): Deleted.
(AesKwReturnValue.result): Deleted.
(ECReturnValue.errorCode): Deleted.
(ECReturnValue.signature): Deleted.
(ECReturnValue.keyBytes): Deleted.
(ECReturnValue.key): Deleted.
(EdReturnValue.errorCode): Deleted.
(EdReturnValue.signature): Deleted.
(EdReturnValue.keyBytes): Deleted.
(HKDFReturnValue.errorCode): Deleted.
(HKDFReturnValue.key): Deleted.
* Source/WebCore/crypto/cocoa/CryptoAlgorithmAESGCMMac.cpp:
(WebCore::encryptCryptoKitAESGCM):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmAESKWMac.cpp:
(WebCore::wrapKeyAESKWCryptoKit):
(WebCore::unwrapKeyAESKWCryptoKit):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmECDHMac.cpp:
(WebCore::platformDeriveBitsCC):
(WebCore::platformDeriveBitsCryptoKit):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmECDSAMac.cpp:
(WebCore::signECDSACryptoKit):
(WebCore::verifyECDSACryptoKit):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmEd25519Cocoa.cpp:
(WebCore::signEd25519CryptoKit):
(WebCore::verifyEd25519CryptoKit):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmHKDFMac.cpp:
(WebCore::platformDeriveBitsCryptoKit):
* Source/WebCore/crypto/cocoa/CryptoAlgorithmX25519Cocoa.cpp:
(WebCore::deriveBitsCryptoKit):
* Source/WebCore/crypto/cocoa/CryptoKeyECMac.cpp:
(WebCore::CryptoKeyEC::platformImportRaw):
(WebCore::CryptoKeyEC::platformExportRaw const):
(WebCore::CryptoKeyEC::platformImportJWKPrivate):
(WebCore::CryptoKeyEC::platformAddFieldElements const):
(WebCore::CryptoKeyEC::platformImportSpki):
(WebCore::CryptoKeyEC::platformExportSpki const):
(WebCore::CryptoKeyEC::platformImportPkcs8):
(WebCore::CryptoKeyEC::platformExportPkcs8 const):

Canonical link: <a href="https://commits.webkit.org/280218@main">https://commits.webkit.org/280218@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4a46a914fbf6b76deb7c668a60532cd75441aa7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8449 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58980 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6413 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6609 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45085 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4436 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33200 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48273 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26223 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29982 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5601 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4556 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5872 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60568 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5993 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52512 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48342 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52044 "run-api-tests-without-change (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8291 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31134 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32218 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33300 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31966 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->