### PR TITLE
REGRESSION (279702@main): [ iOS ] fast/shadow-dom/touch-event-ios.html is constantly crashing.

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
@@ -41,6 +41,16 @@ TEST(WTF_Vector, Basic)
 {
     Vector<int> intVector;
     EXPECT_TRUE(intVector.isEmpty());
+    EXPECT_EQ(nullptr, intVector.data());
+    EXPECT_EQ(0U, intVector.size());
+    EXPECT_EQ(0U, intVector.capacity());
+}
+
+TEST(WTF_Vector, ZeroSize)
+{
+    Vector<int> intVector(0);
+    EXPECT_TRUE(intVector.isEmpty());
+    EXPECT_EQ(nullptr, intVector.data());
     EXPECT_EQ(0U, intVector.size());
     EXPECT_EQ(0U, intVector.capacity());
 }

--- a/Tools/WebKitTestRunner/ios/HIDEventGenerator.mm
+++ b/Tools/WebKitTestRunner/ios/HIDEventGenerator.mm
@@ -616,7 +616,7 @@ static InterpolationType interpolationFromString(NSString *string)
     for (NSUInteger index = 0; index < touchCount; ++index)
         locations[index] = location;
     
-    [self touchDownAtPoints:&locations[0] touchCount:touchCount];
+    [self touchDownAtPoints:locations.data() touchCount:touchCount];
 }
 
 - (void)touchDown:(CGPoint)location
@@ -652,7 +652,7 @@ static InterpolationType interpolationFromString(NSString *string)
     for (NSUInteger index = 0; index < touchCount; ++index)
         locations[index] = location;
     
-    [self liftUpAtPoints:&locations[0] touchCount:touchCount];
+    [self liftUpAtPoints:locations.data() touchCount:touchCount];
 }
 
 - (void)liftUp:(CGPoint)location
@@ -681,7 +681,7 @@ static InterpolationType interpolationFromString(NSString *string)
 
             nextLocations[i] = calculateNextCurveLocation(startLocations[i], newLocations[i], interval);
         }
-        [self _updateTouchPoints:&nextLocations[0] count:touchCount];
+        [self _updateTouchPoints:nextLocations.data() count:touchCount];
 
         delayBetweenMove(eventIndex++, elapsed);
     }


### PR DESCRIPTION
#### de87f88f433ab2aacabbaaa7241c7ef2cc1979de
<pre>
REGRESSION (279702@main): [ iOS ] fast/shadow-dom/touch-event-ios.html is constantly crashing.
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=275752">https://bugs.webkit.org/show_bug.cgi?id=275752</a>&gt;
&lt;<a href="https://rdar.apple.com/130217217">rdar://130217217</a>&gt;

Reviewed by Alexey Proskuryakov.

* Tools/TestWebKitAPI/Tests/WTF/Vector.cpp:
(TestWebKitAPI::TEST(WTF_Vector, Basic)):
(TestWebKitAPI::TEST(WTF_Vector, ZeroSize)): Add.
- Update tests to verify .data() and to explicity test a zero-size
  Vector.

* Tools/WebKitTestRunner/ios/HIDEventGenerator.mm:
(-[HIDEventGenerator touchDown:touchCount:]):
(-[HIDEventGenerator liftUp:touchCount:]):
(-[HIDEventGenerator moveToPoints:touchCount:duration:]):
- Use .data() instead of [0] array offset since .data() returns nullptr
  if the Vector is empty.

Canonical link: <a href="https://commits.webkit.org/280269@main">https://commits.webkit.org/280269@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2c59fd8bb1abaf33c1fc4511feb6c2d9d33619c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56114 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8586 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59720 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6550 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58240 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6744 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/45255 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4537 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33330 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48398 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26305 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30111 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5728 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5554 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52081 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/5999 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61403 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/22 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6126 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52654 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/22 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48465 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52359 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/24 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8328 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31267 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32353 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33436 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32100 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->