### PR TITLE
[Writing Tools] Rename document marker-related Writing Tools symbols

### DIFF
--- a/Source/WebCore/dom/DocumentMarker.h
+++ b/Source/WebCore/dom/DocumentMarker.h
@@ -99,7 +99,7 @@ public:
         PlatformTextChecking = 1 << 15,
 #endif
 #if ENABLE(WRITING_TOOLS)
-        UnifiedTextReplacement = 1 << 16,
+        WritingToolsTextSuggestion = 1 << 16,
 #endif
         TransparentContent = 1 << 17,
     };
@@ -118,17 +118,16 @@ public:
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    struct UnifiedTextReplacementData {
+    struct WritingToolsTextSuggestionData {
         enum class State: uint8_t {
-            Pending,
-            Committed,
-            Reverted
+            Accepted,
+            Rejected
         };
 
         String originalText;
-        WritingTools::TextSuggestionID replacementID;
+        WritingTools::TextSuggestionID suggestionID;
         WritingTools::SessionID sessionID;
-        State state { State::Pending };
+        State state { State::Accepted };
     };
 #endif
 
@@ -149,7 +148,7 @@ public:
         , PlatformTextCheckingData // PlatformTextChecking
 #endif
 #if ENABLE(WRITING_TOOLS)
-        , UnifiedTextReplacementData // UnifiedTextReplacement
+        , WritingToolsTextSuggestionData // WritingToolsTextSuggestion
 #endif
         , TransparentContentData // TransparentContent
     >;
@@ -203,7 +202,7 @@ constexpr auto DocumentMarker::allMarkers() -> OptionSet<Type>
         Type::PlatformTextChecking,
 #endif
 #if ENABLE(WRITING_TOOLS)
-        Type::UnifiedTextReplacement,
+        Type::WritingToolsTextSuggestion,
 #endif
         Type::TransparentContent,
     };
@@ -228,7 +227,7 @@ inline String DocumentMarker::description() const
         return *description;
 
 #if ENABLE(WRITING_TOOLS)
-    if (auto* data = std::get_if<DocumentMarker::UnifiedTextReplacementData>(&m_data))
+    if (auto* data = std::get_if<DocumentMarker::WritingToolsTextSuggestionData>(&m_data))
         return makeString("('"_s, data->originalText, "', state: "_s, enumToUnderlyingType(data->state), ')');
 #endif
 

--- a/Source/WebCore/dom/DocumentMarkerController.h
+++ b/Source/WebCore/dom/DocumentMarkerController.h
@@ -124,7 +124,7 @@ private:
     void forEachOfTypes(OptionSet<DocumentMarker::Type>, Function<bool(Node&, RenderedDocumentMarker&)>&&);
 
     void fadeAnimationTimerFired();
-    void unifiedTextReplacementAnimationTimerFired();
+    void writingToolsTextSuggestionAnimationTimerFired();
 
     Ref<Document> protectedDocument() const;
 
@@ -134,7 +134,7 @@ private:
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
 
     Timer m_fadeAnimationTimer;
-    Timer m_unifiedTextReplacementAnimationTimer;
+    Timer m_writingToolsTextSuggestionAnimationTimer;
 };
 
 

--- a/Source/WebCore/page/writing-tools/WritingToolsController.h
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.h
@@ -27,9 +27,9 @@
 
 #if ENABLE(WRITING_TOOLS)
 
-#include "Range.h"
-#include "ReplaceSelectionCommand.h"
-#include "WritingToolsTypes.h"
+#import "Range.h"
+#import "ReplaceSelectionCommand.h"
+#import "WritingToolsTypes.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -214,8 +214,8 @@ Vector<MarkedText> MarkedText::collectForDocumentMarkers(const RenderText& rende
         case DocumentMarker::Type::CorrectionIndicator:
             return MarkedText::Type::Correction;
 #if ENABLE(WRITING_TOOLS)
