### PR TITLE
[Tools] Don't rely on WTF::Vector::data() being nullptr when empty

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
@@ -44,6 +44,11 @@ TEST(WTF_Vector, Basic)
     EXPECT_EQ(nullptr, intVector.data());
     EXPECT_EQ(0U, intVector.size());
     EXPECT_EQ(0U, intVector.capacity());
+
+    auto intSpan = intVector.span();
+    EXPECT_EQ(nullptr, intSpan.data());
+    EXPECT_EQ(0U, intSpan.size());
+    EXPECT_EQ(0U, intSpan.size_bytes());
 }
 
 TEST(WTF_Vector, ZeroSize)
@@ -53,6 +58,23 @@ TEST(WTF_Vector, ZeroSize)
     EXPECT_EQ(nullptr, intVector.data());
     EXPECT_EQ(0U, intVector.size());
     EXPECT_EQ(0U, intVector.capacity());
+
+    auto intSpan = intVector.span();
+    EXPECT_EQ(nullptr, intSpan.data());
+    EXPECT_EQ(0U, intSpan.size());
+    EXPECT_EQ(0U, intSpan.size_bytes());
+
+    intVector.append(0);
+    intVector.removeLast();
+    EXPECT_TRUE(intVector.isEmpty());
+    EXPECT_NE(nullptr, intVector.data());
+    EXPECT_EQ(0U, intVector.size());
+    EXPECT_NE(0U, intVector.capacity());
+
+    auto intSpanExpanded = intVector.span();
+    EXPECT_NE(nullptr, intSpanExpanded.data());
+    EXPECT_EQ(0U, intSpanExpanded.size());
+    EXPECT_EQ(0U, intSpanExpanded.size_bytes());
 }
 
 TEST(WTF_Vector, Iterator)

--- a/Tools/WebKitTestRunner/ios/HIDEventGenerator.mm
+++ b/Tools/WebKitTestRunner/ios/HIDEventGenerator.mm
@@ -616,7 +616,7 @@ static InterpolationType interpolationFromString(NSString *string)
     for (NSUInteger index = 0; index < touchCount; ++index)
         locations[index] = location;
     
-    [self touchDownAtPoints:locations.data() touchCount:touchCount];
+    [self touchDownAtPoints:(locations.isEmpty() ? nullptr : locations.data()) touchCount:touchCount];
 }
 
 - (void)touchDown:(CGPoint)location
@@ -652,7 +652,7 @@ static InterpolationType interpolationFromString(NSString *string)
     for (NSUInteger index = 0; index < touchCount; ++index)
         locations[index] = location;
     
-    [self liftUpAtPoints:locations.data() touchCount:touchCount];
+    [self liftUpAtPoints:(locations.isEmpty() ? nullptr : locations.data()) touchCount:touchCount];
 }
 
 - (void)liftUp:(CGPoint)location
@@ -681,7 +681,7 @@ static InterpolationType interpolationFromString(NSString *string)
 
             nextLocations[i] = calculateNextCurveLocation(startLocations[i], newLocations[i], interval);
         }
-        [self _updateTouchPoints:nextLocations.data() count:touchCount];
+        [self _updateTouchPoints:(nextLocations.isEmpty() ? nullptr : nextLocations.data()) count:touchCount];
 
         delayBetweenMove(eventIndex++, elapsed);
     }


### PR DESCRIPTION
#### 01fe4ab346d0316ff023eee9eb34bcbafbe6acfa
<pre>
[Tools] Don&apos;t rely on WTF::Vector::data() being nullptr when empty
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=275792">https://bugs.webkit.org/show_bug.cgi?id=275792</a>&gt;
&lt;<a href="https://rdar.apple.com/130372890">rdar://130372890</a>&gt;

Reviewed by Alex Christensen.

WTF::Vector::data() can return a non-nullptr value if it is expanded and
then shrunk.

* Tools/TestWebKitAPI/Tests/WTF/Vector.cpp:
(TestWebKitAPI::TEST(WTF_Vector, Basic)):
(TestWebKitAPI::TEST(WTF_Vector, ZeroSize)):
- Add more tests demonstrating this behavior, including
  WTF::Vector::span() tests.

* Tools/WebKitTestRunner/ios/HIDEventGenerator.mm:
(-[HIDEventGenerator touchDown:touchCount:]):
(-[HIDEventGenerator liftUp:touchCount:]):
(-[HIDEventGenerator moveToPoints:touchCount:duration:]):
- Call WTF::Vector::isEmpty() to determine if nullptr should be used for
  the CGPoint* argument.

Canonical link: <a href="https://commits.webkit.org/280359@main">https://commits.webkit.org/280359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afb388eafb6f722cdcb279cb5970805fd5329bef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56402 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35728 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8874 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60009 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6838 "Failed to checkout and rebase branch from PR 30095") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58528 "Failed to checkout and rebase branch from PR 30095") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7032 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/45690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/59/builds/6838 "Failed to checkout and rebase branch from PR 30095") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58431 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/33601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/48670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/26552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/30378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/5997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5842 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/6269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61694 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/310 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/6388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/310 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/48733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/52838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/88/builds/280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8377 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31555 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32641 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33724 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32388 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->