### PR TITLE
Reject getUserMedia promise for disallowed required constraints

### DIFF
--- a/LayoutTests/fast/mediastream/getUserMedia-mandatory-constraint-expected.txt
+++ b/LayoutTests/fast/mediastream/getUserMedia-mandatory-constraint-expected.txt
@@ -1,0 +1,17 @@
+
+PASS Mandatory video disallowed constraint whiteBalanceMode
+PASS Mandatory video disallowed constraint zoom
+PASS Mandatory video disallowed constraint torch
+PASS Mandatory video disallowed constraint backgroundBlur
+PASS Mandatory video disallowed constraint powerEfficient
+PASS Mandatory video allowed constraint width
+PASS Mandatory video allowed constraint height
+PASS Mandatory video allowed constraint aspectRatio
+PASS Mandatory video allowed constraint frameRate
+PASS Mandatory video allowed constraint facingMode
+PASS Mandatory audio allowed constraint volume
+PASS Mandatory audio allowed constraint sampleRate
+PASS Mandatory audio allowed constraint sampleSize
+PASS Mandatory audio allowed constraint echoCancellation
+PASS Mandatory constraint groupId and deviceId
+

--- a/LayoutTests/fast/mediastream/getUserMedia-mandatory-constraint.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-mandatory-constraint.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+const disallowedVideoConstraints = {
+    whiteBalanceMode: "manual",
+    zoom: 1,
+    torch: true,
+    backgroundBlur: true,
+    powerEfficient: true,
+};
+
+for (let name in disallowedVideoConstraints) {
+    promise_test(async (t) => {
+        const constraints = { };
+        constraints[name] = { exact : disallowedVideoConstraints[name] };
+        return promise_rejects_js(t, TypeError, navigator.mediaDevices.getUserMedia({ video: constraints }));
+    }, "Mandatory video disallowed constraint " + name);
+}
+
+const allowedVideoConstraints = {
+    width: 10,
+    height: 10,
+    aspectRatio: 16/9,
+    frameRate: 30,
+    facingMode: "environment"
+};
+
+for (let name in allowedVideoConstraints) {
+    promise_test(async (t) => {
+        const constraints = { };
+        constraints[name] = { exact : allowedVideoConstraints[name] };
+        return navigator.mediaDevices.getUserMedia({ video: constraints  });
+    }, "Mandatory video allowed constraint " + name);
+}
+
+const allowedAudioConstraints = {
+    volume: 1,
+    sampleRate: 44100,
+    sampleSize: 16,
+    echoCancellation: true,
+};
+
+for (let name in allowedAudioConstraints) {
+    promise_test(async (t) => {
+        const constraints = { };
+        constraints[name] = { exact : allowedAudioConstraints[name] };
+        return navigator.mediaDevices.getUserMedia({ audio: constraints  });
+    }, "Mandatory audio allowed constraint " + name);
+}
+
+promise_test(async (t) => {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    for (let device of devices) {
+        if (device.kind === "audioinput" && device.deviceId) {
+            await navigator.mediaDevices.getUserMedia({ audio: { deviceId : { exact: device.deviceId } } });
+            return;
+        }
+    }
+    for (let device of devices) {
+        if (device.kind === "audioinput" && device.groupId) {
+            await navigator.mediaDevices.getUserMedia({ audio: { groupId : { exact: device.groupId } } });
+            return;
+        }
+    }
+    for (let device of devices) {
+        if (device.kind === "videoinput" && device.deviceId) {
+            await navigator.mediaDevices.getUserMedia({ video: { deviceId : { exact: device.deviceId } } });
+            return;
+        }
+    }
+    for (let device of devices) {
+        if (device.kind === "videoinput" && device.groupId) {
+            await navigator.mediaDevices.getUserMedia({ video: { groupId : { exact: device.groupId } } });
+            return;
+        }
+    }
+}, "Mandatory constraint groupId and deviceId");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -151,10 +151,26 @@ void MediaDevices::getUserMedia(StreamConstraints&& constraints, Promise&& promi
     bool isUserGesturePriviledged = false;
 
     if (audioConstraints.isValid) {
+        if (audioConstraints.hasDisallowedRequiredConstraintForDeviceSelection(MediaConstraints::DeviceType::Microphone)) {
+            // Asynchronous rejection.
+            callOnMainThread([promise = WTFMove(promise)] () mutable {
+                promise.reject(Exception { ExceptionCode::TypeError, "A required constraint."_s });
+
+            });
+            return;
+        }
         isUserGesturePriviledged |= computeUserGesturePriviledge(GestureAllowedRequest::Microphone);
         audioConstraints.setDefaultAudioConstraints();
     }
     if (videoConstraints.isValid) {
+        if (videoConstraints.hasDisallowedRequiredConstraintForDeviceSelection(MediaConstraints::DeviceType::Camera)) {
+            // Asynchronous rejection.
+            callOnMainThread([promise = WTFMove(promise)] () mutable {
+                promise.reject(Exception { ExceptionCode::TypeError, "A required constraint."_s });
+
+            });
+            return;
+        }
         isUserGesturePriviledged |= computeUserGesturePriviledge(GestureAllowedRequest::Camera);
         videoConstraints.setDefaultVideoConstraints();
     }

--- a/Source/WebCore/platform/mediastream/MediaConstraints.cpp
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.cpp
@@ -728,6 +728,27 @@ MediaConstraints MediaConstraints::isolatedCopy() const
     return { crossThreadCopy(mandatoryConstraints), crossThreadCopy(advancedConstraints), isValid };
 }
 