-        case DocumentMarker::Type::UnifiedTextReplacement:
-            return MarkedText::Type::UnifiedTextReplacement;
+        case DocumentMarker::Type::WritingToolsTextSuggestion:
+            return MarkedText::Type::WritingToolsTextSuggestion;
 #endif
         case DocumentMarker::Type::TextMatch:
             return MarkedText::Type::TextMatch;
@@ -245,7 +245,7 @@ Vector<MarkedText> MarkedText::collectForDocumentMarkers(const RenderText& rende
             FALLTHROUGH;
         case DocumentMarker::Type::CorrectionIndicator:
 #if ENABLE(WRITING_TOOLS)
-        case DocumentMarker::Type::UnifiedTextReplacement:
+        case DocumentMarker::Type::WritingToolsTextSuggestion:
 #endif
         case DocumentMarker::Type::Replacement:
         case DocumentMarker::Type::DictationAlternatives:
@@ -290,8 +290,8 @@ Vector<MarkedText> MarkedText::collectForDocumentMarkers(const RenderText& rende
         case DocumentMarker::Type::Spelling:
         case DocumentMarker::Type::CorrectionIndicator:
 #if ENABLE(WRITING_TOOLS)
-        case DocumentMarker::Type::UnifiedTextReplacement:
-            if (marker->type() == DocumentMarker::Type::UnifiedTextReplacement && std::get<DocumentMarker::UnifiedTextReplacementData>(marker->data()).state != DocumentMarker::UnifiedTextReplacementData::State::Pending)
+        case DocumentMarker::Type::WritingToolsTextSuggestion:
+            if (marker->type() == DocumentMarker::Type::WritingToolsTextSuggestion && std::get<DocumentMarker::WritingToolsTextSuggestionData>(marker->data()).state != DocumentMarker::WritingToolsTextSuggestionData::State::Accepted)
                 break;
 
             BFALLTHROUGH;

--- a/Source/WebCore/rendering/MarkedText.h
+++ b/Source/WebCore/rendering/MarkedText.h
@@ -48,7 +48,7 @@ struct MarkedText : public CanMakeCheckedPtr<MarkedText> {
         GrammarError,
         Correction,
 #if ENABLE(WRITING_TOOLS)
-        UnifiedTextReplacement,
+        WritingToolsTextSuggestion,
 #endif
         SpellingError,
         TextMatch,

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -74,7 +74,7 @@ static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, 
     case MarkedText::Type::DictationPhraseWithAlternatives:
 #endif
 #if ENABLE(WRITING_TOOLS)
-    case MarkedText::Type::UnifiedTextReplacement:
+    case MarkedText::Type::WritingToolsTextSuggestion:
 #endif
     case MarkedText::Type::Unmarked:
         break;

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -1066,7 +1066,7 @@ void TextBoxPainter<TextBoxPath>::paintPlatformDocumentMarker(const MarkedText& 
     bounds.moveBy(m_paintRect.location());
 
 #if ENABLE(WRITING_TOOLS)
-    if (markedText.type == MarkedText::Type::UnifiedTextReplacement) {
+    if (markedText.type == MarkedText::Type::WritingToolsTextSuggestion) {
         drawUnifiedTextReplacementUnderline(m_paintInfo.context(), bounds,  m_renderer.frame().view()->size());
         return;
     }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -503,8 +503,8 @@ static bool markerTypeFrom(const String& markerType, DocumentMarker::Type& resul
         result = DocumentMarker::Type::TelephoneNumber;
 #endif
 #if ENABLE(WRITING_TOOLS)
-    else if (equalLettersIgnoringASCIICase(markerType, "unifiedtextreplacement"_s))
-        result = DocumentMarker::Type::UnifiedTextReplacement;
+    else if (equalLettersIgnoringASCIICase(markerType, "writingtoolstextsuggestion"_s))
+        result = DocumentMarker::Type::WritingToolsTextSuggestion;
 #endif
     else if (equalLettersIgnoringASCIICase(markerType, "transparentcontent"_s))
         result = DocumentMarker::Type::TransparentContent;
@@ -2798,9 +2798,9 @@ bool Internals::hasCorrectionIndicatorMarker(int from, int length)
 }
 
 #if ENABLE(WRITING_TOOLS)
-bool Internals::hasUnifiedTextReplacementMarker(int from, int length)
+bool Internals::hasWritingToolsTextSuggestionMarker(int from, int length)
 {
-    return hasMarkerFor(DocumentMarker::Type::UnifiedTextReplacement, from, length);
+    return hasMarkerFor(DocumentMarker::Type::WritingToolsTextSuggestion, from, length);
 }
 #endif
 

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -444,7 +444,7 @@ public:
     bool hasDictationAlternativesMarker(int from, int length);
     bool hasCorrectionIndicatorMarker(int from, int length);
 #if ENABLE(WRITING_TOOLS)
-    bool hasUnifiedTextReplacementMarker(int from, int length);
+    bool hasWritingToolsTextSuggestionMarker(int from, int length);
 #endif
     void setContinuousSpellCheckingEnabled(bool);
     void setAutomaticQuoteSubstitutionEnabled(bool);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -632,7 +632,7 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     boolean hasDictationAlternativesMarker(long from, long length);
     boolean hasCorrectionIndicatorMarker(long from, long length);
 #if defined(ENABLE_WRITING_TOOLS) && ENABLE_WRITING_TOOLS
-    boolean hasUnifiedTextReplacementMarker(long from, long length);
+    boolean hasWritingToolsTextSuggestionMarker(long from, long length);
 #endif
     undefined setContinuousSpellCheckingEnabled(boolean enabled);
     undefined setAutomaticQuoteSubstitutionEnabled(boolean enabled);

--- a/Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp
@@ -64,8 +64,8 @@ std::ostream& operator<<(std::ostream& os, MarkedText::Type type)
         return os << "AppHighlight";
 #endif
 #if ENABLE(WRITING_TOOLS)
-    case MarkedText::Type::UnifiedTextReplacement:
-        return os << "UnifiedTextReplacement";
+    case MarkedText::Type::WritingToolsTextSuggestion:
+        return os << "WritingToolsTextSuggestion";
 #endif
     case MarkedText::Type::TransparentContent:
         return os << "TransparentContent";

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -296,18 +296,18 @@ TEST(WritingTools, ProofreadingAcceptReject)
 
         modifySelection(0, 0);
 
-        NSString *hasFirstUnifiedTextReplacementMarker = [webView stringByEvaluatingJavaScript:@"internals.hasUnifiedTextReplacementMarker(0, 4);"];
-        EXPECT_WK_STREQ("1", hasFirstUnifiedTextReplacementMarker);
+        NSString *hasFirstMarker = [webView stringByEvaluatingJavaScript:@"internals.hasWritingToolsTextSuggestionMarker(0, 4);"];
+        EXPECT_WK_STREQ("1", hasFirstMarker);
 
-        NSString *firstReplacementOriginalString = [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('p').childNodes[0].firstChild, 'unifiedtextreplacement', 0);"];
+        NSString *firstReplacementOriginalString = [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('p').childNodes[0].firstChild, 'writingtoolstextsuggestion', 0);"];
         EXPECT_WK_STREQ(@"('AAAA', state: 0)", firstReplacementOriginalString);
 
         modifySelection(0, 0);
 
-        NSString *hasSecondUnifiedTextReplacementMarker = [webView stringByEvaluatingJavaScript:@"internals.hasUnifiedTextReplacementMarker(10, 4);"];
-        EXPECT_WK_STREQ("1", hasSecondUnifiedTextReplacementMarker);
+        NSString *hasSecondMarker = [webView stringByEvaluatingJavaScript:@"internals.hasWritingToolsTextSuggestionMarker(10, 4);"];
+        EXPECT_WK_STREQ("1", hasSecondMarker);
 
-        NSString *secondReplacementOriginalString = [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('p').childNodes[0].firstChild, 'unifiedtextreplacement', 1);"];
+        NSString *secondReplacementOriginalString = [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('p').childNodes[0].firstChild, 'writingtoolstextsuggestion', 1);"];
         EXPECT_WK_STREQ(@"('CCCC', state: 0)", secondReplacementOriginalString);
 
         EXPECT_WK_STREQ(@"ZZZZ BBBB YYYY", [webView contentsAsString]);
@@ -317,18 +317,18 @@ TEST(WritingTools, ProofreadingAcceptReject)
         EXPECT_WK_STREQ(@"ZZZZ", selectionAfterReviewing);
 
         [[webView writingToolsDelegate] proofreadingSession:session.get() didUpdateState:WTTextSuggestionStateRejected forSuggestionWithUUID:[secondSuggestion uuid] inContext:contexts.firstObject];
-        NSString *hasSecondUnifiedTextReplacementMarkerAfterStateUpdate = [webView stringByEvaluatingJavaScript:@"internals.hasUnifiedTextReplacementMarker(10, 4);"];
-        EXPECT_WK_STREQ("0", hasSecondUnifiedTextReplacementMarkerAfterStateUpdate);
+        NSString *hasSecondMarkerAfterStateUpdate = [webView stringByEvaluatingJavaScript:@"internals.hasWritingToolsTextSuggestionMarker(10, 4);"];
+        EXPECT_WK_STREQ("0", hasSecondMarkerAfterStateUpdate);
 
         EXPECT_WK_STREQ(@"ZZZZ BBBB CCCC", [webView contentsAsString]);
 
         [[webView writingToolsDelegate] didEndWritingToolsSession:session.get() accepted:YES];
 
-        NSString *hasFirstUnifiedTextReplacementMarkerAfterEnding = [webView stringByEvaluatingJavaScript:@"internals.hasUnifiedTextReplacementMarker(0, 4);"];
-        EXPECT_WK_STREQ("0", hasFirstUnifiedTextReplacementMarkerAfterEnding);
+        NSString *hasFirstMarkerAfterEnding = [webView stringByEvaluatingJavaScript:@"internals.hasWritingToolsTextSuggestionMarker(0, 4);"];
+        EXPECT_WK_STREQ("0", hasFirstMarkerAfterEnding);
 
-        NSString *hasSecondUnifiedTextReplacementMarkerAfterEnding = [webView stringByEvaluatingJavaScript:@"internals.hasUnifiedTextReplacementMarker(10, 4);"];
-        EXPECT_WK_STREQ("0", hasSecondUnifiedTextReplacementMarkerAfterEnding);
+        NSString *hasSecondMarkerAfterEnding = [webView stringByEvaluatingJavaScript:@"internals.hasWritingToolsTextSuggestionMarker(10, 4);"];
+        EXPECT_WK_STREQ("0", hasSecondMarkerAfterEnding);
 
         EXPECT_WK_STREQ(@"ZZZZ BBBB CCCC", [webView contentsAsString]);
 
@@ -398,8 +398,8 @@ TEST(WritingTools, ProofreadingWithLongReplacement)
 
         [webView waitForNextPresentationUpdate];
 
-        EXPECT_WK_STREQ(@"('thin', state: 0)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('first').childNodes[0], 'unifiedtextreplacement', 0);"]);
-        EXPECT_WK_STREQ(@"('here', state: 0)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('first').childNodes[0], 'unifiedtextreplacement', 1);"]);
+        EXPECT_WK_STREQ(@"('thin', state: 0)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('first').childNodes[0], 'writingtoolstextsuggestion', 0);"]);
+        EXPECT_WK_STREQ(@"('here', state: 0)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('first').childNodes[0], 'writingtoolstextsuggestion', 1);"]);
 
         EXPECT_WK_STREQ(proofreadText, [webView contentsAsString]);
 
@@ -438,10 +438,10 @@ TEST(WritingTools, ProofreadingShowOriginal)
 
         [webView waitForNextPresentationUpdate];
 
-        EXPECT_WK_STREQ(@"('thin', state: 0)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('first').childNodes[0], 'unifiedtextreplacement', 0);"]);
-        EXPECT_WK_STREQ(@"('here', state: 0)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('first').childNodes[0], 'unifiedtextreplacement', 1);"]);
-        EXPECT_WK_STREQ(@"('they're', state: 0)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('second').childNodes[0], 'unifiedtextreplacement', 0);"]);
-        EXPECT_WK_STREQ(@"('their', state: 0)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('second').childNodes[0], 'unifiedtextreplacement', 1);"]);
+        EXPECT_WK_STREQ(@"('thin', state: 0)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('first').childNodes[0], 'writingtoolstextsuggestion', 0);"]);
+        EXPECT_WK_STREQ(@"('here', state: 0)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('first').childNodes[0], 'writingtoolstextsuggestion', 1);"]);
+        EXPECT_WK_STREQ(@"('they're', state: 0)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('second').childNodes[0], 'writingtoolstextsuggestion', 0);"]);
+        EXPECT_WK_STREQ(@"('their', state: 0)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('second').childNodes[0], 'writingtoolstextsuggestion', 1);"]);
 
         EXPECT_WK_STREQ(proofreadText, [webView contentsAsString]);
 
