### PR TITLE
[WPE][GTK] IPC socket should use SOCK_CLOEXEC on Linux

### DIFF
--- a/Source/WTF/wtf/UniStdExtras.h
+++ b/Source/WTF/wtf/UniStdExtras.h
@@ -32,6 +32,7 @@
 namespace WTF {
 
 WTF_EXPORT_PRIVATE bool setCloseOnExec(int fileDescriptor);
+WTF_EXPORT_PRIVATE bool unsetCloseOnExec(int fileDescriptor);
 WTF_EXPORT_PRIVATE int dupCloseOnExec(int fileDescriptor);
 
 inline int closeWithRetry(int fileDescriptor)
@@ -57,6 +58,7 @@ WTF_EXPORT_PRIVATE bool setNonBlock(int fileDescriptor);
 using WTF::closeWithRetry;
 using WTF::dupCloseOnExec;
 using WTF::setCloseOnExec;
+using WTF::unsetCloseOnExec;
 using WTF::setNonBlock;
 
 #endif // UniStdExtras_h

--- a/Source/WTF/wtf/playstation/UniStdExtrasPlayStation.cpp
+++ b/Source/WTF/wtf/playstation/UniStdExtrasPlayStation.cpp
@@ -35,6 +35,11 @@ bool setCloseOnExec(int)
     return true;
 }
 
+bool unsetCloseOnExec(int)
+{
+    return true;
+}
+
 int dupCloseOnExec(int fileDescriptor)
 {
     int duplicatedFileDescriptor = -1;

--- a/Source/WTF/wtf/unix/UniStdExtrasUnix.cpp
+++ b/Source/WTF/wtf/unix/UniStdExtrasUnix.cpp
@@ -42,6 +42,18 @@ bool setCloseOnExec(int fileDescriptor)
     return returnValue != -1;
 }
 
+bool unsetCloseOnExec(int fileDescriptor)
+{
+    int returnValue = -1;
+    do {
+        int flags = fcntl(fileDescriptor, F_GETFD);
+        if (flags == -1)
+            returnValue = fcntl(fileDescriptor, F_SETFD, flags & ~FD_CLOEXEC);
+    } while (returnValue == -1 && errno == EINTR);
+
+    return returnValue != -1;
+}
+
 int dupCloseOnExec(int fileDescriptor)
 {
     int duplicatedFileDescriptor = -1;


### PR DESCRIPTION
#### 23af623a3a7e6b6458b1f51cf2af9c2fe77b30e8
<pre>
[WPE][GTK] IPC socket should use SOCK_CLOEXEC on Linux
<a href="https://bugs.webkit.org/show_bug.cgi?id=275690">https://bugs.webkit.org/show_bug.cgi?id=275690</a>

Reviewed by Carlos Garcia Campos.

Instead of creating the IPC socket without CLOEXEC and then setting it
afterwards if requested, instead create the socket with CLOEXEC and
unset it afterwards if not requested. This closes the race window where
the socket may leak into a subprocess spawned by another thread (which
seems unlikely, but you never know what applications will do).

In practice, this ensures the server socket will never leak to a
subprocess. The client socket might still get leaked because CLOEXEC has
to get unset at some point for the child process to receive the socket.

* Source/WTF/wtf/UniStdExtras.h:
* Source/WTF/wtf/playstation/UniStdExtrasPlayStation.cpp:
(WTF::unsetCloseOnExec):
* Source/WTF/wtf/unix/UniStdExtrasUnix.cpp:
(WTF::unsetCloseOnExec):
* Source/WebKit/Platform/IPC/unix/ConnectionUnix.cpp:
(IPC::createPlatformConnection):

Canonical link: <a href="https://commits.webkit.org/280858@main">https://commits.webkit.org/280858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b16754d2b4b25383a11f69f84a3b1355f1c7e21

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57798 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37126 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61420 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8243 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8431 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46832 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5849 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34821 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49947 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27661 "Found 1 new API test failure: /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/dom-cache (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31590 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7240 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7247 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/50890 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53541 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7510 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63103 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57040 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7585 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54055 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49958 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54174 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12797 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1455 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/78801 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32955 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13072 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34041 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35125 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33786 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->