### PR TITLE
Use a separate animation ID from the session ID in all cases, including initial animation.

### DIFF
--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -668,9 +668,13 @@ public:
 
     virtual void proofreadingSessionUpdateStateForSuggestionWithID(const WritingTools::SessionID&, WritingTools::TextSuggestionState, const WritingTools::TextSuggestionID&) { }
 
-    virtual void removeTextAnimationForID(const WritingTools::SessionID&) { }
+    virtual void removeTextAnimationForAnimationID(const WTF::UUID&) { }
 
-    virtual void cleanUpTextAnimationsForSessionID(const WritingTools::SessionID&) { }
+    virtual void removeTransparentMarkersForSessionID(const WritingTools::SessionID&) { }
+
+    virtual void removeInitialTextAnimation(const WritingTools::SessionID&) { }
+
+    virtual void addInitialTextAnimation(const WritingTools::SessionID&) { }
 
     virtual void addSourceTextAnimation(const WritingTools::SessionID&, const CharacterRange&) { }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -415,8 +415,8 @@ struct PerWebProcessState {
 #endif // ENABLE(WRITING_TOOLS)
 
 #if ENABLE(WRITING_TOOLS_UI)
-- (void)_addTextAnimationTypeForID:(NSUUID *)uuid withData:(const WebKit::TextAnimationData&)styleData;
-- (void)_removeTextAnimationForID:(NSUUID *)uuid;
+- (void)_addTextAnimationForAnimationID:(NSUUID *)uuid withData:(const WebKit::TextAnimationData&)styleData;
+- (void)_removeTextAnimationForAnimationID:(NSUUID *)uuid;
 #endif
 
 - (void)_internalDoAfterNextPresentationUpdate:(void (^)(void))updateBlock withoutWaitingForPainting:(BOOL)withoutWaitingForPainting withoutWaitingForAnimatedResize:(BOOL)withoutWaitingForAnimatedResize;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -100,8 +100,8 @@ public:
 #endif
 
 #if ENABLE(WRITING_TOOLS_UI)
-    void addTextAnimationTypeForID(const WTF::UUID&, const WebKit::TextAnimationData&) final;
-    void removeTextAnimationForID(const WTF::UUID&) final;
+    void addTextAnimationForAnimationID(const WTF::UUID&, const WebKit::TextAnimationData&) final;
+    void removeTextAnimationForAnimationID(const WTF::UUID&) final;
 #endif
 
     void microphoneCaptureWillChange() final;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -157,14 +157,14 @@ void PageClientImplCocoa::storeAppHighlight(const WebCore::AppHighlight &highlig
 #endif // ENABLE(APP_HIGHLIGHTS)
 
 #if ENABLE(WRITING_TOOLS_UI)
-void PageClientImplCocoa::addTextAnimationTypeForID(const WTF::UUID& uuid, const WebKit::TextAnimationData& data)
+void PageClientImplCocoa::addTextAnimationForAnimationID(const WTF::UUID& uuid, const WebKit::TextAnimationData& data)
 {
-    [m_webView _addTextAnimationTypeForID:uuid withData:data];
+    [m_webView _addTextAnimationForAnimationID:uuid withData:data];
 }
 
-void PageClientImplCocoa::removeTextAnimationForID(const WTF::UUID& uuid)
+void PageClientImplCocoa::removeTextAnimationForAnimationID(const WTF::UUID& uuid)
 {
-    [m_webView _removeTextAnimationForID:uuid];
+    [m_webView _removeTextAnimationForAnimationID:uuid];
 }
 #endif
 

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1215,13 +1215,13 @@ void WebPageProxy::enableTextAnimationTypeForElementWithID(const String& element
     legacyMainFrameProcess().send(Messages::WebPage::EnableTextAnimationTypeForElementWithID(elementID, uuid), webPageIDInMainFrameProcess());
 }
 
-void WebPageProxy::addTextAnimationTypeForID(IPC::Connection& connection, const WTF::UUID& uuid, const TextAnimationData& styleData, const WebCore::TextIndicatorData& indicatorData)
+void WebPageProxy::addTextAnimationForAnimationID(IPC::Connection& connection, const WTF::UUID& uuid, const TextAnimationData& styleData, const WebCore::TextIndicatorData& indicatorData)
 {
     MESSAGE_CHECK(uuid.isValid());
 
     internals().textIndicatorDataForChunk.add(uuid, indicatorData);
 
-    protectedPageClient()->addTextAnimationTypeForID(uuid, styleData);
+    protectedPageClient()->addTextAnimationForAnimationID(uuid, styleData);
 }
 
 void WebPageProxy::getTextIndicatorForID(const WTF::UUID& uuid, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&& completionHandler)
@@ -1251,11 +1251,11 @@ void WebPageProxy::updateUnderlyingTextVisibilityForTextAnimationID(const WTF::U
     legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::updateUnderlyingTextVisibilityForTextAnimationID(uuid, visible), WTFMove(completionHandler), webPageIDInMainFrameProcess());
 }
 
-void WebPageProxy::removeTextAnimationForID(IPC::Connection& connection, const WTF::UUID& uuid)
+void WebPageProxy::removeTextAnimationForAnimationID(IPC::Connection& connection, const WTF::UUID& uuid)
 {
     MESSAGE_CHECK(uuid.isValid());
 
-    protectedPageClient()->removeTextAnimationForID(uuid);
+    protectedPageClient()->removeTextAnimationForAnimationID(uuid);
 }
 
 #endif // ENABLE(WRITING_TOOLS_UI)

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -716,8 +716,8 @@ public:
     virtual void storeAppHighlight(const WebCore::AppHighlight&) = 0;
 #endif
 #if ENABLE(WRITING_TOOLS_UI)
-    virtual void addTextAnimationTypeForID(const WTF::UUID&, const WebKit::TextAnimationData&) = 0;
-    virtual void removeTextAnimationForID(const WTF::UUID&) = 0;
+    virtual void addTextAnimationForAnimationID(const WTF::UUID&, const WebKit::TextAnimationData&) = 0;
+    virtual void removeTextAnimationForAnimationID(const WTF::UUID&) = 0;
 #endif
     virtual void requestScrollToRect(const WebCore::FloatRect& targetRect, const WebCore::FloatPoint& origin) { }
 

--- a/Source/WebKit/UIProcess/WKSTextAnimationManager.h
+++ b/Source/WebKit/UIProcess/WKSTextAnimationManager.h
@@ -32,8 +32,8 @@
 @interface WKSTextAnimationManager : NSObject
 
 - (instancetype)initWithDelegate:(id <WKSTextAnimationSourceDelegate>)delegate NS_DESIGNATED_INITIALIZER;
-- (void)addTextAnimationTypeForID:(NSUUID *)uuid withStyleType:(WKTextAnimationType)styleType;
-- (void)removeTextAnimationForID:(NSUUID *)uuid;
+- (void)addTextAnimationForAnimationID:(NSUUID *)uuid withStyleType:(WKTextAnimationType)styleType;
+- (void)removeTextAnimationForAnimationID:(NSUUID *)uuid;
 @end
 
 #endif // ENABLE(WRITING_TOOLS)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2438,8 +2438,8 @@ public:
 #endif // ENABLE(WRITING_TOOLS)
 
 #if ENABLE(WRITING_TOOLS_UI)
-    void addTextAnimationTypeForID(IPC::Connection&, const WTF::UUID&, const WebKit::TextAnimationData&, const WebCore::TextIndicatorData&);
-    void removeTextAnimationForID(IPC::Connection&, const WTF::UUID&);
+    void addTextAnimationForAnimationID(IPC::Connection&, const WTF::UUID&, const WebKit::TextAnimationData&, const WebCore::TextIndicatorData&);
+    void removeTextAnimationForAnimationID(IPC::Connection&, const WTF::UUID&);
     void enableSourceTextAnimationAfterElementWithID(const String& elementID, const WTF::UUID&);
     void enableTextAnimationTypeForElementWithID(const String& elementID, const WTF::UUID&);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -520,8 +520,8 @@ messages -> WebPageProxy {
 #endif
 
 #if ENABLE(WRITING_TOOLS_UI)
-    AddTextAnimationTypeForID(WTF::UUID uuid, struct WebKit::TextAnimationData styleData, struct WebCore::TextIndicatorData indicatorData)
-    removeTextAnimationForID(WTF::UUID uuid)
+    AddTextAnimationForAnimationID(WTF::UUID uuid, struct WebKit::TextAnimationData styleData, struct WebCore::TextIndicatorData indicatorData)
+    RemoveTextAnimationForAnimationID(WTF::UUID uuid)
 #endif
 
 CreateAppHighlightInSelectedRange)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -846,8 +846,8 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 - (void)clearTextIndicator:(WebCore::TextIndicatorDismissalAnimation)animation;
 
 #if ENABLE(WRITING_TOOLS_UI)
-- (void)addTextAnimationTypeForID:(NSUUID *)uuid withStyleType:(WKTextAnimationType)styleType;
-- (void)removeTextAnimationForID:(NSUUID *)uuid;
+- (void)addTextAnimationForAnimationID:(NSUUID *)uuid withStyleType:(WKTextAnimationType)styleType;
+- (void)removeTextAnimationForAnimationID:(NSUUID *)uuid;
 #endif
 
 @property (nonatomic, readonly) BOOL _shouldUseContextMenus;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -11754,7 +11754,7 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
 
 #if ENABLE(WRITING_TOOLS_UI)
 
-- (void)addTextAnimationTypeForID:(NSUUID *)uuid withStyleType:(WKTextAnimationType)styleType
+- (void)addTextAnimationForAnimationID:(NSUUID *)uuid withStyleType:(WKTextAnimationType)styleType
 {
     if (!_page->preferences().textAnimationsEnabled())
         return;
@@ -11762,10 +11762,10 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
     if (!_textAnimationManager)
         _textAnimationManager = adoptNS([WebKit::allocWKSTextAnimationManagerInstance() initWithDelegate:self]);
 
-    [_textAnimationManager addTextAnimationTypeForID:uuid withStyleType:styleType];
+    [_textAnimationManager addTextAnimationForAnimationID:uuid withStyleType:styleType];
 }
 
-- (void)removeTextAnimationForID:(NSUUID *)uuid
+- (void)removeTextAnimationForAnimationID:(NSUUID *)uuid
 {
     if (!_page->preferences().textAnimationsEnabled())
         return;
@@ -11773,7 +11773,7 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
     if (!_textAnimationManager)
         return;
 
-    [_textAnimationManager removeTextAnimationForID:uuid];
+    [_textAnimationManager removeTextAnimationForAnimationID:uuid];
 }
 
 #endif

--- a/Source/WebKit/UIProcess/mac/WKTextAnimationManager.h
+++ b/Source/WebKit/UIProcess/mac/WKTextAnimationManager.h
@@ -38,8 +38,8 @@ class WebViewImpl;
 @interface WKTextAnimationManager : NSObject
 
 - (instancetype)initWithWebViewImpl:(WebKit::WebViewImpl&)view;
-- (void)addTextAnimationTypeForID:(NSUUID *)uuid withData:(const WebKit::TextAnimationData&)data;
-- (void)removeTextAnimationForID:(NSUUID *)uuid;
+- (void)addTextAnimationForAnimationID:(NSUUID *)uuid withData:(const WebKit::TextAnimationData&)data;
+- (void)removeTextAnimationForAnimationID:(NSUUID *)uuid;
 
 - (BOOL)hasActiveTextAnimationType;
 

--- a/Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm
+++ b/Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm
@@ -85,7 +85,7 @@
     return self;
 }
 
