### PR TITLE
Add `onbegin` event in `SVGAnimationElement.idl`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt
@@ -1636,7 +1636,7 @@ PASS SVGAnimationElement interface: existence and properties of interface protot
 PASS SVGAnimationElement interface: existence and properties of interface prototype object's "constructor" property
 PASS SVGAnimationElement interface: existence and properties of interface prototype object's @@unscopables property
 PASS SVGAnimationElement interface: attribute targetElement
-FAIL SVGAnimationElement interface: attribute onbegin assert_true: The prototype object must have a property "onbegin" expected true got false
+PASS SVGAnimationElement interface: attribute onbegin
 FAIL SVGAnimationElement interface: attribute onend assert_true: The prototype object must have a property "onend" expected true got false
 PASS SVGAnimationElement interface: attribute onrepeat
 PASS SVGAnimationElement interface: operation getStartTime()
@@ -1657,7 +1657,7 @@ PASS SVGAnimateElement interface: existence and properties of interface prototyp
 PASS SVGAnimateElement must be primary interface of objects.animate
 PASS Stringification of objects.animate
 PASS SVGAnimationElement interface: objects.animate must inherit property "targetElement" with the proper type
-FAIL SVGAnimationElement interface: objects.animate must inherit property "onbegin" with the proper type assert_inherits: property "onbegin" not found in prototype chain
+PASS SVGAnimationElement interface: objects.animate must inherit property "onbegin" with the proper type
 FAIL SVGAnimationElement interface: objects.animate must inherit property "onend" with the proper type assert_inherits: property "onend" not found in prototype chain
 PASS SVGAnimationElement interface: objects.animate must inherit property "onrepeat" with the proper type
 PASS SVGAnimationElement interface: objects.animate must inherit property "getStartTime()" with the proper type
@@ -1685,7 +1685,7 @@ PASS SVGSetElement interface: existence and properties of interface prototype ob
 PASS SVGSetElement must be primary interface of objects.set
 PASS Stringification of objects.set
 PASS SVGAnimationElement interface: objects.set must inherit property "targetElement" with the proper type
-FAIL SVGAnimationElement interface: objects.set must inherit property "onbegin" with the proper type assert_inherits: property "onbegin" not found in prototype chain
+PASS SVGAnimationElement interface: objects.set must inherit property "onbegin" with the proper type
 FAIL SVGAnimationElement interface: objects.set must inherit property "onend" with the proper type assert_inherits: property "onend" not found in prototype chain
 PASS SVGAnimationElement interface: objects.set must inherit property "onrepeat" with the proper type
 PASS SVGAnimationElement interface: objects.set must inherit property "getStartTime()" with the proper type
@@ -1713,7 +1713,7 @@ PASS SVGAnimateMotionElement interface: existence and properties of interface pr
 PASS SVGAnimateMotionElement must be primary interface of objects.animateMotion
 PASS Stringification of objects.animateMotion
 PASS SVGAnimationElement interface: objects.animateMotion must inherit property "targetElement" with the proper type
-FAIL SVGAnimationElement interface: objects.animateMotion must inherit property "onbegin" with the proper type assert_inherits: property "onbegin" not found in prototype chain
+PASS SVGAnimationElement interface: objects.animateMotion must inherit property "onbegin" with the proper type
 FAIL SVGAnimationElement interface: objects.animateMotion must inherit property "onend" with the proper type assert_inherits: property "onend" not found in prototype chain
 PASS SVGAnimationElement interface: objects.animateMotion must inherit property "onrepeat" with the proper type
 PASS SVGAnimationElement interface: objects.animateMotion must inherit property "getStartTime()" with the proper type
@@ -1756,7 +1756,7 @@ PASS SVGAnimateTransformElement interface: existence and properties of interface
 PASS SVGAnimateTransformElement must be primary interface of objects.animateTransform
 PASS Stringification of objects.animateTransform
 PASS SVGAnimationElement interface: objects.animateTransform must inherit property "targetElement" with the proper type
-FAIL SVGAnimationElement interface: objects.animateTransform must inherit property "onbegin" with the proper type assert_inherits: property "onbegin" not found in prototype chain
+PASS SVGAnimationElement interface: objects.animateTransform must inherit property "onbegin" with the proper type
 FAIL SVGAnimationElement interface: objects.animateTransform must inherit property "onend" with the proper type assert_inherits: property "onend" not found in prototype chain
 PASS SVGAnimationElement interface: objects.animateTransform must inherit property "onrepeat" with the proper type
 PASS SVGAnimationElement interface: objects.animateTransform must inherit property "getStartTime()" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative-expected.txt
