### PR TITLE
WebExtensionContext::tabsUpdate and windowsUpdate need to properly capture lambdas.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIAlarmsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIAlarmsCocoa.mm
@@ -44,7 +44,7 @@ bool WebExtensionContext::isAlarmsMessageAllowed()
 
 void WebExtensionContext::alarmsCreate(const String& name, Seconds initialInterval, Seconds repeatInterval)
 {
-    m_alarmMap.set(name, WebExtensionAlarm::create(name, initialInterval, repeatInterval, [&](const WebExtensionAlarm& alarm) {
+    m_alarmMap.set(name, WebExtensionAlarm::create(name, initialInterval, repeatInterval, [this, protectedThis = Ref { *this }](const WebExtensionAlarm& alarm) {
         fireAlarmsEventIfNeeded(alarm);
     }));
 }

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm
@@ -46,6 +46,7 @@
 #import "_WKWebExtensionControllerDelegatePrivate.h"
 #import "_WKWebExtensionTabCreationOptionsInternal.h"
 #import <WebCore/ImageBufferUtilitiesCG.h>
+#import <wtf/CallbackAggregator.h>
 
 namespace WebKit {
 
@@ -133,9 +134,9 @@ void WebExtensionContext::tabsUpdate(WebPageProxyIdentifier webPageProxyIdentifi
         return;
     }
 
-    auto updateActiveAndSelected = [&](CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& stepCompletionHandler) {
-        if (parameters.active.value_or(false) && !tab->isActive()) {
-            tab->activate(WTFMove(stepCompletionHandler));
+    auto updateActiveAndSelected = [](WebExtensionTab& tab, const WebExtensionTabParameters& parameters, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& stepCompletionHandler) {
+        if (parameters.active.value_or(false) && !tab.isActive()) {
+            tab.activate(WTFMove(stepCompletionHandler));
             return;
         }
 
@@ -145,58 +146,58 @@ void WebExtensionContext::tabsUpdate(WebPageProxyIdentifier webPageProxyIdentifi
         }
 
         bool shouldSelect = parameters.selected.value();
-        if (shouldSelect && !tab->isSelected()) {
+        if (shouldSelect && !tab.isSelected()) {
             // If active is not explicitly set to false, activate the tab. This matches Firefox.
             if (parameters.active.value_or(true))
-                tab->activate(WTFMove(stepCompletionHandler));
+                tab.activate(WTFMove(stepCompletionHandler));
             else
-                tab->select(WTFMove(stepCompletionHandler));
+                tab.select(WTFMove(stepCompletionHandler));
             return;
         }
 
-        if (!shouldSelect && tab->isSelected()) {
-            tab->deselect(WTFMove(stepCompletionHandler));
+        if (!shouldSelect && tab.isSelected()) {
+            tab.deselect(WTFMove(stepCompletionHandler));
             return;
         }
 
         stepCompletionHandler({ });
     };
 
-    auto updateURL = [&](CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& stepCompletionHandler) {
+    auto updateURL = [](WebExtensionTab& tab, const WebExtensionTabParameters& parameters, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& stepCompletionHandler) {
         if (!parameters.url) {
             stepCompletionHandler({ });
             return;
         }
 
-        tab->loadURL(parameters.url.value(), WTFMove(stepCompletionHandler));
+        tab.loadURL(parameters.url.value(), WTFMove(stepCompletionHandler));
     };
 
-    auto updatePinned = [&](CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& stepCompletionHandler) {
-        if (!parameters.pinned || parameters.pinned.value() == tab->isPinned()) {
+    auto updatePinned = [](WebExtensionTab& tab, const WebExtensionTabParameters& parameters, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& stepCompletionHandler) {
+        if (!parameters.pinned || parameters.pinned.value() == tab.isPinned()) {
             stepCompletionHandler({ });
             return;
         }
 
         if (parameters.pinned.value())
-            tab->pin(WTFMove(stepCompletionHandler));
+            tab.pin(WTFMove(stepCompletionHandler));
         else
-            tab->unpin(WTFMove(stepCompletionHandler));
+            tab.unpin(WTFMove(stepCompletionHandler));
     };
 
-    auto updateMuted = [&](CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& stepCompletionHandler) {
-        if (!parameters.muted || parameters.muted.value() == tab->isMuted()) {
+    auto updateMuted = [](WebExtensionTab& tab, const WebExtensionTabParameters& parameters, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& stepCompletionHandler) {
+        if (!parameters.muted || parameters.muted.value() == tab.isMuted()) {
             stepCompletionHandler({ });
             return;
         }
 
         if (parameters.muted.value())
-            tab->mute(WTFMove(stepCompletionHandler));
+            tab.mute(WTFMove(stepCompletionHandler));
         else
-            tab->unmute(WTFMove(stepCompletionHandler));
+            tab.unmute(WTFMove(stepCompletionHandler));
     };
 
-    auto updateParentTab = [&](CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& stepCompletionHandler) {
-        auto currentParentTab = tab->parentTab();
+    auto updateParentTab = [this, protectedThis = Ref { *this }](WebExtensionTab& tab, const WebExtensionTabParameters& parameters, CompletionHandler<void(Expected<void, WebExtensionError>&&)>&& stepCompletionHandler) {
+        auto currentParentTab = tab.parentTab();
         auto newParentTab = parameters.parentTabIdentifier ? getTab(parameters.parentTabIdentifier.value()) : nullptr;
 
         if (currentParentTab == newParentTab) {
@@ -204,34 +205,34 @@ void WebExtensionContext::tabsUpdate(WebPageProxyIdentifier webPageProxyIdentifi
             return;
         }
 
-        tab->setParentTab(newParentTab, WTFMove(stepCompletionHandler));
+        tab.setParentTab(newParentTab, WTFMove(stepCompletionHandler));
     };
 
-    updateActiveAndSelected([&](Expected<void, WebExtensionError>&& activeOrSelectedResult) {
+    updateActiveAndSelected(*tab, parameters, [tab = Ref { *tab }, parameters, updateURL = WTFMove(updateURL), updatePinned = WTFMove(updatePinned), updateMuted = WTFMove(updateMuted), updateParentTab = WTFMove(updateParentTab), completionHandler = WTFMove(completionHandler)](Expected<void, WebExtensionError>&& activeOrSelectedResult) mutable {
         if (!activeOrSelectedResult) {
             completionHandler(makeUnexpected(activeOrSelectedResult.error()));
             return;
         }
 
-        updateURL([&](Expected<void, WebExtensionError>&& urlResult) {
+        updateURL(tab, parameters, [tab, parameters = WTFMove(parameters), updatePinned = WTFMove(updatePinned), updateMuted = WTFMove(updateMuted), updateParentTab = WTFMove(updateParentTab), completionHandler = WTFMove(completionHandler)](Expected<void, WebExtensionError>&& urlResult) mutable {
             if (!urlResult) {
                 completionHandler(makeUnexpected(urlResult.error()));
                 return;
             }
 
-            updatePinned([&](Expected<void, WebExtensionError>&& pinnedResult) {
+            updatePinned(tab, parameters, [tab, parameters = WTFMove(parameters), updateMuted = WTFMove(updateMuted), updateParentTab = WTFMove(updateParentTab), completionHandler = WTFMove(completionHandler)](Expected<void, WebExtensionError>&& pinnedResult) mutable {
                 if (!pinnedResult) {
                     completionHandler(makeUnexpected(pinnedResult.error()));
                     return;
                 }
 
-                updateMuted([&](Expected<void, WebExtensionError>&& mutedResult) {
+                updateMuted(tab, parameters, [tab, parameters = WTFMove(parameters), updateParentTab = WTFMove(updateParentTab), completionHandler = WTFMove(completionHandler)](Expected<void, WebExtensionError>&& mutedResult) mutable {
                     if (!mutedResult) {
                         completionHandler(makeUnexpected(mutedResult.error()));
                         return;
                     }
 
-                    updateParentTab([&](Expected<void, WebExtensionError>&& parentResult) {
+                    updateParentTab(tab, parameters, [tab, completionHandler = WTFMove(completionHandler)](Expected<void, WebExtensionError>&& parentResult) mutable {
                         if (!parentResult) {
                             completionHandler(makeUnexpected(parentResult.error()));
                             return;
@@ -556,28 +557,12 @@ void WebExtensionContext::tabsRemove(Vector<WebExtensionTabIdentifier> tabIdenti
         return;
     }
 
-    size_t completed = 0;
-    bool errorOccured = false;
-    auto internalCompletionHandler = WTFMove(completionHandler);
+    Ref callbackAggregator = EagerCallbackAggregator<void(Expected<void, WebExtensionError>)>::create(WTFMove(completionHandler), { });
 
     for (RefPtr tab : tabs) {
-        if (errorOccured)
-            break;
-
-        tab->close([&](Expected<void, WebExtensionError>&& result) mutable {
-            if (errorOccured)
-                return;
-
-            if (!result) {
-                errorOccured = true;
-                internalCompletionHandler(makeUnexpected(result.error()));
-                return;
-            }
-
-            if (++completed < tabs.size())
-                return;
-
-            internalCompletionHandler({ });
+        tab->close([callbackAggregator](Expected<void, WebExtensionError>&& result) mutable {
+            if (!result)
+                callbackAggregator.get()(makeUnexpected(result.error()));
         });
     }
 }

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm
@@ -419,62 +419,74 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)toggleReaderModeForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    if (_toggleReaderMode)
-        _toggleReaderMode();
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (self->_toggleReaderMode)
+            self->_toggleReaderMode();
 
-    _showingReaderMode = !_showingReaderMode;
+        self->_showingReaderMode = !self->_showingReaderMode;
 
-    [_extensionController didChangeTabProperties:_WKWebExtensionTabChangedPropertiesReaderMode forTab:self];
+        [self->_extensionController didChangeTabProperties:_WKWebExtensionTabChangedPropertiesReaderMode forTab:self];
 
-    completionHandler(nil);
+        completionHandler(nil);
+    });
 }
 
 - (void)detectWebpageLocaleForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSLocale *, NSError *))completionHandler
 {
-    if (_detectWebpageLocale)
-        completionHandler(_detectWebpageLocale(), nil);
-    else
-        completionHandler(nil, nil);
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (self->_detectWebpageLocale)
+            completionHandler(self->_detectWebpageLocale(), nil);
+        else
+            completionHandler(nil, nil);
+    });
 }
 
 - (void)reloadForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    if (_reload)
-        _reload();
-    else
-        [_mainWebView reload];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (self->_reload)
+            self->_reload();
+        else
+            [self->_mainWebView reload];
 
-    completionHandler(nil);
+        completionHandler(nil);
+    });
 }
 
 - (void)reloadFromOriginForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    if (_reloadFromOrigin)
-        _reloadFromOrigin();
-    else
-        [_mainWebView reloadFromOrigin];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (self->_reloadFromOrigin)
+            self->_reloadFromOrigin();
+        else
+            [self->_mainWebView reloadFromOrigin];
 
-    completionHandler(nil);
+        completionHandler(nil);
+    });
 }
 
 - (void)goBackForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    if (_goBack)
-        _goBack();
-    else
-        [_mainWebView goBack];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (self->_goBack)
+            self->_goBack();
+        else
+            [self->_mainWebView goBack];
 
-    completionHandler(nil);
+        completionHandler(nil);
+    });
 }
 
 - (void)goForwardForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    if (_goForward)
-        _goForward();
-    else
-        [_mainWebView goForward];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (self->_goForward)
+            self->_goForward();
+        else
+            [self->_mainWebView goForward];
 
-    completionHandler(nil);
+        completionHandler(nil);
+    });
 }
 
 - (id<_WKWebExtensionTab>)parentTabForWebExtensionContext:(_WKWebExtensionContext *)context
@@ -484,9 +496,11 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)setParentTab:(id<_WKWebExtensionTab>)parentTab forWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    _parentTab = dynamic_objc_cast<TestWebExtensionTab>(parentTab);
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self->_parentTab = dynamic_objc_cast<TestWebExtensionTab>(parentTab);
 
-    completionHandler(nil);
+        completionHandler(nil);
+    });
 }
 
 - (BOOL)isPinnedForWebExtensionContext:(_WKWebExtensionContext *)context
@@ -496,20 +510,24 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)pinForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    _pinned = YES;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self->_pinned = YES;
 
-    [_extensionController didChangeTabProperties:_WKWebExtensionTabChangedPropertiesPinned forTab:self];
+        [self->_extensionController didChangeTabProperties:_WKWebExtensionTabChangedPropertiesPinned forTab:self];
 
-    completionHandler(nil);
+        completionHandler(nil);
+    });
 }
 
 - (void)unpinForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    _pinned = NO;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self->_pinned = NO;
 
-    [_extensionController didChangeTabProperties:_WKWebExtensionTabChangedPropertiesPinned forTab:self];
+        [self->_extensionController didChangeTabProperties:_WKWebExtensionTabChangedPropertiesPinned forTab:self];
 
-    completionHandler(nil);
+        completionHandler(nil);
+    });
 }
 
 - (BOOL)isMutedForWebExtensionContext:(_WKWebExtensionContext *)context
@@ -519,40 +537,48 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)muteForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    _muted = YES;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self->_muted = YES;
 
-    [_extensionController didChangeTabProperties:_WKWebExtensionTabChangedPropertiesMuted forTab:self];
+        [self->_extensionController didChangeTabProperties:_WKWebExtensionTabChangedPropertiesMuted forTab:self];
 
-    completionHandler(nil);
+        completionHandler(nil);
+    });
 }
 
 - (void)unmuteForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    _muted = NO;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self->_muted = NO;
 
-    [_extensionController didChangeTabProperties:_WKWebExtensionTabChangedPropertiesMuted forTab:self];
+        [self->_extensionController didChangeTabProperties:_WKWebExtensionTabChangedPropertiesMuted forTab:self];
 
-    completionHandler(nil);
+        completionHandler(nil);
+    });
 }
 
 - (void)duplicateForWebExtensionContext:(_WKWebExtensionContext *)context withOptions:(_WKWebExtensionTabCreationOptions *)options completionHandler:(void (^)(id<_WKWebExtensionTab>, NSError *))completionHandler
 {
-    if (_duplicate)
-        _duplicate(options, completionHandler);
-    else
-        completionHandler(nil, nil);
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (self->_duplicate)
+            self->_duplicate(options, completionHandler);
+        else
+            completionHandler(nil, nil);
+    });
 }
 
 - (void)activateForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    auto *previousActiveTab = _window.activeTab;
