### PR TITLE
[Navigation] Initial implementation of NavigationActivation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-history-pushState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-history-pushState-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL navigation.activation.entry should not change due to history.pushState() promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'navigation.activation.entry')"
+PASS navigation.activation.entry should not change due to history.pushState()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-history-replaceState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-history-replaceState-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL navigation.activation.entry should be orphaned by history.replaceState() promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'navigation.activation.entry')"
+PASS navigation.activation.entry should be orphaned by history.replaceState()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-initial-about-blank-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-initial-about-blank-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.activation interaction with initial about:blank assert_equals: expected (object) null but got (undefined) undefined
+PASS navigation.activation interaction with initial about:blank
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-push-cross-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-push-cross-origin-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.activation after push cross-origin promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'i.contentWindow.navigation.activation.entry')"
+PASS navigation.activation after push cross-origin
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-reload-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-reload-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.activation after reload promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'i.contentWindow.navigation.activation.entry')"
+PASS navigation.activation after reload
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-replace-cross-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-replace-cross-origin-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.activation after replace cross-origin promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'i.contentWindow.navigation.activation.entry')"
+PASS navigation.activation after replace cross-origin
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-replace-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-replace-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.activation after replace promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'i.contentWindow.navigation.activation.from')"
+FAIL navigation.activation after replace promise_test: Unhandled rejection with value: object "TypeError: null is not an object (evaluating 'from_entry_after_nav.key')"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-traverse-not-in-entries-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-traverse-not-in-entries-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL navigation.activation - traverse from a non-contiguous same-origin url promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'i.contentWindow.navigation.activation.entry')"
+PASS navigation.activation - traverse from a non-contiguous same-origin url
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1377,6 +1377,7 @@ set(WebCore_NON_SVG_IDL_FILES
     page/Location.idl
     page/NavigateEvent.idl
     page/Navigation.idl
+    page/NavigationActivation.idl
     page/NavigationCurrentEntryChangeEvent.idl
     page/NavigationDestination.idl
     page/NavigationHistoryEntry.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1933,6 +1933,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigateEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigateEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigation.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigation.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigationActivation.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigationActivation.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigationCurrentEntryChangeEvent.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigationCurrentEntryChangeEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigationDestination.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1449,6 +1449,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/page/Location.idl \
     $(WebCore)/page/NavigateEvent.idl \
     $(WebCore)/page/Navigation.idl \
+    $(WebCore)/page/NavigationActivation.idl \
     $(WebCore)/page/NavigationCurrentEntryChangeEvent.idl \
     $(WebCore)/page/NavigationDestination.idl \
     $(WebCore)/page/NavigationHistoryEntry.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1550,6 +1550,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/MediaProducer.h
     page/MemoryRelease.h
     page/ModalContainerTypes.h
+    page/NavigationNavigationType.h
     page/NavigatorIsLoggedIn.h
     page/OriginAccessPatterns.h
     page/Page.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1995,6 +1995,7 @@ page/MemoryRelease.cpp
 page/MouseEventWithHitTestResults.cpp
 page/NavigateEvent.cpp
 page/Navigation.cpp
+page/NavigationActivation.cpp
 page/NavigationCurrentEntryChangeEvent.cpp
 page/NavigationDestination.cpp
 page/NavigationHistoryEntry.cpp
@@ -3995,6 +3996,7 @@ JSMutationRecord.cpp
 JSNamedNodeMap.cpp
 JSNavigateEvent.cpp
 JSNavigation.cpp
+JSNavigationActivation.cpp
 JSNavigationCurrentEntryChangeEvent.cpp
 JSNavigationDestination.cpp
 JSNavigationHistoryEntry.cpp

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -93,6 +93,7 @@ enum class UsedLegacyTLS : bool;
 enum class WasPrivateRelayed : bool;
 enum class IsMainResource : bool { No, Yes };
 enum class ShouldUpdateAppInitiatedValue : bool { No, Yes };
+enum class NavigationNavigationType : uint8_t;
 
 struct WindowFeatures;
 
@@ -454,7 +455,7 @@ private:
     void clearProvisionalLoadForPolicyCheck();
     bool hasOpenedFrames() const;
 
-    void updateNavigationAPIEntries();
+    void updateNavigationAPIEntries(std::optional<NavigationNavigationType>);
     void updateRequestAndAddExtraFields(Frame&, ResourceRequest&, IsMainResource, FrameLoadType, ShouldUpdateAppInitiatedValue, IsServiceWorkerNavigationLoad, WillOpenInNewWindow, Document*);
 
     bool dispatchNavigateEvent(const URL& newURL, FrameLoadType, const NavigationAction&, NavigationHistoryBehavior, bool isSameDocument, FormState* = nullptr);

--- a/Source/WebCore/loader/NavigationAction.h
+++ b/Source/WebCore/loader/NavigationAction.h
@@ -50,6 +50,7 @@ class UIEventWithKeyState;
 
 enum class SyntheticClickType : uint8_t;
 enum class MouseButton : int8_t;
+enum class NavigationNavigationType : uint8_t;
 
 // NavigationAction should never hold a strong reference to the originating document either directly
 // or indirectly as doing so prevents its destruction even after navigating away from it because
@@ -146,6 +147,9 @@ public:
     bool isInitialFrameSrcLoad() const { return m_isInitialFrameSrcLoad; }
     void setIsInitialFrameSrcLoad(bool isInitialFrameSrcLoad) { m_isInitialFrameSrcLoad = isInitialFrameSrcLoad; }
 
+    std::optional<NavigationNavigationType> navigationAPIType() const { return m_navigationAPIType; }
+    void setNavigationAPIType(NavigationNavigationType navigationAPIType) { m_navigationAPIType = navigationAPIType; }
+
 private:
     // Do not add a strong reference to the originating document or a subobject that holds the
     // originating document. See comment above the class for more details.
@@ -161,6 +165,7 @@ private:
     ShouldReplaceDocumentIfJavaScriptURL m_shouldReplaceDocumentIfJavaScriptURL { ReplaceDocumentIfJavaScriptURL };
 
     NavigationType m_type;
+    std::optional<NavigationNavigationType> m_navigationAPIType;
     ShouldOpenExternalURLsPolicy m_shouldOpenExternalURLsPolicy;
     InitiatedByMainFrame m_initiatedByMainFrame;
 

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -225,9 +225,10 @@ private:
 
 class ScheduledLocationChange : public ScheduledURLNavigation {
 public:
-    ScheduledLocationChange(Document& initiatingDocument, SecurityOrigin* securityOrigin, const URL& url, const String& referrer, LockHistory lockHistory, LockBackForwardList lockBackForwardList, bool duringLoad, CompletionHandler<void(bool)>&& completionHandler)
+    ScheduledLocationChange(Document& initiatingDocument, SecurityOrigin* securityOrigin, const URL& url, const String& referrer, LockHistory lockHistory, LockBackForwardList lockBackForwardList, bool duringLoad, NavigationHistoryBehavior navigationHandling, CompletionHandler<void(bool)>&& completionHandler)
         : ScheduledURLNavigation(initiatingDocument, 0.0, securityOrigin, url, referrer, lockHistory, lockBackForwardList, duringLoad, true)
         , m_completionHandler(WTFMove(completionHandler))
+        , m_navigationHistoryBehavior(navigationHandling)
     {
     }
 
@@ -247,6 +248,7 @@ public:
         frameLoadRequest.setLockBackForwardList(lockBackForwardList());
         frameLoadRequest.disableNavigationToInvalidURL();
         frameLoadRequest.setShouldOpenExternalURLsPolicy(shouldOpenExternalURLs());
+        frameLoadRequest.setNavigationHistoryBehavior(m_navigationHistoryBehavior);
 
         auto completionHandler = std::exchange(m_completionHandler, nullptr);
         frame.changeLocation(WTFMove(frameLoadRequest));
@@ -255,6 +257,7 @@ public:
 
 private:
     CompletionHandler<void(bool)> m_completionHandler;
+    NavigationHistoryBehavior m_navigationHistoryBehavior;
 };
 
 class ScheduledRefresh : public ScheduledURLNavigation {
@@ -559,7 +562,7 @@ void NavigationScheduler::scheduleLocationChange(Document& initiatingDocument, S
     // This may happen when a frame changes the location of another frame.
     bool duringLoad = loader && !loader->stateMachine().committedFirstRealDocumentLoad();
 
-    schedule(makeUnique<ScheduledLocationChange>(initiatingDocument, &securityOrigin, url, referrer, lockHistory, lockBackForwardList, duringLoad, [completionHandler = WTFMove(completionHandler)] (bool hasStarted) mutable {
+    schedule(makeUnique<ScheduledLocationChange>(initiatingDocument, &securityOrigin, url, referrer, lockHistory, lockBackForwardList, duringLoad, historyHandling, [completionHandler = WTFMove(completionHandler)] (bool hasStarted) mutable {
         completionHandler(hasStarted ? ScheduleLocationChangeResult::Started : ScheduleLocationChangeResult::Stopped);
     }));
 }

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -40,6 +40,7 @@ class FormState;
 class HistoryItem;
 class SerializedScriptValue;
 class NavigateEvent;
+class NavigationActivation;
 class NavigationDestination;
 
 enum class FrameLoadType : uint8_t;
@@ -120,6 +121,7 @@ public:
     const Vector<Ref<NavigationHistoryEntry>>& entries() const;
     NavigationHistoryEntry* currentEntry() const;
     NavigationTransition* transition() { return m_transition.get(); };
+    NavigationActivation* activation() { return m_activation.get(); };
 
     bool canGoBack() const;
     bool canGoForward() const;
@@ -142,6 +144,7 @@ public:
 
     void updateForNavigation(Ref<HistoryItem>&&, NavigationNavigationType);
     void updateForReactivation(Vector<Ref<HistoryItem>>& newHistoryItems, HistoryItem& reactivatedItem);
+    void updateForActivation(HistoryItem* previousItem, std::optional<NavigationNavigationType>);
 
 private:
     explicit Navigation(LocalDOMWindow&);
@@ -170,6 +173,7 @@ private:
 
     std::optional<size_t> m_currentEntryIndex;
     RefPtr<NavigationTransition> m_transition;
+    RefPtr<NavigationActivation> m_activation;
     Vector<Ref<NavigationHistoryEntry>> m_entries;
 
     RefPtr<NavigateEvent> m_ongoingNavigateEvent;

--- a/Source/WebCore/page/Navigation.idl
+++ b/Source/WebCore/page/Navigation.idl
@@ -7,6 +7,7 @@
   readonly attribute NavigationHistoryEntry? currentEntry;
   undefined updateCurrentEntry(NavigationUpdateCurrentEntryOptions options);
   readonly attribute NavigationTransition? transition;
+  readonly attribute NavigationActivation? activation;
 
   readonly attribute boolean canGoBack;
   readonly attribute boolean canGoForward;

--- a/Source/WebCore/page/NavigationActivation.cpp
+++ b/Source/WebCore/page/NavigationActivation.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "NavigationActivation.h"
+
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(NavigationActivation);
+
+NavigationActivation::NavigationActivation(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& entry, RefPtr<NavigationHistoryEntry>&& fromEntry)
+    : m_navigationType(type)
+    , m_entry(WTFMove(entry))
+    , m_fromEntry(WTFMove(fromEntry))
+{
+}
+
+} // namespace WebCore
+

--- a/Source/WebCore/page/NavigationActivation.h
+++ b/Source/WebCore/page/NavigationActivation.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ScriptWrappable.h"
+
+namespace WebCore {
+
+class NavigationHistoryEntry;
+enum class NavigationNavigationType : uint8_t;
+
+class NavigationActivation final : public RefCounted<NavigationActivation>, public ScriptWrappable {
+    WTF_MAKE_ISO_ALLOCATED(NavigationActivation);
+public:
+    static Ref<NavigationActivation> create(NavigationNavigationType type, Ref<NavigationHistoryEntry>&& entry, RefPtr<NavigationHistoryEntry>&& fromEntry)
+    {
+        return adoptRef(*new NavigationActivation(type, WTFMove(entry), WTFMove(fromEntry)));
+    }
+
+    NavigationNavigationType navigationType() { return m_navigationType; };
+    NavigationHistoryEntry* from() const { return m_fromEntry.get(); };
+    const NavigationHistoryEntry& entry() const { return m_entry; };
+
+private:
+    explicit NavigationActivation(NavigationNavigationType, Ref<NavigationHistoryEntry>&&, RefPtr<NavigationHistoryEntry>&& fromEntry);
+
+    NavigationNavigationType m_navigationType;
+    Ref<NavigationHistoryEntry> m_entry;
+    RefPtr<NavigationHistoryEntry> m_fromEntry;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/page/NavigationActivation.idl
+++ b/Source/WebCore/page/NavigationActivation.idl
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+[Exposed=Window]
+interface NavigationActivation {
+  readonly attribute NavigationHistoryEntry? from;
+  readonly attribute NavigationHistoryEntry entry;
+  readonly attribute NavigationNavigationType navigationType;
+};


### PR DESCRIPTION
#### 484ef912355d668f088f6a521ff44de759268d2a
<pre>
[Navigation] Initial implementation of NavigationActivation
<a href="https://bugs.webkit.org/show_bug.cgi?id=275711">https://bugs.webkit.org/show_bug.cgi?id=275711</a>

Reviewed by Alex Christensen.

<a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-activation">https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-activation</a>

An activation occurs on any cross-document navigation, this sets
an object that exposes where the navigation came from.

This is not yet complete as it doesn&apos;t handle reactivation,
which happens when navigating to a cached page. Unfortunately
the WPT tests for this are skipped as the cache is disabled
so this will come later.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-history-pushState-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-history-replaceState-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-initial-about-blank-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-push-cross-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-reload-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-replace-cross-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-replace-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-traverse-not-in-entries-expected.txt:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::didBeginDocument):
(WebCore::FrameLoader::loadURL):
(WebCore::FrameLoader::loadWithDocumentLoader):
(WebCore::FrameLoader::reload):
(WebCore::FrameLoader::loadDifferentDocumentItem):
(WebCore::FrameLoader::updateNavigationAPIEntries):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/NavigationAction.h:
(WebCore::NavigationAction::navigationAPIType const):
(WebCore::NavigationAction::setNavigationAPIType):

These changes were to fix location.replace() which was exposed
by these tests.

* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::ScheduledLocationChange::ScheduledLocationChange):
(WebCore::NavigationScheduler::scheduleLocationChange):

* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::initializeEntries):
(WebCore::Navigation::updateForActivation):
(WebCore::Navigation::updateForReactivation):
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/Navigation.idl:
* Source/WebCore/page/NavigationActivation.cpp: Added.
(WebCore::NavigationActivation::NavigationActivation):
* Source/WebCore/page/NavigationActivation.h: Added.
* Source/WebCore/page/NavigationActivation.idl: Added.

Canonical link: <a href="https://commits.webkit.org/280355@main">https://commits.webkit.org/280355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d3b07e629fbf722d5ca32bedc5d910726250e33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59970 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6799 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58489 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6993 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45653 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4747 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58392 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48634 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26517 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30346 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5964 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5803 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52337 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6236 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61654 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/271 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6357 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52916 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/271 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48700 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52799 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12483 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/245 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31516 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32602 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33685 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32349 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->