### PR TITLE
REGRESSION (278484@main): Chinese Input Method (pinyin) is broken on ChatGPT/Google translate

### DIFF
--- a/LayoutTests/editing/selection/ios/navigating-in-subframe-does-not-dismiss-edit-menu-expected.txt
+++ b/LayoutTests/editing/selection/ios/navigating-in-subframe-does-not-dismiss-edit-menu-expected.txt
@@ -1,0 +1,15 @@
+This test verifies that subframe navigation does not dismiss the edit menu. This test requires WebKitTestRunner.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS subFrameLoaded became true
+PASS Selected text
+PASS Menu is still showing
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Select me
+
+
+

--- a/LayoutTests/editing/selection/ios/navigating-in-subframe-does-not-dismiss-edit-menu.html
+++ b/LayoutTests/editing/selection/ios/navigating-in-subframe-does-not-dismiss-edit-menu.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<meta name=viewport content="width=device-width, initial-scale=1">
+<style>
+body, html {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+}
+
+h1 {
+    font-size: 40px;
+}
+
+#target {
+    border: solid tomato 1px;
+    padding: 2px;
+}
+
+iframe {
+    width: 300px;
+    height: 100px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+subFrameLoaded = true;
+
+description("This test verifies that subframe navigation does not dismiss the edit menu. This test requires WebKitTestRunner.");
+
+addEventListener("load", async () => {
+    const subframe = document.querySelector("iframe");
+    subframe.addEventListener("load", () => { subFrameLoaded = true; });
+    subframe.srcdoc = "<p>subframe before reload</p>";
+    await shouldBecomeEqual("subFrameLoaded", "true");
+
+    if (!window.testRunner)
+        return;
+
+    const target = document.getElementById("target");
+    await UIHelper.activateElementAndWaitForInputSession(target);
+    document.execCommand("SelectAll", true);
+    testPassed("Selected text");
+
+    await UIHelper.activateElement(target);
+    await UIHelper.waitForMenuToShow();
+
+    subframe.srcdoc = `<p>subframe after reloading</p>`;
+    await UIHelper.delayFor(800);
+
+    if (await UIHelper.isShowingMenu())
+        testPassed("Menu is still showing");
+    else
+        testFailed("Menu is no longer showing");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+<h1 contenteditable><span id="target">Select</span> me</h1>
+<div><iframe></iframe></div>
+<div id="description"></div>
+<div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7248,10 +7248,6 @@ webkit.org/b/274340 fast/events/ios/key-command-transpose.html [ Pass Timeout ]
 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/entries-after-navigations-in-multiple-windows.html [ Failure ]
 imported/w3c/web-platform-tests/navigation-api/navigation-history-entry/key-id-location-replace-cross-origin.html [ Failure ]
 
-# webkit.org/b/274488 REGRESSION (278902@main): [ iOS ] editing/selection/ios/selection-handles-in-iframe.html and fast/images/text-recognition/iOS.. are timing out 
-editing/selection/ios/selection-handles-in-iframe.html [ Timeout ]
-fast/images/text-recognition/ios/select-word-in-image-overlay-inside-link.html [ Timeout ]
-
 webkit.org/b/271916 media/track/track-in-band-layout.html [ Failure ]
 
 webkit.org/b/274766 [ Debug ] http/wpt/webauthn/public-key-credential-get-success-u2f.https.html [ Failure ]

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1069,7 +1069,6 @@ def headers_for_type(type):
         'WebKit::ContentWorldIdentifier': ['"ContentWorldShared.h"'],
         'WebKit::DocumentEditingContextRequest': ['"DocumentEditingContext.h"'],
         'WebKit::DrawingAreaIdentifier': ['"DrawingAreaInfo.h"'],
-        'WebKit::EditorStateIdentifier': ['"IdentifierTypes.h"'],
         'WebKit::FindDecorationStyle': ['"WebFindOptions.h"'],
         'WebKit::FindOptions': ['"WebFindOptions.h"'],
         'WebKit::GestureRecognizerState': ['"GestureTypes.h"'],

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
@@ -175,7 +175,6 @@ private:
     WebCore::Color accentColor() override;
 
     WebKitWebResourceLoadManager* webResourceLoadManager() override;
-    void didClearEditorStateAfterPageTransition() final { }
 
     // Members of PageClientImpl class
     GtkWidget* m_viewWidget;

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
@@ -168,7 +168,6 @@ private:
     void selectionDidChange() override;
 
     WebKitWebResourceLoadManager* webResourceLoadManager() override;
-    void didClearEditorStateAfterPageTransition() final { }
 
     WKWPE::View& m_view;
 };

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -531,8 +531,6 @@ public:
     virtual void scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID) = 0;
 #endif
 
-    virtual void didClearEditorStateAfterPageTransition() = 0;
-
 #if PLATFORM(IOS_FAMILY)
     virtual void commitPotentialTapFailed() = 0;
     virtual void didGetTapHighlightGeometries(WebKit::TapIdentifier requestID, const WebCore::Color&, const Vector<WebCore::FloatQuad>& highlightedQuads, const WebCore::IntSize& topLeftRadius, const WebCore::IntSize& topRightRadius, const WebCore::IntSize& bottomLeftRadius, const WebCore::IntSize& bottomRightRadius, bool nodeHasBuiltInClickHandling) = 0;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3096,17 +3096,6 @@ void WebPageProxy::setMaintainsInactiveSelection(bool newValue)
     m_maintainsInactiveSelection = newValue;
 }
 
