### PR TITLE
Use WTF::forward_like instead of std::forward_like

### DIFF
--- a/Source/WTF/wtf/StdLibExtras.h
+++ b/Source/WTF/wtf/StdLibExtras.h
@@ -782,16 +782,14 @@ using remove_cvref_t = typename remove_cvref<T>::type;
 }
 #endif
 
-#if !(defined(__cpp_lib_forward_like) && __cpp_lib_forward_like >= 202207L)
-namespace std {
+namespace WTF {
 namespace detail {
-template<typename T, typename U> using copy_const = conditional_t<is_const_v<T>, const U, U>;
-template<typename T, typename U> using override_ref = conditional_t<is_rvalue_reference_v<T>, remove_reference_t<U>&&, U&>;
-template<typename T, typename U> using forward_like_impl = override_ref<T&&, copy_const<remove_reference_t<T>, remove_reference_t<U>>>;
+template<typename T, typename U> using copy_const = std::conditional_t<std::is_const_v<T>, const U, U>;
+template<typename T, typename U> using override_ref = std::conditional_t<std::is_rvalue_reference_v<T>, std::remove_reference_t<U>&&, U&>;
+template<typename T, typename U> using forward_like_impl = override_ref<T&&, copy_const<std::remove_reference_t<T>, std::remove_reference_t<U>>>;
 } // namespace detail
 template<typename T, typename U> constexpr auto forward_like(U&& value) -> detail::forward_like_impl<T, U> { return static_cast<detail::forward_like_impl<T, U>>(value); }
-} // namespace std
-#endif
+} // namespace WTF
 
 using WTF::GB;
 using WTF::KB;

--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -303,7 +303,7 @@ template<typename T> struct ArgumentCoder<std::unique_ptr<T>> {
         static_assert(std::is_same_v<std::remove_cvref_t<U>, std::unique_ptr<T>>);
 
         if (object)
-            encoder << true << std::forward_like<U>(*object);
+            encoder << true << WTF::forward_like<U>(*object);
         else
             encoder << false;
     }
@@ -330,7 +330,7 @@ template<typename T> struct ArgumentCoder<UniqueRef<T>> {
     static void encode(Encoder& encoder, U&& object)
     {
         static_assert(std::is_same_v<std::remove_cvref_t<U>, UniqueRef<T>>);
-        encoder << std::forward_like<U>(*object);
+        encoder << WTF::forward_like<U>(*object);
     }
 
     template<typename Decoder>
@@ -382,7 +382,7 @@ template<typename KeyType, typename ValueType> struct ArgumentCoder<WTF::KeyValu
     static void encode(Encoder& encoder, T&& pair)
     {
         static_assert(std::is_same_v<std::remove_cvref_t<T>, WTF::KeyValuePair<KeyType, ValueType>>);
-        encoder << std::forward_like<T>(pair.key) << std::forward_like<T>(pair.value);
+        encoder << WTF::forward_like<T>(pair.key) << WTF::forward_like<T>(pair.value);
     }
 
     template<typename Decoder>
@@ -407,7 +407,7 @@ template<typename T, size_t size> struct ArgumentCoder<std::array<T, size>> {
         static_assert(std::is_same_v<std::remove_cvref_t<U>, std::array<T, size>>);
 
         for (auto&& item : array)
-            encoder << std::forward_like<U>(item);
+            encoder << WTF::forward_like<U>(item);
     }
 
     template<typename Decoder, typename... DecodedTypes>
@@ -458,7 +458,7 @@ template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t min
 
         encoder << static_cast<size_t>(vector.size());
         for (auto&& item : vector)
-            encoder << std::forward_like<U>(item);
+            encoder << WTF::forward_like<U>(item);
     }
 
     template<typename Decoder>
@@ -523,7 +523,7 @@ template<typename KeyArg, typename MappedArg, typename HashArg, typename KeyTrai
 
         encoder << static_cast<unsigned>(hashMap.size());
         for (auto&& entry : hashMap)
-            encoder << std::forward_like<T>(entry);
+            encoder << WTF::forward_like<T>(entry);
     }
 
     template<typename Decoder>
@@ -603,7 +603,7 @@ template<typename KeyArg, typename HashArg, typename KeyTraitsArg> struct Argume
 
         encoder << static_cast<unsigned>(hashCountedSet.size());
         for (auto&& entry : hashCountedSet)
-            encoder << std::forward_like<T>(entry);
+            encoder << WTF::forward_like<T>(entry);
     }
 
     template<typename Decoder>


### PR DESCRIPTION
#### 6a853b6f4759c039ccc6764a2614251a27e2a6c4
<pre>
Use WTF::forward_like instead of std::forward_like
<a href="https://bugs.webkit.org/show_bug.cgi?id=275654">https://bugs.webkit.org/show_bug.cgi?id=275654</a>
<a href="https://rdar.apple.com/130130589">rdar://130130589</a>

Reviewed by Yusuke Suzuki.

Microsoft&apos;s STL implementation uses an inferred return type, and clang has some difficulty
seeing that it is actually defined before it is used.  I&apos;m sure we can eventually move back
to using std::forward_like, but since that is the only known blocker to C++23 adoption,
let&apos;s do this now and figure out how to switch back to std::forward_like later.

* Source/WTF/wtf/StdLibExtras.h:
(std::forward_like): Deleted.
* Source/WebKit/Platform/IPC/ArgumentCoders.h:
(IPC::ArgumentCoder&lt;std::unique_ptr&lt;T&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;UniqueRef&lt;T&gt;&gt;::encode):

Canonical link: <a href="https://commits.webkit.org/280187@main">https://commits.webkit.org/280187@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6087ae07cb9a9f26770287a8a25f79c68e6b9090

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55895 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8363 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58891 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6327 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6523 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45007 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4365 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57924 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33111 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48192 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26143 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29895 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5520 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4470 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/48971 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51863 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5791 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60480 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/55131 "Built successfully and passed tests") | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5911 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52435 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48261 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51936 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/76892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8271 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31048 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/76892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32132 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33214 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31880 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->