### PR TITLE
Rename MediaStreamTrack powerEfficientPixelFormat constraint to powerEfficient

### DIFF
--- a/LayoutTests/fast/mediastream/MediaDevices-getSupportedConstraints-expected.txt
+++ b/LayoutTests/fast/mediastream/MediaDevices-getSupportedConstraints-expected.txt
@@ -30,7 +30,7 @@ PASS supportedConstraints["facingMode"] is true
 PASS supportedConstraints["frameRate"] is true
 PASS supportedConstraints["groupId"] is true
 PASS supportedConstraints["height"] is true
-PASS supportedConstraints["powerEfficientPixelFormat"] is true
+PASS supportedConstraints["powerEfficient"] is true
 PASS supportedConstraints["sampleRate"] is true
 PASS supportedConstraints["sampleSize"] is true
 PASS supportedConstraints["torch"] is true

--- a/LayoutTests/fast/mediastream/camera-powerEfficient-track.html
+++ b/LayoutTests/fast/mediastream/camera-powerEfficient-track.html
@@ -13,14 +13,14 @@ promise_test(async (test) => {
         video.srcObject.getVideoTracks()[0].stop();
     });
 
-    video.srcObject = await navigator.mediaDevices.getUserMedia({ video: { powerEfficientPixelFormat: false, facingMode: "environment" } });
+    video.srcObject = await navigator.mediaDevices.getUserMedia({ video: { powerEfficient: false, facingMode: "environment" } });
     const track = video.srcObject.getVideoTracks()[0];
 
     assert_equals(track.getSettings().width, 640);
     assert_equals(track.getSettings().height, 480);
 
-    assert_equals(undefined, track.getSettings().powerEfficientPixelFormat);
-    assert_equals(undefined, track.getCapabilities().powerEfficientPixelFormat);
+    assert_equals(undefined, track.getSettings().powerEfficient);
+    assert_equals(undefined, track.getCapabilities().powerEfficient);
 
     await video.play();
 
@@ -33,14 +33,14 @@ promise_test(async (test) => {
         video.srcObject.getVideoTracks()[0].stop();
     });
 
-    video.srcObject = await navigator.mediaDevices.getUserMedia({ video: { powerEfficientPixelFormat: true, facingMode: "environment" } });
+    video.srcObject = await navigator.mediaDevices.getUserMedia({ video: { powerEfficient: true, facingMode: "environment" } });
     const track = video.srcObject.getVideoTracks()[0];
 
     assert_equals(track.getSettings().width, 640);
     assert_equals(track.getSettings().height, 360);
 
-    assert_equals(undefined, track.getSettings().powerEfficientPixelFormat);
-    assert_equals(undefined, track.getCapabilities().powerEfficientPixelFormat);
+    assert_equals(undefined, track.getSettings().powerEfficient);
+    assert_equals(undefined, track.getCapabilities().powerEfficient);
 
     await video.play();
 
@@ -55,7 +55,7 @@ promise_test(async (test) => {
         stream2.getVideoTracks()[0].stop();
     });
 
