### PR TITLE
[GStreamer] Buffering hysteresis and buffering improvements for Broadcom

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1301,6 +1301,9 @@ http/wpt/mediasession/setCaptureState-audio-category.html [ Skip ]
 # Lack of voice activity detection mock
 http/wpt/mediasession/voiceActivityDetection.html [ Skip ]
 
+# Seek on live streams not implemented.
+webkit.org/b/280069 imported/w3c/web-platform-tests/webvtt/api/VTTRegion/non-visible-cue-with-region.html [ Failure ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of GStreamer-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebCore/platform/SourcesGStreamer.txt
+++ b/Source/WebCore/platform/SourcesGStreamer.txt
@@ -103,6 +103,7 @@ platform/gstreamer/GStreamerHolePunchQuirkWesteros.cpp
 platform/gstreamer/GStreamerQuirkAmLogic.cpp
 platform/gstreamer/GStreamerQuirkBcmNexus.cpp
 platform/gstreamer/GStreamerQuirkBroadcom.cpp
+platform/gstreamer/GStreamerQuirkBroadcomBase.cpp
 platform/gstreamer/GStreamerQuirkRealtek.cpp
 platform/gstreamer/GStreamerQuirkRialto.cpp
 platform/gstreamer/GStreamerQuirkWesteros.cpp

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1100,6 +1100,38 @@ StringView gstStructureGetName(const GstStructure* structure)
     return StringView::fromLatin1(gst_structure_get_name(structure));
 }
 
+template<typename T>
+Vector<T> gstStructureGetArray(const GstStructure* structure, ASCIILiteral key)
+{
+    static_assert(std::is_same_v<T, int> || std::is_same_v<T, int64_t> || std::is_same_v<T, unsigned>
+        || std::is_same_v<T, uint64_t> || std::is_same_v<T, double> || std::is_same_v<T, const GstStructure*>);
+    Vector<T> result;
+    if (!structure)
+        return result;
+    const GValue* array = gst_structure_get_value(structure, key.characters());
+    if (!GST_VALUE_HOLDS_ARRAY (array))
+        return result;
+    unsigned size = gst_value_array_get_size(array);
+    for (unsigned i = 0; i < size; i++) {
+        const GValue* item = gst_value_array_get_value(array, i);
+        if constexpr(std::is_same_v<T, int>)
+            result.append(g_value_get_int(item));
+        else if constexpr(std::is_same_v<T, int64_t>)
+            result.append(g_value_get_int64(item));
+        else if constexpr(std::is_same_v<T, unsigned>)
+            result.append(g_value_get_uint(item));
+        else if constexpr(std::is_same_v<T, uint64_t>)
+            result.append(g_value_get_uint64(item));
+        else if constexpr(std::is_same_v<T, double>)
+            result.append(g_value_get_double(item));
+        else if constexpr(std::is_same_v<T, const GstStructure*>)
+            result.append(gst_value_get_structure(item));
+    }
+    return result;
+}
+
+template Vector<const GstStructure*> gstStructureGetArray(const GstStructure*, ASCIILiteral key);
+
 static RefPtr<JSON::Value> gstStructureToJSON(const GstStructure*);
 
 static std::optional<RefPtr<JSON::Value>> gstStructureValueToJSON(const GValue* value)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -283,6 +283,9 @@ StringView gstStructureGetString(const GstStructure*, StringView key);
 
 StringView gstStructureGetName(const GstStructure*);
 
+template<typename T>
+Vector<T> gstStructureGetArray(const GstStructure*, ASCIILiteral key);
+
 String gstStructureToJSONString(const GstStructure*);
 
 GstClockTime webkitGstInitTime();

