### PR TITLE
Mouseleave fires on elements no longer in the DOM

### DIFF
--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2781,13 +2781,13 @@ void EventHandler::updateMouseEventTargetNode(const AtomString& eventType, Node*
                 leftElementsChain.shrink(leftElementsChain.size() - i);
                 enteredElementsChain.shrink(enteredElementsChain.size() - i);
             }
-              
+
             if (auto lastElementUnderMouse = m_lastElementUnderMouse) {
-                if(lastElementUnderMouse->isInDocumentTree()) 
+                if (lastElementUnderMouse->isInDocumentTree())
                     lastElementUnderMouse->dispatchMouseEvent(platformMouseEvent, eventNames.mouseoutEvent, 0, m_elementUnderMouse.get());
             }
 
-            if(m_lastElementUnderMouse && m_lastElementUnderMouse->isInDocumentTree()) {
+            if (m_lastElementUnderMouse && m_lastElementUnderMouse->isInDocumentTree()) {
                 for (auto& chain : leftElementsChain) {
                     if (hasCapturingMouseLeaveListener || chain->hasEventListeners(eventNames.pointerleaveEvent) || chain->hasEventListeners(eventNames.mouseleaveEvent))
                         chain->dispatchMouseEvent(platformMouseEvent, eventNames.mouseleaveEvent, 0, m_elementUnderMouse.get());

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2781,13 +2781,17 @@ void EventHandler::updateMouseEventTargetNode(const AtomString& eventType, Node*
                 leftElementsChain.shrink(leftElementsChain.size() - i);
                 enteredElementsChain.shrink(enteredElementsChain.size() - i);
             }
+              
+            if (auto lastElementUnderMouse = m_lastElementUnderMouse) {
+                if(lastElementUnderMouse->isInDocumentTree()) 
+                    lastElementUnderMouse->dispatchMouseEvent(platformMouseEvent, eventNames.mouseoutEvent, 0, m_elementUnderMouse.get());
+            }
 
-            if (auto lastElementUnderMouse = m_lastElementUnderMouse)
-                lastElementUnderMouse->dispatchMouseEvent(platformMouseEvent, eventNames.mouseoutEvent, 0, m_elementUnderMouse.get());
-
-            for (auto& chain : leftElementsChain) {
-                if (hasCapturingMouseLeaveListener || chain->hasEventListeners(eventNames.pointerleaveEvent) || chain->hasEventListeners(eventNames.mouseleaveEvent))
-                    chain->dispatchMouseEvent(platformMouseEvent, eventNames.mouseleaveEvent, 0, m_elementUnderMouse.get());
+            if(m_lastElementUnderMouse && m_lastElementUnderMouse->isInDocumentTree()) {
+                for (auto& chain : leftElementsChain) {
+                    if (hasCapturingMouseLeaveListener || chain->hasEventListeners(eventNames.pointerleaveEvent) || chain->hasEventListeners(eventNames.mouseleaveEvent))
+                        chain->dispatchMouseEvent(platformMouseEvent, eventNames.mouseleaveEvent, 0, m_elementUnderMouse.get());
+                }
             }
 
             if (auto elementUnderMouse = m_elementUnderMouse)


### PR DESCRIPTION
#### a0c6260a323af8114669176a0c69ba4210d17610
<pre>
Mouseleave fires on elements no longer in the DOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=156971">https://bugs.webkit.org/show_bug.cgi?id=156971</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::updateMouseEventTargetNode):
</pre>
----------------------------------------------------------------------
#### a2beaa48d03bf8d42f7a8b7db1c9c37eff018e0a
<pre>
Mouseleave fires on elements no longer in the DOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=156971">https://bugs.webkit.org/show_bug.cgi?id=156971</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::updateMouseEventTargetNode):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a0c6260a323af8114669176a0c69ba4210d17610

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56193 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59799 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6629 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58319 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6823 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/45439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4604 "Found 3 new test failures: fast/events/mouseout-dead-node.html fast/events/mouseover-mouseout.html fast/events/mouseover-mouseout2.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58222 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33409 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48476 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/26371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30189 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5806 "Found 15 new test failures: fast/events/mouseout-dead-node.html fast/events/mouseover-mouseout.html fast/events/mouseover-mouseout2.html fast/events/shadow-event-path.html fast/shadow-dom/mouseenter-mouseleave-across-shadow-boundary.html fast/shadow-dom/mouseenter-mouseleave-inside-shadow-tree.html fast/shadow-dom/trusted-event-scoped-flags.html imported/w3c/web-platform-tests/pointerevents/capturing_boundary_event_handler_at_ua_shadowdom.html?mouse imported/w3c/web-platform-tests/pointerevents/capturing_boundary_event_handler_at_ua_shadowdom.html?pen imported/w3c/web-platform-tests/pointerevents/pointerevent_after_target_removed_interleaved.tentative.html?mouse ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5633 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6078 "Found 15 new test failures: fast/events/mouseout-dead-node.html fast/events/mouseover-mouseout.html fast/events/mouseover-mouseout2.html fast/events/shadow-event-path.html fast/shadow-dom/mouseenter-mouseleave-across-shadow-boundary.html fast/shadow-dom/mouseenter-mouseleave-inside-shadow-tree.html fast/shadow-dom/trusted-event-scoped-flags.html imported/w3c/web-platform-tests/pointerevents/capturing_boundary_event_handler_at_ua_shadowdom.html?mouse imported/w3c/web-platform-tests/pointerevents/capturing_boundary_event_handler_at_ua_shadowdom.html?pen imported/w3c/web-platform-tests/pointerevents/pointerevent_after_target_removed.html?mouse ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61482 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/101 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6203 "Found 15 new test failures: fast/events/mouseout-dead-node.html fast/events/mouseover-mouseout.html fast/events/mouseover-mouseout2.html fast/events/shadow-event-path.html fast/shadow-dom/mouseenter-mouseleave-across-shadow-boundary.html fast/shadow-dom/mouseenter-mouseleave-inside-shadow-tree.html fast/shadow-dom/trusted-event-scoped-flags.html imported/w3c/web-platform-tests/pointerevents/capturing_boundary_event_handler_at_ua_shadowdom.html?mouse imported/w3c/web-platform-tests/pointerevents/capturing_boundary_event_handler_at_ua_shadowdom.html?pen imported/w3c/web-platform-tests/pointerevents/pointerevent_after_target_removed.html?mouse ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52753 "Found 16 new test failures: fast/events/mouseout-dead-node.html fast/events/mouseover-mouseout.html fast/events/mouseover-mouseout2.html fast/events/shadow-event-path.html fast/shadow-dom/mouseenter-mouseleave-across-shadow-boundary.html fast/shadow-dom/mouseenter-mouseleave-inside-shadow-tree.html fast/shadow-dom/trusted-event-scoped-flags.html imported/w3c/web-platform-tests/pointerevents/capturing_boundary_event_handler_at_ua_shadowdom.html?mouse imported/w3c/web-platform-tests/pointerevents/capturing_boundary_event_handler_at_ua_shadowdom.html?pen imported/w3c/web-platform-tests/pointerevents/pointerevent_after_target_removed.html?mouse ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/101 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48543 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52584 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/90 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31346 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32432 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33515 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32179 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->