### PR TITLE
[JSC] Clean up Call IC PolymorphicCallStubRoutine handling

### DIFF
--- a/Source/JavaScriptCore/bytecode/BytecodeList.rb
+++ b/Source/JavaScriptCore/bytecode/BytecodeList.rb
@@ -1417,6 +1417,8 @@ op :llint_default_call_trampoline
 op :llint_virtual_call_trampoline
 op :llint_virtual_construct_trampoline
 op :llint_virtual_tail_call_trampoline
+op :llint_polymorphic_normal_call_trampoline
+op :llint_polymorphic_closure_call_trampoline
 op :checkpoint_osr_exit_from_inlined_call_trampoline
 op :checkpoint_osr_exit_trampoline
 op :normal_osr_exit_trampoline

--- a/Source/JavaScriptCore/bytecode/CallLinkInfo.h
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfo.h
@@ -142,13 +142,6 @@ public:
     bool isDataIC() const { return useDataIC() == UseDataIC::Yes; }
     UseDataIC useDataIC() const { return static_cast<UseDataIC>(m_useDataIC); }
 
-    bool allowStubs() const { return m_allowStubs; }
-
-    void disallowStubs()
-    {
-        m_allowStubs = false;
-    }
-
     void setMonomorphicCallee(VM&, JSCell*, JSObject* callee, CodeBlock*, CodePtr<JSEntryPtrTag>);
     void clearCallee();
     JSObject* callee();
@@ -160,9 +153,7 @@ public:
     void setExecutableDuringCompilation(ExecutableBase*);
     ExecutableBase* executable();
     
-#if ENABLE(JIT)
     void setStub(Ref<PolymorphicCallStubRoutine>&&);
-#endif
     void clearStub();
 
     void setVirtualCall(VM&);
@@ -171,11 +162,7 @@ public:
 
     PolymorphicCallStubRoutine* stub() const
     {
-#if ENABLE(JIT)
         return m_stub.get();
-#else
-        return nullptr;
-#endif
     }
 
     bool seenOnce()
@@ -264,12 +251,10 @@ public:
         return OBJECT_OFFSETOF(CallLinkInfo, u) + OBJECT_OFFSETOF(UnionType, dataIC.m_monomorphicCallDestination);
     }
 
-#if ENABLE(JIT)
     static constexpr ptrdiff_t offsetOfStub()
     {
         return OBJECT_OFFSETOF(CallLinkInfo, m_stub);
     }
