### PR TITLE
[view-transitions] Fix context menu and hit testing when view transition is running

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/hit-test-pseudo-element-element-from-point-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/hit-test-pseudo-element-element-from-point-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Hit-testing view transition pseudo-elements should always return the document element
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/hit-test-pseudo-element-element-from-point.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/hit-test-pseudo-element-element-from-point.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<title>View transitions: hit testing the pseudo-elements should always return the document element</title>
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+html { view-transition-name: none; }
+
+body { margin: 0; }
+
+#target {
+  width: 100px;
+  height: 100vh;
+  view-transition-name: target;
+}
+
+::view-transition {
+  background-color: green;
+}
+
+::view-transition,
+::view-transition-group(target),
+::view-transition-image-pair(target) {
+  height: 100%;
+  padding-left: 100px;
+}
+
+::view-transition-group(target) {
+  animation-duration: 30s;
+  background-color: lightgreen;
+}
+
+::view-transition-image-pair(target) {
+  height: 100%;
+  background-color: skyblue;
+  animation: none;
+  margin-left: 100px;
+}
+
+::view-transition-old(target) {
+  height: 100%;
+  width: 100px;
+  animation: none;
+  background-color: navy;
+}
+::view-transition-new(target) {
+  height: 100%;
+  width: 100px;
+  margin-left: 100px;
+  animation: none;
+  background-color: purple;
+}
+</style>
+
+<div id=target></div>
+
+<script>
+async_test(t => {
+  assert_implements(document.startViewTransition, "Missing document.startViewTransition");
+  document.startViewTransition(() => {
+    requestAnimationFrame(async () => {
+      // ::view-transition-group
+      t.step(() => assert_equals(document.elementFromPoint(20, 20), document.documentElement));
+      // ::view-transition-image-pair
+      t.step(() => assert_equals(document.elementFromPoint(120, 20), document.documentElement));
+      // ::view-transition-old
+      t.step(() => assert_equals(document.elementFromPoint(220, 20), document.documentElement));
+      // ::view-transition-new
+      t.step(() => assert_equals(document.elementFromPoint(320, 20), document.documentElement));
+      // ::view-transition
+      t.step(() => assert_equals(document.elementFromPoint(420, 20), document.documentElement));
+      t.done();
+    });
+  });
+}, "Hit-testing view transition pseudo-elements should always return the document element");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/hit-test-unpainted-element-from-point-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/hit-test-unpainted-element-from-point-expected.txt
@@ -1,4 +1,3 @@
 
-FAIL hit test should not hit unpainted element, but does hit pseudo and unrelated elements assert_equals: expected Element node <body><div id="target" class="after"></div>
-<div id="unre... but got Element node <div id="target" class="after"></div>
+PASS hit test should not hit unpainted element, but does hit pseudo and unrelated elements
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/hit-test-unpainted-element-from-point.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/hit-test-unpainted-element-from-point.html
@@ -63,9 +63,9 @@ async_test(t => {
     target.classList.toggle("before");
     target.classList.toggle("after");
     requestAnimationFrame(async () => {
-      // Check the old location of the element, we should get body.
+      // Check the location of the element, we should get body.
       t.step(() => assert_equals(document.elementFromPoint(20, 20), document.body));
-      // Check the new location of the pseudo element, we should get documentElement,
+      // Check the location of the pseudo element for the old snapshot, we should get documentElement,
       // which is the originating element for the pseudo element.
       t.step(() => assert_equals(document.elementFromPoint(220, 20), document.documentElement));
       // Check the spot that used to be covered by the element but now has

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1957,9 +1957,10 @@ bool RenderBlock::isPointInOverflowControl(HitTestResult& result, const LayoutPo
 
 Node* RenderBlock::nodeForHitTest() const
 {
+    switch (style().pseudoElementType()) {
     // If we're a ::backdrop pseudo-element, we should hit-test to the element that generated it.
     // This matches the behavior that other browsers have.
-    if (style().pseudoElementType() == PseudoId::Backdrop) {
+    case PseudoId::Backdrop:
         for (auto& element : document().topLayerElements()) {
             if (!element->renderer())
                 continue;
@@ -1968,6 +1969,16 @@ Node* RenderBlock::nodeForHitTest() const
                 return element.ptr();
         }
         ASSERT_NOT_REACHED();
+        break;
+
+    // The view transition pseudo-elements should hit-test to their originating element (the document element).
+    case PseudoId::ViewTransition:
+    case PseudoId::ViewTransitionGroup:
+    case PseudoId::ViewTransitionImagePair:
+        return document().documentElement();
+
+    default:
+        break;
     }
 
     // If we are in the margins of block elements that are part of a

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -4148,6 +4148,10 @@ RenderLayer::HitLayer RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLa
     if (!isSelfPaintingLayer() && !hasSelfPaintingLayerDescendant())
         return { nullptr };
 
+    // Renderers that are captured in a view transition are not hit tested.
+    if (renderer().effectiveCapturedInViewTransition())
+        return { nullptr };
+
     // If we're hit testing 'SVG clip content' (aka. RenderSVGResourceClipper) do not early exit.
     if (!request.svgClipContent()) {
         // SVG resource layers and their children are never hit tested.

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.cpp
@@ -113,6 +113,12 @@ LayoutPoint RenderViewTransitionCapture::captureContentInset() const
     return location;
 }
 
+Node* RenderViewTransitionCapture::nodeForHitTest() const
+{
+    // The view transition pseudo-elements should hit-test to their originating element (the document element).
+    return document().documentElement();
+}
+
 String RenderViewTransitionCapture::debugDescription() const
 {
     StringBuilder builder;

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.h
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.h
@@ -60,6 +60,8 @@ private:
 
     void updateFromStyle() override;
 
+    Node* nodeForHitTest() const override;
+
     RefPtr<ImageBuffer> m_oldImage;
     // The overflow rect that the captured image represents, in RenderLayer coordinates
     // of the captured renderer (see layerToLayoutOffset in ViewTransition.cpp).


### PR DESCRIPTION
#### a07047cc7bce61b5aae4f2bfca6868d8d1a37b86
<pre>
[view-transitions] Fix context menu and hit testing when view transition is running
<a href="https://bugs.webkit.org/show_bug.cgi?id=275556">https://bugs.webkit.org/show_bug.cgi?id=275556</a>
<a href="https://rdar.apple.com/129976270">rdar://129976270</a>

Reviewed by Matt Woodrow.

The context menu was broken because hit-testing was returning no element.

View transition pseudo-elements should hit-test to their originating element (document element).

Elements that are captured in a view transition should be ignored from hit testing.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/hit-test-pseudo-element-element-from-point-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/hit-test-pseudo-element-element-from-point.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/hit-test-unpainted-element-from-point-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/hit-test-unpainted-element-from-point.html:
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::nodeForHitTest const):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::hitTestLayer):
* Source/WebCore/rendering/RenderViewTransitionCapture.cpp:
(WebCore::RenderViewTransitionCapture::nodeForHitTest const):
* Source/WebCore/rendering/RenderViewTransitionCapture.h:

Canonical link: <a href="https://commits.webkit.org/280154@main">https://commits.webkit.org/280154@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/817e28b15a59b47c88773a0553899cadbad71d54

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58862 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6298 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57992 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6494 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/44984 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4345 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33083 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48158 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26118 "Found 1 new API test failure: /WPE/TestMultiprocess:/webkit/WebKitWebView/multiprocess-create-ready-close (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29867 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5486 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4441 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5757 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60451 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5887 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52414 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48227 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51911 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12381 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31019 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32103 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33185 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31851 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->