+static bool isAllowedRequiredConstraintForDeviceSelection(MediaConstraints::DeviceType deviceType, MediaConstraintType type)
+{
+    // https://w3c.github.io/mediacapture-main/#dfn-allowed-required-constraints-for-device-selection
+    if (type <= MediaConstraintType::GroupId)
+        return true;
+
+    if (deviceType == MediaConstraints::DeviceType::Microphone)
+        return true;
+
+    return deviceType == MediaConstraints::DeviceType::Microphone || type == MediaConstraintType::DisplaySurface || type == MediaConstraintType::LogicalSurface;
+}
+
+bool MediaConstraints::hasDisallowedRequiredConstraintForDeviceSelection(DeviceType deviceType) const
+{
+    bool result = false;
+    mandatoryConstraints.forEach([&] (auto type, const MediaConstraint& constraint) mutable {
+        result |= !isAllowedRequiredConstraintForDeviceSelection(deviceType, type) && constraint.isRequired();
+    });
+    return result;
+}
+
 }
 
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/mediastream/MediaConstraints.h
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.h
@@ -44,6 +44,12 @@ namespace WebCore {
 class MediaConstraint {
 public:
     enum class DataType : uint8_t { Integer, Double, Boolean, String };
+    explicit MediaConstraint(DataType dataType)
+        : m_dataType(dataType)
+    {
+    }
+
+    virtual ~MediaConstraint() = default;
 
     bool isInt() const { return m_dataType == DataType::Integer; }
     bool isDouble() const { return m_dataType == DataType::Double; }
@@ -54,10 +60,7 @@ public:
 
     void log(MediaConstraintType) const;
 
-    explicit MediaConstraint(DataType dataType)
-        : m_dataType(dataType)
-    {
-    }
+    virtual bool isRequired() const { return false; }
 
 private:
     DataType m_dataType { DataType::Integer };
@@ -360,6 +363,8 @@ protected:
         }
     }
 
+    bool isRequired() const final { return !!m_min || !!m_max || !!m_exact; }
+
     std::optional<ValueType> m_min;
     std::optional<ValueType> m_max;
     std::optional<ValueType> m_exact;
@@ -492,7 +497,9 @@ private:
         , m_ideal(WTFMove(ideal))
     {
     }
-    
+
+    bool isRequired() const final { return !!m_exact; }
+
     std::optional<bool> m_exact;
     std::optional<bool> m_ideal;
 };
@@ -574,7 +581,9 @@ private:
         , m_ideal(WTFMove(ideal))
     {
     }
-    
+
+    bool isRequired() const final { return !m_exact.isEmpty(); }
+
     Vector<String> m_exact;
     Vector<String> m_ideal;
 };
@@ -684,6 +693,9 @@ struct MediaConstraints {
     bool isValid { false };
 
     MediaConstraints isolatedCopy() const;
+
+    enum class DeviceType : bool { Camera, Microphone };
+    bool hasDisallowedRequiredConstraintForDeviceSelection(DeviceType) const;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 4a302dc75a52f0980323c35cda808e49c28a8f3c
<pre>
Reject getUserMedia promise for disallowed required constraints
<a href="https://rdar.apple.com/130365953">rdar://130365953</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=275790">https://bugs.webkit.org/show_bug.cgi?id=275790</a>

Reviewed by Eric Carlson.

Implement <a href="https://w3c.github.io/mediacapture-main/#dfn-allowed-required-constraints-for-device-selection">https://w3c.github.io/mediacapture-main/#dfn-allowed-required-constraints-for-device-selection</a> to ensure new constraints are not used for restricting device selection.

* LayoutTests/fast/mediastream/getUserMedia-mandatory-constraint-expected.txt: Added.
* LayoutTests/fast/mediastream/getUserMedia-mandatory-constraint.html: Added.
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::MediaDevices::getUserMedia):
* Source/WebCore/platform/mediastream/MediaConstraints.cpp:
(WebCore::isAllowedRequiredConstraintForDeviceSelection):
(WebCore::MediaConstraints::hasDisallowedRequiredConstraintForDeviceSelection const):
* Source/WebCore/platform/mediastream/MediaConstraints.h:
(WebCore::MediaConstraint::MediaConstraint):
(WebCore::MediaConstraint::isRequired const):

Canonical link: <a href="https://commits.webkit.org/280325@main">https://commits.webkit.org/280325@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea1682238da51b0a8042d95128c1652b402add96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8771 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59906 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6735 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58425 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6929 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45591 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4691 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33508 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48575 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26462 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30287 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5905 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5739 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6177 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61590 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/207 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/6304 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52863 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/207 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48641 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52743 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12467 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/186 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31452 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32538 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33621 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32285 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->