### PR TITLE
[GStreamer][WebRTC] Caps from SDP and RealtimeOutgoingAudioSourceGStreamer aren't aligned

### DIFF
--- a/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-answer-expected.txt
+++ b/LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-answer-expected.txt
@@ -51,7 +51,7 @@ a=extmap:1 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extension
 a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id
 a=extmap:4 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
-a=extmap:5 urn:ietf:params:rtp-hdrext:ssrc-audio-level
+a=extmap:5 urn:ietf:params:rtp-hdrext:ssrc-audio-level vad=on
 a=fmtp:96 minptime=10;useinbandfec=1
 a=recvonly
 a=fingerprint:sha-256 {fingerprint:OK}

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
@@ -288,6 +288,8 @@ WARN_UNUSED_RETURN GRefPtr<GstCaps> capsFromRtpCapabilities(RefPtr<UniqueSSRCGen
 GstWebRTCRTPTransceiverDirection getDirectionFromSDPMedia(const GstSDPMedia*);
 WARN_UNUSED_RETURN GRefPtr<GstCaps> capsFromSDPMedia(const GstSDPMedia*);
 
+void setSsrcAudioLevelVadOn(GstStructure*);
+
 inline gboolean mapRtpBuffer(GstBuffer* buffer, GstRTPBuffer* rtpBuffer, GstMapFlags flags)
 {
     *rtpBuffer = GST_RTP_BUFFER_INIT;

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp
@@ -145,38 +145,7 @@ bool RealtimeOutgoingAudioSourceGStreamer::setPayloadType(const GRefPtr<GstCaps>
 
     // When not present in caps, the vad support of the ssrc-audio-level extension should be
     // enabled. In order to prevent caps negotiation issues with downstream, explicitely set it.
-    unsigned totalFields = gst_structure_n_fields(structure.get());
-    for (unsigned i = 0; i < totalFields; i++) {
-        String fieldName = WTF::span(gst_structure_nth_field_name(structure.get(), i));
-        if (!fieldName.startsWith("extmap-"_s))
-            continue;
-
-        const auto value = gst_structure_get_value(structure.get(), fieldName.ascii().data());
-        if (!G_VALUE_HOLDS_STRING(value))
-            continue;
-
-        const char* uri = g_value_get_string(value);
-        if (!g_str_equal(uri, GST_RTP_HDREXT_BASE "ssrc-audio-level"))
-            continue;
-
-        GValue arrayValue G_VALUE_INIT;
-        gst_value_array_init(&arrayValue, 3);
-
-        GValue stringValue G_VALUE_INIT;
-        g_value_init(&stringValue, G_TYPE_STRING);
-
-        g_value_set_static_string(&stringValue, "");
-        gst_value_array_append_value(&arrayValue, &stringValue);
-
-        g_value_set_string(&stringValue, uri);
-        gst_value_array_append_value(&arrayValue, &stringValue);
-
-        g_value_set_static_string(&stringValue, "vad=on");
-        gst_value_array_append_and_take_value(&arrayValue, &stringValue);
-
-        gst_structure_remove_field(structure.get(), fieldName.ascii().data());
-        gst_structure_take_value(structure.get(), fieldName.ascii().data(), &arrayValue);
-    }
+    setSsrcAudioLevelVadOn(structure.get());
 
     gst_caps_append_structure(rtpCaps.get(), structure.release());
 


### PR DESCRIPTION
#### 3f3c280f8192b7585a204bbcb7f2db49deace035
<pre>
[GStreamer][WebRTC] Caps from SDP and RealtimeOutgoingAudioSourceGStreamer aren&apos;t aligned
<a href="https://bugs.webkit.org/show_bug.cgi?id=275740">https://bugs.webkit.org/show_bug.cgi?id=275740</a>

Reviewed by Philippe Normand.

Align codec-preferences of webrtcbin&apos;s transceivers with caps from
RealtimeOutgoingAudioSourceGStreamer by setting vad=on in the
ssrc-audio-level extension.

* LayoutTests/platform/glib/fast/mediastream/RTCPeerConnection-inspect-answer-expected.txt:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::capsFromSDPMedia):
(WebCore::setSsrcAudioLevelVadOn):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h:
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingAudioSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingAudioSourceGStreamer::setPayloadType):

Canonical link: <a href="https://commits.webkit.org/280273@main">https://commits.webkit.org/280273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d5d7a84114eb005a582fbb9a5d3b515a7a35d44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56149 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59755 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6585 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58275 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45298 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4565 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33363 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48432 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26331 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30144 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5763 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5589 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6034 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61438 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/57 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6160 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52686 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/57 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48500 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52413 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12441 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/52 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31302 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32388 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33471 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32135 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->