-    const stream = await navigator.mediaDevices.getUserMedia({ video: { powerEfficientPixelFormat: true, facingMode: "environment" } });
+    const stream = await navigator.mediaDevices.getUserMedia({ video: { powerEfficient: true, facingMode: "environment" } });
 
     const stream2 = stream.clone();
     await stream2.getVideoTracks()[0].applyConstraints({ width: 1000 });

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -233,7 +233,7 @@ static bool hasInvalidGetDisplayMediaConstraint(const MediaConstraints& constrai
         case MediaConstraintType::Zoom:
         case MediaConstraintType::Torch:
         case MediaConstraintType::BackgroundBlur:
-        case MediaConstraintType::PowerEfficientPixelFormat:
+        case MediaConstraintType::PowerEfficient:
             // Ignored.
             break;
 

--- a/Source/WebCore/Modules/mediastream/MediaTrackConstraints.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaTrackConstraints.cpp
@@ -179,7 +179,7 @@ static MediaTrackConstraintSetMap convertToInternalForm(ConstraintSetType setTyp
     set(result, setType, MediaConstraintType::Torch, constraintSet.torch);
 
     set(result, setType, MediaConstraintType::BackgroundBlur, constraintSet.backgroundBlur);
-    set(result, setType, MediaConstraintType::PowerEfficientPixelFormat, constraintSet.powerEfficientPixelFormat);
+    set(result, setType, MediaConstraintType::PowerEfficient, constraintSet.powerEfficient);
     return result;
 }
 

--- a/Source/WebCore/Modules/mediastream/MediaTrackConstraints.h
+++ b/Source/WebCore/Modules/mediastream/MediaTrackConstraints.h
@@ -81,7 +81,7 @@ struct MediaTrackConstraintSet {
     std::optional<ConstrainBoolean> torch;
 
     std::optional<ConstrainBoolean> backgroundBlur;
-    std::optional<ConstrainBoolean> powerEfficientPixelFormat;
+    std::optional<ConstrainBoolean> powerEfficient;
 };
 
 struct MediaTrackConstraints : MediaTrackConstraintSet {

--- a/Source/WebCore/Modules/mediastream/MediaTrackConstraints.idl
+++ b/Source/WebCore/Modules/mediastream/MediaTrackConstraints.idl
@@ -73,7 +73,7 @@
     ConstrainBoolean torch;
 
     ConstrainBoolean backgroundBlur;
-    ConstrainBoolean powerEfficientPixelFormat;
+    ConstrainBoolean powerEfficient;
 };
 
 typedef (double or ConstrainDoubleRange) ConstrainDouble;

--- a/Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.h
+++ b/Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.h
@@ -51,7 +51,7 @@ struct MediaTrackSupportedConstraints {
     bool zoom { true };
     bool torch { true };
     bool backgroundBlur { true };
-    bool powerEfficientPixelFormat { true };
+    bool powerEfficient { true };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.idl
+++ b/Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.idl
@@ -66,5 +66,5 @@
     boolean torch = true;
 
     boolean backgroundBlur = true;
-    boolean powerEfficientPixelFormat = true;
+    boolean powerEfficient = true;
 };

--- a/Source/WebCore/platform/mediastream/MediaConstraintType.cpp
+++ b/Source/WebCore/platform/mediastream/MediaConstraintType.cpp
@@ -70,8 +70,8 @@ String convertToString(MediaConstraintType type)
         return "torch"_s;
     case MediaConstraintType::BackgroundBlur:
         return "backgroundBlur"_s;
-    case MediaConstraintType::PowerEfficientPixelFormat:
-        return "powerEfficientPixelFormat"_s;
+    case MediaConstraintType::PowerEfficient:
+        return "powerEfficient"_s;
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/mediastream/MediaConstraintType.h
+++ b/Source/WebCore/platform/mediastream/MediaConstraintType.h
@@ -48,7 +48,7 @@ enum class MediaConstraintType : uint8_t {
     Zoom,
     Torch,
     BackgroundBlur,
-    PowerEfficientPixelFormat
+    PowerEfficient
 };
 
 #if ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/mediastream/MediaConstraints.cpp
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.cpp
@@ -163,7 +163,7 @@ void MediaTrackConstraintSetMap::filter(const Function<bool(MediaConstraintType,
         return;
     if (m_backgroundBlur && !m_backgroundBlur->isEmpty() && callback(MediaConstraintType::BackgroundBlur, *m_backgroundBlur))
         return;
-    if (m_powerEfficientPixelFormat && !m_powerEfficientPixelFormat->isEmpty() && callback(MediaConstraintType::PowerEfficientPixelFormat, *m_powerEfficientPixelFormat))
+    if (m_powerEfficient && !m_powerEfficient->isEmpty() && callback(MediaConstraintType::PowerEfficient, *m_powerEfficient))
         return;
 }
 
@@ -197,7 +197,7 @@ void MediaTrackConstraintSetMap::set(MediaConstraintType constraintType, std::op
     case MediaConstraintType::Zoom:
     case MediaConstraintType::Torch:
     case MediaConstraintType::BackgroundBlur:
-    case MediaConstraintType::PowerEfficientPixelFormat:
+    case MediaConstraintType::PowerEfficient:
     case MediaConstraintType::Unknown:
         ASSERT_NOT_REACHED();
         break;
@@ -234,7 +234,7 @@ void MediaTrackConstraintSetMap::set(MediaConstraintType constraintType, std::op
     case MediaConstraintType::WhiteBalanceMode:
     case MediaConstraintType::Torch:
     case MediaConstraintType::BackgroundBlur:
-    case MediaConstraintType::PowerEfficientPixelFormat:
+    case MediaConstraintType::PowerEfficient:
     case MediaConstraintType::Unknown:
         ASSERT_NOT_REACHED();
         break;
@@ -260,8 +260,8 @@ void MediaTrackConstraintSetMap::set(MediaConstraintType constraintType, std::op
     case MediaConstraintType::BackgroundBlur:
         m_backgroundBlur = WTFMove(constraint);
         break;
-    case MediaConstraintType::PowerEfficientPixelFormat:
-        m_powerEfficientPixelFormat = WTFMove(constraint);
+    case MediaConstraintType::PowerEfficient:
+        m_powerEfficient = WTFMove(constraint);
         break;
     case MediaConstraintType::Width:
     case MediaConstraintType::Height:
@@ -314,7 +314,7 @@ void MediaTrackConstraintSetMap::set(MediaConstraintType constraintType, std::op
     case MediaConstraintType::Zoom:
     case MediaConstraintType::Torch:
     case MediaConstraintType::BackgroundBlur:
-    case MediaConstraintType::PowerEfficientPixelFormat:
+    case MediaConstraintType::PowerEfficient:
     case MediaConstraintType::Unknown:
         ASSERT_NOT_REACHED();
         break;
@@ -380,7 +380,7 @@ void MediaTrackConstraintSetMap::merge(MediaConstraintType constraintType, const
     case MediaConstraintType::Torch:
     case MediaConstraintType::FocusDistance:
     case MediaConstraintType::BackgroundBlur:
-    case MediaConstraintType::PowerEfficientPixelFormat:
+    case MediaConstraintType::PowerEfficient:
     case MediaConstraintType::Unknown:
         ASSERT_NOT_REACHED();
         break;
@@ -428,7 +428,7 @@ void MediaTrackConstraintSetMap::merge(MediaConstraintType constraintType, const
     case MediaConstraintType::Torch:
     case MediaConstraintType::FocusDistance:
     case MediaConstraintType::BackgroundBlur:
-    case MediaConstraintType::PowerEfficientPixelFormat:
+    case MediaConstraintType::PowerEfficient:
     case MediaConstraintType::Unknown:
         ASSERT_NOT_REACHED();
         break;
@@ -476,7 +476,7 @@ void MediaTrackConstraintSetMap::merge(MediaConstraintType constraintType, const
     case MediaConstraintType::Torch:
     case MediaConstraintType::FocusDistance:
     case MediaConstraintType::BackgroundBlur:
-    case MediaConstraintType::PowerEfficientPixelFormat:
+    case MediaConstraintType::PowerEfficient:
     case MediaConstraintType::Unknown:
         ASSERT_NOT_REACHED();
         break;
@@ -516,11 +516,11 @@ void MediaTrackConstraintSetMap::merge(MediaConstraintType constraintType, const
         else
             m_backgroundBlur->merge(constraint);
         break;
-    case MediaConstraintType::PowerEfficientPixelFormat:
-        if (!m_powerEfficientPixelFormat)
-            m_powerEfficientPixelFormat = constraint;
+    case MediaConstraintType::PowerEfficient:
+        if (!m_powerEfficient)
+            m_powerEfficient = constraint;
         else
-            m_powerEfficientPixelFormat->merge(constraint);
+            m_powerEfficient->merge(constraint);
         break;
 
     case MediaConstraintType::FacingMode:
@@ -608,7 +608,7 @@ bool MediaTrackConstraintSetMap::isValid() const
         case MediaConstraintType::BackgroundBlur:
             isValid &= (constraint.dataType() == MediaConstraint::DataType::Boolean);
             break;
-        case MediaConstraintType::PowerEfficientPixelFormat:
+        case MediaConstraintType::PowerEfficient:
             isValid &= (constraint.dataType() == MediaConstraint::DataType::Boolean);
             break;
         case MediaConstraintType::Unknown:
@@ -675,7 +675,7 @@ void MediaConstraints::setDefaultVideoConstraints()
     });
     
     bool needsHeightConstraint = !isConstraintSet([](const MediaTrackConstraintSetMap& constraint) {
-        return !!constraint.width() || !!constraint.height() || !!constraint.aspectRatio() || !!constraint.powerEfficientPixelFormat();
+        return !!constraint.width() || !!constraint.height() || !!constraint.aspectRatio() || !!constraint.powerEfficient();
     });
 
     addDefaultVideoConstraints(mandatoryConstraints, needsFrameRateConstraint, needsWidthConstraint, needsHeightConstraint);
@@ -720,7 +720,7 @@ StringConstraint StringConstraint::isolatedCopy() const
 
 MediaTrackConstraintSetMap MediaTrackConstraintSetMap::isolatedCopy() const
 {
-    return { m_width, m_height, m_sampleRate, m_sampleSize, m_aspectRatio, m_frameRate, m_volume, m_echoCancellation, m_displaySurface, m_logicalSurface, crossThreadCopy(m_facingMode), crossThreadCopy(m_deviceId), crossThreadCopy(m_groupId), crossThreadCopy(m_whiteBalanceMode), m_zoom, m_torch, m_backgroundBlur, m_powerEfficientPixelFormat };
+    return { m_width, m_height, m_sampleRate, m_sampleSize, m_aspectRatio, m_frameRate, m_volume, m_echoCancellation, m_displaySurface, m_logicalSurface, crossThreadCopy(m_facingMode), crossThreadCopy(m_deviceId), crossThreadCopy(m_groupId), crossThreadCopy(m_whiteBalanceMode), m_zoom, m_torch, m_backgroundBlur, m_powerEfficient };
 }
 
 MediaConstraints MediaConstraints::isolatedCopy() const

--- a/Source/WebCore/platform/mediastream/MediaConstraints.h
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.h
@@ -582,7 +582,7 @@ private:
 class MediaTrackConstraintSetMap {
 public:
     MediaTrackConstraintSetMap() = default;
-    MediaTrackConstraintSetMap(std::optional<IntConstraint> width, std::optional<IntConstraint> height, std::optional<IntConstraint> sampleRate, std::optional<IntConstraint> sampleSize, std::optional<DoubleConstraint> aspectRatio, std::optional<DoubleConstraint> frameRate, std::optional<DoubleConstraint> volume, std::optional<BooleanConstraint> echoCancellation, std::optional<BooleanConstraint> displaySurface, std::optional<BooleanConstraint> logicalSurface, std::optional<StringConstraint>&& facingMode, std::optional<StringConstraint>&& deviceId, std::optional<StringConstraint>&& groupId, std::optional<StringConstraint>&& whiteBalanceMode, std::optional<DoubleConstraint> zoom, std::optional<BooleanConstraint> torch, std::optional<BooleanConstraint> backgroundBlur, std::optional<BooleanConstraint> powerEfficientPixelFormat)
+    MediaTrackConstraintSetMap(std::optional<IntConstraint> width, std::optional<IntConstraint> height, std::optional<IntConstraint> sampleRate, std::optional<IntConstraint> sampleSize, std::optional<DoubleConstraint> aspectRatio, std::optional<DoubleConstraint> frameRate, std::optional<DoubleConstraint> volume, std::optional<BooleanConstraint> echoCancellation, std::optional<BooleanConstraint> displaySurface, std::optional<BooleanConstraint> logicalSurface, std::optional<StringConstraint>&& facingMode, std::optional<StringConstraint>&& deviceId, std::optional<StringConstraint>&& groupId, std::optional<StringConstraint>&& whiteBalanceMode, std::optional<DoubleConstraint> zoom, std::optional<BooleanConstraint> torch, std::optional<BooleanConstraint> backgroundBlur, std::optional<BooleanConstraint> powerEfficient)
         : m_width(width)
         , m_height(height)
         , m_sampleRate(sampleRate)
@@ -600,7 +600,7 @@ public:
         , m_zoom(zoom)
         , m_torch(torch)
         , m_backgroundBlur(backgroundBlur)
-        , m_powerEfficientPixelFormat(powerEfficientPixelFormat)
+        , m_powerEfficient(powerEfficient)
     {
     }
 
@@ -643,7 +643,7 @@ public:
     const std::optional<DoubleConstraint>& zoom() const { return m_zoom; }
     const std::optional<BooleanConstraint>& torch() const { return m_torch; }
     const std::optional<BooleanConstraint>& backgroundBlur() const { return m_backgroundBlur; }
-    const std::optional<BooleanConstraint>& powerEfficientPixelFormat() const { return m_powerEfficientPixelFormat; }
+    const std::optional<BooleanConstraint>& powerEfficient() const { return m_powerEfficient; }
 
     MediaTrackConstraintSetMap isolatedCopy() const;
 
@@ -671,7 +671,7 @@ private:
     std::optional<BooleanConstraint> m_torch;
 
     std::optional<BooleanConstraint> m_backgroundBlur;
-    std::optional<BooleanConstraint> m_powerEfficientPixelFormat;
+    std::optional<BooleanConstraint> m_powerEfficient;
 };
 
 struct MediaConstraints {

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -606,7 +606,7 @@ double RealtimeMediaSource::fitnessDistance(MediaConstraintType constraintType, 
     case MediaConstraintType::LogicalSurface:
     case MediaConstraintType::FocusDistance:
     case MediaConstraintType::BackgroundBlur:
-    case MediaConstraintType::PowerEfficientPixelFormat:
+    case MediaConstraintType::PowerEfficient:
     case MediaConstraintType::Unknown:
         break;
     }
@@ -653,7 +653,7 @@ double RealtimeMediaSource::fitnessDistance(MediaConstraintType constraintType, 
     case MediaConstraintType::LogicalSurface:
     case MediaConstraintType::FocusDistance:
     case MediaConstraintType::BackgroundBlur:
-    case MediaConstraintType::PowerEfficientPixelFormat:
+    case MediaConstraintType::PowerEfficient:
     case MediaConstraintType::Unknown:
         break;
     }
@@ -703,7 +703,7 @@ double RealtimeMediaSource::fitnessDistance(MediaConstraintType constraintType, 
     case MediaConstraintType::LogicalSurface:
     case MediaConstraintType::FocusDistance:
     case MediaConstraintType::BackgroundBlur:
-    case MediaConstraintType::PowerEfficientPixelFormat:
+    case MediaConstraintType::PowerEfficient:
     case MediaConstraintType::Unknown:
         break;
     }
@@ -730,7 +730,7 @@ double RealtimeMediaSource::fitnessDistance(MediaConstraintType constraintType, 
 
         return constraint.fitnessDistance(capabilities.torch());
     case MediaConstraintType::BackgroundBlur:
-    case MediaConstraintType::PowerEfficientPixelFormat:
+    case MediaConstraintType::PowerEfficient:
         return 0;
     case MediaConstraintType::Width:
     case MediaConstraintType::Height:
@@ -938,7 +938,7 @@ void RealtimeMediaSource::applyConstraint(MediaConstraintType constraintType, co
         // FIXME: Implement support, https://bugs.webkit.org/show_bug.cgi?id=275491
         break;
     }
-    case MediaConstraintType::PowerEfficientPixelFormat: {
+    case MediaConstraintType::PowerEfficient: {
         ASSERT(constraint.isBoolean());
         // FIXME: Implement support, https://bugs.webkit.org/show_bug.cgi?id=275491
         break;
@@ -994,7 +994,7 @@ std::optional<MediaConstraintType> RealtimeMediaSource::selectSettings(const Med
         if (!supportsConstraint(constraintType))
             return false;
 
-        if (constraintType == MediaConstraintType::Width || constraintType == MediaConstraintType::Height || constraintType == MediaConstraintType::FrameRate || constraintType == MediaConstraintType::Zoom || constraintType == MediaConstraintType::PowerEfficientPixelFormat) {
+        if (constraintType == MediaConstraintType::Width || constraintType == MediaConstraintType::Height || constraintType == MediaConstraintType::FrameRate || constraintType == MediaConstraintType::Zoom || constraintType == MediaConstraintType::PowerEfficient) {
             candidates.set(constraintType, constraint);
             return false;
         }
@@ -1039,7 +1039,7 @@ std::optional<MediaConstraintType> RealtimeMediaSource::selectSettings(const Med
 
         advancedConstraint.forEach([&](auto constraintType, const MediaConstraint& constraint) {
 
-            if (constraintType == MediaConstraintType::Width || constraintType == MediaConstraintType::Height || constraintType == MediaConstraintType::FrameRate || constraintType == MediaConstraintType::Zoom || constraintType == MediaConstraintType::PowerEfficientPixelFormat)
+            if (constraintType == MediaConstraintType::Width || constraintType == MediaConstraintType::Height || constraintType == MediaConstraintType::FrameRate || constraintType == MediaConstraintType::Zoom || constraintType == MediaConstraintType::PowerEfficient)
                 return;
 
             distance = fitnessDistance(constraintType, constraint);
@@ -1112,7 +1112,7 @@ bool RealtimeMediaSource::supportsConstraint(MediaConstraintType constraintType)
         return capabilities.supportsTorch();
     case MediaConstraintType::BackgroundBlur:
         return capabilities.supportsBackgroundBlur();
-    case MediaConstraintType::PowerEfficientPixelFormat:
+    case MediaConstraintType::PowerEfficient:
         return deviceType() == CaptureDevice::DeviceType::Camera;
     case MediaConstraintType::DisplaySurface:
     case MediaConstraintType::LogicalSurface:
@@ -1166,7 +1166,7 @@ std::optional<MediaConstraintType> RealtimeMediaSource::hasAnyInvalidConstraint(
         case MediaConstraintType::Zoom:
         case MediaConstraintType::Torch:
         case MediaConstraintType::BackgroundBlur:
-        case MediaConstraintType::PowerEfficientPixelFormat:
+        case MediaConstraintType::PowerEfficient:
         case MediaConstraintType::Unknown:
             m_fitnessScore += distance ? 1 : 2;
             break;
@@ -1229,7 +1229,7 @@ RealtimeMediaSource::VideoPresetConstraints RealtimeMediaSource::extractVideoPre
         }
     }
 
-    if (auto contraint = constraints.powerEfficientPixelFormat())
+    if (auto contraint = constraints.powerEfficient())
         contraint->getExact(result.shouldPreferPowerEfficiency) || contraint->getIdeal(result.shouldPreferPowerEfficiency);
 
     return result;

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.cpp
@@ -71,7 +71,7 @@ bool RealtimeMediaSourceSupportedConstraints::supportsConstraint(MediaConstraint
         return supportsTorch();
     case MediaConstraintType::BackgroundBlur:
         return supportsBackgroundBlur();
-    case MediaConstraintType::PowerEfficientPixelFormat:
+    case MediaConstraintType::PowerEfficient:
         return false;
     }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2293,7 +2293,7 @@ struct WebCore::MediaStreamRequest {
     std::optional<WebCore::DoubleConstraint> m_zoom;
     std::optional<WebCore::BooleanConstraint> m_torch;
     std::optional<WebCore::BooleanConstraint> m_backgroundBlur;
-    std::optional<WebCore::BooleanConstraint> m_powerEfficientPixelFormat;
+    std::optional<WebCore::BooleanConstraint> m_powerEfficient;
 }
 #endif
 


### PR DESCRIPTION
#### 2c5594788b6c784f3512556b7e2328bd727a6e5d
<pre>
Rename MediaStreamTrack powerEfficientPixelFormat constraint to powerEfficient
<a href="https://bugs.webkit.org/show_bug.cgi?id=275729">https://bugs.webkit.org/show_bug.cgi?id=275729</a>
<a href="https://rdar.apple.com/problem/130265584">rdar://problem/130265584</a>

Reviewed by Eric Carlson.

As per WebRTC WG discussion, the standard is moving to powerEfficient instead of powerEfficientPixelFormat.
Renaming accordingly.

* LayoutTests/fast/mediastream/camera-powerEfficient-track.html:
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::hasInvalidGetDisplayMediaConstraint):
* Source/WebCore/Modules/mediastream/MediaTrackConstraints.cpp:
(WebCore::convertToInternalForm):
* Source/WebCore/Modules/mediastream/MediaTrackConstraints.h:
* Source/WebCore/Modules/mediastream/MediaTrackConstraints.idl:
* Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.h:
* Source/WebCore/Modules/mediastream/MediaTrackSupportedConstraints.idl:
* Source/WebCore/platform/mediastream/MediaConstraintType.cpp:
(WebCore::convertToString):
* Source/WebCore/platform/mediastream/MediaConstraintType.h:
* Source/WebCore/platform/mediastream/MediaConstraints.cpp:
(WebCore::MediaTrackConstraintSetMap::filter const):
(WebCore::MediaTrackConstraintSetMap::set):
(WebCore::MediaTrackConstraintSetMap::merge):
(WebCore::MediaTrackConstraintSetMap::isValid const):
(WebCore::MediaConstraints::setDefaultVideoConstraints):
(WebCore::MediaTrackConstraintSetMap::isolatedCopy const):
* Source/WebCore/platform/mediastream/MediaConstraints.h:
(WebCore::MediaTrackConstraintSetMap::MediaTrackConstraintSetMap):
(WebCore::MediaTrackConstraintSetMap::powerEfficient const):
(WebCore::MediaTrackConstraintSetMap::powerEfficientPixelFormat const): Deleted.
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::fitnessDistance):
(WebCore::RealtimeMediaSource::applyConstraint):
(WebCore::RealtimeMediaSource::selectSettings):
(WebCore::RealtimeMediaSource::supportsConstraint):
(WebCore::RealtimeMediaSource::hasAnyInvalidConstraint):
(WebCore::RealtimeMediaSource::extractVideoPresetConstraints):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.cpp:
(WebCore::RealtimeMediaSourceSupportedConstraints::supportsConstraint const):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/280289@main">https://commits.webkit.org/280289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a225b9736e4c2aecb04972214af1b8ca6d62a155

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56180 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59786 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6616 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58306 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43128 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6810 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/45403 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4592 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58209 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33395 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48462 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26354 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30175 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5792 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5620 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52169 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6064 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61469 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/88 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6190 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52738 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/88 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48529 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/52551 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12448 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/77 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31333 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32419 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33502 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32166 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->