### PR TITLE
[Writing Tools] Rename Writing Tools methods

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -1423,8 +1423,8 @@
 /* Label for the support with Apple Pay button. */
 "Support with Apple Pay" = "Support with Apple Pay";
 
-/* Swap characters context menu item */
-"Swap characters" = "Swap characters";
+/* Writing Tools context menu item */
+"Writing Tools" = "Writing Tools";
 
 /* File Upload alert sheet camera button string for taking only photos */
 "Take Photo (file upload action sheet)" = "Take Photo";

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -130,7 +130,7 @@ class EmptyContextMenuClient final : public ContextMenuClient {
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    void handleSwapCharacters(IntRect) final { };
+    void handleWritingTools(IntRect) final { };
 #endif
 
 #if PLATFORM(GTK)

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -664,9 +664,9 @@ public:
     virtual double baseViewportLayoutSizeScaleFactor() const { return 1; }
 
 #if ENABLE(WRITING_TOOLS)
-    virtual void textReplacementSessionShowInformationForReplacementWithIDRelativeToRect(const WritingTools::SessionID&, const WritingTools::TextSuggestionID&, IntRect) { }
+    virtual void proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WritingTools::SessionID&, const WritingTools::TextSuggestionID&, IntRect) { }
 
-    virtual void textReplacementSessionUpdateStateForReplacementWithID(const WritingTools::SessionID&, WritingTools::TextSuggestionState, const WritingTools::TextSuggestionID&) { }
+    virtual void proofreadingSessionUpdateStateForSuggestionWithID(const WritingTools::SessionID&, WritingTools::TextSuggestionState, const WritingTools::TextSuggestionID&) { }
 
     virtual void removeTextAnimationForID(const WritingTools::SessionID&) { }
 

--- a/Source/WebCore/page/ContextMenuClient.h
+++ b/Source/WebCore/page/ContextMenuClient.h
@@ -63,7 +63,7 @@ public:
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    virtual void handleSwapCharacters(IntRect selectionBoundsInRootView) = 0;
+    virtual void handleWritingTools(IntRect selectionBoundsInRootView) = 0;
 #endif
 
 #if PLATFORM(GTK)

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -647,10 +647,10 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
 #endif
         break;
 
-    case ContextMenuItemTagSwapCharacters:
+    case ContextMenuItemTagWritingTools:
 #if ENABLE(WRITING_TOOLS)
         if (RefPtr view = frame->view())
-            m_client->handleSwapCharacters(view->contentsToRootView(enclosingIntRect(frame->selection().selectionBounds())));
+            m_client->handleWritingTools(view->contentsToRootView(enclosingIntRect(frame->selection().selectionBounds())));
 #endif
         break;
 
@@ -1045,8 +1045,8 @@ void ContextMenuController::populate()
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-        ContextMenuItem swapCharactersItem(ContextMenuItemType::Action, ContextMenuItemTagSwapCharacters, contextMenuItemTagSwapCharacters());
-        appendItem(swapCharactersItem, m_contextMenu.get());
+        ContextMenuItem writingToolsItem(ContextMenuItemType::Action, ContextMenuItemTagWritingTools, contextMenuItemTagWritingTools());
+        appendItem(writingToolsItem, m_contextMenu.get());
 #endif
 
 #if !PLATFORM(GTK)
@@ -1800,7 +1800,7 @@ void ContextMenuController::checkOrEnableIfNeeded(ContextMenuItem& item) const
             break;
         case ContextMenuItemTagLookUpImage:
         case ContextMenuItemTagTranslate:
-        case ContextMenuItemTagSwapCharacters:
+        case ContextMenuItemTagWritingTools:
             break;
     }
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4853,39 +4853,39 @@ void Page::gamepadsRecentlyAccessed()
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-void Page::willBeginTextReplacementSession(const std::optional<WritingTools::Session>& session, CompletionHandler<void(const Vector<WritingTools::Context>&)>&& completionHandler)
+void Page::willBeginWritingToolsSession(const std::optional<WritingTools::Session>& session, CompletionHandler<void(const Vector<WritingTools::Context>&)>&& completionHandler)
 {
-    m_writingToolsController->willBeginTextReplacementSession(session, WTFMove(completionHandler));
+    m_writingToolsController->willBeginWritingToolsSession(session, WTFMove(completionHandler));
 }
 
-void Page::didBeginTextReplacementSession(const WritingTools::Session& session, const Vector<WritingTools::Context>& contexts)
+void Page::didBeginWritingToolsSession(const WritingTools::Session& session, const Vector<WritingTools::Context>& contexts)
 {
-    m_writingToolsController->didBeginTextReplacementSession(session, contexts);
+    m_writingToolsController->didBeginWritingToolsSession(session, contexts);
 }
 
-void Page::textReplacementSessionDidReceiveReplacements(const WritingTools::Session& session, const Vector<WritingTools::TextSuggestion>& replacements, const WritingTools::Context& context, bool finished)
+void Page::proofreadingSessionDidReceiveSuggestions(const WritingTools::Session& session, const Vector<WritingTools::TextSuggestion>& suggestions, const WritingTools::Context& context, bool finished)
 {
-    m_writingToolsController->textReplacementSessionDidReceiveReplacements(session, replacements, context, finished);
+    m_writingToolsController->proofreadingSessionDidReceiveSuggestions(session, suggestions, context, finished);
 }
 
-void Page::textReplacementSessionDidUpdateStateForReplacement(const WritingTools::Session& session, WritingTools::TextSuggestion::State state, const WritingTools::TextSuggestion& replacement, const WritingTools::Context& context)
+void Page::proofreadingSessionDidUpdateStateForSuggestion(const WritingTools::Session& session, WritingTools::TextSuggestion::State state, const WritingTools::TextSuggestion& suggestion, const WritingTools::Context& context)
 {
-    m_writingToolsController->textReplacementSessionDidUpdateStateForReplacement(session, state, replacement, context);
+    m_writingToolsController->proofreadingSessionDidUpdateStateForSuggestion(session, state, suggestion, context);
 }
 
-void Page::didEndTextReplacementSession(const WritingTools::Session& session, bool accepted)
+void Page::didEndWritingToolsSession(const WritingTools::Session& session, bool accepted)
 {
-    m_writingToolsController->didEndTextReplacementSession(session, accepted);
+    m_writingToolsController->didEndWritingToolsSession(session, accepted);
 }
 
-void Page::textReplacementSessionDidReceiveTextWithReplacementRange(const WritingTools::Session& session, const AttributedString& attributedText, const CharacterRange& range, const WritingTools::Context& context, bool finished)
+void Page::compositionSessionDidReceiveTextWithReplacementRange(const WritingTools::Session& session, const AttributedString& attributedText, const CharacterRange& range, const WritingTools::Context& context, bool finished)
 {
-    m_writingToolsController->textReplacementSessionDidReceiveTextWithReplacementRange(session, attributedText, range, context, finished);
+    m_writingToolsController->compositionSessionDidReceiveTextWithReplacementRange(session, attributedText, range, context, finished);
 }
 
-void Page::updateStateForSelectedReplacementIfNeeded()
+void Page::updateStateForSelectedSuggestionIfNeeded()
 {
-    m_writingToolsController->updateStateForSelectedReplacementIfNeeded();
+    m_writingToolsController->updateStateForSelectedSuggestionIfNeeded();
 }
 
 std::optional<SimpleRange> Page::contextRangeForSessionWithID(const WritingTools::Session::ID& sessionID) const
@@ -4893,9 +4893,9 @@ std::optional<SimpleRange> Page::contextRangeForSessionWithID(const WritingTools
     return m_writingToolsController->contextRangeForSessionWithID(sessionID);
 }
 
-void Page::textReplacementSessionDidReceiveEditAction(const WritingTools::Session& session, WritingTools::Action action)
+void Page::writingToolsSessionDidReceiveAction(const WritingTools::Session& session, WritingTools::Action action)
 {
-    m_writingToolsController->textReplacementSessionDidReceiveEditAction(session, action);
+    m_writingToolsController->writingToolsSessionDidReceiveAction(session, action);
 }
 #endif
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1148,21 +1148,21 @@ public:
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    WEBCORE_EXPORT void willBeginTextReplacementSession(const std::optional<WritingTools::Session>&, CompletionHandler<void(const Vector<WritingTools::Context>&)>&&);
+    WEBCORE_EXPORT void willBeginWritingToolsSession(const std::optional<WritingTools::Session>&, CompletionHandler<void(const Vector<WritingTools::Context>&)>&&);
 
-    WEBCORE_EXPORT void didBeginTextReplacementSession(const WritingTools::Session&, const Vector<WritingTools::Context>&);
+    WEBCORE_EXPORT void didBeginWritingToolsSession(const WritingTools::Session&, const Vector<WritingTools::Context>&);
 
-    WEBCORE_EXPORT void textReplacementSessionDidReceiveReplacements(const WritingTools::Session&, const Vector<WritingTools::TextSuggestion>&, const WritingTools::Context&, bool finished);
+    WEBCORE_EXPORT void proofreadingSessionDidReceiveSuggestions(const WritingTools::Session&, const Vector<WritingTools::TextSuggestion>&, const WritingTools::Context&, bool finished);
 
-    WEBCORE_EXPORT void textReplacementSessionDidUpdateStateForReplacement(const WritingTools::Session&, WritingTools::TextSuggestionState, const WritingTools::TextSuggestion&, const WritingTools::Context&);
+    WEBCORE_EXPORT void proofreadingSessionDidUpdateStateForSuggestion(const WritingTools::Session&, WritingTools::TextSuggestionState, const WritingTools::TextSuggestion&, const WritingTools::Context&);
 
-    WEBCORE_EXPORT void didEndTextReplacementSession(const WritingTools::Session&, bool accepted);
+    WEBCORE_EXPORT void didEndWritingToolsSession(const WritingTools::Session&, bool accepted);
 
-    WEBCORE_EXPORT void textReplacementSessionDidReceiveTextWithReplacementRange(const WritingTools::Session&, const AttributedString&, const CharacterRange&, const WritingTools::Context&, bool finished);
+    WEBCORE_EXPORT void compositionSessionDidReceiveTextWithReplacementRange(const WritingTools::Session&, const AttributedString&, const CharacterRange&, const WritingTools::Context&, bool finished);
 
-    WEBCORE_EXPORT void textReplacementSessionDidReceiveEditAction(const WritingTools::Session&, WritingTools::Action);
+    WEBCORE_EXPORT void writingToolsSessionDidReceiveAction(const WritingTools::Session&, WritingTools::Action);
 
-    WEBCORE_EXPORT void updateStateForSelectedReplacementIfNeeded();
+    WEBCORE_EXPORT void updateStateForSelectedSuggestionIfNeeded();
 
     WEBCORE_EXPORT std::optional<SimpleRange> contextRangeForSessionWithID(const WritingTools::SessionID&) const;
 #endif

