### PR TITLE
Fallback to full-layout happens when more than 1 subtree layout is pending

### DIFF
--- a/PerformanceTests/Containment/multiple-changes-in-large-grid.html
+++ b/PerformanceTests/Containment/multiple-changes-in-large-grid.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <script src="../resources/runner.js"></script>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+<style>
+  html, body { height: 100%; }
+
+  #gridContainer {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1px;
+  }
+
+  .gridItemContainStrict {
+      display: block;
+      width: 10px;
+      height: 10px;
+      background-color: #0F0;
+      contain: strict;
+      font-size: 6px;
+  }
+
+  .gridItemContainNone {
+      display: block;
+      width: 10px;
+      height: 10px;
+      background-color: #00F;
+      font-size: 6px;
+  }
+</style>
+
+</head>
+
+<body>
+    <pre id="log"></pre>
+
+    <div id="gridContainer">
+    </div>
+
+    <script>
+      var gridContainer = document.getElementById('gridContainer');
+
+      function makeid(length) {
+          let result = '';
+          const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+          const charactersLength = characters.length;
+          let counter = 0;
+          while (counter < length) {
+              result += characters.charAt(Math.floor(Math.random() * charactersLength));
+              counter += 1;
+          }
+          return result;
+      }
+
+      function createDivElement(className, htmlContent) {
+          let newElement = document.createElement('div');
+          newElement.className = className;
+          newElement.innerHTML = htmlContent;
+          return newElement;
+      }
+
+      function setup() {
+          gridContainer.appendChild(createDivElement("gridItemContainStrict", '<span class="text">qwertyui</span>'));
+          for (let i = 0; i < 5000; ++i) {
+              gridContainer.appendChild(createDivElement("gridItemContainNone", '<span>z</span>'));
+          }
+          gridContainer.appendChild(createDivElement("gridItemContainStrict", '<span class="text">asdfghjk</span>'));
+          for (let i = 0; i < 5000; ++i) {
+              gridContainer.appendChild(createDivElement("gridItemContainNone", '<span>z</span>'));
+          }
+          gridContainer.appendChild(createDivElement("gridItemContainStrict", '<span class="text">zxcvbnm,</span>'));
+      }
+
+      function test() {
+          for (element of document.getElementsByClassName("text")) {
+              element.innerText = makeid(8);
+          }
+          gridContainer.offsetHeight; // Force layout.
+      }
+
+      function done() {
+      }
+
+      setup();
+      PerfTestRunner.measureRunsPerSecond({
+          description: "Measures performance of getting offsetHeight of a large grid container.",
+          run: test,
+          done: done
+      });
+    </script>
+</body>
+
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3365,7 +3365,7 @@ bool Document::updateLayoutIfDimensionsOutOfDate(Element& element, OptionSet<Dim
                 }
             }
 
