### PR TITLE
[wpe][cross-toolchain-helper][browserperfdash] Define application groups for netdata

### DIFF
--- a/Tools/yocto/meta-openembedded_backport-libbacktrace-and-newer-netdata-to-mickledore-branch.patch
+++ b/Tools/yocto/meta-openembedded_backport-libbacktrace-and-newer-netdata-to-mickledore-branch.patch
@@ -26,6 +26,14 @@ index 609e55f4a..46fa81866 100644
 -COMPATIBLE_HOST:riscv64 = "null"
 +# libunwind does not support RISCV32 yet
  COMPATIBLE_HOST:riscv32 = "null"
+diff --git a/sources/meta-openembedded/meta-webserver/recipes-webadmin/netdata/netdata/apps_groups.conf b/sources/meta-openembedded/meta-webserver/recipes-webadmin/netdata/netdata/apps_groups.conf
+new file mode 100644
+index 000000000..630afe443
+--- /dev/null
++++ b/sources/meta-openembedded/meta-webserver/recipes-webadmin/netdata/netdata/apps_groups.conf
+@@ -0,0 +1,2 @@
++cog: cog
++wpe: WPEWebProcess WPENetworkProcess
 diff --git a/sources/meta-openembedded/meta-webserver/recipes-webadmin/netdata/netdata/netdata.service b/sources/meta-openembedded/meta-webserver/recipes-webadmin/netdata/netdata/netdata.service
 index ca13f7287..b13abad11 100644
 --- a/sources/meta-openembedded/meta-webserver/recipes-webadmin/netdata/netdata/netdata.service
@@ -45,13 +53,13 @@ index ca13f7287..b13abad11 100644
  [Install]
  WantedBy=multi-user.target
 diff --git a/sources/meta-openembedded/meta-webserver/recipes-webadmin/netdata/netdata_1.36.1.bb b/sources/meta-openembedded/meta-webserver/recipes-webadmin/netdata/netdata_1.44.3.bb
-similarity index 76%
+similarity index 75%
 rename from meta-webserver/recipes-webadmin/netdata/netdata_1.36.1.bb
 rename to meta-webserver/recipes-webadmin/netdata/netdata_1.44.3.bb
-index 52d99e770..700c6b234 100644
+index 52d99e770..27cc5c705 100644
 --- a/sources/meta-openembedded/meta-webserver/recipes-webadmin/netdata/netdata_1.36.1.bb
 +++ b/sources/meta-openembedded/meta-webserver/recipes-webadmin/netdata/netdata_1.44.3.bb
-@@ -5,19 +5,18 @@ HOMEPAGE = "https://github.com/netdata/netdata/"
+@@ -5,19 +5,19 @@ HOMEPAGE = "https://github.com/netdata/netdata/"
  LICENSE = "GPL-3.0-only"
  LIC_FILES_CHKSUM = "file://LICENSE;md5=fc9b848046ef54b5eaee6071947abd24"
  
@@ -62,6 +70,7 @@ index 52d99e770..700c6b234 100644
 +SRC_URI = "\
 +    https://github.com/${BPN}/${BPN}/releases/download/v${PV}/${BPN}-v${PV}.tar.gz \
 +    file://netdata.conf \
++    file://apps_groups.conf \
 +    file://netdata.service \
  "
 -SRC_URI[sha256sum] = "f4a1233112b55e07e2862ffda0416255f0aa4c8e2b16929b76fa7ad6b69fd931"
@@ -79,7 +88,7 @@ index 52d99e770..700c6b234 100644
  
  S = "${WORKDIR}/${BPN}-v${PV}"
  
-@@ -41,10 +40,10 @@ SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+@@ -41,10 +41,10 @@ SYSTEMD_AUTO_ENABLE:${PN} = "enable"
  USERADD_PACKAGES = "${PN}"
  USERADD_PARAM:${PN} = "--system --no-create-home --home-dir ${localstatedir}/run/netdata --user-group netdata"
  
@@ -94,7 +103,15 @@ index 52d99e770..700c6b234 100644
  
  # ebpf doesn't compile (or detect) the cross compilation well
  EXTRA_OECONF += "--disable-ebpf"
-@@ -79,4 +78,4 @@ do_install:append() {
+@@ -62,6 +62,7 @@ do_install:append() {
+ 
+     # Install default netdata.conf
+     install -d ${D}${sysconfdir}/netdata
++    install -m 0644 ${WORKDIR}/apps_groups.conf ${D}${sysconfdir}/netdata/
+     install -m 0644 ${WORKDIR}/netdata.conf ${D}${sysconfdir}/netdata/
+     sed -i -e 's,@@sysconfdir,${sysconfdir},g' ${D}${sysconfdir}/netdata/netdata.conf
+     sed -i -e 's,@@libdir,${libexecdir},g' ${D}${sysconfdir}/netdata/netdata.conf
+@@ -79,4 +80,4 @@ do_install:append() {
  
  FILES:${PN} += "${localstatedir}/cache/netdata/ ${localstatedir}/lib/netdata/"
  


### PR DESCRIPTION
#### d161b493908aac112d8682eb7eab88760b1bd130
<pre>
[wpe][cross-toolchain-helper][browserperfdash] Define application groups for netdata
<a href="https://bugs.webkit.org/show_bug.cgi?id=275779">https://bugs.webkit.org/show_bug.cgi?id=275779</a>

Unreviewed configuration change.

Define cog / wpe application groups, so we can query netdata for
per-process-group specific metrics, instead of full system metrics.

The cog process group only measures the &apos;cog&apos; process, whereas
the &apos;wpe&apos; group sums up WPEWebProcess + WPENetworkProcess.

* Tools/yocto/meta-openembedded_backport-libbacktrace-and-newer-netdata-to-mickledore-branch.patch:

Canonical link: <a href="https://commits.webkit.org/280287@main">https://commits.webkit.org/280287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b6af47059b9d2db2d09c03878277e19dd9bacee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8650 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/59784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6614 "Built successfully") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58304 "Failed to checkout and rebase branch from PR 30085") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6808 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/59784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/4590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58207 "Failed to checkout and rebase branch from PR 30085") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/33394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/48461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/59784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/30174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/5791 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5618 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/6063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/61467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/86 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/6188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/61467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/86 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/48528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/61467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/75 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8337 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31331 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32417 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33500 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32164 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->