### PR TITLE
[WPE][Qt6] Ignore invalid resize attempts

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp
@@ -72,7 +72,14 @@ bool WPEQtView::event(QEvent* ev)
 void WPEQtView::geometryChange(const QRectF& newGeometry, const QRectF&)
 {
     Q_D(WPEQtView);
-    d->m_size = newGeometry.size().toSize();
+
+    auto newSize = newGeometry.size().toSize();
+    if (newSize.width() <= 0 || newSize.height() <= 0) {
+        qWarning() << "WPEQtView::geometryChange(), ignoring invalid resize to new size " << newSize << " keeping old size " << d->m_size;
+        return;
+    }
+
+    d->m_size = newSize;
     if (!d->m_webView)
         return;
 

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewPrivate.h
@@ -33,7 +33,7 @@ public:
     QUrl m_url;
     QString m_html;
     QUrl m_baseUrl;
-    QSize m_size;
+    QSize m_size { 800, 600 };
     bool m_errorOccured { false };
 };
 


### PR DESCRIPTION
#### 7fc5bfadcbf15c28aa44d5f918d8858c50778344
<pre>
[WPE][Qt6] Ignore invalid resize attempts
<a href="https://bugs.webkit.org/show_bug.cgi?id=275789">https://bugs.webkit.org/show_bug.cgi?id=275789</a>

Reviewed by Philippe Normand.

Do not propagate empty/invalid sizes to the web view upon resizing.
Choose a default size of 800x600, that is used by default, unless
overriden (which is the common case).

Only testable using Qt/WPE integration.

* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp:
(WPEQtView::geometryChange):
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewPrivate.h:

Canonical link: <a href="https://commits.webkit.org/280292@main">https://commits.webkit.org/280292@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e82402c84652c228482e8a6b0679f5b93d25adb1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56181 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59787 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6617 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43129 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6811 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45405 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4593 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48464 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26356 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30177 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5621 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52173 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6066 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61470 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/89 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6191 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52739 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/89 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48531 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52574 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12450 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/78 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31334 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32420 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33503 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32167 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->