-            if (currentRenderer == frameView->layoutContext().subtreeLayoutRoot())
+            if (frameView->layoutContext().hasSubtreeLayoutRoot(*currentRenderer))
                 break;
         }
     }

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -540,12 +540,12 @@ void LocalFrameView::didRestoreFromBackForwardCache()
 void LocalFrameView::willDestroyRenderTree()
 {
     detachCustomScrollbars();
-    layoutContext().clearSubtreeLayoutRoot();
+    layoutContext().clearSubtreeLayoutRoots();
 }
 
 void LocalFrameView::didDestroyRenderTree()
 {
-    ASSERT(!layoutContext().subtreeLayoutRoot());
+    ASSERT(!layoutContext().isSubtreeLayout());
     ASSERT(m_widgetsInRenderTree.isEmpty());
 
     ASSERT(!m_embeddedObjectsToUpdate || m_embeddedObjectsToUpdate->isEmpty());
@@ -730,7 +730,7 @@ void LocalFrameView::calculateScrollbarModesForLayout(ScrollbarMode& hMode, Scro
         vMode = ScrollbarMode::AlwaysOff;
     }
     
-    if (layoutContext().subtreeLayoutRoot())
+    if (layoutContext().isSubtreeLayout())
         return;
 
     RefPtr document = m_frame->document();
@@ -5074,7 +5074,7 @@ void LocalFrameView::autoSizeIfEnabled()
         return;
 
     SetForScope changeInAutoSize(m_inAutoSize, true);
-    if (layoutContext().subtreeLayoutRoot())
+    if (layoutContext().isSubtreeLayout())
         layoutContext().convertSubtreeLayoutToFullLayout();
 
     switch (m_autoSizeMode) {
@@ -6259,7 +6259,7 @@ void LocalFrameView::enableAutoSizeMode(bool enable, const IntSize& viewSize, Au
 
 void LocalFrameView::forceLayout(bool allowSubtreeLayout)
 {
-    if (!allowSubtreeLayout && layoutContext().subtreeLayoutRoot())
+    if (!allowSubtreeLayout && layoutContext().isSubtreeLayout())
         layoutContext().convertSubtreeLayoutToFullLayout();
     layoutContext().layout();
 }

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -74,6 +74,7 @@ UpdateScrollInfoAfterLayoutTransaction::~UpdateScrollInfoAfterLayoutTransaction(
 
 #ifndef NDEBUG
 class RenderTreeNeedsLayoutChecker {
+    WTF_MAKE_FAST_ALLOCATED;
 public :
     RenderTreeNeedsLayoutChecker(const RenderView& renderView)
         : m_renderView(renderView)
@@ -172,7 +173,7 @@ void LocalFrameViewLayoutContext::layout(bool canDeferUpdateLayerPositions)
 
     Ref protectedView(view());
 
-    performLayout(canDeferUpdateLayerPositions);
+    performLayouts(canDeferUpdateLayerPositions);
 
     if (view().hasOneRef())
         return;
@@ -184,7 +185,7 @@ void LocalFrameViewLayoutContext::layout(bool canDeferUpdateLayerPositions)
         if (!needsLayout())
             break;
 
-        performLayout(canDeferUpdateLayerPositions);
+        performLayouts(canDeferUpdateLayerPositions);
 
         if (view().hasOneRef())
             return;
@@ -197,13 +198,35 @@ void LocalFrameViewLayoutContext::interleavedLayout()
 
     Ref protectedView(view());
 
-    performLayout(false);
+    performLayouts(false);
 
     Style::DocumentScope::LayoutDependencyUpdateContext layoutDependencyUpdateContext;
     document()->styleScope().invalidateForLayoutDependencies(layoutDependencyUpdateContext);
 }
 
-void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPositions)
+void LocalFrameViewLayoutContext::performLayouts(bool canDeferUpdateLayerPositions)
+{
+#if PLATFORM(WPE) || PLATFORM(GTK)
+    WTFBeginSignpost(this, PerformSubtreesLayout, "subtrees: %u", m_subtreeLayoutRoots.size());
+#endif
+    if (isSubtreeLayout()) {
+        // When performing a subtree layout, we may need to perform layout for each subtree.
+        // The above might have been done in single pass, but calling performLayout() multiple times
+        // has some nice side-effects such as reporting "Layout" events in the inspector with specific subtree areas.
+        while (performLayout(canDeferUpdateLayerPositions, true) && !m_subtreeLayoutRoots.isEmpty()) { }
+#ifndef NDEBUG
+        // This function may be called recursively so let's do the checking when all the subtrees have been processed.
+        if (m_subtreeLayoutRoots.isEmpty())
+            RenderTreeNeedsLayoutChecker checker(*renderView());
+#endif
+    } else
+        performLayout(canDeferUpdateLayerPositions);
+#if PLATFORM(WPE) || PLATFORM(GTK)
+    WTFEndSignpost(this, PerformSubtreesLayout);
+#endif
+}
+
+bool LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPositions, bool unchecked)
 {
     Ref frame = this->frame();
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!document()->inRenderTreeUpdate());
@@ -215,13 +238,14 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
         || document()->backForwardCacheState() == Document::AboutToEnterBackForwardCache);
     if (!canPerformLayout()) {
         LOG(Layout, "  is not allowed, bailing");
-        return;
+        return false;
     }
 
     LayoutFrameScope layoutFrameScope(*this);
     TraceScope tracingScope(PerformLayoutStart, PerformLayoutEnd);
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
     InspectorInstrumentation::willLayout(frame);
+    RenderElement* subtreeLayoutRoot;
     SingleThreadWeakPtr<RenderElement> layoutRoot;
     
     m_layoutTimer.stop();
@@ -232,7 +256,7 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
         LOG_WITH_STREAM(Layout, stream << "LocalFrameView " << &view() << " elapsed time before first layout: " << document()->timeSinceDocumentCreation());
 #endif
 #if PLATFORM(IOS_FAMILY)
-    if (protect(view())->updateFixedPositionLayoutRect() && subtreeLayoutRoot())
+    if (protect(view())->updateFixedPositionLayoutRect() && isSubtreeLayout())
         convertSubtreeLayoutToFullLayout();
 #endif
     {
@@ -247,16 +271,17 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
         }
 
         if (view().hasOneRef())
-            return;
+            return false;
 
         protect(view())->autoSizeIfEnabled();
         if (!renderView())
-            return;
+            return false;
 
-        layoutRoot = subtreeLayoutRoot() ? subtreeLayoutRoot() : renderView();
+        subtreeLayoutRoot = isSubtreeLayout() ? *m_subtreeLayoutRoots.begin() : nullptr;
+        layoutRoot = subtreeLayoutRoot ?: renderView();
         m_needsFullRepaint = is<RenderView>(layoutRoot) && (m_firstLayout || renderView()->printing());
 
-        LOG_WITH_STREAM(Layout, stream << "LocalFrameView " << &view() << " layout " << m_layoutUpdateCount << " - subtree root " << subtreeLayoutRoot() << ", needsFullRepaint " << m_needsFullRepaint);
+        LOG_WITH_STREAM(Layout, stream << "LocalFrameView " << &view() << " layout " << m_layoutUpdateCount << " - subtree root " << subtreeLayoutRoot << ", needsFullRepaint " << m_needsFullRepaint);
 
         protect(view())->willDoLayout(layoutRoot);
         m_firstLayout = false;
@@ -267,10 +292,14 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
         TraceScope tracingScope(RenderTreeLayoutStart, RenderTreeLayoutEnd);
         SetForScope layoutPhase(m_layoutPhase, LayoutPhase::InRenderTreeLayout);
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
-        SubtreeLayoutStateMaintainer subtreeLayoutStateMaintainer(subtreeLayoutRoot());
+        SubtreeLayoutStateMaintainer subtreeLayoutStateMaintainer(subtreeLayoutRoot);
         RenderView::RepaintRegionAccumulator repaintRegionAccumulator(renderView());
 #ifndef NDEBUG
-        RenderTreeNeedsLayoutChecker checker(*renderView());
+        std::unique_ptr<RenderTreeNeedsLayoutChecker> checker;
+        if (!unchecked)
+            checker = WTF::makeUnique<RenderTreeNeedsLayoutChecker>(*renderView());
+#else
+        UNUSED_PARAM(unchecked);
 #endif
         layoutRoot->layout();
 #if ENABLE(TEXT_AUTOSIZING)
@@ -299,9 +328,11 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
             }
         }
 #endif
