### PR TITLE
Expose 'RTCEncodedVideoFrame' and 'RTCEncodedAudioFrame' to 'Window'

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/idlharness.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/idlharness.https.window-expected.txt
@@ -30,25 +30,25 @@ PASS SFrameTransformErrorEvent interface: existence and properties of interface 
 PASS SFrameTransformErrorEvent interface: attribute errorType
 FAIL SFrameTransformErrorEvent interface: attribute keyID assert_true: The prototype object must have a property "keyID" expected true got false
 FAIL SFrameTransformErrorEvent interface: attribute frame assert_true: The prototype object must have a property "frame" expected true got false
-FAIL RTCEncodedVideoFrame interface: existence and properties of interface object assert_own_property: self does not have own property "RTCEncodedVideoFrame" expected property "RTCEncodedVideoFrame" missing
-FAIL RTCEncodedVideoFrame interface object length assert_own_property: self does not have own property "RTCEncodedVideoFrame" expected property "RTCEncodedVideoFrame" missing
-FAIL RTCEncodedVideoFrame interface object name assert_own_property: self does not have own property "RTCEncodedVideoFrame" expected property "RTCEncodedVideoFrame" missing
-FAIL RTCEncodedVideoFrame interface: existence and properties of interface prototype object assert_own_property: self does not have own property "RTCEncodedVideoFrame" expected property "RTCEncodedVideoFrame" missing
-FAIL RTCEncodedVideoFrame interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "RTCEncodedVideoFrame" expected property "RTCEncodedVideoFrame" missing
-FAIL RTCEncodedVideoFrame interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "RTCEncodedVideoFrame" expected property "RTCEncodedVideoFrame" missing
-FAIL RTCEncodedVideoFrame interface: attribute type assert_own_property: self does not have own property "RTCEncodedVideoFrame" expected property "RTCEncodedVideoFrame" missing
-FAIL RTCEncodedVideoFrame interface: attribute timestamp assert_own_property: self does not have own property "RTCEncodedVideoFrame" expected property "RTCEncodedVideoFrame" missing
-FAIL RTCEncodedVideoFrame interface: attribute data assert_own_property: self does not have own property "RTCEncodedVideoFrame" expected property "RTCEncodedVideoFrame" missing
-FAIL RTCEncodedVideoFrame interface: operation getMetadata() assert_own_property: self does not have own property "RTCEncodedVideoFrame" expected property "RTCEncodedVideoFrame" missing
-FAIL RTCEncodedAudioFrame interface: existence and properties of interface object assert_own_property: self does not have own property "RTCEncodedAudioFrame" expected property "RTCEncodedAudioFrame" missing
-FAIL RTCEncodedAudioFrame interface object length assert_own_property: self does not have own property "RTCEncodedAudioFrame" expected property "RTCEncodedAudioFrame" missing
-FAIL RTCEncodedAudioFrame interface object name assert_own_property: self does not have own property "RTCEncodedAudioFrame" expected property "RTCEncodedAudioFrame" missing
-FAIL RTCEncodedAudioFrame interface: existence and properties of interface prototype object assert_own_property: self does not have own property "RTCEncodedAudioFrame" expected property "RTCEncodedAudioFrame" missing
-FAIL RTCEncodedAudioFrame interface: existence and properties of interface prototype object's "constructor" property assert_own_property: self does not have own property "RTCEncodedAudioFrame" expected property "RTCEncodedAudioFrame" missing
-FAIL RTCEncodedAudioFrame interface: existence and properties of interface prototype object's @@unscopables property assert_own_property: self does not have own property "RTCEncodedAudioFrame" expected property "RTCEncodedAudioFrame" missing
-FAIL RTCEncodedAudioFrame interface: attribute timestamp assert_own_property: self does not have own property "RTCEncodedAudioFrame" expected property "RTCEncodedAudioFrame" missing
-FAIL RTCEncodedAudioFrame interface: attribute data assert_own_property: self does not have own property "RTCEncodedAudioFrame" expected property "RTCEncodedAudioFrame" missing
-FAIL RTCEncodedAudioFrame interface: operation getMetadata() assert_own_property: self does not have own property "RTCEncodedAudioFrame" expected property "RTCEncodedAudioFrame" missing
+PASS RTCEncodedVideoFrame interface: existence and properties of interface object
+PASS RTCEncodedVideoFrame interface object length
+PASS RTCEncodedVideoFrame interface object name
+PASS RTCEncodedVideoFrame interface: existence and properties of interface prototype object
+PASS RTCEncodedVideoFrame interface: existence and properties of interface prototype object's "constructor" property
+PASS RTCEncodedVideoFrame interface: existence and properties of interface prototype object's @@unscopables property
+PASS RTCEncodedVideoFrame interface: attribute type
+PASS RTCEncodedVideoFrame interface: attribute timestamp
+PASS RTCEncodedVideoFrame interface: attribute data
+PASS RTCEncodedVideoFrame interface: operation getMetadata()
+PASS RTCEncodedAudioFrame interface: existence and properties of interface object
+PASS RTCEncodedAudioFrame interface object length
+PASS RTCEncodedAudioFrame interface object name
+PASS RTCEncodedAudioFrame interface: existence and properties of interface prototype object
+PASS RTCEncodedAudioFrame interface: existence and properties of interface prototype object's "constructor" property
+PASS RTCEncodedAudioFrame interface: existence and properties of interface prototype object's @@unscopables property
+PASS RTCEncodedAudioFrame interface: attribute timestamp
+PASS RTCEncodedAudioFrame interface: attribute data
+PASS RTCEncodedAudioFrame interface: operation getMetadata()
 PASS RTCTransformEvent interface: existence and properties of interface object
 PASS RTCRtpScriptTransformer interface: existence and properties of interface object
 PASS RTCRtpScriptTransform interface: existence and properties of interface object