-#endif
 
     uint32_t slowPathCount()
     {
@@ -282,13 +267,9 @@ public:
     void forEachDependentCell(const Functor& functor) const
     {
         if (isLinked()) {
-            if (stub()) {
-#if ENABLE(JIT)
+            if (stub())
                 stub()->forEachDependentCell(functor);
-#else
-                RELEASE_ASSERT_NOT_REACHED();
-#endif
-            } else
+            else
                 functor(m_callee.get());
         }
         if (haveLastSeenCallee())
@@ -327,7 +308,6 @@ protected:
     bool m_hasSeenClosure : 1 { false };
     bool m_clearedByGC : 1 { false };
     bool m_clearedByVirtual : 1 { false };
-    bool m_allowStubs : 1 { true };
     unsigned m_callType : 4 { CallType::None }; // CallType
     unsigned m_useDataIC : 1; // UseDataIC
     unsigned m_type : 1; // Type
@@ -353,9 +333,7 @@ protected:
 
     WriteBarrier<JSObject> m_callee;
     WriteBarrier<JSObject> m_lastSeenCallee;
-#if ENABLE(JIT)
     RefPtr<PolymorphicCallStubRoutine> m_stub;
-#endif
     JSCell* m_owner { nullptr };
     CodeOrigin m_codeOrigin { };
 };

--- a/Source/JavaScriptCore/bytecode/CallLinkInfoBase.cpp
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfoBase.cpp
@@ -39,10 +39,10 @@ void CallLinkInfoBase::unlinkOrUpgrade(VM& vm, CodeBlock* oldCodeBlock, CodeBloc
     case CallSiteType::CallLinkInfo:
         static_cast<CallLinkInfo*>(this)->unlinkOrUpgradeImpl(vm, oldCodeBlock, newCodeBlock);
         break;
-#if ENABLE(JIT)
     case CallSiteType::PolymorphicCallNode:
         static_cast<PolymorphicCallNode*>(this)->unlinkOrUpgradeImpl(vm, oldCodeBlock, newCodeBlock);
         break;
+#if ENABLE(JIT)
     case CallSiteType::DirectCall:
         static_cast<DirectCallLinkInfo*>(this)->unlinkOrUpgradeImpl(vm, oldCodeBlock, newCodeBlock);
         break;

--- a/Source/JavaScriptCore/bytecode/CallLinkInfoBase.h
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfoBase.h
@@ -57,8 +57,8 @@ class CallLinkInfoBase : public BasicRawSentinelNode<CallLinkInfoBase> {
 public:
     enum class CallSiteType : uint8_t {
         CallLinkInfo,
-#if ENABLE(JIT)
         PolymorphicCallNode,
+#if ENABLE(JIT)
         DirectCall,
 #endif
         CachedCall,

--- a/Source/JavaScriptCore/bytecode/RepatchInlines.h
+++ b/Source/JavaScriptCore/bytecode/RepatchInlines.h
@@ -147,12 +147,10 @@ ALWAYS_INLINE void* linkFor(VM& vm, JSCell* owner, CallFrame* calleeFrame, CallL
             }
             case CallLinkInfo::Mode::Monomorphic:
             case CallLinkInfo::Mode::Polymorphic: {
-#if ENABLE(JIT)
-                if (kind == CodeForCall && callLinkInfo->allowStubs()) {
+                if (kind == CodeForCall) {
                     linkPolymorphicCall(vm, owner, calleeFrame, *callLinkInfo, CallVariant(internalFunction));
                     break;
                 }
-#endif
                 callLinkInfo->setVirtualCall(vm);
                 break;
             }
@@ -212,12 +210,10 @@ ALWAYS_INLINE void* linkFor(VM& vm, JSCell* owner, CallFrame* calleeFrame, CallL
     }
     case CallLinkInfo::Mode::Monomorphic:
     case CallLinkInfo::Mode::Polymorphic: {
-#if ENABLE(JIT)
-        if (kind == CodeForCall && callLinkInfo->allowStubs()) {
+        if (kind == CodeForCall) {
             linkPolymorphicCall(vm, owner, calleeFrame, *callLinkInfo, CallVariant(callee));
             break;
         }
-#endif
         callLinkInfo->setVirtualCall(vm);
         break;
     }

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -2890,18 +2890,16 @@ void Heap::addCoreConstraints()
                     m_verifierSlotVisitor->append(conservativeRoots);
                 }
             }
-            if (Options::useJIT()) {
-                // JITStubRoutines must be visited after scanning ConservativeRoots since JITStubRoutines depend on the hook executed during gathering ConservativeRoots.
-                SetRootMarkReasonScope rootScope(visitor, RootMarkReason::JITStubRoutines);
+
+            // JITStubRoutines must be visited after scanning ConservativeRoots since JITStubRoutines depend on the hook executed during gathering ConservativeRoots.
+            SetRootMarkReasonScope rootScope(visitor, RootMarkReason::JITStubRoutines);
+            m_jitStubRoutines->traceMarkedStubRoutines(visitor);
+            if (UNLIKELY(m_verifierSlotVisitor)) {
+                // It's important to cast m_verifierSlotVisitor to an AbstractSlotVisitor here
+                // so that we'll call the AbstractSlotVisitor version of traceMarkedStubRoutines().
+                AbstractSlotVisitor& visitor = *m_verifierSlotVisitor;
                 m_jitStubRoutines->traceMarkedStubRoutines(visitor);
-                if (UNLIKELY(m_verifierSlotVisitor)) {
-                    // It's important to cast m_verifierSlotVisitor to an AbstractSlotVisitor here
-                    // so that we'll call the AbstractSlotVisitor version of traceMarkedStubRoutines().
-                    AbstractSlotVisitor& visitor = *m_verifierSlotVisitor;
-                    m_jitStubRoutines->traceMarkedStubRoutines(visitor);
-                }
             }
-            
             lastVersion = m_phaseVersion;
         })),
         ConstraintVolatility::GreyedByExecution);

--- a/Source/JavaScriptCore/heap/JITStubRoutineSet.h
+++ b/Source/JavaScriptCore/heap/JITStubRoutineSet.h
@@ -73,6 +73,7 @@ private:
         GCAwareJITStubRoutine* routine;
     };
     Vector<Routine> m_routines;
+    Vector<GCAwareJITStubRoutine*> m_immutableCodeRoutines;
     Range<uintptr_t> m_range { 0, 0 };
 };
 

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#if ENABLE(JIT)
-
 #include "DFGCodeOriginPool.h"
 #include "JITStubRoutine.h"
 #include "JSObject.h"