--- a/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkBcmNexus.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkBcmNexus.h
@@ -28,7 +28,7 @@ namespace WebCore {
 
 class GStreamerHolePunchQuirkBcmNexus final : public GStreamerHolePunchQuirk {
 public:
-    const char* identifier() final { return "BcmNexusHolePunch"; }
+    const ASCIILiteral identifier() const final { return "BcmNexusHolePunch"_s; }
 
     // NOTE: We don't override createHolePunchVideoSink here because autovideosink takes care of
     // auto-plugging the right sink.

--- a/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkFake.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkFake.h
@@ -29,7 +29,7 @@ namespace WebCore {
 
 class GStreamerHolePunchQuirkFake final : public GStreamerHolePunchQuirk {
 public:
-    const char* identifier() final { return "FakeHolePunch"; }
+    const ASCIILiteral identifier() const final { return "FakeHolePunch"_s; }
     GstElement* createHolePunchVideoSink(bool, const MediaPlayer*) final { return makeGStreamerElement("fakevideosink", nullptr); }
     bool setHolePunchVideoRectangle(GstElement*, const IntRect&) final { return true; }
 };

--- a/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkRialto.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkRialto.h
@@ -33,7 +33,7 @@ namespace WebCore {
 
 class GStreamerHolePunchQuirkRialto final : public GStreamerHolePunchQuirk {
 public:
-    const char* identifier() final { return "RialtoHolePunch"; }
+    const ASCIILiteral identifier() const final { return "RialtoHolePunch"_s; }
 
     GstElement* createHolePunchVideoSink(bool, const MediaPlayer*) final;
     bool setHolePunchVideoRectangle(GstElement*, const IntRect&) final;

--- a/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkWesteros.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkWesteros.h
@@ -28,7 +28,7 @@ namespace WebCore {
 
 class GStreamerHolePunchQuirkWesteros final : public GStreamerHolePunchQuirk {
 public:
-    const char* identifier() final { return "WesterosHolePunch"; }
+    const ASCIILiteral identifier() const final { return "WesterosHolePunch"_s; }
 
     GstElement* createHolePunchVideoSink(bool, const MediaPlayer*) final;
     bool setHolePunchVideoRectangle(GstElement*, const IntRect&) final;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.h
@@ -29,7 +29,7 @@ namespace WebCore {
 class GStreamerQuirkAmLogic final : public GStreamerQuirk {
 public:
     GStreamerQuirkAmLogic();
-    const char* identifier() final { return "AmLogic"; }
+    const ASCIILiteral identifier() const final { return "AmLogic"_s; }
 
     GstElement* createWebAudioSink() final;
     void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBcmNexus.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBcmNexus.h
@@ -22,14 +22,15 @@
 
 #if USE(GSTREAMER)
 
+#include "GStreamerQuirkBroadcomBase.h"
 #include "GStreamerQuirks.h"
 
 namespace WebCore {
 
-class GStreamerQuirkBcmNexus final : public GStreamerQuirk {
+class GStreamerQuirkBcmNexus final : public GStreamerQuirkBroadcomBase {
 public:
     GStreamerQuirkBcmNexus();
-    const char* identifier() final { return "BcmNexus"; }
+    const ASCIILiteral identifier() const final { return "BcmNexus"_s; }
 
     std::optional<bool> isHardwareAccelerated(GstElementFactory*) final;
     std::optional<GstElementFactoryListType> audioVideoDecoderFactoryListType() const final { return GST_ELEMENT_FACTORY_TYPE_PARSER; }

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.h
@@ -23,14 +23,15 @@
 #if USE(GSTREAMER)
 
 #include "GStreamerCommon.h"
+#include "GStreamerQuirkBroadcomBase.h"
 #include "GStreamerQuirks.h"
 
 namespace WebCore {
 
-class GStreamerQuirkBroadcom final : public GStreamerQuirk {
+class GStreamerQuirkBroadcom final : public GStreamerQuirkBroadcomBase {
 public:
     GStreamerQuirkBroadcom();
-    const char* identifier() final { return "Broadcom"; }
+    const ASCIILiteral identifier() const final { return "Broadcom"_s; }
 
     void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
     std::optional<bool> isHardwareAccelerated(GstElementFactory*) final;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcomBase.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcomBase.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2024 Igalia S.L
+ * Copyright (C) 2024 Metrological Group B.V.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "GStreamerQuirkBroadcomBase.h"
+
+#include <string.h>
+
+#if USE(GSTREAMER)
+
+#include "GStreamerCommon.h"
+
+namespace WebCore {
+
+GST_DEBUG_CATEGORY_STATIC(webkit_broadcom_base_quirks_debug);
+#define GST_CAT_DEFAULT webkit_broadcom_base_quirks_debug
+
+GStreamerQuirkBroadcomBase::GStreamerQuirkBroadcomBase()
+{
+    GST_DEBUG_CATEGORY_INIT(webkit_broadcom_base_quirks_debug, "webkitquirksbroadcombase", 0, "WebKit Broadcom Base Quirks");
+}
+
+ASCIILiteral GStreamerQuirkBroadcomBase::queryBufferingPercentage(MediaPlayerPrivateGStreamer* playerPrivate, const GRefPtr<GstQuery>& query) const
+{
+    auto& state = ensureState(playerPrivate);
+
+    if (playerPrivate->shouldDownload() || !state.m_queue2
+        || !gst_element_query(state.m_queue2.get(), query.get()))
+        return nullptr;
+    return "queue2"_s;
+}
+
+int GStreamerQuirkBroadcomBase::correctBufferingPercentage(MediaPlayerPrivateGStreamer* playerPrivate, int originalBufferingPercentage, GstBufferingMode mode) const
+{
+    auto& state = ensureState(playerPrivate);
+
+    // The Nexus playpump buffers a lot of data. Let's add it as if it had been buffered by the GstQueue2
+    // (only when using in-memory buffering), so we get more realistic percentages.
+    if (mode != GST_BUFFERING_STREAM || !(state.m_vidfilter || state.m_audfilter))
+        return originalBufferingPercentage;
+
+    // The Nexus playpump buffers a lot of data. Let's add it as if it had been buffered by the GstQueue2
+    // (only when using in-memory buffering), so we get more realistic percentages.
+    int correctedBufferingPercentage1 = originalBufferingPercentage;
+    int correctedBufferingPercentage2 = originalBufferingPercentage;
+    unsigned maxSizeBytes = 0;
+
+    // We don't trust the buffering percentage when it's 0, better rely on current-level-bytes and compute a new buffer level accordingly.
+    g_object_get(state.m_queue2.get(), "max-size-bytes", &maxSizeBytes, nullptr);
+    if (!originalBufferingPercentage && state.m_queue2) {
+        unsigned currentLevelBytes = 0;
+        g_object_get(state.m_queue2.get(), "current-level-bytes", &currentLevelBytes, nullptr);
+        correctedBufferingPercentage1 = currentLevelBytes > maxSizeBytes ? 100 : static_cast<int>(currentLevelBytes * 100 / maxSizeBytes);
+    }
+
+    unsigned playpumpBufferedBytes = 0;
+
+    // We believe that the playpump stats are common for audio and video, so only asking the vidfilter or the audfilter
+    // would be enough. Both of them expose the buffered_bytes property (yes, with an underscore!).
+    GstElement* filter = state.m_vidfilter ? state.m_vidfilter.get() : state.m_audfilter.get();
+    if (filter)
+        g_object_get(GST_OBJECT(filter), "buffered_bytes", &playpumpBufferedBytes, nullptr);
+
+    unsigned multiqueueBufferedBytes = 0;
+    if (state.m_multiqueue) {
+        GUniqueOutPtr<GstStructure> stats;
+        g_object_get(state.m_multiqueue.get(), "stats", &stats.outPtr(), nullptr);
+        for (const auto& queue : gstStructureGetArray<const GstStructure*>(stats.get(), "queues"_s))
+            multiqueueBufferedBytes += gstStructureGet<unsigned>(queue, "bytes"_s).value_or(0);
+    }
+
+    // Current-level-bytes seems to be inacurate, so we compute its value from the buffering percentage.
+    size_t currentLevelBytes = static_cast<size_t>(maxSizeBytes) * static_cast<size_t>(originalBufferingPercentage) / static_cast<size_t>(100)
+        + static_cast<size_t>(playpumpBufferedBytes) + static_cast<size_t>(multiqueueBufferedBytes);
+    correctedBufferingPercentage2 = currentLevelBytes > maxSizeBytes ? 100 : static_cast<int>(currentLevelBytes * 100 / maxSizeBytes);
+
+    if (correctedBufferingPercentage2 >= 100)
+        state.m_streamBufferingLevelMovingAverage.reset(100);
+    int averagedBufferingPercentage = state.m_streamBufferingLevelMovingAverage.accumulate(correctedBufferingPercentage2);
+
+    const char* extraElements = state.m_multiqueue ? "playpump and multiqueue" : "playpump";
+    if (!originalBufferingPercentage) {
+        GST_DEBUG("[Buffering] Buffering: mode: GST_BUFFERING_STREAM, status: %d%% (corrected to %d%% with current-level-bytes, "
+            "to %d%% with %s content, and to %d%% with moving average).", originalBufferingPercentage, correctedBufferingPercentage1,
+            correctedBufferingPercentage2, extraElements, averagedBufferingPercentage);
+    } else {
+        GST_DEBUG("[Buffering] Buffering: mode: GST_BUFFERING_STREAM, status: %d%% (corrected to %d%% with %s content and "
+            "to %d%% with moving average).", originalBufferingPercentage, correctedBufferingPercentage2, extraElements,
+            averagedBufferingPercentage);
+    }
+
+    return averagedBufferingPercentage;
+}
+
+void GStreamerQuirkBroadcomBase::resetBufferingPercentage(MediaPlayerPrivateGStreamer* playerPrivate, int bufferingPercentage) const
+{
+    auto& state = ensureState(playerPrivate);
+    state.m_streamBufferingLevelMovingAverage.reset(bufferingPercentage);
+}
+
+void GStreamerQuirkBroadcomBase::setupBufferingPercentageCorrection(MediaPlayerPrivateGStreamer* playerPrivate, GstState currentState, GstState newState, GRefPtr<GstElement>&& element) const
+{
+    auto& state = ensureState(playerPrivate);
+
+    // This code must support being run from different GStreamerQuirkBroadcomBase subclasses without breaking. Only the
+    // first subclass instance should run.
+
+    if (currentState == GST_STATE_NULL && newState == GST_STATE_READY) {
+        bool alsoGetMultiqueue = false;
+        if (!g_strcmp0(G_OBJECT_TYPE_NAME(element.get()), "GstBrcmVidFilter")) {
+            state.m_vidfilter = element;
+            alsoGetMultiqueue = true;
+        } else if (!g_strcmp0(G_OBJECT_TYPE_NAME(element.get()), "GstBrcmAudFilter")) {
+            state.m_audfilter = element;
+            alsoGetMultiqueue = true;
+        } else if (!g_strcmp0(G_OBJECT_TYPE_NAME(element.get()), "GstQueue2"))
+            state.m_queue2 = element;
+
+        // Might have been already retrieved by vidfilter or audfilter, whichever appeared first.
+        if (alsoGetMultiqueue && !state.m_multiqueue) {
+            // Also get the multiqueue (if there's one) attached to the vidfilter/aacparse+audfilter.
+            // We'll need it later to correct the buffering level.
+            for (auto* sinkPad : GstIteratorAdaptor<GstPad>(GUniquePtr<GstIterator>(gst_element_iterate_sink_pads(element.get())))) {
+                GRefPtr<GstPad> peerSrcPad = adoptGRef(gst_pad_get_peer(sinkPad));
+                if (!peerSrcPad)
+                    continue; // And end the loop, because there's only one srcpad.
+                GRefPtr<GstElement> peerElement = adoptGRef(GST_ELEMENT(gst_pad_get_parent(peerSrcPad.get())));
+
+                // If it's NOT a multiqueue, it's probably a parser like aacparse. We try to traverse before it.
+                if (peerElement && g_strcmp0(G_OBJECT_TYPE_NAME(element.get()), "GstMultiQueue")) {
+                    for (auto* peerElementSinkPad : GstIteratorAdaptor<GstPad>(GUniquePtr<GstIterator>(gst_element_iterate_sink_pads(peerElement.get())))) {
+                        peerSrcPad = adoptGRef(gst_pad_get_peer(peerElementSinkPad));
+                        if (!peerSrcPad)
+                            continue; // And end the loop.
+                        // Now we hopefully have peerElement pointing to the multiqueue.
+                        peerElement = adoptGRef(GST_ELEMENT(gst_pad_get_parent(peerSrcPad.get())));
+                        break;
+                    }
+                }
+
+                // The multiqueue reference is useless if we can't access its stats (on older GStreamer versions).
+                if (peerElement && !g_strcmp0(G_OBJECT_TYPE_NAME(element.get()), "GstMultiQueue")
+                    && gstObjectHasProperty(peerElement.get(), "stats"))
+                    state.m_multiqueue = peerElement;
+                break;
+            }
+        }
+    } else if (currentState == GST_STATE_READY && newState == GST_STATE_NULL) {
+        if (!g_strcmp0(G_OBJECT_TYPE_NAME(element.get()), "GstBrcmVidFilter"))
+            state.m_vidfilter = nullptr;
+        else if (!g_strcmp0(G_OBJECT_TYPE_NAME(element.get()), "GstBrcmAudFilter"))
+            state.m_audfilter = nullptr;
+        else if (!g_strcmp0(G_OBJECT_TYPE_NAME(element.get()), "GstMultiQueue") && element == state.m_multiqueue.get())
+            state.m_multiqueue = nullptr;
+        else if (!g_strcmp0(G_OBJECT_TYPE_NAME(element.get()), "GstQueue2"))
+            state.m_queue2 = nullptr;
+    }
+}
+
+GStreamerQuirkBroadcomBase::GStreamerQuirkBroadcomBaseState& GStreamerQuirkBroadcomBase::ensureState(MediaPlayerPrivateGStreamer* playerPrivate) const
+{
+    GStreamerQuirkBase::GStreamerQuirkState* state = playerPrivate->quirkState(this);
+    if (!state) {
+        GST_DEBUG("%s %p setting up quirk state on MediaPlayerPrivate %p", identifier().characters(), this, playerPrivate);
+        playerPrivate->setQuirkState(this, makeUnique<GStreamerQuirkBroadcomBaseState>());
+        state = playerPrivate->quirkState(this);
+    }
+    return reinterpret_cast<GStreamerQuirkBroadcomBaseState&>(*state);
+}
+
+#undef GST_CAT_DEFAULT
+
+} // namespace WebCore
+
+#endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcomBase.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcomBase.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2024 Igalia S.L
+ * Copyright (C) 2024 Metrological Group B.V.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * aint with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if USE(GSTREAMER)
+
+#include "GStreamerCommon.h"
+#include "GStreamerQuirks.h"
+#include "MediaPlayerPrivateGStreamer.h"
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+class GStreamerQuirkBroadcomBase : public GStreamerQuirk {
+public:
+    GStreamerQuirkBroadcomBase();
+
+    bool needsBufferingPercentageCorrection() const { return true; }
+    ASCIILiteral queryBufferingPercentage(MediaPlayerPrivateGStreamer*, const GRefPtr<GstQuery>&) const;
+    int correctBufferingPercentage(MediaPlayerPrivateGStreamer*, int originalBufferingPercentage, GstBufferingMode) const;
+    void resetBufferingPercentage(MediaPlayerPrivateGStreamer*, int bufferingPercentage) const;
+    void setupBufferingPercentageCorrection(MediaPlayerPrivateGStreamer*, GstState currentState, GstState newState, GRefPtr<GstElement>&&) const;
+
+protected:
+    class MovingAverage {
+    public:
+        MovingAverage(size_t length)
+            : m_values(length)
+        {
+            // Ensure that the sum in accumulate() can't ever overflow, considering that the highest value
+            // for stored percentages is 100.
+            ASSERT(length < INT_MAX / 100);
+        }
+
+        void reset(int value)
+        {
+            ASSERT(value <= 100);
+            for (size_t i = 0; i < m_values.size(); i++)
+                m_values[i] = value;
+        }
+
+        int accumulate(int value)
+        {
+            ASSERT(value <= 100);
+            int sum = 0;
+            for (size_t i = 1; i < m_values.size(); i++) {
+                m_values[i - 1] = m_values[i];
+                sum += m_values[i - 1];
+            }
+            m_values[m_values.size() - 1] = value;
+            sum += value;
+            return sum / m_values.size();
+        }
+    private:
+        Vector<int> m_values;
+    };
+
+    using GStreamerQuirkBase::GStreamerQuirkState;
+
+    class GStreamerQuirkBroadcomBaseState : public GStreamerQuirkState {
+    public:
+        GStreamerQuirkBroadcomBaseState() = default;
+        virtual ~GStreamerQuirkBroadcomBaseState() = default;
+
+        GRefPtr<GstElement> m_audfilter;
+        GRefPtr<GstElement> m_vidfilter;
+        GRefPtr<GstElement> m_multiqueue;
+        GRefPtr<GstElement> m_queue2;
+        MovingAverage m_streamBufferingLevelMovingAverage { 10 };
+    };
+
+    virtual GStreamerQuirkBroadcomBaseState& ensureState(MediaPlayerPrivateGStreamer*) const;
+};
+
+} // namespace WebCore
+
+#endif // USE(GSTREAMER)

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.h
@@ -29,7 +29,7 @@ namespace WebCore {
 class GStreamerQuirkRealtek final : public GStreamerQuirk {
 public:
     GStreamerQuirkRealtek();
-    const char* identifier() final { return "Realtek"; }
+    const ASCIILiteral identifier() const final { return "Realtek"_s; }
 
     GstElement* createWebAudioSink() final;
     void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.h
@@ -34,7 +34,7 @@ namespace WebCore {
 class GStreamerQuirkRialto final : public GStreamerQuirk {
 public:
     GStreamerQuirkRialto();
-    const char* identifier() final { return "Rialto"; }
+    const ASCIILiteral identifier() const final { return "Rialto"_s; }
 
     void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
     GstElement* createAudioSink() final;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.h
@@ -29,7 +29,7 @@ namespace WebCore {
 class GStreamerQuirkWesteros final : public GStreamerQuirk {
 public:
     GStreamerQuirkWesteros();
-    const char* identifier() final { return "Westeros"; }
+    const ASCIILiteral identifier() const final { return "Westeros"_s; }
 
     void configureElement(GstElement*, const OptionSet<ElementRuntimeCharacteristics>&) final;
     std::optional<bool> isHardwareAccelerated(GstElementFactory*) final;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.h
@@ -25,11 +25,15 @@
 #include "GStreamerCommon.h"
 #include "MediaPlayer.h"
 #include <wtf/Forward.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
+
+class MediaPlayerPrivateGStreamer;
 
 enum class ElementRuntimeCharacteristics : uint8_t {
     IsMediaStream = 1 << 0,
@@ -45,7 +49,20 @@ public:
     GStreamerQuirkBase() = default;
     virtual ~GStreamerQuirkBase() = default;
 
-    virtual const char* identifier() = 0;
+    virtual const ASCIILiteral identifier() const = 0;
+
+    // Interface of classes supplied to MediaPlayerPrivateGStreamer to store values that the quirks will need for their job.
+    class GStreamerQuirkState {
+        WTF_MAKE_FAST_ALLOCATED;
+        // Prevent accidental https://en.wikipedia.org/wiki/Object_slicing.
+        WTF_MAKE_NONCOPYABLE(GStreamerQuirkState);
+        WTF_MAKE_NONMOVABLE(GStreamerQuirkState);
+    public:
+        GStreamerQuirkState()
+        {
+        }
+        virtual ~GStreamerQuirkState() = default;
+    };
 };
 
 class GStreamerQuirk : public GStreamerQuirkBase {
@@ -63,6 +80,13 @@ public:
     virtual Vector<String> disallowedWebAudioDecoders() const { return { }; }
     virtual unsigned getAdditionalPlaybinFlags() const { return 0; }
     virtual bool shouldParseIncomingLibWebRTCBitStream() const { return true; }
+
+    virtual bool needsBufferingPercentageCorrection() const { return false; }
+    // Returns name of the queried GstElement, or nullptr if no element was queried.
+    virtual ASCIILiteral queryBufferingPercentage(MediaPlayerPrivateGStreamer*, const GRefPtr<GstQuery>&) const { return nullptr; }
+    virtual int correctBufferingPercentage(MediaPlayerPrivateGStreamer*, int originalBufferingPercentage, GstBufferingMode) const { return originalBufferingPercentage; }
+    virtual void resetBufferingPercentage(MediaPlayerPrivateGStreamer*, int) const { };
+    virtual void setupBufferingPercentageCorrection(MediaPlayerPrivateGStreamer*, GstState, GstState, GRefPtr<GstElement>&&) const { }
 };
 
 class GStreamerHolePunchQuirk : public GStreamerQuirkBase {
@@ -107,6 +131,13 @@ public:
     unsigned getAdditionalPlaybinFlags() const;
 
     bool shouldParseIncomingLibWebRTCBitStream() const;
+
+    bool needsBufferingPercentageCorrection() const;
+    // Returns name of the queried GstElement, or nullptr if no element was queried.
+    ASCIILiteral queryBufferingPercentage(MediaPlayerPrivateGStreamer*, const GRefPtr<GstQuery>&) const;
+    int correctBufferingPercentage(MediaPlayerPrivateGStreamer*, int originalBufferingPercentage, GstBufferingMode) const;
+    void resetBufferingPercentage(MediaPlayerPrivateGStreamer*, int bufferingPercentage) const;
+    void setupBufferingPercentageCorrection(MediaPlayerPrivateGStreamer*, GstState currentState, GstState newState, GRefPtr<GstElement>&&) const;
 
 private:
     GStreamerQuirksManager(bool, bool);


### PR DESCRIPTION
#### aededeb7ddd9e55b53d9eda0be721ab3fd8180e4
<pre>
[GStreamer] Buffering hysteresis and buffering improvements for Broadcom
<a href="https://bugs.webkit.org/show_bug.cgi?id=275683">https://bugs.webkit.org/show_bug.cgi?id=275683</a>

Reviewed by Xabier Rodriguez-Calvar.

The usage of a fixed buffering level to evaluate the need for buffering
results in a too unstable behaviour, with quick changes between states
that may create stuttering.

This commit adds hysteresis to the buffering level, with low and high
watermark levels that trigger &quot;buffering needed&quot; (when below the low
watermark), &quot;buffering completed&quot; (when above high watermark) and &quot;same
state as before&quot; when the level is between both marks.

In addition to that, the pipeline is automatically paused on a seek when
working on stream mode (using GstQueue2 for partial in-memory buffering
instead of using GstDownload for full on-disk download of the media).
This is because, when seeking, rebuffering must occur from scratch to
get the data for the new target position, and buffering level starts
from 0% in that case, which means that buffering is needed and the
pipeline must be paused. Both the m_isBuffering flag and
m_bufferingPercentage are immediately forced to true and 0%, respectively.
The previous values (see explanation below) are also set to the same
values by using the new resetHistory parameter in updateBufferingStatus().
This makes sure that the &quot;end of buffering&quot; condition can be properly
detected.

The buffering status and buffering level computation has been
centralized in updateBufferingStatus(). Both the status and the level
now store the last value, so it&apos;s possible to check if there&apos;s been any
difference on them and to decide here on the hysteresis status
evolution.

updateStates() is where the consequences of buffering changes happen.
This method now relies in the status and level updates explained in the
previous paragraph. In the specific case of an async change, the current
values for m_isBuffering and m_bufferingPercentage are ignored (previous
ones are used). This is to be able to detect significant changes in the
hysteresis (watermark level crossing) after the async change has
completed. Otherwise, we would be detecting those crossings in a moment
where nothing can be done (pipeline state changes are ignored can can&apos;t
be enforced during async state changes).

Some extra improvements have been added to adapt to the special
circumstances of Broadcom devices, where the PlayPump Nexus component
can store a lot of data which is hidden to the vanilla buffering
algorithm. Now that data is had into account to compute the realistic
buffering level. Also, more agile low/high watermarks of 20% and 80% are
used for buffering in the case of playbin2 in stream buffering mode on
Broadcom.

20-80% levels for low/high watermark are now used on all devices
(Broadcom and not Broadcom), since usage tests proved that this makes
the buffering more agile also on Raspberry Pi, for instance.

All these changes are compatible with the Quirks framework. A new
needsBufferingPercentageCorrection() method has been added to enable the
extra buffering logic (which corrects the queue2 buffering level with the
buffer levels of PlayPump and multiqueue) on the platforms that use Nexus.
All the code to implement that logic has been hidden in the
GStreamerQuirkBroadcomBase class, from which both GStreamerQuirkBcmNexus
and GStreamerQuirkBroadcom inherit.

That code needs some elements that in principle would be very coupled with
MediaPlayerPrivateGStreamer, such as vidfilter, queue2, multiqueue and a
MovingAverage to smooth buffering levels. To avoid that coupling, they
are stored in an opaque GStreamerQuirkState, stored by the player private
but implemented by a GStreamerQuirkBroadcomBaseState subclass that only
GStreamerQuirkBroadcomBase knows how to interpret (by casting after
ensuring that the casting is legal).

There&apos;s also the problem that multiple competing quirks can be installing
at the same time, but all this buffering percentage correction code must
only be run by one (only one!) of them. To allow the theoretical coexistence
of multiple quirk state, each quirk instance has one associated state, and
the player private maintains that correspondence using a HashMap indexed by
quirk. To ensure that only one quirk is run at each time, the family of methods
in GStreamerQuirksManager only forward the call to the first configured
GStreamerQuirk subclass that declares the need to apply corrections. Any other
configured subclass is ignored.

Finally, some drive-by improvements are present in this commit. For instance,
converting some const char* to ASCIILiteral here and there.

* Source/WebCore/platform/SourcesGStreamer.txt: Added GStreamerQuirkBroadcomBase.
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
(WebCore::gstStructureGetArray): Added.
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::gstStructureGetArray): Method to get a GstArray GstValue stored into a GstStructure. Returns a Vector of the specified type, which includes basic types and &quot;const GstStructure*&quot;.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::play): Make code compatible with InitiallyPaused.
(WebCore::MediaPlayerPrivateGStreamer::doSeek): Pause pipeline and reset buffering level to 0% in case we&apos;re operating in stream mode.
(WebCore::MediaPlayerPrivateGStreamer::queryBufferingPercentage): Get the buffering percentage from the most relevant element and delegate to the quirks.
(WebCore::MediaPlayerPrivateGStreamer::fillTimerFired): Clarify that this method is only used in on-disk buffering. Rely on queryBufferingPercentage() now, instead of manually getting the value from here.
(WebCore::MediaPlayerPrivateGStreamer::handleMessage): Delegate to the quirks to store/delete references to specific elements in the quirks state.
(WebCore::MediaPlayerPrivateGStreamer::processBufferingStats): Delegate to the quierks to apply buffering percentage corrections on platforms that need them.
(WebCore::MediaPlayerPrivateGStreamer::updateBufferingStatus): Update the values of m_wasBuffering, m_isBuffering, m_previousBufferingPercentage, m_bufferingPercentage and m_didDownloadFinish. The first 4 attributes should *ONLY* be modified from this method, in order to guarantee coherency. The only *EXCEPTION* to this rule is the delay which can happen in updateStates(). The new resetHistory parameter sets the value both in the previous value family of attributes and in the current value family of variables. Also, restart the fillTimer if download has restarted (it was never restarted before this patch!)
(WebCore::MediaPlayerPrivateGStreamer::updateStates): Assume that m_wasBuffering, etc. have been precomputed by updateBufferingStatus() before updateStates() is called. In the case of an async state change, delay m_isBuffering and m_bufferingPercentage &quot;to the past&quot; (m_wasBuffering and m_previousBufferingPercentage), so that any change on them can be detected on the next iteration.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h: Added new m_wasBuffering and m_previousBufferingPercentage attributes to store previous values of m_isBuffering and m_bufferingPercentage and ease detection of changes. Added quirks state.
(WebCore::MediaPlayerPrivateGStreamer::shouldDownload): Needed by quirks.
(WebCore::MediaPlayerPrivateGStreamer::setQuirkState): Configure a GStreamerQuirkState for a specific GStreamerQuirk on the player private (each quirk has its own state, and in theory there can be many quirk-state stored).
(WebCore::MediaPlayerPrivateGStreamer::quirkState): Get the quirks state associated to a specific quirk from the player private, or nullptr if there&apos;s no configured state for that quirk.
* Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkBcmNexus.h: identifier() is now const ASCIILiteral.
* Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkFake.h: Ditto.
* Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkRialto.h: Ditto.
* Source/WebCore/platform/gstreamer/GStreamerHolePunchQuirkWesteros.h: Ditto.
* Source/WebCore/platform/gstreamer/GStreamerQuirkAmLogic.h: Ditto.
* Source/WebCore/platform/gstreamer/GStreamerQuirkBcmNexus.h: Ditto. Inherit from base class.
* Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcom.h: Ditto. Inherit from base class.
* Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcomBase.cpp: Added. Base class for GStreamerQuirkBcmNexus and GStreamerQuirkBroadcom.
(WebCore::GStreamerQuirkBroadcomBase::GStreamerQuirkBroadcomBase): Constructor.
(WebCore::GStreamerQuirkBroadcomBase::queryBufferingPercentage const): Get the buffering percentage from Queue2 if present and the player shouldn&apos;t download (streaming mode). Returns the name of the element finally used to query the percentage to, or nullptr if none was queried.
(WebCore::GStreamerQuirkBroadcomBase::correctBufferingPercentage const): On systems using PlayPump (eg: Broadcom Nexus), correct the buffering percentage with the data stored in multiqueue and PlayPump in order to make the buffering percentage more realistic. Uses the MovingAverage. Queries vidfilter and audfilter if needed, so it also works in audio or video-only pipelines.
(WebCore::GStreamerQuirkBroadcomBase::resetBufferingPercentage const): Sets the percentage to a given value in the MovingAverage.
(WebCore::GStreamerQuirkBroadcomBase::setupBufferingPercentageCorrection const): Gets/deletes references to vidfilter, multiqueue and queue2 in the quirks state.
(WebCore::GStreamerQuirkBroadcomBase::ensureState const): Retrieves GStreamerQuirkState associated to this quirk, creating one and storing it on MediaPlayerPrivateGStreamer if not already present.
* Source/WebCore/platform/gstreamer/GStreamerQuirkBroadcomBase.h: Added.
(WebCore::GStreamerQuirkBroadcomBase::needsBufferingPercentageCorrection const): True for this class and derived ones.
(WebCore::GStreamerQuirkBroadcomBase::MovingAverage::MovingAverage): Initialize an array of &quot;length&quot; number of elements, asserting if length is too big that the values would create overflow when computing the average.
(WebCore::GStreamerQuirkBroadcomBase::MovingAverage::reset): Reset all the values to a given value (usually zero).
(WebCore::GStreamerQuirkBroadcomBase::MovingAverage::accumulate): Insert a new value in the array and recompute the moving average.
* Source/WebCore/platform/gstreamer/GStreamerQuirkRealtek.h: identifier() is now const ASCIILiteral.
* Source/WebCore/platform/gstreamer/GStreamerQuirkRialto.h: Ditto.
* Source/WebCore/platform/gstreamer/GStreamerQuirkWesteros.h: Ditto.
* Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp: Added new methods.
(WebCore::GStreamerQuirksManager::GStreamerQuirksManager): Adapt to ASCIILiteral quirk identifier.
(WebCore::GStreamerQuirksManager::createAudioSink): Ditto.
(WebCore::GStreamerQuirksManager::createWebAudioSink): Ditto.
(WebCore::GStreamerQuirksManager::createHolePunchVideoSink): Ditto.
(WebCore::GStreamerQuirksManager::isHardwareAccelerated const): Ditto.
(WebCore::GStreamerQuirksManager::audioVideoDecoderFactoryListType const): Ditto.
(WebCore::GStreamerQuirksManager::getAdditionalPlaybinFlags const): Ditto.
(WebCore::GStreamerQuirksManager::needsBufferingPercentageCorrection const): True if any configured quirk needs it. The first configured quirk that needs it will be the one responsible to fulfill all the requests for this family of methods. The other ones will be ignored, even if they also need percentage correction. This is to avoid more than one implementation doing the corrections, as we don&apos;t want them to accumulate and over-correct.
(WebCore::GStreamerQuirksManager::queryBufferingPercentage const): Forward query request to the first configured quirk needing correction.
(WebCore::GStreamerQuirksManager::correctBufferingPercentage const): Forward correction request to the first configured quirk needing correction.
(WebCore::GStreamerQuirksManager::resetBufferingPercentage const): Ditto, but for reset.
(WebCore::GStreamerQuirksManager::setupBufferingPercentageCorrection const): Ditto, but for setup.
* Source/WebCore/platform/gstreamer/GStreamerQuirks.h:
(WebCore::GStreamerQuirkBase::GStreamerQuirkState::GStreamerQuirkState): Constructor.
(WebCore::GStreamerQuirk::needsBufferingPercentageCorrection const): Default empty implementation.
(WebCore::GStreamerQuirk::queryBufferingPercentage const): Ditto.
(WebCore::GStreamerQuirk::correctBufferingPercentage const): Ditto.
(WebCore::GStreamerQuirk::resetBufferingPercentage const): Ditto.
(WebCore::GStreamerQuirk::setupBufferingPercentageCorrection const): Ditto.
* LayoutTests/platform/glib/TestExpectations: Reported new failing test as <a href="https://bugs.webkit.org/show_bug.cgi?id=280069">https://bugs.webkit.org/show_bug.cgi?id=280069</a>, but IMHO it&apos;s not a regression. The test was passing before by sheer luck.

Canonical link: <a href="https://commits.webkit.org/284072@main">https://commits.webkit.org/284072@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c94695b47d393e07a0ef8bae68fb226c24a6dfb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/68417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/47809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/21076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/72484 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/19562 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/70534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/55605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/19378 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/54628 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/13031 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/71484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/43710 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/59080 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/35091 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/40378 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/16500 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/17919 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/62336 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/16848 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/74176 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/12388 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/16114 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/62079 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/12427 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/59158 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/62100 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15166 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/10022 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/3637 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/43610 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/44684 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/45878 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/44426 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->