### PR TITLE
[Navigation] On intercepted navigations properly update url and history

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7081,10 +7081,10 @@ imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-b
 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-location-reload.html [ Failure ]
 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-location-replace-cross-origin.html [ Failure ]
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-replace-same-document.html [ Failure ]
+imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-replace.html [ Failure ]
 
 # General flakes, almost exclusively on mac-wk2-stress.
 imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-popstate.html [ Pass Timeout Failure ]
-imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-replace.html [ Failure Pass ]
 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-url-censored.html [ Pass Failure ]
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/back-forward-multiple-frames.html [ Failure Pass ]
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-state-repeated-await.html [ Timeout Failure Pass ]

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-intercept-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-intercept-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL currententrychange fires for navigation.navigate() intercepted by intercept() assert_true: expected true got false
+PASS currententrychange fires for navigation.navigate() intercepted by intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-replace-intercept-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-replace-intercept-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL currententrychange fires for navigation.navigate() with replace intercepted by intercept() assert_true: expected true got false
+PASS currententrychange fires for navigation.navigate() with replace intercepted by intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-and-navigate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-and-navigate-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Using intercept() then navigate() in the ensuing currententrychange should abort the finished promise (but not the committed promise) assert_equals: expected "#2" but got ""
+FAIL Using intercept() then navigate() in the ensuing currententrychange should abort the finished promise (but not the committed promise) assert_unreached: Should have rejected: undefined Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-handler-returns-non-promise-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-handler-returns-non-promise-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL event.intercept() should resolve immediately if the handler doesn't return a promise assert_equals: expected "#1" but got ""
+PASS event.intercept() should resolve immediately if the handler doesn't return a promise
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-handler-throws-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-handler-throws-expected.txt
@@ -2,5 +2,5 @@ CONSOLE MESSAGE: TypeError: a message
 
 Harness Error (FAIL), message = TypeError: a message
 
-FAIL event.intercept() should abort if the handler throws assert_equals: expected "#1" but got ""
+FAIL event.intercept() should abort if the handler throws assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-history-pushState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-history-pushState-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL event.intercept() should proceed if the given promise resolves assert_equals: expected "#1" but got ""
+PASS event.intercept() should proceed if the given promise resolves
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-history-replaceState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-history-replaceState-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL event.intercept() should proceed if the given promise resolves assert_equals: expected "#1" but got ""
+PASS event.intercept() should proceed if the given promise resolves
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-multiple-times-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-multiple-times-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL navigation.navigate() returns a finished promise that awaits all promises if event.intercept() is called multiple times assert_equals: expected "#1" but got ""
+FAIL navigation.navigate() returns a finished promise that awaits all promises if event.intercept() is called multiple times assert_true: expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-popstate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-popstate-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT event.intercept() should provide popstate with a valid state object Test timed out
+PASS event.intercept() should provide popstate with a valid state object
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-resolve-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-resolve-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL event.intercept() should proceed if the given promise resolves assert_equals: expected "#1" but got ""
+PASS event.intercept() should proceed if the given promise resolves
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-same-document-history-back-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-same-document-history-back-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT event.intercept() can intercept same-document history.back() Test timed out
+FAIL event.intercept() can intercept same-document history.back() assert_equals: expected 1 but got 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-intercept-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-intercept-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT event.intercept() does not signal event.signal Test timed out
+PASS event.intercept() does not signal event.signal
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-replace-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-replace-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.activation after replace promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'from_entry_after_nav.key')"
+FAIL navigation.activation after replace assert_equals: expected "bda7783c-e584-483e-ad30-88339ca06c57" but got "eb3c4530-37d5-4f6b-84e8-152ccfdf7c72"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-dynamic-url-censored-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-dynamic-url-censored-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL The url of a document is censored by a no-referrer policy dynamically promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'i.contentWindow.navigation.activation.from')"
+FAIL The url of a document is censored by a no-referrer policy dynamically promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'i.contentWindow.navigation.activation.from.url')"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-history-push-same-url-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-history-push-same-url-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT navigate() to the current URL with history: 'push' and intercept so it remains same-document Test timed out
+PASS navigate() to the current URL with history: 'push' and intercept so it remains same-document
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-intercept-history-state-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-intercept-history-state-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT history.story should be nulled by navigate() handled by intercept() Test timed out
+FAIL history.story should be nulled by navigate() handled by intercept() assert_equals: expected (object) null but got (string) "state1"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-state-repeated-await-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-state-repeated-await-expected.txt
@@ -1,3 +1,3 @@
-FAIL: Timed out waiting for notifyDone to be called
 
