### PR TITLE
[JSC] Add simple ByVal handlers

### DIFF
--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
@@ -369,6 +369,8 @@ public:
 
     static void emitDataICPrologue(CCallHelpers&);
     static void emitDataICEpilogue(CCallHelpers&);
+    static CCallHelpers::Jump emitDataICCheckStructure(CCallHelpers&, GPRReg baseGPR, GPRReg scratchGPR);
+    static CCallHelpers::JumpList emitDataICCheckUid(CCallHelpers&, bool isSymbol, JSValueRegs, GPRReg scratchGPR);
     static void emitDataICJumpNextHandler(CCallHelpers&);
 
     bool useHandlerIC() const;
@@ -435,6 +437,24 @@ MacroAssemblerCodeRef<JITThunkPtrTag> inByIdHitHandler(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> inByIdMissHandler(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> instanceOfHitHandler(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> instanceOfMissHandler(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithStringLoadOwnPropertyHandlerCodeGenerator(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithStringLoadPrototypePropertyHandlerCodeGenerator(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithStringMissHandlerCodeGenerator(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithSymbolLoadOwnPropertyHandlerCodeGenerator(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithSymbolLoadPrototypePropertyHandlerCodeGenerator(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithSymbolMissHandlerCodeGenerator(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithStringReplaceHandlerCodeGenerator(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithStringTransitionNonAllocatingHandlerCodeGenerator(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithStringTransitionNewlyAllocatingHandlerCodeGenerator(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithStringTransitionReallocatingHandlerCodeGenerator(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithSymbolReplaceHandlerCodeGenerator(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithSymbolTransitionNonAllocatingHandlerCodeGenerator(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithSymbolTransitionNewlyAllocatingHandlerCodeGenerator(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> putByValWithSymbolTransitionReallocatingHandlerCodeGenerator(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> inByValWithStringHitHandler(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> inByValWithStringMissHandler(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> inByValWithSymbolHitHandler(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> inByValWithSymbolMissHandler(VM&);
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/jit/GPRInfo.h
+++ b/Source/JavaScriptCore/jit/GPRInfo.h
@@ -48,28 +48,25 @@ static constexpr GPRReg InvalidGPRReg { GPRReg::InvalidGPRReg };
 #if USE(JSVALUE64)
 class JSValueRegs {
 public:
-    constexpr JSValueRegs()
-        : m_gpr(InvalidGPRReg)
-    {
-    }
-    
+    constexpr JSValueRegs() = default;
+
     constexpr explicit JSValueRegs(GPRReg gpr)
         : m_gpr(gpr)
     {
     }
     
-    static JSValueRegs payloadOnly(GPRReg gpr)
+    static constexpr JSValueRegs payloadOnly(GPRReg gpr)
     {
         return JSValueRegs(gpr);
     }
     
-    static JSValueRegs withTwoAvailableRegs(GPRReg gpr, GPRReg)
+    static constexpr JSValueRegs withTwoAvailableRegs(GPRReg gpr, GPRReg)
     {
         return JSValueRegs(gpr);
     }
     
-    bool operator!() const { return m_gpr == InvalidGPRReg; }
-    explicit operator bool() const { return m_gpr != InvalidGPRReg; }
+    constexpr bool operator!() const { return m_gpr == InvalidGPRReg; }
+    explicit constexpr operator bool() const { return m_gpr != InvalidGPRReg; }
 
     friend constexpr bool operator==(const JSValueRegs&, const JSValueRegs&) = default;
 
@@ -88,7 +85,7 @@ public:
     void dump(PrintStream&) const;
     
     // Intentionally public to make JSValueRegs usable for template parameters.
-    GPRReg m_gpr;
+    GPRReg m_gpr { InvalidGPRReg };
 };
 
 class JSValueSource {
@@ -167,12 +164,8 @@ private:
 #if USE(JSVALUE32_64)
 class JSValueRegs {
 public:
-    constexpr JSValueRegs()
-        : m_tagGPR(InvalidGPRReg)
-        , m_payloadGPR(InvalidGPRReg)
-    {
-    }
-    
+    constexpr JSValueRegs() = default;
+
     constexpr JSValueRegs(GPRReg tagGPR, GPRReg payloadGPR)
         : m_tagGPR(tagGPR)
         , m_payloadGPR(payloadGPR)
@@ -189,8 +182,8 @@ public:
         return JSValueRegs(InvalidGPRReg, payloadGPR);
     }
     
-    bool operator!() const { return !static_cast<bool>(*this); }
-    explicit operator bool() const
+    constexpr bool operator!() const { return !static_cast<bool>(*this); }
+    explicit constexpr operator bool() const
     {
         return static_cast<GPRReg>(m_tagGPR) != InvalidGPRReg
             || static_cast<GPRReg>(m_payloadGPR) != InvalidGPRReg;
@@ -226,8 +219,8 @@ public:
     void dump(PrintStream&) const;
     
     // Intentionally public to make JSValueRegs usable for template parameters.
-    GPRReg m_tagGPR;
-    GPRReg m_payloadGPR;
+    GPRReg m_tagGPR { InvalidGPRReg };
+    GPRReg m_payloadGPR { InvalidGPRReg };
 };
 
 class JSValueSource {

--- a/Source/JavaScriptCore/jit/JITThunks.h
+++ b/Source/JavaScriptCore/jit/JITThunks.h
@@ -91,6 +91,24 @@ class NativeExecutable;
     macro(InByIdMissHandler, inByIdMissHandler) \
     macro(InstanceOfHitHandler, instanceOfHitHandler) \
     macro(InstanceOfMissHandler, instanceOfMissHandler) \
+    macro(GetByValWithStringLoadOwnPropertyHandler, getByValWithStringLoadOwnPropertyHandlerCodeGenerator) \
+    macro(GetByValWithStringLoadPrototypePropertyHandler, getByValWithStringLoadPrototypePropertyHandlerCodeGenerator) \
+    macro(GetByValWithStringMissHandler, getByValWithStringMissHandlerCodeGenerator) \
+    macro(GetByValWithSymbolLoadOwnPropertyHandler, getByValWithSymbolLoadOwnPropertyHandlerCodeGenerator) \
+    macro(GetByValWithSymbolLoadPrototypePropertyHandler, getByValWithSymbolLoadPrototypePropertyHandlerCodeGenerator) \
+    macro(GetByValWithSymbolMissHandler, getByValWithSymbolMissHandlerCodeGenerator) \
+    macro(PutByValWithStringReplaceHandler, putByValWithStringReplaceHandlerCodeGenerator) \
+    macro(PutByValWithStringTransitionNonAllocatingHandler, putByValWithStringTransitionNonAllocatingHandlerCodeGenerator) \
+    macro(PutByValWithStringTransitionNewlyAllocatingHandler, putByValWithStringTransitionNewlyAllocatingHandlerCodeGenerator) \
+    macro(PutByValWithStringTransitionReallocatingHandler, putByValWithStringTransitionReallocatingHandlerCodeGenerator) \
+    macro(PutByValWithSymbolReplaceHandler, putByValWithSymbolReplaceHandlerCodeGenerator) \
+    macro(PutByValWithSymbolTransitionNonAllocatingHandler, putByValWithSymbolTransitionNonAllocatingHandlerCodeGenerator) \
+    macro(PutByValWithSymbolTransitionNewlyAllocatingHandler, putByValWithSymbolTransitionNewlyAllocatingHandlerCodeGenerator) \
+    macro(PutByValWithSymbolTransitionReallocatingHandler, putByValWithSymbolTransitionReallocatingHandlerCodeGenerator) \
+    macro(InByValWithStringHitHandler, inByValWithStringHitHandler) \
+    macro(InByValWithStringMissHandler, inByValWithStringMissHandler) \
+    macro(InByValWithSymbolHitHandler, inByValWithSymbolHitHandler) \
+    macro(InByValWithSymbolMissHandler, inByValWithSymbolMissHandler) \
 
 #if ENABLE(YARR_JIT_BACKREFERENCES_FOR_16BIT_EXPRS)
 #define JSC_FOR_EACH_YARR_JIT_BACKREFERENCES_THUNK(macro) \


### PR DESCRIPTION
#### 8b9a484586ea691225d52739ef780a8878ed8fbd
<pre>
[JSC] Add simple ByVal handlers
<a href="https://bugs.webkit.org/show_bug.cgi?id=275644">https://bugs.webkit.org/show_bug.cgi?id=275644</a>
<a href="https://rdar.apple.com/130117255">rdar://130117255</a>

Reviewed by Yijia Huang.

This patch adds simple handlers for ByVal cases. In particular, this patch adds GetByVal Load/Miss, PutByVal Replace/Transition, and InByVal InHit/InMiss.
These cases are dominated in code-generating handlers right now.

* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::emitDataICCheckStructure):
(JSC::InlineCacheCompiler::emitDataICCheckUid):
(JSC::InlineCacheHandler::createPreCompiled):
(JSC::loadHandlerImpl):
(JSC::getByIdLoadHandlerCodeGeneratorImpl):
(JSC::getByIdMissHandlerCodeGenerator):
(JSC::getByIdCustomHandlerImpl):
(JSC::getByIdGetterHandler):
(JSC::getByIdProxyObjectLoadHandler):
(JSC::putByIdReplaceHandlerCodeGenerator):
(JSC::transitionHandlerImpl):
(JSC::putByIdTransitionHandlerCodeGeneratorImpl):
(JSC::putByIdCustomHandlerImpl):
(JSC::putByIdSetterHandlerImpl):
(JSC::inByIdInHandlerImpl):
(JSC::instanceOfHandlerImpl):
(JSC::getByValLoadHandlerCodeGeneratorImpl):
(JSC::getByValWithStringLoadOwnPropertyHandlerCodeGenerator):
(JSC::getByValWithStringLoadPrototypePropertyHandlerCodeGenerator):
(JSC::getByValWithSymbolLoadOwnPropertyHandlerCodeGenerator):
(JSC::getByValWithSymbolLoadPrototypePropertyHandlerCodeGenerator):
(JSC::getByValMissHandlerCodeGeneratorImpl):
(JSC::getByValWithStringMissHandlerCodeGenerator):
(JSC::getByValWithSymbolMissHandlerCodeGenerator):
(JSC::putByValReplaceHandlerCodeGeneratorImpl):
(JSC::putByValWithStringReplaceHandlerCodeGenerator):
(JSC::putByValWithSymbolReplaceHandlerCodeGenerator):
(JSC::putByValTransitionHandlerCodeGeneratorImpl):
(JSC::putByValWithStringTransitionNonAllocatingHandlerCodeGenerator):
(JSC::putByValWithSymbolTransitionNonAllocatingHandlerCodeGenerator):
(JSC::putByValWithStringTransitionNewlyAllocatingHandlerCodeGenerator):
(JSC::putByValWithSymbolTransitionNewlyAllocatingHandlerCodeGenerator):
(JSC::putByValWithStringTransitionReallocatingHandlerCodeGenerator):
(JSC::putByValWithSymbolTransitionReallocatingHandlerCodeGenerator):
(JSC::inByValInHandlerImpl):
(JSC::inByValWithStringHitHandler):
(JSC::inByValWithStringMissHandler):
(JSC::inByValWithSymbolHitHandler):
(JSC::inByValWithSymbolMissHandler):
(JSC::InlineCacheCompiler::compileOneAccessCaseHandler):
(JSC::InlineCacheCompiler::compileGetByIdDOMJITHandler):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.h:
* Source/JavaScriptCore/jit/GPRInfo.h:
(JSC::JSValueRegs::payloadOnly):
(JSC::JSValueRegs::withTwoAvailableRegs):
(JSC::JSValueRegs::operator! const):
(JSC::JSValueRegs::operator bool const):
* Source/JavaScriptCore/jit/JITThunks.h:

Canonical link: <a href="https://commits.webkit.org/280199@main">https://commits.webkit.org/280199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c3934ff0abed059f59731db7625a1829852c2cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58943 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6376 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6572 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45052 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4407 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57973 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33171 "Found 60 new test failures: accessibility/accessibility-node-reparent.html accessibility/ancestor-computation.html accessibility/announcement-notification.html accessibility/aria-braillelabel.html accessibility/aria-brailleroledescription.html accessibility/aria-checked-mixed-value.html accessibility/aria-current-state-changed-notification.html accessibility/aria-current.html accessibility/aria-describedby-on-input.html accessibility/aria-description.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48236 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26190 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29954 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5564 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4519 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/49020 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51926 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5835 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60530 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/55180 "Built successfully and passed tests") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5956 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52480 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48305 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51999 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/76941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8278 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31097 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/76941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32181 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33263 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31929 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->