### PR TITLE
Drop ShareableBitmap::data() in favor of span()

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.cpp
@@ -76,7 +76,7 @@ void ImageBufferBackend::convertToLuminanceMask()
     putPixelBuffer(*pixelBuffer, sourceRect, IntPoint::zero(), AlphaPremultiplication::Premultiplied);
 }
 
-void ImageBufferBackend::getPixelBuffer(const IntRect& sourceRect, void* sourceData, PixelBuffer& destinationPixelBuffer)
+void ImageBufferBackend::getPixelBuffer(const IntRect& sourceRect, const uint8_t* sourceData, PixelBuffer& destinationPixelBuffer)
 {
     IntRect backendRect { { }, size() };
     auto sourceRectClipped = intersection(backendRect, sourceRect);
@@ -95,7 +95,7 @@ void ImageBufferBackend::getPixelBuffer(const IntRect& sourceRect, void* sourceD
     ConstPixelBufferConversionView source {
         { AlphaPremultiplication::Premultiplied, convertToPixelFormat(pixelFormat()), colorSpace() },
         sourceBytesPerRow,
-        static_cast<uint8_t*>(sourceData) + sourceRectClipped.y() * sourceBytesPerRow + sourceRectClipped.x() * 4
+        sourceData + sourceRectClipped.y() * sourceBytesPerRow + sourceRectClipped.x() * 4
     };
     unsigned destinationBytesPerRow = static_cast<unsigned>(4u * sourceRect.width());
     PixelBufferConversionView destination {
@@ -107,7 +107,7 @@ void ImageBufferBackend::getPixelBuffer(const IntRect& sourceRect, void* sourceD
     convertImagePixels(source, destination, destinationRect.size());
 }
 
-void ImageBufferBackend::putPixelBuffer(const PixelBuffer& sourcePixelBuffer, const IntRect& sourceRect, const IntPoint& destinationPoint, AlphaPremultiplication destinationAlphaFormat, void* destinationData)
+void ImageBufferBackend::putPixelBuffer(const PixelBuffer& sourcePixelBuffer, const IntRect& sourceRect, const IntPoint& destinationPoint, AlphaPremultiplication destinationAlphaFormat, uint8_t* destinationData)
 {
     IntRect backendRect { { }, size() };
     auto sourceRectClipped = intersection({ IntPoint::zero(), sourcePixelBuffer.size() }, sourceRect);
@@ -133,7 +133,7 @@ void ImageBufferBackend::putPixelBuffer(const PixelBuffer& sourcePixelBuffer, co
     PixelBufferConversionView destination {
         { destinationAlphaFormat, convertToPixelFormat(pixelFormat()), colorSpace() },
         destinationBytesPerRow,
-        static_cast<uint8_t*>(destinationData) + destinationRect.y() * destinationBytesPerRow + destinationRect.x() * 4
+        destinationData + destinationRect.y() * destinationBytesPerRow + destinationRect.x() * 4
     };
 
     convertImagePixels(source, destination, destinationRect.size());

--- a/Source/WebCore/platform/graphics/ImageBufferBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferBackend.h
@@ -168,8 +168,8 @@ protected:
     const DestinationColorSpace& colorSpace() const { return m_parameters.colorSpace; }
     ImageBufferPixelFormat pixelFormat() const { return m_parameters.pixelFormat; }
 
-    WEBCORE_EXPORT void getPixelBuffer(const IntRect& srcRect, void* data, PixelBuffer& destination);
-    WEBCORE_EXPORT void putPixelBuffer(const PixelBuffer&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat, void* destination);
+    WEBCORE_EXPORT void getPixelBuffer(const IntRect& srcRect, const uint8_t* data, PixelBuffer& destination);
+    WEBCORE_EXPORT void putPixelBuffer(const PixelBuffer&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat, uint8_t* destination);
 
     Parameters m_parameters;
 };

--- a/Source/WebCore/platform/graphics/ShareableBitmap.cpp
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.cpp
@@ -168,9 +168,14 @@ ShareableBitmap::ShareableBitmap(ShareableBitmapConfiguration configuration, Ref
 {
 }
 
-void* ShareableBitmap::data() const
+std::span<const uint8_t> ShareableBitmap::span() const
 {
-    return m_sharedMemory->mutableSpan().data();
+    return m_sharedMemory->span();
+}
+
+std::span<uint8_t> ShareableBitmap::mutableSpan()
+{
+    return m_sharedMemory->mutableSpan();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ShareableBitmap.h
+++ b/Source/WebCore/platform/graphics/ShareableBitmap.h
@@ -159,7 +159,8 @@ public:
     IntSize size() const { return m_configuration.size(); }
     IntRect bounds() const { return IntRect(IntPoint(), size()); }
 
-    WEBCORE_EXPORT void* data() const;
+    WEBCORE_EXPORT std::span<const uint8_t> span() const;
+    WEBCORE_EXPORT std::span<uint8_t> mutableSpan();
     size_t bytesPerRow() const { return m_configuration.bytesPerRow(); }
     size_t sizeInBytes() const { return m_configuration.sizeInBytes(); }
 

--- a/Source/WebCore/platform/graphics/cairo/ShareableBitmapCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/ShareableBitmapCairo.cpp
@@ -53,10 +53,10 @@ CheckedUint32 ShareableBitmapConfiguration::calculateBytesPerRow(const IntSize& 
     return cairo_format_stride_for_width(cairoFormat, size.width());
 }
 
-static inline RefPtr<cairo_surface_t> createSurfaceFromData(void* data, const IntSize& size)
+static inline RefPtr<cairo_surface_t> createSurfaceFromData(uint8_t* data, const IntSize& size)
 {
     const int stride = cairo_format_stride_for_width(cairoFormat, size.width());
-    return adoptRef(cairo_image_surface_create_for_data(static_cast<unsigned char*>(data), cairoFormat, size.width(), size.height(), stride));
+    return adoptRef(cairo_image_surface_create_for_data(data, cairoFormat, size.width(), size.height(), stride));
 }
 
 std::unique_ptr<GraphicsContext> ShareableBitmap::createGraphicsContext()
@@ -72,7 +72,7 @@ void ShareableBitmap::paint(GraphicsContext& context, const IntPoint& dstPoint, 
 
 void ShareableBitmap::paint(GraphicsContext& context, float scaleFactor, const IntPoint& dstPoint, const IntRect& srcRect)
 {
-    RefPtr<cairo_surface_t> surface = createSurfaceFromData(data(), size());
+    RefPtr<cairo_surface_t> surface = createSurfaceFromData(mutableSpan().data(), size());
     cairo_surface_set_device_scale(surface.get(), scaleFactor, scaleFactor);
     FloatRect destRect(dstPoint, srcRect.size());
 
@@ -83,12 +83,12 @@ void ShareableBitmap::paint(GraphicsContext& context, float scaleFactor, const I
 
 RefPtr<cairo_surface_t> ShareableBitmap::createPersistentCairoSurface()
 {
-    return createSurfaceFromData(data(), size());
+    return createSurfaceFromData(mutableSpan().data(), size());
 }
 
 RefPtr<cairo_surface_t> ShareableBitmap::createCairoSurface()
 {
-    RefPtr<cairo_surface_t> image = createSurfaceFromData(data(), size());
+    RefPtr<cairo_surface_t> image = createSurfaceFromData(mutableSpan().data(), size());
 
     ref(); // Balanced by deref in releaseSurfaceData.
     static cairo_user_data_key_t dataKey;

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp
@@ -518,7 +518,7 @@ RefPtr<NativeImage> GraphicsContextGL::createNativeImageFromPixelBuffer(const Gr
     Ref protectedPixelBuffer = pixelBuffer;
     auto data = pixelBuffer->bytes();
 
-    verifyImageBufferIsBigEnough(data.data(), data.size());
+    verifyImageBufferIsBigEnough(data);
 
     auto dataProvider = adoptCF(CGDataProviderCreateWithData(&protectedPixelBuffer.leakRef(), data.data(), data.size(), [] (void* context, const void*, size_t) {
         static_cast<PixelBuffer*>(context)->deref();

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp
@@ -78,7 +78,7 @@ std::unique_ptr<ImageBufferCGBitmapBackend> ImageBufferCGBitmapBackend::create(c
     ASSERT(!(reinterpret_cast<intptr_t>(data) & 3));
 
     size_t numBytes = backendSize.height() * bytesPerRow;
-    verifyImageBufferIsBigEnough(data, numBytes);
+    verifyImageBufferIsBigEnough({ static_cast<const uint8_t*>(data), numBytes });
 
     auto cgContext = adoptCF(CGBitmapContextCreate(data, backendSize.width(), backendSize.height(), 8, bytesPerRow, parameters.colorSpace.platformColorSpace(), static_cast<uint32_t>(kCGImageAlphaPremultipliedFirst) | static_cast<uint32_t>(kCGBitmapByteOrder32Host)));
     if (!cgContext)
@@ -90,10 +90,10 @@ std::unique_ptr<ImageBufferCGBitmapBackend> ImageBufferCGBitmapBackend::create(c
         fastFree(const_cast<void*>(data));
     }));
 
-    return std::unique_ptr<ImageBufferCGBitmapBackend>(new ImageBufferCGBitmapBackend(parameters, data, WTFMove(dataProvider), WTFMove(context)));
+    return std::unique_ptr<ImageBufferCGBitmapBackend>(new ImageBufferCGBitmapBackend(parameters, static_cast<uint8_t*>(data), WTFMove(dataProvider), WTFMove(context)));
 }
 
-ImageBufferCGBitmapBackend::ImageBufferCGBitmapBackend(const Parameters& parameters, void* data, RetainPtr<CGDataProviderRef>&& dataProvider, std::unique_ptr<GraphicsContextCG>&& context)
+ImageBufferCGBitmapBackend::ImageBufferCGBitmapBackend(const Parameters& parameters, uint8_t* data, RetainPtr<CGDataProviderRef>&& dataProvider, std::unique_ptr<GraphicsContextCG>&& context)
     : ImageBufferCGBackend(parameters)
     , m_data(data)
     , m_dataProvider(WTFMove(dataProvider))

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h
@@ -47,7 +47,7 @@ public:
     GraphicsContext& context() final;
 
 private:
-    ImageBufferCGBitmapBackend(const Parameters&, void* data, RetainPtr<CGDataProviderRef>&&, std::unique_ptr<GraphicsContextCG>&&);
+    ImageBufferCGBitmapBackend(const Parameters&, uint8_t* data, RetainPtr<CGDataProviderRef>&&, std::unique_ptr<GraphicsContextCG>&&);
 
     unsigned bytesPerRow() const final;
 
@@ -57,7 +57,7 @@ private:
     void getPixelBuffer(const IntRect&, PixelBuffer&) final;
     void putPixelBuffer(const PixelBuffer&, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat) final;
 
-    void* m_data;
+    uint8_t* m_data;
     RetainPtr<CGDataProviderRef> m_dataProvider;
 };
 

--- a/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp
@@ -184,14 +184,14 @@ void ImageBufferIOSurfaceBackend::getPixelBuffer(const IntRect& srcRect, PixelBu
 {
     const_cast<ImageBufferIOSurfaceBackend*>(this)->prepareForExternalRead();
     if (auto lock = m_surface->lock<IOSurface::AccessMode::ReadOnly>())
-        ImageBufferBackend::getPixelBuffer(srcRect, lock->surfaceBaseAddress(), destination);
+        ImageBufferBackend::getPixelBuffer(srcRect, static_cast<const uint8_t*>(lock->surfaceBaseAddress()), destination);
 }
 
 void ImageBufferIOSurfaceBackend::putPixelBuffer(const PixelBuffer& pixelBuffer, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat)
 {
     prepareForExternalWrite();
     if (auto lock = m_surface->lock<IOSurface::AccessMode::ReadWrite>())
-        ImageBufferBackend::putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat, lock->surfaceBaseAddress());
+        ImageBufferBackend::putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat, static_cast<uint8_t*>(lock->surfaceBaseAddress()));
 }
 
 bool ImageBufferIOSurfaceBackend::canMapBackingStore() const

--- a/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp
@@ -41,12 +41,12 @@ namespace WebCore {
 
 using PutBytesCallback = size_t(std::span<const uint8_t>);
 
-uint8_t verifyImageBufferIsBigEnough(const void* buffer, size_t bufferSize)
+uint8_t verifyImageBufferIsBigEnough(std::span<const uint8_t> buffer)
 {
-    RELEASE_ASSERT(bufferSize);
+    RELEASE_ASSERT(!buffer.empty());
 
     uintptr_t lastByte;
-    bool isSafe = WTF::safeAdd((uintptr_t)buffer, bufferSize - 1, lastByte);
+    bool isSafe = WTF::safeAdd((uintptr_t)buffer.data(), buffer.size() - 1, lastByte);
     RELEASE_ASSERT(isSafe);
 
     return *(uint8_t*)lastByte;
@@ -174,7 +174,7 @@ static bool encode(const PixelBuffer& source, const String& mimeType, std::optio
         data = premultipliedData.mutableSpan();
     }
 
-    verifyImageBufferIsBigEnough(data.data(), dataSize);
+    verifyImageBufferIsBigEnough(data);
 
     auto dataProvider = adoptCF(CGDataProviderCreateWithData(nullptr, data.data(), dataSize, nullptr));
     if (!dataProvider)

--- a/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h
@@ -34,7 +34,7 @@ namespace WebCore {
 
 class PixelBuffer;
 
-WEBCORE_EXPORT uint8_t verifyImageBufferIsBigEnough(const void* buffer, size_t bufferSize);
+WEBCORE_EXPORT uint8_t verifyImageBufferIsBigEnough(std::span<const uint8_t> buffer);
 
 RetainPtr<CFStringRef> utiFromImageBufferMIMEType(const String& mimeType);
 CFStringRef jpegUTI();

--- a/Source/WebCore/platform/graphics/cv/PixelBufferConformerCV.cpp
+++ b/Source/WebCore/platform/graphics/cv/PixelBufferConformerCV.cpp
@@ -101,7 +101,7 @@ static const void* CVPixelBufferGetBytePointerCallback(void* refcon)
 
     size_t byteLength = CVPixelBufferGetBytesPerRow(info->pixelBuffer.get()) * CVPixelBufferGetHeight(info->pixelBuffer.get());
 
-    verifyImageBufferIsBigEnough(address, byteLength);
+    verifyImageBufferIsBigEnough({ static_cast<const uint8_t*>(address), byteLength });
     RELEASE_LOG_INFO(Media, "CVPixelBufferGetBytePointerCallback() returning bytePointer: %p, size: %zu", address, byteLength);
     return address;
 }

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaUnacceleratedBackend.cpp
@@ -82,14 +82,14 @@ void ImageBufferSkiaUnacceleratedBackend::getPixelBuffer(const IntRect& srcRect,
 {
     SkPixmap pixmap;
     if (m_surface->peekPixels(&pixmap))
-        ImageBufferBackend::getPixelBuffer(srcRect, pixmap.writable_addr(), destination);
+        ImageBufferBackend::getPixelBuffer(srcRect, static_cast<const uint8_t*>(pixmap.writable_addr()), destination);
 }
 
 void ImageBufferSkiaUnacceleratedBackend::putPixelBuffer(const PixelBuffer& pixelBuffer, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat)
 {
     SkPixmap pixmap;
     if (m_surface->peekPixels(&pixmap))
-        ImageBufferBackend::putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat, pixmap.writable_addr());
+        ImageBufferBackend::putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat, static_cast<uint8_t*>(pixmap.writable_addr()));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ShareableBitmapSkia.cpp
@@ -56,7 +56,7 @@ std::unique_ptr<GraphicsContext> ShareableBitmap::createGraphicsContext()
 {
     ref();
     SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
-    auto surface = SkSurfaces::WrapPixels(m_configuration.imageInfo(), data(), bytesPerRow(), [](void*, void* context) {
+    auto surface = SkSurfaces::WrapPixels(m_configuration.imageInfo(), mutableSpan().data(), bytesPerRow(), [](void*, void* context) {
         static_cast<ShareableBitmap*>(context)->deref();
     }, this, &properties);
 
@@ -91,10 +91,10 @@ PlatformImagePtr ShareableBitmap::createPlatformImage(BackingStoreCopy backingSt
 {
     sk_sp<SkData> pixelData;
     if (backingStoreCopy == BackingStoreCopy::CopyBackingStore)
-        pixelData = SkData::MakeWithCopy(data(), sizeInBytes());
+        pixelData = SkData::MakeWithCopy(span().data(), sizeInBytes());
     else {
         ref();
-        pixelData = SkData::MakeWithProc(data(), sizeInBytes(), [](const void*, void* bitmap) -> void {
+        pixelData = SkData::MakeWithProc(span().data(), sizeInBytes(), [](const void*, void* bitmap) -> void {
             static_cast<ShareableBitmap*>(bitmap)->deref();
         }, this);
     }

--- a/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
@@ -273,7 +273,7 @@ std::optional<UpdateInfo> WCScene::update(WCUpdateInfo&& update)
         m_fpsCounter.updateFPSAndDisplay(*m_textureMapper);
     if (readPixel) {
         bitmap = WebCore::ShareableBitmap::create({ update.viewport });
-        glReadPixels(0, 0, update.viewport.width(), update.viewport.height(), GL_BGRA, GL_UNSIGNED_BYTE, bitmap->data());
+        glReadPixels(0, 0, update.viewport.width(), update.viewport.height(), GL_BGRA, GL_UNSIGNED_BYTE, bitmap->mutableSpan().data());
     }
     m_textureMapper->endPainting();
 

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
@@ -407,7 +407,7 @@ void AcceleratedBackingStoreDMABuf::BufferSHM::didUpdateContents()
 #if USE(CAIRO)
     m_surface = m_bitmap->createCairoSurface();
 #elif USE(SKIA)
-    m_surface = cairo_image_surface_create_for_data(static_cast<unsigned char*>(m_bitmap->data()), CAIRO_FORMAT_ARGB32, m_size.width(), m_size.height(), m_bitmap->bytesPerRow());
+    m_surface = cairo_image_surface_create_for_data(m_bitmap->mutableSpan().data(), CAIRO_FORMAT_ARGB32, m_size.width(), m_size.height(), m_bitmap->bytesPerRow());
     m_bitmap->ref();
     static cairo_user_data_key_t s_surfaceDataKey;
     cairo_surface_set_user_data(m_surface.get(), &s_surfaceDataKey, m_bitmap.get(), [](void* userData) {

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp
@@ -106,10 +106,9 @@ void AcceleratedBackingStoreDMABuf::didCreateBufferSHM(uint64_t id, WebCore::Sha
         return;
 
     auto size = bitmap->size();
-    const auto* data = bitmap->data();
-    auto dataSize = bitmap->sizeInBytes();
+    auto data = bitmap->span();
     auto stride = bitmap->bytesPerRow();
-    GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new_with_free_func(data, dataSize, [](gpointer userData) {
+    GRefPtr<GBytes> bytes = adoptGRef(g_bytes_new_with_free_func(data.data(), data.size(), [](gpointer userData) {
         delete static_cast<WebCore::ShareableBitmap*>(userData);
     }, bitmap.leakRef()));
 

--- a/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp
@@ -152,12 +152,12 @@ RefPtr<NativeImage> ImageBufferShareableBitmapBackend::createNativeImageReferenc
 
 void ImageBufferShareableBitmapBackend::getPixelBuffer(const IntRect& srcRect, PixelBuffer& destination)
 {
-    ImageBufferBackend::getPixelBuffer(srcRect, m_bitmap->data(), destination);
+    ImageBufferBackend::getPixelBuffer(srcRect, m_bitmap->span().data(), destination);
 }
 
 void ImageBufferShareableBitmapBackend::putPixelBuffer(const PixelBuffer& pixelBuffer, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat)
 {
-    ImageBufferBackend::putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat, m_bitmap->data());
+    ImageBufferBackend::putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat, m_bitmap->mutableSpan().data());
 }
 
 String ImageBufferShareableBitmapBackend::debugDescription() const

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
@@ -270,7 +270,7 @@ AcceleratedSurfaceDMABuf::RenderTargetSHMImage::RenderTargetSHMImage(uint64_t su
 
 void AcceleratedSurfaceDMABuf::RenderTargetSHMImage::didRenderFrame()
 {
-    glReadPixels(0, 0, m_bitmap->size().width(), m_bitmap->size().height(), GL_BGRA, GL_UNSIGNED_BYTE, m_bitmap->data());
+    glReadPixels(0, 0, m_bitmap->size().width(), m_bitmap->size().height(), GL_BGRA, GL_UNSIGNED_BYTE, m_bitmap->mutableSpan().data());
 }
 
 std::unique_ptr<AcceleratedSurfaceDMABuf::RenderTarget> AcceleratedSurfaceDMABuf::RenderTargetTexture::create(uint64_t surfaceID, const WebCore::IntSize& size)


### PR DESCRIPTION
#### abd9ee6fa29738188a7b2c58181c70f87b50e3f2
<pre>
Drop ShareableBitmap::data() in favor of span()
<a href="https://bugs.webkit.org/show_bug.cgi?id=275707">https://bugs.webkit.org/show_bug.cgi?id=275707</a>

Reviewed by Darin Adler.

* Source/WebCore/platform/graphics/ImageBufferBackend.cpp:
(WebCore::ImageBufferBackend::getPixelBuffer):
(WebCore::ImageBufferBackend::putPixelBuffer):
* Source/WebCore/platform/graphics/ImageBufferBackend.h:
* Source/WebCore/platform/graphics/ShareableBitmap.cpp:
(WebCore::ShareableBitmap::span const):
(WebCore::ShareableBitmap::mutableSpan):
(WebCore::ShareableBitmap::data const): Deleted.
* Source/WebCore/platform/graphics/ShareableBitmap.h:
* Source/WebCore/platform/graphics/cg/GraphicsContextGLCG.cpp:
(WebCore::GraphicsContextGL::createNativeImageFromPixelBuffer):
* Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.cpp:
(WebCore::ImageBufferCGBitmapBackend::create):
(WebCore::ImageBufferCGBitmapBackend::ImageBufferCGBitmapBackend):
* Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.cpp:
(WebCore::ImageBufferIOSurfaceBackend::getPixelBuffer):
(WebCore::ImageBufferIOSurfaceBackend::putPixelBuffer):
* Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp:
(WebCore::verifyImageBufferIsBigEnough):
(WebCore::encode):
* Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h:
* Source/WebCore/platform/graphics/cg/ShareableBitmapCG.mm:
(WebCore::ShareableBitmap::createGraphicsContext):
(WebCore::ShareableBitmap::makeCGImage):
(WebCore::ShareableBitmap::releaseBitmapContextData):
* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
* Source/WebCore/platform/graphics/cv/PixelBufferConformerCV.cpp:
(WebCore::CVPixelBufferGetBytePointerCallback):
* Source/WebKit/WebProcess/GPU/graphics/ImageBufferShareableBitmapBackend.cpp:
(WebKit::ImageBufferShareableBitmapBackend::getPixelBuffer):
(WebKit::ImageBufferShareableBitmapBackend::putPixelBuffer):

Canonical link: <a href="https://commits.webkit.org/280293@main">https://commits.webkit.org/280293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a21b0f041557f1a2fbc93b3edabf3fa8b717651e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56195 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59801 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6631 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58321 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43143 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6825 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45435 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4605 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33410 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26368 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30190 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5807 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5635 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52192 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61484 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/103 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6205 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52756 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/103 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48544 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52588 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/91 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8338 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31348 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32434 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33517 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32181 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->