@@ -89,5 +89,6 @@ PASS getAttributeType("dummy", "onunhandledrejection", "dummyNs", attrNs)
 PASS getAttributeType("dummy", "onunload", "dummyNs", attrNs)
 PASS getAttributeType("dummy", "onencrypted", "dummyNs", attrNs)
 PASS getAttributeType("dummy", "onwaitingforkey", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onbegin", "dummyNs", attrNs)
 PASS getAttributeType("dummy", "onrepeat", "dummyNs", attrNs)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative-expected.txt
@@ -499,11 +499,13 @@ PASS AUDIO.setAttribute(onwaitingforkey, "unsafe_handler()") calls default polic
 PASS AUDIO.setAttributeNS(onwaitingforkey, "unsafe_handler()") calls default policy
 PASS VIDEO.setAttribute(onwaitingforkey, "unsafe_handler()") calls default policy
 PASS VIDEO.setAttributeNS(onwaitingforkey, "unsafe_handler()") calls default policy
+PASS animation.setAttribute(onbegin, "unsafe_handler()") calls default policy
+PASS animation.setAttributeNS(onbegin, "unsafe_handler()") calls default policy
 PASS animation.setAttribute(onrepeat, "unsafe_handler()") calls default policy
 PASS animation.setAttributeNS(onrepeat, "unsafe_handler()") calls default policy
 PASS DIV.setAttribute("onafterprint", "unsafe_handler()") calls default policy
 PASS DIV.setAttribute("onwaitingforkey", "unsafe_handler()") calls default policy
-FAIL DIV.setAttribute("onbegin", "unsafe_handler()") calls default policy assert_equals: expected (string) "Element onbegin" but got (undefined) undefined
+PASS DIV.setAttribute("onbegin", "unsafe_handler()") calls default policy
 FAIL DIV.setAttribute("onreadystatechange", "unsafe_handler()") does not call default policy assert_equals: expected (undefined) undefined but got (string) "Element onreadystatechange"
 FAIL DIV.setAttribute("onvisibilitychange", "unsafe_handler()") does not call default policy assert_equals: expected (undefined) undefined but got (string) "Element onvisibilitychange"
 FAIL DIV.setAttribute("ondevicemotion", "unsafe_handler()") does not call default policy assert_equals: expected (undefined) undefined but got (string) "Element ondevicemotion"

--- a/Source/WebCore/dom/EventNames.json
+++ b/Source/WebCore/dom/EventNames.json
@@ -37,6 +37,7 @@
     "beforeprint": { },
     "beforetoggle": { },
     "beforeunload": { },
+    "begin": { },
     "beginEvent": { },
     "blocked": { },
     "blur": { "defaultEventHandler": true },

--- a/Source/WebCore/svg/SVGAnimationElement.idl
+++ b/Source/WebCore/svg/SVGAnimationElement.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006, 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2009 Cameron McCormack <cam@mcc.id.au>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,6 +40,7 @@
     undefined endElement();
     undefined endElementAt(float offset);
 
+    attribute EventHandler onbegin;
     attribute EventHandler onrepeat;
 };
 


### PR DESCRIPTION
#### db45fa396ca71e63e7879629e810755c7c818f22
<pre>
Add `onbegin` event in `SVGAnimationElement.idl`
<a href="https://bugs.webkit.org/show_bug.cgi?id=275669">https://bugs.webkit.org/show_bug.cgi?id=275669</a>
<a href="https://rdar.apple.com/problem/130609424">rdar://problem/130609424</a>

Reviewed by Said Abou-Hallawa.

This patch adds &apos;onbegin&apos; event in &apos;SVGAnimationElement&apos; IDL interface
as per web specification [1]:

[1] <a href="https://svgwg.org/specs/animations/#InterfaceSVGAnimationElement">https://svgwg.org/specs/animations/#InterfaceSVGAnimationElement</a>

* Source/WebCore/dom/EventNames.json:
* Source/WebCore/svg/SVGAnimationElement.idl:
* LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt:

&gt; Rebaselines:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative-expected.txt:

Canonical link: <a href="https://commits.webkit.org/299724@main">https://commits.webkit.org/299724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c422b189ed332095294bbdbc18c857c3b2890bc3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/119962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/39655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30306 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/126294 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/72035 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d8cc8a48-7757-4d20-a33c-13c3eaef4c8e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/121838 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/40350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/48232 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/91099 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/60411 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bdfc2711-bdb9-40ea-8da2-7b4d9039ce41) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/122914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/32229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/107565 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/71655 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/d683b5c9-f286-41a3-8277-466de610e40f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/31260 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/25671 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/69927 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/101704 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25859 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/129208 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/46882 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/35545 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/99717 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/47248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/103754 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/99562 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/25281 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/45015 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/23030 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/43503 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/46744 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/52450 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/46210 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/49559 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/47896 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->