### PR TITLE
Revert "[WebDriver] If Safari window is not focused, WebDriver-automated mouse events do not get sent to the page"

### DIFF
--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -227,7 +227,6 @@ public:
 #endif
 
 #if PLATFORM(MAC)
-    static const int synthesizedMouseEventMagicEventNumber = 0;
     bool wasEventSynthesizedForAutomation(NSEvent *);
     void markEventAsSynthesizedForAutomation(NSEvent *);
 #endif

--- a/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
+++ b/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
@@ -72,6 +72,7 @@ void WebAutomationSession::inspectBrowsingContext(const Inspector::Protocol::Aut
 
 #pragma mark AppKit Event Simulation Support
 
+static const NSInteger synthesizedMouseEventMagicEventNumber = 0;
 static const void *synthesizedAutomationEventAssociatedObjectKey = &synthesizedAutomationEventAssociatedObjectKey;
 
 void WebAutomationSession::sendSynthesizedEventsToPage(WebPageProxy& page, NSArray *eventsToSend)
@@ -144,7 +145,7 @@ bool WebAutomationSession::wasEventSynthesizedForAutomation(NSEvent *event)
     case NSEventTypeRightMouseUp:
         // Use this as a backup for checking mouse events, which are frequently copied
         // and/or faked by AppKit, causing them to lose their associated object tag.
-        return event.eventNumber == WebAutomationSession::synthesizedMouseEventMagicEventNumber;
+        return event.eventNumber == synthesizedMouseEventMagicEventNumber;
     default:
         break;
     }