--- a/Source/WebCore/Modules/mediastream/RTCEncodedAudioFrame.idl
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedAudioFrame.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,6 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/webrtc-encoded-transform/#RTCEncodedAudioFrameMetadata
+
 [
     Conditional=WEB_RTC,
     JSGenerateToJSObject,
@@ -32,10 +34,12 @@ dictionary RTCEncodedAudioFrameMetadata {
     sequence<unsigned long> contributingSources;
 };
 
+// https://w3c.github.io/webrtc-encoded-transform/#RTCEncodedAudioFrame-interface
+
 [
     Conditional=WEB_RTC,
     EnabledBySetting=WebRTCEncodedTransformEnabled,
-    Exposed=DedicatedWorker,
+    Exposed=(Window,DedicatedWorker),
 ] interface RTCEncodedAudioFrame {
     readonly attribute unsigned long long timestamp;
     attribute ArrayBuffer data;

--- a/Source/WebCore/Modules/mediastream/RTCEncodedVideoFrame.idl
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedVideoFrame.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,7 +23,11 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// https://w3c.github.io/webrtc-encoded-transform/#RTCEncodedVideoFrameType
+
 enum RTCEncodedVideoFrameType { "empty", "key", "delta" };
+
+// // https://w3c.github.io/webrtc-encoded-transform/#RTCEncodedVideoFrameMetadata
 
 [
     Conditional=WEB_RTC,
@@ -41,10 +45,12 @@ dictionary RTCEncodedVideoFrameMetadata {
     // sequence<unsigned long> contributingSources;
 };
 
+// https://w3c.github.io/webrtc-encoded-transform/#RTCEncodedVideoFrame-interface
+
 [
     Conditional=WEB_RTC,
     EnabledBySetting=WebRTCEncodedTransformEnabled,
-    Exposed=DedicatedWorker,
+    Exposed=(Window,DedicatedWorker),
 ] interface RTCEncodedVideoFrame {
     readonly attribute RTCEncodedVideoFrameType type;
     readonly attribute unsigned long long timestamp;


### PR DESCRIPTION
#### b6d3b63a9d78fcbc286ac2c6e72a8d94c2b8c218
<pre>
Expose &apos;RTCEncodedVideoFrame&apos; and &apos;RTCEncodedAudioFrame&apos; to &apos;Window&apos;

<a href="https://bugs.webkit.org/show_bug.cgi?id=264687">https://bugs.webkit.org/show_bug.cgi?id=264687</a>
<a href="https://rdar.apple.com/problem/118607685">rdar://problem/118607685</a>

Reviewed by Youenn Fablet.

This patch aligns WebKit with web-specification [1], [2] and expose both
interfaces to &apos;Window&apos; alongside &apos;DedicatedWorker&apos;.

[1] <a href="https://w3c.github.io/webrtc-encoded-transform/#RTCEncodedAudioFrame-interface">https://w3c.github.io/webrtc-encoded-transform/#RTCEncodedAudioFrame-interface</a>
[2] <a href="https://w3c.github.io/webrtc-encoded-transform/#RTCEncodedVideoFrame-interface">https://w3c.github.io/webrtc-encoded-transform/#RTCEncodedVideoFrame-interface</a>

* Source/WebCore/Modules/mediastream/RTCEncodedAudioFrame.idl:
* Source/WebCore/Modules/mediastream/RTCEncodedVideoFrame.idl:
* LayoutTests/imported/w3c/web-platform-tests/webrtc-encoded-transform/idlharness.https.window-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/280198@main">https://commits.webkit.org/280198@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac51e58e1d1042a0ebe61bd727aad257d220e2cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55933 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8401 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58932 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6365 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58059 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6561 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45041 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4398 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48227 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26179 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29933 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5555 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4508 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51901 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5826 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60519 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5946 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52469 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48296 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51986 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12405 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31086 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32170 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33252 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31918 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->