### PR TITLE
Make WebBackForwardCache's m_itemsWithCachedPage more robust

### DIFF
--- a/Source/WebKit/UIProcess/WebBackForwardCache.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.cpp
@@ -50,8 +50,9 @@ WebBackForwardCache::~WebBackForwardCache()
 
 inline void WebBackForwardCache::removeOldestEntry()
 {
-    ASSERT(!m_itemsWithCachedPage.isEmpty());
-    removeEntry(*m_itemsWithCachedPage.first());
+    ASSERT(!m_itemsWithCachedPage.isEmptyIgnoringNullReferences());
+    if (RefPtr item = m_itemsWithCachedPage.tryTakeFirst())
+        item->setBackForwardCacheEntry(nullptr);
 }
 
 void WebBackForwardCache::setCapacity(unsigned capacity)
@@ -72,12 +73,12 @@ void WebBackForwardCache::addEntry(WebBackForwardListItem& item, std::unique_ptr
     ASSERT(backForwardCacheEntry);
 
     if (item.backForwardCacheEntry()) {
-        ASSERT(m_itemsWithCachedPage.contains(&item));
-        m_itemsWithCachedPage.removeFirst(&item);
+        ASSERT(m_itemsWithCachedPage.contains(item));
+        m_itemsWithCachedPage.remove(item);
     }
 
     item.setBackForwardCacheEntry(WTFMove(backForwardCacheEntry));
-    m_itemsWithCachedPage.append(&item);
+    m_itemsWithCachedPage.add(item);
 
     if (size() > capacity())
         removeOldestEntry();
@@ -98,8 +99,8 @@ void WebBackForwardCache::addEntry(WebBackForwardListItem& item, WebCore::Proces
 
 void WebBackForwardCache::removeEntry(WebBackForwardListItem& item)
 {
-    ASSERT(m_itemsWithCachedPage.contains(&item));
-    m_itemsWithCachedPage.removeFirst(&item);
+    ASSERT(m_itemsWithCachedPage.contains(item));
+    m_itemsWithCachedPage.remove(item);
     RELEASE_LOG(BackForwardCache, "WebBackForwardCache::removeEntry: item=%s, size=%u/%u", item.itemID().toString().utf8().data(), size(), capacity());
     item.setBackForwardCacheEntry(nullptr); // item may be dead after this call.
 }
@@ -115,7 +116,7 @@ std::unique_ptr<SuspendedPageProxy> WebBackForwardCache::takeSuspendedPage(WebBa
 {
     RELEASE_LOG(BackForwardCache, "WebBackForwardCache::takeSuspendedPage: item=%s", item.itemID().toString().utf8().data());
 
-    ASSERT(m_itemsWithCachedPage.contains(&item));
+    ASSERT(m_itemsWithCachedPage.contains(item));
     ASSERT(item.backForwardCacheEntry());
     auto suspendedPage = item.backForwardCacheEntry()->takeSuspendedPage();
     ASSERT(suspendedPage);
@@ -157,16 +158,14 @@ void WebBackForwardCache::removeEntriesForPageAndProcess(WebPageProxy& page, Web
 void WebBackForwardCache::removeEntriesMatching(const Function<bool(WebBackForwardListItem&)>& matches)
 {
     Vector<Ref<WebBackForwardListItem>> itemsWithEntriesToClear;
-    m_itemsWithCachedPage.removeAllMatching([&](auto& item) {
-        if (matches(*item)) {
-            itemsWithEntriesToClear.append(*item);
-            return true;
-        }
-        return false;
-    });
-
-    for (auto& item : itemsWithEntriesToClear)
+    for (auto& item : m_itemsWithCachedPage) {
+        if (matches(item))
+            itemsWithEntriesToClear.append(item);
+    }
+    for (auto& item : itemsWithEntriesToClear) {
+        m_itemsWithCachedPage.remove(item.get());
         item->setBackForwardCacheEntry(nullptr);
+    }
 }
 
 void WebBackForwardCache::clear()
@@ -174,7 +173,7 @@ void WebBackForwardCache::clear()
     RELEASE_LOG(BackForwardCache, "WebBackForwardCache::clear");
     auto itemsWithCachedPage = WTFMove(m_itemsWithCachedPage);
     for (auto& item : itemsWithCachedPage)
-        item->setBackForwardCacheEntry(nullptr);
+        item.setBackForwardCacheEntry(nullptr);
 }
 
 void WebBackForwardCache::pruneToSize(unsigned newSize)

--- a/Source/WebKit/UIProcess/WebBackForwardCache.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.h
@@ -29,7 +29,7 @@
 #include <pal/SessionID.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/Forward.h>
-#include <wtf/Vector.h>
+#include <wtf/WeakListHashSet.h>
 
 namespace WebKit {
 
@@ -49,7 +49,7 @@ public:
 
     void setCapacity(unsigned);
     unsigned capacity() const { return m_capacity; }
-    unsigned size() const { return m_itemsWithCachedPage.size(); }
+    unsigned size() const { return m_itemsWithCachedPage.computeSize(); }
 
     void clear();
     void pruneToSize(unsigned);
@@ -71,8 +71,7 @@ private:
 
     WebProcessPool& m_processPool;
     unsigned m_capacity { 0 };
-    // Items cannot be null, we're using WeakPtr for hardening.
-    Vector<WeakPtr<WebBackForwardListItem>, 2> m_itemsWithCachedPage;
+    WeakListHashSet<WebBackForwardListItem> m_itemsWithCachedPage;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### e127c6bb3b51fa1c5b2448c44f64d512f3aa7cd0
<pre>
Make WebBackForwardCache&apos;s m_itemsWithCachedPage more robust
<a href="https://bugs.webkit.org/show_bug.cgi?id=275744">https://bugs.webkit.org/show_bug.cgi?id=275744</a>
<a href="https://rdar.apple.com/129706255">rdar://129706255</a>

Reviewed by Alex Christensen.

Use a WeakListHashSet instead of a Vector&lt;WeakPtr&lt;&gt;&gt; for m_itemsWithCachedPage.
This is less error-prone as it will avoid crashes if a WebBackForwardList item
gets destroyed without unregistering itself from the WebBackForwardListCache
first.

This should avoid crashes such as in <a href="https://rdar.apple.com/129706255">rdar://129706255</a>.

* Source/WebKit/UIProcess/WebBackForwardCache.cpp:
(WebKit::WebBackForwardCache::addEntry):
(WebKit::WebBackForwardCache::removeEntry):
(WebKit::WebBackForwardCache::takeSuspendedPage):
(WebKit::WebBackForwardCache::removeEntriesMatching):
(WebKit::WebBackForwardCache::clear):
* Source/WebKit/UIProcess/WebBackForwardCache.h:

Canonical link: <a href="https://commits.webkit.org/280264@main">https://commits.webkit.org/280264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67a4084447475a5684e3f3b726c9ca6e8a27e387

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56108 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35434 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59714 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6544 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43056 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6738 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/45249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4531 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58137 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48391 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26299 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30105 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5548 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52076 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5992 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61396 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/16 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6120 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52648 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/16 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48458 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/52353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/14 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8324 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31261 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32347 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33430 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32094 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->