@@ -227,7 +228,7 @@ void WebAutomationSession::platformSimulateMouseInteraction(WebPageProxy& page, 
 
     auto eventsToBeSent = adoptNS([[NSMutableArray alloc] init]);
 
-    NSInteger eventNumber = WebAutomationSession::synthesizedMouseEventMagicEventNumber;
+    NSInteger eventNumber = synthesizedMouseEventMagicEventNumber;
 
     switch (interaction) {
     case MouseInteraction::Move: {

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -47,7 +47,6 @@
 #import "WKBrowsingContextControllerInternal.h"
 #import "WKQuickLookPreviewController.h"
 #import "WKSharingServicePickerDelegate.h"
-#import "WebAutomationSession.h"
 #import "WebContextMenuProxyMac.h"
 #import "WebPageMessages.h"
 #import "WebPageProxyInternals.h"
@@ -365,10 +364,6 @@ bool WebPageProxy::shouldDelayWindowOrderingForEvent(const WebKit::WebMouseEvent
 
 bool WebPageProxy::acceptsFirstMouse(int eventNumber, const WebKit::WebMouseEvent& event)
 {
-    // FIXME <https://webkit.org/b/275500>: Find a way to properly ensure that automated events get delivered into an unfocused window.
-    if (eventNumber == WebAutomationSession::synthesizedMouseEventMagicEventNumber)
-        return true;
-
     if (!hasRunningProcess())
         return false;
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -43,7 +43,6 @@
 #include "ProvisionalFrameCreationParameters.h"
 #include "WKAPICast.h"
 #include "WKBundleAPICast.h"
-#include "WebAutomationSession.h"
 #include "WebChromeClient.h"
 #include "WebContextMenu.h"
 #include "WebCoreArgumentCoders.h"
@@ -1320,23 +1319,18 @@ WebCore::HandleUserInputEventResult WebFrame::handleMouseEvent(const WebMouseEve
             coreLocalFrame->eventHandler().invalidateClick();
         return coreLocalFrame->eventHandler().handleMouseReleaseEvent(platformMouseEvent);
 
-    case PlatformEvent::Type::MouseMoved: {
+    case PlatformEvent::Type::MouseMoved:
 #if PLATFORM(COCOA)
-        // FIXME <https://webkit.org/b/275500>: Find a way to properly ensure that automated events get delivered into an unfocused window.
-        bool isEventSynthesized = false;
-#if PLATFORM(MAC)
-        isEventSynthesized = platformMouseEvent.eventNumber() == WebAutomationSession::synthesizedMouseEventMagicEventNumber;
-#endif
         // We need to do a full, normal hit test during this mouse event if the page is active or if a mouse
         // button is currently pressed. It is possible that neither of those things will be true since on
         // Lion when legacy scrollbars are enabled, WebKit receives mouse events all the time. If it is one
         // of those cases where the page is not active and the mouse is not pressed, then we can fire a more
         // efficient scrollbars-only version of the event.
-        if (!isEventSynthesized && !page()->corePage()->focusController().isActive() && mouseEvent.button() == WebMouseEventButton::None)
+        if (!(page()->corePage()->focusController().isActive() || (mouseEvent.button() != WebMouseEventButton::None)))
             return coreLocalFrame->eventHandler().passMouseMovedEventToScrollbars(platformMouseEvent);
-#endif // PLATFORM(COCOA)
+#endif
         return coreLocalFrame->eventHandler().mouseMoved(platformMouseEvent);
-    }
+
     case PlatformEvent::Type::MouseForceChanged:
     case PlatformEvent::Type::MouseForceDown:
     case PlatformEvent::Type::MouseForceUp:

--- a/Tools/TestWebKitAPI/Tests/mac/AcceptsFirstMouse.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/AcceptsFirstMouse.mm
@@ -56,11 +56,11 @@ void AcceptsFirstMouse::runTest(View view)
     CGFloat viewHeight = view.bounds.size.height;
 
     NSPoint pointInsideSelection = NSMakePoint(50, viewHeight - 50);
-    NSEvent *mouseEventInsideSelection = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown location:pointInsideSelection modifierFlags:0 timestamp:0 windowNumber:[window.get() windowNumber] context:nil eventNumber:1 clickCount:1 pressure:1];
+    NSEvent *mouseEventInsideSelection = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown location:pointInsideSelection modifierFlags:0 timestamp:0 windowNumber:[window.get() windowNumber] context:nil eventNumber:0 clickCount:1 pressure:1];
     EXPECT_TRUE([[view hitTest:pointInsideSelection] acceptsFirstMouse:mouseEventInsideSelection]);
 
     NSPoint pointOutsideSelection = NSMakePoint(150, viewHeight - 150);
-    NSEvent *mouseEventOutsideSelection = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown location:pointOutsideSelection modifierFlags:0 timestamp:0 windowNumber:[window.get() windowNumber] context:nil eventNumber:1 clickCount:1 pressure:1];
+    NSEvent *mouseEventOutsideSelection = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown location:pointOutsideSelection modifierFlags:0 timestamp:0 windowNumber:[window.get() windowNumber] context:nil eventNumber:0 clickCount:1 pressure:1];
     EXPECT_FALSE([[view hitTest:pointInsideSelection] acceptsFirstMouse:mouseEventOutsideSelection]);
 }
 


### PR DESCRIPTION
#### cc82de0de6783bea7827acca4116556c40e5ce79
<pre>
Revert &quot;[WebDriver] If Safari window is not focused, WebDriver-automated mouse events do not get sent to the page&quot;

Reviewed by BJ Burg.

This reverts commit 3e29d37be2b6cd98183fd643223f0070f55c913e.

We found a better alternative fix which let WebDriver activate Safari to
focus the newly-created Safari window at the start of an automation
session.

Canonical link: <a href="https://commits.webkit.org/280262@main">https://commits.webkit.org/280262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a8cab1c9c555d87aa8f40c26dccd0724c1dce00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59724 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6554 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58244 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43066 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6748 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/45257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4540 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58147 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33332 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/48400 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26306 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30113 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5730 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5558 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6001 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61407 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/26 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6130 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/26 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48467 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/52364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12434 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/22 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31271 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32357 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33440 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32104 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->