### PR TITLE
[UnifiedPDF] Crash under UnifiedPDFPlugin::performCopyEditingOperation() when using Command-C to copy on a full frame plugin with empty selection

### DIFF
--- a/Source/WebCore/plugins/PluginViewBase.h
+++ b/Source/WebCore/plugins/PluginViewBase.h
@@ -75,6 +75,7 @@ public:
     virtual id accessibilityAssociatedPluginParentForElement(Element*) const { return nullptr; }
 #endif
     virtual void setPDFDisplayModeForTesting(const String&) { };
+    virtual bool sendEditingCommandToPDFForTesting(const String&, const String&) { return false; }
     virtual Vector<FloatRect> pdfAnnotationRectsForTesting() const { return { }; }
 
     virtual void releaseMemory() { }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7458,6 +7458,19 @@ void Internals::setPDFDisplayModeForTesting(Element& element, const String& disp
     pluginViewBase->setPDFDisplayModeForTesting(displayMode);
 }
 
+bool Internals::sendEditingCommandToPDFForTesting(Element& element, const String& commandName, const String& argument) const
+{
+    RefPtr pluginElement = dynamicDowncast<HTMLPlugInElement>(element);
+    if (!pluginElement)
+        return false;
+
+    RefPtr pluginViewBase = pluginElement->pluginWidget();
+    if (!pluginViewBase)
+        return false;
+
+    return pluginViewBase->sendEditingCommandToPDFForTesting(commandName, argument);
+}
+
 Vector<Internals::PDFAnnotationRect> Internals::pdfAnnotationRectsForTesting(Element& element) const
 {
     Vector<PDFAnnotationRect> annotationRects;

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1469,6 +1469,7 @@ public:
 
     Vector<PDFAnnotationRect> pdfAnnotationRectsForTesting(Element& pluginElement) const;
     void setPDFDisplayModeForTesting(Element&, const String&) const;
+    bool sendEditingCommandToPDFForTesting(Element&, const String& commandName, const String& argument) const;
     void registerPDFTest(Ref<VoidCallback>&&, Element&);
 
     const String& defaultSpatialTrackingLabel() const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1348,6 +1348,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     sequence<PDFAnnotationRect> pdfAnnotationRectsForTesting(Element element);
     undefined registerPDFTest(VoidCallback callback, Element element);
     undefined setPDFDisplayModeForTesting(Element element, DOMString mode);
+    boolean sendEditingCommandToPDFForTesting(Element element, DOMString commandName, optional DOMString argument = "");
 
     readonly attribute DOMString defaultSpatialTrackingLabel;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -3123,13 +3123,23 @@ bool UnifiedPDFPlugin::performCopyEditingOperation() const
         return false;
     }
 
-    NSString *plainString = [m_currentSelection string];
-    NSString *htmlString = [m_currentSelection html];
-    NSData *webArchiveData = [m_currentSelection webArchive];
+    NSMutableArray *types = [NSMutableArray array];
+    NSMutableArray *items = [NSMutableArray array];
 
-    NSArray *types = @[ PasteboardTypes::WebArchivePboardType, NSPasteboardTypeString, NSPasteboardTypeHTML ];
+    if (NSData *webArchiveData = [m_currentSelection webArchive]) {
+        [types addObject:PasteboardTypes::WebArchivePboardType];
+        [items addObject:webArchiveData];
+    }
 
-    NSArray *items = @[ webArchiveData, [plainString dataUsingEncoding:NSUTF8StringEncoding], [htmlString dataUsingEncoding:NSUTF8StringEncoding] ];
+    if (NSData *plainStringData = [[m_currentSelection string] dataUsingEncoding:NSUTF8StringEncoding]) {
+        [types addObject:NSPasteboardTypeString];
+        [items addObject:plainStringData];
+    }
+
+    if (NSData *htmlStringData = [[m_currentSelection html] dataUsingEncoding:NSUTF8StringEncoding]) {
+        [types addObject:NSPasteboardTypeHTML];
+        [items addObject:htmlStringData];
+    }
 
     writeItemsToPasteboard(NSPasteboardNameGeneral, items, types);
     return true;

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -1032,6 +1032,11 @@ void PluginView::didSameDocumentNavigationForFrame(WebFrame& frame)
     return protectedPlugin()->didSameDocumentNavigationForFrame(frame);
 }
 
+bool PluginView::sendEditingCommandToPDFForTesting(const String& commandName, const String& argument)
+{
+    return protectedPlugin()->handleEditingCommand(commandName, argument);
+}
+
 void PluginView::setPDFDisplayModeForTesting(const String& mode)
 {
     protectedPlugin()->setPDFDisplayModeForTesting(mode);

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -207,6 +207,7 @@ private:
     // This snapshot is used to avoid side effects should the plugin run JS during painting.
     RefPtr<WebCore::ShareableBitmap> m_transientPaintingSnapshot;
 
+    bool sendEditingCommandToPDFForTesting(const String& commandName, const String& argument) final;
     void setPDFDisplayModeForTesting(const String&) final;
     Vector<WebCore::FloatRect> pdfAnnotationRectsForTesting() const override;
     void registerPDFTestCallback(RefPtr<WebCore::VoidCallback> &&) final;


### PR DESCRIPTION
#### 1d977e76f609d034cf9b24a1e739d1b8988d93e6
<pre>
[UnifiedPDF] Crash under UnifiedPDFPlugin::performCopyEditingOperation() when using Command-C to copy on a full frame plugin with empty selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=275639">https://bugs.webkit.org/show_bug.cgi?id=275639</a>
<a href="https://rdar.apple.com/129820140">rdar://129820140</a>

Reviewed by Wenson Hsieh and Sammy Gill.

We were crashing under performCopyEditingOperation() when trying to
build up an NSArray of pasteboard items because we failed to ensure that
one (or more) of the web archive, plain string, and HTML data
representations were nil. It is entirely possible for, say,
-[NSString dataUsingEncoding:] to return nil if the conversion is lossy.

To address this crash, we ensure each data representation we want to put
on the pasteboard is non-nil before adding them to the NSArray collecting
said items.

* Source/WebCore/plugins/PluginViewBase.h:
(WebCore::PluginViewBase::sendEditingCommandToPDFForTesting):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::sendEditingCommandToPDFForTesting const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::performCopyEditingOperation const):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::sendEditingCommandToPDFForTesting):
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:
(TestWebKitAPI::TEST(UnifiedPDF, CopyEditingCommandOnEmptySelectionShouldNotCrash)):

Canonical link: <a href="https://commits.webkit.org/280163@main">https://commits.webkit.org/280163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a7a53d5af05b5b4c36e7b4b6a47a6aedba52eec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58867 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6303 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/57997 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42816 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6499 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/44988 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4349 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57900 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33087 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48166 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26122 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29871 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5494 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4446 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5765 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60456 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5890 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52421 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48235 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51920 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12384 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31024 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32108 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33190 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31856 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->