@@ -91,6 +89,8 @@ protected:
     bool m_isCodeImmutable : 1 { false };
     bool m_isInSharedJITStubSet : 1 { false };
 };
+
+#if ENABLE(JIT)
 
 class PolymorphicAccessJITStubRoutine : public GCAwareJITStubRoutine {
 public:
@@ -234,6 +234,6 @@ Ref<PolymorphicAccessJITStubRoutine> createICJITStubRoutine(
 
 Ref<PolymorphicAccessJITStubRoutine> createPreCompiledICJITStubRoutine(const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, VM&);
 
-} // namespace JSC
-
 #endif // ENABLE(JIT)
+
+} // namespace JSC

--- a/Source/JavaScriptCore/jit/JITStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/JITStubRoutine.cpp
@@ -31,8 +31,6 @@
 #include "GCAwareJITStubRoutine.h"
 #include "PolymorphicCallStubRoutine.h"
 
-#if ENABLE(JIT)
-
 namespace JSC {
 
 void JITStubRoutine::observeZeroRefCountImpl()
@@ -51,11 +49,12 @@ void JITStubRoutine::runWithDowncast(const Func& function)
     case Type::GCAwareJITStubRoutineType:
         function(static_cast<GCAwareJITStubRoutine*>(this));
         break;
-    case Type::PolymorphicAccessJITStubRoutineType:
-        function(static_cast<PolymorphicAccessJITStubRoutine*>(this));
-        break;
     case Type::PolymorphicCallStubRoutineType:
         function(static_cast<PolymorphicCallStubRoutine*>(this));
+        break;
+#if ENABLE(JIT)
+    case Type::PolymorphicAccessJITStubRoutineType:
+        function(static_cast<PolymorphicAccessJITStubRoutine*>(this));
         break;
     case Type::MarkingGCAwareJITStubRoutineType:
         function(static_cast<MarkingGCAwareJITStubRoutine*>(this));
@@ -63,6 +62,7 @@ void JITStubRoutine::runWithDowncast(const Func& function)
     case Type::GCAwareJITStubRoutineWithExceptionHandlerType:
         function(static_cast<GCAwareJITStubRoutineWithExceptionHandler*>(this));
         break;
+#endif
     }
 }
 
@@ -120,6 +120,3 @@ void JITStubRoutine::operator delete(JITStubRoutine* stubRoutine, std::destroyin
 }
 
 } // namespace JSC
-
-#endif // ENABLE(JIT)
-

--- a/Source/JavaScriptCore/jit/JITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/JITStubRoutine.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#if ENABLE(JIT)
-
 #include "ExecutableAllocator.h"
 #include "MacroAssemblerCodeRef.h"
 #include "StructureID.h"
@@ -62,10 +60,12 @@ public:
     enum class Type : uint8_t {
         JITStubRoutineType,
         GCAwareJITStubRoutineType,
-        PolymorphicAccessJITStubRoutineType,
         PolymorphicCallStubRoutineType,
+#if ENABLE(JIT)
+        PolymorphicAccessJITStubRoutineType,
         MarkingGCAwareJITStubRoutineType,
         GCAwareJITStubRoutineWithExceptionHandlerType,
+#endif
     };
 
     friend class GCAwareJITStubRoutine;
@@ -166,5 +166,3 @@ protected:
     (adoptRef(new JITStubRoutine(FINALIZE_CODE_FOR((codeBlock), (patchBuffer), (resultPtrTag), (simpleName), __VA_ARGS__))))
 
 } // namespace JSC
-
-#endif // ENABLE(JIT)

--- a/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp
+++ b/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp
@@ -26,9 +26,6 @@
 #include "config.h"
 #include "PolymorphicCallStubRoutine.h"
 
-#if ENABLE(JIT)
-
-#include "AccessCase.h"
 #include "CachedCall.h"
 #include "CallLinkInfo.h"
 #include "CodeBlock.h"
@@ -181,21 +178,12 @@ bool PolymorphicCallStubRoutine::visitWeakImpl(VM& vm)
     return isStillLive;
 }
 
-template<typename Visitor>
-ALWAYS_INLINE void PolymorphicCallStubRoutine::markRequiredObjectsInternalImpl(Visitor& visitor)
+void PolymorphicCallStubRoutine::markRequiredObjectsImpl(AbstractSlotVisitor&)
 {
-    forEachDependentCell([&](JSCell* cell) {
-        visitor.appendUnbarriered(cell);
-    });
 }
 