-        layoutRoot->absoluteQuads(layoutAreas);
+        for (auto* subtreeLayoutRoot : m_subtreeLayoutRoots)
+            subtreeLayoutRoot->absoluteQuads(layoutAreas);
 
-        clearSubtreeLayoutRoot();
+        if (subtreeLayoutRoot)
+            removeSubtreeLayoutRoot(*subtreeLayoutRoot);
         ASSERT(m_percentHeightIgnoreList.isEmptyIgnoringNullReferences());
 
 #if !LOG_DISABLED && ENABLE(TREE_DEBUGGING)
@@ -322,7 +353,7 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
             // FIXME: Firing media query callbacks synchronously on nested frames could produced a detached FrameView here by
             // navigating away from the current document (see webkit.org/b/173329).
             if (view().hasOneRef())
-                return;
+                return true;
         }
     }
     {
@@ -335,6 +366,7 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
     }
     InspectorInstrumentation::didLayout(frame, *layoutRoot, layoutAreas);
     DebugPageOverlays::didLayout(frame);
+    return true;
 }
 
 void LocalFrameViewLayoutContext::runOrScheduleAsynchronousTasks(bool canDeferUpdateLayerPositions)
@@ -661,7 +693,7 @@ bool LocalFrameViewLayoutContext::updateCompositingLayersAfterLayoutIfNeeded()
 void LocalFrameViewLayoutContext::reset()
 {
     m_layoutPhase = LayoutPhase::OutsideLayout;
-    clearSubtreeLayoutRoot();
+    clearSubtreeLayoutRoots();
     m_layoutSchedulingIsEnabled = true;
     m_layoutTimer.stop();
     m_firstLayout = true;
@@ -688,7 +720,7 @@ bool LocalFrameViewLayoutContext::needsLayoutInternal() const
     auto* renderView = this->renderView();
     return isLayoutPending()
         || (renderView && renderView->needsLayout())
-        || subtreeLayoutRoot()
+        || isSubtreeLayout()
         || (m_disableSetNeedsLayoutCount && m_setNeedsLayoutWasDeferred);
 }
 
