### PR TITLE
fast/events/touch/touch-constructor.html needs a baseline.

### DIFF
--- a/LayoutTests/fast/events/touch/touch-constructor-expected.txt
+++ b/LayoutTests/fast/events/touch/touch-constructor-expected.txt
@@ -1,0 +1,55 @@
+Test the Touch constructor
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS new Touch({ }) threw exception TypeError: Member TouchInit.identifier is required and must be an instance of long.
+PASS new Touch({ identifier: 0 }) threw exception TypeError: Member TouchInit.target is required and must be an instance of EventTarget.
+PASS new Touch({ target: document.body }) threw exception TypeError: Member TouchInit.identifier is required and must be an instance of long.
+PASS new Touch({ identifier: 0, target: null }) threw exception TypeError: Type error.
+
+PASS touch = new Touch({ identifier: 1, target: document.body }) did not throw exception.
+PASS createdTouch.identifier is init.identifier
+PASS createdTouch.target is init.target
+PASS createdTouch.screenX is 0
+PASS createdTouch.screenY is 0
+PASS createdTouch.pageX is 0
+PASS createdTouch.pageY is 0
+PASS createdTouch.clientX is 0
+PASS createdTouch.clientY is 0
+PASS createdTouch.radiusX is 0
+PASS createdTouch.radiusY is 0
+PASS createdTouch.rotationAngle is 0
+PASS createdTouch.force is 0
+
+PASS touch = new Touch({ identifier: 1, target: document.body, clientX: 1, clientY: 2, screenX: 3, screenY: 4, pageX: 5, pageY: 6, force: 7, radiusX: 8, radiusY: 9, rotationAngle: 10 }) did not throw exception.
+PASS createdTouch.identifier is init.identifier
+PASS createdTouch.target is init.target
+PASS createdTouch.screenX is init.screenX
+PASS createdTouch.screenY is init.screenY
+PASS createdTouch.pageX is init.pageX
+PASS createdTouch.pageY is init.pageY
+PASS createdTouch.clientX is init.clientX
+PASS createdTouch.clientY is init.clientY
+PASS createdTouch.radiusX is init.radiusX
+PASS createdTouch.radiusY is init.radiusY
+PASS createdTouch.rotationAngle is init.rotationAngle
+PASS createdTouch.force is init.force
+
+PASS touch = new Touch({ identifier: 1, target: document.body, clientX: 1.5, clientY: 2.5, screenX: 3.5, screenY: 4.5, pageX: 5.5, pageY: 6.5, force: 7.5, radiusX: 8.5, radiusY: 9.5, rotationAngle: 10.5 }) did not throw exception.
+PASS createdTouch.identifier is init.identifier
+PASS createdTouch.target is init.target
+PASS createdTouch.screenX is init.screenX
+PASS createdTouch.screenY is init.screenY
+PASS createdTouch.pageX is init.pageX
+PASS createdTouch.pageY is init.pageY
+PASS createdTouch.clientX is init.clientX
+PASS createdTouch.clientY is init.clientY
+PASS createdTouch.radiusX is init.radiusX
+PASS createdTouch.radiusY is init.radiusY
+PASS createdTouch.rotationAngle is init.rotationAngle
+PASS createdTouch.force is init.force
+PASS successfullyParsed is true
+
+TEST COMPLETE
+


### PR DESCRIPTION
#### f617e21d0bd10351e19c2a270b279b35247c0c4b
<pre>
fast/events/touch/touch-constructor.html needs a baseline.
<a href="https://bugs.webkit.org/show_bug.cgi?id=275653">https://bugs.webkit.org/show_bug.cgi?id=275653</a>
<a href="https://rdar.apple.com/130130408">rdar://130130408</a>

Unreviewed.

Adding baseline for fast/events/touch/touch-constructor.html.

* LayoutTests/fast/events/touch/touch-constructor-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/280162@main">https://commits.webkit.org/280162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7f773543b217ab9dc62119abe9e0de8bf7adee0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55894 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58890 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/6326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6522 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/45004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/6326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57923 "Failed to checkout and rebase branch from PR 29970") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/33108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/48191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/26140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/29892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/5519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4469 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/5790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/60479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5908 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/60479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/48260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/60479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8260 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31047 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/32131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33213 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/31879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->