### PR TITLE
Canonicalize wasm options

### DIFF
--- a/JSTests/wasm/ipint-tests/perf.py
+++ b/JSTests/wasm/ipint-tests/perf.py
@@ -17,9 +17,9 @@ COMMONENV = {
 }
 
 JSCRELEASE = ['/Volumes/WebKit/DebugVersion/OpenSource/WebKitBuild/Release/jsc', '--validateOptions=1', '--useWebAssemblySIMD=0']
-IPINT_RUNS = ['--useWasmIPInt=1', '--useBBQJIT=0', '--useOMGJIT=0']
+IPINT_RUNS = ['--useWebAssemblyIPInt=1', '--useBBQJIT=0', '--useOMGJIT=0']
 LLINT_RUNS = ['--useBBQJIT=0', '--useOMGJIT=0']
-BBQJIT_RUNS = ['--useWasmLLInt=0', '--useBBQJIT=1', '--useOMGJIT=0']
+BBQJIT_RUNS = ['--useWebAssemblyLLInt=0', '--useBBQJIT=1', '--useOMGJIT=0']
 FILE = ['-m', sys.argv[1]]
 
 MEMORY_SLEEP = 0

--- a/JSTests/wasm/stress/cc-int-to-int-cross-module-with-exception.js
+++ b/JSTests/wasm/stress/cc-int-to-int-cross-module-with-exception.js
@@ -1,7 +1,7 @@
 //@ skip
 //@ skip unless $isWasmPlatform
 //@ requireOptions("--useJITCage=0") # temporary workaround for rdar://127308350
-//@ runDefaultWasm("-m", "--wasmFunctionIndexRangeToCompile=0:5", "--useOMGJIT=0", "--useInterpretedJSEntryWrappers=1")
+//@ runDefaultWasm("-m", "--webAssemblyFunctionIndexRangeToCompile=0:5", "--useOMGJIT=0", "--useInterpretedJSEntryWrappers=1")
 
 // This tests will use more than the 600M that $memoryLimited devices are capped
 // at due JSCTEST_memoryLimit. Skip it to avoid the crash as a result of exceeding

--- a/JSTests/wasm/stress/cc-int-to-int-jit-to-llint.js
+++ b/JSTests/wasm/stress/cc-int-to-int-jit-to-llint.js
@@ -1,5 +1,5 @@
 //@ skip
-//@ runDefaultWasm("-m", "--wasmFunctionIndexRangeToCompile=1:2")
+//@ runDefaultWasm("-m", "--webAssemblyFunctionIndexRangeToCompile=1:2")
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-regalloc-stress-2.js
+++ b/JSTests/wasm/stress/simd-regalloc-stress-2.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=0", "--useWasmLLInt=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=0", "--useWebAssemblyLLInt=1")
 //@ skip if !$isSIMDPlatform or $memoryLimited
 import * as assert from "../assert.js"
 

--- a/JSTests/wasm/stress/simd-unreachable.js
+++ b/JSTests/wasm/stress/simd-unreachable.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useWebAssemblySIMD=1", "--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip if !$isSIMDPlatform
 import { instantiate } from "../wabt-wrapper.js"
 import * as assert from "../assert.js"

--- a/JSTests/wasm/stress/simple-inline-stacktrace-2.js
+++ b/JSTests/wasm/stress/simple-inline-stacktrace-2.js
@@ -1,6 +1,6 @@
 //@ skip if !$isWasmPlatform
 //@ skip if $memoryLimited
-//@ runDefault("--maximumWasmDepthForInlining=10", "--maximumWasmCalleeSizeForInlining=10000000", "--maximumWasmCallerSizeForInlining=10000000", "--useBBQJIT=0")
+//@ runDefault("--maximumWebAssemblyDepthForInlining=10", "--maximumWebAssemblyCalleeSizeForInlining=10000000", "--maximumWebAssemblyCallerSizeForInlining=10000000", "--useBBQJIT=0")
 var wasm_code = read('simple-inline-stacktrace.wasm', 'binary')
 var wasm_module = new WebAssembly.Module(wasm_code);
 var wasm_instance = new WebAssembly.Instance(wasm_module, { a: { doThrow: () => { throw new Error() } } });

--- a/JSTests/wasm/stress/simple-inline-stacktrace-with-catch-2.js
+++ b/JSTests/wasm/stress/simple-inline-stacktrace-with-catch-2.js
@@ -1,5 +1,5 @@
 //@ skip if !$isWasmPlatform
-//@ runDefault("--maximumWasmDepthForInlining=10", "--maximumWasmCalleeSizeForInlining=10000000", "--maximumWasmCallerSizeForInlining=10000000", "--useBBQJIT=0")
+//@ runDefault("--maximumWebAssemblyDepthForInlining=10", "--maximumWebAssemblyCalleeSizeForInlining=10000000", "--maximumWebAssemblyCallerSizeForInlining=10000000", "--useBBQJIT=0")
 var wasm_code = read('simple-inline-stacktrace-with-catch.wasm', 'binary')
 var wasm_module = new WebAssembly.Module(wasm_code);
 let throwCounter = 0

--- a/JSTests/wasm/stress/tail-call.js
+++ b/JSTests/wasm/stress/tail-call.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWebAssemblyTailCalls=true", "--maximumWasmCalleeSizeForInlining=0")
+//@ requireOptions("--useWebAssemblyTailCalls=true", "--maximumWebAssemblyCalleeSizeForInlining=0")
 //@ skip
 import * as assert from "../assert.js";
 import Builder from "../Builder.js";

--- a/JSTests/wasm/v8/adapter-frame.js
+++ b/JSTests/wasm/v8/adapter-frame.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/add-getters.js
+++ b/JSTests/wasm/v8/add-getters.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/anyfunc.js
+++ b/JSTests/wasm/v8/anyfunc.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/array-copy-benchmark.js
+++ b/JSTests/wasm/v8/array-copy-benchmark.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/array-init-from-segment.js
+++ b/JSTests/wasm/v8/array-init-from-segment.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/asm-wasm-copy.js
+++ b/JSTests/wasm/v8/asm-wasm-copy.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/asm-wasm-deopt.js
+++ b/JSTests/wasm/v8/asm-wasm-deopt.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DeoptimizeFunction()

--- a/JSTests/wasm/v8/asm-wasm-exception-in-tonumber.js
+++ b/JSTests/wasm/v8/asm-wasm-exception-in-tonumber.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure (line 0):

--- a/JSTests/wasm/v8/asm-wasm-expr.js
+++ b/JSTests/wasm/v8/asm-wasm-expr.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-f32.js
+++ b/JSTests/wasm/v8/asm-wasm-f32.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-f64.js
+++ b/JSTests/wasm/v8/asm-wasm-f64.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-heap.js
+++ b/JSTests/wasm/v8/asm-wasm-heap.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-i32.js
+++ b/JSTests/wasm/v8/asm-wasm-i32.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-imports.js
+++ b/JSTests/wasm/v8/asm-wasm-imports.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-literals.js
+++ b/JSTests/wasm/v8/asm-wasm-literals.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-math-intrinsic.js
+++ b/JSTests/wasm/v8/asm-wasm-math-intrinsic.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-memory.js
+++ b/JSTests/wasm/v8/asm-wasm-memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-names.js
+++ b/JSTests/wasm/v8/asm-wasm-names.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/asm-wasm-stack.js
+++ b/JSTests/wasm/v8/asm-wasm-stack.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-stdlib.js
+++ b/JSTests/wasm/v8/asm-wasm-stdlib.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-switch.js
+++ b/JSTests/wasm/v8/asm-wasm-switch.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm-u32.js
+++ b/JSTests/wasm/v8/asm-wasm-u32.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-wasm.js
+++ b/JSTests/wasm/v8/asm-wasm.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/asm-with-wasm-off.js
+++ b/JSTests/wasm/v8/asm-with-wasm-off.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DisallowWasmCodegen()

--- a/JSTests/wasm/v8/atomics-non-shared.js
+++ b/JSTests/wasm/v8/atomics-non-shared.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Module@[native code]

--- a/JSTests/wasm/v8/atomics-stress.js
+++ b/JSTests/wasm/v8/atomics-stress.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: ReferenceError: Can't find variable: Worker

--- a/JSTests/wasm/v8/atomics.js
+++ b/JSTests/wasm/v8/atomics.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure (Error message):

--- a/JSTests/wasm/v8/atomics64-stress.js
+++ b/JSTests/wasm/v8/atomics64-stress.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: ReferenceError: Can't find variable: Worker

--- a/JSTests/wasm/v8/bigint-i64-to-imported-js-func.js
+++ b/JSTests/wasm/v8/bigint-i64-to-imported-js-func.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/bigint-opt.js
+++ b/JSTests/wasm/v8/bigint-opt.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %OptimizeFunctionOnNextCall()

--- a/JSTests/wasm/v8/bigint-rematerialize.js
+++ b/JSTests/wasm/v8/bigint-rematerialize.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/bigint.js
+++ b/JSTests/wasm/v8/bigint.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/bit-shift-right.js
+++ b/JSTests/wasm/v8/bit-shift-right.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/bounds-check-64bit.js
+++ b/JSTests/wasm/v8/bounds-check-64bit.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/bounds-check-turbofan.js
+++ b/JSTests/wasm/v8/bounds-check-turbofan.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %WasmTierUpFunction()

