### PR TITLE
[GStreamer] Make use of gstStructureGet<T>

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -1653,9 +1653,8 @@ void GStreamerMediaEndpoint::processStats(const GValue* value)
 
     // Just check a single timestamp, inbound RTP for instance.
     if (!m_statsFirstDeliveredTimestamp && statsType == GST_WEBRTC_STATS_INBOUND_RTP) {
-        double timestamp;
-        if (gst_structure_get_double(structure, "timestamp", &timestamp)) {
-            auto ts = Seconds::fromMilliseconds(timestamp);
+        if (auto timestamp = gstStructureGet<double>(structure, "timestamp"_s)) {
+            auto ts = Seconds::fromMilliseconds(*timestamp);
             m_statsFirstDeliveredTimestamp = ts;
 
             if (!isStopped() && m_statsLogTimer.repeatInterval() != statsLogInterval(ts)) {

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -144,33 +144,27 @@ static inline RTCRtpEncodingParameters toRTCEncodingParameters(const GstStructur
 {
     RTCRtpEncodingParameters parameters;
 
-    unsigned ssrc;
-    if (gst_structure_get_uint(rtcParameters, "ssrc", &ssrc))
-        parameters.ssrc = ssrc;
+    if (auto ssrc = gstStructureGet<unsigned>(rtcParameters, "ssrc"_s))
+        parameters.ssrc = *ssrc;
 
     gst_structure_get(rtcParameters, "active", G_TYPE_BOOLEAN, &(parameters.active), nullptr);
 
-    uint64_t maxBitrate;
-    if (gst_structure_get_uint64(rtcParameters, "max-bitrate", &maxBitrate))
-        parameters.maxBitrate = maxBitrate;
+    if (auto maxBitrate = gstStructureGet<uint64_t>(rtcParameters, "max-bitrate"_s))
+        parameters.maxBitrate = *maxBitrate;
 
-    uint64_t maxFramerate;
-    if (gst_structure_get_uint64(rtcParameters, "max-framerate", &maxFramerate))
-        parameters.maxFramerate = maxFramerate;
+    if (auto maxFramerate = gstStructureGet<uint64_t>(rtcParameters, "max-framerate"_s))
+        parameters.maxFramerate = *maxFramerate;
 
     parameters.rid = String::fromLatin1(gst_structure_get_string(rtcParameters, "rid"));
 
-    double scaleResolutionDownBy;
-    if (gst_structure_get_double(rtcParameters, "scale-resolution-down-by", &scaleResolutionDownBy))
-        parameters.scaleResolutionDownBy = scaleResolutionDownBy;
+    if (auto scaleResolutionDownBy = gstStructureGet<double>(rtcParameters, "scale-resolution-down-by"_s))
+        parameters.scaleResolutionDownBy = *scaleResolutionDownBy;
 
-    double bitratePriority;
-    if (gst_structure_get_double(rtcParameters, "bitrate-priority", &bitratePriority))
-        parameters.priority = fromWebRTCBitRatePriority(bitratePriority);
+    if (auto bitratePriority = gstStructureGet<double>(rtcParameters, "bitrate-priority"_s))
+        parameters.priority = fromWebRTCBitRatePriority(*bitratePriority);
 
-    int networkPriority;
-    if (gst_structure_get_int(rtcParameters, "network-priority", &networkPriority))
-        parameters.networkPriority = static_cast<RTCPriorityType>(networkPriority);
+    if (auto networkPriority = gstStructureGet<int>(rtcParameters, "network-priority"_s))
+        parameters.networkPriority = static_cast<RTCPriorityType>(*networkPriority);
 
     return parameters;
 }

--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp
@@ -71,10 +71,8 @@ static unsigned long maximumNumberOfOutputChannels()
                 auto* structure = gst_caps_get_structure(caps.get(), i);
                 if (!g_str_equal(gst_structure_get_name(structure), "audio/x-raw"))
                     continue;
-                int value;
-                if (!gst_structure_get_int(structure, "channels", &value))
-                    continue;
-                count = std::max(count, value);
+                if (auto value = gstStructureGet<int>(structure, "channels"_s))
+                    count = std::max(count, *value);
             }
             devices = g_list_delete_link(devices, devices);
         }

--- a/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
@@ -232,14 +232,8 @@ GStreamerInternalAudioEncoder::GStreamerInternalAudioEncoder(AudioEncoder::Descr
                 GstMappedBuffer buffer(header, GST_MAP_READ);
                 configuration.description = { { buffer.data(), buffer.size() } };
             }
-            int numberOfChannels;
-            if (gst_structure_get_int(structure, "channels", &numberOfChannels))
-                configuration.numberOfChannels = numberOfChannels;
-
-            int sampleRate;
-            if (gst_structure_get_int(structure, "rate", &sampleRate))
-                configuration.sampleRate = sampleRate;
-
+            configuration.numberOfChannels = gstStructureGet<int>(structure, "channels"_s);
+            configuration.sampleRate = gstStructureGet<int>(structure, "rate"_s);
             encoder->m_descriptionCallback(WTFMove(configuration));
         });
     }), new ThreadSafeWeakPtr { *this }, [](void* data, GClosure*) {

--- a/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp
@@ -132,12 +132,11 @@ void AudioTrackPrivateGStreamer::updateConfigurationFromCaps(GRefPtr<GstCaps>&& 
 #endif
 
     if (areEncryptedCaps(caps.get())) {
-        int sampleRate, numberOfChannels;
         const auto* structure = gst_caps_get_structure(caps.get(), 0);
-        if (gst_structure_get_int(structure, "rate", &sampleRate))
-            configuration.sampleRate = sampleRate;
-        if (gst_structure_get_int(structure, "channels", &numberOfChannels))
-            configuration.numberOfChannels = numberOfChannels;
+        if (auto sampleRate = gstStructureGet<int>(structure, "rate"_s))
+            configuration.sampleRate = *sampleRate;
+        if (auto numberOfChannels = gstStructureGet<int>(structure, "channels"_s))
+            configuration.numberOfChannels = *numberOfChannels;
         return;
     }
 

--- a/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
@@ -184,11 +184,7 @@ static std::optional<unsigned> retrieveTemporalIndex(const GRefPtr<GstSample>& s
         auto metaStructure = gst_custom_meta_get_structure(meta);
         RELEASE_ASSERT(metaStructure);
         GST_TRACE("Looking-up layer id in %" GST_PTR_FORMAT, metaStructure);
-        unsigned temporalLayerId;
-        if (!gst_structure_get_uint(metaStructure, "layer-id", &temporalLayerId))
-            return { };
-
-        return temporalLayerId;
+        return gstStructureGet<unsigned>(metaStructure, "layer-id"_s);
     }
     GST_TRACE("Retrieval of temporal index from encoded format %s is not yet supported.", gst_structure_get_name(structure));
 #endif

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
@@ -131,9 +131,8 @@ bool RealtimeOutgoingAudioSourceGStreamer::setPayloadType(const GRefPtr<GstCaps>
         gst_structure_remove_field(structure.get(), "minptime");
     }
 
-    int payloadType;
-    if (gst_structure_get_int(structure.get(), "payload", &payloadType)) {
-        g_object_set(m_payloader.get(), "pt", payloadType, nullptr);
+    if (auto payloadType = gstStructureGet<int>(structure.get(), "payload"_s)) {
+        g_object_set(m_payloader.get(), "pt", *payloadType, nullptr);
         gst_structure_remove_field(structure.get(), "payload");
     }
 

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp
@@ -178,9 +178,8 @@ bool RealtimeOutgoingVideoSourceGStreamer::setPayloadType(const GRefPtr<GstCaps>
         return false;
     }
 
-    int payloadType;
-    if (gst_structure_get_int(structure.get(), "payload", &payloadType))
-        g_object_set(m_payloader.get(), "pt", payloadType, nullptr);
+    if (auto payloadType = gstStructureGet<int>(structure.get(), "payload"_s))
+        g_object_set(m_payloader.get(), "pt", *payloadType, nullptr);
 
     if (m_payloaderState) {
         g_object_set(m_payloader.get(), "seqnum-offset", m_payloaderState->seqnum, nullptr);


### PR DESCRIPTION
#### 06463409ee8aa2a75c70ac1fcc8abb4c363755c2
<pre>
[GStreamer] Make use of gstStructureGet&lt;T&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=275658">https://bugs.webkit.org/show_bug.cgi?id=275658</a>

Reviewed by Philippe Normand.

Make use of gstStructureGet&lt;T&gt; where it makes sense.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::processStats):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
(WebCore::RTCStatsReport::Stats::Stats):
(WebCore::RTCStatsReport::RtpStreamStats::RtpStreamStats):
(WebCore::RTCStatsReport::SentRtpStreamStats::SentRtpStreamStats):
(WebCore::RTCStatsReport::CodecStats::CodecStats):
(WebCore::RTCStatsReport::ReceivedRtpStreamStats::ReceivedRtpStreamStats):
(WebCore::RTCStatsReport::RemoteInboundRtpStreamStats::RemoteInboundRtpStreamStats):
(WebCore::RTCStatsReport::RemoteOutboundRtpStreamStats::RemoteOutboundRtpStreamStats):
(WebCore::RTCStatsReport::InboundRtpStreamStats::InboundRtpStreamStats):
(WebCore::RTCStatsReport::OutboundRtpStreamStats::OutboundRtpStreamStats):
(WebCore::RTCStatsReport::PeerConnectionStats::PeerConnectionStats):
(WebCore::RTCStatsReport::IceCandidateStats::IceCandidateStats):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::toRTCEncodingParameters):
* Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.cpp:
(WebCore::maximumNumberOfOutputChannels):
* Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp:
(WebCore::GStreamerInternalAudioEncoder::GStreamerInternalAudioEncoder):
* Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp:
(WebCore::AudioTrackPrivateGStreamer::updateConfigurationFromCaps):
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp:
(WebCore::retrieveTemporalIndex):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingAudioSourceGStreamer::setPayloadType):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingVideoSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingVideoSourceGStreamer::setPayloadType):

Canonical link: <a href="https://commits.webkit.org/280177@main">https://commits.webkit.org/280177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66579a3a30a88ee806167414a25299e1bdc70bff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35246 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58931 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6354 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58048 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6550 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/45040 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4386 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57951 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48216 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26178 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5544 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4497 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5815 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60508 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5933 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52457 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48285 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51971 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12390 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/input-targets-root-while-render-blocked.html (failure)") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8266 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31075 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32159 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33241 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31907 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->