### PR TITLE
[JSC] Attach JIT RegExp names to JITDump

### DIFF
--- a/Source/JavaScriptCore/assembler/LinkBuffer.cpp
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.cpp
@@ -34,6 +34,7 @@
 #include "Options.h"
 #include "PerfLog.h"
 #include "WasmCallee.h"
+#include "YarrJIT.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
@@ -94,6 +95,15 @@ void LinkBuffer::logJITCodeForPerf(CodeRef<LinkBufferPtrTag>& codeRef, ASCIILite
     case Profile::WasmBBQ: {
         if (m_ownerUID)
             out.print(makeString(static_cast<Wasm::Callee*>(m_ownerUID)->indexOrName()));
+        else
+            dumpSimpleName(out, simpleName);
+        break;
+    }
+#endif
+#if ENABLE(YARR_JIT)
+    case Profile::YarrJIT: {
+        if (m_ownerUID)
+            static_cast<Yarr::YarrCodeBlock*>(m_ownerUID)->dumpSimpleName(out);
         else
             dumpSimpleName(out, simpleName);
         break;

--- a/Source/JavaScriptCore/assembler/LinkBuffer.h
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.h
@@ -31,8 +31,7 @@
 #define DUMP_CODE 0
 
 #define GLOBAL_THUNK_ID reinterpret_cast<void*>(static_cast<intptr_t>(-1))
-#define REGEXP_CODE_ID reinterpret_cast<void*>(static_cast<intptr_t>(-2))
-#define CSS_CODE_ID reinterpret_cast<void*>(static_cast<intptr_t>(-3))
+#define CSS_CODE_ID reinterpret_cast<void*>(static_cast<intptr_t>(-2))
 
 #include "JITCompilationEffort.h"
 #include "MacroAssembler.h"

--- a/Source/JavaScriptCore/runtime/RegExp.h
+++ b/Source/JavaScriptCore/runtime/RegExp.h
@@ -56,6 +56,7 @@ public:
     static void destroy(JSCell*);
     static size_t estimatedSize(JSCell*, VM&);
     JS_EXPORT_PRIVATE static void dumpToStream(const JSCell*, PrintStream&);
+    void dumpSimpleName(PrintStream&) const;
 
     OptionSet<Yarr::Flags> flags() const { return m_flags; }
 #define JSC_DEFINE_REGEXP_FLAG_ACCESSOR(key, name, lowerCaseName, index) bool lowerCaseName() const { return m_flags.contains(Yarr::Flags::name); }
@@ -197,7 +198,7 @@ private:
     Yarr::YarrCodeBlock& ensureRegExpJITCode()
     {
         if (!m_regExpJITCode)
-            m_regExpJITCode = makeUnique<Yarr::YarrCodeBlock>();
+            m_regExpJITCode = makeUnique<Yarr::YarrCodeBlock>(this);
         return *m_regExpJITCode.get();
     }
 #endif

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -4770,7 +4770,7 @@ public:
             });
         }
 
-        LinkBuffer linkBuffer(m_jit, REGEXP_CODE_ID, LinkBuffer::Profile::YarrJIT, JITCompilationCanFail);
+        LinkBuffer linkBuffer(m_jit, &codeBlock, LinkBuffer::Profile::YarrJIT, JITCompilationCanFail);
         if (linkBuffer.didFailToAllocate()) {
             codeBlock.setFallBackWithFailureReason(JITFailureReason::ExecutableMemoryAllocationFailure);
             return;
@@ -5246,7 +5246,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> areCanonicallyEquivalentThunkGenerator(VM&
     jit.emitFunctionEpilogue();
     jit.ret();
 
-    LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::YarrJIT);
+    LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::Thunk);
 
     return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, nullptr, "YARR areCanonicallyEquivalent call");
 }
@@ -5334,6 +5334,14 @@ void jitCompileInlinedTest(StackCheck* m_compilationThreadStackChecker, StringVi
     yarrGenerator.compileInline(boyerMooreData);
 }
 #endif
+
+void YarrCodeBlock::dumpSimpleName(PrintStream& out) const
+{
+    if (m_regExp)
+        RegExp::dumpToStream(m_regExp, out);
+    else
+        out.print("unspecified");
+}
 
 }}
 

--- a/Source/JavaScriptCore/yarr/YarrJIT.h
+++ b/Source/JavaScriptCore/yarr/YarrJIT.h
@@ -238,7 +238,7 @@ private:
     Vector<UniqueRef<BoyerMooreBitmap::Map>> m_maps;
 };
 