-    _window.activeTab = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        auto *previousActiveTab = self->_window.activeTab;
+        self->_window.activeTab = self;
 
-    _selected = YES;
+        self->_selected = YES;
 
-    [_extensionController didActivateTab:self previousActiveTab:previousActiveTab];
+        [self->_extensionController didActivateTab:self previousActiveTab:previousActiveTab];
 
-    completionHandler(nil);
+        completionHandler(nil);
+    });
 }
 
 - (BOOL)isSelectedForWebExtensionContext:(_WKWebExtensionContext *)context
@@ -562,27 +588,33 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)selectForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    _selected = YES;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self->_selected = YES;
 
-    [_extensionController didSelectTabs:[NSSet setWithObject:self]];
+        [self->_extensionController didSelectTabs:[NSSet setWithObject:self]];
 
-    completionHandler(nil);
+        completionHandler(nil);
+    });
 }
 
 - (void)deselectForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    _selected = NO;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self->_selected = NO;
 
-    [_extensionController didDeselectTabs:[NSSet setWithObject:self]];
+        [self->_extensionController didDeselectTabs:[NSSet setWithObject:self]];
 
-    completionHandler(nil);
+        completionHandler(nil);
+    });
 }
 
 - (void)closeForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *))completionHandler
 {
-    [_window closeTab:self];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self->_window closeTab:self];
 
