### PR TITLE
Align CocoaColor IPC metadata with actual definition

### DIFF
--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -354,14 +354,6 @@ enum class WebCore::PlatformCALayerLayerType : uint8_t {
     LayerTypeHost,
 };
 
-#if USE(APPKIT)
-using WebCore::CocoaColor = NSColor;
-#endif
-
-#if PLATFORM(IOS_FAMILY)
-using WebCore::CocoaColor = PlatformColor;
-#endif
-
 #if HAVE(WK_SECURE_CODING_DATA_DETECTORS)
 DDScannerResult wrapped by CoreIPCDDScannerResult
 #if PLATFORM(MAC)
@@ -390,7 +382,6 @@ NSValue wrapped by CoreIPCNSValue
 NSURLCredential wrapped by CoreIPCNSURLCredential
 NSPersonNameComponents wrapped by CoreIPCPersonNameComponents
 NSDateComponents wrapped by CoreIPCDateComponents
-PlatformColor wrapped by CoreIPCColor
 NSData wrapped by CoreIPCData
 NSURL wrapped by CoreIPCURL
 NSNull wrapped by CoreIPCNull
@@ -405,8 +396,12 @@ NSDictionary wrapped by CoreIPCDictionary
 NSPresentationIntent wrapped by CoreIPCPresentationIntent
 
 #if PLATFORM(MAC)
-using NSColor = PlatformColor
 using CGDirectDisplayID = uint32_t
+using WebCore::CocoaColor = NSColor;
+NSColor wrapped by CoreIPCColor
+#else
+using WebCore::CocoaColor = UIColor;
+UIColor wrapped by CoreIPCColor
 #endif
 
 using CFTimeInterval = double


### PR DESCRIPTION
#### f47bfdae53699b5e67a16a4055889ac07c7a5c4d
<pre>
Align CocoaColor IPC metadata with actual definition
<a href="https://bugs.webkit.org/show_bug.cgi?id=275772">https://bugs.webkit.org/show_bug.cgi?id=275772</a>
<a href="https://rdar.apple.com/130320800">rdar://130320800</a>

Reviewed by Youenn Fablet.

This is responding to Youenn&apos;s excellent review feedback on 280068@main
which I didn&apos;t notice until after it was merged.

* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:

Canonical link: <a href="https://commits.webkit.org/280279@main">https://commits.webkit.org/280279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82dfda2fba08fc0ef5f844bb1a5002d26405b93a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56148 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8620 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59754 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6584 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6778 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45294 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4564 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58177 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48431 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26330 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30143 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5588 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52119 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6033 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61437 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/56 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6159 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52684 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/56 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48499 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52409 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/51 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8333 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31301 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32387 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33470 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32134 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->