-void PolymorphicCallStubRoutine::markRequiredObjectsImpl(AbstractSlotVisitor& visitor)
+void PolymorphicCallStubRoutine::markRequiredObjectsImpl(SlotVisitor&)
 {
-    markRequiredObjectsInternalImpl(visitor);
-}
-void PolymorphicCallStubRoutine::markRequiredObjectsImpl(SlotVisitor& visitor)
-{
-    markRequiredObjectsInternalImpl(visitor);
 }
 
 void PolymorphicCallStubRoutine::destroy(PolymorphicCallStubRoutine* derived)
@@ -204,5 +192,3 @@ void PolymorphicCallStubRoutine::destroy(PolymorphicCallStubRoutine* derived)
 }
 
 } // namespace JSC
-
-#endif // ENABLE(JIT)

--- a/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h
+++ b/Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#if ENABLE(JIT)
-
 #include "CallEdge.h"
 #include "CallLinkInfoBase.h"
 #include "CallVariant.h"
@@ -123,7 +121,6 @@ public:
     bool isClosureCall() const { return m_isClosureCall; }
 
 private:
-    template<typename Visitor> void markRequiredObjectsInternalImpl(Visitor&);
     void markRequiredObjectsImpl(AbstractSlotVisitor&);
     void markRequiredObjectsImpl(SlotVisitor&);
 
@@ -136,5 +133,3 @@ private:
 };
 
 } // namespace JSC