@@ -449,10 +449,10 @@ TEST(WritingTools, ProofreadingShowOriginal)
 
         [webView waitForNextPresentationUpdate];
 
-        EXPECT_WK_STREQ(@"('think', state: 2)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('first').childNodes[0], 'unifiedtextreplacement', 0);"]);
-        EXPECT_WK_STREQ(@"('hear', state: 2)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('first').childNodes[0], 'unifiedtextreplacement', 1);"]);
-        EXPECT_WK_STREQ(@"('there', state: 2)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('second').childNodes[0], 'unifiedtextreplacement', 0);"]);
-        EXPECT_WK_STREQ(@"('there', state: 2)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('second').childNodes[0], 'unifiedtextreplacement', 1);"]);
+        EXPECT_WK_STREQ(@"('think', state: 2)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('first').childNodes[0], 'writingtoolstextsuggestion', 0);"]);
+        EXPECT_WK_STREQ(@"('hear', state: 2)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('first').childNodes[0], 'writingtoolstextsuggestion', 1);"]);
+        EXPECT_WK_STREQ(@"('there', state: 2)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('second').childNodes[0], 'writingtoolstextsuggestion', 0);"]);
+        EXPECT_WK_STREQ(@"('there', state: 2)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('second').childNodes[0], 'writingtoolstextsuggestion', 1);"]);
 
         EXPECT_WK_STREQ(originalText, [webView contentsAsString]);
 