--- a/Source/WebCore/page/writing-tools/WritingToolsController.h
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.h
@@ -48,21 +48,21 @@ class WritingToolsController final {
 public:
     explicit WritingToolsController(Page&);
 
-    void willBeginTextReplacementSession(const std::optional<WritingTools::Session>&, CompletionHandler<void(const Vector<WritingTools::Context>&)>&&);
+    void willBeginWritingToolsSession(const std::optional<WritingTools::Session>&, CompletionHandler<void(const Vector<WritingTools::Context>&)>&&);
 
-    void didBeginTextReplacementSession(const WritingTools::Session&, const Vector<WritingTools::Context>&);
+    void didBeginWritingToolsSession(const WritingTools::Session&, const Vector<WritingTools::Context>&);
 
-    void textReplacementSessionDidReceiveReplacements(const WritingTools::Session&, const Vector<WritingTools::TextSuggestion>&, const WritingTools::Context&, bool finished);
+    void proofreadingSessionDidReceiveSuggestions(const WritingTools::Session&, const Vector<WritingTools::TextSuggestion>&, const WritingTools::Context&, bool finished);
 
-    void textReplacementSessionDidUpdateStateForReplacement(const WritingTools::Session&, WritingTools::TextSuggestion::State, const WritingTools::TextSuggestion&, const WritingTools::Context&);
+    void proofreadingSessionDidUpdateStateForSuggestion(const WritingTools::Session&, WritingTools::TextSuggestion::State, const WritingTools::TextSuggestion&, const WritingTools::Context&);
 
-    void didEndTextReplacementSession(const WritingTools::Session&, bool accepted);
+    void didEndWritingToolsSession(const WritingTools::Session&, bool accepted);
 
-    void textReplacementSessionDidReceiveTextWithReplacementRange(const WritingTools::Session&, const AttributedString&, const CharacterRange&, const WritingTools::Context&, bool finished);
+    void compositionSessionDidReceiveTextWithReplacementRange(const WritingTools::Session&, const AttributedString&, const CharacterRange&, const WritingTools::Context&, bool finished);
 
-    void textReplacementSessionDidReceiveEditAction(const WritingTools::Session&, WritingTools::Action);
+    void writingToolsSessionDidReceiveAction(const WritingTools::Session&, WritingTools::Action);
 
-    void updateStateForSelectedReplacementIfNeeded();
+    void updateStateForSelectedSuggestionIfNeeded();
 
     // FIXME: Refactor `TextAnimationController` in such a way so as to not explicitly depend on `WritingToolsController`,
     // and then remove this method after doing so.
@@ -131,10 +131,10 @@ private:
     void replaceContentsOfRangeInSession(CompositionState&, const SimpleRange&, RefPtr<DocumentFragment>&&, MatchStyle);
 
     template<WritingTools::Session::Type Type>
-    void textReplacementSessionDidReceiveEditAction(const WritingTools::Session&, WritingTools::Action);
+    void writingToolsSessionDidReceiveAction(const WritingTools::Session&, WritingTools::Action);
 
     template<WritingTools::Session::Type Type>
-    void didEndTextReplacementSession(const WritingTools::Session&, bool accepted);
+    void didEndWritingToolsSession(const WritingTools::Session&, bool accepted);
 
     RefPtr<Document> document() const;
 

--- a/Source/WebCore/platform/ContextMenuItem.cpp
+++ b/Source/WebCore/platform/ContextMenuItem.cpp
@@ -266,7 +266,7 @@ static bool isValidContextMenuAction(WebCore::ContextMenuAction action)
     case ContextMenuAction::ContextMenuItemTagToggleVideoEnhancedFullscreen:
     case ContextMenuAction::ContextMenuItemTagLookUpImage:
     case ContextMenuAction::ContextMenuItemTagTranslate:
-    case ContextMenuAction::ContextMenuItemTagSwapCharacters:
+    case ContextMenuAction::ContextMenuItemTagWritingTools:
     case ContextMenuAction::ContextMenuItemBaseCustomTag:
     case ContextMenuAction::ContextMenuItemLastCustomTag:
     case ContextMenuAction::ContextMenuItemBaseApplicationTag:

--- a/Source/WebCore/platform/ContextMenuItem.h
+++ b/Source/WebCore/platform/ContextMenuItem.h
@@ -157,7 +157,7 @@ enum ContextMenuAction {
     ContextMenuItemTagAddHighlightToNewQuickNote,
     ContextMenuItemTagLookUpImage,
     ContextMenuItemTagTranslate,
-    ContextMenuItemTagSwapCharacters,
+    ContextMenuItemTagWritingTools,
     ContextMenuItemTagCopySubject,
     ContextMenuItemPDFSinglePageContinuous,
     ContextMenuItemPDFTwoPages,

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -504,9 +504,9 @@ String contextMenuItemTagTranslate(const String& selectedString)
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-String contextMenuItemTagSwapCharacters()
+String contextMenuItemTagWritingTools()
 {
-    return WEB_UI_STRING("Swap characters", "Swap characters context menu item");
+    return WEB_UI_STRING("Writing Tools", "Writing Tools context menu item");
 }
 #endif
 

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -177,7 +177,7 @@ namespace WebCore {
     String contextMenuItemTagTranslate(const String& selectedString);
 #endif
 #if ENABLE(WRITING_TOOLS)
-    String contextMenuItemTagSwapCharacters();
+    String contextMenuItemTagWritingTools();
 #endif
 #if ENABLE(UNIFIED_PDF)
     WEBCORE_EXPORT String contextMenuItemPDFOpenWithPreview();

--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -133,7 +133,7 @@ namespace WebCore {
     M(TextShaping) \
     M(Tiling) \
     M(Threading) \
-    M(UnifiedTextReplacement) \
+    M(WritingTools) \
     M(URLParser) \
     M(Viewports) \
     M(ViewTransitions) \

--- a/Source/WebKit/Shared/API/c/WKContextMenuItemTypes.h
+++ b/Source/WebKit/Shared/API/c/WKContextMenuItemTypes.h
@@ -133,7 +133,7 @@ enum {
     kWKContextMenuItemTagRevealImage,
     kWKContextMenuItemTagTranslate,
     kWKContextMenuItemTagCopyCroppedImage,
-    kWKContextMenuItemTagSwapCharacters,
+    kWKContextMenuItemTagWritingTools,
     kWKContextMenuItemTagCopyLinkToHighlight,
     kWKContextMenuItemBaseApplicationTag = 10000
 };

--- a/Source/WebKit/Shared/API/c/WKSharedAPICast.h
+++ b/Source/WebKit/Shared/API/c/WKSharedAPICast.h
@@ -579,8 +579,8 @@ inline WKContextMenuItemTag toAPI(WebCore::ContextMenuAction action)
         return kWKContextMenuItemTagRevealImage;
     case WebCore::ContextMenuItemTagTranslate:
         return kWKContextMenuItemTagTranslate;
-    case WebCore::ContextMenuItemTagSwapCharacters:
-        return kWKContextMenuItemTagSwapCharacters;
+    case WebCore::ContextMenuItemTagWritingTools:
+        return kWKContextMenuItemTagWritingTools;
     case WebCore::ContextMenuItemTagCopySubject:
         return kWKContextMenuItemTagCopyCroppedImage;
     default:
@@ -799,8 +799,8 @@ inline WebCore::ContextMenuAction toImpl(WKContextMenuItemTag tag)
         return WebCore::ContextMenuItemTagLookUpImage;
     case kWKContextMenuItemTagTranslate:
         return WebCore::ContextMenuItemTagTranslate;
-    case kWKContextMenuItemTagSwapCharacters:
-        return WebCore::ContextMenuItemTagSwapCharacters;
+    case kWKContextMenuItemTagWritingTools:
+        return WebCore::ContextMenuItemTagWritingTools;
     case kWKContextMenuItemTagCopyCroppedImage:
         return WebCore::ContextMenuItemTagCopySubject;
     case kWKContextMenuItemTagOpenLinkInThisWindow:

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -383,8 +383,8 @@ public:
     void setAllowsInlinePredictions(bool allows) { m_data.allowsInlinePredictions = allows; }
 
 #if ENABLE(WRITING_TOOLS)
-    WebCore::WritingTools::Behavior unifiedTextReplacementBehavior() const { return m_data.unifiedTextReplacementBehavior; }
-    void setUnifiedTextReplacementBehavior(WebCore::WritingTools::Behavior behavior) { m_data.unifiedTextReplacementBehavior = behavior; }
+    WebCore::WritingTools::Behavior writingToolsBehavior() const { return m_data.writingToolsBehavior; }
+    void setWritingToolsBehavior(WebCore::WritingTools::Behavior behavior) { m_data.writingToolsBehavior = behavior; }
 #endif
 
     void setShouldRelaxThirdPartyCookieBlocking(WebCore::ShouldRelaxThirdPartyCookieBlocking value) { m_data.shouldRelaxThirdPartyCookieBlocking = value; }
@@ -587,7 +587,7 @@ private:
         bool scrollToTextFragmentMarkingEnabled { true };
 
 #if ENABLE(WRITING_TOOLS)
-        WebCore::WritingTools::Behavior unifiedTextReplacementBehavior { WebCore::WritingTools::Behavior::Default };
+        WebCore::WritingTools::Behavior writingToolsBehavior { WebCore::WritingTools::Behavior::Default };
 #endif
 
         WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking { WebCore::ShouldRelaxThirdPartyCookieBlocking::No };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm
@@ -60,7 +60,7 @@ NSString * const _WKMenuItemIdentifierShareMenu = @"WKMenuItemIdentifierShareMen
 NSString * const _WKMenuItemIdentifierSpeechMenu = @"WKMenuItemIdentifierSpeechMenu";
 
 NSString * const _WKMenuItemIdentifierTranslate = @"WKMenuItemIdentifierTranslate";
-NSString * const _WKMenuItemIdentifierSwapCharacters = @"WKMenuItemIdentifierSwapCharacters";
+NSString * const _WKMenuItemIdentifierWritingTools = @"WKMenuItemIdentifierWritingTools";
 NSString * const _WKMenuItemIdentifierCopySubject = @"WKMenuItemIdentifierCopySubject";
 
 NSString * const _WKMenuItemIdentifierSpellingMenu = @"WKMenuItemIdentifierSpellingMenu";

--- a/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h
@@ -61,7 +61,7 @@ WK_EXTERN NSString * const _WKMenuItemIdentifierAddHighlightToCurrentQuickNote W
 WK_EXTERN NSString * const _WKMenuItemIdentifierAddHighlightToNewQuickNote WK_API_AVAILABLE(macos(12.0), ios(15.0));
 
 WK_EXTERN NSString * const _WKMenuItemIdentifierTranslate WK_API_AVAILABLE(macos(12.0), ios(15.0));
-WK_EXTERN NSString * const _WKMenuItemIdentifierSwapCharacters WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+WK_EXTERN NSString * const _WKMenuItemIdentifierWritingTools WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 WK_EXTERN NSString * const _WKMenuItemIdentifierCopySubject WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
 WK_EXTERN NSString * const _WKMenuItemIdentifierSpellingMenu WK_API_AVAILABLE(macos(13.0), ios(16.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -563,12 +563,12 @@ static NSString *defaultApplicationNameForUserAgent()
 
 - (void)setWritingToolsBehavior:(PlatformWritingToolsBehavior)writingToolsBehavior
 {
-    _pageConfiguration->setUnifiedTextReplacementBehavior(WebKit::convertToWebWritingToolsBehavior(writingToolsBehavior));
+    _pageConfiguration->setWritingToolsBehavior(WebKit::convertToWebWritingToolsBehavior(writingToolsBehavior));
 }
 
 - (PlatformWritingToolsBehavior)writingToolsBehavior
 {
-    return WebKit::convertToPlatformWritingToolsBehavior(_pageConfiguration->unifiedTextReplacementBehavior());
+    return WebKit::convertToPlatformWritingToolsBehavior(_pageConfiguration->writingToolsBehavior());
 }
 
 #endif // ENABLE(WRITING_TOOLS)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
@@ -48,13 +48,6 @@ typedef NS_ENUM(NSUInteger, _WKContentSecurityPolicyModeForExtension) {
     _WKContentSecurityPolicyModeForExtensionManifestV3
 } WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
-typedef NS_ENUM(NSUInteger, _WKUnifiedTextReplacementBehavior) {
-    _WKUnifiedTextReplacementBehaviorNone = 0,
-    _WKUnifiedTextReplacementBehaviorDefault,
-    _WKUnifiedTextReplacementBehaviorLimited,
-    _WKUnifiedTextReplacementBehaviorComplete
-} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
-
 @class WKWebView;
 @class _WKApplicationManifest;
 @class _WKVisitedLinkStore;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -248,8 +248,8 @@ struct PerWebProcessState {
     CocoaEdgeInsets _maximumViewportInset;
 
 #if ENABLE(WRITING_TOOLS)
-    RetainPtr<NSMapTable<NSUUID *, WTTextSuggestion *>> _unifiedTextReplacementSessionReplacements;
-    RetainPtr<NSMapTable<NSUUID *, WTSession *>> _unifiedTextReplacementSessions;
+    RetainPtr<NSMapTable<NSUUID *, WTTextSuggestion *>> _writingToolsTextSuggestions;
+    RetainPtr<NSMapTable<NSUUID *, WTSession *>> _writingToolsSessions;
 #endif
 
 #if PLATFORM(MAC)
@@ -402,9 +402,9 @@ struct PerWebProcessState {
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-- (void)_textReplacementSession:(NSUUID *)sessionUUID showInformationForReplacementWithUUID:(NSUUID *)replacementUUID relativeToRect:(CGRect)rect;
+- (void)_proofreadingSessionWithUUID:(NSUUID *)sessionUUID showDetailsForSuggestionWithUUID:(NSUUID *)replacementUUID relativeToRect:(CGRect)rect;
 
-- (void)_textReplacementSession:(NSUUID *)sessionUUID updateState:(WebCore::WritingTools::TextSuggestionState)state forReplacementWithUUID:(NSUUID *)replacementUUID;
+- (void)_proofreadingSessionWithUUID:(NSUUID *)sessionUUID updateState:(WebCore::WritingTools::TextSuggestionState)state forSuggestionWithUUID:(NSUUID *)replacementUUID;
 
 #if PLATFORM(MAC)
 - (NSWritingToolsAllowedInputOptions)writingToolsAllowedInputOptions;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -561,8 +561,6 @@ typedef NS_OPTIONS(NSUInteger, WKDisplayCaptureSurfaces) {
 
 @property (nonatomic, readonly) NSURL *_requiredWebExtensionBaseURL WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
-@property (nonatomic, readonly, getter=_isUnifiedTextReplacementActive) BOOL _unifiedTextReplacementActive WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
-
 @end
 
 #if TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1233,7 +1233,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 #if ENABLE(WRITING_TOOLS)
-- (BOOL)_web_wantsCompleteUnifiedTextReplacementBehavior
+- (BOOL)_web_wantsWritingToolsInlineEditing
 {
     return [self wantsWritingToolsInlineEditing];
 }

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -119,12 +119,12 @@ public:
     WindowKind windowKind() final;
 
 #if ENABLE(WRITING_TOOLS)
-    void textReplacementSessionShowInformationForReplacementWithIDRelativeToRect(const WebCore::WritingTools::SessionID&, const WebCore::WritingTools::TextSuggestionID&, WebCore::IntRect selectionBoundsInRootView) final;
+    void proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::SessionID&, const WebCore::WritingTools::TextSuggestionID&, WebCore::IntRect selectionBoundsInRootView) final;
 
-    void textReplacementSessionUpdateStateForReplacementWithID(const WebCore::WritingTools::SessionID&, WebCore::WritingTools::TextSuggestionState, const WTF::UUID& replacementUUID) final;
+    void proofreadingSessionUpdateStateForSuggestionWithID(const WebCore::WritingTools::SessionID&, WebCore::WritingTools::TextSuggestionState, const WTF::UUID& replacementUUID) final;
 
-    void unifiedTextReplacementActiveWillChange() final;
-    void unifiedTextReplacementActiveDidChange() final;
+    void writingToolsActiveWillChange() final;
+    void writingToolsActiveDidChange() final;
 #endif
 
 #if ENABLE(GAMEPAD)

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -287,24 +287,24 @@ WindowKind PageClientImplCocoa::windowKind()
 }
 
 #if ENABLE(WRITING_TOOLS)
-void PageClientImplCocoa::textReplacementSessionShowInformationForReplacementWithIDRelativeToRect(const WebCore::WritingTools::Session::ID& sessionID, const WebCore::WritingTools::TextSuggestion::ID& replacementID, WebCore::IntRect selectionBoundsInRootView)
+void PageClientImplCocoa::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::Session::ID& sessionID, const WebCore::WritingTools::TextSuggestion::ID& replacementID, WebCore::IntRect selectionBoundsInRootView)
 {
-    [m_webView _textReplacementSession:sessionID showInformationForReplacementWithUUID:replacementID relativeToRect:selectionBoundsInRootView];
+    [m_webView _proofreadingSessionWithUUID:sessionID showDetailsForSuggestionWithUUID:replacementID relativeToRect:selectionBoundsInRootView];
 }
 
-void PageClientImplCocoa::textReplacementSessionUpdateStateForReplacementWithID(const WebCore::WritingTools::Session::ID& sessionID, WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion::ID& replacementID)
+void PageClientImplCocoa::proofreadingSessionUpdateStateForSuggestionWithID(const WebCore::WritingTools::Session::ID& sessionID, WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion::ID& replacementID)
 {
-    [m_webView _textReplacementSession:sessionID updateState:state forReplacementWithUUID:replacementID];
+    [m_webView _proofreadingSessionWithUUID:sessionID updateState:state forSuggestionWithUUID:replacementID];
 }
 
 static NSString *writingToolsActiveKey = @"writingToolsActive";
 
-void PageClientImplCocoa::unifiedTextReplacementActiveWillChange()
+void PageClientImplCocoa::writingToolsActiveWillChange()
 {
     [m_webView willChangeValueForKey:writingToolsActiveKey];
 }
 
-void PageClientImplCocoa::unifiedTextReplacementActiveDidChange()
+void PageClientImplCocoa::writingToolsActiveDidChange()
 {
     [m_webView didChangeValueForKey:writingToolsActiveKey];
 }

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -863,14 +863,14 @@ void WebPageProxy::handleContextMenuTranslation(const TranslationContextMenuInfo
 
 #if ENABLE(WRITING_TOOLS)
 
-bool WebPageProxy::canHandleSwapCharacters() const
+bool WebPageProxy::canHandleContextMenuWritingTools() const
 {
-    return protectedPageClient()->canHandleSwapCharacters();
+    return protectedPageClient()->canHandleContextMenuWritingTools();
 }
 
-void WebPageProxy::handleContextMenuSwapCharacters(WebCore::IntRect selectionBoundsInRootView)
+void WebPageProxy::handleContextMenuWritingTools(WebCore::IntRect selectionBoundsInRootView)
 {
-    protectedPageClient()->handleContextMenuSwapCharacters(selectionBoundsInRootView);
+    protectedPageClient()->handleContextMenuWritingTools(selectionBoundsInRootView);
 }
 
 #endif // ENABLE(WRITING_TOOLS)
@@ -1149,49 +1149,49 @@ bool WebPageProxy::shouldDeactivateMediaCapability() const
 
 #if ENABLE(WRITING_TOOLS)
 
-void WebPageProxy::setUnifiedTextReplacementActive(bool active)
+void WebPageProxy::setWritingToolsActive(bool active)
 {
-    if (m_isUnifiedTextReplacementActive == active)
+    if (m_isWritingToolsActive == active)
         return;
 
-    protectedPageClient()->unifiedTextReplacementActiveWillChange();
-    m_isUnifiedTextReplacementActive = active;
-    protectedPageClient()->unifiedTextReplacementActiveDidChange();
+    protectedPageClient()->writingToolsActiveWillChange();
+    m_isWritingToolsActive = active;
+    protectedPageClient()->writingToolsActiveDidChange();
 }
 
-void WebPageProxy::willBeginTextReplacementSession(const std::optional<WebCore::WritingTools::Session>& session, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&& completionHandler)
+void WebPageProxy::willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>& session, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&& completionHandler)
 {
-    sendWithAsyncReply(Messages::WebPage::WillBeginTextReplacementSession(session), WTFMove(completionHandler));
+    sendWithAsyncReply(Messages::WebPage::WillBeginWritingToolsSession(session), WTFMove(completionHandler));
 }
 
-void WebPageProxy::didBeginTextReplacementSession(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::Context>& contexts)
+void WebPageProxy::didBeginWritingToolsSession(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::Context>& contexts)
 {
-    send(Messages::WebPage::DidBeginTextReplacementSession(session, contexts));
+    send(Messages::WebPage::DidBeginWritingToolsSession(session, contexts));
 }
 
-void WebPageProxy::textReplacementSessionDidReceiveReplacements(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::TextSuggestion>& replacements, const WebCore::WritingTools::Context& context, bool finished)
+void WebPageProxy::proofreadingSessionDidReceiveSuggestions(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::TextSuggestion>& suggestions, const WebCore::WritingTools::Context& context, bool finished)
 {
-    send(Messages::WebPage::TextReplacementSessionDidReceiveReplacements(session, replacements, context, finished));
+    send(Messages::WebPage::ProofreadingSessionDidReceiveSuggestions(session, suggestions, context, finished));
 }
 
-void WebPageProxy::textReplacementSessionDidUpdateStateForReplacement(const WebCore::WritingTools::Session& session, WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion& replacement, const WebCore::WritingTools::Context& context)
+void WebPageProxy::proofreadingSessionDidUpdateStateForSuggestion(const WebCore::WritingTools::Session& session, WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion& suggestion, const WebCore::WritingTools::Context& context)
 {
-    send(Messages::WebPage::TextReplacementSessionDidUpdateStateForReplacement(session, state, replacement, context));
+    send(Messages::WebPage::ProofreadingSessionDidUpdateStateForSuggestion(session, state, suggestion, context));
 }
 
-void WebPageProxy::didEndTextReplacementSession(const WebCore::WritingTools::Session& session, bool accepted)
+void WebPageProxy::didEndWritingToolsSession(const WebCore::WritingTools::Session& session, bool accepted)
 {
-    send(Messages::WebPage::DidEndTextReplacementSession(session, accepted));
+    send(Messages::WebPage::DidEndWritingToolsSession(session, accepted));
 }
 
-void WebPageProxy::textReplacementSessionDidReceiveTextWithReplacementRange(const WebCore::WritingTools::Session& session, const WebCore::AttributedString& attributedText, const WebCore::CharacterRange& range, const WebCore::WritingTools::Context& context, bool finished)
+void WebPageProxy::compositionSessionDidReceiveTextWithReplacementRange(const WebCore::WritingTools::Session& session, const WebCore::AttributedString& attributedText, const WebCore::CharacterRange& range, const WebCore::WritingTools::Context& context, bool finished)
 {
-    send(Messages::WebPage::TextReplacementSessionDidReceiveTextWithReplacementRange(session, attributedText, range, context, finished));
+    send(Messages::WebPage::CompositionSessionDidReceiveTextWithReplacementRange(session, attributedText, range, context, finished));
 }
 
-void WebPageProxy::textReplacementSessionDidReceiveEditAction(const WebCore::WritingTools::Session& session, WebCore::WritingTools::Action action)
+void WebPageProxy::writingToolsSessionDidReceiveAction(const WebCore::WritingTools::Session& session, WebCore::WritingTools::Action action)
 {
-    send(Messages::WebPage::TextReplacementSessionDidReceiveEditAction(session, action));
+    send(Messages::WebPage::WritingToolsSessionDidReceiveAction(session, action));
 }
 
 #endif // ENABLE(WRITING_TOOLS)
@@ -1261,18 +1261,18 @@ void WebPageProxy::removeTextAnimationForID(const WTF::UUID& uuid)
 
 #if ENABLE(WRITING_TOOLS)
 
-void WebPageProxy::textReplacementSessionShowInformationForReplacementWithIDRelativeToRect(const WebCore::WritingTools::Session::ID& sessionID, const WebCore::WritingTools::TextSuggestion::ID& replacementID, WebCore::IntRect selectionBoundsInRootView)
+void WebPageProxy::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::Session::ID& sessionID, const WebCore::WritingTools::TextSuggestion::ID& replacementID, WebCore::IntRect selectionBoundsInRootView)
 {
     MESSAGE_CHECK(sessionID.isValid());
 
-    protectedPageClient()->textReplacementSessionShowInformationForReplacementWithIDRelativeToRect(sessionID, replacementID, selectionBoundsInRootView);
+    protectedPageClient()->proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(sessionID, replacementID, selectionBoundsInRootView);
 }
 
-void WebPageProxy::textReplacementSessionUpdateStateForReplacementWithID(const WebCore::WritingTools::Session::ID& sessionID, WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion::ID& replacementID)
+void WebPageProxy::proofreadingSessionUpdateStateForSuggestionWithID(const WebCore::WritingTools::Session::ID& sessionID, WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion::ID& replacementID)
 {
     MESSAGE_CHECK(sessionID.isValid());
 
-    protectedPageClient()->textReplacementSessionUpdateStateForReplacementWithID(sessionID, state, replacementID);
+    protectedPageClient()->proofreadingSessionUpdateStateForSuggestionWithID(sessionID, state, replacementID);
 }
 
 #endif // ENABLE(WRITING_TOOLS)

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -740,18 +740,18 @@ public:
 #endif
 
 #if ENABLE(WRITING_TOOLS) && ENABLE(CONTEXT_MENUS)
-    virtual bool canHandleSwapCharacters() const = 0;
-    virtual void handleContextMenuSwapCharacters(WebCore::IntRect selectionBoundsInRootView) = 0;
+    virtual bool canHandleContextMenuWritingTools() const = 0;
+    virtual void handleContextMenuWritingTools(WebCore::IntRect selectionBoundsInRootView) = 0;
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    virtual void textReplacementSessionShowInformationForReplacementWithIDRelativeToRect(const WebCore::WritingTools::SessionID&, const WebCore::WritingTools::TextSuggestionID&, WebCore::IntRect selectionBoundsInRootView) = 0;
+    virtual void proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::SessionID&, const WebCore::WritingTools::TextSuggestionID&, WebCore::IntRect selectionBoundsInRootView) = 0;
 
-    virtual void textReplacementSessionUpdateStateForReplacementWithID(const WebCore::WritingTools::SessionID&, WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestionID&) = 0;
+    virtual void proofreadingSessionUpdateStateForSuggestionWithID(const WebCore::WritingTools::SessionID&, WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestionID&) = 0;
 
-    virtual void unifiedTextReplacementActiveWillChange() = 0;
+    virtual void writingToolsActiveWillChange() = 0;
 
-    virtual void unifiedTextReplacementActiveDidChange() = 0;
+    virtual void writingToolsActiveDidChange() = 0;
 #endif
 
 #if ENABLE(DATA_DETECTION)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2267,8 +2267,8 @@ public:
 
 #if ENABLE(WRITING_TOOLS)
 #if ENABLE(CONTEXT_MENUS)
-    bool canHandleSwapCharacters() const;
-    void handleContextMenuSwapCharacters(WebCore::IntRect selectionBoundsInRootView);
+    bool canHandleContextMenuWritingTools() const;
+    void handleContextMenuWritingTools(WebCore::IntRect selectionBoundsInRootView);
 #endif
 #endif
 
@@ -2415,26 +2415,26 @@ public:
     void requestTextExtraction(std::optional<WebCore::FloatRect>&& collectionRectInRootView, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&&);
 
 #if ENABLE(WRITING_TOOLS)
-    void setUnifiedTextReplacementActive(bool);
+    void setWritingToolsActive(bool);
 
-    void willBeginTextReplacementSession(const std::optional<WebCore::WritingTools::Session>&, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&&);
+    void willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>&, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&&);
 
-    void didBeginTextReplacementSession(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::Context>&);
+    void didBeginWritingToolsSession(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::Context>&);
 
-    void textReplacementSessionDidReceiveReplacements(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::TextSuggestion>&, const WebCore::WritingTools::Context&, bool finished);
+    void proofreadingSessionDidReceiveSuggestions(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::TextSuggestion>&, const WebCore::WritingTools::Context&, bool finished);
 
-    void textReplacementSessionDidUpdateStateForReplacement(const WebCore::WritingTools::Session&, WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestion&, const WebCore::WritingTools::Context&);
+    void proofreadingSessionDidUpdateStateForSuggestion(const WebCore::WritingTools::Session&, WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestion&, const WebCore::WritingTools::Context&);
 
-    void didEndTextReplacementSession(const WebCore::WritingTools::Session&, bool accepted);
+    void didEndWritingToolsSession(const WebCore::WritingTools::Session&, bool accepted);
 
-    void textReplacementSessionDidReceiveTextWithReplacementRange(const WebCore::WritingTools::Session&, const WebCore::AttributedString&, const WebCore::CharacterRange&, const WebCore::WritingTools::Context&, bool finished);
+    void compositionSessionDidReceiveTextWithReplacementRange(const WebCore::WritingTools::Session&, const WebCore::AttributedString&, const WebCore::CharacterRange&, const WebCore::WritingTools::Context&, bool finished);
 
-    void textReplacementSessionDidReceiveEditAction(const WebCore::WritingTools::Session&, WebCore::WritingTools::Action);
+    void writingToolsSessionDidReceiveAction(const WebCore::WritingTools::Session&, WebCore::WritingTools::Action);
 
-    bool isUnifiedTextReplacementActive() const { return m_isUnifiedTextReplacementActive; }
+    bool isWritingToolsActive() const { return m_isWritingToolsActive; }
 
-    void textReplacementSessionShowInformationForReplacementWithIDRelativeToRect(const WebCore::WritingTools::SessionID&, const WebCore::WritingTools::TextSuggestionID&, WebCore::IntRect selectionBoundsInRootView);
-    void textReplacementSessionUpdateStateForReplacementWithID(const WebCore::WritingTools::SessionID&, WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestionID&);
+    void proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::SessionID&, const WebCore::WritingTools::TextSuggestionID&, WebCore::IntRect selectionBoundsInRootView);
+    void proofreadingSessionUpdateStateForSuggestionWithID(const WebCore::WritingTools::SessionID&, WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestionID&);
 #endif // ENABLE(WRITING_TOOLS)
 
 #if ENABLE(WRITING_TOOLS_UI)
@@ -3620,7 +3620,7 @@ private:
     std::unique_ptr<WebCore::NowPlayingMetadataObserver> m_nowPlayingMetadataObserverForTesting;
 
 #if ENABLE(WRITING_TOOLS)
-    bool m_isUnifiedTextReplacementActive { false };
+    bool m_isWritingToolsActive { false };
 #endif
 
 #if ENABLE(GAMEPAD)

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -234,13 +234,13 @@ messages -> WebPageProxy {
 #endif
 
 #if ENABLE(WRITING_TOOLS) && ENABLE(CONTEXT_MENUS)
-    HandleContextMenuSwapCharacters(WebCore::IntRect selectionBoundsInRootView)
+    HandleContextMenuWritingTools(WebCore::IntRect selectionBoundsInRootView)
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    TextReplacementSessionShowInformationForReplacementWithIDRelativeToRect(struct WebCore::WritingTools::Session::ID sessionID, struct WebCore::WritingTools::TextSuggestion::ID replacementID, WebCore::IntRect selectionBoundsInRootView)
+    ProofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(struct WebCore::WritingTools::Session::ID sessionID, struct WebCore::WritingTools::TextSuggestion::ID replacementID, WebCore::IntRect selectionBoundsInRootView)
 
-    TextReplacementSessionUpdateStateForReplacementWithID(struct WebCore::WritingTools::Session::ID sessionID, enum:uint8_t WebCore::WritingTools::TextSuggestion::State state, struct WebCore::WritingTools::TextSuggestion::ID replacementID)
+    ProofreadingSessionUpdateStateForSuggestionWithID(struct WebCore::WritingTools::Session::ID sessionID, enum:uint8_t WebCore::WritingTools::TextSuggestion::State state, struct WebCore::WritingTools::TextSuggestion::ID replacementID)
 #endif
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -4434,7 +4434,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 #if ENABLE(WRITING_TOOLS)
     if (action == @selector(_startWritingTools:))
-        return [self unifiedTextReplacementBehavior] != WebCore::WritingTools::Behavior::None && [super canPerformAction:action withSender:sender];
+        return _page->configuration().writingToolsBehavior() != WebCore::WritingTools::Behavior::None && [super canPerformAction:action withSender:sender];
 #endif
 
     if (action == @selector(paste:) || action == @selector(_pasteAsQuotation:) || action == @selector(_pasteAndMatchStyle:) || action == @selector(pasteAndMatchStyle:)) {
@@ -6929,7 +6929,8 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    [self _updateTextInputTraitsForUnifiedTextReplacement:traits];
+    auto behavior = WebKit::convertToPlatformWritingToolsBehavior(_page->configuration().writingToolsBehavior());
+    [traits setWritingToolsBehavior:behavior];
 #endif
 
     [self _updateTextInputTraitsForInteractionTintColor];
@@ -11780,15 +11781,6 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
 
 #endif
 
-#if ENABLE(WRITING_TOOLS)
-
-- (WebCore::WritingTools::Behavior)unifiedTextReplacementBehavior
-{
-    return _page->configuration().unifiedTextReplacementBehavior();
-}
-
-#endif
-
 #if HAVE(UIFINDINTERACTION)
 
 - (void)find:(id)sender
@@ -13240,12 +13232,6 @@ inline static NSString *extendSelectionCommand(UITextLayoutDirection direction)
 - (void)writingToolsSession:(WTSession *)session didReceiveAction:(WTAction)action
 {
     [_webView writingToolsSession:session didReceiveAction:action];
-}
-
-- (void)_updateTextInputTraitsForUnifiedTextReplacement:(id<UITextInputTraits>)traits
-{
-    auto behavior = WebKit::convertToPlatformWritingToolsBehavior([self unifiedTextReplacementBehavior]);
-    [traits setWritingToolsBehavior:behavior];
 }
 
 #endif

--- a/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.mm
+++ b/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.mm
@@ -132,12 +132,12 @@
     self.selectionHighlightColor = nil;
 
 #if ENABLE(WRITING_TOOLS)
-    [self restoreDefaultUnifiedTextReplacementBehaviorValue];
+    [self restoreDefaultWritingToolsBehaviorValue];
 #endif
 }
 
 #if ENABLE(WRITING_TOOLS)
-- (void)restoreDefaultUnifiedTextReplacementBehaviorValue
+- (void)restoreDefaultWritingToolsBehaviorValue
 {
     self.writingToolsBehavior = UIWritingToolsBehaviorLimited;
 }

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -309,8 +309,8 @@ private:
 #endif
 
 #if ENABLE(WRITING_TOOLS) && ENABLE(CONTEXT_MENUS)
-    bool canHandleSwapCharacters() const override;
-    void handleContextMenuSwapCharacters(WebCore::IntRect selectionBoundsInRootView) override;
+    bool canHandleContextMenuWritingTools() const override;
+    void handleContextMenuWritingTools(WebCore::IntRect selectionBoundsInRootView) override;
 #endif
 
 #if ENABLE(DATA_DETECTION)

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -1097,14 +1097,14 @@ void PageClientImpl::handleContextMenuTranslation(const TranslationContextMenuIn
 
 #if ENABLE(WRITING_TOOLS) && ENABLE(CONTEXT_MENUS)
 
-bool PageClientImpl::canHandleSwapCharacters() const
+bool PageClientImpl::canHandleContextMenuWritingTools() const
 {
-    return m_impl->canHandleSwapCharacters();
+    return m_impl->canHandleContextMenuWritingTools();
 }
 
-void PageClientImpl::handleContextMenuSwapCharacters(IntRect selectionBoundsInRootView)
+void PageClientImpl::handleContextMenuWritingTools(IntRect selectionBoundsInRootView)
 {
-    m_impl->handleContextMenuSwapCharacters(selectionBoundsInRootView);
+    m_impl->handleContextMenuWritingTools(selectionBoundsInRootView);
 }
 
 #endif

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -627,8 +627,8 @@ static NSString *menuItemIdentifier(const WebCore::ContextMenuAction action)
     case ContextMenuItemTagTranslate:
         return _WKMenuItemIdentifierTranslate;
 
-    case ContextMenuItemTagSwapCharacters:
-        return _WKMenuItemIdentifierSwapCharacters;
+    case ContextMenuItemTagWritingTools:
+        return _WKMenuItemIdentifierWritingTools;
 
     case ContextMenuItemTagCopySubject:
         return _WKMenuItemIdentifierCopySubject;
@@ -750,9 +750,9 @@ void WebContextMenuProxyMac::getContextMenuFromItems(const Vector<WebContextMenu
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    if (!page()->canHandleSwapCharacters() || isPopover) {
+    if (!page()->canHandleContextMenuWritingTools() || isPopover) {
         filteredItems.removeAllMatching([] (auto& item) {
-            return item.action() == ContextMenuItemTagSwapCharacters;
+            return item.action() == ContextMenuItemTagWritingTools;
         });
     }
 #endif

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -166,7 +166,7 @@ enum class ReplacementBehavior : uint8_t;
 - (void)_didUpdateCandidateListVisibility:(BOOL)visible;
 
 #if ENABLE(WRITING_TOOLS)
-- (BOOL)_web_wantsCompleteUnifiedTextReplacementBehavior;
+- (BOOL)_web_wantsWritingToolsInlineEditing;
 #endif
 
 @end
@@ -717,12 +717,12 @@ public:
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    WebCore::WritingTools::Behavior unifiedTextReplacementBehavior() const;
+    WebCore::WritingTools::Behavior writingToolsBehavior() const;
 #endif
 
 #if ENABLE(WRITING_TOOLS) && ENABLE(CONTEXT_MENUS)
-    bool canHandleSwapCharacters() const;
-    void handleContextMenuSwapCharacters(WebCore::IntRect selectionBoundsInRootView);
+    bool canHandleContextMenuWritingTools() const;
+    void handleContextMenuWritingTools(WebCore::IntRect selectionBoundsInRootView);
 #endif
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
@@ -744,10 +744,6 @@ public:
 #if HAVE(INLINE_PREDICTIONS)
     void setInlinePredictionsEnabled(bool enabled) { m_inlinePredictionsEnabled = enabled; }
     bool inlinePredictionsEnabled() const { return m_inlinePredictionsEnabled; }
-#endif
-
-#if ENABLE(WRITING_TOOLS)
-    bool wantsCompleteUnifiedTextReplacementBehavior() const;
 #endif
 
 #if ENABLE(WRITING_TOOLS_UI)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2787,7 +2787,7 @@ void WebViewImpl::selectionDidChange()
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    if (wantsCompleteUnifiedTextReplacementBehavior()) {
+    if ([m_view _web_wantsWritingToolsInlineEditing]) {
         auto isRange = m_page->editorState().hasPostLayoutData() && m_page->editorState().selectionIsRange;
         auto selectionRect = isRange ? m_page->editorState().postLayoutData->selectionBoundingRect : IntRect { };
 
@@ -6453,28 +6453,16 @@ void WebViewImpl::handleContextMenuTranslation(const WebCore::TranslationContext
 
 #endif // HAVE(TRANSLATION_UI_SERVICES) && ENABLE(CONTEXT_MENUS)
 
-#if ENABLE(WRITING_TOOLS)
-WebCore::WritingTools::Behavior WebViewImpl::unifiedTextReplacementBehavior() const
-{
-    return m_page->configuration().unifiedTextReplacementBehavior();
-}
-
-bool WebViewImpl::wantsCompleteUnifiedTextReplacementBehavior() const
-{
-    return [m_view _web_wantsCompleteUnifiedTextReplacementBehavior];
-}
-#endif
-
 #if ENABLE(WRITING_TOOLS) && ENABLE(CONTEXT_MENUS)
 
-bool WebViewImpl::canHandleSwapCharacters() const
+bool WebViewImpl::canHandleContextMenuWritingTools() const
 {
-    return [PAL::getWTWritingToolsViewControllerClass() isAvailable] && unifiedTextReplacementBehavior() != WebCore::WritingTools::Behavior::None;
+    return [PAL::getWTWritingToolsViewControllerClass() isAvailable] && m_page->configuration().writingToolsBehavior() != WebCore::WritingTools::Behavior::None;
 }
 
-void WebViewImpl::handleContextMenuSwapCharacters(IntRect selectionBoundsInRootView)
+void WebViewImpl::handleContextMenuWritingTools(IntRect selectionBoundsInRootView)
 {
-    if (!canHandleSwapCharacters()) {
+    if (!canHandleContextMenuWritingTools()) {
         ASSERT_NOT_REACHED();
         return;
     }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1846,14 +1846,14 @@ void WebChromeClient::gamepadsRecentlyAccessed()
 
 #if ENABLE(WRITING_TOOLS)
 
-void WebChromeClient::textReplacementSessionShowInformationForReplacementWithIDRelativeToRect(const WebCore::WritingTools::Session::ID& sessionID, const WebCore::WritingTools::TextSuggestion::ID& replacementID, WebCore::IntRect selectionBoundsInRootView)
+void WebChromeClient::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::Session::ID& sessionID, const WebCore::WritingTools::TextSuggestion::ID& replacementID, WebCore::IntRect selectionBoundsInRootView)
 {
-    protectedPage()->textReplacementSessionShowInformationForReplacementWithIDRelativeToRect(sessionID, replacementID, selectionBoundsInRootView);
+    protectedPage()->proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(sessionID, replacementID, selectionBoundsInRootView);
 }
 
-void WebChromeClient::textReplacementSessionUpdateStateForReplacementWithID(const WritingTools::Session::ID& sessionID, WritingTools::TextSuggestion::State state, const WritingTools::TextSuggestion::ID& replacementID)
+void WebChromeClient::proofreadingSessionUpdateStateForSuggestionWithID(const WritingTools::Session::ID& sessionID, WritingTools::TextSuggestion::State state, const WritingTools::TextSuggestion::ID& replacementID)
 {
-    protectedPage()->textReplacementSessionUpdateStateForReplacementWithID(sessionID, state, replacementID);
+    protectedPage()->proofreadingSessionUpdateStateForSuggestionWithID(sessionID, state, replacementID);
 }
 
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -507,9 +507,9 @@ private:
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    void textReplacementSessionShowInformationForReplacementWithIDRelativeToRect(const WebCore::WritingTools::SessionID&, const WebCore::WritingTools::TextSuggestionID&, WebCore::IntRect selectionBoundsInRootView) final;
+    void proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::SessionID&, const WebCore::WritingTools::TextSuggestionID&, WebCore::IntRect selectionBoundsInRootView) final;
 
-    void textReplacementSessionUpdateStateForReplacementWithID(const WebCore::WritingTools::SessionID&, WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestionID&) final;
+    void proofreadingSessionUpdateStateForSuggestionWithID(const WebCore::WritingTools::SessionID&, WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestionID&) final;
 #endif
 
 #if ENABLE(WRITING_TOOLS_UI)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h
@@ -62,7 +62,7 @@ private:
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    void handleSwapCharacters(WebCore::IntRect selectionBoundsInRootView) final;
+    void handleWritingTools(WebCore::IntRect selectionBoundsInRootView) final;
 #endif
 
 #if PLATFORM(GTK)

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
@@ -81,12 +81,12 @@ void WebContextMenuClient::handleTranslation(const WebCore::TranslationContextMe
 
 #if ENABLE(WRITING_TOOLS)
 
-void WebContextMenuClient::handleSwapCharacters(WebCore::IntRect selectionBoundsInRootView)
+void WebContextMenuClient::handleWritingTools(WebCore::IntRect selectionBoundsInRootView)
 {
     if (!m_page)
         return;
 
-    m_page->send(Messages::WebPageProxy::HandleContextMenuSwapCharacters(selectionBoundsInRootView));
+    m_page->send(Messages::WebPageProxy::HandleContextMenuWritingTools(selectionBoundsInRootView));
 }
 
 #endif

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -945,49 +945,49 @@ void WebPage::setMediaEnvironment(const String& mediaEnvironment)
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-void WebPage::willBeginTextReplacementSession(const std::optional<WebCore::WritingTools::Session>& session, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&& completionHandler)
+void WebPage::willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>& session, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&& completionHandler)
 {
-    corePage()->willBeginTextReplacementSession(session, WTFMove(completionHandler));
+    corePage()->willBeginWritingToolsSession(session, WTFMove(completionHandler));
 }
 
-void WebPage::didBeginTextReplacementSession(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::Context>& contexts)
+void WebPage::didBeginWritingToolsSession(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::Context>& contexts)
 {
-    corePage()->didBeginTextReplacementSession(session, contexts);
+    corePage()->didBeginWritingToolsSession(session, contexts);
 }
 
-void WebPage::textReplacementSessionDidReceiveReplacements(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::TextSuggestion>& replacements, const WebCore::WritingTools::Context& context, bool finished)
+void WebPage::proofreadingSessionDidReceiveSuggestions(const WebCore::WritingTools::Session& session, const Vector<WebCore::WritingTools::TextSuggestion>& suggestions, const WebCore::WritingTools::Context& context, bool finished)
 {
-    corePage()->textReplacementSessionDidReceiveReplacements(session, replacements, context, finished);
+    corePage()->proofreadingSessionDidReceiveSuggestions(session, suggestions, context, finished);
 }
 
-void WebPage::textReplacementSessionDidUpdateStateForReplacement(const WebCore::WritingTools::Session& session, WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion& replacement, const WebCore::WritingTools::Context& context)
+void WebPage::proofreadingSessionDidUpdateStateForSuggestion(const WebCore::WritingTools::Session& session, WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion& suggestion, const WebCore::WritingTools::Context& context)
 {
-    corePage()->textReplacementSessionDidUpdateStateForReplacement(session, state, replacement, context);
+    corePage()->proofreadingSessionDidUpdateStateForSuggestion(session, state, suggestion, context);
 }
 
-void WebPage::didEndTextReplacementSession(const WebCore::WritingTools::Session& session, bool accepted)
+void WebPage::didEndWritingToolsSession(const WebCore::WritingTools::Session& session, bool accepted)
 {
-    corePage()->didEndTextReplacementSession(session, accepted);
+    corePage()->didEndWritingToolsSession(session, accepted);
 }
 
-void WebPage::textReplacementSessionDidReceiveTextWithReplacementRange(const WebCore::WritingTools::Session& session, const WebCore::AttributedString& attributedText, const WebCore::CharacterRange& range, const WebCore::WritingTools::Context& context, bool finished)
+void WebPage::compositionSessionDidReceiveTextWithReplacementRange(const WebCore::WritingTools::Session& session, const WebCore::AttributedString& attributedText, const WebCore::CharacterRange& range, const WebCore::WritingTools::Context& context, bool finished)
 {
-    corePage()->textReplacementSessionDidReceiveTextWithReplacementRange(session, attributedText, range, context, finished);
+    corePage()->compositionSessionDidReceiveTextWithReplacementRange(session, attributedText, range, context, finished);
 }
 
-void WebPage::textReplacementSessionDidReceiveEditAction(const WritingTools::Session& session, WebCore::WritingTools::Action action)
+void WebPage::writingToolsSessionDidReceiveAction(const WritingTools::Session& session, WebCore::WritingTools::Action action)
 {
-    corePage()->textReplacementSessionDidReceiveEditAction(session, action);
+    corePage()->writingToolsSessionDidReceiveAction(session, action);
 }
 
-void WebPage::textReplacementSessionShowInformationForReplacementWithIDRelativeToRect(const WebCore::WritingTools::Session::ID& sessionID, const WebCore::WritingTools::TextSuggestion::ID& replacementID, WebCore::IntRect rect)
+void WebPage::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::Session::ID& sessionID, const WebCore::WritingTools::TextSuggestion::ID& replacementID, WebCore::IntRect rect)
 {
-    send(Messages::WebPageProxy::TextReplacementSessionShowInformationForReplacementWithIDRelativeToRect(sessionID, replacementID, rect));
+    send(Messages::WebPageProxy::ProofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(sessionID, replacementID, rect));
 }
 
-void WebPage::textReplacementSessionUpdateStateForReplacementWithID(const WebCore::WritingTools::Session::ID& sessionID, WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion::ID& replacementID)
+void WebPage::proofreadingSessionUpdateStateForSuggestionWithID(const WebCore::WritingTools::Session::ID& sessionID, WebCore::WritingTools::TextSuggestion::State state, const WebCore::WritingTools::TextSuggestion::ID& replacementID)
 {
-    send(Messages::WebPageProxy::TextReplacementSessionUpdateStateForReplacementWithID(sessionID, state, replacementID));
+    send(Messages::WebPageProxy::ProofreadingSessionUpdateStateForSuggestionWithID(sessionID, state, replacementID));
 }
 
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7051,7 +7051,7 @@ void WebPage::didChangeSelection(LocalFrame& frame)
     didChangeSelectionOrOverflowScrollPosition();
 
 #if ENABLE(WRITING_TOOLS)
-    corePage()->updateStateForSelectedReplacementIfNeeded();
+    corePage()->updateStateForSelectedSuggestionIfNeeded();
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -9188,9 +9188,9 @@ void WebPage::handleContextMenuTranslation(const TranslationContextMenuInfo& inf
 #endif
 
 #if ENABLE(WRITING_TOOLS) && ENABLE(CONTEXT_MENUS)
-void WebPage::handleContextMenuSwapCharacters(WebCore::IntRect selectionBoundsInRootView)
+void WebPage::handleContextMenuWritingTools(WebCore::IntRect selectionBoundsInRootView)
 {
-    send(Messages::WebPageProxy::HandleContextMenuSwapCharacters(selectionBoundsInRootView));
+    send(Messages::WebPageProxy::HandleContextMenuWritingTools(selectionBoundsInRootView));
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1616,7 +1616,7 @@ public:
 #endif
 
 #if ENABLE(WRITING_TOOLS) && ENABLE(CONTEXT_MENUS)
-    void handleContextMenuSwapCharacters(WebCore::IntRect selectionBoundsInRootView);
+    void handleContextMenuWritingTools(WebCore::IntRect selectionBoundsInRootView);
 #endif
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS) && USE(UICONTEXTMENU)
@@ -1751,9 +1751,9 @@ public:
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    void textReplacementSessionShowInformationForReplacementWithIDRelativeToRect(const WebCore::WritingTools::SessionID&, const WebCore::WritingTools::TextSuggestionID&, WebCore::IntRect);
+    void proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect(const WebCore::WritingTools::SessionID&, const WebCore::WritingTools::TextSuggestionID&, WebCore::IntRect);
 
-    void textReplacementSessionUpdateStateForReplacementWithID(const WebCore::WritingTools::SessionID&, WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestionID&);
+    void proofreadingSessionUpdateStateForSuggestionWithID(const WebCore::WritingTools::SessionID&, WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestionID&);
 #endif
 
 #if ENABLE(WRITING_TOOLS_UI)
@@ -2266,19 +2266,19 @@ private:
     void frameWasFocusedInAnotherProcess(WebCore::FrameIdentifier);
 
 #if ENABLE(WRITING_TOOLS)
-    void willBeginTextReplacementSession(const std::optional<WebCore::WritingTools::Session>&, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&&);
+    void willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>&, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&&);
 
-    void didBeginTextReplacementSession(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::Context>&);
+    void didBeginWritingToolsSession(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::Context>&);
 
-    void textReplacementSessionDidReceiveReplacements(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::TextSuggestion>&, const WebCore::WritingTools::Context&, bool finished);
+    void proofreadingSessionDidReceiveSuggestions(const WebCore::WritingTools::Session&, const Vector<WebCore::WritingTools::TextSuggestion>&, const WebCore::WritingTools::Context&, bool finished);
 
-    void textReplacementSessionDidUpdateStateForReplacement(const WebCore::WritingTools::Session&, WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestion&, const WebCore::WritingTools::Context&);
+    void proofreadingSessionDidUpdateStateForSuggestion(const WebCore::WritingTools::Session&, WebCore::WritingTools::TextSuggestionState, const WebCore::WritingTools::TextSuggestion&, const WebCore::WritingTools::Context&);
 
-    void didEndTextReplacementSession(const WebCore::WritingTools::Session&, bool accepted);
+    void didEndWritingToolsSession(const WebCore::WritingTools::Session&, bool accepted);
 
-    void textReplacementSessionDidReceiveTextWithReplacementRange(const WebCore::WritingTools::Session&, const WebCore::AttributedString&, const WebCore::CharacterRange&, const WebCore::WritingTools::Context&, bool finished);
+    void compositionSessionDidReceiveTextWithReplacementRange(const WebCore::WritingTools::Session&, const WebCore::AttributedString&, const WebCore::CharacterRange&, const WebCore::WritingTools::Context&, bool finished);
 
-    void textReplacementSessionDidReceiveEditAction(const WebCore::WritingTools::Session&, WebCore::WritingTools::Action);
+    void writingToolsSessionDidReceiveAction(const WebCore::WritingTools::Session&, WebCore::WritingTools::Action);
 
     void updateUnderlyingTextVisibilityForTextAnimationID(const WTF::UUID&, bool, CompletionHandler<void()>&&);
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -780,19 +780,19 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    WillBeginTextReplacementSession(std::optional<WebCore::WritingTools::Session> session) -> (Vector<WebCore::WritingTools::Context> contexts)
+    WillBeginWritingToolsSession(std::optional<WebCore::WritingTools::Session> session) -> (Vector<WebCore::WritingTools::Context> contexts)
 
-    DidBeginTextReplacementSession(struct WebCore::WritingTools::Session session, Vector<WebCore::WritingTools::Context> contexts)
+    DidBeginWritingToolsSession(struct WebCore::WritingTools::Session session, Vector<WebCore::WritingTools::Context> contexts)
 
-    TextReplacementSessionDidReceiveReplacements(struct WebCore::WritingTools::Session session, Vector<WebCore::WritingTools::TextSuggestion> replacements, struct WebCore::WritingTools::Context context, bool finished)
+    ProofreadingSessionDidReceiveSuggestions(struct WebCore::WritingTools::Session session, Vector<WebCore::WritingTools::TextSuggestion> suggestions, struct WebCore::WritingTools::Context context, bool finished)
 
-    TextReplacementSessionDidUpdateStateForReplacement(struct WebCore::WritingTools::Session session, enum:uint8_t WebCore::WritingTools::TextSuggestion::State state, struct WebCore::WritingTools::TextSuggestion replacement, struct WebCore::WritingTools::Context context)
+    ProofreadingSessionDidUpdateStateForSuggestion(struct WebCore::WritingTools::Session session, enum:uint8_t WebCore::WritingTools::TextSuggestion::State state, struct WebCore::WritingTools::TextSuggestion suggestion, struct WebCore::WritingTools::Context context)
 
-    DidEndTextReplacementSession(struct WebCore::WritingTools::Session session, bool accepted)
+    DidEndWritingToolsSession(struct WebCore::WritingTools::Session session, bool accepted)
 
-    TextReplacementSessionDidReceiveTextWithReplacementRange(struct WebCore::WritingTools::Session session, struct WebCore::AttributedString attributedText, struct WebCore::CharacterRange range, struct WebCore::WritingTools::Context context, bool finished);
+    CompositionSessionDidReceiveTextWithReplacementRange(struct WebCore::WritingTools::Session session, struct WebCore::AttributedString attributedText, struct WebCore::CharacterRange range, struct WebCore::WritingTools::Context context, bool finished);
 
-    TextReplacementSessionDidReceiveEditAction(struct WebCore::WritingTools::Session session, enum:uint8_t WebCore::WritingTools::Action action);
+    WritingToolsSessionDidReceiveAction(struct WebCore::WritingTools::Session session, enum:uint8_t WebCore::WritingTools::Action action);
 #endif
 
 #if ENABLE(WRITING_TOOLS_UI)

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.h
@@ -77,7 +77,7 @@ public:
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    void handleSwapCharacters(WebCore::IntRect selectionBoundsInRootView) final;
+    void handleWritingTools(WebCore::IntRect selectionBoundsInRootView) final;
 #endif
 
 private:

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm
@@ -148,7 +148,7 @@ void WebContextMenuClient::handleTranslation(const TranslationContextMenuInfo& i
 
 #if ENABLE(WRITING_TOOLS)
 
-void WebContextMenuClient::handleSwapCharacters(IntRect selectionBoundsInRootView)
+void WebContextMenuClient::handleWritingTools(IntRect selectionBoundsInRootView)
 {
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -415,8 +415,8 @@ static std::optional<WebCore::ContextMenuAction> toAction(NSInteger tag)
         return ContextMenuItemTagDictationAlternative;
     case WebMenuItemTagTranslate:
         return ContextMenuItemTagTranslate;
-    case WebMenuItemTagSwapCharacters:
-        return ContextMenuItemTagSwapCharacters;
+    case WebMenuItemTagWritingTools:
+        return ContextMenuItemTagWritingTools;
     }
     return std::nullopt;
 }
@@ -599,8 +599,8 @@ static std::optional<NSInteger> toTag(WebCore::ContextMenuAction action)
         return WebMenuItemTagToggleVideoViewer;
     case ContextMenuItemTagTranslate:
         return WebMenuItemTagTranslate;
-    case ContextMenuItemTagSwapCharacters:
-        return WebMenuItemTagSwapCharacters;
+    case ContextMenuItemTagWritingTools:
+        return WebMenuItemTagWritingTools;
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
     case ContextMenuItemTagPlayAllAnimations:
         return WebMenuItemTagPlayAllAnimations;

--- a/Source/WebKitLegacy/mac/WebView/WebUIDelegatePrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebUIDelegatePrivate.h
@@ -111,7 +111,7 @@ enum {
     WebMenuItemTagPauseAllAnimations,
     WebMenuItemTagPlayAnimation,
     WebMenuItemTagPauseAnimation,
-    WebMenuItemTagSwapCharacters,
+    WebMenuItemTagWritingTools,
 };
 
 // Deprecated; remove when there are no more clients.

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -1687,7 +1687,7 @@ TEST(WritingTools, APIWithBehaviorNone)
     [webView mouseUpAtPoint:NSMakePoint(10, 10) withFlags:0 eventType:NSEventTypeRightMouseUp];
     TestWebKitAPI::Util::run(&gotProposedMenu);
 
-    NSMenuItem *writingToolsMenuItem = [proposedMenu itemWithIdentifier:_WKMenuItemIdentifierSwapCharacters];
+    NSMenuItem *writingToolsMenuItem = [proposedMenu itemWithIdentifier:_WKMenuItemIdentifierWritingTools];
     EXPECT_NULL(writingToolsMenuItem);
 #endif
 
@@ -1734,7 +1734,7 @@ TEST(WritingTools, APIWithBehaviorDefault)
     [webView mouseUpAtPoint:NSMakePoint(10, 10) withFlags:0 eventType:NSEventTypeRightMouseUp];
     TestWebKitAPI::Util::run(&gotProposedMenu);
 
-    NSMenuItem *writingToolsMenuItem = [proposedMenu itemWithIdentifier:_WKMenuItemIdentifierSwapCharacters];
+    NSMenuItem *writingToolsMenuItem = [proposedMenu itemWithIdentifier:_WKMenuItemIdentifierWritingTools];
     EXPECT_NOT_NULL(writingToolsMenuItem);
 #endif
 
@@ -1781,7 +1781,7 @@ TEST(WritingTools, APIWithBehaviorComplete)
     [webView mouseUpAtPoint:NSMakePoint(10, 10) withFlags:0 eventType:NSEventTypeRightMouseUp];
     TestWebKitAPI::Util::run(&gotProposedMenu);
 
-    NSMenuItem *writingToolsMenuItem = [proposedMenu itemWithIdentifier:_WKMenuItemIdentifierSwapCharacters];
+    NSMenuItem *writingToolsMenuItem = [proposedMenu itemWithIdentifier:_WKMenuItemIdentifierWritingTools];
     EXPECT_NOT_NULL(writingToolsMenuItem);
 #endif
 


### PR DESCRIPTION
#### 88e0d4623c8d3afce5dd71538244a7e2c1fe1cf8
<pre>
[Writing Tools] Rename Writing Tools methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=275670">https://bugs.webkit.org/show_bug.cgi?id=275670</a>
<a href="https://rdar.apple.com/130162952">rdar://130162952</a>

Reviewed by Abrar Rahman Protyasha.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect):
(WebCore::ChromeClient::proofreadingSessionUpdateStateForSuggestionWithID):
(WebCore::ChromeClient::textReplacementSessionShowInformationForReplacementWithIDRelativeToRect): Deleted.
(WebCore::ChromeClient::textReplacementSessionUpdateStateForReplacementWithID): Deleted.
* Source/WebCore/page/ContextMenuClient.h:
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::contextMenuItemSelected):
(WebCore::ContextMenuController::populate):
(WebCore::ContextMenuController::checkOrEnableIfNeeded const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::willBeginWritingToolsSession):
(WebCore::Page::didBeginWritingToolsSession):
(WebCore::Page::proofreadingSessionDidReceiveSuggestions):
(WebCore::Page::proofreadingSessionDidUpdateStateForSuggestion):
(WebCore::Page::didEndWritingToolsSession):
(WebCore::Page::compositionSessionDidReceiveTextWithReplacementRange):
(WebCore::Page::updateStateForSelectedSuggestionIfNeeded):
(WebCore::Page::writingToolsSessionDidReceiveAction):
(WebCore::Page::willBeginTextReplacementSession): Deleted.
(WebCore::Page::didBeginTextReplacementSession): Deleted.
(WebCore::Page::textReplacementSessionDidReceiveReplacements): Deleted.
(WebCore::Page::textReplacementSessionDidUpdateStateForReplacement): Deleted.
(WebCore::Page::didEndTextReplacementSession): Deleted.
(WebCore::Page::textReplacementSessionDidReceiveTextWithReplacementRange): Deleted.
(WebCore::Page::updateStateForSelectedReplacementIfNeeded): Deleted.
(WebCore::Page::textReplacementSessionDidReceiveEditAction): Deleted.
* Source/WebCore/page/Page.h:
* Source/WebCore/page/writing-tools/WritingToolsController.h:
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::willBeginWritingToolsSession):
(WebCore::WritingToolsController::didBeginWritingToolsSession):
(WebCore::WritingToolsController::proofreadingSessionDidReceiveSuggestions):
(WebCore::WritingToolsController::proofreadingSessionDidUpdateStateForSuggestion):
(WebCore::WritingToolsController::compositionSessionDidReceiveTextWithReplacementRange):
(WebCore::WritingToolsController::writingToolsSessionDidReceiveAction&lt;WritingTools::Session::Type::Proofreading&gt;):
(WebCore::WritingToolsController::writingToolsSessionDidReceiveAction&lt;WritingTools::Session::Type::Composition&gt;):
(WebCore::WritingToolsController::writingToolsSessionDidReceiveAction):
(WebCore::WritingToolsController::didEndWritingToolsSession&lt;WritingTools::Session::Type::Proofreading&gt;):
(WebCore::WritingToolsController::didEndWritingToolsSession&lt;WritingTools::Session::Type::Composition&gt;):
(WebCore::WritingToolsController::didEndWritingToolsSession):
(WebCore::WritingToolsController::updateStateForSelectedSuggestionIfNeeded):
(WebCore::WritingToolsController::willBeginTextReplacementSession): Deleted.
(WebCore::WritingToolsController::didBeginTextReplacementSession): Deleted.
(WebCore::WritingToolsController::textReplacementSessionDidReceiveReplacements): Deleted.
(WebCore::WritingToolsController::textReplacementSessionDidUpdateStateForReplacement): Deleted.
(WebCore::WritingToolsController::textReplacementSessionDidReceiveTextWithReplacementRange): Deleted.
(WebCore::WritingToolsController::textReplacementSessionDidReceiveEditAction&lt;WritingTools::Session::Type::Proofreading&gt;): Deleted.
(WebCore::WritingToolsController::textReplacementSessionDidReceiveEditAction&lt;WritingTools::Session::Type::Composition&gt;): Deleted.
(WebCore::WritingToolsController::textReplacementSessionDidReceiveEditAction): Deleted.
(WebCore::WritingToolsController::didEndTextReplacementSession&lt;WritingTools::Session::Type::Proofreading&gt;): Deleted.
(WebCore::WritingToolsController::didEndTextReplacementSession&lt;WritingTools::Session::Type::Composition&gt;): Deleted.
(WebCore::WritingToolsController::didEndTextReplacementSession): Deleted.
(WebCore::WritingToolsController::updateStateForSelectedReplacementIfNeeded): Deleted.
* Source/WebCore/platform/ContextMenuItem.cpp:
(WebCore::isValidContextMenuAction):
* Source/WebCore/platform/ContextMenuItem.h:
* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::contextMenuItemTagWritingTools):
(WebCore::contextMenuItemTagSwapCharacters): Deleted.
* Source/WebCore/platform/LocalizedStrings.h:
* Source/WebCore/platform/Logging.h:
* Source/WebKit/Shared/API/c/WKContextMenuItemTypes.h:
* Source/WebKit/Shared/API/c/WKSharedAPICast.h:
(WebKit::toAPI):
(WebKit::toImpl):
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::writingToolsBehavior const):
(API::PageConfiguration::setWritingToolsBehavior):
(API::PageConfiguration::unifiedTextReplacementBehavior const): Deleted.
(API::PageConfiguration::setUnifiedTextReplacementBehavior): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _initializeWithConfiguration:]):
(-[WKWebView isWritingToolsActive]):
(-[WKWebView willBeginWritingToolsSession:requestContexts:]):
(-[WKWebView didBeginWritingToolsSession:contexts:]):
(-[WKWebView proofreadingSession:didReceiveSuggestions:processedRange:inContext:finished:]):
(-[WKWebView proofreadingSession:didUpdateState:forSuggestionWithUUID:inContext:]):
(-[WKWebView didEndWritingToolsSession:accepted:]):
(-[WKWebView compositionSession:didReceiveText:replacementRange:inContext:finished:]):
(-[WKWebView writingToolsSession:didReceiveAction:]):
(-[WKWebView _proofreadingSessionWithUUID:showDetailsForSuggestionWithUUID:relativeToRect:]):
(-[WKWebView _proofreadingSessionWithUUID:updateState:forSuggestionWithUUID:]):
(-[WKWebView _textReplacementSession:showInformationForReplacementWithUUID:relativeToRect:]): Deleted.
(-[WKWebView _textReplacementSession:updateState:forReplacementWithUUID:]): Deleted.
(-[WKWebView _isUnifiedTextReplacementActive]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration setWritingToolsBehavior:]):
(-[WKWebViewConfiguration writingToolsBehavior]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _web_wantsWritingToolsInlineEditing]):
(-[WKWebView _web_wantsCompleteUnifiedTextReplacementBehavior]): Deleted.
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect):
(WebKit::PageClientImplCocoa::proofreadingSessionUpdateStateForSuggestionWithID):
(WebKit::PageClientImplCocoa::writingToolsActiveWillChange):
(WebKit::PageClientImplCocoa::writingToolsActiveDidChange):
(WebKit::PageClientImplCocoa::textReplacementSessionShowInformationForReplacementWithIDRelativeToRect): Deleted.
(WebKit::PageClientImplCocoa::textReplacementSessionUpdateStateForReplacementWithID): Deleted.
(WebKit::PageClientImplCocoa::unifiedTextReplacementActiveWillChange): Deleted.
(WebKit::PageClientImplCocoa::unifiedTextReplacementActiveDidChange): Deleted.
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::canHandleContextMenuWritingTools const):
(WebKit::WebPageProxy::handleContextMenuWritingTools):
(WebKit::WebPageProxy::setWritingToolsActive):
(WebKit::WebPageProxy::willBeginWritingToolsSession):
(WebKit::WebPageProxy::didBeginWritingToolsSession):
(WebKit::WebPageProxy::proofreadingSessionDidReceiveSuggestions):
(WebKit::WebPageProxy::proofreadingSessionDidUpdateStateForSuggestion):
(WebKit::WebPageProxy::didEndWritingToolsSession):
(WebKit::WebPageProxy::compositionSessionDidReceiveTextWithReplacementRange):
(WebKit::WebPageProxy::writingToolsSessionDidReceiveAction):
(WebKit::WebPageProxy::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect):
(WebKit::WebPageProxy::proofreadingSessionUpdateStateForSuggestionWithID):
(WebKit::WebPageProxy::canHandleSwapCharacters const): Deleted.
(WebKit::WebPageProxy::handleContextMenuSwapCharacters): Deleted.
(WebKit::WebPageProxy::setUnifiedTextReplacementActive): Deleted.
(WebKit::WebPageProxy::willBeginTextReplacementSession): Deleted.
(WebKit::WebPageProxy::didBeginTextReplacementSession): Deleted.
(WebKit::WebPageProxy::textReplacementSessionDidReceiveReplacements): Deleted.
(WebKit::WebPageProxy::textReplacementSessionDidUpdateStateForReplacement): Deleted.
(WebKit::WebPageProxy::didEndTextReplacementSession): Deleted.
(WebKit::WebPageProxy::textReplacementSessionDidReceiveTextWithReplacementRange): Deleted.
(WebKit::WebPageProxy::textReplacementSessionDidReceiveEditAction): Deleted.
(WebKit::WebPageProxy::textReplacementSessionShowInformationForReplacementWithIDRelativeToRect): Deleted.
(WebKit::WebPageProxy::textReplacementSessionUpdateStateForReplacementWithID): Deleted.
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView canPerformActionForWebView:withSender:]):
(-[WKContentView _updateTextInputTraits:]):
(-[WKContentView unifiedTextReplacementBehavior]): Deleted.
(-[WKContentView _updateTextInputTraitsForUnifiedTextReplacement:]): Deleted.
* Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.mm:
(-[WKExtendedTextInputTraits restoreDefaultValues]):
(-[WKExtendedTextInputTraits restoreDefaultWritingToolsBehaviorValue]):
(-[WKExtendedTextInputTraits restoreDefaultUnifiedTextReplacementBehaviorValue]): Deleted.
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::canHandleContextMenuWritingTools const):
(WebKit::PageClientImpl::handleContextMenuWritingTools):
(WebKit::PageClientImpl::canHandleSwapCharacters const): Deleted.
(WebKit::PageClientImpl::handleContextMenuSwapCharacters): Deleted.
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::menuItemIdentifier):
(WebKit::WebContextMenuProxyMac::getContextMenuFromItems):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::selectionDidChange):
(WebKit::WebViewImpl::canHandleContextMenuWritingTools const):
(WebKit::WebViewImpl::handleContextMenuWritingTools):
(WebKit::WebViewImpl::unifiedTextReplacementBehavior const): Deleted.
(WebKit::WebViewImpl::wantsCompleteUnifiedTextReplacementBehavior const): Deleted.
(WebKit::WebViewImpl::canHandleSwapCharacters const): Deleted.
(WebKit::WebViewImpl::handleContextMenuSwapCharacters): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect):
(WebKit::WebChromeClient::proofreadingSessionUpdateStateForSuggestionWithID):
(WebKit::WebChromeClient::textReplacementSessionShowInformationForReplacementWithIDRelativeToRect): Deleted.
(WebKit::WebChromeClient::textReplacementSessionUpdateStateForReplacementWithID): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm:
(WebKit::WebContextMenuClient::handleWritingTools):
(WebKit::WebContextMenuClient::handleSwapCharacters): Deleted.
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::willBeginWritingToolsSession):
(WebKit::WebPage::didBeginWritingToolsSession):
(WebKit::WebPage::proofreadingSessionDidReceiveSuggestions):
(WebKit::WebPage::proofreadingSessionDidUpdateStateForSuggestion):
(WebKit::WebPage::didEndWritingToolsSession):
(WebKit::WebPage::compositionSessionDidReceiveTextWithReplacementRange):
(WebKit::WebPage::writingToolsSessionDidReceiveAction):
(WebKit::WebPage::proofreadingSessionShowDetailsForSuggestionWithIDRelativeToRect):
(WebKit::WebPage::proofreadingSessionUpdateStateForSuggestionWithID):
(WebKit::WebPage::willBeginTextReplacementSession): Deleted.
(WebKit::WebPage::didBeginTextReplacementSession): Deleted.
(WebKit::WebPage::textReplacementSessionDidReceiveReplacements): Deleted.
(WebKit::WebPage::textReplacementSessionDidUpdateStateForReplacement): Deleted.
(WebKit::WebPage::didEndTextReplacementSession): Deleted.
(WebKit::WebPage::textReplacementSessionDidReceiveTextWithReplacementRange): Deleted.
(WebKit::WebPage::textReplacementSessionDidReceiveEditAction): Deleted.
(WebKit::WebPage::textReplacementSessionShowInformationForReplacementWithIDRelativeToRect): Deleted.
(WebKit::WebPage::textReplacementSessionUpdateStateForReplacementWithID): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didChangeSelection):
(WebKit::WebPage::handleContextMenuWritingTools):
(WebKit::WebPage::handleContextMenuSwapCharacters): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebContextMenuClient.mm:
(WebContextMenuClient::handleWritingTools):
(WebContextMenuClient::handleSwapCharacters): Deleted.
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(toAction):
(toTag):
* Source/WebKitLegacy/mac/WebView/WebUIDelegatePrivate.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(TEST(WritingTools, APIWithBehaviorNone)):
(TEST(WritingTools, APIWithBehaviorDefault)):
(TEST(WritingTools, APIWithBehaviorComplete)):

Canonical link: <a href="https://commits.webkit.org/280205@main">https://commits.webkit.org/280205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/983b3f68ef4509ba43877addb80d15ee1306e084

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/55941 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8409 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/58940 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6373 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58067 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42886 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6569 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45047 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4405 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/57970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48235 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26185 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/29941 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5563 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4516 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51909 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5834 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60527 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/5954 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52476 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48304 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/51995 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8280 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31094 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32178 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33260 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31926 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->