### PR TITLE
[LBSE] Adopt more smart pointers in SVG code

### DIFF
--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -213,7 +213,7 @@ void RenderSVGImage::paintForeground(PaintInfo& paintInfo, const LayoutPoint& pa
 
     FloatRect contentBoxRect = borderBoxRectEquivalent();
     FloatRect replacedContentRect(0, 0, image->width(), image->height());
-    imageElement().preserveAspectRatio().transformRect(contentBoxRect, replacedContentRect);
+    protectedImageElement()->preserveAspectRatio().transformRect(contentBoxRect, replacedContentRect);
 
     contentBoxRect.moveBy(paintOffset);
 
@@ -278,12 +278,13 @@ bool RenderSVGImage::updateImageViewport()
     m_objectBoundingBox = calculateObjectBoundingBox();
 
     bool updatedViewport = false;
-    URL imageSourceURL = document().completeURL(imageElement().imageSourceURL());
+    Ref imageElement = this->imageElement();
+    URL imageSourceURL = document().completeURL(imageElement->imageSourceURL());
 
     // Images with preserveAspectRatio=none should force non-uniform scaling. This can be achieved
     // by setting the image's container size to its intrinsic size.
     // See: http://www.w3.org/TR/SVG/single-page.html, 7.8 The ‘preserveAspectRatio’ attribute.
-    if (imageElement().preserveAspectRatio().align() == SVGPreserveAspectRatioValue::SVG_PRESERVEASPECTRATIO_NONE) {
+    if (imageElement->preserveAspectRatio().align() == SVGPreserveAspectRatioValue::SVG_PRESERVEASPECTRATIO_NONE) {
         if (CachedImage* cachedImage = imageResource().cachedImage()) {
             LayoutSize intrinsicSize = cachedImage->imageSizeForRenderer(nullptr, style().usedZoom());
             if (intrinsicSize != imageResource().imageSize(style().usedZoom())) {
@@ -398,7 +399,8 @@ bool RenderSVGImage::bufferForeground(PaintInfo& paintInfo, const LayoutPoint& p
     paintForeground(bufferedInfo, paintOffset);
 
     destinationContext.concatCTM(absoluteTransform.inverse().value_or(AffineTransform()));
-    destinationContext.drawImageBuffer(*m_bufferedForeground.copyRef(), absoluteTargetRect);
+    RefPtr bufferedForeground = m_bufferedForeground.copyRef();
+    destinationContext.drawImageBuffer(*bufferedForeground, absoluteTargetRect);
     destinationContext.concatCTM(absoluteTransform);
 
     return true;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
@@ -82,7 +82,7 @@ RefPtr<SVGGraphicsElement> RenderSVGResourceClipper::shouldApplyPathClipping() c
 {
     if (currentClippingMode() == ClippingMode::MaskClipping)
         return nullptr;
-    return clipPathElement().shouldApplyPathClipping();
+    return protectedClipPathElement()->shouldApplyPathClipping();
 }
 
 void RenderSVGResourceClipper::applyPathClipping(GraphicsContext& context, const RenderLayerModelObject& targetRenderer, const FloatRect& objectBoundingBox, SVGGraphicsElement& graphicsElement)

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
@@ -36,7 +36,6 @@ public:
     RenderSVGResourceClipper(SVGClipPathElement&, RenderStyle&&);
     virtual ~RenderSVGResourceClipper();
 
-    inline SVGClipPathElement& clipPathElement() const;
     inline Ref<SVGClipPathElement> protectedClipPathElement() const;
 
     RefPtr<SVGGraphicsElement> shouldApplyPathClipping() const;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipperInlines.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipperInlines.h
@@ -30,19 +30,14 @@
 
 namespace WebCore {
 
-inline SVGClipPathElement& RenderSVGResourceClipper::clipPathElement() const
+inline Ref<SVGClipPathElement> RenderSVGResourceClipper::protectedClipPathElement() const
 {
     return downcast<SVGClipPathElement>(nodeForNonAnonymous());
 }
 
-inline Ref<SVGClipPathElement> RenderSVGResourceClipper::protectedClipPathElement() const
-{
-    return clipPathElement();
-}
-
 inline SVGUnitTypes::SVGUnitType RenderSVGResourceClipper::clipPathUnits() const
 {
-    return clipPathElement().clipPathUnits();
+    return protectedClipPathElement()->clipPathUnits();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMarker.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMarker.h
@@ -48,6 +48,7 @@ private:
     ASCIILiteral renderName() const final { return "RenderSVGResourceMarker"_s; }
 
     inline SVGMarkerElement& markerElement() const;
+    inline Ref<SVGMarkerElement> protectedMarkerElement() const;
     inline FloatPoint referencePoint() const;
     inline std::optional<float> angle() const;
     inline SVGMarkerUnitsType markerUnits() const;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMarkerInlines.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMarkerInlines.h
@@ -29,6 +29,11 @@ inline SVGMarkerElement& RenderSVGResourceMarker::markerElement() const
     return downcast<SVGMarkerElement>(RenderSVGResourceContainer::element());
 }
 
+inline Ref<SVGMarkerElement> RenderSVGResourceMarker::protectedMarkerElement() const
+{
+    return markerElement();
+}
+
 FloatPoint RenderSVGResourceMarker::referencePoint() const
 {
     Ref markerElement = this->markerElement();
@@ -38,19 +43,19 @@ FloatPoint RenderSVGResourceMarker::referencePoint() const
 
 std::optional<float> RenderSVGResourceMarker::angle() const
 {
-    if (markerElement().orientType() == SVGMarkerOrientAngle)
-        return markerElement().orientAngle().value();
+    if (Ref markerElement = this->markerElement(); markerElement->orientType() == SVGMarkerOrientAngle)
+        return markerElement->orientAngle().value();
     return std::nullopt;
 }
 
 SVGMarkerUnitsType RenderSVGResourceMarker::markerUnits() const
 {
-    return markerElement().markerUnits();
+    return protectedMarkerElement()->markerUnits();
 }
 
 bool RenderSVGResourceMarker::hasReverseStart() const
 {
-    return markerElement().orientType() == SVGMarkerOrientAutoStartReverse;
+    return protectedMarkerElement()->orientType() == SVGMarkerOrientAutoStartReverse;
 }
 
 }

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
@@ -184,7 +184,7 @@ bool RenderSVGResourceMasker::drawContentIntoContext(GraphicsContext& context, c
     // Eventually adjust the mask image context according to the target objectBoundingBox.
     AffineTransform maskContentTransformation;
 
-    if (maskElement().maskContentUnits() == SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX) {
+    if (protectedMaskElement()->maskContentUnits() == SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX) {
         maskContentTransformation.translate(objectBoundingBox.location());
         maskContentTransformation.scale(objectBoundingBox.size());
     }

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMasker.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMasker.h
@@ -38,6 +38,7 @@ public:
     virtual ~RenderSVGResourceMasker();
 
     inline SVGMaskElement& maskElement() const;
+    inline Ref<SVGMaskElement> protectedMaskElement() const;
 
     void applyMask(PaintInfo&, const RenderLayerModelObject& targetRenderer, const LayoutPoint& adjustedPaintOffset);
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMaskerInlines.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMaskerInlines.h
@@ -35,14 +35,19 @@ inline SVGMaskElement& RenderSVGResourceMasker::maskElement() const
     return downcast<SVGMaskElement>(RenderSVGResourceContainer::element());
 }
 
+inline Ref<SVGMaskElement> RenderSVGResourceMasker::protectedMaskElement() const
+{
+    return maskElement();
+}
+
 SVGUnitTypes::SVGUnitType RenderSVGResourceMasker::maskUnits() const
 {
-    return maskElement().maskUnits();
+    return protectedMaskElement()->maskUnits();
 }
 
 SVGUnitTypes::SVGUnitType RenderSVGResourceMasker::maskContentUnits() const
 {
-    return maskElement().maskContentUnits();
+    return protectedMaskElement()->maskContentUnits();
 }
 
 }


### PR DESCRIPTION
#### 636b19890dbccb5e6a2a33ac411659fa1f6d65ae
<pre>
[LBSE] Adopt more smart pointers in SVG code
<a href="https://bugs.webkit.org/show_bug.cgi?id=275689">https://bugs.webkit.org/show_bug.cgi?id=275689</a>

Reviewed by Alex Christensen.

Based on [alpha.webkit.UncountedCallArgsChecker] warnings.

* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
(WebCore::RenderSVGImage::paintForeground):
(WebCore::RenderSVGImage::updateImageViewport):
(WebCore::RenderSVGImage::bufferForeground):
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
(WebCore::RenderSVGResourceClipper::shouldApplyPathClipping const):
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.h:
* Source/WebCore/rendering/svg/RenderSVGResourceClipperInlines.h:
(WebCore::RenderSVGResourceClipper::protectedClipPathElement const):
(WebCore::RenderSVGResourceClipper::clipPathUnits const):
(WebCore::RenderSVGResourceClipper::clipPathElement const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGResourceMarker.h:
* Source/WebCore/rendering/svg/RenderSVGResourceMarkerInlines.h:
(WebCore::RenderSVGResourceMarker::protectedMarkerElement const):
(WebCore::RenderSVGResourceMarker::angle const):
(WebCore::RenderSVGResourceMarker::markerUnits const):
(WebCore::RenderSVGResourceMarker::hasReverseStart const):
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp:
(WebCore::RenderSVGResourceMasker::drawContentIntoContext):
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.h:
* Source/WebCore/rendering/svg/RenderSVGResourceMaskerInlines.h:
(WebCore::RenderSVGResourceMasker::protectedMaskElement const):
(WebCore::RenderSVGResourceMasker::maskUnits const):
(WebCore::RenderSVGResourceMasker::maskContentUnits const):

Canonical link: <a href="https://commits.webkit.org/280244@main">https://commits.webkit.org/280244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf6d23414a024d4f3901562e1ef3895219064650

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8528 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/59662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6492 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58182 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43004 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6686 "Build is in progress. Recent messages:OS: Sonoma (14.5), Xcode: 15.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/59662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4492 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33277 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48343 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/59662 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30058 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5673 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/5496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52027 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5944 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/61341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6073 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/61341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48410 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/61341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12422 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31209 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32295 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33378 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32042 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->