-- (void)addTextAnimationTypeForID:(NSUUID *)uuid withData:(const WebKit::TextAnimationData&)data
+- (void)addTextAnimationForAnimationID:(NSUUID *)uuid withData:(const WebKit::TextAnimationData&)data
 {
     RetainPtr<id<_WTTextEffect>> effect;
     RetainPtr chunk = adoptNS([PAL::alloc_WTTextChunkInstance() initChunkWithIdentifier:uuid.UUIDString]);
@@ -118,7 +118,7 @@
     [_chunkToEffect setObject:effectData.get() forKey:uuid];
 }
 
-- (void)removeTextAnimationForID:(NSUUID *)uuid
+- (void)removeTextAnimationForAnimationID:(NSUUID *)uuid
 {
     RetainPtr effectData = [_chunkToEffect objectForKey:uuid];
     if (effectData) {
@@ -148,7 +148,7 @@
     for (NSUUID *chunkID in [_chunkToEffect allKeys]) {
         RetainPtr effectData = [_chunkToEffect objectForKey:chunkID];
         if ([effectData type] == WebKit::TextAnimationType::Initial)
-            [self addTextAnimationTypeForID:chunkID withData: { WebKit::TextAnimationType::Initial, WTF::UUID(WTF::UUID::emptyValue) }];
+            [self addTextAnimationForAnimationID:chunkID withData: { WebKit::TextAnimationType::Initial, WTF::UUID(WTF::UUID::emptyValue) }];
     }
 }
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -747,8 +747,8 @@ public:
 #endif
 
 #if ENABLE(WRITING_TOOLS_UI)
-    void addTextAnimationTypeForID(WTF::UUID, const WebKit::TextAnimationData&);
-    void removeTextAnimationForID(WTF::UUID);
+    void addTextAnimationForAnimationID(WTF::UUID, const WebKit::TextAnimationData&);
+    void removeTextAnimationForAnimationID(WTF::UUID);
 #endif
 
 #if HAVE(INLINE_PREDICTIONS)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4606,7 +4606,7 @@ void WebViewImpl::removeTextPlaceholder(NSTextPlaceholder *placeholder, bool wil
 }
 
 #if ENABLE(WRITING_TOOLS_UI)