-    completionHandler(nil);
+        completionHandler(nil);
+    });
 }
 
 @end
@@ -800,17 +832,19 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)setWindowState:(_WKWebExtensionWindowState)state forWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *error))completionHandler
 {
-    _windowState = state;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self->_windowState = state;
 
-    if (state == _WKWebExtensionWindowStateFullscreen) {
-        _previousFrame = _frame;
-        _frame = _screenFrame;
-    } else if (!CGRectIsEmpty(_previousFrame)) {
-        _frame = _previousFrame;
-        _previousFrame = CGRectNull;
-    }
+        if (state == _WKWebExtensionWindowStateFullscreen) {
+            self->_previousFrame = self->_frame;
+            self->_frame = self->_screenFrame;
+        } else if (!CGRectIsEmpty(self->_previousFrame)) {
+            self->_frame = self->_previousFrame;
+            self->_previousFrame = CGRectNull;
+        }
 
-    completionHandler(nil);
+        completionHandler(nil);
+    });
 }
 
 - (BOOL)isUsingPrivateBrowsingForWebExtensionContext:(_WKWebExtensionContext *)context
@@ -830,9 +864,11 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)setFrame:(CGRect)frame forWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *error))completionHandler
 {
-    _frame = frame;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self->_frame = frame;
 
-    completionHandler(nil);
+        completionHandler(nil);
+    });
 }
 
 - (void)focusForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *error))completionHandler