-class YarrCodeBlock : public YarrBoyerMooreData {
+class YarrCodeBlock final : public YarrBoyerMooreData {
     struct InlineStats {
         InlineStats()
             : m_insnCount(0)
@@ -281,7 +281,9 @@ public:
     using YarrJITCodeMatchOnly8 = UGPRPair (*)(const LChar* input, UCPURegister start, UCPURegister length, void*, MatchingContextHolder*) YARR_CALL;
     using YarrJITCodeMatchOnly16 = UGPRPair (*)(const UChar* input, UCPURegister start, UCPURegister length, void*, MatchingContextHolder*) YARR_CALL;
 
-    YarrCodeBlock() = default;
+    YarrCodeBlock(RegExp* regExp)
+        : m_regExp(regExp)
+    { }
 
     void setFallBackWithFailureReason(JITFailureReason failureReason) { m_failureReason = failureReason; }
     std::optional<JITFailureReason> failureReason() { return m_failureReason; }
@@ -419,6 +421,8 @@ public:
         clearMaps();
     }
 
+    void dumpSimpleName(PrintStream&) const;
+
 private:
     MacroAssemblerCodeRef<Yarr8BitPtrTag> m_ref8;
     MacroAssemblerCodeRef<Yarr16BitPtrTag> m_ref16;
@@ -426,6 +430,7 @@ private:
     MacroAssemblerCodeRef<YarrMatchOnly16BitPtrTag> m_matchOnly16;
     InlineStats m_matchOnly8Stats;
     InlineStats m_matchOnly16Stats;
+    RegExp* m_regExp { nullptr };
 
     bool m_usesPatternContextBuffer { false };
     std::optional<JITFailureReason> m_failureReason;


### PR DESCRIPTION
#### 077604017fc2bcfc0f32f0ce34b53ffe4480c4ad
<pre>
[JSC] Attach JIT RegExp names to JITDump
<a href="https://bugs.webkit.org/show_bug.cgi?id=275787">https://bugs.webkit.org/show_bug.cgi?id=275787</a>
<a href="https://rdar.apple.com/130348602">rdar://130348602</a>

Reviewed by Yijia Huang.

This patch adds JIT RegExp names to JITDump so that we can get JIT patterns in JITDump logging.

* Source/JavaScriptCore/assembler/LinkBuffer.cpp:
(JSC::LinkBuffer::logJITCodeForPerf):
* Source/JavaScriptCore/assembler/LinkBuffer.h:
* Source/JavaScriptCore/runtime/RegExp.h:
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::areCanonicallyEquivalentThunkGenerator):
(JSC::Yarr::YarrCodeBlock::dumpSimpleName const):
* Source/JavaScriptCore/yarr/YarrJIT.h:
(JSC::Yarr::YarrCodeBlock::InlineStats::InlineStats): Deleted.
(JSC::Yarr::YarrCodeBlock::InlineStats::set): Deleted.
(JSC::Yarr::YarrCodeBlock::InlineStats::clear): Deleted.
(JSC::Yarr::YarrCodeBlock::InlineStats::codeSize const): Deleted.
(JSC::Yarr::YarrCodeBlock::InlineStats::stackSize const): Deleted.
(JSC::Yarr::YarrCodeBlock::InlineStats::canInline const): Deleted.
(JSC::Yarr::YarrCodeBlock::InlineStats::needsTemp2 const): Deleted.
(JSC::Yarr::YarrCodeBlock::setFallBackWithFailureReason): Deleted.
(JSC::Yarr::YarrCodeBlock::failureReason): Deleted.
(JSC::Yarr::YarrCodeBlock::has8BitCode): Deleted.
(JSC::Yarr::YarrCodeBlock::has16BitCode): Deleted.
(JSC::Yarr::YarrCodeBlock::set8BitCode): Deleted.
(JSC::Yarr::YarrCodeBlock::set16BitCode): Deleted.
(JSC::Yarr::YarrCodeBlock::has8BitCodeMatchOnly): Deleted.
(JSC::Yarr::YarrCodeBlock::has16BitCodeMatchOnly): Deleted.
(JSC::Yarr::YarrCodeBlock::set8BitCodeMatchOnly): Deleted.
(JSC::Yarr::YarrCodeBlock::set16BitCodeMatchOnly): Deleted.
(JSC::Yarr::YarrCodeBlock::usesPatternContextBuffer): Deleted.
(JSC::Yarr::YarrCodeBlock::setUsesPatternContextBuffer): Deleted.
(JSC::Yarr::YarrCodeBlock::set8BitInlineStats): Deleted.
(JSC::Yarr::YarrCodeBlock::set16BitInlineStats): Deleted.
(JSC::Yarr::YarrCodeBlock::get8BitInlineStats): Deleted.
(JSC::Yarr::YarrCodeBlock::get16BitInlineStats): Deleted.
(JSC::Yarr::YarrCodeBlock::execute): Deleted.
(JSC::Yarr::YarrCodeBlock::get8BitMatchOnlyAddr): Deleted.
(JSC::Yarr::YarrCodeBlock::get16BitMatchOnlyAddr): Deleted.
(JSC::Yarr::YarrCodeBlock::get8BitMatchAddr): Deleted.
(JSC::Yarr::YarrCodeBlock::get16BitMatchAddr): Deleted.
(JSC::Yarr::YarrCodeBlock::size const): Deleted.
(JSC::Yarr::YarrCodeBlock::clear): Deleted.

Canonical link: <a href="https://commits.webkit.org/280284@main">https://commits.webkit.org/280284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bd56c538f89fe656820fd5ca19cb2f56e223e51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59783 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6613 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43125 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6807 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/45366 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4588 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33393 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/48460 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26353 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30173 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5790 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5617 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/49255 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52158 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6061 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61466 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/55414 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/85 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6187 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52724 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/85 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48527 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/52498 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/74 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/77174 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8335 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31330 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/12789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32416 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33499 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32163 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->