### PR TITLE
REGRESSION (278902@main): [ iOS ] editing/selection/ios/selection-handles-in-iframe.html and fast/images/text-recognition/iOS.. are timing out

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7248,10 +7248,6 @@ webkit.org/b/274340 fast/events/ios/key-command-transpose.html [ Pass Timeout ]
 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-navigations-in-multiple-windows.html [ Failure ]
 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-location-replace-cross-origin.html [ Failure ]
 
-# webkit.org/b/274488 REGRESSION (278902@main): [ iOS ] editing/selection/ios/selection-handles-in-iframe.html and fast/images/text-recognition/iOS.. are timing out 
-editing/selection/ios/selection-handles-in-iframe.html [ Timeout ]
-fast/images/text-recognition/ios/select-word-in-image-overlay-inside-link.html [ Timeout ]
-
 webkit.org/b/271916 media/track/track-in-band-layout.html [ Failure ]
 
 webkit.org/b/274766 [ Debug ] http/wpt/webauthn/public-key-credential-get-success-u2f.https.html [ Failure ]

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3091,6 +3091,8 @@ void WebPageProxy::clearEditorStateAfterPageTransition(EditorStateIdentifier ide
 
     internals().editorState = { };
     internals().editorState.identifier = identifier;
+    internals().editorState.postLayoutData = EditorState::PostLayoutData { };
+    internals().editorState.visualData = EditorState::VisualData { };
 
     protectedPageClient()->didClearEditorStateAfterPageTransition();
 }

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -1741,6 +1741,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     [self _updateTapHighlight];
 
+    if (_page->editorState().selectionIsNone && _lastSelectionDrawingInfo.type == WebKit::WKSelectionDrawingInfo::SelectionType::None)
+        return;
+
     _selectionNeedsUpdate = YES;
     [self _updateChangedSelection:YES];
 }


### PR DESCRIPTION
#### 7df081b547fdc5591f155d7e0f476c26e3330032
<pre>
REGRESSION (278902@main): [ iOS ] editing/selection/ios/selection-handles-in-iframe.html and fast/images/text-recognition/iOS.. are timing out
<a href="https://bugs.webkit.org/show_bug.cgi?id=274488">https://bugs.webkit.org/show_bug.cgi?id=274488</a>
<a href="https://rdar.apple.com/128497371">rdar://128497371</a>

Reviewed by NOBODY (OOPS!).

These layout tests began to flake after the changes in 278902@main. This seems to be because the
process of clearing out `_lastSelectionDrawingInfo` while leaving the cached editor state without
post-layout and visual data, which causes us to return early in some selection-related codepaths
without allowing selection to begin.

Instead, we revisit an older version of the fix, <a href="https://github.com/WebKit/WebKit/commit/d8c1e8702">https://github.com/WebKit/WebKit/commit/d8c1e8702</a>,
which works by ensuring that the `EditorState` is left in a consistent state (with post-layout data
and visual data) after calling `clearEditorStateAfterPageTransition()`:

```
diff --git a/Source/WebKit/UIProcess/WebPageProxy.cpp b/Source/WebKit/UIProcess/WebPageProxy.cpp
index 3572b7564cd1..a5ca4620d580 100644
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3053,6 +3053,8 @@ void WebPageProxy::clearEditorStateAfterPageTransition(EditorStateIdentifier ide

     internals().editorState = { };
     internals().editorState.identifier = identifier;
+    internals().editorState.visualData = EditorState::VisualData { };
+    internals().editorState.postLayoutData = EditorState::PostLayoutData { };
```

I previously abandoned this approach because it breaks an existing API test on iOS:
`ScrollViewScrollabilityTests.ScrollableWithOverflowHiddenWhenZoomed`. However, after investigating
it further, I discovered that this happens because leaving `EditorState` with post-layout data means
that logic in `-[WKContentView observeValueForKeyPath:ofObject:change:context:]`, which attempts to
adjust platform selection views to accomodate new transforms on the content view, will now call into
`-_updateChangedSelection:` without returning immediately in that method. As a consequence, we end
up calling into UIKit code under `-selectionChanged`, which (internally) instantiates the shared
`UIKeyboardImpl` instance in order to post a `UITextInputResponderCapabilitiesChangedNotification`.

Instantiating a `UIKeyboardImpl` in the middle of a call to `-[WKScrollView setZoomScale:animated:]`
subsequently causes UIKit to install some native views under the scroll view, which (for reasons
that are still unclear) causes the scroll view to revert to a zoom scale of 1.

To keep this test passing after setting `visualData` and `postLayoutData` above, we add a slight
optimization to `-[WKContentView observeValueForKeyPath:ofObject:change:context:]`, such that we
avoid trying to update UIKit&apos;s selection views (and therefore cause `UIKeyboardImpl` to be
instantiated) in the case where the following conditions are both true:

1. There is no selection (i.e. the current `EditorState` has a selection type that is `None`).
2. No selection was previously shown (i.e. `_lastSelectionDrawingInfo`&apos;s type is also `None`).

There should be need to update platform selection state in this case, since nothing is visually
changing.

* LayoutTests/platform/ios/TestExpectations:

Remove the failing test expectations.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::clearEditorStateAfterPageTransition):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView observeValueForKeyPath:ofObject:change:context:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7df081b547fdc5591f155d7e0f476c26e3330032

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59709 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6539 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43051 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6733 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45246 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4526 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58132 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33320 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48386 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26295 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30101 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5716 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5543 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52072 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61391 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/11 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6116 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52646 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/11 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48453 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52349 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/7 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31256 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32342 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33425 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32089 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->