@@ -845,10 +881,12 @@ static WKUserContentController *userContentController(BOOL usingPrivateBrowsing)
 
 - (void)closeForWebExtensionContext:(_WKWebExtensionContext *)context completionHandler:(void (^)(NSError *error))completionHandler
 {
-    if (_didClose)
-        _didClose();
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (self->_didClose)
+            self->_didClose();
 
-    completionHandler(nil);
+        completionHandler(nil);
+    });
 }
 
 @end


### PR DESCRIPTION
#### 8db235e14a7fcce78fc3896d18b2259f7cf75406
<pre>
WebExtensionContext::tabsUpdate and windowsUpdate need to properly capture lambdas.
<a href="https://webkit.org/b/270804">https://webkit.org/b/270804</a>
<a href="https://rdar.apple.com/problem/124393562">rdar://problem/124393562</a>

Reviewed by Jeff Miller.

Fix tabsUpdate, windowsUpdate, and tabsRemove to properly capture the lambdas’
variables so the completion handler blocks can be called async. Also fixed
alarmsCreate to protect the WebExtensionContext lambda capture with a Ref.

Updated the TestWebExtensionTab and TestWebExtensionWindow to call all the completion
handlers async so this is tested.

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIAlarmsCocoa.mm:
(WebKit::WebExtensionContext::alarmsCreate):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPITabsCocoa.mm:
(WebKit::WebExtensionContext::tabsUpdate):
(WebKit::WebExtensionContext::tabsRemove):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIWindowsCocoa.mm:
(WebKit::WebExtensionContext::windowsUpdate):
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionTab toggleReaderModeForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab detectWebpageLocaleForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab reloadForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab reloadFromOriginForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab goBackForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab goForwardForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab setParentTab:forWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab pinForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab unpinForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab muteForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab unmuteForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab duplicateForWebExtensionContext:withOptions:completionHandler:]):
(-[TestWebExtensionTab activateForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab selectForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab deselectForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionTab closeForWebExtensionContext:completionHandler:]):
(-[TestWebExtensionWindow setWindowState:forWebExtensionContext:completionHandler:]):
(-[TestWebExtensionWindow setFrame:forWebExtensionContext:completionHandler:]):
(-[TestWebExtensionWindow closeForWebExtensionContext:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/280233@main">https://commits.webkit.org/280233@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34a9453ed05939a2fd9d151fc762b8f005d56ebd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56011 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35335 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8479 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59010 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6452 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58137 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42956 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6639 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45117 "Found 1 new test failure: http/tests/scroll-to-text-fragment/no-scroll-after-stylesheet-load.html (failure)") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4465 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58040 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33233 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48298 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26249 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30014 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5627 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4586 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51986 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/60598 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6028 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52543 "Passed tests") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48367 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52073 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8306 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31164 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32248 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33334 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/31997 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->