@@ -460,10 +460,10 @@ TEST(WritingTools, ProofreadingShowOriginal)
 
         [webView waitForNextPresentationUpdate];
 
-        EXPECT_WK_STREQ(@"('thin', state: 0)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('first').childNodes[0], 'unifiedtextreplacement', 0);"]);
-        EXPECT_WK_STREQ(@"('here', state: 0)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('first').childNodes[0], 'unifiedtextreplacement', 1);"]);
-        EXPECT_WK_STREQ(@"('they're', state: 0)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('second').childNodes[0], 'unifiedtextreplacement', 0);"]);
-        EXPECT_WK_STREQ(@"('their', state: 0)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('second').childNodes[0], 'unifiedtextreplacement', 1);"]);
+        EXPECT_WK_STREQ(@"('thin', state: 0)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('first').childNodes[0], 'writingtoolstextsuggestion', 0);"]);
+        EXPECT_WK_STREQ(@"('here', state: 0)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('first').childNodes[0], 'writingtoolstextsuggestion', 1);"]);
+        EXPECT_WK_STREQ(@"('they're', state: 0)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('second').childNodes[0], 'writingtoolstextsuggestion', 0);"]);
+        EXPECT_WK_STREQ(@"('their', state: 0)", [webView stringByEvaluatingJavaScript:@"internals.markerDescriptionForNode(document.getElementById('second').childNodes[0], 'writingtoolstextsuggestion', 1);"]);
 
         EXPECT_WK_STREQ(proofreadText, [webView contentsAsString]);
 