--- a/JSTests/wasm/v8/bulk-memory.js
+++ b/JSTests/wasm/v8/bulk-memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/call-ref.js
+++ b/JSTests/wasm/v8/call-ref.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: TypeError: undefined is not a constructor (evaluating 'new WebAssembly.Function(

--- a/JSTests/wasm/v8/call_indirect.js
+++ b/JSTests/wasm/v8/call_indirect.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 10: invalid opcode 19, in function at index 0 (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/calls.js
+++ b/JSTests/wasm/v8/calls.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/code-space-overflow.js
+++ b/JSTests/wasm/v8/code-space-overflow.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/committed-code-exhaustion.js
+++ b/JSTests/wasm/v8/committed-code-exhaustion.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/compare-exchange-stress.js
+++ b/JSTests/wasm/v8/compare-exchange-stress.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 90: byte alignment 1 does not match against atomic op's natural alignment 4, in function at index 0 (evaluating 'new WebAssembly.Module(builder.toBuffer())')

--- a/JSTests/wasm/v8/compare-exchange64-stress.js
+++ b/JSTests/wasm/v8/compare-exchange64-stress.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 94: byte alignment 1 does not match against atomic op's natural alignment 8, in function at index 0 (evaluating 'new WebAssembly.Module(builder.toBuffer())')

--- a/JSTests/wasm/v8/compilation-hints-async-compilation.js
+++ b/JSTests/wasm/v8/compilation-hints-async-compilation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure: unreachable - [object WebAssembly.Module]

--- a/JSTests/wasm/v8/compilation-hints-decoder.js
+++ b/JSTests/wasm/v8/compilation-hints-decoder.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Did not throw exception, expected CompileError

--- a/JSTests/wasm/v8/compilation-hints-ignored.js
+++ b/JSTests/wasm/v8/compilation-hints-ignored.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be found
 // in the LICENSE file.

--- a/JSTests/wasm/v8/compilation-hints-lazy-validation.js
+++ b/JSTests/wasm/v8/compilation-hints-lazy-validation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't validate: I32Mul right value type mismatch, in function at index 0 (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/compilation-hints-streaming-compilation.js
+++ b/JSTests/wasm/v8/compilation-hints-streaming-compilation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: TypeError: WebAssembly.instantiateStreaming is not a function. (In 'WebAssembly.instantiateStreaming(Promise.resolve(bytes),

--- a/JSTests/wasm/v8/compilation-hints-streaming-lazy-validation.js
+++ b/JSTests/wasm/v8/compilation-hints-streaming-lazy-validation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: TypeError: WebAssembly.instantiateStreaming is not a function. (In 'WebAssembly.instantiateStreaming(Promise.resolve(bytes))', 'WebAssembly.instantiateStreaming' is undefined)

--- a/JSTests/wasm/v8/compilation-hints-sync-compilation.js
+++ b/JSTests/wasm/v8/compilation-hints-sync-compilation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Did not throw exception, expected CompileError

--- a/JSTests/wasm/v8/compilation-limits-asm.js
+++ b/JSTests/wasm/v8/compilation-limits-asm.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsAsmWasmCode()

--- a/JSTests/wasm/v8/compilation-limits.js
+++ b/JSTests/wasm/v8/compilation-limits.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %AbortJS()

--- a/JSTests/wasm/v8/compiled-module-management.js
+++ b/JSTests/wasm/v8/compiled-module-management.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %WasmGetNumberOfInstances()

--- a/JSTests/wasm/v8/compiled-module-serialization.js
+++ b/JSTests/wasm/v8/compiled-module-serialization.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DeserializeWasmModule()

--- a/JSTests/wasm/v8/data-segments.js
+++ b/JSTests/wasm/v8/data-segments.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/disable-trap-handler.js
+++ b/JSTests/wasm/v8/disable-trap-handler.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsWasmTrapHandlerEnabled()

--- a/JSTests/wasm/v8/disallow-codegen.js
+++ b/JSTests/wasm/v8/disallow-codegen.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DisallowWasmCodegen()

--- a/JSTests/wasm/v8/divrem-trap.js
+++ b/JSTests/wasm/v8/divrem-trap.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/element-segments-with-reftypes.js
+++ b/JSTests/wasm/v8/element-segments-with-reftypes.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 79: opcode for exp in element section's should be either ref.func or ref.null 0th element's 0th index (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/empirical_max_memory.js
+++ b/JSTests/wasm/v8/empirical_max_memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/ensure-wasm-binaries-up-to-date.js
+++ b/JSTests/wasm/v8/ensure-wasm-binaries-up-to-date.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: ReferenceError: Can't find variable: readbuffer

--- a/JSTests/wasm/v8/errors.js
+++ b/JSTests/wasm/v8/errors.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DebugTrace()

--- a/JSTests/wasm/v8/export-global.js
+++ b/JSTests/wasm/v8/export-global.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/export-identity.js
+++ b/JSTests/wasm/v8/export-identity.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure: expected <function () {

--- a/JSTests/wasm/v8/export-mutable-global.js
+++ b/JSTests/wasm/v8/export-mutable-global.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/export-table.js
+++ b/JSTests/wasm/v8/export-table.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/expose-wasm.js
+++ b/JSTests/wasm/v8/expose-wasm.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Did not throw exception

--- a/JSTests/wasm/v8/extended-constants.js
+++ b/JSTests/wasm/v8/extended-constants.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 35: init_expr should end with end, ended with 35 (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/externref-globals.js
+++ b/JSTests/wasm/v8/externref-globals.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure: expected <null> found <undefined>

--- a/JSTests/wasm/v8/externref-table.js
+++ b/JSTests/wasm/v8/externref-table.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure (Error message):

--- a/JSTests/wasm/v8/externref.js
+++ b/JSTests/wasm/v8/externref.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/ffi-error.js
+++ b/JSTests/wasm/v8/ffi-error.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/ffi.js
+++ b/JSTests/wasm/v8/ffi.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %GetCallable()

--- a/JSTests/wasm/v8/float-constant-folding.js
+++ b/JSTests/wasm/v8/float-constant-folding.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/function-names.js
+++ b/JSTests/wasm/v8/function-names.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure (should start with 'at exec_unreachable (': '<?>.wasm-function[1]@[wasm code]'): expected <true> found <false>

--- a/JSTests/wasm/v8/function-prototype.js
+++ b/JSTests/wasm/v8/function-prototype.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/futex.js
+++ b/JSTests/wasm/v8/futex.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %AtomicsNumWaitersForTesting()

--- a/JSTests/wasm/v8/gc-buffer.js
+++ b/JSTests/wasm/v8/gc-buffer.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/gc-casts-from-any.js
+++ b/JSTests/wasm/v8/gc-casts-from-any.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 13: 0th type failed to parse because rec types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/gc-casts-invalid.js
+++ b/JSTests/wasm/v8/gc-casts-invalid.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure (Error message):

--- a/JSTests/wasm/v8/gc-casts-subtypes.js
+++ b/JSTests/wasm/v8/gc-casts-subtypes.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 13: 0th type failed to parse because rec types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/gc-experimental-string-conversions.js
+++ b/JSTests/wasm/v8/gc-experimental-string-conversions.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %OptimizeFunctionOnNextCall()

--- a/JSTests/wasm/v8/gc-experiments.js
+++ b/JSTests/wasm/v8/gc-experiments.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/gc-frame.js
+++ b/JSTests/wasm/v8/gc-frame.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/gc-js-interop-async-debugger.js
+++ b/JSTests/wasm/v8/gc-js-interop-async-debugger.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to db.debugger.enable()

--- a/JSTests/wasm/v8/gc-js-interop-collections.js
+++ b/JSTests/wasm/v8/gc-js-interop-collections.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // This uses gc-js-interop-helpers.js which has %calls that haven't been resolved.
 

--- a/JSTests/wasm/v8/gc-js-interop-export.mjs
+++ b/JSTests/wasm/v8/gc-js-interop-export.mjs
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // gc-js-interop-helpers.js needs to have %function remapping and then we can add it to run-jsc-stress-test loading..
 

--- a/JSTests/wasm/v8/gc-js-interop-global-constructors.js
+++ b/JSTests/wasm/v8/gc-js-interop-global-constructors.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // This uses gc-js-interop-helpers.js which has %calls that haven't been resolved.
 

--- a/JSTests/wasm/v8/gc-js-interop-import.mjs
+++ b/JSTests/wasm/v8/gc-js-interop-import.mjs
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: TypeError: Module specifier, 'gc-js-interop-export.mjs' is not absolute and does not start with "./" or "../".

--- a/JSTests/wasm/v8/gc-js-interop-numeric.js
+++ b/JSTests/wasm/v8/gc-js-interop-numeric.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // This uses gc-js-interop-helpers.js which has %calls that haven't been resolved.
 

--- a/JSTests/wasm/v8/gc-js-interop-objects.js
+++ b/JSTests/wasm/v8/gc-js-interop-objects.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // This uses gc-js-interop-helpers.js which has %calls that haven't been resolved.
 

--- a/JSTests/wasm/v8/gc-js-interop-wasm.js
+++ b/JSTests/wasm/v8/gc-js-interop-wasm.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // This uses gc-js-interop-helpers.js which has %calls that haven't been resolved.
 

--- a/JSTests/wasm/v8/gc-js-interop.js
+++ b/JSTests/wasm/v8/gc-js-interop.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // This uses gc-js-interop-helpers.js which has %calls that haven't been resolved.
 

--- a/JSTests/wasm/v8/gc-memory.js
+++ b/JSTests/wasm/v8/gc-memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/gc-nominal.js
+++ b/JSTests/wasm/v8/gc-nominal.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/gc-optimizations.js
+++ b/JSTests/wasm/v8/gc-optimizations.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/gc-stress.js
+++ b/JSTests/wasm/v8/gc-stress.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/gc-typecheck-reducer.js
+++ b/JSTests/wasm/v8/gc-typecheck-reducer.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/gdbjit.js
+++ b/JSTests/wasm/v8/gdbjit.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/generic-wrapper.js
+++ b/JSTests/wasm/v8/generic-wrapper.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DeoptimizeFunction()

--- a/JSTests/wasm/v8/globals-import-export-identity.js
+++ b/JSTests/wasm/v8/globals-import-export-identity.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/globals.js
+++ b/JSTests/wasm/v8/globals.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/graceful_shutdown.js
+++ b/JSTests/wasm/v8/graceful_shutdown.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/graceful_shutdown_during_tierup.js
+++ b/JSTests/wasm/v8/graceful_shutdown_during_tierup.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/grow-huge-memory.js
+++ b/JSTests/wasm/v8/grow-huge-memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip if $memoryLimited or ($architecture != "arm64" && $architecture != "x86_64")
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/grow-memory-detaching.js
+++ b/JSTests/wasm/v8/grow-memory-detaching.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/grow-memory-in-branch.js
+++ b/JSTests/wasm/v8/grow-memory-in-branch.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/grow-memory-in-call.js
+++ b/JSTests/wasm/v8/grow-memory-in-call.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/grow-memory-in-loop.js
+++ b/JSTests/wasm/v8/grow-memory-in-loop.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/grow-memory.js
+++ b/JSTests/wasm/v8/grow-memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip if ($architecture != "arm64" && $architecture != "x86_64")
 //@ skip if $memoryLimited
 // Copyright 2016 the V8 project authors. All rights reserved.

--- a/JSTests/wasm/v8/grow-shared-memory.js
+++ b/JSTests/wasm/v8/grow-shared-memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: ReferenceError: Can't find variable: Worker

--- a/JSTests/wasm/v8/huge-memory.js
+++ b/JSTests/wasm/v8/huge-memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip if $memoryLimited or $addressBits <= 32
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/huge-typedarray.js
+++ b/JSTests/wasm/v8/huge-typedarray.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip if $memoryLimited or $addressBits <= 32
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/i31ref.js
+++ b/JSTests/wasm/v8/i31ref.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 3: can't get Function local's type in group 0, in function at index 0 (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/import-function.js
+++ b/JSTests/wasm/v8/import-function.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/import-memory.js
+++ b/JSTests/wasm/v8/import-memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/import-mutable-global.js
+++ b/JSTests/wasm/v8/import-mutable-global.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/import-table.js
+++ b/JSTests/wasm/v8/import-table.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/imported-function-types.js
+++ b/JSTests/wasm/v8/imported-function-types.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 25: can't get 0th argument Type (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/indirect-call-non-zero-table.js
+++ b/JSTests/wasm/v8/indirect-call-non-zero-table.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/indirect-calls.js
+++ b/JSTests/wasm/v8/indirect-calls.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/indirect-sig-mismatch.js
+++ b/JSTests/wasm/v8/indirect-sig-mismatch.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/indirect-tables.js
+++ b/JSTests/wasm/v8/indirect-tables.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure: expected <"2"> found <"">

--- a/JSTests/wasm/v8/inlining.js
+++ b/JSTests/wasm/v8/inlining.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 7: invalid opcode 18, in function at index 0 (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/instance-gc.js
+++ b/JSTests/wasm/v8/instance-gc.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/instance-memory-gc-stress.js
+++ b/JSTests/wasm/v8/instance-memory-gc-stress.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/instantiate-module-basic.js
+++ b/JSTests/wasm/v8/instantiate-module-basic.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/instantiate-run-basic.js
+++ b/JSTests/wasm/v8/instantiate-run-basic.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/js-api.js
+++ b/JSTests/wasm/v8/js-api.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/large-offset.js
+++ b/JSTests/wasm/v8/large-offset.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/lazy-compilation.js
+++ b/JSTests/wasm/v8/lazy-compilation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %FreezeWasmLazyCompilation()

--- a/JSTests/wasm/v8/lazy-feedback-vector-allocation.js
+++ b/JSTests/wasm/v8/lazy-feedback-vector-allocation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/liftoff-debug.js
+++ b/JSTests/wasm/v8/liftoff-debug.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %ScheduleGCInStackCheck()

--- a/JSTests/wasm/v8/liftoff-trap-handler.js
+++ b/JSTests/wasm/v8/liftoff-trap-handler.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/liftoff.js
+++ b/JSTests/wasm/v8/liftoff.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsLiftoffFunction()

--- a/JSTests/wasm/v8/load-immutable.js
+++ b/JSTests/wasm/v8/load-immutable.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because array types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/log-code-after-post-message.js
+++ b/JSTests/wasm/v8/log-code-after-post-message.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to db.profiler.*()

--- a/JSTests/wasm/v8/loop-rotation.js
+++ b/JSTests/wasm/v8/loop-rotation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/loop-unrolling.js
+++ b/JSTests/wasm/v8/loop-unrolling.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failed:
 //  Exception: CompileError: WebAssembly.Module doesn't parse at byte 10: invalid opcode 18, in function at index 1 (evaluating 'new WebAssembly.Module(builder.toBuffer())')

--- a/JSTests/wasm/v8/many-memories-no-trap-handler.js
+++ b/JSTests/wasm/v8/many-memories-no-trap-handler.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1", "--useWebAssemblyFastMemory=0")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1", "--useWebAssemblyFastMemory=0")
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/many-memories.js
+++ b/JSTests/wasm/v8/many-memories.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/many-modules.js
+++ b/JSTests/wasm/v8/many-modules.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/many-parameters.js
+++ b/JSTests/wasm/v8/many-parameters.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/JSTests/wasm/v8/max-module-size-flag.js
+++ b/JSTests/wasm/v8/max-module-size-flag.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Did not throw exception, expected RangeError

--- a/JSTests/wasm/v8/max-wasm-functions.js
+++ b/JSTests/wasm/v8/max-wasm-functions.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 23: Function section's count is too big 1000010 maximum 1000000 (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/memory-external-call.js
+++ b/JSTests/wasm/v8/memory-external-call.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/memory-instance-validation.js
+++ b/JSTests/wasm/v8/memory-instance-validation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/memory-size.js
+++ b/JSTests/wasm/v8/memory-size.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/memory.js
+++ b/JSTests/wasm/v8/memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/memory64.js
+++ b/JSTests/wasm/v8/memory64.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 30: resizable limits flag should be 0x00, 0x01, or 0x03 but 0x05 (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/memory_1gb_oob.js
+++ b/JSTests/wasm/v8/memory_1gb_oob.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/memory_2gb_oob.js
+++ b/JSTests/wasm/v8/memory_2gb_oob.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/memory_4gb_oob.js
+++ b/JSTests/wasm/v8/memory_4gb_oob.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 //  RuntimeError: Out of bounds memory access (evaluating 'a.store(i, f(i))')

--- a/JSTests/wasm/v8/module-memory.js
+++ b/JSTests/wasm/v8/module-memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %GetWasmRecoveredTrapCount()

--- a/JSTests/wasm/v8/multi-table-element-section.js
+++ b/JSTests/wasm/v8/multi-table-element-section.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/multiple-code-spaces.js
+++ b/JSTests/wasm/v8/multiple-code-spaces.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %WasmNumCodeSpaces()

--- a/JSTests/wasm/v8/mutable-globals.js
+++ b/JSTests/wasm/v8/mutable-globals.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/names.js
+++ b/JSTests/wasm/v8/names.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/parallel_compilation.js
+++ b/JSTests/wasm/v8/parallel_compilation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/params.js
+++ b/JSTests/wasm/v8/params.js
@@ -1,5 +1,5 @@
 //@ skip if $architecture == "arm" and !$cloop
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/print-code.js
+++ b/JSTests/wasm/v8/print-code.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DeserializeWasmModule()

--- a/JSTests/wasm/v8/prototype.js
+++ b/JSTests/wasm/v8/prototype.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2021 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/receiver.js
+++ b/JSTests/wasm/v8/receiver.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/reference-globals-import.js
+++ b/JSTests/wasm/v8/reference-globals-import.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/reference-globals.js
+++ b/JSTests/wasm/v8/reference-globals.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because rec types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/reference-table-js-interop.js
+++ b/JSTests/wasm/v8/reference-table-js-interop.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: TypeError: WebAssembly.Table expects its 'element' field to be the string 'funcref' or 'externref'

--- a/JSTests/wasm/v8/reference-tables.js
+++ b/JSTests/wasm/v8/reference-tables.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 37: Table type should be funcref or anyref, got -20 (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/regress/regress-9017.js
+++ b/JSTests/wasm/v8/regress/regress-9017.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useWasmLLInt=true")
+//@ requireOptions("--useWebAssemblyLLInt=true")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/resizablearraybuffer-growablesharedarraybuffer-wasm.js
+++ b/JSTests/wasm/v8/resizablearraybuffer-growablesharedarraybuffer-wasm.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/return-calls.js
+++ b/JSTests/wasm/v8/return-calls.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 6: invalid opcode 18, in function at index 1 (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/runtime-type-canonicalization.js
+++ b/JSTests/wasm/v8/runtime-type-canonicalization.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/serialization-with-compilation-hints.js
+++ b/JSTests/wasm/v8/serialization-with-compilation-hints.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DeserializeWasmModule()

--- a/JSTests/wasm/v8/serialize-lazy-module.js
+++ b/JSTests/wasm/v8/serialize-lazy-module.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DeserializeWasmModule()

--- a/JSTests/wasm/v8/shared-arraybuffer-worker-simple-gc.js
+++ b/JSTests/wasm/v8/shared-arraybuffer-worker-simple-gc.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failed because  Exception: ReferenceError: Can't find variable: Worker
 

--- a/JSTests/wasm/v8/shared-memory-gc-stress.js
+++ b/JSTests/wasm/v8/shared-memory-gc-stress.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/shared-memory-worker-explicit-gc-stress.js
+++ b/JSTests/wasm/v8/shared-memory-worker-explicit-gc-stress.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // This uses worker-ping-test.js which has %calls that haven't been resolved.
 

--- a/JSTests/wasm/v8/shared-memory-worker-gc-stress.js
+++ b/JSTests/wasm/v8/shared-memory-worker-gc-stress.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // This uses worker-ping-test.js which has %calls that haven't been resolved.
 

--- a/JSTests/wasm/v8/shared-memory-worker-gc.js
+++ b/JSTests/wasm/v8/shared-memory-worker-gc.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: ReferenceError: Can't find variable: Worker

--- a/JSTests/wasm/v8/shared-memory-worker-simple-gc.js
+++ b/JSTests/wasm/v8/shared-memory-worker-simple-gc.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: ReferenceError: Can't find variable: Worker

--- a/JSTests/wasm/v8/shared-memory-worker-stress.js
+++ b/JSTests/wasm/v8/shared-memory-worker-stress.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // This uses worker-ping-test.js which has %calls that haven't been resolved.
 

--- a/JSTests/wasm/v8/shared-memory.js
+++ b/JSTests/wasm/v8/shared-memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: TypeError: WebAssembly.Memory 'initial' and 'minimum' options are specified at the same time

--- a/JSTests/wasm/v8/single-threaded-compilation.js
+++ b/JSTests/wasm/v8/single-threaded-compilation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2020 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/speculative-inlining.js
+++ b/JSTests/wasm/v8/speculative-inlining.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %WasmTierUpFunction()

--- a/JSTests/wasm/v8/stack-switching-export.js
+++ b/JSTests/wasm/v8/stack-switching-export.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DeoptimizeFunction()

--- a/JSTests/wasm/v8/stack-switching.js
+++ b/JSTests/wasm/v8/stack-switching.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: TypeError: undefined is not a constructor (evaluating 'new WebAssembly.Suspender()')

--- a/JSTests/wasm/v8/stack.js
+++ b/JSTests/wasm/v8/stack.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure:

--- a/JSTests/wasm/v8/stackwalk.js
+++ b/JSTests/wasm/v8/stackwalk.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DeoptimizeFunction()

--- a/JSTests/wasm/v8/start-function.js
+++ b/JSTests/wasm/v8/start-function.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/streaming-api.js
+++ b/JSTests/wasm/v8/streaming-api.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: TypeError: WebAssembly.compileStreaming is not a function. (In 'WebAssembly.compileStreaming(Promise.resolve(bytes))', 'WebAssembly.compileStreaming' is undefined)

--- a/JSTests/wasm/v8/streaming-compile.js
+++ b/JSTests/wasm/v8/streaming-compile.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure (Error message):

--- a/JSTests/wasm/v8/streaming-error-position.js
+++ b/JSTests/wasm/v8/streaming-error-position.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure (Error message):

--- a/JSTests/wasm/v8/streaming-trap-location.js
+++ b/JSTests/wasm/v8/streaming-trap-location.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Failure (trap reason):

--- a/JSTests/wasm/v8/stringrefs-exec-gc.js
+++ b/JSTests/wasm/v8/stringrefs-exec-gc.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because array types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/stringrefs-exec.js
+++ b/JSTests/wasm/v8/stringrefs-exec.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 17: can't get 0th Type's return value (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/stringrefs-invalid.js
+++ b/JSTests/wasm/v8/stringrefs-invalid.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure (Error message):

--- a/JSTests/wasm/v8/stringrefs-js.js
+++ b/JSTests/wasm/v8/stringrefs-js.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 14: can't get 0th argument Type (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/stringrefs-regressions.js
+++ b/JSTests/wasm/v8/stringrefs-regressions.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %WasmTierUpFunction()

--- a/JSTests/wasm/v8/stringrefs-valid.js
+++ b/JSTests/wasm/v8/stringrefs-valid.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure: expected <true> found <false>

--- a/JSTests/wasm/v8/table-access.js
+++ b/JSTests/wasm/v8/table-access.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/table-copy-externref.js
+++ b/JSTests/wasm/v8/table-copy-externref.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/table-copy.js
+++ b/JSTests/wasm/v8/table-copy.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/table-fill.js
+++ b/JSTests/wasm/v8/table-fill.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/table-get.js
+++ b/JSTests/wasm/v8/table-get.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure: expected <Object()> found <undefined>

--- a/JSTests/wasm/v8/table-grow-from-wasm.js
+++ b/JSTests/wasm/v8/table-grow-from-wasm.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2019 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/table-grow.js
+++ b/JSTests/wasm/v8/table-grow.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/table-limits.js
+++ b/JSTests/wasm/v8/table-limits.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Did not throw exception, expected RangeError

--- a/JSTests/wasm/v8/tagged-stack-parameters.js
+++ b/JSTests/wasm/v8/tagged-stack-parameters.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/test-partial-serialization.js
+++ b/JSTests/wasm/v8/test-partial-serialization.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DeserializeWasmModule()

--- a/JSTests/wasm/v8/test-serialization-with-lazy-compilation.js
+++ b/JSTests/wasm/v8/test-serialization-with-lazy-compilation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %DeserializeWasmModule()

--- a/JSTests/wasm/v8/test-wasm-module-builder.js
+++ b/JSTests/wasm/v8/test-wasm-module-builder.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 2022: can't get 0th Type's return value (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/tier-down-to-liftoff.js
+++ b/JSTests/wasm/v8/tier-down-to-liftoff.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsLiftoffFunction()

--- a/JSTests/wasm/v8/tier-up-testing-flag.js
+++ b/JSTests/wasm/v8/tier-up-testing-flag.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsLiftoffFunction()

--- a/JSTests/wasm/v8/type-based-optimizations.js
+++ b/JSTests/wasm/v8/type-based-optimizations.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because rec types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/type-reflection-with-externref.js
+++ b/JSTests/wasm/v8/type-reflection-with-externref.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: TypeError: undefined is not a constructor (evaluating 'new WebAssembly.Function({parameters:[], results:["i32"]}, _ => 7)')

--- a/JSTests/wasm/v8/type-reflection-with-mv.js
+++ b/JSTests/wasm/v8/type-reflection-with-mv.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: TypeError: undefined is not a constructor (evaluating 'new WebAssembly.Function({parameters:p, results:r}, testFun)')

--- a/JSTests/wasm/v8/type-reflection.js
+++ b/JSTests/wasm/v8/type-reflection.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure: expected <true> found <false>

--- a/JSTests/wasm/v8/typed-funcref.js
+++ b/JSTests/wasm/v8/typed-funcref.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: TypeError: WebAssembly.Table.prototype.grow expects the second argument to be null or an instance of WebAssembly.Function

--- a/JSTests/wasm/v8/unicode-validation.js
+++ b/JSTests/wasm/v8/unicode-validation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure:

--- a/JSTests/wasm/v8/unicode.js
+++ b/JSTests/wasm/v8/unicode.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/unreachable-validation.js
+++ b/JSTests/wasm/v8/unreachable-validation.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure: expected <true> found <false>

--- a/JSTests/wasm/v8/unreachable.js
+++ b/JSTests/wasm/v8/unreachable.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: Failure:

--- a/JSTests/wasm/v8/user-properties-constructed.js
+++ b/JSTests/wasm/v8/user-properties-constructed.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/user-properties-exported.js
+++ b/JSTests/wasm/v8/user-properties-exported.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/user-properties-module.js
+++ b/JSTests/wasm/v8/user-properties-module.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/user-properties-reexport.js
+++ b/JSTests/wasm/v8/user-properties-reexport.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/verify-module-basic-errors.js
+++ b/JSTests/wasm/v8/verify-module-basic-errors.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/wasm-api-overloading.js
+++ b/JSTests/wasm/v8/wasm-api-overloading.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2017 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/wasm-default.js
+++ b/JSTests/wasm/v8/wasm-default.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2016 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/wasm-dynamic-tiering.js
+++ b/JSTests/wasm/v8/wasm-dynamic-tiering.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Skipping this test due to the following issues:
 // call to %IsLiftoffFunction()

--- a/JSTests/wasm/v8/wasm-gc-externalize-internalize.js
+++ b/JSTests/wasm/v8/wasm-gc-externalize-internalize.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/wasm-gc-js-ref.js
+++ b/JSTests/wasm/v8/wasm-gc-js-ref.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 12: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/wasm-gc-js-roundtrip.js
+++ b/JSTests/wasm/v8/wasm-gc-js-roundtrip.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: CompileError: WebAssembly.Module doesn't parse at byte 13: 0th type failed to parse because struct types are not enabled (evaluating 'new WebAssembly.Module(this.toBuffer(debug))')

--- a/JSTests/wasm/v8/wasm-invalid-local.js
+++ b/JSTests/wasm/v8/wasm-invalid-local.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2022 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/wasm-math-intrinsic.js
+++ b/JSTests/wasm/v8/wasm-math-intrinsic.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2018 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/wasm-object-api.js
+++ b/JSTests/wasm/v8/wasm-object-api.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 // Copyright 2015 the V8 project authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/JSTests/wasm/v8/worker-memory.js
+++ b/JSTests/wasm/v8/worker-memory.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 //  Exception: ReferenceError: Can't find variable: Worker

--- a/JSTests/wasm/v8/worker-module.js
+++ b/JSTests/wasm/v8/worker-module.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failed because Exception: ReferenceError: Can't find variable: Worker
 

--- a/JSTests/wasm/v8/worker-running-empty-loop-interruptible.js
+++ b/JSTests/wasm/v8/worker-running-empty-loop-interruptible.js
@@ -1,4 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
+//@ requireOptions("--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1")
 //@ skip
 // Failure:
 // Exception: ReferenceError: Can't find variable: Worker

--- a/Source/JavaScriptCore/assembler/LinkBuffer.h
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.h
@@ -451,7 +451,7 @@ private:
     FINALIZE_CODE_IF(JSC::Options::asyncDisassembly() || JSC::Options::dumpDisassembly() || Options::dumpRegExpDisassembly(), linkBufferReference, resultPtrTag, simpleName, dataLogFArgumentsForHeading)
 
 #define FINALIZE_WASM_CODE(linkBufferReference, resultPtrTag, simpleName, ...)  \
-    FINALIZE_CODE_IF((JSC::Options::asyncDisassembly() || JSC::Options::dumpDisassembly() || Options::dumpWasmDisassembly()), linkBufferReference, resultPtrTag, simpleName, __VA_ARGS__)
+    FINALIZE_CODE_IF((JSC::Options::asyncDisassembly() || JSC::Options::dumpDisassembly() || Options::dumpWebAssemblyDisassembly()), linkBufferReference, resultPtrTag, simpleName, __VA_ARGS__)
 
 #define FINALIZE_WASM_CODE_FOR_MODE(mode, linkBufferReference, resultPtrTag, simpleName, ...)  \
     FINALIZE_CODE_IF(shouldDumpDisassemblyFor(mode), linkBufferReference, resultPtrTag, simpleName, __VA_ARGS__)

--- a/Source/JavaScriptCore/assembler/MacroAssembler.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.cpp
@@ -40,7 +40,7 @@ const double MacroAssembler::twoToThe32 = (double)0x100000000ull;
 
 void MacroAssembler::jitAssert(const ScopedLambda<Jump(void)>& functor)
 {
-    if (Options::enableJITDebugAssertions()) {
+    if (Options::useJITDebugAssertions()) {
         Jump passed = functor();
         breakpoint();
         passed.link(this);

--- a/Source/JavaScriptCore/assembler/MacroAssemblerCodeRef.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerCodeRef.cpp
@@ -62,7 +62,7 @@ bool shouldDumpDisassemblyFor(CodeBlock* codeBlock)
 
 bool shouldDumpDisassemblyFor(Wasm::CompilationMode mode)
 {
-    if (Options::asyncDisassembly() || Options::dumpDisassembly() || Options::dumpWasmDisassembly())
+    if (Options::asyncDisassembly() || Options::dumpDisassembly() || Options::dumpWebAssemblyDisassembly())
         return true;
     if (Wasm::isAnyBBQ(mode))
         return Options::dumpBBQDisassembly();

--- a/Source/JavaScriptCore/b3/B3Procedure.h
+++ b/Source/JavaScriptCore/b3/B3Procedure.h
@@ -297,7 +297,7 @@ public:
         if (Options::forceAllFunctionsToUseSIMD())
             return true;
         // The LLInt discovers this value.
-        ASSERT(Options::useWasmLLInt() || Options::useWasmIPInt());
+        ASSERT(Options::useWebAssemblyLLInt() || Options::useWebAssemblyIPInt());
         return m_usesSIMD;
     }
 

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -116,7 +116,7 @@ void initialize()
 
         AssemblyCommentRegistry::initialize();
 #if ENABLE(WEBASSEMBLY)
-        if (Options::useWasmIPInt() || Options::useInterpretedJSEntryWrappers())
+        if (Options::useWebAssemblyIPInt() || Options::useInterpretedJSEntryWrappers())
             IPInt::initialize();
 #endif
         LLInt::initialize();

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -579,14 +579,14 @@ static void overrideDefaults()
 
 #if !ENABLE(WEBASSEMBLY)
     Options::useWebAssemblyFastMemory() = false;
-    Options::useWasmFaultSignalHandler() = false;
+    Options::useWebAssemblyFaultSignalHandler() = false;
 #endif
 
 #if !HAVE(MACH_EXCEPTIONS)
     Options::useMachForExceptions() = false;
 #endif
 
-    if (Options::useWasmLLInt() && !Options::wasmLLIntTiersUpToBBQ()) {
+    if (Options::useWebAssemblyLLInt() && !Options::webAssemblyLLIntTiersUpToBBQ()) {
         Options::thresholdForOMGOptimizeAfterWarmUp() = 1500;
         Options::thresholdForOMGOptimizeSoon() = 100;
     }
@@ -640,7 +640,7 @@ static inline void disableAllJITOptions()
     Options::dumpDFGDisassembly() = false;
     Options::dumpFTLDisassembly() = false;
     Options::dumpRegExpDisassembly() = false;
-    Options::dumpWasmDisassembly() = false;
+    Options::dumpWebAssemblyDisassembly() = false;
     Options::dumpBBQDisassembly() = false;
     Options::dumpOMGDisassembly() = false;
     Options::needDisassemblySupport() = false;
@@ -760,7 +760,7 @@ void Options::notifyOptionsChanged()
             || Options::dumpDFGDisassembly()
             || Options::dumpFTLDisassembly()
             || Options::dumpRegExpDisassembly()
-            || Options::dumpWasmDisassembly()
+            || Options::dumpWebAssemblyDisassembly()
             || Options::dumpBBQDisassembly()
             || Options::dumpOMGDisassembly())
             Options::needDisassemblySupport() = true;
@@ -818,7 +818,7 @@ void Options::notifyOptionsChanged()
         ASSERT((static_cast<int64_t>(Options::thresholdForOptimizeAfterLongWarmUp()) << Options::reoptimizationRetryCounterMax()) <= static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
 
         if (!Options::useBBQJIT() && Options::useOMGJIT())
-            Options::wasmLLIntTiersUpToBBQ() = false;
+            Options::webAssemblyLLIntTiersUpToBBQ() = false;
 
 #if CPU(X86_64) && ENABLE(JIT)
         if (!MacroAssembler::supportsAVX())
@@ -834,11 +834,11 @@ void Options::notifyOptionsChanged()
             // is added.
             // FIXME: Add WASM tail calls support to single-pass BBQ JIT. https://bugs.webkit.org/show_bug.cgi?id=253192
             Options::useBBQJIT() = false;
-            Options::useWasmLLInt() = true;
-            Options::wasmLLIntTiersUpToBBQ() = false;
+            Options::useWebAssemblyLLInt() = true;
+            Options::webAssemblyLLIntTiersUpToBBQ() = false;
         }
 
-        if (Options::useWebAssemblySIMD() && !(Options::useWasmLLInt() || Options::useWasmIPInt())) {
+        if (Options::useWebAssemblySIMD() && !(Options::useWebAssemblyLLInt() || Options::useWebAssemblyIPInt())) {
             // The LLInt is responsible for discovering if functions use SIMD.
             // If we can't run using it, then we should be conservative.
             Options::forceAllFunctionsToUseSIMD() = true;
@@ -906,13 +906,13 @@ void Options::notifyOptionsChanged()
         Options::verifyGC() = true;
 
 #if ASAN_ENABLED && OS(LINUX)
-    if (Options::useWasmFaultSignalHandler()) {
+    if (Options::useWebAssemblyFaultSignalHandler()) {
         const char* asanOptions = getenv("ASAN_OPTIONS");
         bool okToUseWebAssemblyFastMemory = asanOptions
             && (strstr(asanOptions, "allow_user_segv_handler=1") || strstr(asanOptions, "handle_segv=0"));
         if (!okToUseWebAssemblyFastMemory) {
             dataLogLn("WARNING: ASAN interferes with JSC signal handlers; useWebAssemblyFastMemory and useWasmFaultSignalHandler will be disabled.");
-            Options::useWasmFaultSignalHandler() = false;
+            Options::useWebAssemblyFaultSignalHandler() = false;
         }
     }
 #endif
@@ -922,7 +922,7 @@ void Options::notifyOptionsChanged()
     if (!Options::useMachForExceptions() || Options::useJITCage())
         Options::allowNonSPTagging() = true;
 
-    if (!Options::useWasmFaultSignalHandler())
+    if (!Options::useWebAssemblyFaultSignalHandler())
         Options::useWebAssemblyFastMemory() = false;
 
 #if CPU(ADDRESS32)
@@ -1284,9 +1284,9 @@ void Options::assertOptionsAreCoherent()
         coherent = false;
         dataLog("INCOHERENT OPTIONS: at least one of useLLInt or useJIT must be true\n");
     }
-    if (useWebAssembly() && !(useWasmLLInt() || useBBQJIT())) {
+    if (useWebAssembly() && !(useWebAssemblyLLInt() || useBBQJIT())) {
         coherent = false;
-        dataLog("INCOHERENT OPTIONS: at least one of useWasmLLInt or useBBQJIT must be true\n");
+        dataLog("INCOHERENT OPTIONS: at least one of useWebAssemblyLLInt or useBBQJIT must be true\n");
     }
     if (useProfiler() && useConcurrentJIT()) {
         coherent = false;

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -113,7 +113,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, initialRepatchBufferingCountdown, 6, Normal, nullptr) \
     \
     v(Bool, dumpGeneratedBytecodes, false, Normal, nullptr) \
-    v(Bool, dumpGeneratedWasmBytecodes, false, Normal, nullptr) \
+    v(Bool, dumpGeneratedWebAssemblyBytecodes, false, Normal, nullptr) \
     v(Bool, dumpBytecodeLivenessResults, false, Normal, nullptr) \
     v(Bool, validateBytecode, false, Normal, nullptr) \
     v(Bool, forceDebuggerBytecodeGeneration, false, Normal, nullptr) \
@@ -139,11 +139,11 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, dumpDFGDisassembly, false, Normal, "dumps disassembly of DFG function upon compilation"_s) \
     v(Bool, dumpFTLDisassembly, false, Normal, "dumps disassembly of FTL function upon compilation"_s) \
     v(Bool, dumpRegExpDisassembly, false, Normal, "dumps disassembly of RegExp upon compilation"_s) \
-    v(Bool, dumpWasmDisassembly, false, Normal, "dumps disassembly of all Wasm code upon compilation"_s) \
-    v(OptionString, dumpWasmSourceFileName, nullptr, Normal, "log every wasm module validation, and dump source bytes to <filename>.0.wasm, <filename>.1.wasm, etc..."_s) \
-    v(OptionString, wasmOMGFunctionsToDump, nullptr, Normal, "file with newline separated list of function indices to dump IR/disassembly for, if no such file exists, the function index itself"_s) \
-    v(Bool, dumpBBQDisassembly, false, Normal, "dumps disassembly of BBQ Wasm code upon compilation"_s) \
-    v(Bool, dumpOMGDisassembly, false, Normal, "dumps disassembly of OMG Wasm code upon compilation"_s) \
+    v(Bool, dumpWebAssemblyDisassembly, false, Normal, "dumps disassembly of all wasm code upon compilation"_s) \
+    v(OptionString, dumpWebAssemblySourceFileName, nullptr, Normal, "log every wasm module validation, and dump source bytes to <filename>.0.wasm, <filename>.1.wasm, etc..."_s) \
+    v(OptionString, webAssemblyOMGFunctionsToDump, nullptr, Normal, "file with newline separated list of function indices to dump IR/disassembly for, if no such file exists, the function index itself"_s) \
+    v(Bool, dumpBBQDisassembly, false, Normal, "dumps disassembly of BBQ wasm code upon compilation"_s) \
+    v(Bool, dumpOMGDisassembly, false, Normal, "dumps disassembly of OMG wasm code upon compilation"_s) \
     v(Bool, logJITCodeForPerf, false, Configurable, nullptr) \
     v(OptionString, jitDumpDirectory, nullptr, Normal, "Directory to place JITDump"_s) \
     v(OptionRange, bytecodeRangeToJITCompile, nullptr, Normal, "bytecode size range to allow compilation on, e.g. 1:100"_s) \
@@ -244,7 +244,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, validateSerializedValue, false, Normal, nullptr) /* tests CloneSerializer/Deserializer */ \
     v(Bool, ftlCrashes, false, Normal, nullptr) /* fool-proof way of checking that you ended up in the FTL. ;-) */\
     v(Bool, clobberAllRegsInFTLICSlowPath, ASSERT_ENABLED, Normal, nullptr) \
-    v(Bool, enableJITDebugAssertions, ASSERT_ENABLED, Normal, nullptr) \
+    v(Bool, useJITDebugAssertions, ASSERT_ENABLED, Normal, nullptr) \
     v(Bool, useAccessInlining, true, Normal, nullptr) \
     v(Unsigned, maxAccessVariantListSize, 8, Normal, nullptr) \
     v(Bool, usePolyvariantDevirtualization, true, Normal, nullptr) \
@@ -271,10 +271,10 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, numberOfWorklistThreads, computeNumberOfWorkerThreads(3, 2), Normal, nullptr) \
     v(Unsigned, numberOfDFGCompilerThreads, computeNumberOfWorkerThreads(3, 2) - 1, Normal, nullptr) \
     v(Unsigned, numberOfFTLCompilerThreads, computeNumberOfWorkerThreads(MAXIMUM_NUMBER_OF_FTL_COMPILER_THREADS, 2) - 1, Normal, nullptr) \
-    v(Unsigned, numberOfWasmCompilerThreads, computeNumberOfWorkerThreads(INT32_MAX, 2) - 1, Normal, nullptr) \
+    v(Unsigned, numberOfWebAssemblyCompilerThreads, computeNumberOfWorkerThreads(INT32_MAX, 2) - 1, Normal, nullptr) \
     v(Int32, priorityDeltaOfDFGCompilerThreads, computePriorityDeltaOfWorkerThreads(-1, 0), Normal, nullptr) \
     v(Int32, priorityDeltaOfFTLCompilerThreads, computePriorityDeltaOfWorkerThreads(-2, 0), Normal, nullptr) \
-    v(Int32, priorityDeltaOfWasmCompilerThreads, computePriorityDeltaOfWorkerThreads(-1, 0), Normal, nullptr) \
+    v(Int32, priorityDeltaOfWebAssemblyCompilerThreads, computePriorityDeltaOfWorkerThreads(-1, 0), Normal, nullptr) \
     \
     v(Bool, useProfiler, false, Normal, nullptr) \
     v(Bool, dumpProfilerDataAtExit, false, Normal, nullptr) \
@@ -310,9 +310,9 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, maximumBinaryStringSwitchTotalLength, 2000, Normal, nullptr) \
     v(Unsigned, maximumRegExpTestInlineCodesize, 500, Normal, "Maximum code size in bytes for inlined RegExp.test JIT code."_s) \
     \
-    v(Unsigned, maximumWasmDepthForInlining, isIOS() ? 2 : 8, Normal, "Maximum inlining depth to consider inlining a wasm function."_s) \
-    v(Unsigned, maximumWasmCalleeSizeForInlining, 200, Normal, "Maximum wasm size in bytes to consider inlining a wasm function."_s) \
-    v(Unsigned, maximumWasmCallerSizeForInlining, 10000, Normal, "Maximum wasm size in bytes for the caller of an inlined function."_s) \
+    v(Unsigned, maximumWebAssemblyDepthForInlining, isIOS() ? 2 : 8, Normal, "Maximum inlining depth to consider inlining a wasm function."_s) \
+    v(Unsigned, maximumWebAssemblyCalleeSizeForInlining, 200, Normal, "Maximum wasm size in bytes to consider inlining a wasm function."_s) \
+    v(Unsigned, maximumWebAssemblyCallerSizeForInlining, 10000, Normal, "Maximum wasm size in bytes for the caller of an inlined function."_s) \
     \
     v(Double, jitPolicyScale, 1.0, Normal, "scale JIT thresholds to this specified ratio between 0.0 (compile ASAP) and 1.0 (compile like normal)."_s) \
     v(Bool, forceEagerCompilation, false, Normal, nullptr) \
@@ -501,7 +501,6 @@ bool hasCapacityToUseLargeGigacage();
     \
     v(Bool, failToCompileWebAssemblyCode, false, Normal, "If true, no Wasm::Plan will sucessfully compile a function."_s) \
     v(Size, webAssemblyPartialCompileLimit, 5000, Normal, "Limit on the number of bytes a Wasm::Plan::compile should attempt before checking for other work."_s) \
-    v(Unsigned, webAssemblyBBQB3OptimizationLevel, 1, Normal, "B3 Optimization level for BBQ Web Assembly module compilations."_s) \
     v(Unsigned, webAssemblyOMGOptimizationLevel, Options::defaultB3OptLevel(), Normal, "B3 Optimization level for OMG Web Assembly module compilations."_s) \
     \
     v(Bool, useBBQTierUpChecks, true, Normal, "Enables tier up checks for our BBQ code."_s) \
@@ -520,14 +519,14 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, maxNumWebAssemblyFastMemories, hasCapacityToUseLargeGigacage() ? 8 : 3, Normal, nullptr) \
     v(Bool, verboseBBQJITAllocation, false, Normal, "Logs extra information about register allocation during BBQ JIT"_s) \
     v(Bool, verboseBBQJITInstructions, false, Normal, "Logs instruction information during BBQ JIT"_s) \
-    v(Bool, useWasmLLInt, true, Normal, nullptr) \
+    v(Bool, useWebAssemblyLLInt, true, Normal, nullptr) \
     v(Bool, useBBQJIT, true, Normal, "allows the BBQ JIT to be used if true"_s) \
     v(Bool, useOMGJIT, !isARM_THUMB2(), Normal, "allows the OMG JIT to be used if true"_s) \
-    v(Bool, useWasmLLIntPrologueOSR, true, Normal, "allows prologue OSR from Wasm LLInt if true"_s) \
-    v(Bool, useWasmLLIntLoopOSR, true, Normal, "allows loop OSR from Wasm LLInt if true"_s) \
-    v(Bool, useWasmLLIntEpilogueOSR, true, Normal, "allows epilogue OSR from Wasm LLInt if true"_s) \
-    v(OptionRange, wasmFunctionIndexRangeToCompile, nullptr, Normal, "wasm function index range to allow compilation on, e.g. 1:100"_s) \
-    v(Bool, wasmLLIntTiersUpToBBQ, true, Normal, nullptr) \
+    v(Bool, useWebAssemblyLLIntPrologueOSR, true, Normal, "allows prologue OSR from wasm LLInt if true"_s) \
+    v(Bool, useWebAssemblyLLIntLoopOSR, true, Normal, "allows loop OSR from wasm LLInt if true"_s) \
+    v(Bool, useWebAssemblyLLIntEpilogueOSR, true, Normal, "allows epilogue OSR from wasm LLInt if true"_s) \
+    v(OptionRange, webAssemblyFunctionIndexRangeToCompile, nullptr, Normal, "wasm function index range to allow compilation on, e.g. 1:100"_s) \
+    v(Bool, webAssemblyLLIntTiersUpToBBQ, true, Normal, nullptr) \
     v(Bool, useEagerWebAssemblyModuleHashing, false, Normal, "Unnamed WebAssembly modules are identified in backtraces through their hash, if available."_s) \
     v(Bool, useArrayAllocationProfiling, true, Normal, "If true, we will use our normal array allocation profiling. If false, the allocation profile will always claim to be undecided."_s) \
     v(Bool, forcePolyProto, false, Normal, "If true, create_this will always create an object with a poly proto structure."_s) \
@@ -567,19 +566,19 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useLLIntICs, true, Normal, "Use property and call ICs in LLInt code."_s) \
     v(Bool, useBaselineJITCodeSharing, is64Bit(), Normal, nullptr) \
     v(Bool, libpasScavengeContinuously, false, Normal, nullptr) \
-    v(Bool, useWasmFaultSignalHandler, true, Normal, nullptr) \
+    v(Bool, useWebAssemblyFaultSignalHandler, true, Normal, nullptr) \
     v(Bool, dumpUnlinkedDFGValidation, false, Normal, nullptr) \
-    v(Bool, dumpWasmOpcodeStatistics, false, Normal, nullptr) \
-    v(Bool, dumpWasmWarnings, false, Normal, nullptr) \
+    v(Bool, dumpWebAssemblyOpcodeStatistics, false, Normal, nullptr) \
+    v(Bool, dumpWebAssemblyWarnings, false, Normal, nullptr) \
     v(Bool, useRecursiveJSONParse, true, Normal, nullptr) \
     v(Unsigned, thresholdForStringReplaceCache, 0x1000, Normal, nullptr) \
-    v(Bool, useWasmIPInt, false, Normal, "Use the in-place interpereter for WASM instead of LLInt."_s) \
-    v(Bool, useWasmIPIntPrologueOSR, true, Normal, "Allow IPInt to tier up during function prologues"_s) \
-    v(Bool, useWasmIPIntLoopOSR, true, Normal, "Allow IPInt to tier up during loop iterations"_s) \
-    v(Bool, useWasmIPIntEpilogueOSR, true, Normal, "Allow IPInt to tier up during function epilogues"_s) \
-    v(Bool, wasmIPIntTiersUpToBBQ, true, Normal, "Allow IPInt to tier up to BBQ"_s) \
-    v(Bool, wasmIPIntTiersUpToOMG, true, Normal, "Allow IPInt to tier up to OMG"_s) \
-    v(Bool, useInterpretedJSEntryWrappers, false, Normal, "Allow some JS->Wasm wrappers to be replaced by jit-less versions."_s) \
+    v(Bool, useWebAssemblyIPInt, false, Normal, "Use the in-place interpereter for WASM instead of LLInt."_s) \
+    v(Bool, useWebAssemblyIPIntPrologueOSR, true, Normal, "Allow IPInt to tier up during function prologues"_s) \
+    v(Bool, useWebAssemblyIPIntLoopOSR, true, Normal, "Allow IPInt to tier up during loop iterations"_s) \
+    v(Bool, useWebAssemblyIPIntEpilogueOSR, true, Normal, "Allow IPInt to tier up during function epilogues"_s) \
+    v(Bool, webAssemblyIPIntTiersUpToBBQ, true, Normal, "Allow IPInt to tier up to BBQ"_s) \
+    v(Bool, webAssemblyIPIntTiersUpToOMG, true, Normal, "Allow IPInt to tier up to OMG"_s) \
+    v(Bool, useInterpretedJSEntryWrappers, false, Normal, "Allow some JS->wasm wrappers to be replaced by jit-less versions."_s) \
     v(Bool, forceAllFunctionsToUseSIMD, false, Normal, "Force all functions to act conservatively w.r.t fp/vector registers for testing."_s) \
     \
     /* Feature Flags */\
@@ -600,7 +599,6 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useStringWellFormed, true, Normal, "Expose the String well-formed methods."_s) \
     v(Bool, useTemporal, false, Normal, "Expose the Temporal object."_s) \
     v(Bool, useTrustedTypes, false, Normal, "Enable trusted types eval protection feature."_s) \
-    v(Bool, useWebAssemblyThreading, true, Normal, "Allow instructions from the wasm threading spec."_s) \
     v(Bool, useWebAssemblyTypedFunctionReferences, true, Normal, "Allow function types from the wasm typed function references spec."_s) \
     v(Bool, useWebAssemblyGC, false, Normal, "Allow gc types from the wasm gc proposal."_s) \
     v(Bool, useWebAssemblySIMD, true, Normal, "Allow the new simd instructions and types from the wasm simd spec."_s) \
@@ -644,11 +642,11 @@ enum OptionEquivalence {
     v(enableExecutableAllocationFuzz, useExecutableAllocationFuzz, SameOption) \
     v(enableOSRExitFuzz, useOSRExitFuzz, SameOption) \
     v(enableDollarVM, useDollarVM, SameOption) \
-    v(enableWebAssembly, useWebAssembly, SameOption) \
     v(maximumOptimizationCandidateInstructionCount, maximumOptimizationCandidateBytecodeCost, SameOption) \
     v(maximumFTLCandidateInstructionCount, maximumFTLCandidateBytecodeCost, SameOption) \
     v(maximumInliningCallerSize, maximumInliningCallerBytecodeCost, SameOption) \
-    v(validateBCE, validateBoundsCheckElimination, SameOption)
+    v(validateBCE, validateBoundsCheckElimination, SameOption) \
+
 
 enum ExperimentalOptionFlags {
     LLIntAndBaselineOnly = 0,

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -3209,7 +3209,7 @@ StackMap BBQJIT::makeStackMap(const ControlData& data, Stack& enclosingStack)
     for (unsigned i = 0; i < m_locals.size(); i ++)
         stackMap[stackMapIndex ++] = OSREntryValue(toB3Rep(m_locals[i]), toB3Type(m_localTypes[i]));
 
-    if (Options::useWasmIPInt()) {
+    if (Options::useWebAssemblyIPInt()) {
         // Do rethrow slots first because IPInt has them in a shadow stack.
         for (const ControlEntry& entry : m_parser->controlStack()) {
             for (unsigned i = 0; i < entry.controlData.implicitSlots(); i ++) {

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -200,7 +200,7 @@ void BBQPlan::work(CompilationEffort effort)
         m_calleeGroup->callsiteCollection().updateCallsitesToCallUs(locker, *m_calleeGroup, CodeLocationLabel<WasmEntryPtrTag>(entrypoint), m_functionIndex, functionIndexSpace);
 
         {
-            if (Options::useWasmIPInt()) {
+            if (Options::useWebAssemblyIPInt()) {
                 IPIntCallee& ipintCallee = m_calleeGroup->m_ipintCallees->at(m_functionIndex).get();
                 Locker locker { ipintCallee.tierUpCounter().m_lock };
                 ipintCallee.setReplacement(callee.copyRef(), mode());

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -764,7 +764,7 @@ public:
     ALWAYS_INLINE uint64_t getConstant(VirtualRegister reg) const { return m_constants[reg.toConstantIndex()]; }
     ALWAYS_INLINE Type getConstantType(VirtualRegister reg) const
     {
-        ASSERT(Options::dumpGeneratedWasmBytecodes());
+        ASSERT(Options::dumpGeneratedWebAssemblyBytecodes());
         return m_constantTypes[reg.toConstantIndex()];
     }
 

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -75,7 +75,7 @@ CalleeGroup::CalleeGroup(VM& vm, MemoryMode mode, ModuleInformation& moduleInfor
     , m_callsiteCollection(m_calleeCount)
 {
     RefPtr<CalleeGroup> protectedThis = this;
-    if (Options::useWasmLLInt()) {
+    if (Options::useWebAssemblyLLInt()) {
         m_plan = adoptRef(*new LLIntPlan(vm, moduleInformation, m_llintCallees->data(), createSharedTask<Plan::CallbackType>([this, protectedThis = WTFMove(protectedThis)] (Plan&) {
             if (!m_plan) {
                 m_errorMessage = makeString("Out of memory while creating LLInt CalleeGroup"_s);
@@ -149,7 +149,7 @@ CalleeGroup::CalleeGroup(VM& vm, MemoryMode mode, ModuleInformation& moduleInfor
     , m_callsiteCollection(m_calleeCount)
 {
     RefPtr<CalleeGroup> protectedThis = this;
-    if (Options::useWasmIPInt()) {
+    if (Options::useWebAssemblyIPInt()) {
         m_plan = adoptRef(*new IPIntPlan(vm, moduleInformation, m_ipintCallees->data(), createSharedTask<Plan::CallbackType>([this, protectedThis = WTFMove(protectedThis)] (Plan&) {
             Locker locker { m_lock };
             if (m_plan->failed()) {

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
@@ -102,7 +102,7 @@ public:
         if (!m_bbqCallees.isEmpty() && m_bbqCallees[calleeIndex])
             return *m_bbqCallees[calleeIndex].get();
 #endif
-        if (Options::useWasmIPInt())
+        if (Options::useWebAssemblyIPInt())
             return m_ipintCallees->at(calleeIndex).get();
         return m_llintCallees->at(calleeIndex).get();
     }

--- a/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp
@@ -124,7 +124,7 @@ void activateSignalingMemory()
         if (!Wasm::isSupported())
             return;
 
-        if (!Options::useWasmFaultSignalHandler())
+        if (!Options::useWebAssemblyFaultSignalHandler())
             return;
 
         activateSignalHandlersFor(Signal::AccessFault);
@@ -138,7 +138,7 @@ void prepareSignalingMemory()
         if (!Wasm::isSupported())
             return;
 
-        if (!Options::useWasmFaultSignalHandler())
+        if (!Options::useWebAssemblyFaultSignalHandler())
             return;
 
 #if CPU(ARM64E) && HAVE(HARDENED_MACH_EXCEPTIONS)

--- a/Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.h
@@ -95,7 +95,7 @@ public:
     ALWAYS_INLINE uint64_t getConstant(VirtualRegister reg) const { return m_constants[reg.toConstantIndex()]; }
     ALWAYS_INLINE Type getConstantType(VirtualRegister reg) const
     {
-        ASSERT(Options::dumpGeneratedWasmBytecodes());
+        ASSERT(Options::dumpGeneratedWebAssemblyBytecodes());
         return m_constantTypes[reg.toConstantIndex()];
     }
 

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -490,7 +490,7 @@ auto FunctionParser<Context>::parseBody() -> PartialResult
 
         m_currentOpcode = static_cast<OpType>(op);
 #if ENABLE(WEBASSEMBLY_OMGJIT)
-        if (UNLIKELY(Options::dumpWasmOpcodeStatistics()))
+        if (UNLIKELY(Options::dumpWebAssemblyOpcodeStatistics()))
             WasmOpcodeCounter::singleton().increment(m_currentOpcode);
 #endif
 
@@ -2661,7 +2661,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
 
         ExtAtomicOpType op = static_cast<ExtAtomicOpType>(extOp);
 #if ENABLE(WEBASSEMBLY_OMGJIT)
-        if (UNLIKELY(Options::dumpWasmOpcodeStatistics()))
+        if (UNLIKELY(Options::dumpWebAssemblyOpcodeStatistics()))
             WasmOpcodeCounter::singleton().increment(op);
 #endif
 
@@ -3448,7 +3448,7 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         constexpr bool isReachable = true;
 
         ExtSIMDOpType op = static_cast<ExtSIMDOpType>(extOp);
-        if (UNLIKELY(Options::dumpWasmOpcodeStatistics()))
+        if (UNLIKELY(Options::dumpWebAssemblyOpcodeStatistics()))
             WasmOpcodeCounter::singleton().increment(op);
 
         switch (op) {
@@ -3805,7 +3805,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
 
         ExtGCOpType op = static_cast<ExtGCOpType>(extOp);
 #if ENABLE(WEBASSEMBLY_OMGJIT)
-        if (UNLIKELY(Options::dumpWasmOpcodeStatistics()))
+        if (UNLIKELY(Options::dumpWebAssemblyOpcodeStatistics()))
             WasmOpcodeCounter::singleton().increment(op);
 #endif
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -80,14 +80,14 @@ static inline bool shouldJIT(Wasm::IPIntCallee* callee, RequiredWasmJIT required
         if (!Options::useOMGJIT() || !Wasm::OMGPlan::ensureGlobalOMGAllowlist().containsWasmFunction(callee->functionIndex()))
             return false;
     } else {
-        if (Options::wasmIPIntTiersUpToBBQ()
+        if (Options::webAssemblyIPIntTiersUpToBBQ()
             && (!Options::useBBQJIT() || !Wasm::BBQPlan::ensureGlobalBBQAllowlist().containsWasmFunction(callee->functionIndex())))
             return false;
-        if (!Options::wasmIPIntTiersUpToOMG()
+        if (!Options::webAssemblyIPIntTiersUpToOMG()
             && (!Options::useOMGJIT() || !Wasm::OMGPlan::ensureGlobalOMGAllowlist().containsWasmFunction(callee->functionIndex())))
             return false;
     }
-    if (!Options::wasmFunctionIndexRangeToCompile().isInRange(callee->functionIndex()))
+    if (!Options::webAssemblyFunctionIndexRangeToCompile().isInRange(callee->functionIndex()))
         return false;
     return true;
 }
@@ -128,7 +128,7 @@ static inline bool jitCompileAndSetHeuristics(Wasm::IPIntCallee* callee, Wasm::I
     if (compile) {
         uint32_t functionIndex = callee->functionIndex();
         RefPtr<Wasm::Plan> plan;
-        if (Options::wasmIPIntTiersUpToBBQ() && Wasm::BBQPlan::ensureGlobalBBQAllowlist().containsWasmFunction(functionIndex))
+        if (Options::webAssemblyIPIntTiersUpToBBQ() && Wasm::BBQPlan::ensureGlobalBBQAllowlist().containsWasmFunction(functionIndex))
             plan = adoptRef(*new Wasm::BBQPlan(instance->vm(), const_cast<Wasm::ModuleInformation&>(instance->module().moduleInformation()), functionIndex, callee->hasExceptionHandlers(), instance->calleeGroup(), Wasm::Plan::dontFinalize()));
         else // No need to check OMG allow list: if we didn't want to compile this function, shouldJIT should have returned false.
             plan = adoptRef(*new Wasm::OMGPlan(instance->vm(), Ref<Wasm::Module>(instance->module()), functionIndex, callee->hasExceptionHandlers(), memoryMode, Wasm::Plan::dontFinalize()));
@@ -152,7 +152,7 @@ WASM_IPINT_EXTERN_CPP_DECL(prologue_osr, CallFrame* callFrame)
         WASM_RETURN_TWO(nullptr, nullptr);
     }
 
-    if (!Options::useWasmIPIntPrologueOSR())
+    if (!Options::useWebAssemblyIPIntPrologueOSR())
         WASM_RETURN_TWO(nullptr, nullptr);
 
     dataLogLnIf(Options::verboseOSR(), *callee, ": Entered prologue_osr with tierUpCounter = ", callee->tierUpCounter());
@@ -167,7 +167,7 @@ WASM_IPINT_EXTERN_CPP_DECL(loop_osr, CallFrame* callFrame, uint32_t pc, uint64_t
     Wasm::IPIntCallee* callee = IPINT_CALLEE();
     Wasm::IPIntTierUpCounter& tierUpCounter = callee->tierUpCounter();
 
-    if (!Options::useWebAssemblyOSR() || !Options::useWasmIPIntLoopOSR() || !shouldJIT(callee, RequiredWasmJIT::OMG)) {
+    if (!Options::useWebAssemblyOSR() || !Options::useWebAssemblyIPIntLoopOSR() || !shouldJIT(callee, RequiredWasmJIT::OMG)) {
         ipint_extern_prologue_osr(instance, callFrame);
         WASM_RETURN_TWO(nullptr, nullptr);
     }
@@ -182,7 +182,7 @@ WASM_IPINT_EXTERN_CPP_DECL(loop_osr, CallFrame* callFrame, uint32_t pc, uint64_t
     unsigned loopOSREntryBytecodeOffset = pc;
     const auto& osrEntryData = tierUpCounter.osrEntryDataForLoop(loopOSREntryBytecodeOffset);
 
-    if (Options::wasmIPIntTiersUpToBBQ() && Options::useBBQJIT()) {
+    if (Options::webAssemblyIPIntTiersUpToBBQ() && Options::useBBQJIT()) {
         if (!jitCompileAndSetHeuristics(callee, instance))
             WASM_RETURN_TWO(nullptr, nullptr);
 
@@ -291,7 +291,7 @@ WASM_IPINT_EXTERN_CPP_DECL(epilogue_osr, CallFrame* callFrame)
         callee->tierUpCounter().deferIndefinitely();
         WASM_RETURN_TWO(nullptr, nullptr);
     }
-    if (!Options::useWasmIPIntEpilogueOSR())
+    if (!Options::useWebAssemblyIPIntEpilogueOSR())
         WASM_RETURN_TWO(nullptr, nullptr);
 
     dataLogLnIf(Options::verboseOSR(), *callee, ": Entered epilogue_osr with tierUpCounter = ", callee->tierUpCounter());

--- a/Source/JavaScriptCore/wasm/WasmIPIntTierUpCounter.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntTierUpCounter.h
@@ -63,7 +63,7 @@ public:
 
     void optimizeAfterWarmUp()
     {
-        if (Options::wasmLLIntTiersUpToBBQ())
+        if (Options::webAssemblyLLIntTiersUpToBBQ())
             setNewThreshold(Options::thresholdForBBQOptimizeAfterWarmUp());
         else
             setNewThreshold(Options::thresholdForOMGOptimizeAfterWarmUp());
@@ -76,7 +76,7 @@ public:
 
     void optimizeSoon()
     {
-        if (Options::wasmLLIntTiersUpToBBQ())
+        if (Options::webAssemblyLLIntTiersUpToBBQ())
             setNewThreshold(Options::thresholdForBBQOptimizeSoon());
         else
             setNewThreshold(Options::thresholdForOMGOptimizeSoon());

--- a/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp
@@ -424,7 +424,7 @@ private:
         if (UNLIKELY(!m_jsNullConstant.isValid())) {
             m_jsNullConstant = VirtualRegister(FirstConstantRegisterIndex + m_codeBlock->m_constants.size());
             m_codeBlock->m_constants.append(JSValue::encode(jsNull()));
-            if (UNLIKELY(Options::dumpGeneratedWasmBytecodes()))
+            if (UNLIKELY(Options::dumpGeneratedWebAssemblyBytecodes()))
                 m_codeBlock->m_constantTypes.append(Types::Externref);
         }
         return m_jsNullConstant;
@@ -435,7 +435,7 @@ private:
         if (UNLIKELY(!m_zeroConstant.isValid())) {
             m_zeroConstant = VirtualRegister(FirstConstantRegisterIndex + m_codeBlock->m_constants.size());
             m_codeBlock->m_constants.append(0);
-            if (UNLIKELY(Options::dumpGeneratedWasmBytecodes()))
+            if (UNLIKELY(Options::dumpGeneratedWebAssemblyBytecodes()))
                 m_codeBlock->m_constantTypes.append(Types::I32);
         }
         return m_zeroConstant;
@@ -971,7 +971,7 @@ auto LLIntGenerator::addConstantWithoutPush(Type type, int64_t value) -> Express
     if (!result.isNewEntry)
         return result.iterator->value;
     m_codeBlock->m_constants.append(value);
-    if (UNLIKELY(Options::dumpGeneratedWasmBytecodes()))
+    if (UNLIKELY(Options::dumpGeneratedWebAssemblyBytecodes()))
         m_codeBlock->m_constantTypes.append(type);
     return source;
 }

--- a/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp
@@ -321,7 +321,7 @@ void LLIntPlan::didCompleteCompilation()
 
     unsigned functionCount = m_wasmInternalFunctions.size();
     if (!m_callees && functionCount) {
-        if (UNLIKELY(Options::dumpGeneratedWasmBytecodes())) {
+        if (UNLIKELY(Options::dumpGeneratedWebAssemblyBytecodes())) {
             for (unsigned i = 0; i < functionCount; ++i)
                 BytecodeDumper::dumpBlock(m_wasmInternalFunctions[i].get(), m_moduleInformation, WTF::dataFile());
         }

--- a/Source/JavaScriptCore/wasm/WasmLLIntTierUpCounter.h
+++ b/Source/JavaScriptCore/wasm/WasmLLIntTierUpCounter.h
@@ -61,7 +61,7 @@ public:
 
     void optimizeAfterWarmUp()
     {
-        if (Options::wasmLLIntTiersUpToBBQ())
+        if (Options::webAssemblyLLIntTiersUpToBBQ())
             setNewThreshold(Options::thresholdForBBQOptimizeAfterWarmUp());
         else
             setNewThreshold(Options::thresholdForOMGOptimizeAfterWarmUp());
@@ -74,7 +74,7 @@ public:
 
     void optimizeSoon()
     {
-        if (Options::wasmLLIntTiersUpToBBQ())
+        if (Options::webAssemblyLLIntTiersUpToBBQ())
             setNewThreshold(Options::thresholdForBBQOptimizeSoon());
         else
             setNewThreshold(Options::thresholdForOMGOptimizeSoon());

--- a/Source/JavaScriptCore/wasm/WasmModule.cpp
+++ b/Source/JavaScriptCore/wasm/WasmModule.cpp
@@ -78,7 +78,7 @@ static Plan::CompletionTask makeValidationCallback(Module::AsyncValidationCallba
 {
     return createSharedTask<Plan::CallbackType>([callback = WTFMove(callback)] (Plan& plan) {
         ASSERT(!plan.hasWork());
-        if (Options::useWasmIPInt())
+        if (Options::useWebAssemblyIPInt())
             callback->run(makeValidationResult(static_cast<IPIntPlan&>(plan)));
         else
             callback->run(makeValidationResult(static_cast<LLIntPlan&>(plan)));
@@ -87,7 +87,7 @@ static Plan::CompletionTask makeValidationCallback(Module::AsyncValidationCallba
 
 Module::ValidationResult Module::validateSync(VM& vm, Vector<uint8_t>&& source)
 {
-    if (Options::useWasmIPInt()) {
+    if (Options::useWebAssemblyIPInt()) {
         Ref<IPIntPlan> plan = adoptRef(*new IPIntPlan(vm, WTFMove(source), CompilerMode::Validation, Plan::dontFinalize()));
         Wasm::ensureWorklist().enqueue(plan.get());
         plan->waitForCompletion();
@@ -101,7 +101,7 @@ Module::ValidationResult Module::validateSync(VM& vm, Vector<uint8_t>&& source)
 
 void Module::validateAsync(VM& vm, Vector<uint8_t>&& source, Module::AsyncValidationCallback&& callback)
 {
-    if (Options::useWasmIPInt()) {
+    if (Options::useWebAssemblyIPInt()) {
         Ref<Plan> plan = adoptRef(*new IPIntPlan(vm, WTFMove(source), CompilerMode::Validation, makeValidationCallback(WTFMove(callback))));
         Wasm::ensureWorklist().enqueue(WTFMove(plan));
     } else {
@@ -121,9 +121,9 @@ Ref<CalleeGroup> Module::getOrCreateCalleeGroup(VM& vm, MemoryMode mode)
     // FIXME: We might want to back off retrying at some point:
     // https://bugs.webkit.org/show_bug.cgi?id=170607
     if (!calleeGroup || (calleeGroup->compilationFinished() && !calleeGroup->runnable())) {
-        if (Options::useWasmIPInt())
+        if (Options::useWebAssemblyIPInt())
             m_calleeGroups[static_cast<uint8_t>(mode)] = calleeGroup = CalleeGroup::createFromIPInt(vm, mode, const_cast<ModuleInformation&>(moduleInformation()), m_ipintCallees.copyRef());
-        else if (Options::useWasmLLInt())
+        else if (Options::useWebAssemblyLLInt())
             m_calleeGroups[static_cast<uint8_t>(mode)] = calleeGroup = CalleeGroup::createFromLLInt(vm, mode, const_cast<ModuleInformation&>(moduleInformation()), m_llintCallees.copyRef());
         else
             m_calleeGroups[static_cast<uint8_t>(mode)] = calleeGroup = CalleeGroup::createFromLLInt(vm, mode, const_cast<ModuleInformation&>(moduleInformation()), nullptr);

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.h
@@ -140,7 +140,7 @@ struct ModuleInformation : public ThreadSafeRefCounted<ModuleInformation> {
         if (Options::forceAllFunctionsToUseSIMD())
             return true;
         // The LLInt discovers this value.
-        ASSERT(Options::useWasmLLInt() || Options::useWasmIPInt());
+        ASSERT(Options::useWebAssemblyLLInt() || Options::useWebAssemblyIPInt());
 
         return functions[index].usesSIMD;
     }

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -4049,7 +4049,7 @@ void OMGIRGenerator::emitLoopTierUpCheck(uint32_t loopIndex, const Stack& enclos
     for (auto& local : m_locals)
         stackmap.append(get(local));
 
-    if (Options::useWasmIPInt()) {
+    if (Options::useWebAssemblyIPInt()) {
         // Do rethrow slots first because IPInt has them in a shadow stack.
         for (unsigned controlIndex = 0; controlIndex < m_parser->controlStack().size(); ++controlIndex) {
             auto& data = m_parser->controlStack()[controlIndex].controlData;
@@ -4801,8 +4801,8 @@ auto OMGIRGenerator::createTailCallPatchpoint(BasicBlock* block, CallInformation
 bool OMGIRGenerator::canInline() const
 {
     ASSERT(!m_inlinedBytes || !m_inlineParent);
-    return m_inlineDepth < Options::maximumWasmDepthForInlining()
-        && m_inlineRoot->m_inlinedBytes.value() < Options::maximumWasmCallerSizeForInlining()
+    return m_inlineDepth < Options::maximumWebAssemblyDepthForInlining()
+        && m_inlineRoot->m_inlinedBytes.value() < Options::maximumWebAssemblyCallerSizeForInlining()
         && (m_inlineDepth <= 1 || StackCheck().isSafeToRecurse());
 }
 
@@ -5017,7 +5017,7 @@ auto OMGIRGenerator::addCall(uint32_t functionIndex, const TypeDefinition& signa
 
     if (callType == CallType::Call
         && functionIndex - m_numImportFunctions != m_functionIndex
-        && m_info.functionWasmSizeImportSpace(functionIndex) < Options::maximumWasmCalleeSizeForInlining()
+        && m_info.functionWasmSizeImportSpace(functionIndex) < Options::maximumWebAssemblyCalleeSizeForInlining()
         && isAnyOMG(m_compilationMode)
         && canInline()
         && !m_info.callCanClobberInstance(functionIndex)) {
@@ -5270,7 +5270,7 @@ static bool shouldDumpIRFor(uint32_t functionIndex)
     static LazyNeverDestroyed<FunctionAllowlist> dumpAllowlist;
     static std::once_flag initializeAllowlistFlag;
     std::call_once(initializeAllowlistFlag, [] {
-        const char* functionAllowlistFile = Options::wasmOMGFunctionsToDump();
+        const char* functionAllowlistFile = Options::webAssemblyOMGFunctionsToDump();
         dumpAllowlist.construct(functionAllowlistFile);
     });
     return dumpAllowlist->shouldDumpWasmFunction(functionIndex);
@@ -5311,9 +5311,7 @@ Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileOMG(Compilati
     // optLevel=1.
     procedure.setNeedsUsedRegisters(false);
     
-    procedure.setOptLevel(isAnyBBQ(compilationMode)
-        ? Options::webAssemblyBBQB3OptimizationLevel()
-        : Options::webAssemblyOMGOptimizationLevel());
+    procedure.setOptLevel(Options::webAssemblyOMGOptimizationLevel());
 
     procedure.code().setForceIRCRegisterAllocation();
 

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -183,13 +183,13 @@ void OMGPlan::work(CompilationEffort)
                 bbqCallee->setReplacement(callee.copyRef());
                 bbqCallee->tierUpCount()->setCompilationStatusForOMG(mode(), TierUpCount::CompilationStatus::Compiled);
             }
-            if (Options::useWasmIPInt() && m_calleeGroup->m_ipintCallees) {
+            if (Options::useWebAssemblyIPInt() && m_calleeGroup->m_ipintCallees) {
                 IPIntCallee& ipintCallee = m_calleeGroup->m_ipintCallees->at(m_functionIndex).get();
                 Locker locker { ipintCallee.tierUpCounter().m_lock };
                 ipintCallee.setReplacement(callee.copyRef(), mode());
                 ipintCallee.tierUpCounter().setCompilationStatus(mode(), IPIntTierUpCounter::CompilationStatus::Compiled);
             }
-            if (!Options::useWasmIPInt() && m_calleeGroup->m_llintCallees) {
+            if (!Options::useWebAssemblyIPInt() && m_calleeGroup->m_llintCallees) {
                 LLIntCallee& llintCallee = m_calleeGroup->m_llintCallees->at(m_functionIndex).get();
                 Locker locker { llintCallee.tierUpCounter().m_lock };
                 llintCallee.setReplacement(callee.copyRef(), mode());

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -267,7 +267,7 @@ static void doOSREntry(Instance* instance, Probe::Context& context, BBQCallee& c
 
 inline bool shouldJIT(unsigned functionIndex)
 {
-    if (!Options::wasmFunctionIndexRangeToCompile().isInRange(functionIndex))
+    if (!Options::webAssemblyFunctionIndexRangeToCompile().isInRange(functionIndex))
         return false;
     return true;
 }

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -269,7 +269,7 @@ auto SectionParser::parseResizableLimits(uint32_t& initial, std::optional<uint32
     WASM_PARSER_FAIL_IF(!parseVarUInt32(initial), "can't parse resizable limits initial page count"_s);
 
     isShared = flags == 0x3;
-    WASM_PARSER_FAIL_IF(isShared && !Options::useWasmFaultSignalHandler(), "shared memory is not enabled"_s);
+    WASM_PARSER_FAIL_IF(isShared && !Options::useWebAssemblyFaultSignalHandler(), "shared memory is not enabled"_s);
 
     if (flags) {
         uint32_t maximumInt;
@@ -1410,7 +1410,7 @@ auto SectionParser::parseCustom() -> PartialResult
         if (nameSection)
             m_info->nameSection = WTFMove(*nameSection);
         else
-            dataLogLnIf(Options::dumpWasmWarnings(), "Could not parse name section: ", nameSection.error());
+            dataLogLnIf(Options::dumpWebAssemblyWarnings(), "Could not parse name section: ", nameSection.error());
     } else if (section.name == branchHintsName) {
         BranchHintsSectionParser branchHintsSectionParser(section.payload, m_info);
         branchHintsSectionParser.parse();

--- a/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
@@ -75,7 +75,7 @@ NEVER_INLINE auto WARN_UNUSED_RETURN StreamingParser::fail(Args... args) -> Stat
 static void dumpWasmSource(const Vector<uint8_t>& source)
 {
     static int count = 0;
-    const char* file = Options::dumpWasmSourceFileName();
+    const char* file = Options::dumpWebAssemblySourceFileName();
     if (!file)
         return;
     auto fileHandle = FileSystem::openFile(WTF::makeString(span(file), (count++), ".wasm"_s),
@@ -99,9 +99,9 @@ StreamingParser::StreamingParser(ModuleInformation& info, StreamingParserClient&
     dataLogLnIf(WasmStreamingParserInternal::verbose, "starting validation");
 
 #if ASSERT_ENABLED
-    dataLogLnIf(!!Options::dumpWasmSourceFileName(), "Wasm streaming parser created, capturing source.");
+    dataLogLnIf(!!Options::dumpWebAssemblySourceFileName(), "Wasm streaming parser created, capturing source.");
 #else
-    dataLogLnIf(!!Options::dumpWasmSourceFileName(), "Wasm streaming parser created, but we can only dump source in debug builds.");
+    dataLogLnIf(!!Options::dumpWebAssemblySourceFileName(), "Wasm streaming parser created, but we can only dump source in debug builds.");
 #endif
 }
 
@@ -281,7 +281,7 @@ auto StreamingParser::consumeVarUInt32(std::span<const uint8_t> bytes, size_t& o
 auto StreamingParser::addBytes(std::span<const uint8_t> bytes, IsEndOfStream isEndOfStream) -> State
 {
 #if ASSERT_ENABLED
-    if (Options::dumpWasmSourceFileName()) {
+    if (Options::dumpWebAssemblySourceFileName()) {
         m_buffer.append(bytes);
 
         if (isEndOfStream == IsEndOfStream::Yes) {

--- a/Source/JavaScriptCore/wasm/WasmWorklist.cpp
+++ b/Source/JavaScriptCore/wasm/WasmWorklist.cpp
@@ -224,7 +224,7 @@ Worklist::Worklist()
     : m_lock(Box<Lock>::create())
     , m_planEnqueued(AutomaticThreadCondition::create())
 {
-    unsigned numberOfCompilationThreads = Options::useConcurrentJIT() ? Options::numberOfWasmCompilerThreads() : 1;
+    unsigned numberOfCompilationThreads = Options::useConcurrentJIT() ? Options::numberOfWebAssemblyCompilerThreads() : 1;
     Locker locker { *m_lock };
     m_threads = Vector<Ref<Thread>>(numberOfCompilationThreads, [&](size_t) {
         return Worklist::Thread::create(locker, *this);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -137,7 +137,7 @@ void JSWebAssemblyInstance::finalizeCreation(VM& vm, JSGlobalObject* globalObjec
     // results, so that later when memory imports become available, the appropriate CalleeGroup can be used.
     // If LLInt is disabled, we instead defer compilation to module evaluation.
     // If the code is already compiled, e.g. the module was already instantiated before, we do not re-initialize.
-    if (Options::useWasmLLInt() && module()->moduleInformation().hasMemoryImport())
+    if (Options::useWebAssemblyLLInt() && module()->moduleInformation().hasMemoryImport())
         module()->module().copyInitialCalleeGroupToAllMemoryModes(memoryMode());
 
     for (unsigned importFunctionNum = 0; importFunctionNum < instance().numImportFunctions(); ++importFunctionNum) {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp
@@ -110,7 +110,7 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyMemory, (JSGlobalObject* globalOb
     // Even though Options::useSharedArrayBuffer() is false, we can create SharedArrayBuffer through wasm shared memory.
     // But we cannot send SharedArrayBuffer to the other workers, so it is not effective.
     MemorySharingMode sharingMode = MemorySharingMode::Default;
-    if (LIKELY(Options::useWasmFaultSignalHandler())) {
+    if (LIKELY(Options::useWebAssemblyFaultSignalHandler())) {
         JSValue sharedValue = memoryDescriptor->get(globalObject, Identifier::fromString(vm, "shared"_s));
         RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
         bool shared = sharedValue.toBoolean(globalObject);

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -674,12 +674,12 @@ end
 
 # We force all tests to use a smaller (1.5M) stack so that stack overflow tests can run faster.
 BASE_OPTIONS = ["--validateOptions=true", "--useFTLJIT=false", "--useFunctionDotArguments=true", "--validateExceptionChecks=true", "--useDollarVM=true", "--maxPerThreadStackUsage=1572864"]
-EAGER_OPTIONS = ["--thresholdForJITAfterWarmUp=10", "--thresholdForJITSoon=10", "--thresholdForOptimizeAfterWarmUp=20", "--thresholdForOptimizeAfterLongWarmUp=20", "--thresholdForOptimizeSoon=20", "--thresholdForFTLOptimizeAfterWarmUp=20", "--thresholdForFTLOptimizeSoon=20", "--thresholdForOMGOptimizeAfterWarmUp=20", "--thresholdForOMGOptimizeSoon=20", "--maximumEvalCacheableSourceLength=150000", "--useEagerCodeBlockJettisonTiming=true", "--repatchBufferingCountdown=0"]
+EAGER_OPTIONS = ["--validateOptions=true", "--thresholdForJITAfterWarmUp=10", "--thresholdForJITSoon=10", "--thresholdForOptimizeAfterWarmUp=20", "--thresholdForOptimizeAfterLongWarmUp=20", "--thresholdForOptimizeSoon=20", "--thresholdForFTLOptimizeAfterWarmUp=20", "--thresholdForFTLOptimizeSoon=20", "--thresholdForOMGOptimizeAfterWarmUp=20", "--thresholdForOMGOptimizeSoon=20", "--maximumEvalCacheableSourceLength=150000", "--useEagerCodeBlockJettisonTiming=true", "--repatchBufferingCountdown=0"]
 # NOTE: Tests rely on this using scribbleFreeCells.
-NO_CJIT_OPTIONS = ["--useConcurrentJIT=false", "--thresholdForJITAfterWarmUp=100", "--scribbleFreeCells=true"]
+NO_CJIT_OPTIONS = ["--validateOptions=true", "--useConcurrentJIT=false", "--thresholdForJITAfterWarmUp=100", "--scribbleFreeCells=true"]
 B3O1_OPTIONS = ["--defaultB3OptLevel=1", "--useDataICInFTL=1", "--forceUnlinkedDFG=1"]
 B3O0_OPTIONS = ["--maxDFGNodesInBasicBlockForPreciseAnalysis=100", "--defaultB3OptLevel=0"]
-FTL_OPTIONS = ["--useFTLJIT=true"]
+FTL_OPTIONS = ["--validateOptions=true", "--useFTLJIT=true"]
 FORCE_LLINT_EXIT_OPTIONS = ["--forceOSRExitToLLInt=true"]
 EXECUTABLE_FUZZER_OPTIONS = ["--useExecutableAllocationFuzz=true", "--fireExecutableAllocationFuzzRandomly=true"]
 
@@ -1814,11 +1814,11 @@ def runWebAssembly
         run("wasm-eager-jettison", "-m", "--forceCodeBlockToJettisonDueToOldAge=true", "--useRandomizingExecutableIslandAllocation=true", "--verifyGC=true", *FTL_OPTIONS)
         run("wasm-slow-memory", "-m", "--useWebAssemblyFastMemory=false", *FTL_OPTIONS)
         run("wasm-collect-continuously", "-m", "--collectContinuously=true", "--verifyGC=true", *FTL_OPTIONS) if shouldCollectContinuously?
-        run("wasm-bbq", "-m", "--useWasmLLInt=false", *FTL_OPTIONS)
+        run("wasm-bbq", "-m", "--useWebAssemblyLLInt=false", *FTL_OPTIONS)
         if $isFTLPlatform
-            run("wasm-omg", "-m", "--useWasmLLInt=true", "--useBBQJIT=false", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0", *FTL_OPTIONS)
+            run("wasm-omg", "-m", "--useWebAssemblyLLInt=true", "--useBBQJIT=false", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0", *FTL_OPTIONS)
             run("wasm-simd", "-m", "--useWebAssemblySIMD=1", "--forceAllFunctionsToUseSIMD=1", *FTL_OPTIONS) unless !$isSIMDPlatform
-            run("wasm-aggressive-inline", "-m", "--maximumWasmCalleeSizeForInlining=2147483647", "--maximumWasmCallerSizeForInlining=2147483647", "--maximumWasmDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
+            run("wasm-aggressive-inline", "-m", "--maximumWebAssemblyCalleeSizeForInlining=2147483647", "--maximumWebAssemblyCallerSizeForInlining=2147483647", "--maximumWebAssemblyDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
         end
     end
 end
@@ -1843,11 +1843,11 @@ def runWebAssemblyJetStream2
         run("wasm-eager-jettison", "--forceCodeBlockToJettisonDueToOldAge=true", "--verifyGC=true", *FTL_OPTIONS)
         run("wasm-slow-memory", "--useWebAssemblyFastMemory=false", *FTL_OPTIONS)
         run("wasm-collect-continuously", "--collectContinuously=true", "--verifyGC=true", *FTL_OPTIONS) if shouldCollectContinuously?
-        run("wasm-bbq", "--useWasmLLInt=false", *FTL_OPTIONS)
+        run("wasm-bbq", "--useWebAssemblyLLInt=false", *FTL_OPTIONS)
         if $isFTLPlatform
-            run("wasm-omg", "--useWasmLLInt=true", "--useBBQJIT=false", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0", *FTL_OPTIONS)
+            run("wasm-omg", "--useWebAssemblyLLInt=true", "--useBBQJIT=false", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0", *FTL_OPTIONS)
             run("wasm-simd", "--useWebAssemblySIMD=1", "--forceAllFunctionsToUseSIMD=1", *FTL_OPTIONS) unless !$isSIMDPlatform
-            run("wasm-aggressive-inline", "--maximumWasmCalleeSizeForInlining=2147483647", "--maximumWasmCallerSizeForInlining=2147483647", "--maximumWasmDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
+            run("wasm-aggressive-inline", "--maximumWebAssemblyCalleeSizeForInlining=2147483647", "--maximumWebAssemblyCallerSizeForInlining=2147483647", "--maximumWebAssemblyDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
         end
     end
 end
@@ -1874,11 +1874,11 @@ def runWebAssemblySuite(*optionalTestSpecificOptions)
         run("wasm-eager-jettison", "--forceCodeBlockToJettisonDueToOldAge=true", "--useRandomizingExecutableIslandAllocation=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions))
         run("wasm-slow-memory", "--useWebAssemblyFastMemory=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
         run("wasm-collect-continuously", "--collectContinuously=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions)) if shouldCollectContinuously?
-        run("wasm-bbq", "--useWasmLLInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
+        run("wasm-bbq", "--useWebAssemblyLLInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
         if $isFTLPlatform
-            run("wasm-omg", "--useWasmLLInt=true", "--useBBQJIT=false", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0", *(FTL_OPTIONS + optionalTestSpecificOptions))
+            run("wasm-omg", "--useWebAssemblyLLInt=true", "--useBBQJIT=false", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0", *(FTL_OPTIONS + optionalTestSpecificOptions))
             run("wasm-simd", "--useWebAssemblySIMD=1", "--forceAllFunctionsToUseSIMD=1", *(FTL_OPTIONS + optionalTestSpecificOptions)) unless !$isSIMDPlatform
-            run("wasm-aggressive-inline", "--maximumWasmCalleeSizeForInlining=2147483647", "--maximumWasmCallerSizeForInlining=2147483647", "--maximumWasmDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS + optionalTestSpecificOptions)) unless $skipModes.include?(:wasm_aggressive_inline)
+            run("wasm-aggressive-inline", "--maximumWebAssemblyCalleeSizeForInlining=2147483647", "--maximumWebAssemblyCallerSizeForInlining=2147483647", "--maximumWebAssemblyDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS + optionalTestSpecificOptions)) unless $skipModes.include?(:wasm_aggressive_inline)
         end
     end
 end
@@ -1898,11 +1898,11 @@ def runV8WebAssemblySuite(*optionalTestSpecificOptions)
         run("wasm-eager-jettison", "--forceCodeBlockToJettisonDueToOldAge=true", "--useRandomizingExecutableIslandAllocation=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions))
         run("wasm-slow-memory", "--useWebAssemblyFastMemory=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
         run("wasm-collect-continuously", "--collectContinuously=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions)) if shouldCollectContinuously?
-        run("wasm-bbq", "--useWasmLLInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
+        run("wasm-bbq", "--useWebAssemblyLLInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
         if $isFTLPlatform
-            run("wasm-omg", "--useWasmLLInt=true", "--useBBQJIT=false", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0", *(FTL_OPTIONS + optionalTestSpecificOptions))
+            run("wasm-omg", "--useWebAssemblyLLInt=true", "--useBBQJIT=false", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0", *(FTL_OPTIONS + optionalTestSpecificOptions))
             run("wasm-simd", "--useWebAssemblySIMD=1", "--forceAllFunctionsToUseSIMD=1", *(FTL_OPTIONS + optionalTestSpecificOptions)) unless !$isSIMDPlatform
-            run("wasm-aggressive-inline", "--maximumWasmCalleeSizeForInlining=2147483647", "--maximumWasmCallerSizeForInlining=2147483647", "--maximumWasmDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS + optionalTestSpecificOptions)) unless $skipModes.include?(:wasm_aggressive_inline)
+            run("wasm-aggressive-inline", "--maximumWebAssemblyCalleeSizeForInlining=2147483647", "--maximumWebAssemblyCallerSizeForInlining=2147483647", "--maximumWebAssemblyDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS + optionalTestSpecificOptions)) unless $skipModes.include?(:wasm_aggressive_inline)
         end
     end
 end
@@ -1943,11 +1943,11 @@ def runWebAssemblyWithHarness(*optionalTestSpecificOptions)
         runWasmHarnessTest("wasm-eager-jettison", "--forceCodeBlockToJettisonDueToOldAge=true", "--useRandomizingExecutableIslandAllocation=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions))
         runWasmHarnessTest("wasm-slow-memory", "--useWebAssemblyFastMemory=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
         runWasmHarnessTest("wasm-collect-continuously", "--collectContinuously=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions)) if shouldCollectContinuously?
-        runWasmHarnessTest("wasm-bbq", "--useWasmLLInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions)) # Doesn't actually depend on FTL, but we enable it on the same platforms for now.
+        runWasmHarnessTest("wasm-bbq", "--useWebAssemblyLLInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions)) # Doesn't actually depend on FTL, but we enable it on the same platforms for now.
         if $isFTLPlatform
-            runWasmHarnessTest("wasm-omg", "--useWasmLLInt=true", "--useBBQJIT=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
+            runWasmHarnessTest("wasm-omg", "--useWebAssemblyLLInt=true", "--useBBQJIT=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
             runWasmHarnessTest("wasm-simd", "--useWebAssemblySIMD=1", "--forceAllFunctionsToUseSIMD=1", *FTL_OPTIONS) unless !$isSIMDPlatform
-            runWasmHarnessTest("wasm-aggressive-inline", "--maximumWasmCalleeSizeForInlining=2147483647", "--maximumWasmCallerSizeForInlining=2147483647", "--maximumWasmDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
+            runWasmHarnessTest("wasm-aggressive-inline", "--maximumWebAssemblyCalleeSizeForInlining=2147483647", "--maximumWebAssemblyCallerSizeForInlining=2147483647", "--maximumWebAssemblyDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
         end
     end
 end
@@ -1965,11 +1965,11 @@ def runWebAssemblyEmscripten(mode)
         run("wasm-no-cjit", *(FTL_OPTIONS + NO_CJIT_OPTIONS))
         run("wasm-eager-jettison", "--forceCodeBlockToJettisonDueToOldAge=true", "--useRandomizingExecutableIslandAllocation=true", "--verifyGC=true", *FTL_OPTIONS)
         run("wasm-collect-continuously", "--collectContinuously=true", "--verifyGC=true", *FTL_OPTIONS) if shouldCollectContinuously?
-        run("wasm-bbq", "--useWasmLLInt=false", *FTL_OPTIONS) # Doesn't actually depend on FTL, but we enable it on the same platforms for now.
+        run("wasm-bbq", "--useWebAssemblyLLInt=false", *FTL_OPTIONS) # Doesn't actually depend on FTL, but we enable it on the same platforms for now.
         if $isFTLPlatform
-            run("wasm-omg", "--useWasmLLInt=true", "--useBBQJIT=false", *FTL_OPTIONS)
+            run("wasm-omg", "--useWebAssemblyLLInt=true", "--useBBQJIT=false", *FTL_OPTIONS)
             run("wasm-simd", "--useWebAssemblySIMD=1", "--forceAllFunctionsToUseSIMD=1", *FTL_OPTIONS) unless !$isSIMDPlatform
-            run("wasm-aggressive-inline", "--maximumWasmCalleeSizeForInlining=2147483647", "--maximumWasmCallerSizeForInlining=2147483647", "--maximumWasmDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
+            run("wasm-aggressive-inline", "--maximumWebAssemblyCalleeSizeForInlining=2147483647", "--maximumWebAssemblyCallerSizeForInlining=2147483647", "--maximumWebAssemblyDepthForInlining=5", *(FTL_OPTIONS + EAGER_OPTIONS)) unless $skipModes.include?(:wasm_aggressive_inline)
         end
     end
 end
@@ -1994,9 +1994,9 @@ def runWebAssemblySpecTestBase(mode, specHarnessPath, postfix, *optionalTestSpec
         runWithOutputHandler("wasm-no-cjit" + (postfix || ''), noisyOutputHandler, specHarnessJsPath,  *(FTL_OPTIONS + NO_CJIT_OPTIONS + optionalTestSpecificOptions))
         runWithOutputHandler("wasm-eager-jettison" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--forceCodeBlockToJettisonDueToOldAge=true", "--useRandomizingExecutableIslandAllocation=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions))
         runWithOutputHandler("wasm-collect-continuously" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--collectContinuously=true", "--verifyGC=true", *(FTL_OPTIONS + optionalTestSpecificOptions)) if shouldCollectContinuously?
-        runWithOutputHandler("wasm-bbq" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--useWasmLLInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
+        runWithOutputHandler("wasm-bbq" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--useWebAssemblyLLInt=false", *(FTL_OPTIONS + optionalTestSpecificOptions))
         if $isFTLPlatform
-            runWithOutputHandler("wasm-omg" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--useWasmLLInt=true", "--useBBQJIT=false", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0", *(FTL_OPTIONS + optionalTestSpecificOptions))
+            runWithOutputHandler("wasm-omg" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--useWebAssemblyLLInt=true", "--useBBQJIT=false", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0", *(FTL_OPTIONS + optionalTestSpecificOptions))
             runWithOutputHandler("wasm-simd" + (postfix || ''), noisyOutputHandler, specHarnessJsPath, "--useWebAssemblySIMD=1", "--forceAllFunctionsToUseSIMD=1", *(FTL_OPTIONS + optionalTestSpecificOptions))
         end
     end
@@ -2021,7 +2021,7 @@ end
 def runWebAssemblySIMDSpecTest(mode)
     return if !$isSIMDPlatform
     runWebAssemblySpecTestBase(mode, "spec-harness", nil, "--useWebAssemblySIMD=true")
-    runWebAssemblySpecTestBase(mode, "spec-harness", "-eager", "--useWebAssemblySIMD=true", "--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0")
+    runWebAssemblySpecTestBase(mode, "spec-harness", "-eager", "--useWebAssemblySIMD=true", "--useBBQJIT=1", "--useWebAssemblyLLInt=1", "--webAssemblyLLIntTiersUpToBBQ=1", "--thresholdForOMGOptimizeAfterWarmUp=0", "--thresholdForOMGOptimizeSoon=0")
 end
 
 def runWebAssemblyTailCallSpecTest(mode)


### PR DESCRIPTION
#### 9dd3ce144c26c8d10468250e36eebc8e9968716e
<pre>
Canonicalize wasm options
<a href="https://bugs.webkit.org/show_bug.cgi?id=275760">https://bugs.webkit.org/show_bug.cgi?id=275760</a>

Reviewed by Yusuke Suzuki and Darin Adler.

It is always a pain trying to remember which combo of JSC_(use|enable)(wasm|WebAssembly)Option=0
to use. Arbitrarily we canoncialize all wasm options to useWebAssemblyOption.

We also change enableJITDebugAssertions to useJITDebugAssertions, and
remove useWebAssemblyThreading and webAssemblyBBQB3OptimizationLevel as
they are disused.

* Source/JavaScriptCore/assembler/LinkBuffer.h:
* Source/JavaScriptCore/assembler/MacroAssembler.cpp:
(JSC::MacroAssembler::jitAssert):
* Source/JavaScriptCore/assembler/MacroAssemblerCodeRef.cpp:
(JSC::shouldDumpDisassemblyFor):
* Source/JavaScriptCore/b3/B3Procedure.h:
(JSC::B3::Procedure::usesSIMD const):
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::overrideDefaults):
(JSC::disableAllJITOptions):
(JSC::Options::notifyOptionsChanged):
(JSC::Options::assertOptionsAreCoherent):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::makeStackMap):
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::work):
* Source/JavaScriptCore/wasm/WasmCallee.h:
* Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp:
(JSC::Wasm::CalleeGroup::CalleeGroup):
* Source/JavaScriptCore/wasm/WasmCalleeGroup.h:
* Source/JavaScriptCore/wasm/WasmFaultSignalHandler.cpp:
(JSC::Wasm::activateSignalingMemory):
(JSC::Wasm::prepareSignalingMemory):
* Source/JavaScriptCore/wasm/WasmFunctionCodeBlockGenerator.h:
(JSC::Wasm::FunctionCodeBlockGenerator::getConstantType const):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseBody):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseUnreachableExpression):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::shouldJIT):
(JSC::IPInt::jitCompileAndSetHeuristics):
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmIPIntTierUpCounter.h:
(JSC::Wasm::IPIntTierUpCounter::optimizeAfterWarmUp):
(JSC::Wasm::IPIntTierUpCounter::optimizeSoon):
* Source/JavaScriptCore/wasm/WasmLLIntGenerator.cpp:
(JSC::Wasm::LLIntGenerator::jsNullConstant):
(JSC::Wasm::LLIntGenerator::zeroConstant):
(JSC::Wasm::LLIntGenerator::addConstantWithoutPush):
* Source/JavaScriptCore/wasm/WasmLLIntPlan.cpp:
(JSC::Wasm::LLIntPlan::didCompleteCompilation):
* Source/JavaScriptCore/wasm/WasmLLIntTierUpCounter.h:
(JSC::Wasm::LLIntTierUpCounter::optimizeAfterWarmUp):
(JSC::Wasm::LLIntTierUpCounter::optimizeSoon):
* Source/JavaScriptCore/wasm/WasmModule.cpp:
(JSC::Wasm::makeValidationCallback):
(JSC::Wasm::Module::validateSync):
(JSC::Wasm::Module::validateAsync):
(JSC::Wasm::Module::getOrCreateCalleeGroup):
* Source/JavaScriptCore/wasm/WasmModuleInformation.h:
(JSC::Wasm::ModuleInformation::usesSIMD const):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::emitLoopTierUpCheck):
(JSC::Wasm::OMGIRGenerator::canInline const):
(JSC::Wasm::OMGIRGenerator::addCall):
(JSC::Wasm::shouldDumpIRFor):
(JSC::Wasm::parseAndCompileOMG):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::emitLoopTierUpCheck):
(JSC::Wasm::OMGIRGenerator::canInline const):
(JSC::Wasm::OMGIRGenerator::addCall):
(JSC::Wasm::shouldDumpIRFor):
(JSC::Wasm::parseAndCompileOMG):
* Source/JavaScriptCore/wasm/WasmOMGPlan.cpp:
(JSC::Wasm::OMGPlan::work):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::shouldJIT):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseResizableLimits):
(JSC::Wasm::SectionParser::parseCustom):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::shouldJIT):
(JSC::LLInt::jitCompileAndSetHeuristics):
(JSC::LLInt::jitCompileSIMDFunction):
(JSC::LLInt::WASM_SLOW_PATH_DECL):
* Source/JavaScriptCore/wasm/WasmStreamingParser.cpp:
(JSC::Wasm::dumpWasmSource):
(JSC::Wasm::StreamingParser::StreamingParser):
(JSC::Wasm::StreamingParser::addBytes):
* Source/JavaScriptCore/wasm/WasmWorklist.cpp:
(JSC::Wasm::Worklist::Worklist):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::finalizeCreation):
* Source/JavaScriptCore/wasm/js/WebAssemblyMemoryConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/280358@main">https://commits.webkit.org/280358@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fef3960c44cfcf857d6becf48ee9d65c53a75c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56374 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35700 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59981 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6810 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58500 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7004 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45670 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4763 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58403 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33576 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48645 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26532 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30356 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5975 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5814 "Built successfully") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/49455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6247 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61665 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/55613 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/282 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6367 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52928 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/282 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48711 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52811 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12481 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/256 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/77371 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31527 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12828 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32613 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33696 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32360 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->