### PR TITLE
Drop BufferSource::data() in favor of span()

### DIFF
--- a/Source/JavaScriptCore/runtime/ArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.h
@@ -334,6 +334,7 @@ public:
     Expected<int64_t, GrowFailReason> grow(VM&, size_t newByteLength);
     Expected<int64_t, GrowFailReason> resize(VM&, size_t newByteLength);
 
+    std::span<uint8_t> mutableSpan() { return { static_cast<uint8_t*>(data()), byteLength() }; }
     std::span<const uint8_t> span() const { return { static_cast<const uint8_t*>(data()), byteLength() }; }
     Vector<uint8_t> toVector() const { return { span() }; }
 

--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -267,7 +267,7 @@ bool appendFileContentsToFileHandle(const String& path, PlatformFileHandle& targ
     });
 
     do {
-        int readBytes = readFromFile(source, buffer.data(), bufferSize);
+        int readBytes = readFromFile(source, buffer.mutableSpan());
 
         if (readBytes < 0)
             return false;
@@ -510,7 +510,7 @@ std::optional<Salt> readOrMakeSalt(const String& path)
     if (FileSystem::fileExists(path)) {
         auto file = FileSystem::openFile(path, FileSystem::FileOpenMode::Read);
         Salt salt;
-        auto bytesRead = static_cast<std::size_t>(FileSystem::readFromFile(file, salt.data(), salt.size()));
+        auto bytesRead = static_cast<std::size_t>(FileSystem::readFromFile(file, salt));
         FileSystem::closeFile(file);
         if (bytesRead == salt.size())
             return salt;
@@ -549,7 +549,7 @@ std::optional<Vector<uint8_t>> readEntireFile(PlatformFileHandle handle)
     size_t totalBytesRead = 0;
     int bytesRead;
 
-    while ((bytesRead = FileSystem::readFromFile(handle, buffer.data() + totalBytesRead, bytesToRead - totalBytesRead)) > 0)
+    while ((bytesRead = FileSystem::readFromFile(handle, buffer.mutableSpan().subspan(totalBytesRead))) > 0)
         totalBytesRead += bytesRead;
 
     if (totalBytesRead != bytesToRead)

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -170,7 +170,7 @@ WTF_EXPORT_PRIVATE bool flushFile(PlatformFileHandle);
 // Returns number of bytes actually read if successful, -1 otherwise.
 WTF_EXPORT_PRIVATE int64_t writeToFile(PlatformFileHandle, std::span<const uint8_t> data);
 // Returns number of bytes actually written if successful, -1 otherwise.
-WTF_EXPORT_PRIVATE int64_t readFromFile(PlatformFileHandle, void* data, size_t length);
+WTF_EXPORT_PRIVATE int64_t readFromFile(PlatformFileHandle, std::span<uint8_t> data);
 
 WTF_EXPORT_PRIVATE PlatformFileHandle openAndLockFile(const String&, FileOpenMode, OptionSet<FileLockMode> = FileLockMode::Exclusive);
 WTF_EXPORT_PRIVATE void unlockAndCloseFile(PlatformFileHandle);

--- a/Source/WTF/wtf/cocoa/SpanCocoa.h
+++ b/Source/WTF/wtf/cocoa/SpanCocoa.h
@@ -36,6 +36,14 @@ inline std::span<const uint8_t> span(NSData *data)
     return { static_cast<const uint8_t*>(data.bytes), data.length };
 }
 
+#ifdef __OBJC__
+inline RetainPtr<NSData> toNSData(std::span<const uint8_t> span)
+{
+    return adoptNS([[NSData alloc] initWithBytes:span.data() length:span.size()]);
+}
+#endif
+
 } // namespace WTF
 
 using WTF::span;
+using WTF::toNSData;

--- a/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
@@ -144,10 +144,10 @@ int64_t writeToFile(PlatformFileHandle handle, std::span<const uint8_t> data)
     return -1;
 }
 
-int64_t readFromFile(PlatformFileHandle handle, void* data, size_t length)
+int64_t readFromFile(PlatformFileHandle handle, std::span<uint8_t> data)
 {
     do {
-        auto bytesRead = read(handle, data, length);
+        auto bytesRead = read(handle, data.data(), data.size());
         if (bytesRead >= 0)
             return bytesRead;
     } while (errno == EINTR);

--- a/Source/WTF/wtf/win/FileSystemWin.cpp
+++ b/Source/WTF/wtf/win/FileSystemWin.cpp
@@ -288,13 +288,13 @@ int64_t writeToFile(PlatformFileHandle handle, std::span<const uint8_t> data)
     return static_cast<int64_t>(bytesWritten);
 }
 
