### PR TITLE
[wpe][cross-toolchain-helper][browserperfdash] Improve netdata systemd unit file to auto-restart upon failure/crash

### DIFF
--- a/Tools/yocto/meta-openembedded_backport-libbacktrace-and-newer-netdata-to-mickledore-branch.patch
+++ b/Tools/yocto/meta-openembedded_backport-libbacktrace-and-newer-netdata-to-mickledore-branch.patch
@@ -27,10 +27,10 @@ index 609e55f4a..46fa81866 100644
 +# libunwind does not support RISCV32 yet
  COMPATIBLE_HOST:riscv32 = "null"
 diff --git a/sources/meta-openembedded/meta-webserver/recipes-webadmin/netdata/netdata/netdata.service b/sources/meta-openembedded/meta-webserver/recipes-webadmin/netdata/netdata/netdata.service
-index ca13f7287..f4911f3b6 100644
+index ca13f7287..b13abad11 100644
 --- a/sources/meta-openembedded/meta-webserver/recipes-webadmin/netdata/netdata/netdata.service
 +++ b/sources/meta-openembedded/meta-webserver/recipes-webadmin/netdata/netdata/netdata.service
-@@ -7,7 +7,7 @@ After=network.target
+@@ -7,9 +7,12 @@ After=network.target
  [Service]
  Type=simple
  ExecStartPre=/bin/mkdir -p /var/log/netdata
@@ -38,7 +38,12 @@ index ca13f7287..f4911f3b6 100644
 +ExecStartPre=/bin/chown -R netdata:netdata /var/log/netdata
  ExecStart=/usr/sbin/netdata -D -u netdata
  
++# restart netdata if it crashes
++Restart=on-failure
++RestartSec=10
  
+ [Install]
+ WantedBy=multi-user.target
 diff --git a/sources/meta-openembedded/meta-webserver/recipes-webadmin/netdata/netdata_1.36.1.bb b/sources/meta-openembedded/meta-webserver/recipes-webadmin/netdata/netdata_1.44.3.bb
 similarity index 76%
 rename from meta-webserver/recipes-webadmin/netdata/netdata_1.36.1.bb


### PR DESCRIPTION
#### b8f876b231ab91a7df950c7c0617945620d944e2
<pre>
[wpe][cross-toolchain-helper][browserperfdash] Improve netdata systemd unit file to auto-restart upon failure/crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=275712">https://bugs.webkit.org/show_bug.cgi?id=275712</a>

Reviewed by Carlos Alberto Lopez Perez.

Improve the netdata systemd unit file to auto-restart netdata upon
crashes/failures.

* Tools/yocto/meta-openembedded_backport-libbacktrace-and-newer-netdata-to-mickledore-branch.patch:

Canonical link: <a href="https://commits.webkit.org/280238@main">https://commits.webkit.org/280238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a83f6ad94ce73f5f670639e93fdcabb0d9fe51c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59029 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6464 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58154 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/42976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6658 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/45155 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4474 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33249 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48318 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26260 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30030 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5647 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/4620 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/51998 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5919 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/60878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6044 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/60878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48385 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/60878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12419 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31181 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32267 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33350 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32014 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->