### PR DESCRIPTION
#### 000db278d3cbcc4810a92c1166d0e46013165c0b
<pre>
[Writing Tools] Rename document marker-related Writing Tools symbols
<a href="https://bugs.webkit.org/show_bug.cgi?id=275676">https://bugs.webkit.org/show_bug.cgi?id=275676</a>
<a href="https://rdar.apple.com/130182884">rdar://130182884</a>

Reviewed by Megan Gardner.

Also, add some more comments, and use the modern `std::views::reverse` way to make a reverse for loop.

* Source/WebCore/dom/DocumentMarker.h:
(WebCore::DocumentMarker::allMarkers):
(WebCore::DocumentMarker::description const):
* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::DocumentMarkerController::DocumentMarkerController):
(WebCore::DocumentMarkerController::detach):
(WebCore::shouldInsertAsSeparateMarker):
(WebCore::DocumentMarkerController::addMarker):
(WebCore::DocumentMarkerController::removeMarkers):
(WebCore::DocumentMarkerController::writingToolsTextSuggestionAnimationTimerFired):
(WebCore::DocumentMarkerController::unifiedTextReplacementAnimationTimerFired): Deleted.
* Source/WebCore/dom/DocumentMarkerController.h:
* Source/WebCore/page/writing-tools/WritingToolsController.h:
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::contextRangeForDocument):
(WebCore::WritingToolsController::willBeginWritingToolsSession):
(WebCore::WritingToolsController::proofreadingSessionDidReceiveSuggestions):
(WebCore::WritingToolsController::proofreadingSessionDidUpdateStateForSuggestion):
(WebCore::WritingToolsController::compositionSessionDidReceiveTextWithReplacementRange):
(WebCore::WritingToolsController::writingToolsSessionDidReceiveAction&lt;WritingTools::Session::Type::Proofreading&gt;):
(WebCore::WritingToolsController::writingToolsSessionDidReceiveAction&lt;WritingTools::Session::Type::Composition&gt;):
(WebCore::WritingToolsController::didEndWritingToolsSession&lt;WritingTools::Session::Type::Proofreading&gt;):
(WebCore::WritingToolsController::didEndWritingToolsSession&lt;WritingTools::Session::Type::Composition&gt;):
(WebCore::WritingToolsController::didEndWritingToolsSession):
(WebCore::WritingToolsController::updateStateForSelectedSuggestionIfNeeded):
(WebCore::WritingToolsController::findTextSuggestionMarkerByID const):
(WebCore::WritingToolsController::findTextSuggestionMarkerContainingRange const):
(WebCore::WritingToolsController::replaceContentsOfRangeInSession):
* Source/WebCore/rendering/MarkedText.cpp:
(WebCore::MarkedText::collectForDocumentMarkers):
* Source/WebCore/rendering/MarkedText.h:
* Source/WebCore/rendering/StyledMarkedText.cpp:
(WebCore::resolveStyleForMarkedText):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintPlatformDocumentMarker):
* Source/WebCore/testing/Internals.cpp:
(WebCore::markerTypeFrom):
(WebCore::Internals::hasWritingToolsTextSuggestionMarker):
(WebCore::Internals::hasUnifiedTextReplacementMarker): Deleted.
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp:
(WebCore::operator&lt;&lt;):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(TEST(WritingTools, ProofreadingAcceptReject)):
(TEST(WritingTools, ProofreadingWithLongReplacement)):
(TEST(WritingTools, ProofreadingShowOriginal)):

Canonical link: <a href="https://commits.webkit.org/280219@main">https://commits.webkit.org/280219@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33a482dcde555bd5e8a9b0f249e20bc304ec2eaf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56020 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8492 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/59021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/59/builds/6456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58146 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6650 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/59021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/59/builds/6456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58049 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/33245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/48311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/59021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/30026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/5640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/4597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/51995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/5912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/60610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/6037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/60610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/48378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/60610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8292 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/31173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/46/builds/32259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/33342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/45/builds/32006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->