-void WebPageProxy::clearEditorStateAfterPageTransition(EditorStateIdentifier identifier)
-{
-    if (identifier < internals().editorState.identifier)
-        return;
-
-    internals().editorState = { };
-    internals().editorState.identifier = identifier;
-
-    protectedPageClient()->didClearEditorStateAfterPageTransition();
-}
-
 void WebPageProxy::scheduleFullEditorStateUpdate()
 {
     if (!hasRunningProcess())

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "APIObject.h"
-#include "IdentifierTypes.h"
 #include "MessageReceiver.h"
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/NowPlayingMetadataObserver.h>
@@ -1946,7 +1945,6 @@ public:
     bool updateEditorState(const EditorState& newEditorState, ShouldMergeVisualEditorState = ShouldMergeVisualEditorState::Default);
     void scheduleFullEditorStateUpdate();
     void dispatchDidUpdateEditorState();
-    void clearEditorStateAfterPageTransition(EditorStateIdentifier);
 
     void requestStorageAccessConfirm(const WebCore::RegistrableDomain& subFrameDomain, const WebCore::RegistrableDomain& topFrameDomain, WebCore::FrameIdentifier, std::optional<WebCore::OrganizationStorageAccessPromptQuirk>&&, CompletionHandler<void(bool)>&&);
     void didCommitCrossSiteLoadWithDataTransferFromPrevalentResource();

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -223,7 +223,6 @@ messages -> WebPageProxy {
     EditorStateChanged(struct WebKit::EditorState editorState)
     CompositionWasCanceled()
     SetHasHadSelectionChangesFromUserInteraction(bool hasHadUserSelectionChanges)
-    ClearEditorStateAfterPageTransition(WebKit::EditorStateIdentifier identifier)
 
 #if ENABLE(IMAGE_ANALYSIS)
     RequestTextRecognition(URL imageURL, WebCore::ShareableBitmapHandle imageData, String source, String target) -> (struct WebCore::TextRecognitionResult result)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -197,7 +197,6 @@ private:
     void elementDidBlur() override;
     void focusedElementDidChangeInputMode(WebCore::InputMode) override;
     void didUpdateEditorState() override;
-    void didClearEditorStateAfterPageTransition() final;
     bool isFocusingElement() override;
     void selectionDidChange() override;
     bool interpretKeyEvent(const NativeWebKeyboardEvent&, bool isCharEvent) override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -713,11 +713,6 @@ void PageClientImpl::didUpdateEditorState()
     [contentView() _didUpdateEditorState];
 }
 
-void PageClientImpl::didClearEditorStateAfterPageTransition()
-{
-    [contentView() _didClearEditorStateAfterPageTransition];
-}
-
 void PageClientImpl::showPlaybackTargetPicker(bool hasVideo, const IntRect& elementRect, WebCore::RouteSharingPolicy policy, const String& contextUID)
 {
     [contentView() _showPlaybackTargetPicker:hasVideo fromRect:elementRect routeSharingPolicy:policy routingContextUID:contextUID];

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -745,7 +745,6 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 - (void)_elementDidBlur;
 - (void)_didUpdateInputMode:(WebCore::InputMode)mode;
 - (void)_didUpdateEditorState;
-- (void)_didClearEditorStateAfterPageTransition;
 - (void)_hardwareKeyboardAvailabilityChanged;
 - (void)_selectionChanged;
 - (void)_updateChangedSelection;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -1741,6 +1741,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     [self _updateTapHighlight];
 
+    if (_page->editorState().selectionIsNone && _lastSelectionDrawingInfo.type == WebKit::WKSelectionDrawingInfo::SelectionType::None)
+        return;
+
     _selectionNeedsUpdate = YES;
     [self _updateChangedSelection:YES];
 }
@@ -8235,12 +8238,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     for (auto block : std::exchange(_actionsToPerformAfterEditorStateUpdate, { }))
         block();
-}
-
-- (void)_didClearEditorStateAfterPageTransition
-{
-    _cachedSelectedTextRange = nil;
-    _lastSelectionDrawingInfo = { };
 }
 
 - (void)_updateInitialWritingDirectionIfNecessary

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -113,7 +113,6 @@ private:
     void clearSafeBrowsingWarning() override;
     void clearSafeBrowsingWarningIfForMainFrameNavigation() override;
     bool hasSafeBrowsingWarning() const override;