-void WebViewImpl::addTextAnimationTypeForID(WTF::UUID uuid, const WebKit::TextAnimationData& data)
+void WebViewImpl::addTextAnimationForAnimationID(WTF::UUID uuid, const WebKit::TextAnimationData& data)
 {
     if (!m_page->preferences().textAnimationsEnabled())
         return;
@@ -4614,15 +4614,15 @@ void WebViewImpl::addTextAnimationTypeForID(WTF::UUID uuid, const WebKit::TextAn
     if (!m_TextAnimationTypeManager)
         m_TextAnimationTypeManager = adoptNS([[WKTextAnimationManager alloc] initWithWebViewImpl:*this]);
 
-    [m_TextAnimationTypeManager addTextAnimationTypeForID:uuid withData:data];
+    [m_TextAnimationTypeManager addTextAnimationForAnimationID:uuid withData:data];
 }
 
-void WebViewImpl::removeTextAnimationForID(WTF::UUID uuid)
+void WebViewImpl::removeTextAnimationForAnimationID(WTF::UUID uuid)
 {
     if (!m_page->preferences().textAnimationsEnabled())
         return;
 
-    [m_TextAnimationTypeManager removeTextAnimationForID:uuid];
+    [m_TextAnimationTypeManager removeTextAnimationForAnimationID:uuid];
 }
 #endif
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -10447,6 +10447,7 @@
 			isa = PBXGroup;
 			children = (
 				0214701A2995D2FE0077AFD6 /* DrawingAreaCocoa.mm */,
+				442C116B2C06ACB1004C67CA /* TextAnimationController.h */,
 				442C116A2C06AC48004C67CA /* TextAnimationController.mm */,
 				2D9CD5ED21FA503F0029ACFA /* TextCheckingControllerProxy.h */,
 				2D9CD5EB21FA503F0029ACFA /* TextCheckingControllerProxy.messages.in */,
@@ -13776,7 +13777,6 @@
 				2DEE709D2755A46800FBF864 /* MomentumEventDispatcher.h */,
 				7C387433172F5615001BD88A /* PageBanner.cpp */,
 				7CF47FF917275C57008ACB91 /* PageBanner.h */,
-				442C116B2C06ACB1004C67CA /* TextAnimationController.h */,
 				2D819B99186275B3001F03D1 /* ViewGestureGeometryCollector.cpp */,
 				2D819B9A186275B3001F03D1 /* ViewGestureGeometryCollector.h */,
 				2D819B9B186275B3001F03D1 /* ViewGestureGeometryCollector.messages.in */,

--- a/Source/WebKit/WebKitSwift/TextAnimation/TextAnimationManager.swift
+++ b/Source/WebKit/WebKitSwift/TextAnimation/TextAnimationManager.swift
@@ -41,7 +41,7 @@ import WebKitSwift
         delegate.containingViewForTextAnimationType().addSubview(self.effectView)
     }
     
-    @objc(addTextAnimationTypeForID:withStyleType:) public func beginEffect(for uuid: UUID, style: WKTextAnimationType) {
+    @objc(addTextAnimationForAnimationID:withStyleType:) public func beginEffect(for uuid: UUID, style: WKTextAnimationType) {
         if style == .initial {
             let newEffect = self.effectView.addEffect(UITextEffectView.PonderingEffect(chunk: TextEffectChunk(uuid: uuid), view: self.effectView) as UITextEffectView.TextEffect)
             self.chunkToEffect[uuid] = newEffect
@@ -51,7 +51,7 @@ import WebKitSwift
         }
     }
     
-    @objc(removeTextAnimationForID:) public func endEffect(for uuid: UUID) {
+    @objc(removeTextAnimationForAnimationID:) public func endEffect(for uuid: UUID) {
         if let effectID = chunkToEffect.removeValue(forKey: uuid) {
             self.effectView.removeEffect(effectID)
         }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1860,14 +1860,24 @@ void WebChromeClient::proofreadingSessionUpdateStateForSuggestionWithID(const Wr
 
 #if ENABLE(WRITING_TOOLS_UI)
 
-void WebChromeClient::removeTextAnimationForID(const WritingTools::Session::ID& sessionID)
+void WebChromeClient::removeTextAnimationForAnimationID(const WTF::UUID& animationID)
 {
-    protectedPage()->removeTextAnimationForID(sessionID);
+    protectedPage()->removeTextAnimationForAnimationID(animationID);
 }
 
-void WebChromeClient::cleanUpTextAnimationsForSessionID(const WritingTools::Session::ID& sessionID)
+void WebChromeClient::removeTransparentMarkersForSessionID(const WritingTools::Session::ID& sessionID)
 {
-    protectedPage()->cleanUpTextAnimationsForSessionID(sessionID);
+    protectedPage()->removeTransparentMarkersForSessionID(sessionID);
+}
+
+void WebChromeClient::removeInitialTextAnimation(const WritingTools::Session::ID& sessionID)
+{
+    protectedPage()->removeInitialTextAnimation(sessionID);
+}
+
+void WebChromeClient::addInitialTextAnimation(const WritingTools::Session::ID& sessionID)
+{
+    protectedPage()->addInitialTextAnimation(sessionID);
 }
 
 void WebChromeClient::addSourceTextAnimation(const WritingTools::Session::ID& sessionID, const CharacterRange& range)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -513,9 +513,13 @@ private:
 #endif
 
 #if ENABLE(WRITING_TOOLS_UI)
-    void removeTextAnimationForID(const WebCore::WritingTools::SessionID&) final;
+    void removeTextAnimationForAnimationID(const WTF::UUID&) final;
 
-    void cleanUpTextAnimationsForSessionID(const WebCore::WritingTools::SessionID&) final;
+    void removeInitialTextAnimation(const WebCore::WritingTools::SessionID&) final;
+
+    void addInitialTextAnimation(const WebCore::WritingTools::SessionID&) final;
+
+    void removeTransparentMarkersForSessionID(const WebCore::WritingTools::SessionID&) final;
 
     void addSourceTextAnimation(const WebCore::WritingTools::SessionID&, const WebCore::CharacterRange&) final;
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h
@@ -69,9 +69,11 @@ class TextAnimationController final {
 public:
     explicit TextAnimationController(WebPage&);
 
-    void cleanUpTextAnimationsForSessionID(const WTF::UUID& sessionUUID);
+    void removeTransparentMarkersForSessionID(const WTF::UUID& sessionUUID);
     void removeTransparentMarkersForTextAnimationID(const WTF::UUID&);
 
+    void removeInitialTextAnimation(const WTF::UUID& sessionUUID);
+    void addInitialTextAnimation(const WTF::UUID& sessionUUID);
     void addSourceTextAnimation(const WTF::UUID& sessionUUID, const WebCore::CharacterRange&);
     void addDestinationTextAnimation(const WTF::UUID& sessionUUID, const WebCore::CharacterRange&);
 
@@ -84,12 +86,14 @@ public:
     void enableTextAnimationTypeForElementWithID(const String& elementID, const WTF::UUID&);
 
 private:
-    std::optional<WebCore::SimpleRange> contextRangeForTextAnimationType(const WTF::UUID&) const;
+    std::optional<WebCore::SimpleRange> contextRangeForTextAnimationID(const WTF::UUID&) const;
     std::optional<WebCore::SimpleRange> contextRangeForSessionWithID(const WebCore::WritingTools::SessionID&) const;
 
     RefPtr<WebCore::Document> document() const;
     WeakPtr<WebPage> m_webPage;
 
+    // All of these HashMap keys are SessionIDs
+    HashMap<WTF::UUID, WTF::UUID> m_initialAnimations;
     HashMap<WTF::UUID, Vector<TextAnimationState>> m_activeTextAnimations;
     HashMap<WTF::UUID, WebCore::CharacterRange> m_alreadyReplacedRanges;
     HashMap<WTF::UUID, std::optional<TextAnimationUnstyledRangeData>> m_unstyledRanges;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
@@ -93,17 +93,19 @@ std::optional<WebCore::SimpleRange> TextAnimationController::contextRangeForSess
     return corePage->contextRangeForSessionWithID(sessionID);
 }
 
-std::optional<WebCore::SimpleRange> TextAnimationController::contextRangeForTextAnimationType(const WTF::UUID& uuid) const
+std::optional<WebCore::SimpleRange> TextAnimationController::contextRangeForTextAnimationID(const WTF::UUID& animationUUID) const
 {
-    if (auto sessionRange = contextRangeForSessionWithID(uuid))
-        return sessionRange;
+    if (auto iterator = m_manuallyEnabledAnimationRanges.find(animationUUID); iterator != m_manuallyEnabledAnimationRanges.end())
+        return WebCore::makeSimpleRange(iterator->value.get());
 
-    if (m_manuallyEnabledAnimationRanges.contains(uuid))
-        return WebCore::makeSimpleRange(m_manuallyEnabledAnimationRanges.find(uuid)->value.get());
+    for (auto sessionUUID : m_initialAnimations.keys()) {
+        if (m_initialAnimations.get(sessionUUID) == animationUUID)
+            return contextRangeForSessionWithID(sessionUUID);
+    }
 
     for (auto sessionUUID : m_activeTextAnimations.keys()) {
         for (auto animationState : m_activeTextAnimations.get(sessionUUID)) {
-            if (animationState.styleID == uuid) {
+            if (animationState.styleID == animationUUID) {
                 if (auto fullSessionRange = contextRangeForSessionWithID(sessionUUID))
                     return WebCore::resolveCharacterRange(*fullSessionRange, animationState.range, defaultTextAnimationControllerTextIteratorBehaviors);
             }
@@ -112,17 +114,19 @@ std::optional<WebCore::SimpleRange> TextAnimationController::contextRangeForText
     return std::nullopt;
 }
 
-void TextAnimationController::cleanUpTextAnimationsForSessionID(const WTF::UUID& sessionUUID)
+void TextAnimationController::removeTransparentMarkersForSessionID(const WTF::UUID& sessionUUID)
 {
+    if (auto iterator = m_initialAnimations.find(sessionUUID); iterator != m_initialAnimations.end())
+        removeTransparentMarkersForTextAnimationID(iterator->value);
+
     auto animationStates = m_activeTextAnimations.take(sessionUUID);
     if (animationStates.isEmpty())
         return;
     for (auto animationState : animationStates)
         removeTransparentMarkersForTextAnimationID(animationState.styleID);
 
-    auto unstyledRange = m_unstyledRanges.find(sessionUUID);
-    if (unstyledRange->value)
-        removeTransparentMarkersForTextAnimationID(unstyledRange->value->styleID);
+    if (auto rangeData = m_unstyledRanges.get(sessionUUID))
+        removeTransparentMarkersForTextAnimationID(rangeData->styleID);
 }
 
 void TextAnimationController::removeTransparentMarkersForTextAnimationID(const WTF::UUID& uuid)
@@ -138,6 +142,12 @@ void TextAnimationController::removeTransparentMarkersForTextAnimationID(const W
     });
 }
 
+void TextAnimationController::removeInitialTextAnimation(const WTF::UUID& sessionUUID)
+{
+    if (auto animationID = m_initialAnimations.take(sessionUUID))
+        m_webPage->removeTextAnimationForAnimationID(animationID);
+}
+
 #if PLATFORM(MAC)
 static WebCore::CharacterRange newlyReplacedCharacterRange(WebCore::CharacterRange superRange, WebCore::CharacterRange previousRange)
 {
@@ -150,6 +160,27 @@ static WebCore::CharacterRange newlyReplacedCharacterRange(WebCore::CharacterRan
     return WebCore::CharacterRange { location, length };
 };
 #endif
+
+void TextAnimationController::addInitialTextAnimation(const WTF::UUID& sessionUUID)
+{
+    auto initialAnimationUUID = WTF::UUID::createVersion4();
+    auto sessionRange = contextRangeForSessionWithID(sessionUUID);
+
+    if (!sessionRange) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    createTextIndicatorForRange(*sessionRange, [initialAnimationUUID, weakWebPage = WeakPtr { m_webPage }](std::optional<WebCore::TextIndicatorData>&& textIndicatorData) {
+        if (!weakWebPage)
+            return;
+        RefPtr protectedWebPage = weakWebPage.get();
+        if (textIndicatorData)
+            protectedWebPage->addTextAnimationForAnimationID(initialAnimationUUID, { TextAnimationType::Initial, WTF::UUID(WTF::UUID::emptyValue) }, *textIndicatorData);
+    });
+    m_initialAnimations.add(sessionUUID, initialAnimationUUID);
+}
+
 
 void TextAnimationController::addSourceTextAnimation(const WTF::UUID& sessionUUID, const WebCore::CharacterRange& currentReplacedRange)
 {
@@ -173,7 +204,7 @@ void TextAnimationController::addSourceTextAnimation(const WTF::UUID& sessionUUI
             return;
         RefPtr protectedWebPage = weakWebPage.get();
         if (textIndicatorData)
-            protectedWebPage->addTextAnimationTypeForID(sourceTextIndicatorUUID, { WebKit::TextAnimationType::Source, WTF::UUID(WTF::UUID::emptyValue)  }, *textIndicatorData);
+            protectedWebPage->addTextAnimationForAnimationID(sourceTextIndicatorUUID, { WebKit::TextAnimationType::Source, WTF::UUID(WTF::UUID::emptyValue)  }, *textIndicatorData);
     });
     TextAnimationState animationState = { sourceTextIndicatorUUID, replaceCharacterRange };
     auto& animationStates = m_activeTextAnimations.ensure(sessionUUID, [&] {
@@ -216,7 +247,7 @@ void TextAnimationController::addDestinationTextAnimation(const WTF::UUID& sessi
             return;
         RefPtr protectedWebPage = weakWebPage.get();
         if (textIndicatorData)
-            protectedWebPage->addTextAnimationTypeForID(finalTextIndicatorUUID, { TextAnimationType::Final, unstyledRangeUUID }, *textIndicatorData);
+            protectedWebPage->addTextAnimationForAnimationID(finalTextIndicatorUUID, { TextAnimationType::Final, unstyledRangeUUID }, *textIndicatorData);
     });
     TextAnimationState animationState = { finalTextIndicatorUUID, characterRangeAfterReplace };
     auto& animationStates = m_activeTextAnimations.ensure(sessionUUID, [&] {
@@ -238,7 +269,7 @@ void TextAnimationController::updateUnderlyingTextVisibilityForTextAnimationID(c
     if (visible)
         removeTransparentMarkersForTextAnimationID(uuid);
     else {
-        auto sessionRange = contextRangeForTextAnimationType(uuid);
+        auto sessionRange = contextRangeForTextAnimationID(uuid);
 
         if (!sessionRange) {
             completionHandler();
@@ -285,7 +316,7 @@ void TextAnimationController::createTextIndicatorForRange(const WebCore::SimpleR
 
 void TextAnimationController::createTextIndicatorForTextAnimationID(const WTF::UUID& uuid, CompletionHandler<void(std::optional<WebCore::TextIndicatorData>&&)>&& completionHandler)
 {
-    auto sessionRange = contextRangeForTextAnimationType(uuid);
+    auto sessionRange = contextRangeForTextAnimationID(uuid);
 
     if (!sessionRange) {
         completionHandler(std::nullopt);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9152,20 +9152,31 @@ void WebPage::lastNavigationWasAppInitiated(CompletionHandler<void(bool)>&& comp
 
 #if ENABLE(WRITING_TOOLS_UI)
 
-void WebPage::addTextAnimationTypeForID(const WTF::UUID& uuid, const WebKit::TextAnimationData& styleData, const WebCore::TextIndicatorData& indicatorData)
+void WebPage::addTextAnimationForAnimationID(const WTF::UUID& uuid, const WebKit::TextAnimationData& styleData, const WebCore::TextIndicatorData& indicatorData)
 {
-    send(Messages::WebPageProxy::AddTextAnimationTypeForID(uuid, styleData, indicatorData));
+    send(Messages::WebPageProxy::AddTextAnimationForAnimationID(uuid, styleData, indicatorData));
 }
 
-void WebPage::removeTextAnimationForID(const WTF::UUID& uuid)
+void WebPage::removeTextAnimationForAnimationID(const WTF::UUID& uuid)
 {
-    send(Messages::WebPageProxy::removeTextAnimationForID(uuid));
+    send(Messages::WebPageProxy::RemoveTextAnimationForAnimationID(uuid));
 }
 
-void WebPage::cleanUpTextAnimationsForSessionID(const WTF::UUID& uuid)
+void WebPage::removeTransparentMarkersForSessionID(const WTF::UUID& uuid)
 {
-    m_textAnimationController->cleanUpTextAnimationsForSessionID(uuid);
+    m_textAnimationController->removeTransparentMarkersForSessionID(uuid);
 }
+
+void WebPage::removeInitialTextAnimation(const WTF::UUID& uuid)
+{
+    m_textAnimationController->removeInitialTextAnimation(uuid);
+}
+
+void WebPage::addInitialTextAnimation(const WTF::UUID& uuid)
+{
+    m_textAnimationController->addInitialTextAnimation(uuid);
+}
+
 
 void WebPage::addSourceTextAnimation(const WTF::UUID& uuid, const CharacterRange& range)
 {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1759,12 +1759,13 @@ public:
     void enableSourceTextAnimationAfterElementWithID(const String&, const WTF::UUID&);
     void enableTextAnimationTypeForElementWithID(const String&, const WTF::UUID&);
 
-    void addTextAnimationTypeForID(const WTF::UUID&, const WebKit::TextAnimationData&, const WebCore::TextIndicatorData&);
-    // FIXME: try and combine these two and/or clarify why both are needed.
-    // rdar://129882958 (Combine or clarify removeTextAnimationForID and cleanUpTextAnimationsForSessionID)
-    void removeTextAnimationForID(const WebCore::WritingTools::SessionID&);
-    void cleanUpTextAnimationsForSessionID(const WebCore::WritingTools::SessionID&);
+    void addTextAnimationForAnimationID(const WTF::UUID&, const WebKit::TextAnimationData&, const WebCore::TextIndicatorData&);
 
+    void removeTextAnimationForAnimationID(const WTF::UUID&);
+    void removeTransparentMarkersForSessionID(const WebCore::WritingTools::SessionID&);
+
+    void removeInitialTextAnimation(const WebCore::WritingTools::SessionID&);
+    void addInitialTextAnimation(const WebCore::WritingTools::SessionID&);
     void addSourceTextAnimation(const WebCore::WritingTools::SessionID&, const WebCore::CharacterRange&);
     void addDestinationTextAnimation(const WebCore::WritingTools::SessionID&, const WebCore::CharacterRange&);
 


### PR DESCRIPTION
#### c5c0cb2d749aea4fd57661a4bbdfd4bfca617dbc
<pre>
Use a separate animation ID from the session ID in all cases, including initial animation.
<a href="https://bugs.webkit.org/show_bug.cgi?id=275700">https://bugs.webkit.org/show_bug.cgi?id=275700</a>
<a href="https://rdar.apple.com/130217887">rdar://130217887</a>

Reviewed by Richard Robinson.

Perviously, I was using the sessionUUID for the first animation. This has made it difficult
to write clean and compartmentalized code, and caused issues where the wrong UUID was used.
This patch separated these into two separate concepts, and added mapping storage in the animation
controller. I also clean up some of the naming for the clean up code, and generally make the code
easier to understand.

* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::removeTextAnimationForAnimationID):
(WebCore::ChromeClient::removeTransparentMarkersForSessionID):
(WebCore::ChromeClient::removeInitialTextAnimation):
(WebCore::ChromeClient::addInitialTextAnimation):
(WebCore::ChromeClient::removeTextAnimationForID): Deleted.
(WebCore::ChromeClient::cleanUpTextAnimationsForSessionID): Deleted.
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::didBeginWritingToolsSession):
(WebCore::WritingToolsController::proofreadingSessionDidReceiveSuggestions):
(WebCore::WritingToolsController::compositionSessionDidReceiveTextWithReplacementRange):
(WebCore::WritingToolsController::didEndWritingToolsSession):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _addTextAnimationForAnimationID:withData:]):
(-[WKWebView _removeTextAnimationForAnimationID:]):
(-[WKWebView didBeginWritingToolsSession:contexts:]):
(-[WKWebView _enableSourceTextAnimationAfterElementWithID:]):
(-[WKWebView _enableFinalTextAnimationForElementWithID:]):
(-[WKWebView _disableTextAnimationWithUUID:]):
(-[WKWebView _addTextAnimationTypeForID:withData:]): Deleted.
(-[WKWebView _removeTextAnimationForID:]): Deleted.
(-[WKWebView beginWritingToolsAnimationForSessionWithUUID:]): Deleted.
(-[WKWebView endWritingToolsAnimationForSessionWithUUID:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::addTextAnimationForAnimationID):
(WebKit::PageClientImplCocoa::removeTextAnimationForAnimationID):
(WebKit::PageClientImplCocoa::addTextAnimationTypeForID): Deleted.
(WebKit::PageClientImplCocoa::removeTextAnimationForID): Deleted.
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::addTextAnimationForAnimationID):
(WebKit::WebPageProxy::removeTextAnimationForAnimationID):
(WebKit::WebPageProxy::addTextAnimationTypeForID): Deleted.
(WebKit::WebPageProxy::removeTextAnimationForID): Deleted.
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WKSTextAnimationManager.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView addTextAnimationForAnimationID:withStyleType:]):
(-[WKContentView removeTextAnimationForAnimationID:]):
(-[WKContentView addTextAnimationTypeForID:withStyleType:]): Deleted.
(-[WKContentView removeTextAnimationForID:]): Deleted.
* Source/WebKit/UIProcess/mac/WKTextAnimationManager.h:
* Source/WebKit/UIProcess/mac/WKTextAnimationManager.mm:
(-[WKTextAnimationManager addTextAnimationForAnimationID:withData:]):
(-[WKTextAnimationManager removeTextAnimationForAnimationID:]):
(-[WKTextAnimationManager restoreTextAnimationType]):
(-[WKTextAnimationManager addTextAnimationTypeForID:withData:]): Deleted.
(-[WKTextAnimationManager removeTextAnimationForID:]): Deleted.
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::addTextAnimationForAnimationID):
(WebKit::WebViewImpl::removeTextAnimationForAnimationID):
(WebKit::WebViewImpl::addTextAnimationTypeForID): Deleted.
(WebKit::WebViewImpl::removeTextAnimationForID): Deleted.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebKitSwift/TextAnimation/TextAnimationManager.swift:
(beginEffect(for:style:)):
(endEffect(for:)):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::removeTextAnimationForAnimationID):
(WebKit::WebChromeClient::removeTransparentMarkersForSessionID):
(WebKit::WebChromeClient::removeInitialTextAnimation):
(WebKit::WebChromeClient::addInitialTextAnimation):
(WebKit::WebChromeClient::removeTextAnimationForID): Deleted.
(WebKit::WebChromeClient::cleanUpTextAnimationsForSessionID): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h: Renamed from Source/WebKit/WebProcess/WebPage/TextAnimationController.h.
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm:
(WebKit::TextAnimationController::contextRangeForTextAnimationID const):
(WebKit::TextAnimationController::removeTransparentMarkersForSessionID):
(WebKit::TextAnimationController::removeInitialTextAnimation):
(WebKit::TextAnimationController::addInitialTextAnimation):
(WebKit::TextAnimationController::addSourceTextAnimation):
(WebKit::TextAnimationController::addDestinationTextAnimation):
(WebKit::TextAnimationController::updateUnderlyingTextVisibilityForTextAnimationID):
(WebKit::TextAnimationController::createTextIndicatorForTextAnimationID):
(WebKit::TextAnimationController::contextRangeForTextAnimationType const): Deleted.
(WebKit::TextAnimationController::cleanUpTextAnimationsForSessionID): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::addTextAnimationForAnimationID):
(WebKit::WebPage::removeTextAnimationForAnimationID):
(WebKit::WebPage::removeTransparentMarkersForSessionID):
(WebKit::WebPage::removeInitialTextAnimation):
(WebKit::WebPage::addInitialTextAnimation):
(WebKit::WebPage::addTextAnimationTypeForID): Deleted.
(WebKit::WebPage::removeTextAnimationForID): Deleted.
(WebKit::WebPage::cleanUpTextAnimationsForSessionID): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/280319@main">https://commits.webkit.org/280319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f4399f5f4da2e2f2347a90975a012561e1f1aa9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8739 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59873 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6703 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58393 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43215 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6897 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45554 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4661 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58296 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48544 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26431 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30256 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5874 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5707 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52264 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6146 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61556 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/175 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6273 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52834 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/175 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52720 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12464 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/no-raf-while-render-blocked.html (failure)") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/156 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8353 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31420 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32506 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33589 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32253 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->