@@ -727,7 +759,7 @@ void LocalFrameViewLayoutContext::scheduleLayout()
     if (!document)
         return;
 
-    if (subtreeLayoutRoot())
+    if (isSubtreeLayout())
         convertSubtreeLayoutToFullLayout();
 
     if (isLayoutPending())
@@ -774,49 +806,51 @@ void LocalFrameViewLayoutContext::scheduleSubtreeLayout(RenderElement& layoutRoo
     ASSERT(!renderView->renderTreeBeingDestroyed());
     ASSERT(frame().view() == &view());
 
-    if (renderView->needsLayout() && !subtreeLayoutRoot()) {
+    if (renderView->needsLayout() && !isSubtreeLayout()) {
         layoutRoot.markContainingBlocksForLayout(renderView.ptr());
         return;
     }
 
     if (!isLayoutPending() && isLayoutSchedulingEnabled()) {
         ASSERT(!layoutRoot.container() || is<RenderView>(layoutRoot.container()) || !layoutRoot.container()->needsLayout());
-        setSubtreeLayoutRoot(layoutRoot);
+        addSubtreeLayoutRoot(layoutRoot);
         InspectorInstrumentation::didScheduleLayout(layoutRoot);
         m_layoutTimer.startOneShot(0_s);
         return;
     }
 
-    CheckedPtr subtreeLayoutRoot = this->subtreeLayoutRoot();
-    if (subtreeLayoutRoot == &layoutRoot)
+    if (hasSubtreeLayoutRoot(layoutRoot))
         return;
 
-    if (!subtreeLayoutRoot) {
+    if (!isSubtreeLayout()) {
         // We already have a pending (full) layout. Just mark the subtree for layout.
         layoutRoot.markContainingBlocksForLayout(renderView.ptr());
         InspectorInstrumentation::didScheduleLayout(renderView);
         return;
     }
 
-    if (subtreeLayoutRoot->isAncestorContainerOfRenderer(layoutRoot)) {
-        // Keep the current root.
-        layoutRoot.markContainingBlocksForLayout(subtreeLayoutRoot);
-        ASSERT(!subtreeLayoutRoot->container() || is<RenderView>(subtreeLayoutRoot->container()) || !subtreeLayoutRoot->container()->needsLayout());
-        return;
+    // Combine new subtree with existing ones to make sure we store only independent subtrees.
+    for (auto* subtreeLayoutRoot : m_subtreeLayoutRoots) {
+        if (subtreeLayoutRoot->isAncestorContainerOfRenderer(layoutRoot)) {
+            // New subtree is a subtree of existing subtree.
+            layoutRoot.markContainingBlocksForLayout(subtreeLayoutRoot);
+            ASSERT(!subtreeLayoutRoot->container() || is<RenderView>(subtreeLayoutRoot->container()) || !subtreeLayoutRoot->container()->needsLayout());
+            return;
+        }
+        if (layoutRoot.isAncestorContainerOfRenderer(*subtreeLayoutRoot)) {
+            // Existing subtree is a subtree of new subtree.
+            subtreeLayoutRoot->markContainingBlocksForLayout(&layoutRoot);
+            ASSERT(!layoutRoot.container() || is<RenderView>(layoutRoot.container()) || !layoutRoot.container()->needsLayout());
+            InspectorInstrumentation::didScheduleLayout(layoutRoot);
+            removeSubtreeLayoutRoot(*subtreeLayoutRoot);
+            addSubtreeLayoutRoot(layoutRoot);
+            return;
+        }
     }
 
-    if (layoutRoot.isAncestorContainerOfRenderer(*subtreeLayoutRoot)) {
-        // Re-root at newRelayoutRoot.
-        subtreeLayoutRoot->markContainingBlocksForLayout(&layoutRoot);
-        setSubtreeLayoutRoot(layoutRoot);
-        ASSERT(!layoutRoot.container() || is<RenderView>(layoutRoot.container()) || !layoutRoot.container()->needsLayout());
-        InspectorInstrumentation::didScheduleLayout(layoutRoot);
-        return;
-    }
-    // Two disjoint subtrees need layout. Mark both of them and issue a full layout instead.
-    convertSubtreeLayoutToFullLayout();
-    layoutRoot.markContainingBlocksForLayout(renderView.ptr());
-    InspectorInstrumentation::didScheduleLayout(renderView);
+    // We already have a pending subtree layout. Just add new subtree to collection.
+    addSubtreeLayoutRoot(layoutRoot);
+    InspectorInstrumentation::didScheduleLayout(layoutRoot);
 }
 
 void LocalFrameViewLayoutContext::layoutTimerFired()
@@ -828,21 +862,32 @@ void LocalFrameViewLayoutContext::layoutTimerFired()
     layout();
 }
 
-RenderElement* LocalFrameViewLayoutContext::subtreeLayoutRoot() const
+bool LocalFrameViewLayoutContext::hasSubtreeLayoutRoot(const RenderElement& subtreeLayoutRoot) const
 {
-    return m_subtreeLayoutRoot.get();
+    return m_subtreeLayoutRoots.contains(const_cast<RenderElement*>(&subtreeLayoutRoot));
+}
+
+void LocalFrameViewLayoutContext::clearSubtreeLayoutRoots()
+{
+    m_subtreeLayoutRoots.clear();
 }
 
 void LocalFrameViewLayoutContext::convertSubtreeLayoutToFullLayout()
 {
-    ASSERT(subtreeLayoutRoot());
-    subtreeLayoutRoot()->markContainingBlocksForLayout(renderView());
-    clearSubtreeLayoutRoot();
+    ASSERT(!m_subtreeLayoutRoots.isEmpty());
+    for (auto* subtreeLayoutRoot : m_subtreeLayoutRoots)
+        subtreeLayoutRoot->markContainingBlocksForLayout(renderView());
+    clearSubtreeLayoutRoots();
 }
 
-void LocalFrameViewLayoutContext::setSubtreeLayoutRoot(RenderElement& layoutRoot)
+void LocalFrameViewLayoutContext::addSubtreeLayoutRoot(RenderElement& subtreeLayoutRoot)
 {
-    m_subtreeLayoutRoot = layoutRoot;
+    m_subtreeLayoutRoots.add(&subtreeLayoutRoot);
+}
+
+void LocalFrameViewLayoutContext::removeSubtreeLayoutRoot(const RenderElement& subtreeLayoutRoot)
+{
+    m_subtreeLayoutRoots.remove(const_cast<RenderElement*>(&subtreeLayoutRoot));
 }
 
 bool LocalFrameViewLayoutContext::canPerformLayout() const
@@ -853,7 +898,7 @@ bool LocalFrameViewLayoutContext::canPerformLayout() const
     if (view().isPainting())
         return false;
 
-    if (!subtreeLayoutRoot() && !document()->renderView())
+    if (!isSubtreeLayout() && !document()->renderView())
         return false;
 
     return true;

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -103,6 +103,7 @@ public:
     LayoutPhase layoutPhase() const { return m_layoutPhase; }
     bool isLayoutNested() const { return m_layoutNestedState == LayoutNestedState::Nested; }
     bool isLayoutPending() const { return m_layoutTimer.isActive(); }
+    bool isSubtreeLayout() const { return !m_subtreeLayoutRoots.isEmpty(); }
     bool isInLayout() const { return layoutPhase() != LayoutPhase::OutsideLayout; }
     bool isInRenderTreeLayout() const { return layoutPhase() == LayoutPhase::InRenderTreeLayout; }
     bool inPaintableState() const { return layoutPhase() != LayoutPhase::InRenderTreeLayout && layoutPhase() != LayoutPhase::InViewSizeAdjust && (layoutPhase() != LayoutPhase::InPostLayout || inAsynchronousTasks()); }
@@ -120,8 +121,9 @@ public:
     std::optional<TextBoxTrim> textBoxTrim() const { return m_textBoxTrim; }
     void setTextBoxTrim(std::optional<TextBoxTrim> textBoxTrim) { m_textBoxTrim = textBoxTrim; }
 
-    RenderElement* NODELETE subtreeLayoutRoot() const;
-    void clearSubtreeLayoutRoot() { m_subtreeLayoutRoot.clear(); }
+    bool hasSubtreeLayoutRoot(const RenderElement&) const;
+    void removeSubtreeLayoutRoot(const RenderElement&);
+    void clearSubtreeLayoutRoots();
     void convertSubtreeLayoutToFullLayout();
 
     void reset();
@@ -209,7 +211,8 @@ private:
 
     bool NODELETE needsLayoutInternal() const;
 
-    void performLayout(bool canDeferUpdateLayerPositions);
+    void performLayouts(bool canDeferUpdateLayerPositions);
+    bool performLayout(bool canDeferUpdateLayerPositions, bool unchecked = false);
     bool NODELETE canPerformLayout() const;
     bool isLayoutSchedulingEnabled() const { return m_layoutSchedulingIsEnabled; }
 
@@ -220,7 +223,7 @@ private:
     void runOrScheduleAsynchronousTasks(bool canDeferUpdateLayerPositions);
     bool inAsynchronousTasks() const { return m_inAsynchronousTasks; }
 
-    void NODELETE setSubtreeLayoutRoot(RenderElement&);
+    void NODELETE addSubtreeLayoutRoot(RenderElement&);
 
 #if ENABLE(TEXT_AUTOSIZING)
     void applyTextSizingIfNeeded(RenderElement& layoutRoot);
@@ -267,7 +270,7 @@ private:
     SingleThreadWeakRef<LocalFrameView> m_frameView;
     Timer m_layoutTimer;
     Timer m_postLayoutTaskTimer;
-    SingleThreadWeakPtr<RenderElement> m_subtreeLayoutRoot;
+    HashSet<RenderElement*> m_subtreeLayoutRoots;
 
     bool m_layoutSchedulingIsEnabled { true };
     bool m_firstLayout { true };

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -5715,7 +5715,7 @@ void RenderBox::updateFloatPainterAfterSelfPaintingLayerChange()
     // Find the ancestor renderer that is supposed to paint this float now that it is not self painting anymore.
     auto floatingObjectForFloatPainting = [&]() -> FloatingObject* {
         auto& layoutContext = view().frameView().layoutContext();
-        if (!layoutContext.isInLayout() || layoutContext.subtreeLayoutRoot() != this)
+        if (!layoutContext.isInLayout() || !layoutContext.hasSubtreeLayoutRoot(*this))
             return nullptr;
 
         FloatingObject* floatPainter = nullptr;

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1266,7 +1266,7 @@ inline void RenderElement::clearSubtreeLayoutRootIfNeeded() const
     if (renderTreeBeingDestroyed())
         return;
 
-    if (view().frameView().layoutContext().subtreeLayoutRoot() != this)
+    if (!view().frameView().layoutContext().hasSubtreeLayoutRoot(*this))
         return;
 
     // Normally when a renderer is detached from the tree, the appropriate dirty bits get set
@@ -1276,7 +1276,7 @@ inline void RenderElement::clearSubtreeLayoutRootIfNeeded() const
     // This indicates a failure to layout the child, which is why
     // the layout root is still set to |this|. Make sure to clear it
     // since we are getting destroyed.
-    view().frameView().layoutContext().clearSubtreeLayoutRoot();
+    view().frameView().layoutContext().removeSubtreeLayoutRoot(*this);
 }
 
 void RenderElement::willBeDestroyed()

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -347,7 +347,7 @@ bool RenderFlexibleBox::canUseFlexItemForPercentageResolution(const RenderBox& f
             return true;
         }
 
-        if (&flexItem == view().frameView().layoutContext().subtreeLayoutRoot())
+        if (view().frameView().layoutContext().hasSubtreeLayoutRoot(flexItem))
             return !FlexFormattingUtils::mainAxisIsFlexItemInlineAxis(flexItem);
 
         // Outside of layout (i.e. when using relative percentage positioning), base the decision on style alone.


### PR DESCRIPTION
#### a2a20ee89178522a24560a62b0c99a7018dc2be4
<pre>
Fallback to full-layout happens when more than 1 subtree layout is pending
<a href="https://bugs.webkit.org/show_bug.cgi?id=275394">https://bugs.webkit.org/show_bug.cgi?id=275394</a>

Reviewed by NOBODY (OOPS!).

Originally, subtree layout was designed to work with a single subtree. However,
there are use-cases which require subtree layout to support multiple subtrees at once
so that no fallback to &quot;full&quot; layout is done.

One of such use-cases is CSS containment, which (under certain conditions)
allows one to isolate parts of DOM tree so that in case of internal changes they can
be laid out without layouting full tree. With CSS containment, it&apos;s fairly common that
such internal subtree changes will happen at once thus leading to multiple subtree layouts
being scheduled. Unfortunately, currenly such situation leads to fallback to &quot;full&quot; layout
as only single subtree layout is supported. Fortunately, currently it&apos;s possible (although
not ideal) to workaround that problem by forcing layout after each subtree change using
position queries such as document.body.offsetLeft etc.

This PR adds support for layouting multiple subtrees at once. This is achived
by collecting pending subtrees and eventually layouting them one by one.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2a20ee89178522a24560a62b0c99a7018dc2be4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188048 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141680 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180295 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53664 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52080 "Hash a2a20ee8 for PR 30000 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139110 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96603 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181389 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/42671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/159867 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/119564 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41337 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/52080 "Hash a2a20ee8 for PR 30000 does not build (failure)") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/151737 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39366 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36503 "Built successfully") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/44970 "Found 7 new failures in rendering/RenderFlexibleBox.cpp, rendering/RenderElement.cpp, page/LocalFrameViewLayoutContext.cpp") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/52080 "Hash a2a20ee8 for PR 30000 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190475 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52039 "Built successfully") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148267 "Found 13 new test failures: inspector/timeline/timeline-event-CancelAnimationFrame.html inspector/timeline/timeline-event-EventDispatch.html inspector/timeline/timeline-event-FireAnimationFrame.html inspector/timeline/timeline-event-RequestAnimationFrame.html inspector/timeline/timeline-event-TimerFire.html inspector/timeline/timeline-event-TimerInstall.html inspector/timeline/timeline-event-TimerRemove.html inspector/timeline/timeline-event-performance-mark.html inspector/timeline/timeline-event-screenshots.html inspector/timeline/timeline-layout-events-iframe.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52720 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/35989 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148038 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/42750 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/124986 "Found 7 new failures in rendering/RenderFlexibleBox.cpp, rendering/RenderElement.cpp, page/LocalFrameViewLayoutContext.cpp") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119623 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51238 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14341 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50623 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50863 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50685 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->