### PR TITLE
REGRESSION (278473@main): [ iOS ] http/tests/site-isolation/window-open-with-name-cross-site.html is a consistent timeout

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7238,8 +7238,6 @@ webkit.org/b/273848 [ Release ] imported/w3c/web-platform-tests/html/semantics/e
 
 webkit.org/b/273905 svg/filters/filter-on-root-tile-boundary.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/273984 http/tests/site-isolation/window-open-with-name-cross-site.html [ Timeout ]
-
 # webkit.org/b/274219 (REGRESSION (278786@main): [ MacOS iOS ] 3X http/wpt/webauthn tests are consistent failures)
 http/wpt/webauthn/idl.https.html [ Failure ]
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6387,9 +6387,9 @@ void WebPageProxy::didCommitLoadForFrame(IPC::Connection& connection, FrameIdent
     }
 
     // FIXME: We ought to be able to know what site a navigation is to even before it commits, even for the first navigation.
-    if (frame->frameProcess().site().isEmpty() && m_preferences->siteIsolationEnabled()) {
+    if (m_preferences->siteIsolationEnabled()) {
         Site navigationSite(request.url());
-        if (!navigationSite.isEmpty())
+        if (!navigationSite.isEmpty() && frame->frameProcess().site() != navigationSite)
             frame->setProcess(m_browsingContextGroup->ensureProcessForSite(navigationSite, m_legacyMainFrameProcess, preferences()));
     }
 


### PR DESCRIPTION
#### 2d924a32402016dfc54ffad87c0fc1a35b62f3e7
<pre>
REGRESSION (278473@main): [ iOS ] http/tests/site-isolation/window-open-with-name-cross-site.html is a consistent timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=273984">https://bugs.webkit.org/show_bug.cgi?id=273984</a>
<a href="https://rdar.apple.com/127848665">rdar://127848665</a>

Reviewed by Alex Christensen.

278473@main added a new test that performs top-level navigation from domain 127.0.0.1 to localhost. After the test runs,
the web page is hosted in a FrameProcess with site `<a href="http://localhost`">http://localhost`</a>, and BrowsingContextGroup of the WebPageProxy only
has one FrameProcess for `<a href="http://localhost`.">http://localhost`.</a> When WebKitTestRunner loads the next test URL of domain 127.0.0.1 in the
web page, a new FrameProcess for site `<a href="http://127.0.0.1`">http://127.0.0.1`</a> should be created, added to BrowsingContextGroup, and used for
the main frame of the page. Otherwise, UI process will not use the same process for other frames loading
`<a href="http://127.0.0.1`">http://127.0.0.1`</a> (since it cannot find it in BrowsingContextGroup), and it may create a new web process.

The timeout is directly caused by opener of frame with `<a href="http://127.0.0.1`">http://127.0.0.1`</a> not being set, which is supposed to be set
after provisional frame is committed. In this case, provisional frame is not created becasuse
takeRemotePageInProcessForProvisionalPage does not find remote page in the new web process (see
`ProvisionalPageProxy::initializeWebPage`), and the new web prcess should not be created. To fix this, create new
FrameProcess when frame load is committed and existing frame process has different site from load site.

* LayoutTests/platform/ios/TestExpectations:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLoadForFrame):

Canonical link: <a href="https://commits.webkit.org/280263@main">https://commits.webkit.org/280263@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39e888151bfe96eaba75819edbfba5f370933075

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56055 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35381 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59661 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6491 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6685 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45207 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4491 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58084 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33276 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48344 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26269 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30057 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5674 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5495 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52026 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61381 "Built successfully") | 
| | [⏳ 🛠 vision ](https://ews-build.webkit.org/#/builders/visionOS-1-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6072 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52641 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🛠 vision-sim ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52340 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12435 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-1-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31208 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32294 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33377 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32041 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->