-    void didClearEditorStateAfterPageTransition() final { }
     
     bool showShareSheet(const WebCore::ShareDataWithParsedURL&, WTF::CompletionHandler<void(bool)>&&) override;
         

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.h
@@ -164,8 +164,6 @@ private:
     UnixFileDescriptor hostFileDescriptor() override;
 #endif
 
-    void didClearEditorStateAfterPageTransition() final { }
-
     PlayStationWebView& m_view;
 };
 

--- a/Source/WebKit/UIProcess/win/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/win/PageClientImpl.h
@@ -155,7 +155,6 @@ private:
     WebCore::UserInterfaceLayoutDirection userInterfaceLayoutDirection() override { return WebCore::UserInterfaceLayoutDirection::LTR; }
 
     void requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, WebCore::DOMPasteRequiresInteraction, const WebCore::IntRect&, const String&, CompletionHandler<void(WebCore::DOMPasteAccessResponse)>&&) final;
-    void didClearEditorStateAfterPageTransition() final { }
 
     // Members of PageClientImpl class
     DefaultUndoController m_undoController;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1585,7 +1585,7 @@ void WebLocalFrameLoaderClient::transitionToCommittedForNewPage(InitializingIfra
         view->setScrollPinningBehavior(webPage->scrollPinningBehavior());
 
     if (initializingIframe == InitializingIframe::No)
-        webPage->clearEditorStateAfterPageTransition();
+        webPage->scheduleFullEditorStateUpdate();
 
 #if USE(COORDINATED_GRAPHICS)
     if (shouldUseFixedLayout) {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7729,11 +7729,6 @@ void WebPage::sendEditorStateUpdate()
         scheduleFullEditorStateUpdate();
 }
 
-void WebPage::clearEditorStateAfterPageTransition()
-{
-    send(Messages::WebPageProxy::ClearEditorStateAfterPageTransition(m_lastEditorStateIdentifier.increment()));
-}
-
 void WebPage::scheduleFullEditorStateUpdate()
 {
     m_needsEditorStateVisualDataUpdate = true;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1543,7 +1543,6 @@ public:
     void flushPendingIntrinsicContentSizeUpdate();
     void updateIntrinsicContentSizeIfNeeded(const WebCore::IntSize&);
 
-    void clearEditorStateAfterPageTransition();
     void scheduleFullEditorStateUpdate();
 
     bool userIsInteracting() const { return m_userIsInteracting; }


### PR DESCRIPTION
#### aa6c1d4264f0176f1a925227bd3e80266ec7e2f6
<pre>
REGRESSION (278484@main): Chinese Input Method (pinyin) is broken on ChatGPT/Google translate
<a href="https://bugs.webkit.org/show_bug.cgi?id=275754">https://bugs.webkit.org/show_bug.cgi?id=275754</a>
<a href="https://rdar.apple.com/130020224">rdar://130020224</a>

Reviewed by Abrar Rahman Protyasha.

After the changes in 278484@main, navigations occurring in subframes that are not empty now cause us
to clear UI-side editor state, through `WebPage::clearEditorStateAfterPageTransition()`. The
intention in 278484@main was to only trigger this codepath when completing a page transition due to
mainframe navigation, but because the `InitializingIframe` flag is set when navigating away from
subframes that have already loaded content, this ended up sometimes clearing the UI-side selection
when loading subframes.

To fix this, this patch begins by reverting the &quot;clear UI-side editor state during page transition&quot;
approach that I previously attempted in 278484@main and 278902@main. Of course, this causes the API
test `ScrollViewScrollabilityTests.ScrollableWithOverflowHiddenWhenZoomed` to start failing again.

After investigating this test failure further, I discovered that this happens because having an up-
to-date `EditorState` with post-layout data means that logic which attempts to adjust the selection
views after scale changes in `-[WKContentView observeValueForKeyPath:ofObject:change:context:]` will
now call into `-_updateChangedSelection:` without returning immediately in that method. As a
consequence, we end up calling into UIKit code under `-selectionChanged`, which (internally)
instantiates the shared `UIKeyboardImpl` instance in the process of posting a notification for
`UITextInputResponderCapabilitiesChangedNotification`.

Instantiating a `UIKeyboardImpl` in the middle of a call to `-[WKScrollView setZoomScale:animated:]`
subsequently causes UIKit to install some native selection views under the scroll view, which (for
reasons that are still unclear) causes the scroll view to revert to a zoom scale of 1.

To keep this test passing after reverting 278484@main and 278902@main, we add a slight optimization
to `-[WKContentView observeValueForKeyPath:ofObject:change:context:]`, such that we avoid trying to
update UIKit&apos;s selection views (and therefore prevent `UIKeyboardImpl` from being instantiated) in
the case where the following conditions are both true:

1. There is no selection (i.e. the current `EditorState` has a selection type that is `None`).
2. No selection was previously shown (i.e. `_lastSelectionDrawingInfo`&apos;s type is also `None`).

There should be no need to update platform selection state in this case, since nothing is visually
changing.

For easier bookkeeping — the full tree of fixes (and followup fixes) is currently:

```
<a href="https://rdar.apple.com/102563363">rdar://102563363</a> (fixed in 276962@main)
    ↳ …caused: <a href="https://rdar.apple.com/126280854">rdar://126280854</a> (fixed in 277910@main)
    ↳ …caused: <a href="https://rdar.apple.com/127547621">rdar://127547621</a> (fixed in 278484@main)
        ↳ …caused: <a href="https://rdar.apple.com/130020224">rdar://130020224</a> (fixed by this PR)
        ↳ …caused: <a href="https://rdar.apple.com/128086114">rdar://128086114</a> (fixed in 278902@main)
            ↳ …caused: <a href="https://rdar.apple.com/128497371">rdar://128497371</a> (fixed by this PR)
```

* LayoutTests/editing/selection/ios/navigating-in-subframe-does-not-dismiss-edit-menu-expected.txt: Added.
* LayoutTests/editing/selection/ios/navigating-in-subframe-does-not-dismiss-edit-menu.html: Added.

Add a new layout test to verify that UI-side editor state isn&apos;t cleared when navigating in subframes
that don&apos;t contain the selection (which is the root cause of the bug on ChatGPT/Google Translate).

* LayoutTests/platform/ios/TestExpectations:

Remove some layout test failure expectations, which are also fixed by this change.

* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.h:
* Source/WebKit/UIProcess/API/wpe/PageClientImpl.h:
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::clearEditorStateAfterPageTransition): Deleted.

Revert all logic to clear the editor state between page transitions, added in 278484@main.

* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::didClearEditorStateAfterPageTransition): Deleted.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView observeValueForKeyPath:ofObject:change:context:]):

Apply a mitigation to prevent `ScrollViewScrollabilityTests.ScrollableWithOverflowHiddenWhenZoomed`
from failing again, by preventing unnecessary instantiation of the `UIKeyboardImpl` when changing
the zoom scale.

(-[WKContentView _didClearEditorStateAfterPageTransition]): Deleted.
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/playstation/PageClientImpl.h:
* Source/WebKit/UIProcess/win/PageClientImpl.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::transitionToCommittedForNewPage):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::clearEditorStateAfterPageTransition): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/280291@main">https://commits.webkit.org/280291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/684c3e90d31e290d7a0052ad6106a1630f16d3a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8661 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59795 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6625 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43137 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6819 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/45427 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4600 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58218 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33405 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48472 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26365 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/55715 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30185 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5802 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5629 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61478 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/97 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6199 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52751 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/97 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48539 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/52577 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12449 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/86 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31342 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32428 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33511 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32175 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->