-
-#endif // ENABLE(JIT)

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.h
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.h
@@ -41,6 +41,7 @@ extern "C" UGPRPair SYSV_ABI llint_trace_operand(CallFrame*, const JSInstruction
 extern "C" UGPRPair SYSV_ABI llint_trace_value(CallFrame*, const JSInstruction*, int fromWhere, VirtualRegister operand) REFERENCED_FROM_ASM WTF_INTERNAL;
 extern "C" UGPRPair SYSV_ABI llint_default_call(CallFrame*, CallLinkInfo*) REFERENCED_FROM_ASM WTF_INTERNAL;
 extern "C" UGPRPair SYSV_ABI llint_virtual_call(CallFrame*, CallLinkInfo*) REFERENCED_FROM_ASM WTF_INTERNAL;
+extern "C" UGPRPair SYSV_ABI llint_polymorphic_call(CallFrame*, CallLinkInfo*) REFERENCED_FROM_ASM WTF_INTERNAL;
 extern "C" void SYSV_ABI llint_write_barrier_slow(CallFrame*, JSCell*) REFERENCED_FROM_ASM WTF_INTERNAL;
 
 #define LLINT_SLOW_PATH_DECL(name) \

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -2552,6 +2552,67 @@ op(llint_virtual_tail_call_trampoline, macro ()
     linkFor(_llint_virtual_call)
 end)
 
+# 64bit:t0 32bit(t0,t1) is callee
+# t2 is CallLinkInfo*
+op(llint_polymorphic_normal_call_trampoline, macro ()
+    if not JSVALUE64
+        bineq t1, CellTag, .slowCase
+    end
+    loadp CallLinkInfo::m_stub[t2], t5
+    addp (constexpr (PolymorphicCallStubRoutine::offsetOfTrailingData())), t5
+
+.loop:
+    loadp CallSlot::m_calleeOrExecutable[t5], t3
+    bpeq t3, t0, .found
+    btpz t3, .slowCase
+    addp (constexpr (sizeof(CallSlot))), t5
+    jmp .loop
+
+.found:
+    loadp CallSlot::m_target[t5], t1
+    loadp CallSlot::m_codeBlock[t5], t5
+    storep t5, CodeBlock - PrologueStackPointerDelta[sp]
+    jmp t1, JSEntryPtrTag
+
+.slowCase:
+    linkFor(_llint_polymorphic_call)
+end)
+
+# 64bit:t0 32bit(t0,t1) is callee
+# t2 is CallLinkInfo*
+op(llint_polymorphic_closure_call_trampoline, macro ()
+    if JSVALUE64
+        btqnz t0, NotCellMask, .slowCase
+    else
+        bineq t1, CellTag, .slowCase
+    end
+
+    bbneq JSCell::m_type[t0], JSFunctionType, .slowCase
+    loadp JSFunction::m_executableOrRareData[t0], t6
+    btpz t6, (constexpr JSFunction::rareDataTag), .isExecutable
+    loadp (FunctionRareData::m_executable - (constexpr JSFunction::rareDataTag))[t6], t6
+.isExecutable:
+
+    loadp CallLinkInfo::m_stub[t2], t5
+    addp (constexpr (PolymorphicCallStubRoutine::offsetOfTrailingData())), t5
+
+.loop:
+    loadp CallSlot::m_calleeOrExecutable[t5], t3
+    bpeq t3, t6, .found
+    btpz t3, .slowCase
+    addp (constexpr (sizeof(CallSlot))), t5
+    jmp .loop
+
+.found:
+    loadp CallSlot::m_target[t5], t1
+    loadp CallSlot::m_codeBlock[t5], t5
+    storep t5, CodeBlock - PrologueStackPointerDelta[sp]
+    jmp t1, JSEntryPtrTag
+
+.slowCase:
+    linkFor(_llint_polymorphic_call)
+end)
+
 if JIT
     macro loadBaselineJITConstantPool()
         # Baseline uses LLInt's PB register for its JIT constant pool.


### PR DESCRIPTION
#### 8d5223b8908d0851e3535e45699f5a78a7524d59
<pre>
[JSC] Clean up Call IC PolymorphicCallStubRoutine handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=275781">https://bugs.webkit.org/show_bug.cgi?id=275781</a>
<a href="https://rdar.apple.com/130337376">rdar://130337376</a>

Reviewed by Justin Michaud.

This patch adds pre-generated LLInt Polymorphic Call IC code. As a result, LLInt w/o JIT can fully use the same
Polymorphic Call IC as the same to JIT version (and this is possible now since we no longer generate any code for Call IC).

* Source/JavaScriptCore/bytecode/BytecodeList.rb:
* Source/JavaScriptCore/bytecode/CallLinkInfo.cpp:
(JSC::CallLinkInfo::clearStub):
(JSC::CallLinkInfo::visitWeak):
(JSC::CallLinkInfo::revertCallToStub):
(JSC::DataOnlyCallLinkInfo::initialize):
(JSC::CallLinkInfo::setStub):
* Source/JavaScriptCore/bytecode/CallLinkInfo.h:
(JSC::CallLinkInfo::stub const):
(JSC::CallLinkInfo::offsetOfStub):
(JSC::CallLinkInfo::forEachDependentCell const):
(JSC::CallLinkInfo::allowStubs const): Deleted.
(JSC::CallLinkInfo::disallowStubs): Deleted.
* Source/JavaScriptCore/bytecode/CallLinkInfoBase.cpp:
(JSC::CallLinkInfoBase::unlinkOrUpgrade):
* Source/JavaScriptCore/bytecode/CallLinkInfoBase.h:
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::linkSlowFor):
(JSC::linkMonomorphicCall):
(JSC::linkPolymorphicCall):
(JSC::ecmaModeFor):
* Source/JavaScriptCore/bytecode/RepatchInlines.h:
(JSC::linkFor):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::addCoreConstraints):
* Source/JavaScriptCore/heap/JITStubRoutineSet.cpp:
(JSC::JITStubRoutineSet::~JITStubRoutineSet):
(JSC::JITStubRoutineSet::add):
(JSC::JITStubRoutineSet::prepareForConservativeScan):
(JSC::JITStubRoutineSet::clearMarks):
(JSC::JITStubRoutineSet::markSlow):
(JSC::JITStubRoutineSet::deleteUnmarkedJettisonedStubRoutines):
(JSC::JITStubRoutineSet::traceMarkedStubRoutines):
* Source/JavaScriptCore/heap/JITStubRoutineSet.h:
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.cpp:
(JSC::GCAwareJITStubRoutine::makeGCAware):
(JSC::GCAwareJITStubRoutine::removeDeadOwners):
* Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h:
* Source/JavaScriptCore/jit/JITStubRoutine.cpp:
(JSC::JITStubRoutine::runWithDowncast):
* Source/JavaScriptCore/jit/JITStubRoutine.h:
* Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.cpp:
(JSC::PolymorphicCallStubRoutine::markRequiredObjectsImpl):
(JSC::PolymorphicCallStubRoutine::markRequiredObjectsInternalImpl): Deleted.
* Source/JavaScriptCore/jit/PolymorphicCallStubRoutine.h:
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::llint_polymorphic_call):
* Source/JavaScriptCore/llint/LLIntSlowPaths.h:
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:

Canonical link: <a href="https://commits.webkit.org/280314@main">https://commits.webkit.org/280314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d89b582956d45fcc9ae6260b23af6b0a620cca9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59771 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6601 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6795 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45340 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4577 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58194 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33381 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48448 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26341 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30161 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5778 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5605 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/49243 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52141 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6049 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61454 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/55402 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/73 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6175 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52709 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/73 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48515 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52474 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/65 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/77162 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8350 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31318 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12786 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32404 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33487 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32151 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->