-{"error": {"code": 404, "message": "404"}}
+PASS navigate() with state should work correctly when called repeatedly - with awaits
+

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-state-repeated-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-state-repeated-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL navigate() with state should work correctly when called repeatedly promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'navigation.currentEntry.getState().foo')"
+PASS navigate() with state should work correctly when called repeatedly
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-intercept-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-intercept-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT navigate() and intercept() with a fulfilled promise Test timed out
+PASS navigate() and intercept() with a fulfilled promise
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-intercept-interrupted-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-intercept-interrupted-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL interrupted navigate() promises with intercept() assert_equals: expected 3 but got 1
+FAIL interrupted navigate() promises with intercept() assert_unreached: Should have rejected: undefined Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-intercept-rejected-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-intercept-rejected-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT navigate() and intercept() with a rejected promise Test timed out
+FAIL navigate() and intercept() with a rejected promise assert_unreached: Should have rejected: undefined Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-pagehide-unserializablestate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-pagehide-unserializablestate-expected.txt
@@ -1,5 +1,4 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: Error: assert_throws_dom: function "() => { throw committedReason; }" threw undefined with type "undefined", not an object
 
 
-FAIL reload() with an unserializable state inside onpagehide throws "DataCloneError", not "InvalidStateError" assert_equals: expected 1 but got 0
+PASS reload() with an unserializable state inside onpagehide throws "DataCloneError", not "InvalidStateError"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-intercept-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-intercept-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL dispose events when forward-pruning same-document entries assert_equals: expected 3 but got 4
+PASS dispose events when forward-pruning same-document entries
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-replace-with-intercept-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-replace-with-intercept-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL dispose events when doing a same-document replace using navigation.navigate() and intercept() assert_true: expected true got false
+PASS dispose events when doing a same-document replace using navigation.navigate() and intercept()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-away-and-back-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-away-and-back-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL entry.getState() behavior after navigating away and back assert_equals: expected 1 but got 2
+FAIL entry.getState() behavior after navigating away and back assert_equals: expected 2 but got 1
 

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -352,6 +352,8 @@ public:
     void loadItem(HistoryItem&, HistoryItem* fromItem, FrameLoadType, ShouldTreatAsContinuingLoad);
     HistoryItem* requestedHistoryItem() const { return m_requestedHistoryItem.get(); }
 
+    void updateURLAndHistory(const URL&, RefPtr<SerializedScriptValue>&& stateObject, NavigationHistoryBehavior = NavigationHistoryBehavior::Replace);
+
 private:
     enum FormSubmissionCacheLoadPolicy {
         MayAttemptCacheOnlyLoadForFormSubmissionItem,

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -302,17 +302,8 @@ ExceptionOr<void> History::stateObjectAdded(RefPtr<SerializedScriptValue>&& data
 
     m_mostRecentStateObjectUsage = payloadSize;
 
-    if (!urlString.isEmpty())
-        frame->protectedDocument()->updateURLForPushOrReplaceState(fullURL);
-
-    if (stateObjectType == StateObjectType::Push) {
-        frame->checkedHistory()->pushState(WTFMove(data), fullURL.string());
-        frame->loader().client().dispatchDidPushStateWithinPage();
-    } else if (stateObjectType == StateObjectType::Replace) {
-        frame->checkedHistory()->replaceState(WTFMove(data), fullURL.string());
-        frame->loader().client().dispatchDidReplaceStateWithinPage();
-    }
-
+    auto historyBehavior = stateObjectType == StateObjectType::Replace ? NavigationHistoryBehavior::Replace : NavigationHistoryBehavior::Push;
+    frame->loader().updateURLAndHistory(fullURL, WTFMove(data), historyBehavior);
     return { };
 }
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -706,7 +706,10 @@ bool Navigation::innerDispatchNavigateEvent(NavigationNavigationType navigationT
         if (navigationType == NavigationNavigationType::Traverse)
             m_suppressNormalScrollRestorationDuringOngoingNavigation = true;
 
-        // FIXME: Step 7: URL and history update
+        if (navigationType == NavigationNavigationType::Push || navigationType == NavigationNavigationType::Replace) {
+            auto historyHandling = navigationType == NavigationNavigationType::Replace ? NavigationHistoryBehavior::Replace : NavigationHistoryBehavior::Push;
+            frame()->loader().updateURLAndHistory(destination->url(), classicHistoryAPIState, historyHandling);
+        }
     }
 
     if (endResultIsSameDocument) {


### PR DESCRIPTION
#### 43c0f59f9fe5fa1c151c14f95132c90f075d4890
<pre>
[Navigation] On intercepted navigations properly update url and history
<a href="https://bugs.webkit.org/show_bug.cgi?id=276375">https://bugs.webkit.org/show_bug.cgi?id=276375</a>

Reviewed by Darin Adler.

Per the spec an interception can immediately apply the new navigation to
the browsers history.

<a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigate-event-firing">https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigate-event-firing</a>:url-and-history-update-steps-2

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-intercept-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/currententrychange-event/navigation-navigate-replace-intercept-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-and-navigate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-handler-returns-non-promise-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-handler-throws-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-history-pushState-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-history-replaceState-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-multiple-times-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-popstate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-resolve-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/intercept-same-document-history-back-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-intercept-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-replace-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/no-referrer-dynamic-url-censored-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-history-push-same-url-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-intercept-history-state-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-state-repeated-await-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/navigate-state-repeated-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-intercept-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-intercept-interrupted-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/navigate-intercept-rejected-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/reload-rejection-order-pagehide-unserializablestate-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-intercept-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/per-entry-events/dispose-same-document-replace-with-intercept-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/state/cross-document-away-and-back-expected.txt:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::updateURLAndHistory):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/page/History.cpp:
(WebCore::History::stateObjectAdded):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::innerDispatchNavigateEvent):

Canonical link: <a href="https://commits.webkit.org/281063@main">https://commits.webkit.org/281063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e5b0d5b9ad6f3b560cc0f5c96f0185a63148acb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58538 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62164 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8982 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60667 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47390 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6396 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35443 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50611 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28242 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32193 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7913 "Found 1 new test failure: imported/w3c/web-platform-tests/mathml/relations/html5-tree/dynamic-childlist-002.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7986 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54145 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8184 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63867 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2451 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8192 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54709 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2459 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50637 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54788 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12935 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2071 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33694 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34780 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35864 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34525 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->