### PR TITLE
[JSC] Add private name related handlers

### DIFF
--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.h
@@ -464,6 +464,8 @@ MacroAssemblerCodeRef<JITThunkPtrTag> deleteByValWithStringDeleteMissHandler(VM&
 MacroAssemblerCodeRef<JITThunkPtrTag> deleteByValWithSymbolDeleteHandler(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> deleteByValWithSymbolDeleteNonConfigurableHandler(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> deleteByValWithSymbolDeleteMissHandler(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> checkPrivateBrandHandler(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> setPrivateBrandHandler(VM&);
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/jit/JITThunks.h
+++ b/Source/JavaScriptCore/jit/JITThunks.h
@@ -120,6 +120,8 @@ class NativeExecutable;
     macro(DeleteByValWithSymbolDeleteHandler, deleteByValWithSymbolDeleteHandler) \
     macro(DeleteByValWithSymbolDeleteNonConfigurableHandler, deleteByValWithSymbolDeleteNonConfigurableHandler) \
     macro(DeleteByValWithSymbolDeleteMissHandler, deleteByValWithSymbolDeleteMissHandler) \
+    macro(CheckPrivateBrandHandler, checkPrivateBrandHandler) \
+    macro(SetPrivateBrandHandler, setPrivateBrandHandler) \
 
 #if ENABLE(YARR_JIT_BACKREFERENCES_FOR_16BIT_EXPRS)
 #define JSC_FOR_EACH_YARR_JIT_BACKREFERENCES_THUNK(macro) \


### PR DESCRIPTION
#### 8ca6c3acfc2b6998b79a46502908cbb1b95ac71f
<pre>
[JSC] Add private name related handlers
<a href="https://bugs.webkit.org/show_bug.cgi?id=275785">https://bugs.webkit.org/show_bug.cgi?id=275785</a>
<a href="https://rdar.apple.com/problem/130344843">rdar://problem/130344843</a>

Reviewed by Yijia Huang.

This patch adds simple handlers more, in particular for private name related ones.
We also remove some of condition checks for AccessCases which never has ObjectPropertyConditionSet.

* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheHandler::createPreCompiled):
(JSC::checkPrivateBrandHandler):
(JSC::setPrivateBrandHandler):
(JSC::InlineCacheCompiler::compileOneAccessCaseHandler):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.h:
* Source/JavaScriptCore/jit/JITThunks.h:

Canonical link: <a href="https://commits.webkit.org/280286@main">https://commits.webkit.org/280286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbf37bd2e1f86ad567829bf4c4a1a4fe1ca93886

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35501 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8647 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59781 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6611 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45360 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4587 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58204 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33390 "Found 60 new test failures: accessibility/accessibility-node-reparent.html accessibility/ancestor-computation.html accessibility/announcement-notification.html accessibility/aria-braillelabel.html accessibility/aria-brailleroledescription.html accessibility/aria-checked-mixed-value.html accessibility/aria-current-state-changed-notification.html accessibility/aria-current.html accessibility/aria-describedby-on-input.html accessibility/aria-description.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48458 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26350 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30170 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5788 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5615 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/49253 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52155 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61464 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/55412 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/83 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52722 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/83 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48525 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52494 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/72 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/77172 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8336 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31328 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12787 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32414 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33497 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32161 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->