-int64_t readFromFile(PlatformFileHandle handle, void* data, size_t length)
+int64_t readFromFile(PlatformFileHandle handle, std::span<uint8_t> data)
 {
     if (!isHandleValid(handle))
         return -1;
 
     DWORD bytesRead;
-    bool success = ::ReadFile(handle, data, length, &bytesRead, nullptr);
+    bool success = ::ReadFile(handle, data.data(), data.size(), &bytesRead, nullptr);
 
     if (!success)
         return -1;

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp
@@ -118,7 +118,7 @@ ExceptionOr<unsigned long long> FileSystemSyncAccessHandle::read(BufferSource&& 
             return Exception { ExceptionCode::InvalidStateError, "Failed to read at offset"_s };
     }
 
-    int result = FileSystem::readFromFile(m_file.handle(), buffer.mutableData(), buffer.length());
+    int result = FileSystem::readFromFile(m_file.handle(), buffer.mutableSpan());
     if (result == -1)
         return Exception { ExceptionCode::InvalidStateError, "Failed to read from file"_s };
 

--- a/Source/WebCore/Modules/notifications/NotificationDataCocoa.mm
+++ b/Source/WebCore/Modules/notifications/NotificationDataCocoa.mm
@@ -109,7 +109,7 @@ NSDictionary *NotificationData::dictionaryRepresentation() const
         WebNotificationUUIDStringKey : (NSString *)notificationID.toString(),
         WebNotificationContextUUIDStringKey : (NSString *)contextIdentifier.toString(),
         WebNotificationSessionIDKey : @(sourceSession.toUInt64()),
-        WebNotificationDataKey: [NSData dataWithBytes:data.data() length:data.size()],
+        WebNotificationDataKey: toNSData(data).autorelease(),
     }.mutableCopy;
 
     if (silent != std::nullopt)

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp
@@ -144,8 +144,7 @@ ExceptionOr<void> WebCodecsAudioData::copyTo(BufferSource&& source, CopyToOption
     if (allocationSize > source.length())
         return Exception { ExceptionCode::RangeError, "Buffer is too small"_s };
 
-    std::span buffer { static_cast<uint8_t*>(source.mutableData()), source.length() };
-    m_data.audioData->copyTo(buffer, destFormat, options.planeIndex, options.frameOffset, options.frameCount, maxCopyElementCount);
+    m_data.audioData->copyTo(source.mutableSpan(), destFormat, options.planeIndex, options.frameOffset, options.frameCount, maxCopyElementCount);
     return { };
 }
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
@@ -162,7 +162,7 @@ ExceptionOr<void> WebCodecsAudioDecoder::decode(Ref<WebCodecsEncodedAudioChunk>&
         --m_decodeQueueSize;
         scheduleDequeueEvent();
 
-        m_internalDecoder->decode({ { chunk->data(), chunk->byteLength() }, chunk->type() == WebCodecsEncodedAudioChunkType::Key, chunk->timestamp(), chunk->duration() }, [this](String&& result) {
+        m_internalDecoder->decode({ chunk->span(), chunk->type() == WebCodecsEncodedAudioChunkType::Key, chunk->timestamp(), chunk->duration() }, [this](String&& result) {
             --m_beingDecodedQueueSize;
             if (!result.isNull())
                 closeDecoder(Exception { ExceptionCode::EncodingError, WTFMove(result) });

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.cpp
@@ -29,6 +29,8 @@
 
 #if ENABLE(WEB_CODECS)
 
+#include <wtf/StdLibExtras.h>
+
 namespace WebCore {
 
 WebCodecsEncodedAudioChunk::WebCodecsEncodedAudioChunk(Init&& init)
@@ -41,7 +43,7 @@ ExceptionOr<void> WebCodecsEncodedAudioChunk::copyTo(BufferSource&& source)
     if (source.length() < byteLength())
         return Exception { ExceptionCode::TypeError, "buffer is too small"_s };
 
-    std::memcpy(source.mutableData(), data(), byteLength());
+    memcpySpan(source.mutableSpan().first(byteLength()), span());
     return { };
 }
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.h
@@ -70,7 +70,7 @@ public:
 
     ExceptionOr<void> copyTo(BufferSource&&);
 
-    const uint8_t* data() const { return m_storage->data().buffer.data(); }
+    std::span<const uint8_t> span() const { return m_storage->data().buffer.span(); }
     WebCodecsEncodedAudioChunkStorage& storage() { return m_storage.get(); }
 
 private:

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.cpp
@@ -28,6 +28,8 @@
 
 #if ENABLE(WEB_CODECS)
 
+#include <wtf/StdLibExtras.h>
+
 namespace WebCore {
 
 WebCodecsEncodedVideoChunk::WebCodecsEncodedVideoChunk(Init&& init)
@@ -40,7 +42,7 @@ ExceptionOr<void> WebCodecsEncodedVideoChunk::copyTo(BufferSource&& source)
     if (source.length() < byteLength())
         return Exception { ExceptionCode::TypeError, "buffer is too small"_s };
 
-    std::memcpy(source.mutableData(), data(), byteLength());
+    memcpySpan(source.mutableSpan().first(byteLength()), span());
     return { };
 }
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.h
@@ -69,7 +69,7 @@ public:
 
     ExceptionOr<void> copyTo(BufferSource&&);
 
-    const uint8_t* data() const { return m_storage->data().buffer.data(); }
+    std::span<const uint8_t> span() const { return m_storage->data().buffer.span(); }
     WebCodecsEncodedVideoChunkStorage& storage() { return m_storage.get(); }
 
 private:

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -198,7 +198,7 @@ ExceptionOr<void> WebCodecsVideoDecoder::decode(Ref<WebCodecsEncodedVideoChunk>&
         --m_decodeQueueSize;
         scheduleDequeueEvent();
 
-        m_internalDecoder->decode({ { chunk->data(), chunk->byteLength() }, chunk->type() == WebCodecsEncodedVideoChunkType::Key, chunk->timestamp(), chunk->duration() }, [this](auto&& result) {
+        m_internalDecoder->decode({ chunk->span(), chunk->type() == WebCodecsEncodedVideoChunkType::Key, chunk->timestamp(), chunk->duration() }, [this](auto&& result) {
             --m_beingDecodedQueueSize;
             if (!result.isNull())
                 closeDecoder(Exception { ExceptionCode::EncodingError, WTFMove(result) });

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -307,19 +307,19 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutio
             return Exception { ExceptionCode::TypeError, "coded width or height is odd"_s };
         if (init.visibleRect && (static_cast<size_t>(init.visibleRect->x) % 2 || static_cast<size_t>(init.visibleRect->x) % 2))
             return Exception { ExceptionCode::TypeError, "visible x or y is odd"_s };
-        videoFrame = VideoFrame::createNV12({ data.data(), data.length() }, parsedRect.width, parsedRect.height, layout.computedLayouts[0], layout.computedLayouts[1], WTFMove(colorSpace));
+        videoFrame = VideoFrame::createNV12(data.span(), parsedRect.width, parsedRect.height, layout.computedLayouts[0], layout.computedLayouts[1], WTFMove(colorSpace));
     } else if (init.format == VideoPixelFormat::RGBA || init.format == VideoPixelFormat::RGBX)
-        videoFrame = VideoFrame::createRGBA({ data.data(), data.length() }, parsedRect.width, parsedRect.height, layout.computedLayouts[0], WTFMove(colorSpace));
+        videoFrame = VideoFrame::createRGBA(data.span(), parsedRect.width, parsedRect.height, layout.computedLayouts[0], WTFMove(colorSpace));
     else if (init.format == VideoPixelFormat::BGRA || init.format == VideoPixelFormat::BGRX)
-        videoFrame = VideoFrame::createBGRA({ data.data(), data.length() }, parsedRect.width, parsedRect.height, layout.computedLayouts[0], WTFMove(colorSpace));
+        videoFrame = VideoFrame::createBGRA(data.span(), parsedRect.width, parsedRect.height, layout.computedLayouts[0], WTFMove(colorSpace));
     else if (init.format == VideoPixelFormat::I420) {
         if (auto exception = validateI420Sizes(init))
             return WTFMove(*exception);
-        videoFrame = VideoFrame::createI420({ data.data(), data.length() }, parsedRect.width, parsedRect.height, layout.computedLayouts[0], layout.computedLayouts[1], layout.computedLayouts[2], WTFMove(colorSpace));
+        videoFrame = VideoFrame::createI420(data.span(), parsedRect.width, parsedRect.height, layout.computedLayouts[0], layout.computedLayouts[1], layout.computedLayouts[2], WTFMove(colorSpace));
     } else if (init.format == VideoPixelFormat::I420A) {
         if (auto exception = validateI420Sizes(init))
             return WTFMove(*exception);
-        videoFrame = VideoFrame::createI420A({ data.data(), data.length() }, parsedRect.width, parsedRect.height, layout.computedLayouts[0], layout.computedLayouts[1], layout.computedLayouts[2], layout.computedLayouts[3], WTFMove(colorSpace));
+        videoFrame = VideoFrame::createI420A(data.span(), parsedRect.width, parsedRect.height, layout.computedLayouts[0], layout.computedLayouts[1], layout.computedLayouts[2], layout.computedLayouts[3], WTFMove(colorSpace));
     } else
         return Exception { ExceptionCode::NotSupportedError, "VideoPixelFormat is not supported"_s };
 
@@ -502,7 +502,7 @@ void WebCodecsVideoFrame::copyTo(BufferSource&& source, CopyToOptions&& options,
         return;
     }
 
-    std::span buffer { static_cast<uint8_t*>(source.mutableData()), source.length() };
+    auto buffer = source.mutableSpan();
     m_data.internalFrame->copyTo(buffer, *m_data.format, WTFMove(combinedLayout.computedLayouts), [source = WTFMove(source), promise = WTFMove(promise)](auto planeLayouts) mutable {
         if (!planeLayouts) {
             promise.reject(Exception { ExceptionCode::TypeError,  "Unable to copy data"_s });

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -826,8 +826,7 @@ void AXRemoteFrame::initializePlatformElementWithRemoteToken(std::span<const uin
     m_processIdentifier = processIdentifier;
     if ([wrapper() respondsToSelector:@selector(accessibilitySetPresenterProcessIdentifier:)])
         [(id)wrapper() accessibilitySetPresenterProcessIdentifier:processIdentifier];
-    NSData *tokenData = [NSData dataWithBytes:token.data() length:token.size()];
-    m_remoteFramePlatformElement = adoptNS([[NSAccessibilityRemoteUIElement alloc] initWithRemoteToken:tokenData]);
+    m_remoteFramePlatformElement = adoptNS([[NSAccessibilityRemoteUIElement alloc] initWithRemoteToken:toNSData(token).get()]);
 
     if (auto* cache = axObjectCache())
         cache->onRemoteFrameInitialized(*this);

--- a/Source/WebCore/bindings/js/BufferSource.h
+++ b/Source/WebCore/bindings/js/BufferSource.h
@@ -52,28 +52,25 @@ public:
 
     const VariantType& variant() const { return m_variant; }
 
-    const uint8_t* data() const
-    {
-        return std::visit([](auto& buffer) -> const uint8_t* {
-            return buffer ? static_cast<const uint8_t*>(buffer->data()) : nullptr;
-        }, m_variant);
-    }
-    
-    void* mutableData() const
-    {
-        return std::visit([](auto& buffer) -> void* {
-            return buffer->data();
-        }, m_variant);
-    }
-
     size_t length() const
     {
-        return std::visit([](auto& buffer) -> size_t {
+        return std::visit([](auto& buffer) {
             return buffer ? buffer->byteLength() : 0;
         }, m_variant);
     }
 
-    std::span<const uint8_t> span() const { return { data(), length() }; }
+    std::span<const uint8_t> span() const
+    {
+        return std::visit([](auto& buffer) {
+            return buffer ? buffer->span() : std::span<const uint8_t> { };
+        }, m_variant);
+    }
+    std::span<uint8_t> mutableSpan()
+    {
+        return std::visit([](auto& buffer) {
+            return buffer ? buffer->mutableSpan() : std::span<uint8_t> { };
+        }, m_variant);
+    }
 
 private:
     VariantType m_variant;
@@ -92,7 +89,7 @@ inline BufferSource toBufferSource(NSData *data)
 
 inline RetainPtr<NSData> toNSData(const BufferSource& data)
 {
-    return adoptNS([[NSData alloc] initWithBytes:data.data() length:data.length()]);
+    return WTF::toNSData(data.span());
 }
 #endif
 

--- a/Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapMac.mm
+++ b/Source/WebCore/crypto/cocoa/SerializedCryptoKeyWrapMac.mm
@@ -150,7 +150,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         (id)kSecAttrComment : webCryptoMasterKeyKeychainComment(),
         (id)kSecAttrLabel : localizedItemName,
         (id)kSecAttrAccount : masterKeyAccountNameForCurrentApplication(),
-        (id)kSecValueData : [NSData dataWithBytes:base64EncodedMasterKeyData.data() length:base64EncodedMasterKeyData.size()],
+        (id)kSecValueData : toNSData(base64EncodedMasterKeyData).autorelease(),
     };
 
     status = SecItemAdd((CFDictionaryRef)attributes, nullptr);
@@ -252,8 +252,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     auto dictionary = @{
         versionKey: [NSNumber numberWithUnsignedInteger:currentSerializationVersion],
-        wrappedKEKKey: [NSData dataWithBytes:wrappedKEK.data() length:wrappedKEK.size()],
-        encryptedKeyKey: [NSData dataWithBytes:encryptedKey.data() length:encryptedKey.size()],
+        wrappedKEKKey: toNSData(wrappedKEK).autorelease(),
+        encryptedKeyKey: toNSData(encryptedKey).autorelease(),
         tagKey: [NSData dataWithBytes:tag length:tagLength]
     };
 

--- a/Source/WebCore/loader/cocoa/PrivateClickMeasurementCocoa.mm
+++ b/Source/WebCore/loader/cocoa/PrivateClickMeasurementCocoa.mm
@@ -53,7 +53,7 @@ std::optional<String> PrivateClickMeasurement::calculateAndUpdateUnlinkableToken
         auto serverPublicKeyData = base64URLDecode(serverPublicKeyBase64URL);
         if (!serverPublicKeyData)
             return makeString("Could not decode the "_s, contextForLogMessage, "'s public key data."_s);
-        auto serverPublicKey = adoptNS([[NSData alloc] initWithBytes:serverPublicKeyData->data() length:serverPublicKeyData->size()]);
+        RetainPtr serverPublicKey = toNSData(serverPublicKeyData->span());
 
         NSError* nsError = 0;
         unlinkableToken.blinder = adoptNS([PAL::allocRSABSSATokenBlinderInstance() initWithPublicKey:serverPublicKey.get() error:&nsError]);
@@ -109,7 +109,7 @@ std::optional<String> PrivateClickMeasurement::calculateAndUpdateSecretToken(con
         auto serverResponseData = base64URLDecode(serverResponseBase64URL);
         if (!serverResponseData)
             return makeString("Could not decode "_s, contextForLogMessage, " response data."_s);
-        auto serverResponse = adoptNS([[NSData alloc] initWithBytes:serverResponseData->data() length:serverResponseData->size()]);
+        RetainPtr serverResponse = toNSData(serverResponseData->span());
 
         NSError* nsError = 0;
         unlinkableToken.readyToken = [unlinkableToken.waitingToken activateTokenWithServerResponse:serverResponse.get() error:&nsError];

--- a/Source/WebCore/platform/FileHandle.cpp
+++ b/Source/WebCore/platform/FileHandle.cpp
@@ -106,7 +106,7 @@ int FileHandle::read(void* data, int length)
     if (!open())
         return -1;
 
-    return FileSystem::readFromFile(m_fileHandle, data, length);
+    return FileSystem::readFromFile(m_fileHandle, { static_cast<uint8_t*>(data), static_cast<size_t>(length) });
 }
 
 int FileHandle::write(std::span<const uint8_t> data)

--- a/Source/WebCore/platform/FileStream.cpp
+++ b/Source/WebCore/platform/FileStream.cpp
@@ -105,7 +105,7 @@ int FileStream::read(void* buffer, int bufferSize)
     int bytesToRead = (remaining < bufferSize) ? static_cast<int>(remaining) : bufferSize;
     int bytesRead = 0;
     if (bytesToRead > 0)
-        bytesRead = FileSystem::readFromFile(m_handle, buffer, bytesToRead);
+        bytesRead = FileSystem::readFromFile(m_handle, { static_cast<uint8_t*>(buffer), static_cast<size_t>(bytesToRead) });
     if (bytesRead < 0)
         return -1;
     if (bytesRead > 0)

--- a/Source/WebCore/platform/cocoa/SharedMemoryCocoa.mm
+++ b/Source/WebCore/platform/cocoa/SharedMemoryCocoa.mm
@@ -35,6 +35,7 @@
 #import <mach/vm_map.h>
 #import <wtf/MachSendRight.h>
 #import <wtf/RefPtr.h>
+#import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/spi/cocoa/MachVMSPI.h>
 
 #if HAVE(MACH_MEMORY_ENTRY)
@@ -230,8 +231,7 @@ WTF::MachSendRight SharedMemory::createSendRight(Protection protection) const
 
 RetainPtr<NSData> SharedMemory::toNSData() const
 {
-    auto span = this->span();
-    return adoptNS([[NSData alloc] initWithBytes:span.data() length:span.size()]);
+    return WTF::toNSData(span());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm
@@ -90,7 +90,7 @@ RefPtr<Uint8Array> CDMSessionAVFoundationObjC::generateKeyRequest(const String& 
         return nullptr;
     }
 
-    RetainPtr<NSData> certificateData = adoptNS([[NSData alloc] initWithBytes:certificate->baseAddress() length:certificate->byteLength()]);
+    RetainPtr certificateData = toNSData(certificate->span());
     NSString* assetStr = keyID;
     RetainPtr<NSData> assetID = [NSData dataWithBytes: [assetStr cStringUsingEncoding:NSUTF8StringEncoding] length:[assetStr lengthOfBytesUsingEncoding:NSUTF8StringEncoding]];
     NSError* nsError = 0;
@@ -120,7 +120,7 @@ void CDMSessionAVFoundationObjC::releaseKeys()
 
 bool CDMSessionAVFoundationObjC::update(Uint8Array* key, RefPtr<Uint8Array>& nextMessage, unsigned short& errorCode, uint32_t& systemCode)
 {
-    RetainPtr<NSData> keyData = adoptNS([[NSData alloc] initWithBytes:key->baseAddress() length:key->byteLength()]);
+    RetainPtr keyData = toNSData(key->span());
     [[m_request dataRequest] respondWithData:keyData.get()];
     [m_request finishLoading];
     errorCode = MediaPlayer::NoError;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -2151,7 +2151,7 @@ static void fulfillRequestWithKeyData(AVAssetResourceLoadingRequest *request, Ar
         ASSERT(start <= std::numeric_limits<int>::max());
         ASSERT(end <= std::numeric_limits<int>::max());
         auto requestedKeyData = keyData->slice(static_cast<int>(start), static_cast<int>(end));
-        RetainPtr<NSData> nsData = adoptNS([[NSData alloc] initWithBytes:requestedKeyData->data() length:requestedKeyData->byteLength()]);
+        RetainPtr nsData = toNSData(requestedKeyData->span());
         [dataRequest respondWithData:nsData.get()];
     }
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -145,6 +145,8 @@ public:
     bool isValid() const { return m_isValid; }
     uint8_t* data() { RELEASE_ASSERT(m_isValid); return static_cast<uint8_t*>(m_info.data); }
     const uint8_t* data() const { RELEASE_ASSERT(m_isValid); return static_cast<uint8_t*>(m_info.data); }
+    std::span<uint8_t> mutableSpan() { return { data(), size() }; }
+    std::span<const uint8_t> span() const { return { data(), size() }; }
     size_t size() const { ASSERT(m_isValid); return m_isValid ? static_cast<size_t>(m_info.size) : 0; }
     MapType* mappedData() const  { ASSERT(m_isValid); return m_isValid ? const_cast<MapType*>(&m_info) : nullptr; }
     Vector<uint8_t> createVector() const;

--- a/Source/WebCore/platform/graphics/mac/ImageAdapterMac.mm
+++ b/Source/WebCore/platform/graphics/mac/ImageAdapterMac.mm
@@ -30,6 +30,7 @@
 #import "FloatRect.h"
 #import "GraphicsContext.h"
 #import "SharedBuffer.h"
+#import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/text/WTFString.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -105,7 +106,7 @@ WebMultiRepresentationHEICAttachment *ImageAdapter::multiRepresentationHEIC()
 
     Vector<uint8_t> data = buffer->copyData();
 
-    RetainPtr nsData = adoptNS([[NSData alloc] initWithBytes:data.data() length:data.size()]);
+    RetainPtr nsData = toNSData(data.span());
     m_multiRepHEIC = adoptNS([[PlatformWebMultiRepresentationHEICAttachment alloc] initWithImageContent:nsData.get()]);
 
     return m_multiRepHEIC.get();

--- a/Source/WebCore/platform/network/curl/CurlFormDataStream.cpp
+++ b/Source/WebCore/platform/network/curl/CurlFormDataStream.cpp
@@ -146,7 +146,7 @@ std::optional<size_t> CurlFormDataStream::readFromFile(const FormDataElement::En
         return std::nullopt;
     }
 
-    auto readBytes = FileSystem::readFromFile(m_fileHandle, buffer, size);
+    auto readBytes = FileSystem::readFromFile(m_fileHandle, { byteCast<uint8_t>(buffer), size });
     if (readBytes < 0) {
         LOG(Network, "Curl - Failed while trying to read %s for upload\n", fileData.filename.utf8().data());
         FileSystem::closeFile(m_fileHandle);

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -120,7 +120,7 @@ public:
     void webProcessConnectionCountForTesting(CompletionHandler<void(uint64_t)>&&);
 
 #if USE(EXTENSIONKIT)
-    void resolveBookmarkDataForCacheDirectory(const std::span<const uint8_t>& bookmarkData);
+    void resolveBookmarkDataForCacheDirectory(std::span<const uint8_t> bookmarkData);
 #endif
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)

--- a/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
@@ -37,6 +37,7 @@
 #import <pal/spi/cocoa/AVFoundationSPI.h>
 #import <pal/spi/cocoa/MetalSPI.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/SpanCocoa.h>
 
 #if PLATFORM(MAC)
 #include <pal/spi/cocoa/LaunchServicesSPI.h>
@@ -123,9 +124,9 @@ void GPUProcess::platformInitializeGPUProcess(GPUProcessCreationParameters& para
 }
 
 #if USE(EXTENSIONKIT)
-void GPUProcess::resolveBookmarkDataForCacheDirectory(const std::span<const uint8_t>& bookmarkData)
+void GPUProcess::resolveBookmarkDataForCacheDirectory(std::span<const uint8_t> bookmarkData)
 {
-    auto bookmark = adoptNS([[NSData alloc] initWithBytes:bookmarkData.data() length:bookmarkData.size()]);
+    RetainPtr bookmark = toNSData(bookmarkData);
     BOOL bookmarkIsStale = NO;
     NSError* error = nil;
     [NSURL URLByResolvingBookmarkData:bookmark.get() options:NSURLBookmarkResolutionWithoutUI relativeToURL:nil bookmarkDataIsStale:&bookmarkIsStale error:&error];

--- a/Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm
@@ -36,6 +36,7 @@
 #import <pal/spi/cocoa/NSURLConnectionSPI.h>
 #import <pal/text/TextEncoding.h>
 #import <wtf/URL.h>
+#import <wtf/cocoa/SpanCocoa.h>
 
 using namespace WebKit;
 
@@ -188,7 +189,7 @@ void LegacyCustomProtocolManager::didLoadData(LegacyCustomProtocolID customProto
     if (!protocol)
         return;
 
-    RetainPtr<NSData> nsData = adoptNS([[NSData alloc] initWithBytes:data.data() length:data.size()]);
+    RetainPtr nsData = toNSData(data);
 
     dispatchOnInitializationRunLoop(protocol.get(), ^ {
         [[protocol client] URLProtocol:protocol.get() didLoadData:nsData.get()];

--- a/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
@@ -47,7 +47,7 @@ void Download::resume(std::span<const uint8_t> resumeData, const String& path, S
         return;
     }
     auto& cocoaSession = static_cast<NetworkSessionCocoa&>(*networkSession);
-    auto nsData = adoptNS([[NSData alloc] initWithBytes:resumeData.data() length:resumeData.size()]);
+    RetainPtr nsData = toNSData(resumeData);
 
     NSMutableDictionary *dictionary = [NSPropertyListSerialization propertyListWithData:nsData.get() options:NSPropertyListMutableContainersAndLeaves format:0 error:nullptr];
     [dictionary setObject:static_cast<NSString*>(path) forKey:@"NSURLSessionResumeInfoLocalPath"];

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm
@@ -121,7 +121,7 @@ void NetworkLoader::start(URL&& url, RefPtr<JSON::Object>&& jsonPayload, WebCore
         request.get().HTTPMethod = @"POST";
         [request setValue:WebCore::HTTPHeaderValues::applicationJSONContentType() forHTTPHeaderField:@"Content-Type"];
         auto body = jsonPayload->toJSONString().utf8();
-        request.get().HTTPBody = adoptNS([[NSData alloc] initWithBytes:body.data() length:body.length()]).get();
+        request.get().HTTPBody = toNSData(body.span()).get();
     }
 
     setPCMDataCarriedOnRequest(pcmDataCarried, request.get());

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCurl.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCurl.cpp
@@ -68,7 +68,7 @@ void IOChannel::read(size_t offset, size_t size, WTF::WorkQueueBase& queue, Func
         readSize = std::min(size, readSize);
         Vector<uint8_t> buffer(readSize);
         FileSystem::seekFile(m_fileDescriptor, offset, FileSystem::FileSeekOrigin::Beginning);
-        int err = FileSystem::readFromFile(m_fileDescriptor, buffer.data(), readSize);
+        int err = FileSystem::readFromFile(m_fileDescriptor, buffer.mutableSpan());
         err = err < 0 ? err : 0;
         auto data = Data(WTFMove(buffer));
         completionHandler(data, err);

--- a/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
@@ -144,7 +144,7 @@ void WebSocketTask::sendString(std::span<const uint8_t> utf8String, CompletionHa
 
 void WebSocketTask::sendData(std::span<const uint8_t> data, CompletionHandler<void()>&& callback)
 {
-    auto nsData = adoptNS([[NSData alloc] initWithBytes:data.data() length:data.size()]);
+    RetainPtr nsData = toNSData(data);
     auto message = adoptNS([[NSURLSessionWebSocketMessage alloc] initWithData:nsData.get()]);
     [m_task sendMessage:message.get() completionHandler:makeBlockPtr([callback = WTFMove(callback)](NSError * _Nullable) mutable {
         callback();
@@ -156,7 +156,7 @@ void WebSocketTask::close(int32_t code, const String& reason)
     if (code == WebCore::ThreadableWebSocketChannel::CloseEventCodeNotSpecified)
         code = NSURLSessionWebSocketCloseCodeInvalid;
     auto utf8 = reason.utf8();
-    auto nsData = adoptNS([[NSData alloc] initWithBytes:utf8.data() length:utf8.length()]);
+    RetainPtr nsData = toNSData(utf8.span());
     if ([m_task respondsToSelector:@selector(_sendCloseCode:reason:)]) {
         [m_task _sendCloseCode:(NSURLSessionWebSocketCloseCode)code reason:nsData.get()];
         return;

--- a/Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebPushMessageCocoa.mm
@@ -83,7 +83,7 @@ NSDictionary *WebPushMessage::toDictionary() const
 {
     RetainPtr<NSData> nsData;
     if (pushData)
-        nsData = nsData = adoptNS([[NSData alloc] initWithBytes:pushData->data() length:pushData->size()]);
+        nsData = nsData = toNSData(pushData->span());
 
     NSDictionary *nsPayload = nil;
 #if ENABLE(DECLARATIVE_WEB_PUSH)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKDataTask.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKDataTask.mm
@@ -37,6 +37,7 @@
 #import <WebCore/ResourceRequest.h>
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/cocoa/SpanCocoa.h>
 
 class WKDataTaskClient final : public API::DataTaskClient {
 public:
@@ -93,7 +94,7 @@ private:
     {
         if (!m_delegate || !m_respondsToDidReceiveData)
             return;
-        [m_delegate dataTask:wrapper(task) didReceiveData:adoptNS([[NSData alloc] initWithBytes:data.data() length:data.size()]).get()];
+        [m_delegate dataTask:wrapper(task) didReceiveData:toNSData(data).get()];
     }
 
     void didCompleteWithError(API::DataTask& task, WebCore::ResourceError&& error) const final

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -406,7 +406,7 @@ void WebInspectorUIProxy::showSavePanel(NSWindow *frontendWindow, NSURL *platfor
             auto decodedData = base64Decode(contentString, { Base64DecodeOption::ValidatePadding });
             if (!decodedData)
                 return;
-            auto dataContent = adoptNS([[NSData alloc] initWithBytes:decodedData->data() length:decodedData->size()]);
+            RetainPtr dataContent = toNSData(decodedData->span());
             [dataContent writeToURL:actualURL atomically:YES];
         } else
             [[controller content] writeToURL:actualURL atomically:YES encoding:NSUTF8StringEncoding error:NULL];

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.mm
@@ -31,6 +31,7 @@
 #import "AuthenticatorManager.h"
 #import "WKASCAuthorizationPresenterDelegate.h"
 #import <wtf/BlockPtr.h>
+#import <wtf/cocoa/SpanCocoa.h>
 
 #import "AuthenticationServicesCoreSoftLink.h"
 
@@ -194,7 +195,7 @@ void AuthenticatorPresenterCoordinator::selectAssertionResponse(Vector<Ref<Authe
 
             RetainPtr<NSData> userHandle;
             if (response->userHandle())
-                userHandle = adoptNS([[NSData alloc] initWithBytes:response->userHandle()->data() length:response->userHandle()->byteLength()]);
+                userHandle = toNSData(response->userHandle()->span());
 
             auto loginChoice = adoptNS([allocASCSecurityKeyPublicKeyCredentialLoginChoiceInstance() initWithName:response->name() displayName:response->displayName() userHandle:userHandle.get()]);
             [loginChoices addObject:loginChoice.get()];
@@ -211,7 +212,7 @@ void AuthenticatorPresenterCoordinator::selectAssertionResponse(Vector<Ref<Authe
         for (auto& response : responses) {
             RetainPtr<NSData> userHandle;
             if (response->userHandle())
-                userHandle = adoptNS([[NSData alloc] initWithBytes:response->userHandle()->data() length:response->userHandle()->byteLength()]);
+                userHandle = toNSData(response->userHandle()->span());
 
             auto loginChoice = adoptNS([allocASCPlatformPublicKeyCredentialLoginChoiceInstance() initWithName:response->name() displayName:response->displayName() userHandle:userHandle.get()]);
             [m_context addLoginChoice:loginChoice.get()];

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm
@@ -116,7 +116,7 @@ void CcidConnection::transact(Vector<uint8_t>&& data, DataReceivedCallback&& cal
     [m_smartCard beginSessionWithReply:makeBlockPtr([this, data = WTFMove(data), callback = WTFMove(callback)] (BOOL success, NSError *error) mutable {
         if (!success)
             return;
-        [m_smartCard transmitRequest:adoptNS([[NSData alloc] initWithBytes:data.data() length:data.size()]).autorelease() reply:makeBlockPtr([this, callback = WTFMove(callback)](NSData * _Nullable nsResponse, NSError * _Nullable error) mutable {
+        [m_smartCard transmitRequest:toNSData(data).autorelease() reply:makeBlockPtr([this, callback = WTFMove(callback)](NSData * _Nullable nsResponse, NSError * _Nullable error) mutable {
             [m_smartCard endSession];
             callOnMainRunLoop([response = makeVector(nsResponse), callback = WTFMove(callback)] () mutable {
                 callback(WTFMove(response));

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalConnection.mm
@@ -33,6 +33,7 @@
 #import <WebCore/WebAuthenticationConstants.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/RunLoop.h>
+#import <wtf/cocoa/SpanCocoa.h>
 
 #import "AppAttestInternalSoftLink.h"
 #import "LocalAuthenticationSoftLink.h"
@@ -54,11 +55,6 @@ static inline String bundleName()
 }
 #endif
 } // namespace
-
-static inline RetainPtr<NSData> toNSData(const Vector<uint8_t>& data)
-{
-    return adoptNS([[NSData alloc] initWithBytes:data.data() length:data.size()]);
-}
 
 LocalConnection::~LocalConnection()
 {

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcConnection.mm
@@ -92,7 +92,7 @@ NfcConnection::~NfcConnection()
 Vector<uint8_t> NfcConnection::transact(Vector<uint8_t>&& data) const
 {
     // The method will return an empty NSData if the tag is disconnected.
-    auto *responseData = [m_session transceive:adoptNS([[NSData alloc] initWithBytes:data.data() length:data.size()]).get()];
+    auto *responseData = [m_session transceive:toNSData(data).get()];
     return makeVector(responseData);
 }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -123,11 +123,6 @@ static inline RefPtr<ArrayBuffer> toArrayBufferNilIfEmpty(NSData *data)
     return ArrayBuffer::create(span(data));
 }
 
-static inline RetainPtr<NSData> toNSData(const Vector<uint8_t>& data)
-{
-    return adoptNS([[NSData alloc] initWithBytes:data.data() length:data.size()]);
-}
-
 static inline ExceptionCode toExceptionCode(NSInteger nsErrorCode)
 {
     ExceptionCode exceptionCode = (ExceptionCode)nsErrorCode;
@@ -757,7 +752,7 @@ static RetainPtr<ASCCredentialRequestContext> configureRegistrationRequestContex
     auto credentialCreationOptions = adoptNS([allocASCPublicKeyCredentialCreationOptionsInstance() init]);
 
     auto clientDataJson = WebCore::buildClientDataJson(ClientDataType::Create, options.challenge, callerOrigin.securityOrigin(), WebAuthn::Scope::SameOrigin);
-    RetainPtr nsClientDataJSON = adoptNS([[NSData alloc] initWithBytes:clientDataJson->data() length:clientDataJson->byteLength()]);
+    RetainPtr nsClientDataJSON = toNSData(clientDataJson->span());
     [credentialCreationOptions setClientDataJSON:nsClientDataJSON.get()];
 
     [credentialCreationOptions setRelyingPartyIdentifier:*options.rp.id];
@@ -815,7 +810,7 @@ static inline RetainPtr<ASCPublicKeyCredentialAssertionOptions> configureAsserti
     auto scope = parentOrigin ? WebAuthn::Scope::CrossOrigin : WebAuthn::Scope::SameOrigin;
     auto topOrigin = parentOrigin ? parentOrigin->toString() : nullString();
     auto clientDataJson = WebCore::buildClientDataJson(ClientDataType::Get, options.challenge, callerOrigin.securityOrigin(), scope, topOrigin);
-    RetainPtr nsClientDataJSON = adoptNS([[NSData alloc] initWithBytes:clientDataJson->data() length:clientDataJson->byteLength()]);
+    RetainPtr nsClientDataJSON = toNSData(clientDataJson->span());
     auto assertionOptions = adoptNS([allocASCPublicKeyCredentialAssertionOptionsInstance() initWithKind:kind relyingPartyIdentifier:options.rpId clientDataJSON:nsClientDataJSON.get() userVerificationPreference:userVerification.get() allowedCredentials:allowedCredentials.get() origin:callerOrigin.toString()]);
     if (options.extensions) {
         if ([assertionOptions respondsToSelector:@selector(setExtensionsCBOR:)])

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -76,6 +76,7 @@
 #import <WebCore/ValidationBubble.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/cocoa/Entitlements.h>
+#import <wtf/cocoa/SpanCocoa.h>
 
 #define MESSAGE_CHECK(assertion) do { \
     if (auto webView = this->webView()) { \
@@ -400,8 +401,7 @@ void PageClientImpl::executeUndoRedo(UndoOrRedo undoOrRedo)
 
 void PageClientImpl::accessibilityWebProcessTokenReceived(std::span<const uint8_t> data, WebCore::FrameIdentifier, pid_t)
 {
-    NSData *remoteToken = [NSData dataWithBytes:data.data() length:data.size()];
-    [contentView() _setAccessibilityWebProcessToken:remoteToken];
+    [contentView() _setAccessibilityWebProcessToken:toNSData(data).get()];
 }
 
 bool PageClientImpl::interpretKeyEvent(const NativeWebKeyboardEvent& event, bool isCharEvent)
@@ -839,8 +839,7 @@ void PageClientImpl::beganExitFullScreen(const IntRect& initialFrame, const IntR
 
 void PageClientImpl::didFinishLoadingDataForCustomContentProvider(const String& suggestedFilename, std::span<const uint8_t> dataReference)
 {
-    RetainPtr<NSData> data = adoptNS([[NSData alloc] initWithBytes:dataReference.data() length:dataReference.size()]);
-    [webView() _didFinishLoadingDataForCustomContentProviderWithSuggestedFilename:suggestedFilename data:data.get()];
+    [webView() _didFinishLoadingDataForCustomContentProviderWithSuggestedFilename:suggestedFilename data:toNSData(dataReference).get()];
 }
 
 void PageClientImpl::scrollingNodeScrollViewWillStartPanGesture(ScrollingNodeID)

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -80,6 +80,7 @@
 #import <pal/spi/ios/MobileGestaltSPI.h>
 #import <pal/system/ios/UserInterfaceIdiom.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/text/TextStream.h>
 
 #if USE(QUICK_LOOK)
@@ -739,8 +740,7 @@ void WebPageProxy::registerWebProcessAccessibilityToken(std::span<const uint8_t>
 
 void WebPageProxy::relayAccessibilityNotification(const String& notificationName, std::span<const uint8_t> data)
 {
-    NSData *notificationData = [NSData dataWithBytes:data.data() length:data.size()];
-    protectedPageClient()->relayAccessibilityNotification(notificationName, notificationData);
+    protectedPageClient()->relayAccessibilityNotification(notificationName, toNSData(data).get());
 }
 
 void WebPageProxy::assistiveTechnologyMakeFirstResponder()

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -82,6 +82,7 @@
 #import <pal/spi/mac/NSApplicationSPI.h>
 #import <wtf/ProcessPrivilege.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/text/CString.h>
 #import <wtf/text/WTFString.h>
 
@@ -582,7 +583,7 @@ void PageClientImpl::setTextIndicatorAnimationProgress(float progress)
 
 void PageClientImpl::accessibilityWebProcessTokenReceived(std::span<const uint8_t> data, WebCore::FrameIdentifier frameID, pid_t pid)
 {
-    m_impl->setAccessibilityWebProcessToken([NSData dataWithBytes:data.data() length:data.size()], frameID, pid);
+    m_impl->setAccessibilityWebProcessToken(toNSData(data).get(), frameID, pid);
 }
     
 void PageClientImpl::enterAcceleratedCompositingMode(const LayerTreeContext& layerTreeContext)

--- a/Source/WebKit/UIProcess/mac/WKPrintingView.mm
+++ b/Source/WebKit/UIProcess/mac/WKPrintingView.mm
@@ -39,6 +39,7 @@
 #import <WebCore/LocalDefaultSystemAppearance.h>
 #import <WebCore/ShareableBitmap.h>
 #import <wtf/RunLoop.h>
+#import <wtf/cocoa/SpanCocoa.h>
 
 #import "PDFKitSoftLink.h"
 
@@ -586,7 +587,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     ASSERT(!_printedPagesData.isEmpty()); // Prepared by knowsPageRange:
 
     if (!_printedPagesPDFDocument) {
-        RetainPtr<NSData> pdfData = adoptNS([[NSData alloc] initWithBytes:_printedPagesData.data() length:_printedPagesData.size()]);
+        RetainPtr pdfData = toNSData(_printedPagesData.span());
         _printedPagesPDFDocument = adoptNS([WebKit::allocPDFDocumentInstance() initWithData:pdfData.get()]);
 
         unsigned pageCount = [_printedPagesPDFDocument pageCount];

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -676,8 +676,7 @@ void WebPage::registerRemoteFrameAccessibilityTokens(pid_t, std::span<const uint
 
 void WebPage::registerUIProcessAccessibilityTokens(std::span<const uint8_t> elementToken, std::span<const uint8_t>)
 {
-    NSData *elementTokenData = [NSData dataWithBytes:elementToken.data() length:elementToken.size()];
-    [m_mockAccessibilityElement setRemoteTokenData:elementTokenData];
+    [m_mockAccessibilityElement setRemoteTokenData:toNSData(elementToken).get()];
 }
 
 void WebPage::getStringSelectionForPasteboard(CompletionHandler<void(String&&)>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -440,8 +440,8 @@ void WebPage::updateRemotePageAccessibilityOffset(WebCore::FrameIdentifier frame
 
 void WebPage::registerRemoteFrameAccessibilityTokens(pid_t pid, std::span<const uint8_t> elementToken)
 {
-    NSData *elementTokenData = [NSData dataWithBytes:elementToken.data() length:elementToken.size()];
-    auto remoteElement = elementTokenData.length ? adoptNS([[NSAccessibilityRemoteUIElement alloc] initWithRemoteToken:elementTokenData]) : nil;
+    RetainPtr elementTokenData = toNSData(elementToken);
+    auto remoteElement = [elementTokenData length] ? adoptNS([[NSAccessibilityRemoteUIElement alloc] initWithRemoteToken:elementTokenData.get()]) : nil;
 
     createMockAccessibilityElement(pid);
     [accessibilityRemoteObject() setRemoteParent:remoteElement.get()];
@@ -449,10 +449,10 @@ void WebPage::registerRemoteFrameAccessibilityTokens(pid_t pid, std::span<const 
 
 void WebPage::registerUIProcessAccessibilityTokens(std::span<const uint8_t> elementToken, std::span<const uint8_t> windowToken)
 {
-    NSData *elementTokenData = [NSData dataWithBytes:elementToken.data() length:elementToken.size()];
-    NSData *windowTokenData = [NSData dataWithBytes:windowToken.data() length:windowToken.size()];
-    auto remoteElement = elementTokenData.length ? adoptNS([[NSAccessibilityRemoteUIElement alloc] initWithRemoteToken:elementTokenData]) : nil;
-    auto remoteWindow = windowTokenData.length ? adoptNS([[NSAccessibilityRemoteUIElement alloc] initWithRemoteToken:windowTokenData]) : nil;
+    RetainPtr elementTokenData = toNSData(elementToken);
+    RetainPtr windowTokenData = toNSData(windowToken);
+    auto remoteElement = [elementTokenData length] ? adoptNS([[NSAccessibilityRemoteUIElement alloc] initWithRemoteToken:elementTokenData.get()]) : nil;
+    auto remoteWindow = [windowTokenData length] ? adoptNS([[NSAccessibilityRemoteUIElement alloc] initWithRemoteToken:windowTokenData.get()]) : nil;
 
     [remoteElement setWindowUIElement:remoteWindow.get()];
     [remoteElement setTopLevelUIElement:remoteWindow.get()];

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -214,8 +214,7 @@ void WebProcess::bindAccessibilityFrameWithData(WebCore::FrameIdentifier frameID
         m_accessibilityRemoteFrameTokenCache = adoptNS([[NSMutableDictionary alloc] init]);
 
     auto frameInt = frameID.object().toUInt64();
-    NSData *nsData = [NSData dataWithBytes:data.data() length:data.size()];
-    [m_accessibilityRemoteFrameTokenCache setObject:nsData forKey:@(frameInt)];
+    [m_accessibilityRemoteFrameTokenCache setObject:toNSData(data).get() forKey:@(frameInt)];
 }
 
 id WebProcess::accessibilityFocusedUIElement()

--- a/Source/WebKit/webpushd/ApplePushServiceConnection.mm
+++ b/Source/WebKit/webpushd/ApplePushServiceConnection.mm
@@ -81,8 +81,7 @@ ApplePushServiceConnection::~ApplePushServiceConnection()
 
 static RetainPtr<APSURLTokenInfo> makeTokenInfo(const String& topic, const Vector<uint8_t>& vapidPublicKey)
 {
-    auto serverPublicKey = adoptNS([[NSData alloc] initWithBytes:vapidPublicKey.data() length:vapidPublicKey.size()]);
-    return adoptNS([[APSURLTokenInfo alloc] initWithTopic:topic vapidPublicKey:serverPublicKey.get()]);
+    return adoptNS([[APSURLTokenInfo alloc] initWithTopic:topic vapidPublicKey:toNSData(vapidPublicKey).get()]);
 }
 
 void ApplePushServiceConnection::subscribe(const String& topic, const Vector<uint8_t>& vapidPublicKey, SubscribeHandler&& subscribeHandler)

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -45,6 +45,7 @@
 #import <wtf/NeverDestroyed.h>
 #import <wtf/URL.h>
 #import <wtf/WorkQueue.h>
+#import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/spi/darwin/XPCSPI.h>
 #import <wtf/text/StringConcatenateNumbers.h>
 
@@ -328,7 +329,7 @@ void WebPushDaemon::injectEncryptedPushMessageForTesting(PushClientConnection& c
         }
 
         auto bytes = message.utf8();
-        RetainPtr<NSData> data = adoptNS([[NSData alloc] initWithBytes:bytes.data() length: bytes.length()]);
+        RetainPtr data = toNSData(bytes.span());
 
         id obj = [NSJSONSerialization JSONObjectWithData:data.get() options:0 error:nullptr];
         if (!obj || ![obj isKindOfClass:[NSDictionary class]]) {

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
@@ -55,6 +55,7 @@
 #import <WebKitLegacy/DOMExtensions.h>
 #import <algorithm>
 #import <wtf/NakedPtr.h>
+#import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/text/Base64.h>
 
 using namespace WebCore;
@@ -426,7 +427,7 @@ void WebInspectorFrontendClient::save(Vector<InspectorFrontendClient::SaveData>&
             auto decodedData = base64Decode(contentCopy, { Base64DecodeOption::ValidatePadding });
             if (!decodedData)
                 return;
-            RetainPtr<NSData> dataContent = adoptNS([[NSData alloc] initWithBytes:decodedData->data() length:decodedData->size()]);
+            RetainPtr dataContent = toNSData(decodedData->span());
             [dataContent writeToURL:actualURL atomically:YES];
         } else
             [contentCopy writeToURL:actualURL atomically:YES encoding:NSUTF8StringEncoding error:NULL];

--- a/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp
@@ -269,7 +269,7 @@ TEST_F(GStreamerTest, harnessParseMP4)
         auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, bytesToRead, nullptr));
         {
             GstMappedBuffer mappedBuffer(buffer.get(), GST_MAP_WRITE);
-            FileSystem::readFromFile(handle, mappedBuffer.data(), bytesToRead);
+            FileSystem::readFromFile(handle, mappedBuffer.mutableSpan());
         }
         auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
         EXPECT_TRUE(harness->pushSample(WTFMove(sample)));
@@ -357,7 +357,7 @@ TEST_F(GStreamerTest, harnessDecodeMP4Video)
         auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, bytesToRead, nullptr));
         {
             GstMappedBuffer mappedBuffer(buffer.get(), GST_MAP_WRITE);
-            FileSystem::readFromFile(handle, mappedBuffer.data(), bytesToRead);
+            FileSystem::readFromFile(handle, mappedBuffer.mutableSpan());
         }
         EXPECT_TRUE(harness->pushBuffer(WTFMove(buffer)));
         totalRead += bytesToRead;
@@ -407,7 +407,7 @@ TEST_F(GStreamerTest, harnessDecodeMP4Video)
         auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, bytesToRead, nullptr));
         {
             GstMappedBuffer mappedBuffer(buffer.get(), GST_MAP_WRITE);
-            FileSystem::readFromFile(handle, mappedBuffer.data(), bytesToRead);
+            FileSystem::readFromFile(handle, mappedBuffer.mutableSpan());
         }
         EXPECT_TRUE(harness->pushBuffer(WTFMove(buffer)));
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
@@ -56,7 +56,9 @@
 #import <WebKit/_WKWebAuthenticationPanel.h>
 #import <WebKit/_WKWebAuthenticationPanelForTesting.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/WeakRandomNumber.h>
+#import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/spi/cocoa/SecuritySPI.h>
 #import <wtf/text/StringConcatenateNumbers.h>
 
@@ -1465,12 +1467,12 @@ TEST(WebAuthenticationPanel, LAGetAssertionMultipleOrder)
 
 TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMinimum)
 {
-    uint8_t identifier[] = { 0x01, 0x02, 0x03, 0x04 };
-    NSData *nsIdentifier = [NSData dataWithBytes:identifier length:sizeof(identifier)];
+    auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
+    RetainPtr nsIdentifier = toNSData(identifier);
     auto parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
 
     auto rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
-    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier displayName:@"J Appleseed"]);
+    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
     NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters = @[ parameters.get() ];
 
     auto options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
@@ -1482,8 +1484,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMinimum)
 
     EXPECT_WK_STREQ(result.user.name, "jappleseed@example.com");
     EXPECT_TRUE(result.user.icon.isNull());
-    EXPECT_EQ(result.user.id.length(), sizeof(identifier));
-    EXPECT_EQ(memcmp(result.user.id.data(), identifier, sizeof(identifier)), 0);
+    EXPECT_TRUE(equalSpans(result.user.id.span(), std::span<const uint8_t> { identifier }));
     EXPECT_WK_STREQ(result.user.displayName, "J Appleseed");
 
     EXPECT_EQ(result.pubKeyCredParams.size(), 1lu);
@@ -1499,14 +1500,14 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMinimum)
 
 TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximumDefault)
 {
-    uint8_t identifier[] = { 0x01, 0x02, 0x03, 0x04 };
-    NSData *nsIdentifier = [NSData dataWithBytes:identifier length:sizeof(identifier)];
+    auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
+    RetainPtr nsIdentifier = toNSData(identifier);
     auto parameters1 = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
     auto parameters2 = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-257]);
-    auto descriptor = adoptNS([[_WKPublicKeyCredentialDescriptor alloc] initWithIdentifier:nsIdentifier]);
+    auto descriptor = adoptNS([[_WKPublicKeyCredentialDescriptor alloc] initWithIdentifier:nsIdentifier.get()]);
 
     auto rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
-    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier displayName:@"J Appleseed"]);
+    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
     NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters = @[ parameters1.get(), parameters2.get() ];
     auto authenticatorSelection = adoptNS([[_WKAuthenticatorSelectionCriteria alloc] init]);
     auto extensions = adoptNS([[_WKAuthenticationExtensionsClientInputs alloc] init]);
@@ -1525,8 +1526,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximumDefault)
 
     EXPECT_WK_STREQ(result.user.name, "jappleseed@example.com");
     EXPECT_TRUE(result.user.icon.isNull());
-    EXPECT_EQ(result.user.id.length(), sizeof(identifier));
-    EXPECT_EQ(memcmp(result.user.id.data(), identifier, sizeof(identifier)), 0);
+    EXPECT_TRUE(equalSpans(result.user.id.span(), std::span<const uint8_t> { identifier }));
     EXPECT_WK_STREQ(result.user.displayName, "J Appleseed");
 
     EXPECT_EQ(result.pubKeyCredParams.size(), 2lu);
@@ -1539,8 +1539,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximumDefault)
 
     EXPECT_EQ(result.excludeCredentials.size(), 1lu);
     EXPECT_EQ(result.excludeCredentials[0].type, WebCore::PublicKeyCredentialType::PublicKey);
-    EXPECT_EQ(result.excludeCredentials[0].id.length(), sizeof(identifier));
-    EXPECT_EQ(memcmp(result.excludeCredentials[0].id.data(), identifier, sizeof(identifier)), 0);
+    EXPECT_TRUE(equalSpans(result.excludeCredentials[0].id.span(), std::span<const uint8_t> { identifier }));
 
     EXPECT_EQ(result.authenticatorSelection->authenticatorAttachment, std::nullopt);
     EXPECT_EQ(result.authenticatorSelection->requireResidentKey, false);
@@ -1552,8 +1551,8 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximumDefault)
 
 TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum1)
 {
-    uint8_t identifier[] = { 0x01, 0x02, 0x03, 0x04 };
-    NSData *nsIdentifier = [NSData dataWithBytes:identifier length:sizeof(identifier)];
+    auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
+    RetainPtr nsIdentifier = toNSData(identifier);
     auto parameters1 = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
     auto parameters2 = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-257]);
 
@@ -1561,7 +1560,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum1)
     [rp setIcon:@"https//www.example.com/icon.jpg"];
     [rp setIdentifier:@"example.com"];
 
-    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier displayName:@"J Appleseed"]);
+    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
     [user setIcon:@"https//www.example.com/icon.jpg"];
 
     NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters = @[ parameters1.get(), parameters2.get() ];
@@ -1573,7 +1572,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum1)
     RetainPtr nfc = [NSNumber numberWithInt:_WKWebAuthenticationTransportNFC];
     RetainPtr internal = [NSNumber numberWithInt:_WKWebAuthenticationTransportInternal];
     RetainPtr hybrid = [NSNumber numberWithInt:_WKWebAuthenticationTransportHybrid];
-    RetainPtr credential = adoptNS([[_WKPublicKeyCredentialDescriptor alloc] initWithIdentifier:nsIdentifier]);
+    RetainPtr credential = adoptNS([[_WKPublicKeyCredentialDescriptor alloc] initWithIdentifier:nsIdentifier.get()]);
     [credential setTransports:@[ usb.get(), nfc.get(), internal.get(), hybrid.get() ]];
     [options setExcludeCredentials:@[ credential.get(), credential.get() ]];
 
@@ -1593,8 +1592,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum1)
 
     EXPECT_WK_STREQ(result.user.name, "jappleseed@example.com");
     EXPECT_WK_STREQ(result.user.icon, @"https//www.example.com/icon.jpg");
-    EXPECT_EQ(result.user.id.length(), sizeof(identifier));
-    EXPECT_EQ(memcmp(result.user.id.data(), identifier, sizeof(identifier)), 0);
+    EXPECT_TRUE(equalSpans(result.user.id.span(), std::span<const uint8_t> { identifier }));
     EXPECT_WK_STREQ(result.user.displayName, "J Appleseed");
 
     EXPECT_EQ(result.pubKeyCredParams.size(), 2lu);
@@ -1607,8 +1605,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum1)
 
     EXPECT_EQ(result.excludeCredentials.size(), 2lu);
     EXPECT_EQ(result.excludeCredentials[0].type, WebCore::PublicKeyCredentialType::PublicKey);
-    EXPECT_EQ(result.excludeCredentials[0].id.length(), sizeof(identifier));
-    EXPECT_EQ(memcmp(result.excludeCredentials[0].id.data(), identifier, sizeof(identifier)), 0);
+    EXPECT_TRUE(equalSpans(result.excludeCredentials[0].id.span(), std::span<const uint8_t> { identifier }));
     EXPECT_EQ(result.excludeCredentials[0].transports.size(), 4lu);
     EXPECT_EQ(result.excludeCredentials[0].transports[0], AuthenticatorTransport::Usb);
     EXPECT_EQ(result.excludeCredentials[0].transports[1], AuthenticatorTransport::Nfc);
@@ -1624,8 +1621,8 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum1)
 
 TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum2)
 {
-    uint8_t identifier[] = { 0x01, 0x02, 0x03, 0x04 };
-    NSData *nsIdentifier = [NSData dataWithBytes:identifier length:sizeof(identifier)];
+    auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
+    RetainPtr nsIdentifier = toNSData(identifier);
     auto parameters1 = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
     auto parameters2 = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-257]);
 
@@ -1633,7 +1630,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum2)
     [rp setIcon:@"https//www.example.com/icon.jpg"];
     [rp setIdentifier:@"example.com"];
 
-    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier displayName:@"J Appleseed"]);
+    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
     [user setIcon:@"https//www.example.com/icon.jpg"];
 
     NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters = @[ parameters1.get(), parameters2.get() ];
@@ -1644,7 +1641,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum2)
     RetainPtr usb = [NSNumber numberWithInt:_WKWebAuthenticationTransportUSB];
     RetainPtr nfc = [NSNumber numberWithInt:_WKWebAuthenticationTransportNFC];
     RetainPtr internal = [NSNumber numberWithInt:_WKWebAuthenticationTransportInternal];
-    RetainPtr credential = adoptNS([[_WKPublicKeyCredentialDescriptor alloc] initWithIdentifier:nsIdentifier]);
+    RetainPtr credential = adoptNS([[_WKPublicKeyCredentialDescriptor alloc] initWithIdentifier:nsIdentifier.get()]);
     [credential setTransports:@[ usb.get(), nfc.get(), internal.get() ]];
     [options setExcludeCredentials:@[ credential.get(), credential.get() ]];
 
@@ -1664,8 +1661,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum2)
 
     EXPECT_WK_STREQ(result.user.name, "jappleseed@example.com");
     EXPECT_WK_STREQ(result.user.icon, @"https//www.example.com/icon.jpg");
-    EXPECT_EQ(result.user.id.length(), sizeof(identifier));
-    EXPECT_EQ(memcmp(result.user.id.data(), identifier, sizeof(identifier)), 0);
+    EXPECT_TRUE(equalSpans(result.user.id.span(), std::span<const uint8_t> { identifier }));
     EXPECT_WK_STREQ(result.user.displayName, "J Appleseed");
 
     EXPECT_EQ(result.pubKeyCredParams.size(), 2lu);
@@ -1678,8 +1674,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum2)
 
     EXPECT_EQ(result.excludeCredentials.size(), 2lu);
     EXPECT_EQ(result.excludeCredentials[0].type, WebCore::PublicKeyCredentialType::PublicKey);
-    EXPECT_EQ(result.excludeCredentials[0].id.length(), sizeof(identifier));
-    EXPECT_EQ(memcmp(result.excludeCredentials[0].id.data(), identifier, sizeof(identifier)), 0);
+    EXPECT_TRUE(equalSpans(result.excludeCredentials[0].id.span(), std::span<const uint8_t> { identifier }));
     EXPECT_EQ(result.excludeCredentials[0].transports.size(), 3lu);
     EXPECT_EQ(result.excludeCredentials[0].transports[0], AuthenticatorTransport::Usb);
     EXPECT_EQ(result.excludeCredentials[0].transports[1], AuthenticatorTransport::Nfc);
@@ -1696,14 +1691,14 @@ TEST(WebAuthenticationPanel, MakeCredentialSPITimeout)
 {
     reset();
 
-    uint8_t identifier[] = { 0x01, 0x02, 0x03, 0x04 };
+    auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
     uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
-    NSData *nsIdentifier = [NSData dataWithBytes:identifier length:sizeof(identifier)];
+    RetainPtr nsIdentifier = toNSData(identifier);
     NSData *nsHash = [NSData dataWithBytes:hash length:sizeof(hash)];
     auto parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
 
     auto rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
-    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier displayName:@"J Appleseed"]);
+    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
     NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters = @[ parameters.get() ];
     auto options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
     [options setTimeout:@10];
@@ -1726,15 +1721,15 @@ TEST(WebAuthenticationPanel, MakeCredentialLA)
 {
     reset();
 
-    uint8_t identifier[] = { 0x01, 0x02, 0x03, 0x04 };
+    auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
     uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
-    NSData *nsIdentifier = [NSData dataWithBytes:identifier length:sizeof(identifier)];
+    RetainPtr nsIdentifier = toNSData(identifier);
     auto nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
     auto parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
 
     auto rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
     [rp setIdentifier:@"example.com"];
-    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier displayName:@"J Appleseed"]);
+    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
     NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters = @[ parameters.get() ];
     auto options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
 
@@ -1763,15 +1758,15 @@ TEST(WebAuthenticationPanel, MakeCredentialLAClientDataHashMediation)
 {
     reset();
 
-    uint8_t identifier[] = { 0x01, 0x02, 0x03, 0x04 };
+    auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
     uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
-    NSData *nsIdentifier = [NSData dataWithBytes:identifier length:sizeof(identifier)];
+    RetainPtr nsIdentifier = toNSData(identifier);
     auto nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
     auto parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
 
     auto rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
     [rp setIdentifier:@"example.com"];
-    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier displayName:@"J Appleseed"]);
+    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
     NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters = @[ parameters.get() ];
     auto options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
 
@@ -1801,15 +1796,15 @@ TEST(WebAuthenticationPanel, MakeCredentialLAAttestationFalback)
 {
     reset();
 
-    uint8_t identifier[] = { 0x01, 0x02, 0x03, 0x04 };
+    auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
     uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
-    NSData *nsIdentifier = [NSData dataWithBytes:identifier length:sizeof(identifier)];
+    RetainPtr nsIdentifier = toNSData(identifier);
     auto nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
     auto parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
 
     auto rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
     [rp setIdentifier:@"example.com"];
-    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier displayName:@"J Appleseed"]);
+    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
     NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters = @[ parameters.get() ];
     auto options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);
     options.get().attestation = _WKAttestationConveyancePreferenceDirect;
@@ -1845,9 +1840,9 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMinimun)
 
 TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMaximumDefault)
 {
-    uint8_t identifier[] = { 0x01, 0x02, 0x03, 0x04 };
-    NSData *nsIdentifier = [NSData dataWithBytes:identifier length:sizeof(identifier)];
-    auto descriptor = adoptNS([[_WKPublicKeyCredentialDescriptor alloc] initWithIdentifier:nsIdentifier]);
+    auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
+    RetainPtr nsIdentifier = toNSData(identifier);
+    auto descriptor = adoptNS([[_WKPublicKeyCredentialDescriptor alloc] initWithIdentifier:nsIdentifier.get()]);
     auto extensions = adoptNS([[_WKAuthenticationExtensionsClientInputs alloc] init]);
 
     auto options = adoptNS([[_WKPublicKeyCredentialRequestOptions alloc] init]);
@@ -1861,8 +1856,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMaximumDefault)
 
     EXPECT_EQ(result.allowCredentials.size(), 1lu);
     EXPECT_EQ(result.allowCredentials[0].type, WebCore::PublicKeyCredentialType::PublicKey);
-    EXPECT_EQ(result.allowCredentials[0].id.length(), sizeof(identifier));
-    EXPECT_EQ(memcmp(result.allowCredentials[0].id.data(), identifier, sizeof(identifier)), 0);
+    EXPECT_TRUE(equalSpans(result.allowCredentials[0].id.span(), std::span<const uint8_t> { identifier }));
 
     EXPECT_EQ(result.userVerification, UserVerificationRequirement::Preferred);
     EXPECT_TRUE(result.extensions->appid.isNull());
@@ -1870,8 +1864,8 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMaximumDefault)
 
 TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMaximum)
 {
-    uint8_t identifier[] = { 0x01, 0x02, 0x03, 0x04 };
-    NSData *nsIdentifier = [NSData dataWithBytes:identifier length:sizeof(identifier)];
+    auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
+    RetainPtr nsIdentifier = toNSData(identifier);
 
     auto options = adoptNS([[_WKPublicKeyCredentialRequestOptions alloc] init]);
     [options setTimeout:@120];
@@ -1879,7 +1873,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMaximum)
     RetainPtr usb = [NSNumber numberWithInt:_WKWebAuthenticationTransportUSB];
     RetainPtr nfc = [NSNumber numberWithInt:_WKWebAuthenticationTransportNFC];
     RetainPtr internal = [NSNumber numberWithInt:_WKWebAuthenticationTransportInternal];
-    RetainPtr credential = adoptNS([[_WKPublicKeyCredentialDescriptor alloc] initWithIdentifier:nsIdentifier]);
+    RetainPtr credential = adoptNS([[_WKPublicKeyCredentialDescriptor alloc] initWithIdentifier:nsIdentifier.get()]);
     [credential setTransports:@[ usb.get(), nfc.get(), internal.get() ]];
     [options setAllowCredentials:@[ credential.get(), credential.get() ]];
 
@@ -1895,8 +1889,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMaximum)
 
     EXPECT_EQ(result.allowCredentials.size(), 2lu);
     EXPECT_EQ(result.allowCredentials[0].type, WebCore::PublicKeyCredentialType::PublicKey);
-    EXPECT_EQ(result.allowCredentials[0].id.length(), sizeof(identifier));
-    EXPECT_EQ(memcmp(result.allowCredentials[0].id.data(), identifier, sizeof(identifier)), 0);
+    EXPECT_TRUE(equalSpans(result.allowCredentials[0].id.span(), std::span<const uint8_t> { identifier }));
     EXPECT_EQ(result.allowCredentials[0].transports.size(), 3lu);
     EXPECT_EQ(result.allowCredentials[0].transports[0], AuthenticatorTransport::Usb);
     EXPECT_EQ(result.allowCredentials[0].transports[1], AuthenticatorTransport::Nfc);
@@ -2237,12 +2230,12 @@ TEST(WebAuthenticationPanel, EncodeCTAPCreation)
 {
     uint8_t hash[] = { 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04, 0x01, 0x02, 0x03, 0x04 };
     auto nsHash = adoptNS([[NSData alloc] initWithBytes:hash length:sizeof(hash)]);
-    uint8_t identifier[] = { 0x01, 0x02, 0x03, 0x04 };
-    NSData *nsIdentifier = [NSData dataWithBytes:identifier length:sizeof(identifier)];
+    auto identifier = std::to_array<uint8_t>({ 0x01, 0x02, 0x03, 0x04 });
+    RetainPtr nsIdentifier = toNSData(identifier);
     auto parameters = adoptNS([[_WKPublicKeyCredentialParameters alloc] initWithAlgorithm:@-7]);
 
     auto rp = adoptNS([[_WKPublicKeyCredentialRelyingPartyEntity alloc] initWithName:@"example.com"]);
-    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier displayName:@"J Appleseed"]);
+    auto user = adoptNS([[_WKPublicKeyCredentialUserEntity alloc] initWithName:@"jappleseed@example.com" identifier:nsIdentifier.get() displayName:@"J Appleseed"]);
     NSArray<_WKPublicKeyCredentialParameters *> *publicKeyCredentialParamaters = @[ parameters.get() ];
 
     auto options = adoptNS([[_WKPublicKeyCredentialCreationOptions alloc] initWithRelyingParty:rp.get() user:user.get() publicKeyCredentialParamaters:publicKeyCredentialParamaters]);


### PR DESCRIPTION
#### c98317135048a7921f493b04679f707e4ac4f197
<pre>
Drop BufferSource::data() in favor of span()
<a href="https://bugs.webkit.org/show_bug.cgi?id=275796">https://bugs.webkit.org/show_bug.cgi?id=275796</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/runtime/ArrayBuffer.h:
* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::appendFileContentsToFileHandle):
(WTF::FileSystemImpl::readOrMakeSalt):
(WTF::FileSystemImpl::readEntireFile):
* Source/WTF/wtf/FileSystem.h:
* Source/WTF/wtf/posix/FileSystemPOSIX.cpp:
(WTF::FileSystemImpl::readFromFile):
* Source/WTF/wtf/win/FileSystemWin.cpp:
(WTF::FileSystemImpl::readFromFile):
* Source/WebCore/Modules/filesystemaccess/FileSystemSyncAccessHandle.cpp:
(WebCore::FileSystemSyncAccessHandle::read):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioData.cpp:
(WebCore::WebCodecsAudioData::copyTo):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
(WebCore::WebCodecsAudioDecoder::decode):
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.cpp:
(WebCore::WebCodecsEncodedAudioChunk::copyTo):
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedAudioChunk.h:
(WebCore::WebCodecsEncodedAudioChunk::span const):
(WebCore::WebCodecsEncodedAudioChunk::data const): Deleted.
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.cpp:
(WebCore::WebCodecsEncodedVideoChunk::copyTo):
* Source/WebCore/Modules/webcodecs/WebCodecsEncodedVideoChunk.h:
(WebCore::WebCodecsEncodedVideoChunk::span const):
(WebCore::WebCodecsEncodedVideoChunk::data const): Deleted.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::WebCodecsVideoDecoder::decode):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::WebCodecsVideoFrame::create):
(WebCore::WebCodecsVideoFrame::copyTo):
* Source/WebCore/bindings/js/BufferSource.h:
(WebCore::BufferSource::length const):
(WebCore::BufferSource::span const):
(WebCore::BufferSource::mutableSpan):
(WebCore::toNSData):
(WebCore::BufferSource::data const): Deleted.
(WebCore::BufferSource::mutableData const): Deleted.
* Source/WebCore/platform/FileHandle.cpp:
(WebCore::FileHandle::read):
* Source/WebCore/platform/FileStream.cpp:
(WebCore::FileStream::read):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
(WebCore::unmapFunction):
* Source/WebCore/platform/network/curl/CurlFormDataStream.cpp:
(WebCore::CurlFormDataStream::readFromFile):
* Source/WebKit/NetworkProcess/cache/NetworkCacheIOChannelCurl.cpp:
(WebKit::NetworkCache::IOChannel::read):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticator::deleteDuplicateCredential const):
* Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/280309@main">https://commits.webkit.org/280309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d39ccfe535094bfc91e2dcf97f7797d5f1184cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56241 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59847 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6677 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58367 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43189 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6871 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45535 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4643 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58270 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33452 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48520 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26418 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30232 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5851 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5681 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/49319 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6123 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61530 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/55478 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/149 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6249 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52814 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52693 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/132 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/77238 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8345 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31394 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12800 "Found 1 new JSC stress test failure: stress/try-get-value-without-gc.js.default (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32480 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33563 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32227 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->