### PR TITLE
[WPE] WPE Platform: add WPEToplevel

### DIFF
--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -564,8 +564,9 @@ if (ENABLE_WPE_QT_API)
         #        SHARED here works on Linux and probably some other systems, but
         #        not on MacOS or Windows.
         add_library(qtwpe SHARED
-            UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp
             UIProcess/API/wpe/qt6/WPEDisplayQtQuick.cpp
+            UIProcess/API/wpe/qt6/WPEToplevelQtQuick.cpp
+            UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp
             UIProcess/API/wpe/qt6/WPEQmlExtensionPlugin.cpp
             UIProcess/API/wpe/qt6/WPEQtView.cpp
             UIProcess/API/wpe/qt6/WPEQtViewLoadRequest.cpp

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEDisplayQtQuick.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEDisplayQtQuick.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WPEDisplayQtQuick.h"
 
+#include "WPEToplevelQtQuick.h"
 #include "WPEViewQtQuick.h"
 
 #include <epoxy/egl.h>
@@ -94,7 +95,13 @@ static gboolean wpeDisplayQtQuickConnect(WPEDisplay* display, GError** error)
 
 static WPEView* wpeDisplayQtQuickCreateView(WPEDisplay* display)
 {
-    return wpe_view_qtquick_new(WPE_DISPLAY_QTQUICK(display));
+    auto* displayQt = WPE_DISPLAY_QTQUICK(display);
+    auto* view = wpe_view_qtquick_new(displayQt);
+
+    GRefPtr<WPEToplevel> toplevel = adoptGRef(wpe_toplevel_qtquick_new(displayQt));
+    wpe_view_set_toplevel(view, toplevel.get());
+
+    return view;
 }
 
 static gpointer wpeDisplayQtQuickGetEGLDisplay(WPEDisplay* display, GError**)

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEToplevelQtQuick.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEToplevelQtQuick.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,34 +22,38 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef __WPE_PLATFORM_H__
-#define __WPE_PLATFORM_H__
 
-#define __WPE_PLATFORM_H_INSIDE__
+#include "config.h"
+#include "WPEToplevelQtQuick.h"
 
-#include <wpe/WPEEnumTypes.h>
-#include <wpe/WPEEvent.h>
-#include <wpe/WPEBuffer.h>
-#include <wpe/WPEBufferDMABuf.h>
-#include <wpe/WPEBufferDMABufFormats.h>
-#include <wpe/WPEBufferSHM.h>
-#include <wpe/WPEColor.h>
-#include <wpe/WPEConfig.h>
-#include <wpe/WPEDefines.h>
-#include <wpe/WPEDisplay.h>
-#include <wpe/WPEEGLError.h>
-#include <wpe/WPEInputMethodContext.h>
-#include <wpe/WPEKeymap.h>
-#include <wpe/WPEKeyUnicode.h>
-#include <wpe/WPEKeymapXKB.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEMonitor.h>
-#include <wpe/WPERectangle.h>
-#include <wpe/WPEToplevel.h>
-#include <wpe/WPEVersion.h>
-#include <wpe/WPEView.h>
+/**
+ * WPEToplevelQtQuick:
+ *
+ */
+struct _WPEToplevelQtQuickPrivate {
+};
+WEBKIT_DEFINE_FINAL_TYPE(WPEToplevelQtQuick, wpe_toplevel_qtquick, WPE_TYPE_TOPLEVEL, WPEToplevel)
 
-#undef __WPE_PLATFORM_H_INSIDE__
+static gboolean wpeToplevelQtQuickResize(WPEToplevel* toplevel, int width, int height)
+{
+    wpe_toplevel_resized(toplevel, width, height);
+    wpe_toplevel_foreach_view(toplevel, [](WPEToplevel* toplevel, WPEView* view, gpointer) -> gboolean {
+        int width, height;
+        wpe_toplevel_get_size(toplevel, &width, &height);
+        wpe_view_resized(view, width, height);
+        return FALSE;
+    }, nullptr);
+    return TRUE;
+}
 
-#endif /* __WPE_PLATFORM_H__ */
+static void wpe_toplevel_qtquick_class_init(WPEToplevelQtQuickClass* toplevelQtQuickClass)
+{
+    WPEToplevelClass* toplevelClass = WPE_TOPLEVEL_CLASS(toplevelQtQuickClass);
+    toplevelClass->resize = wpeToplevelQtQuickResize;
+}
+
+WPEToplevel* wpe_toplevel_qtquick_new(WPEDisplayQtQuick* display)
+{
+    g_return_val_if_fail(WPE_IS_DISPLAY_QTQUICK(display), nullptr);
+    return WPE_TOPLEVEL(g_object_new(WPE_TYPE_TOPLEVEL_QTQUICK, "display", display, nullptr));
+}

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEToplevelQtQuick.h
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEToplevelQtQuick.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,34 +22,19 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef __WPE_PLATFORM_H__
-#define __WPE_PLATFORM_H__
 
-#define __WPE_PLATFORM_H_INSIDE__
+#ifndef WPEToplevelQtQuick_h
+#define WPEToplevelQtQuick_h
 
-#include <wpe/WPEEnumTypes.h>
-#include <wpe/WPEEvent.h>
-#include <wpe/WPEBuffer.h>
-#include <wpe/WPEBufferDMABuf.h>
-#include <wpe/WPEBufferDMABufFormats.h>
-#include <wpe/WPEBufferSHM.h>
-#include <wpe/WPEColor.h>
-#include <wpe/WPEConfig.h>
-#include <wpe/WPEDefines.h>
-#include <wpe/WPEDisplay.h>
-#include <wpe/WPEEGLError.h>
-#include <wpe/WPEInputMethodContext.h>
-#include <wpe/WPEKeymap.h>
-#include <wpe/WPEKeyUnicode.h>
-#include <wpe/WPEKeymapXKB.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEMonitor.h>
-#include <wpe/WPERectangle.h>
-#include <wpe/WPEToplevel.h>
-#include <wpe/WPEVersion.h>
-#include <wpe/WPEView.h>
+#include "WPEDisplayQtQuick.h"
 
-#undef __WPE_PLATFORM_H_INSIDE__
+G_BEGIN_DECLS
 
-#endif /* __WPE_PLATFORM_H__ */
+#define WPE_TYPE_TOPLEVEL_QTQUICK (wpe_toplevel_qtquick_get_type())
+G_DECLARE_FINAL_TYPE (WPEToplevelQtQuick, wpe_toplevel_qtquick, WPE, TOPLEVEL_QTQUICK, WPEToplevel)
+
+WPEToplevel *wpe_toplevel_qtquick_new (WPEDisplayQtQuick *display);
+
+G_END_DECLS
+
+#endif /* WPEToplevelQtQuick_h */

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp
@@ -84,12 +84,6 @@ static gboolean wpeViewQtQuickRenderBuffer(WPEView* view, WPEBuffer* buffer, GEr
     return TRUE;
 }
 
-static gboolean wpeViewQtQuickResize(WPEView* view, int width, int height)
-{
-    wpe_view_resized(view, width, height);
-    return TRUE;
-}
-
 static void wpe_view_qtquick_class_init(WPEViewQtQuickClass* viewQtQuickClass)
 {
     GObjectClass* objectClass = G_OBJECT_CLASS(viewQtQuickClass);
@@ -97,7 +91,6 @@ static void wpe_view_qtquick_class_init(WPEViewQtQuickClass* viewQtQuickClass)
 
     WPEViewClass* viewClass = WPE_VIEW_CLASS(viewQtQuickClass);
     viewClass->render_buffer = wpeViewQtQuickRenderBuffer;
-    viewClass->resize = wpeViewQtQuickResize;
 }
 
 WPEView* wpe_view_qtquick_new(WPEDisplayQtQuick* display)

--- a/Source/WebKit/WPEPlatform/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/CMakeLists.txt
@@ -28,6 +28,7 @@ set(WPEPlatform_SOURCES
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeymapXKB.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEMonitor.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPERectangle.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEToplevel.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEVersion.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEView.cpp
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/WPEEnumTypes.cpp
@@ -50,6 +51,7 @@ set(WPEPlatform_INSTALLED_HEADERS
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEKeysyms.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEMonitor.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPERectangle.h
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEToplevel.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEView.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/wpe-platform.h
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/WPEConfig.h

--- a/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
@@ -1,0 +1,533 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEToplevel.h"
+
+#include "WPEBufferDMABufFormats.h"
+#include "WPEDisplay.h"
+#include "WPEViewPrivate.h"
+#include <wtf/HashSet.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GWeakPtr.h>
+#include <wtf/glib/WTFGType.h>
+#include <wtf/text/WTFString.h>
+
+#if USE(LIBDRM)
+#include <drm_fourcc.h>
+#endif
+
+/**
+ * WPEToplevel:
+ *
+ */
+struct _WPEToplevelPrivate {
+    GWeakPtr<WPEDisplay> display;
+    HashSet<WPEView*> views;
+
+    int width;
+    int height;
+    gdouble scale { 1 };
+    WPEToplevelState state;
+    bool closed;
+#if USE(LIBDRM)
+    GRefPtr<WPEBufferDMABufFormats> overridenDMABufFormats;
+#endif
+};
+
+WEBKIT_DEFINE_TYPE(WPEToplevel, wpe_toplevel, G_TYPE_OBJECT)
+
+enum {
+    PROP_0,
+
+    PROP_DISPLAY,
+
+    N_PROPERTIES
+};
+
+static GParamSpec* sObjProperties[N_PROPERTIES] = { nullptr, };
+
+static void wpeToplevelSetProperty(GObject* object, guint propId, const GValue* value, GParamSpec* paramSpec)
+{
+    auto* toplevel = WPE_TOPLEVEL(object);
+
+    switch (propId) {
+    case PROP_DISPLAY:
+        toplevel->priv->display.reset(WPE_DISPLAY(g_value_get_object(value)));
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
+    }
+}
+
+static void wpeToplevelGetProperty(GObject* object, guint propId, GValue* value, GParamSpec* paramSpec)
+{
+    auto* toplevel = WPE_TOPLEVEL(object);
+
+    switch (propId) {
+    case PROP_DISPLAY:
+        g_value_set_object(value, wpe_toplevel_get_display(toplevel));
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, paramSpec);
+    }
+}
+
+static void wpe_toplevel_class_init(WPEToplevelClass* toplevelClass)
+{
+    GObjectClass* objectClass = G_OBJECT_CLASS(toplevelClass);
+    objectClass->set_property = wpeToplevelSetProperty;
+    objectClass->get_property = wpeToplevelGetProperty;
+
+    /**
+     * WPEToplevel:display:
+     *
+     * The #WPEDisplay of the toplevel.
+     */
+    sObjProperties[PROP_DISPLAY] =
+        g_param_spec_object(
+            "display",
+            nullptr, nullptr,
+            WPE_TYPE_DISPLAY,
+            static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+
+    g_object_class_install_properties(objectClass, N_PROPERTIES, sObjProperties);
+}
+
+void wpeToplevelAddView(WPEToplevel* toplevel, WPEView* view)
+{
+    toplevel->priv->views.add(view);
+}
+
+void wpeToplevelRemoveView(WPEToplevel* toplevel, WPEView* view)
+{
+    toplevel->priv->views.remove(view);
+}
+
+/**
+ * wpe_toplevel_get_display:
+ * @toplevel: a #WPEToplevel
+ *
+ * Get the #WPEDisplay of @toplevel
+ *
+ * Returns: (transfer none) (nullable): a #WPEDisplay or %NULL
+ */
+WPEDisplay* wpe_toplevel_get_display(WPEToplevel* toplevel)
+{
+    g_return_val_if_fail(WPE_IS_TOPLEVEL(toplevel), nullptr);
+
+    return toplevel->priv->display.get();
+}
+
+/**
+ * wpe_toplevel_set_title:
+ * @toplevel: a #WPEToplevel
+ * @title: (nullable): title to set, or %NULL
+ *
+ * Set the @toplevel title
+ */
+void wpe_toplevel_set_title(WPEToplevel* toplevel, const char* title)
+{
+    g_return_if_fail(WPE_IS_TOPLEVEL(toplevel));
+
+    auto* toplevelClass = WPE_TOPLEVEL_GET_CLASS(toplevel);
+    if (toplevelClass->set_title)
+        toplevelClass->set_title(toplevel, title);
+}
+
+/**
+ * wpe_toplevel_get_max_views:
+ * @toplevel: a #WPEToplevel
+ *
+ * Get the maximum number of #WPEView that @toplevel can contain.
+ *
+ * Returns: the maximum number of views supported.
+ */
+guint wpe_toplevel_get_max_views(WPEToplevel* toplevel)
+{
+    g_return_val_if_fail(WPE_IS_TOPLEVEL(toplevel), 0);
+
+    auto* toplevelClass = WPE_TOPLEVEL_GET_CLASS(toplevel);
+    return toplevelClass->get_max_views ? toplevelClass->get_max_views(toplevel) : 1;
+}
+
+/**
+ * wpe_toplevel_get_n_views:
+ * @toplevel: a #WPEToplevel
+ *
+ * Get the number of #WPEView contained by @toplevel
+ *
+ * Returns: the number of view in @toplevel
+ */
+guint wpe_toplevel_get_n_views(WPEToplevel* toplevel)
+{
+    g_return_val_if_fail(WPE_IS_TOPLEVEL(toplevel), 0);
+
+    return toplevel->priv->views.size();
+}
+
+/**
+ * wpe_toplevel_foreach_view:
+ * @toplevel: a #WPEToplevel
+ * @func: (scope call): the function to call for each #WPEView
+ * @user_data: user data to pass to the function
+ *
+ * Call @func for each #WPEView of @toplevel
+ */
+void wpe_toplevel_foreach_view(WPEToplevel* toplevel, WPEToplevelForeachViewFunc func, gpointer userData)
+{
+    g_return_if_fail(WPE_IS_TOPLEVEL(toplevel));
+
+    for (auto* view : toplevel->priv->views) {
+        if (func(toplevel, view, userData))
+            return;
+    }
+}
+
+/**
+ * wpe_toplevel_closed:
+ * @toplevel: a #WPEToplevel
+ *
+ * Set @toplevel as closed if not already closed.
+ *
+ * This function should only be called by #WPEToplevel derived classes
+ * in platform implementations.
+ */
+void wpe_toplevel_closed(WPEToplevel* toplevel)
+{
+    g_return_if_fail(WPE_IS_TOPLEVEL(toplevel));
+
+    if (toplevel->priv->closed)
+        return;
+
+    toplevel->priv->closed = true;
+    for (auto* view : toplevel->priv->views)
+        wpe_view_closed(view);
+}
+
+/**
+ * wpe_toplevel_get_size:
+ * @toplevel: a #WPEToplevel
+ * @width: (out) (nullable): return location for width, or %NULL
+ * @height: (out) (nullable): return location for width, or %NULL
+ *
+ * Get the @vtoplevel size in logical coordinates
+ */
+void wpe_toplevel_get_size(WPEToplevel* toplevel, int* width, int* height)
+{
+    g_return_if_fail(WPE_IS_TOPLEVEL(toplevel));
+
+    if (width)
+        *width = toplevel->priv->width;
+    if (height)
+        *height = toplevel->priv->height;
+}
+
+/**
+ * wpe_toplevel_resize:
+ * @toplevel: a #WPEToplevel
+ * @width: width in logical coordinates
+ * @height: height in logical coordinates
+ *
+ * Request that the @toplevel is resized at @width x @height.
+ *
+ * Returns: %TRUE if resizing is supported and given dimensions are
+ *    different than current size, otherwise %FALSE
+ */
+gboolean wpe_toplevel_resize(WPEToplevel* toplevel, int width, int height)
+{
+    g_return_val_if_fail(WPE_IS_TOPLEVEL(toplevel), FALSE);
+
+    auto* priv = toplevel->priv;
+    if (priv->width == width && priv->height == height)
+        return FALSE;
+
+    auto* toplevelClass = WPE_TOPLEVEL_GET_CLASS(toplevel);
+    return toplevelClass->resize ? toplevelClass->resize(toplevel, width, height) : FALSE;
+}
+
+/**
+ * wpe_toplevel_resized:
+ * @toplevel: a #WPEToplevel
+ * @width: width in logical coordinates
+ * @height: height in logical coordinates
+ *
+ * Update @toplevel size.
+ *
+ * This function should only be called by #WPEToplevel derived classes
+ * in platform implementations.
+ */
+void wpe_toplevel_resized(WPEToplevel* toplevel, int width, int height)
+{
+    g_return_if_fail(WPE_IS_TOPLEVEL(toplevel));
+
+    auto* priv = toplevel->priv;
+    priv->width = width;
+    priv->height = height;
+}
+
+/**
+ * wpe_toplevel_get_state:
+ * @toplevel: a #WPEToplevel
+ *
+ * Get the current state of @toplevel
+ *
+ * Returns: a #WPEToplevelState
+ */
+WPEToplevelState wpe_toplevel_get_state(WPEToplevel* toplevel)
+{
+    g_return_val_if_fail(WPE_IS_TOPLEVEL(toplevel), WPE_TOPLEVEL_STATE_NONE);
+
+    return toplevel->priv->state;
+}
+
+/**
+ * wpe_toplevel_state_changed:
+ * @toplevel: a #WPEToplevel
+ * @state: a set of #WPEToplevelState
+ *
+ * Update the current state of @toplevel
+ *
+ * This function should only be called by #WPEToplevel derived classes
+ * in platform implementations.
+ */
+void wpe_toplevel_state_changed(WPEToplevel* toplevel, WPEToplevelState state)
+{
+    g_return_if_fail(WPE_IS_TOPLEVEL(toplevel));
+
+    if (toplevel->priv->state == state)
+        return;
+
+    toplevel->priv->state = state;
+    for (auto* view : toplevel->priv->views)
+        wpeViewToplevelStateChanged(view, state);
+}
+
+/**
+ * wpe_toplevel_get_scale:
+ * @toplevel: a #WPEToplevel
+ *
+ * Get the @toplevel scale
+ *
+ * Returns: the toplevel scale
+ */
+gdouble wpe_toplevel_get_scale(WPEToplevel* toplevel)
+{
+    g_return_val_if_fail(WPE_IS_TOPLEVEL(toplevel), 1.);
+
+    return toplevel->priv->scale;
+}
+
+/**
+ * wpe_toplevel_scale_changed:
+ * @toplevel: a #WPEToplevel
+ * @scale: the new scale
+ *
+ * Update the @toplevel scale.
+ *
+ * This function should only be called by #WPEToplevel derived classes
+ * in platform implementations.
+ */
+void wpe_toplevel_scale_changed(WPEToplevel* toplevel, gdouble scale)
+{
+    g_return_if_fail(WPE_IS_TOPLEVEL(toplevel));
+    g_return_if_fail(scale > 0);
+
+    if (toplevel->priv->scale == scale)
+        return;
+
+    toplevel->priv->scale = scale;
+    for (auto* view : toplevel->priv->views)
+        wpeViewScaleChanged(view, scale);
+}
+
+/**
+ * wpe_toplevel_get_monitor:
+ * @toplevel: a #WPEToplevel
+ *
+ * Get current #WPEMonitor of @toplevel
+ *
+ * Returns: (transfer none) (nullable): a #WPEMonitor, or %NULL
+ */
+WPEMonitor* wpe_toplevel_get_monitor(WPEToplevel* toplevel)
+{
+    g_return_val_if_fail(WPE_IS_TOPLEVEL(toplevel), nullptr);
+
+    auto* toplevelClass = WPE_TOPLEVEL_GET_CLASS(toplevel);
+    return toplevelClass->get_monitor ? toplevelClass->get_monitor(toplevel) : nullptr;
+}
+
+/**
+ * wpe_toplevel_monitor_changed:
+ * @toplevel: a #WPEToplevel
+ *
+ * Notify that @toplevel monitor has changed.
+ *
+ * This function should only be called by #WPEToplevel derived classes
+ * in platform implementations.
+ */
+void wpe_toplevel_monitor_changed(WPEToplevel* toplevel)
+{
+    g_return_if_fail(WPE_IS_TOPLEVEL(toplevel));
+
+    for (auto* view : toplevel->priv->views)
+        wpeViewMonitorChanged(view);
+}
+
+/**
+ * wpe_toplevel_fullscreen:
+ * @toplevel: a #WPEToplevel
+ *
+ * Request that the @toplevel goes into a fullscreen state.
+ *
+ * Returns: %TRUE if fullscreen is supported, otherwise %FALSE
+ */
+gboolean wpe_toplevel_fullscreen(WPEToplevel* toplevel)
+{
+    g_return_val_if_fail(WPE_IS_TOPLEVEL(toplevel), FALSE);
+
+    auto* toplevelClass = WPE_TOPLEVEL_GET_CLASS(toplevel);
+    return toplevelClass->set_fullscreen ? toplevelClass->set_fullscreen(toplevel, TRUE) : FALSE;
+}
+
+/**
+ * wpe_toplevel_unfullscreen:
+ * @toplevel: a #WPEToplevel
+ *
+ * Request that the @toplevel leaves a fullscreen state.
+ *
+ * Returns: %TRUE if unfullscreen is supported, otherwise %FALSE
+ */
+gboolean wpe_toplevel_unfullscreen(WPEToplevel* toplevel)
+{
+    g_return_val_if_fail(WPE_IS_TOPLEVEL(toplevel), FALSE);
+
+    auto* toplevelClass = WPE_TOPLEVEL_GET_CLASS(toplevel);
+    return toplevelClass->set_fullscreen ? toplevelClass->set_fullscreen(toplevel, FALSE) : FALSE;
+}
+
+/**
+ * wpe_toplevel_maximize:
+ * @toplevel: a #WPEToplevel
+ *
+ * Request that the @toplevel is maximized. If the toplevel is already maximized this function
+ * does nothing.
+ *
+ * Returns: %TRUE if maximize is supported, otherwise %FALSE
+ */
+gboolean wpe_toplevel_maximize(WPEToplevel* toplevel)
+{
+    g_return_val_if_fail(WPE_IS_TOPLEVEL(toplevel), FALSE);
+
+    auto* toplevelClass = WPE_TOPLEVEL_GET_CLASS(toplevel);
+    return toplevelClass->set_maximized ? toplevelClass->set_maximized(toplevel, TRUE) : FALSE;
+}
+
+/**
+ * wpe_toplevel_unmaximize:
+ * @toplevel: a #WPEToplevel
+ *
+ * Request that the @toplevel is unmaximized. If the toplevel is not maximized this function
+ * does nothing.
+ *
+ * Returns: %TRUE if maximize is supported, otherwise %FALSE
+ */
+gboolean wpe_toplevel_unmaximize(WPEToplevel* toplevel)
+{
+    g_return_val_if_fail(WPE_IS_TOPLEVEL(toplevel), FALSE);
+
+    auto* toplevelClass = WPE_TOPLEVEL_GET_CLASS(toplevel);
+    return toplevelClass->set_maximized ? toplevelClass->set_maximized(toplevel, FALSE) : FALSE;
+}
+
+/**
+ * wpe_toplevel_get_preferred_dma_buf_formats:
+ * @toplevel: a #WPEToplevel
+ *
+ * Get the list of preferred DMA-BUF buffer formats for @toplevel.
+ *
+ * Returns: (transfer none) (nullable): a #WPEBufferDMABufFormats
+ */
+WPEBufferDMABufFormats* wpe_toplevel_get_preferred_dma_buf_formats(WPEToplevel* toplevel)
+{
+    g_return_val_if_fail(WPE_IS_TOPLEVEL(toplevel), nullptr);
+
+    auto* priv = toplevel->priv;
+#if USE(LIBDRM)
+    if (priv->overridenDMABufFormats)
+        return priv->overridenDMABufFormats.get();
+
+    const char* formatString = getenv("WPE_DMABUF_BUFFER_FORMAT");
+    if (formatString && *formatString) {
+        auto tokens = String::fromUTF8(formatString).split(':');
+        if (!tokens.isEmpty() && tokens[0].length() >= 2 && tokens[0].length() <= 4) {
+            guint32 format = fourcc_code(tokens[0][0], tokens[0][1], tokens[0].length() > 2 ? tokens[0][2] : ' ', tokens[0].length() > 3 ? tokens[0][3] : ' ');
+            char* endptr = nullptr;
+            guint64 modifier = tokens.size() > 1 ? g_ascii_strtoull(tokens[1].ascii().data(), &endptr, 16) : DRM_FORMAT_MOD_INVALID;
+            if (!(modifier == G_MAXUINT64 && errno == ERANGE) && !(!modifier && !endptr)) {
+                WPEBufferDMABufFormatUsage usage = WPE_BUFFER_DMA_BUF_FORMAT_USAGE_RENDERING;
+                if (tokens.size() > 2) {
+                    if (tokens[2] == "rendering"_s)
+                        usage = WPE_BUFFER_DMA_BUF_FORMAT_USAGE_RENDERING;
+                    else if (tokens[2] == "mapping"_s)
+                        usage = WPE_BUFFER_DMA_BUF_FORMAT_USAGE_MAPPING;
+                    else if (tokens[2] == "scanout"_s)
+                        usage = WPE_BUFFER_DMA_BUF_FORMAT_USAGE_SCANOUT;
+                }
+                auto* builder = wpe_buffer_dma_buf_formats_builder_new(priv->display ? wpe_display_get_drm_render_node(priv->display.get()) : nullptr);
+                wpe_buffer_dma_buf_formats_builder_append_group(builder, nullptr, usage);
+                wpe_buffer_dma_buf_formats_builder_append_format(builder, format, modifier);
+                priv->overridenDMABufFormats = adoptGRef(wpe_buffer_dma_buf_formats_builder_end(builder));
+                return priv->overridenDMABufFormats.get();
+            }
+        }
+
+        WTFLogAlways("Invalid format %s set in WPE_DMABUF_BUFFER_FORMAT, ignoring...", formatString);
+    }
+#endif
+
+    auto* toplevelClass = WPE_TOPLEVEL_GET_CLASS(toplevel);
+    if (toplevelClass->get_preferred_dma_buf_formats)
+        return toplevelClass->get_preferred_dma_buf_formats(toplevel);
+
+    return priv->display ? wpe_display_get_preferred_dma_buf_formats(priv->display.get()) : nullptr;
+}
+
+/**
+ * wpe_toplevel_preferred_dma_buf_formats_changed:
+ * @toplevel: a #WPEToplevel
+ *
+ * Notify that @toplevel preferred DMA-BUF formats have changed.
+ *
+ * This function should only be called by #WPEToplevel derived classes
+ * in platform implementations.
+ */
+void wpe_toplevel_preferred_dma_buf_formats_changed(WPEToplevel* toplevel)
+{
+    g_return_if_fail(WPE_IS_TOPLEVEL(toplevel));
+
+    for (auto* view : toplevel->priv->views)
+        wpeViewPreferredDMABufFormatsChanged(view);
+}

--- a/Source/WebKit/WPEPlatform/wpe/WPEToplevel.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEToplevel.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef WPEToplevel_h
+#define WPEToplevel_h
+
+#if !defined(__WPE_PLATFORM_H_INSIDE__) && !defined(BUILDING_WEBKIT)
+#error "Only <wpe/wpe-platform.h> can be included directly."
+#endif
+
+#include <glib-object.h>
+#include <wpe/WPEDefines.h>
+
+G_BEGIN_DECLS
+
+#define WPE_TYPE_TOPLEVEL (wpe_toplevel_get_type())
+WPE_DECLARE_DERIVABLE_TYPE (WPEToplevel, wpe_toplevel, WPE, TOPLEVEL, GObject)
+
+typedef struct _WPEBufferDMABufFormats WPEBufferDMABufFormats;
+typedef struct _WPEDisplay WPEDisplay;
+typedef struct _WPEMonitor WPEMonitor;
+typedef struct _WPEView WPEView;
+
+struct _WPEToplevelClass
+{
+    GObjectClass parent_class;
+
+    void                    (* set_title)                     (WPEToplevel *toplevel,
+                                                               const char  *title);
+    guint                   (* get_max_views)                 (WPEToplevel *toplevel);
+    WPEMonitor             *(* get_monitor)                   (WPEToplevel *toplevel);
+    gboolean                (* resize)                        (WPEToplevel *toplevel,
+                                                               int          width,
+                                                               int          height);
+    gboolean                (* set_fullscreen)                (WPEToplevel *toplevel,
+                                                               gboolean     fullscreen);
+    gboolean                (* set_maximized)                 (WPEToplevel *toplevel,
+                                                               gboolean     maximized);
+    WPEBufferDMABufFormats *(* get_preferred_dma_buf_formats) (WPEToplevel *toplevel);
+
+    gpointer padding[32];
+};
+
+/**
+ * WPEToplevelState:
+ * @WPE_TOPLEVEL_STATE_NONE: the toplevel is in normal state
+ * @WPE_TOPLEVEL_STATE_FULLSCREEN: the toplevel is fullscreen
+ * @WPE_TOPLEVEL_STATE_MAXIMIZED: the toplevel is maximized
+ * @WPE_TOPLEVEL_STATE_ACTIVE: the toplevel is active
+ *
+ * The current state of a #WPEToplevel.
+ */
+typedef enum {
+    WPE_TOPLEVEL_STATE_NONE       = 0,
+    WPE_TOPLEVEL_STATE_FULLSCREEN = (1 << 0),
+    WPE_TOPLEVEL_STATE_MAXIMIZED  = (1 << 1),
+    WPE_TOPLEVEL_STATE_ACTIVE     = (1 << 2)
+} WPEToplevelState;
+
+/**
+ * WPEToplevelForeachViewFunc:
+ * @toplevel: a #WPEToplevel
+ * @view: a #WPEView
+ * @user_data: (closure): user data
+ *
+ * A function used by wpe_toplevel_foreach_view().
+ *
+ * Returns: %TRUE to stop the iteration, or %FALSE to continue
+ */
+typedef gboolean (* WPEToplevelForeachViewFunc) (WPEToplevel *toplevel,
+                                                 WPEView     *view,
+                                                 gpointer     user_data);
+
+WPE_API WPEDisplay             *wpe_toplevel_get_display                       (WPEToplevel               *toplevel);
+WPE_API void                    wpe_toplevel_set_title                         (WPEToplevel               *toplevel,
+                                                                                const char                *title);
+WPE_API guint                   wpe_toplevel_get_max_views                     (WPEToplevel               *toplevel);
+WPE_API guint                   wpe_toplevel_get_n_views                       (WPEToplevel               *toplevel);
+WPE_API void                    wpe_toplevel_foreach_view                      (WPEToplevel               *toplevel,
+                                                                                WPEToplevelForeachViewFunc func,
+                                                                                gpointer                   user_data);
+WPE_API void                    wpe_toplevel_closed                            (WPEToplevel               *toplevel);
+WPE_API void                    wpe_toplevel_get_size                          (WPEToplevel               *toplevel,
+                                                                                int                       *width,
+                                                                                int                       *height);
+WPE_API gboolean                wpe_toplevel_resize                            (WPEToplevel               *toplevel,
+                                                                                int                        width,
+                                                                                int                        height);
+WPE_API void                    wpe_toplevel_resized                           (WPEToplevel               *toplevel,
+                                                                                int                        width,
+                                                                                int                        height);
+WPE_API WPEToplevelState        wpe_toplevel_get_state                         (WPEToplevel               *toplevel);
+WPE_API void                    wpe_toplevel_state_changed                     (WPEToplevel               *toplevel,
+                                                                                WPEToplevelState           state);
+WPE_API gdouble                 wpe_toplevel_get_scale                         (WPEToplevel               *toplevel);
+WPE_API void                    wpe_toplevel_scale_changed                     (WPEToplevel               *toplevel,
+                                                                                gdouble                    scale);
+WPE_API WPEMonitor             *wpe_toplevel_get_monitor                       (WPEToplevel               *toplevel);
+WPE_API void                    wpe_toplevel_monitor_changed                   (WPEToplevel               *toplevel);
+WPE_API gboolean                wpe_toplevel_fullscreen                        (WPEToplevel               *toplevel);
+WPE_API gboolean                wpe_toplevel_unfullscreen                      (WPEToplevel               *toplevel);
+WPE_API gboolean                wpe_toplevel_maximize                          (WPEToplevel               *toplevel);
+WPE_API gboolean                wpe_toplevel_unmaximize                        (WPEToplevel               *toplevel);
+WPE_API WPEBufferDMABufFormats *wpe_toplevel_get_preferred_dma_buf_formats     (WPEToplevel               *toplevel);
+WPE_API void                    wpe_toplevel_preferred_dma_buf_formats_changed (WPEToplevel               *toplevel);
+
+G_END_DECLS
+
+#endif /* WPEToplevel_h */

--- a/Source/WebKit/WPEPlatform/wpe/WPEToplevelPrivate.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEToplevelPrivate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,34 +22,11 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef __WPE_PLATFORM_H__
-#define __WPE_PLATFORM_H__
 
-#define __WPE_PLATFORM_H_INSIDE__
+#pragma once
 
-#include <wpe/WPEEnumTypes.h>
-#include <wpe/WPEEvent.h>
-#include <wpe/WPEBuffer.h>
-#include <wpe/WPEBufferDMABuf.h>
-#include <wpe/WPEBufferDMABufFormats.h>
-#include <wpe/WPEBufferSHM.h>
-#include <wpe/WPEColor.h>
-#include <wpe/WPEConfig.h>
-#include <wpe/WPEDefines.h>
-#include <wpe/WPEDisplay.h>
-#include <wpe/WPEEGLError.h>
-#include <wpe/WPEInputMethodContext.h>
-#include <wpe/WPEKeymap.h>
-#include <wpe/WPEKeyUnicode.h>
-#include <wpe/WPEKeymapXKB.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEMonitor.h>
-#include <wpe/WPERectangle.h>
-#include <wpe/WPEToplevel.h>
-#include <wpe/WPEVersion.h>
-#include <wpe/WPEView.h>
+#include "WPEToplevel.h"
+#include "WPEView.h"
 
-#undef __WPE_PLATFORM_H_INSIDE__
-
-#endif /* __WPE_PLATFORM_H__ */
+void wpeToplevelAddView(WPEToplevel*, WPEView*);
+void wpeToplevelRemoveView(WPEToplevel*, WPEView*);

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -31,14 +31,10 @@
 #include "WPEDisplayPrivate.h"
 #include "WPEEnumTypes.h"
 #include "WPEEvent.h"
-#include <wtf/SetForScope.h>
+#include "WPEToplevelPrivate.h"
+#include "WPEViewPrivate.h"
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/WTFGType.h>
-#include <wtf/text/WTFString.h>
-
-#if USE(LIBDRM)
-#include <drm_fourcc.h>
-#endif
 
 /**
  * WPEView:
@@ -46,16 +42,14 @@
  */
 struct _WPEViewPrivate {
     GRefPtr<WPEDisplay> display;
+    GRefPtr<WPEToplevel> toplevel;
     int width;
     int height;
     gdouble scale { 1 };
-    WPEViewState state;
+    WPEToplevelState state;
     bool closed;
     bool visible { true };
     bool mapped;
-#if USE(LIBDRM)
-    GRefPtr<WPEBufferDMABufFormats> overridenDMABufFormats;
-#endif
 
     struct {
         unsigned pressCount { 0 };
@@ -81,10 +75,11 @@ enum {
     PROP_0,
 
     PROP_DISPLAY,
+    PROP_TOPLEVEL,
     PROP_WIDTH,
     PROP_HEIGHT,
     PROP_SCALE,
-    PROP_STATE,
+    PROP_TOPLEVEL_STATE,
     PROP_MONITOR,
     PROP_VISIBLE,
     PROP_MAPPED,
@@ -102,7 +97,7 @@ enum {
     EVENT,
     FOCUS_IN,
     FOCUS_OUT,
-    STATE_CHANGED,
+    TOPLEVEL_STATE_CHANGED,
     PREFERRED_DMA_BUF_FORMATS_CHANGED,
 
     LAST_SIGNAL
@@ -117,6 +112,9 @@ static void wpeViewSetProperty(GObject* object, guint propId, const GValue* valu
     switch (propId) {
     case PROP_DISPLAY:
         view->priv->display = WPE_DISPLAY(g_value_get_object(value));
+        break;
+    case PROP_TOPLEVEL:
+        wpe_view_set_toplevel(view, WPE_TOPLEVEL(g_value_get_object(value)));
         break;
     case PROP_VISIBLE:
         wpe_view_set_visible(view, g_value_get_boolean(value));
@@ -134,6 +132,9 @@ static void wpeViewGetProperty(GObject* object, guint propId, GValue* value, GPa
     case PROP_DISPLAY:
         g_value_set_object(value, wpe_view_get_display(view));
         break;
+    case PROP_TOPLEVEL:
+        g_value_set_object(value, wpe_view_get_toplevel(view));
+        break;
     case PROP_WIDTH:
         g_value_set_int(value, wpe_view_get_width(view));
         break;
@@ -143,8 +144,8 @@ static void wpeViewGetProperty(GObject* object, guint propId, GValue* value, GPa
     case PROP_SCALE:
         g_value_set_double(value, wpe_view_get_scale(view));
         break;
-    case PROP_STATE:
-        g_value_set_flags(value, wpe_view_get_state(view));
+    case PROP_TOPLEVEL_STATE:
+        g_value_set_flags(value, wpe_view_get_toplevel_state(view));
         break;
     case PROP_MONITOR:
         g_value_set_object(value, wpe_view_get_monitor(view));
@@ -170,12 +171,20 @@ static void wpeViewConstructed(GObject* object)
     priv->height = 768;
 }
 
+static void wpeViewDispose(GObject* object)
+{
+    wpe_view_set_toplevel(WPE_VIEW(object), nullptr);
+
+    G_OBJECT_CLASS(wpe_view_parent_class)->dispose(object);
+}
+
 static void wpe_view_class_init(WPEViewClass* viewClass)
 {
     GObjectClass* objectClass = G_OBJECT_CLASS(viewClass);
     objectClass->set_property = wpeViewSetProperty;
     objectClass->get_property = wpeViewGetProperty;
     objectClass->constructed = wpeViewConstructed;
+    objectClass->dispose = wpeViewDispose;
 
     /**
      * WPEView:display:
@@ -188,6 +197,18 @@ static void wpe_view_class_init(WPEViewClass* viewClass)
             nullptr, nullptr,
             WPE_TYPE_DISPLAY,
             static_cast<GParamFlags>(WEBKIT_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+
+    /**
+     * WPEView:toplevel:
+     *
+     * The #WPEToplevel of the view
+     */
+    sObjProperties[PROP_TOPLEVEL] =
+        g_param_spec_object(
+            "toplevel",
+            nullptr, nullptr,
+            WPE_TYPE_TOPLEVEL,
+            WEBKIT_PARAM_READWRITE);
 
     /**
      * WPEView:width:
@@ -226,16 +247,16 @@ static void wpe_view_class_init(WPEViewClass* viewClass)
             WEBKIT_PARAM_READABLE);
 
     /**
-     * WPEView:state:
+     * WPEView:toplevel-state:
      *
-     * The view state
+     * The view's toplevel state
      */
-    sObjProperties[PROP_STATE] =
+    sObjProperties[PROP_TOPLEVEL_STATE] =
         g_param_spec_flags(
-            "flags",
+            "toplevel-state",
             nullptr, nullptr,
-            WPE_TYPE_VIEW_STATE,
-            WPE_VIEW_STATE_NONE,
+            WPE_TYPE_TOPLEVEL_STATE,
+            WPE_TOPLEVEL_STATE_NONE,
             WEBKIT_PARAM_READABLE);
 
     /**
@@ -395,20 +416,20 @@ static void wpe_view_class_init(WPEViewClass* viewClass)
         G_TYPE_NONE, 0);
 
     /**
-     * WPEView::state-changed:
+     * WPEView::toplevel-state-changed:
      * @view: a #WPEView
-     * @previous_state: a #WPEViewState
+     * @previous_state: a #WPEToplevelState
      *
-     * Emitted when @view state changes
+     * Emitted when @view's toplevel state changes
      */
-    signals[STATE_CHANGED] = g_signal_new(
-        "state-changed",
+    signals[TOPLEVEL_STATE_CHANGED] = g_signal_new(
+        "toplevel-state-changed",
         G_TYPE_FROM_CLASS(viewClass),
         G_SIGNAL_RUN_LAST,
         0, nullptr, nullptr,
         g_cclosure_marshal_generic,
         G_TYPE_NONE, 1,
-        WPE_TYPE_VIEW_STATE);
+        WPE_TYPE_TOPLEVEL_STATE);
 
     /**
      * WPEView::preferred-dma-buf-formats-changed:
@@ -424,6 +445,36 @@ static void wpe_view_class_init(WPEViewClass* viewClass)
         0, nullptr, nullptr,
         g_cclosure_marshal_generic,
         G_TYPE_NONE, 0);
+}
+
+void wpeViewToplevelStateChanged(WPEView* view, WPEToplevelState state)
+{
+    if (view->priv->state == state)
+        return;
+
+    auto previousState = view->priv->state;
+    view->priv->state = state;
+    g_object_notify_by_pspec(G_OBJECT(view), sObjProperties[PROP_TOPLEVEL_STATE]);
+    g_signal_emit(view, signals[TOPLEVEL_STATE_CHANGED], 0, previousState);
+}
+
+void wpeViewScaleChanged(WPEView* view, double scale)
+{
+    if (view->priv->scale == scale)
+        return;
+
+    view->priv->scale = scale;
+    g_object_notify_by_pspec(G_OBJECT(view), sObjProperties[PROP_SCALE]);
+}
+
+void wpeViewMonitorChanged(WPEView* view)
+{
+    g_object_notify_by_pspec(G_OBJECT(view), sObjProperties[PROP_MONITOR]);
+}
+
+void wpeViewPreferredDMABufFormatsChanged(WPEView* view)
+{
+    g_signal_emit(view, signals[PREFERRED_DMA_BUF_FORMATS_CHANGED], 0);
 }
 
 /**
@@ -454,6 +505,58 @@ WPEDisplay* wpe_view_get_display(WPEView* view)
     g_return_val_if_fail(WPE_IS_VIEW(view), nullptr);
 
     return view->priv->display.get();
+}
+
+/**
+ * wpe_view_get_toplevel:
+ * @view: a #WPEView
+ *
+ * Get the #WPEToplevel of @view
+ *
+ * Returns: (transfer none) (nullable): a #WPEToplevel
+ */
+WPEToplevel* wpe_view_get_toplevel(WPEView* view)
+{
+    g_return_val_if_fail(WPE_IS_VIEW(view), nullptr);
+
+    return view->priv->toplevel.get();
+}
+
+/**
+ * wpe_view_set_toplevel:
+ * @view: a #WPEView
+ * @toplevel: (nullable): a #WPEToplevel, or %NULL
+ *
+ * Set the current toplevel of @view.
+ * If @toplevel has already reached the maximum number of views (see wpe_toplevel_get_max_views())
+ * this function does nothing.
+ */
+void wpe_view_set_toplevel(WPEView* view, WPEToplevel* toplevel)
+{
+    g_return_if_fail(WPE_IS_VIEW(view));
+    g_return_if_fail(!toplevel || (WPE_IS_TOPLEVEL(toplevel) && wpe_toplevel_get_display(toplevel) == view->priv->display.get()));
+
+    auto* priv = view->priv;
+    if (priv->toplevel == toplevel)
+        return;
+
+    if (toplevel && wpe_toplevel_get_n_views(toplevel) == wpe_toplevel_get_max_views(toplevel))
+        return;
+
+    if (priv->toplevel)
+        wpeToplevelRemoveView(priv->toplevel.get(), view);
+
+    priv->toplevel = toplevel;
+
+    if (priv->toplevel) {
+        wpeToplevelAddView(priv->toplevel.get(), view);
+        wpeViewScaleChanged(view, wpe_toplevel_get_scale(priv->toplevel.get()));
+        wpeViewToplevelStateChanged(view, wpe_toplevel_get_state(priv->toplevel.get()));
+        wpeViewMonitorChanged(view);
+        wpeViewPreferredDMABufFormatsChanged(view);
+    }
+
+    g_object_notify_by_pspec(G_OBJECT(view), sObjProperties[PROP_TOPLEVEL]);
 }
 
 /**
@@ -508,31 +611,6 @@ void wpe_view_closed(WPEView* view)
 }
 
 /**
- * wpe_view_resize:
- * @view: a #WPEView
- * @width: width in logical coordinates
- * @height: height in logical coordinates
- *
- * Request that the @view is resized at @width x @height.
- *
- * Signal #WPEView::resized will be emitted when the resize is performed.
- *
- * Returns: %TRUE if resizing is supported and given dimensions are
- *    different than current size, otherwise %FALSE
- */
-gboolean wpe_view_resize(WPEView* view, int width, int height)
-{
-    g_return_val_if_fail(WPE_IS_VIEW(view), FALSE);
-
-    auto* priv = view->priv;
-    if (priv->width == width && priv->height == height)
-        return FALSE;
-
-    auto* viewClass = WPE_VIEW_GET_CLASS(view);
-    return viewClass->resize ? viewClass->resize(view, width, height) : FALSE;
-}
-
-/**
  * wpe_view_resized:
  * @view: a #WPEView
  * @width: width in logical coordinates
@@ -578,28 +656,6 @@ gdouble wpe_view_get_scale(WPEView* view)
     g_return_val_if_fail(WPE_IS_VIEW(view), 1.);
 
     return view->priv->scale;
-}
-
-/**
- * wpe_view_scale_changed:
- * @view: a #WPEView
- * @scale: the new scale
- *
- * Update the @view scale.
- *
- * This function should only be called by #WPEView derived classes
- * in platform implementations.
- */
-void wpe_view_scale_changed(WPEView* view, gdouble scale)
-{
-    g_return_if_fail(WPE_IS_VIEW(view));
-    g_return_if_fail(scale > 0);
-
-    if (view->priv->scale == scale)
-        return;
-
-    view->priv->scale = scale;
-    g_object_notify_by_pspec(G_OBJECT(view), sObjProperties[PROP_SCALE]);
 }
 
 /**
@@ -749,41 +805,18 @@ void wpe_view_set_cursor_from_bytes(WPEView* view, GBytes* bytes, guint width, g
 }
 
 /**
- * wpe_view_get_state:
+ * wpe_view_get_toplevel_state:
  * @view: a #WPEView
  *
- * Get the current state of @view
+ * Get the current state of @view's toplevel
  *
- * Returns: the view's state
+ * Returns: the view's toplevel state
  */
-WPEViewState wpe_view_get_state(WPEView* view)
+WPEToplevelState wpe_view_get_toplevel_state(WPEView* view)
 {
-    g_return_val_if_fail(WPE_IS_VIEW(view), WPE_VIEW_STATE_NONE);
+    g_return_val_if_fail(WPE_IS_VIEW(view), WPE_TOPLEVEL_STATE_NONE);
 
     return view->priv->state;
-}
-
-/**
- * wpe_view_state_changed:
- * @view: a #WPEView
- * @state: a set of #WPEViewState
- *
- * Update the current state of @view and emit @WPEView::state-changed if changed.
- *
- * This function should only be called by #WPEView derived classes
- * in platform implementations.
- */
-void wpe_view_state_changed(WPEView* view, WPEViewState state)
-{
-    g_return_if_fail(WPE_IS_VIEW(view));
-
-    if (view->priv->state == state)
-        return;
-
-    auto previousState = view->priv->state;
-    view->priv->state = state;
-    g_object_notify_by_pspec(G_OBJECT(view), sObjProperties[PROP_STATE]);
-    g_signal_emit(view, signals[STATE_CHANGED], 0, previousState);
 }
 
 /**
@@ -798,82 +831,7 @@ WPEMonitor* wpe_view_get_monitor(WPEView* view)
 {
     g_return_val_if_fail(WPE_IS_VIEW(view), nullptr);
 
-    auto* viewClass = WPE_VIEW_GET_CLASS(view);
-    return viewClass->get_monitor ? viewClass->get_monitor(view) : nullptr;
-}
-
-/**
- * wpe_view_fullscreen:
- * @view: a #WPEView
- *
- * Request that the @view goes into a fullscreen state.
- *
- * To track the state see #WPEView::state-changed
- *
- * Returns: %TRUE if fullscreen is supported, otherwise %FALSE
- */
-gboolean wpe_view_fullscreen(WPEView* view)
-{
-    g_return_val_if_fail(WPE_IS_VIEW(view), FALSE);
-
-    auto* viewClass = WPE_VIEW_GET_CLASS(view);
-    return viewClass->set_fullscreen ? viewClass->set_fullscreen(view, TRUE) : FALSE;
-}
-
-/**
- * wpe_view_unfullscreen:
- * @view: a #WPEView
- *
- * Request that the @view leaves a fullscreen state.
- *
- * To track the state see #WPEView::state-changed
- *
- * Returns: %TRUE if unfullscreen is supported, otherwise %FALSE
- */
-gboolean wpe_view_unfullscreen(WPEView* view)
-{
-    g_return_val_if_fail(WPE_IS_VIEW(view), FALSE);
-
-    auto* viewClass = WPE_VIEW_GET_CLASS(view);
-    return viewClass->set_fullscreen ? viewClass->set_fullscreen(view, FALSE) : FALSE;
-}
-
-/**
- * wpe_view_maximize:
- * @view: a #WPEView
- *
- * Request that the @view is maximized. If the view is already maximized this function
- * does nothing.
- *
- * To track the state see #WPEView::state-changed
- *
- * Returns: %TRUE if maximize is supported, otherwise %FALSE
- */
-gboolean wpe_view_maximize(WPEView* view)
-{
-    g_return_val_if_fail(WPE_IS_VIEW(view), FALSE);
-
-    auto* viewClass = WPE_VIEW_GET_CLASS(view);
-    return viewClass->set_maximized ? viewClass->set_maximized(view, TRUE) : FALSE;
-}
-
-/**
- * wpe_view_unmaximize:
- * @view: a #WPEView
- *
- * Request that the @view is unmaximized. If the view is not maximized this function
- * does nothing.
- *
- * To track the state see #WPEView::state-changed
- *
- * Returns: %TRUE if maximize is supported, otherwise %FALSE
- */
-gboolean wpe_view_unmaximize(WPEView* view)
-{
-    g_return_val_if_fail(WPE_IS_VIEW(view), FALSE);
-
-    auto* viewClass = WPE_VIEW_GET_CLASS(view);
-    return viewClass->set_maximized ? viewClass->set_maximized(view, FALSE) : FALSE;
+    return view->priv->toplevel ? wpe_toplevel_get_monitor(view->priv->toplevel.get()) : nullptr;
 }
 
 /**
@@ -1017,44 +975,10 @@ WPEBufferDMABufFormats* wpe_view_get_preferred_dma_buf_formats(WPEView* view)
 {
     g_return_val_if_fail(WPE_IS_VIEW(view), nullptr);
 
-#if USE(LIBDRM)
-    if (view->priv->overridenDMABufFormats)
-        return view->priv->overridenDMABufFormats.get();
+    if (!view->priv->toplevel)
+        return nullptr;
 
-    const char* formatString = getenv("WPE_DMABUF_BUFFER_FORMAT");
-    if (formatString && *formatString) {
-        auto tokens = String::fromUTF8(formatString).split(':');
-        if (!tokens.isEmpty() && tokens[0].length() >= 2 && tokens[0].length() <= 4) {
-            guint32 format = fourcc_code(tokens[0][0], tokens[0][1], tokens[0].length() > 2 ? tokens[0][2] : ' ', tokens[0].length() > 3 ? tokens[0][3] : ' ');
-            char* endptr = nullptr;
-            guint64 modifier = tokens.size() > 1 ? g_ascii_strtoull(tokens[1].ascii().data(), &endptr, 16) : DRM_FORMAT_MOD_INVALID;
-            if (!(modifier == G_MAXUINT64 && errno == ERANGE) && !(!modifier && !endptr)) {
-                WPEBufferDMABufFormatUsage usage = WPE_BUFFER_DMA_BUF_FORMAT_USAGE_RENDERING;
-                if (tokens.size() > 2) {
-                    if (tokens[2] == "rendering"_s)
-                        usage = WPE_BUFFER_DMA_BUF_FORMAT_USAGE_RENDERING;
-                    else if (tokens[2] == "mapping"_s)
-                        usage = WPE_BUFFER_DMA_BUF_FORMAT_USAGE_MAPPING;
-                    else if (tokens[2] == "scanout"_s)
-                        usage = WPE_BUFFER_DMA_BUF_FORMAT_USAGE_SCANOUT;
-                }
-                auto* builder = wpe_buffer_dma_buf_formats_builder_new(wpe_display_get_drm_render_node(wpe_view_get_display(view)));
-                wpe_buffer_dma_buf_formats_builder_append_group(builder, nullptr, usage);
-                wpe_buffer_dma_buf_formats_builder_append_format(builder, format, modifier);
-                view->priv->overridenDMABufFormats = adoptGRef(wpe_buffer_dma_buf_formats_builder_end(builder));
-                return view->priv->overridenDMABufFormats.get();
-            }
-        }
-
-        WTFLogAlways("Invalid format %s set in WPE_DMABUF_BUFFER_FORMAT, ignoring...", formatString);
-    }
-#endif
-
-    auto* viewClass = WPE_VIEW_GET_CLASS(view);
-    if (viewClass->get_preferred_dma_buf_formats)
-        return viewClass->get_preferred_dma_buf_formats(view);
-
-    return wpe_display_get_preferred_dma_buf_formats(view->priv->display.get());
+    return wpe_toplevel_get_preferred_dma_buf_formats(view->priv->toplevel.get());
 }
 
 /**

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.h
@@ -32,6 +32,7 @@
 
 #include <glib-object.h>
 #include <wpe/WPEDefines.h>
+#include <wpe/WPEToplevel.h>
 
 G_BEGIN_DECLS
 
@@ -49,50 +50,27 @@ struct _WPEViewClass
 {
     GObjectClass parent_class;
 
-    gboolean                (* render_buffer)                 (WPEView            *view,
-                                                               WPEBuffer          *buffer,
-                                                               const WPERectangle *damage_rects,
-                                                               guint               n_damage_rects,
-                                                               GError            **error);
-    WPEMonitor             *(* get_monitor)                   (WPEView            *view);
-    gboolean                (* resize)                        (WPEView            *view,
-                                                               int                 width,
-                                                               int                 height);
-    gboolean                (* set_fullscreen)                (WPEView            *view,
-                                                               gboolean            fullscreen);
-    gboolean                (* set_maximized)                 (WPEView            *view,
-                                                               gboolean            maximized);
-    WPEBufferDMABufFormats *(* get_preferred_dma_buf_formats) (WPEView            *view);
-    void                    (* set_cursor_from_name)          (WPEView            *view,
-                                                               const char         *name);
-    void                    (* set_cursor_from_bytes)         (WPEView            *view,
-                                                               GBytes             *bytes,
-                                                               guint               width,
-                                                               guint               height,
-                                                               guint               stride,
-                                                               guint               hotspot_x,
-                                                               guint               hotspot_y);
-    void                    (* set_opaque_rectangles)         (WPEView            *view,
-                                                               WPERectangle       *rects,
-                                                               guint               n_rects);
-    gboolean                (* can_be_mapped)                 (WPEView            *view);
+    gboolean (* render_buffer)         (WPEView            *view,
+                                        WPEBuffer          *buffer,
+                                        const WPERectangle *damage_rects,
+                                        guint               n_damage_rects,
+                                        GError            **error);
+    void     (* set_cursor_from_name)  (WPEView            *view,
+                                        const char         *name);
+    void     (* set_cursor_from_bytes) (WPEView            *view,
+                                        GBytes             *bytes,
+                                        guint               width,
+                                        guint               height,
+                                        guint               stride,
+                                        guint               hotspot_x,
+                                        guint               hotspot_y);
+    void     (* set_opaque_rectangles) (WPEView            *view,
+                                        WPERectangle       *rects,
+                                        guint               n_rects);
+    gboolean (* can_be_mapped)         (WPEView            *view);
 
     gpointer padding[32];
 };
-
-/**
- * WPEViewState:
- * @WPE_VIEW_STATE_NONE: the view is in normal state
- * @WPE_VIEW_STATE_FULLSCREEN: the view is fullscreen
- * @WPE_VIEW_STATE_MAXIMIZED: the view is maximized
- *
- * The current state of the view.
- */
-typedef enum {
-    WPE_VIEW_STATE_NONE = 0,
-    WPE_VIEW_STATE_FULLSCREEN = (1 << 0),
-    WPE_VIEW_STATE_MAXIMIZED = (1 << 1)
-} WPEViewState;
 
 #define WPE_VIEW_ERROR (wpe_view_error_quark())
 
@@ -110,18 +88,16 @@ WPE_API GQuark                  wpe_view_error_quark                   (void);
 
 WPE_API WPEView                *wpe_view_new                           (WPEDisplay         *display);
 WPE_API WPEDisplay             *wpe_view_get_display                   (WPEView            *view);
+WPE_API WPEToplevel            *wpe_view_get_toplevel                  (WPEView            *view);
+WPE_API void                    wpe_view_set_toplevel                  (WPEView            *view,
+                                                                        WPEToplevel        *toplevel);
 WPE_API int                     wpe_view_get_width                     (WPEView            *view);
 WPE_API int                     wpe_view_get_height                    (WPEView            *view);
 WPE_API void                    wpe_view_closed                        (WPEView            *view);
-WPE_API gboolean                wpe_view_resize                        (WPEView            *view,
-                                                                        int                 width,
-                                                                        int                 height);
 WPE_API void                    wpe_view_resized                       (WPEView            *view,
                                                                         int                 width,
                                                                         int                 height);
 WPE_API gdouble                 wpe_view_get_scale                     (WPEView            *view);
-WPE_API void                    wpe_view_scale_changed                 (WPEView            *view,
-                                                                        gdouble             scale);
 WPE_API gboolean                wpe_view_get_visible                   (WPEView            *view);
 WPE_API void                    wpe_view_set_visible                   (WPEView            *view,
                                                                         gboolean            visible);
@@ -137,14 +113,8 @@ WPE_API void                    wpe_view_set_cursor_from_bytes         (WPEView 
                                                                         guint               stride,
                                                                         guint               hotspot_x,
                                                                         guint               hotspot_y);
-WPE_API WPEViewState            wpe_view_get_state                     (WPEView            *view);
-WPE_API void                    wpe_view_state_changed                 (WPEView            *view,
-                                                                        WPEViewState        state);
+WPE_API WPEToplevelState        wpe_view_get_toplevel_state            (WPEView            *view);
 WPE_API WPEMonitor             *wpe_view_get_monitor                   (WPEView            *view);
-WPE_API gboolean                wpe_view_fullscreen                    (WPEView            *view);
-WPE_API gboolean                wpe_view_unfullscreen                  (WPEView            *view);
-WPE_API gboolean                wpe_view_maximize                      (WPEView            *view);
-WPE_API gboolean                wpe_view_unmaximize                    (WPEView            *view);
 WPE_API gboolean                wpe_view_render_buffer                 (WPEView            *view,
                                                                         WPEBuffer          *buffer,
                                                                         const WPERectangle *damage_rects,

--- a/Source/WebKit/WPEPlatform/wpe/WPEViewPrivate.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEViewPrivate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,34 +22,12 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef __WPE_PLATFORM_H__
-#define __WPE_PLATFORM_H__
 
-#define __WPE_PLATFORM_H_INSIDE__
+#pragma once
 
-#include <wpe/WPEEnumTypes.h>
-#include <wpe/WPEEvent.h>
-#include <wpe/WPEBuffer.h>
-#include <wpe/WPEBufferDMABuf.h>
-#include <wpe/WPEBufferDMABufFormats.h>
-#include <wpe/WPEBufferSHM.h>
-#include <wpe/WPEColor.h>
-#include <wpe/WPEConfig.h>
-#include <wpe/WPEDefines.h>
-#include <wpe/WPEDisplay.h>
-#include <wpe/WPEEGLError.h>
-#include <wpe/WPEInputMethodContext.h>
-#include <wpe/WPEKeymap.h>
-#include <wpe/WPEKeyUnicode.h>
-#include <wpe/WPEKeymapXKB.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEMonitor.h>
-#include <wpe/WPERectangle.h>
-#include <wpe/WPEToplevel.h>
-#include <wpe/WPEVersion.h>
-#include <wpe/WPEView.h>
+#include "WPEView.h"
 
-#undef __WPE_PLATFORM_H_INSIDE__
-
-#endif /* __WPE_PLATFORM_H__ */
+void wpeViewToplevelStateChanged(WPEView*, WPEToplevelState);
+void wpeViewScaleChanged(WPEView*, double);
+void wpeViewMonitorChanged(WPEView*);
+void wpeViewPreferredDMABufFormatsChanged(WPEView*);

--- a/Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt
@@ -11,6 +11,7 @@ set(WPEPlatformDRM_SOURCES
     ${WEBKIT_DIR}/WPEPlatform/wpe/drm/WPEDRMSessionLogind.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/drm/WPEMonitorDRM.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/drm/WPEToplevelDRM.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/drm/WPEViewDRM.cpp
 )
 
@@ -18,6 +19,7 @@ set(WPEPlatformDRM_INSTALLED_HEADERS
     ${WEBKIT_DIR}/WPEPlatform/wpe/drm/wpe-drm.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/drm/WPEDisplayDRM.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/drm/WPEMonitorDRM.h
+    ${WEBKIT_DIR}/WPEPlatform/wpe/drm/WPEToplevelDRM.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/drm/WPEViewDRM.h
 )
 

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
@@ -32,6 +32,7 @@
 #include "WPEDisplayDRMPrivate.h"
 #include "WPEExtensions.h"
 #include "WPEMonitorDRMPrivate.h"
+#include "WPEToplevelDRM.h"
 #include "WPEViewDRM.h"
 #include <fcntl.h>
 #include <gio/gio.h>
@@ -308,6 +309,10 @@ static WPEView* wpeDisplayDRMCreateView(WPEDisplay* display)
 {
     auto* displayDRM = WPE_DISPLAY_DRM(display);
     auto* view = wpe_view_drm_new(displayDRM);
+
+    GRefPtr<WPEToplevel> toplevel = adoptGRef(wpe_toplevel_drm_new(displayDRM));
+    wpe_view_set_toplevel(view, toplevel.get());
+
     displayDRM->priv->seat->setView(view);
     return view;
 }

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEToplevelDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEToplevelDRM.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEToplevelDRM.h"
+
+#include "WPEDisplayDRMPrivate.h"
+#include "WPEMonitorDRMPrivate.h"
+#include <wtf/glib/WTFGType.h>
+
+/**
+ * WPEToplevelDRM:
+ *
+ */
+struct _WPEToplevelDRMPrivate {
+};
+WEBKIT_DEFINE_FINAL_TYPE(WPEToplevelDRM, wpe_toplevel_drm, WPE_TYPE_TOPLEVEL, WPEToplevel)
+
+static void wpeToplevelDRMConstructed(GObject* object)
+{
+    G_OBJECT_CLASS(wpe_toplevel_drm_parent_class)->constructed(object);
+
+    auto* toplevel = WPE_TOPLEVEL(object);
+    auto* display = WPE_DISPLAY_DRM(wpe_toplevel_get_display(toplevel));
+    auto* monitor = wpeDisplayDRMGetMonitor(display);
+    auto* mode = wpeMonitorDRMGetMode(WPE_MONITOR_DRM(monitor));
+    double scale = wpe_monitor_get_scale(monitor);
+    wpe_toplevel_resized(toplevel, mode->hdisplay / scale, mode->vdisplay / scale);
+    wpe_toplevel_scale_changed(toplevel, scale);
+    wpe_toplevel_state_changed(toplevel, WPE_TOPLEVEL_STATE_FULLSCREEN);
+}
+
+static WPEMonitor* wpeToplevelDRMGetMonitor(WPEToplevel* toplevel)
+{
+    if (auto* display = wpe_toplevel_get_display(toplevel))
+        return wpeDisplayDRMGetMonitor(WPE_DISPLAY_DRM(display));
+    return nullptr;
+}
+
+static void wpe_toplevel_drm_class_init(WPEToplevelDRMClass* toplevelDRMClass)
+{
+    GObjectClass* objectClass = G_OBJECT_CLASS(toplevelDRMClass);
+    objectClass->constructed = wpeToplevelDRMConstructed;
+
+    WPEToplevelClass* toplevelClass = WPE_TOPLEVEL_CLASS(toplevelDRMClass);
+    toplevelClass->get_monitor = wpeToplevelDRMGetMonitor;
+}
+
+/**
+ * wpe_toplevel_drm_new:
+ * @display: a #WPEDisplayDRM
+ *
+ * Create a new #WPEToplevel on @display.
+ *
+ * Returns: (transfer full): a #WPEToplevel
+ */
+WPEToplevel* wpe_toplevel_drm_new(WPEDisplayDRM* display)
+{
+    return WPE_TOPLEVEL(g_object_new(WPE_TYPE_TOPLEVEL_DRM, "display", display, nullptr));
+}

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEToplevelDRM.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEToplevelDRM.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,34 +22,25 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef __WPE_PLATFORM_H__
-#define __WPE_PLATFORM_H__
 
-#define __WPE_PLATFORM_H_INSIDE__
+#ifndef WPEToplevelDRM_h
+#define WPEToplevelDRM_h
 
-#include <wpe/WPEEnumTypes.h>
-#include <wpe/WPEEvent.h>
-#include <wpe/WPEBuffer.h>
-#include <wpe/WPEBufferDMABuf.h>
-#include <wpe/WPEBufferDMABufFormats.h>
-#include <wpe/WPEBufferSHM.h>
-#include <wpe/WPEColor.h>
-#include <wpe/WPEConfig.h>
-#include <wpe/WPEDefines.h>
-#include <wpe/WPEDisplay.h>
-#include <wpe/WPEEGLError.h>
-#include <wpe/WPEInputMethodContext.h>
-#include <wpe/WPEKeymap.h>
-#include <wpe/WPEKeyUnicode.h>
-#include <wpe/WPEKeymapXKB.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEMonitor.h>
-#include <wpe/WPERectangle.h>
-#include <wpe/WPEToplevel.h>
-#include <wpe/WPEVersion.h>
-#include <wpe/WPEView.h>
+#if !defined(__WPE_DRM_H_INSIDE__) && !defined(BUILDING_WEBKIT)
+#error "Only <wpe/drm/wpe-drm.h> can be included directly."
+#endif
 
-#undef __WPE_PLATFORM_H_INSIDE__
+#include <glib-object.h>
+#include <wpe/wpe-platform.h>
+#include <wpe/drm/WPEDisplayDRM.h>
 
-#endif /* __WPE_PLATFORM_H__ */
+G_BEGIN_DECLS
+
+#define WPE_TYPE_TOPLEVEL_DRM (wpe_toplevel_drm_get_type())
+WPE_API G_DECLARE_FINAL_TYPE (WPEToplevelDRM, wpe_toplevel_drm, WPE, TOPLEVEL_DRM, WPEToplevel)
+
+WPE_API WPEToplevel *wpe_toplevel_drm_new (WPEDisplayDRM *display);
+
+G_END_DECLS
+
+#endif /* WPEToplevelDRM_h */

--- a/Source/WebKit/WPEPlatform/wpe/drm/wpe-drm.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/wpe-drm.h
@@ -29,6 +29,7 @@
 
 #include <wpe/drm/WPEDisplayDRM.h>
 #include <wpe/drm/WPEMonitorDRM.h>
+#include <wpe/drm/WPEToplevelDRM.h>
 #include <wpe/drm/WPEViewDRM.h>
 
 #undef __WPE_DRM_H_INSIDE__

--- a/Source/WebKit/WPEPlatform/wpe/headless/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/wpe/headless/CMakeLists.txt
@@ -3,12 +3,14 @@ configure_file(wpe-platform-headless-uninstalled.pc.in ${CMAKE_BINARY_DIR}/wpe-p
 
 set(WPEPlatformHeadless_SOURCES
     ${WEBKIT_DIR}/WPEPlatform/wpe/headless/WPEDisplayHeadless.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/headless/WPEToplevelHeadless.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/headless/WPEViewHeadless.cpp
 )
 
 set(WPEPlatformHeadless_INSTALLED_HEADERS
     ${WEBKIT_DIR}/WPEPlatform/wpe/headless/wpe-headless.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/headless/WPEDisplayHeadless.h
+    ${WEBKIT_DIR}/WPEPlatform/wpe/headless/WPEToplevelHeadless.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/headless/WPEViewHeadless.h
 )
 

--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.cpp
@@ -28,6 +28,7 @@
 
 #include "WPEBufferDMABufFormats.h"
 #include "WPEExtensions.h"
+#include "WPEToplevelHeadless.h"
 #include "WPEViewHeadless.h"
 #include <gio/gio.h>
 #include <wtf/glib/GRefPtr.h>
@@ -55,7 +56,10 @@ static gboolean wpeDisplayHeadlessConnect(WPEDisplay*, GError**)
 
 static WPEView* wpeDisplayHeadlessCreateView(WPEDisplay* display)
 {
-    return wpe_view_headless_new(WPE_DISPLAY_HEADLESS(display));
+    auto* view = wpe_view_headless_new(WPE_DISPLAY_HEADLESS(display));
+    GRefPtr<WPEToplevel> toplevel = adoptGRef(wpe_toplevel_headless_new(WPE_DISPLAY_HEADLESS(display)));
+    wpe_view_set_toplevel(view, toplevel.get());
+    return view;
 }
 
 #if USE(LIBDRM)

--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEToplevelHeadless.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEToplevelHeadless.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEToplevelHeadless.h"
+
+#include <wtf/glib/WTFGType.h>
+
+/**
+ * WPEToplevelHeadless:
+ *
+ */
+struct _WPEToplevelHeadlessPrivate {
+};
+WEBKIT_DEFINE_FINAL_TYPE(WPEToplevelHeadless, wpe_toplevel_headless, WPE_TYPE_TOPLEVEL, WPEToplevel)
+
+static gboolean wpeToplevelHeadlessResize(WPEToplevel* toplevel, int width, int height)
+{
+    wpe_toplevel_resized(toplevel, width, height);
+    wpe_toplevel_foreach_view(toplevel, [](WPEToplevel* toplevel, WPEView* view, gpointer) -> gboolean {
+        int width, height;
+        wpe_toplevel_get_size(toplevel, &width, &height);
+        wpe_view_resized(view, width, height);
+        return FALSE;
+    }, nullptr);
+    return TRUE;
+}
+
+static gboolean wpeToplevelHeadlessSetFullscreen(WPEToplevel* toplevel, gboolean fullscreen)
+{
+    auto state = wpe_toplevel_get_state(toplevel);
+    if (fullscreen)
+        state = static_cast<WPEToplevelState>(state | WPE_TOPLEVEL_STATE_FULLSCREEN);
+    else
+        state = static_cast<WPEToplevelState>(state & ~WPE_TOPLEVEL_STATE_FULLSCREEN);
+    wpe_toplevel_state_changed(toplevel, state);
+    return TRUE;
+}
+
+static void wpe_toplevel_headless_class_init(WPEToplevelHeadlessClass* toplevelHeadlessClass)
+{
+    WPEToplevelClass* toplevelClass = WPE_TOPLEVEL_CLASS(toplevelHeadlessClass);
+    toplevelClass->resize = wpeToplevelHeadlessResize;
+    toplevelClass->set_fullscreen = wpeToplevelHeadlessSetFullscreen;
+}
+
+/**
+ * wpe_toplevel_headless_new:
+ * @display: a #WPEDisplayHeadless
+ *
+ * Create a new #WPEToplevel on @display.
+ *
+ * Returns: (transfer full): a #WPEToplevel
+ */
+WPEToplevel* wpe_toplevel_headless_new(WPEDisplayHeadless* display)
+{
+    return WPE_TOPLEVEL(g_object_new(WPE_TYPE_TOPLEVEL_HEADLESS, "display", display, nullptr));
+}

--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEToplevelHeadless.h
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEToplevelHeadless.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,34 +22,25 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef __WPE_PLATFORM_H__
-#define __WPE_PLATFORM_H__
 
-#define __WPE_PLATFORM_H_INSIDE__
+#ifndef WPEToplevelHeadless_h
+#define WPEToplevelHeadless_h
 
-#include <wpe/WPEEnumTypes.h>
-#include <wpe/WPEEvent.h>
-#include <wpe/WPEBuffer.h>
-#include <wpe/WPEBufferDMABuf.h>
-#include <wpe/WPEBufferDMABufFormats.h>
-#include <wpe/WPEBufferSHM.h>
-#include <wpe/WPEColor.h>
-#include <wpe/WPEConfig.h>
-#include <wpe/WPEDefines.h>
-#include <wpe/WPEDisplay.h>
-#include <wpe/WPEEGLError.h>
-#include <wpe/WPEInputMethodContext.h>
-#include <wpe/WPEKeymap.h>
-#include <wpe/WPEKeyUnicode.h>
-#include <wpe/WPEKeymapXKB.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEMonitor.h>
-#include <wpe/WPERectangle.h>
-#include <wpe/WPEToplevel.h>
-#include <wpe/WPEVersion.h>
-#include <wpe/WPEView.h>
+#if !defined(__WPE_HEADLESS_H_INSIDE__) && !defined(BUILDING_WEBKIT)
+#error "Only <wpe/headless/wpe-headless.h> can be included directly."
+#endif
 
-#undef __WPE_PLATFORM_H_INSIDE__
+#include <glib-object.h>
+#include <wpe/wpe-platform.h>
+#include <wpe/headless/WPEDisplayHeadless.h>
 
-#endif /* __WPE_PLATFORM_H__ */
+G_BEGIN_DECLS
+
+#define WPE_TYPE_TOPLEVEL_HEADLESS (wpe_toplevel_headless_get_type())
+WPE_API G_DECLARE_FINAL_TYPE (WPEToplevelHeadless, wpe_toplevel_headless, WPE, TOPLEVEL_HEADLESS, WPEToplevel)
+
+WPE_API WPEToplevel *wpe_toplevel_headless_new (WPEDisplayHeadless *display);
+
+G_END_DECLS
+
+#endif /* WPEToplevelHeadless_h */

--- a/Source/WebKit/WPEPlatform/wpe/headless/wpe-headless.h
+++ b/Source/WebKit/WPEPlatform/wpe/headless/wpe-headless.h
@@ -28,6 +28,7 @@
 #define __WPE_HEADLESS_H_INSIDE__
 
 #include <wpe/headless/WPEDisplayHeadless.h>
+#include <wpe/headless/WPEToplevelHeadless.h>
 #include <wpe/headless/WPEViewHeadless.h>
 
 #undef __WPE_HEADLESS_H_INSIDE__

--- a/Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt
@@ -8,6 +8,7 @@ set(WPEPlatformWayland_SOURCES
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV1.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV3.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEMonitorWayland.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEWaylandCursor.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEWaylandCursorTheme.cpp
@@ -23,6 +24,7 @@ set(WPEPlatformWayland_INSTALLED_HEADERS
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/wpe-wayland.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEDisplayWayland.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEMonitorWayland.h
+    ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEToplevelWayland.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/wayland/WPEViewWayland.h
 )
 

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
@@ -32,6 +32,7 @@
 #include "WPEInputMethodContextWaylandV1.h"
 #include "WPEInputMethodContextWaylandV3.h"
 #include "WPEMonitorWaylandPrivate.h"
+#include "WPEToplevelWayland.h"
 #include "WPEViewWayland.h"
 #include "WPEWaylandCursor.h"
 #include "WPEWaylandSeat.h"
@@ -405,11 +406,14 @@ static gboolean wpeDisplayWaylandConnect(WPEDisplay* display, GError** error)
 
 static WPEView* wpeDisplayWaylandCreateView(WPEDisplay* display)
 {
-    auto* priv = WPE_DISPLAY_WAYLAND(display)->priv;
-    if (!priv->wlDisplay || !priv->wlCompositor)
-        return nullptr;
+    auto* displayWayland = WPE_DISPLAY_WAYLAND(display);
+    auto* view = wpe_view_wayland_new(displayWayland);
 
-    return wpe_view_wayland_new(WPE_DISPLAY_WAYLAND(display));
+    // FIXME: create the toplevel conditionally.
+    GRefPtr<WPEToplevel> toplevel = adoptGRef(wpe_toplevel_wayland_new(displayWayland));
+    wpe_view_set_toplevel(view, toplevel.get());
+
+    return view;
 }
 
 static WPEInputMethodContext* wpeDisplayWaylandCreateInputMethodContext(WPEDisplay* display)

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp
@@ -1,0 +1,824 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEToplevelWayland.h"
+
+#include "WPEBufferDMABufFormats.h"
+#include "WPEDisplayWaylandPrivate.h"
+#include "WPEToplevelWaylandPrivate.h"
+#include "linux-dmabuf-unstable-v1-client-protocol.h"
+#include "xdg-shell-client-protocol.h"
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <wtf/Vector.h>
+#include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GWeakPtr.h>
+#include <wtf/glib/WTFGType.h>
+#include <wtf/text/CString.h>
+
+#if USE(LIBDRM)
+#include <xf86drm.h>
+#endif
+
+struct DMABufFeedback {
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
+
+    struct FormatTable {
+        struct Data {
+            uint32_t format { 0 };
+            uint32_t padding { 0 };
+            uint64_t modifier { 0 };
+        };
+
+        FormatTable(const FormatTable&) = delete;
+        FormatTable& operator=(const FormatTable&) = delete;
+        FormatTable(FormatTable&& other)
+        {
+            *this = WTFMove(other);
+        }
+
+        FormatTable(unsigned size, Data* data)
+            : size(size)
+            , data(data)
+        {
+        }
+
+        explicit FormatTable() = default;
+        explicit FormatTable(uint32_t size, int fd)
+            : size(size)
+            , data(static_cast<FormatTable::Data*>(mmap(nullptr, size, PROT_READ, MAP_PRIVATE, fd, 0)))
+        {
+            if (data == MAP_FAILED) {
+                data = nullptr;
+                size = 0;
+            }
+        }
+
+        explicit operator bool() const
+        {
+            return size && data;
+        }
+
+        FormatTable& operator=(FormatTable&& other)
+        {
+            if (data != other.data) {
+                if (data)
+                    munmap(data, size);
+                data = std::exchange(other.data, nullptr);
+                size = std::exchange(other.size, 0);
+            }
+            return *this;
+        }
+
+        ~FormatTable()
+        {
+            if (data)
+                munmap(data, size);
+        }
+
+        unsigned size { 0 };
+        Data* data { nullptr };
+    };
+
+    DMABufFeedback()
+    {
+#if USE(LIBDRM)
+        memset(&mainDevice, 0, sizeof(dev_t));
+#endif
+    }
+
+    ~DMABufFeedback() = default;
+
+    DMABufFeedback(const DMABufFeedback&) = delete;
+    DMABufFeedback& operator=(const DMABufFeedback&) = delete;
+
+    DMABufFeedback(DMABufFeedback&& other)
+        : formatTable(WTFMove(other.formatTable))
+        , pendingTranche(WTFMove(other.pendingTranche))
+        , tranches(WTFMove(other.tranches))
+    {
+#if USE(LIBDRM)
+        memcpy(&mainDevice, &other.mainDevice, sizeof(dev_t));
+        memset(&other.mainDevice, 0, sizeof(dev_t));
+#endif
+    }
+
+#if USE(LIBDRM)
+    static CString drmDeviceForUsage(const dev_t* device, bool isScanout)
+    {
+        drmDevicePtr drmDevice;
+        if (drmGetDeviceFromDevId(*device, 0, &drmDevice))
+            return { };
+
+        CString returnValue;
+        if (isScanout) {
+            if (drmDevice->available_nodes & (1 << DRM_NODE_PRIMARY))
+                returnValue = drmDevice->nodes[DRM_NODE_PRIMARY];
+        } else {
+            if (drmDevice->available_nodes & (1 << DRM_NODE_RENDER))
+                returnValue = drmDevice->nodes[DRM_NODE_RENDER];
+            else if (drmDevice->available_nodes & (1 << DRM_NODE_PRIMARY))
+                returnValue = drmDevice->nodes[DRM_NODE_PRIMARY];
+        }
+
+        drmFreeDevice(&drmDevice);
+
+        return returnValue;
+    }
+#endif
+
+    CString drmDevice() const
+    {
+#if USE(LIBDRM)
+        return drmDeviceForUsage(&mainDevice, false);
+#else
+        return { };
+#endif
+    }
+
+    struct Tranche {
+        Tranche()
+        {
+#if USE(LIBDRM)
+            memset(&targetDevice, 0, sizeof(dev_t));
+#endif
+        }
+        ~Tranche() = default;
+        Tranche(const Tranche&) = delete;
+        Tranche& operator=(const Tranche&) = delete;
+        Tranche(Tranche&& other)
+            : flags(other.flags)
+            , formats(WTFMove(other.formats))
+        {
+            other.flags = 0;
+#if USE(LIBDRM)
+            memcpy(&targetDevice, &other.targetDevice, sizeof(dev_t));
+            memset(&other.targetDevice, 0, sizeof(dev_t));
+#endif
+        }
+
+        CString drmDevice() const
+        {
+#if USE(LIBDRM)
+            return drmDeviceForUsage(&targetDevice, flags & ZWP_LINUX_DMABUF_FEEDBACK_V1_TRANCHE_FLAGS_SCANOUT);
+#else
+            return { };
+#endif
+        }
+
+        uint32_t flags { 0 };
+        Vector<uint16_t> formats;
+#if USE(LIBDRM)
+        dev_t targetDevice;
+#endif
+    };
+
+    std::pair<uint32_t, uint64_t> format(uint16_t index)
+    {
+        ASSERT(index < formatTable.size);
+        if (UNLIKELY(index >= formatTable.size))
+            return { 0, 0 };
+
+        return { formatTable.data[index].format, formatTable.data[index].modifier };
+    }
+
+    FormatTable formatTable;
+    Tranche pendingTranche;
+    Vector<Tranche> tranches;
+#if USE(LIBDRM)
+    dev_t mainDevice;
+#endif
+};
+
+/**
+ * WPEToplevelWayland:
+ *
+ */
+struct _WPEToplevelWaylandPrivate {
+    struct wl_surface* wlSurface;
+    struct xdg_surface* xdgSurface;
+    struct xdg_toplevel* xdgToplevel;
+
+    struct zwp_linux_dmabuf_feedback_v1* dmabufFeedback;
+    std::unique_ptr<DMABufFeedback> pendingDMABufFeedback;
+    std::unique_ptr<DMABufFeedback> committedDMABufFeedback;
+    GRefPtr<WPEBufferDMABufFormats> preferredDMABufFormats;
+
+    bool hasPointer;
+    bool isFocused;
+    GWeakPtr<WPEView> visibleView;
+
+    Vector<GRefPtr<WPEMonitor>, 1> monitors;
+    GRefPtr<WPEMonitor> currentMonitor;
+
+    struct {
+        std::optional<uint32_t> width;
+        std::optional<uint32_t> height;
+        WPEToplevelState state { WPE_TOPLEVEL_STATE_NONE };
+    } pendingState;
+
+    struct {
+        std::optional<uint32_t> width;
+        std::optional<uint32_t> height;
+    } savedSize;
+
+    struct {
+        Vector<WPERectangle, 1> rects;
+        bool dirty;
+    } opaqueRegion;
+};
+WEBKIT_DEFINE_FINAL_TYPE(WPEToplevelWayland, wpe_toplevel_wayland, WPE_TYPE_TOPLEVEL, WPEToplevel)
+
+static void wpeToplevelWaylandSaveSize(WPEToplevel* toplevel)
+{
+    auto state = wpe_toplevel_get_state(toplevel);
+    if (state & (WPE_TOPLEVEL_STATE_FULLSCREEN | WPE_TOPLEVEL_STATE_MAXIMIZED))
+        return;
+
+    auto* priv = WPE_TOPLEVEL_WAYLAND(toplevel)->priv;
+    int width, height;
+    wpe_toplevel_get_size(toplevel, &width, &height);
+    priv->savedSize.width = width;
+    priv->savedSize.height = height;
+}
+
+static void wpeToplevelWaylandResized(WPEToplevel* toplevel, int width, int height)
+{
+    wpe_toplevel_resized(toplevel, width, height);
+    wpe_toplevel_foreach_view(toplevel, [](WPEToplevel* toplevel, WPEView* view, gpointer) -> gboolean {
+        int width, height;
+        wpe_toplevel_get_size(toplevel, &width, &height);
+        wpe_view_resized(view, width, height);
+        return FALSE;
+    }, nullptr);
+}
+
+const struct xdg_surface_listener xdgSurfaceListener = {
+    // configure
+    [](void* data, struct xdg_surface* surface, uint32_t serial)
+    {
+        auto* toplevel = WPE_TOPLEVEL(data);
+        auto* priv = WPE_TOPLEVEL_WAYLAND(toplevel)->priv;
+
+        bool isFixedSize = priv->pendingState.state & (WPE_TOPLEVEL_STATE_FULLSCREEN | WPE_TOPLEVEL_STATE_MAXIMIZED);
+        bool wasFixedSize = wpe_toplevel_get_state(toplevel) & (WPE_TOPLEVEL_STATE_FULLSCREEN | WPE_TOPLEVEL_STATE_MAXIMIZED);
+        auto width = priv->pendingState.width;
+        auto height = priv->pendingState.height;
+        bool useSavedSize = !width.has_value() && !height.has_value();
+        if (useSavedSize && !isFixedSize && wasFixedSize) {
+            width = priv->savedSize.width;
+            height = priv->savedSize.height;
+        }
+
+        if (width.has_value() && height.has_value()) {
+            if (!useSavedSize)
+                wpeToplevelWaylandSaveSize(toplevel);
+            wpeToplevelWaylandResized(toplevel, width.value(), height.value());
+        }
+
+        wpe_toplevel_state_changed(toplevel, priv->pendingState.state);
+        priv->pendingState = { };
+        xdg_surface_ack_configure(surface, serial);
+    },
+};
+
+const struct xdg_toplevel_listener xdgToplevelListener = {
+    // configure
+    [](void* data, struct xdg_toplevel*, int32_t width, int32_t height, struct wl_array* states)
+    {
+        auto* toplevel = WPE_TOPLEVEL_WAYLAND(data);
+        auto* priv = toplevel->priv;
+        if (width && height) {
+            priv->pendingState.width = width;
+            priv->pendingState.height = height;
+        }
+
+        uint32_t pendingState = 0;
+        const auto* stateData = static_cast<uint32_t*>(states->data);
+        for (size_t i = 0; i < states->size; i++) {
+            uint32_t state = stateData[i];
+
+            switch (state) {
+            case XDG_TOPLEVEL_STATE_FULLSCREEN:
+                pendingState |= WPE_TOPLEVEL_STATE_FULLSCREEN;
+                break;
+            case XDG_TOPLEVEL_STATE_MAXIMIZED:
+                pendingState |= WPE_TOPLEVEL_STATE_MAXIMIZED;
+                break;
+            default:
+                break;
+            }
+        }
+
+        priv->pendingState.state = static_cast<WPEToplevelState>(priv->pendingState.state | pendingState);
+    },
+    // close
+    [](void* data, struct xdg_toplevel*)
+    {
+        wpe_toplevel_closed(WPE_TOPLEVEL(data));
+    },
+#ifdef XDG_TOPLEVEL_CONFIGURE_BOUNDS_SINCE_VERSION
+    // configure_bounds
+    [](void*, struct xdg_toplevel*, int32_t, int32_t)
+    {
+    },
+#endif
+#ifdef XDG_TOPLEVEL_WM_CAPABILITIES_SINCE_VERSION
+    // wm_capabilities
+    [](void*, struct xdg_toplevel*, struct wl_array*)
+    {
+    },
+#endif
+};
+
+static void wpeToplevelWaylandUpdateScale(WPEToplevelWayland* toplevel)
+{
+    auto* priv = toplevel->priv;
+    if (priv->monitors.isEmpty())
+        return;
+
+    double scale = 1;
+    for (const auto& monitor : priv->monitors)
+        scale = std::max(scale, wpe_monitor_get_scale(monitor.get()));
+
+    if (wl_surface_get_version(priv->wlSurface) >= WL_SURFACE_SET_BUFFER_SCALE_SINCE_VERSION)
+        wl_surface_set_buffer_scale(priv->wlSurface, scale);
+
+    wpe_toplevel_scale_changed(WPE_TOPLEVEL(toplevel), scale);
+}
+
+static const struct wl_surface_listener surfaceListener = {
+    // enter
+    [](void* data, struct wl_surface*, struct wl_output* wlOutput)
+    {
+        auto* toplevel = WPE_TOPLEVEL(data);
+        auto* display = wpe_toplevel_get_display(toplevel);
+        if (!display)
+            return;
+
+        auto* monitor = wpeDisplayWaylandFindMonitor(WPE_DISPLAY_WAYLAND(display), wlOutput);
+        if (!monitor)
+            return;
+
+        auto* priv = WPE_TOPLEVEL_WAYLAND(toplevel)->priv;
+        // For now we just use the last entered monitor as current, but we could do someting smarter.
+        bool monitorChanged = false;
+        if (priv->currentMonitor.get() != monitor) {
+            priv->currentMonitor = monitor;
+            monitorChanged = true;
+        }
+        priv->monitors.append(monitor);
+        wpeToplevelWaylandUpdateScale(WPE_TOPLEVEL_WAYLAND(toplevel));
+        if (monitorChanged)
+            wpe_toplevel_monitor_changed(toplevel);
+        g_signal_connect_object(monitor, "notify::scale", G_CALLBACK(+[](WPEToplevelWayland* toplevel) {
+            wpeToplevelWaylandUpdateScale(WPE_TOPLEVEL_WAYLAND(toplevel));
+        }), toplevel, G_CONNECT_SWAPPED);
+    },
+    // leave
+    [](void* data, struct wl_surface*, struct wl_output* wlOutput)
+    {
+        auto* toplevel = WPE_TOPLEVEL(data);
+        auto* display = wpe_toplevel_get_display(toplevel);
+        if (!display)
+            return;
+
+        auto* monitor = wpeDisplayWaylandFindMonitor(WPE_DISPLAY_WAYLAND(display), wlOutput);
+        if (!monitor)
+            return;
+
+        auto* priv = WPE_TOPLEVEL_WAYLAND(toplevel)->priv;
+        priv->monitors.removeLast(monitor);
+        if (!priv->monitors.isEmpty())
+            priv->currentMonitor = priv->monitors.last();
+        else
+            priv->currentMonitor = nullptr;
+        wpeToplevelWaylandUpdateScale(WPE_TOPLEVEL_WAYLAND(toplevel));
+        wpe_toplevel_monitor_changed(toplevel);
+        g_signal_handlers_disconnect_by_data(monitor, toplevel);
+    },
+#ifdef WL_SURFACE_PREFERRED_BUFFER_SCALE_SINCE_VERSION
+    // preferred_buffer_scale
+    [](void*, struct wl_surface*, int /* factor */)
+    {
+    },
+#endif
+#ifdef WL_SURFACE_PREFERRED_BUFFER_TRANSFORM_SINCE_VERSION
+    // preferred_buffer_transform
+    [](void*, struct wl_surface*, uint32_t) {
+    },
+#endif
+};
+
+static const struct zwp_linux_dmabuf_feedback_v1_listener linuxDMABufFeedbackListener = {
+    // done
+    [](void* data, struct zwp_linux_dmabuf_feedback_v1*)
+    {
+        auto* toplevel = WPE_TOPLEVEL(data);
+        auto* priv = WPE_TOPLEVEL_WAYLAND(toplevel)->priv;
+        if (!priv->pendingDMABufFeedback)
+            return;
+
+        // The compositor might not have sent the formats table. In that case, try to reuse the previous
+        // one. Return early and skip emitting the signal if there is no usable formats table in the end.
+        if (!priv->pendingDMABufFeedback->formatTable) {
+            if (priv->committedDMABufFeedback && priv->committedDMABufFeedback->formatTable)
+                priv->pendingDMABufFeedback->formatTable = WTFMove(priv->committedDMABufFeedback->formatTable);
+            else {
+                priv->pendingDMABufFeedback.reset();
+                return;
+            }
+        }
+
+        priv->committedDMABufFeedback = WTFMove(priv->pendingDMABufFeedback);
+        priv->preferredDMABufFormats = nullptr;
+        wpe_toplevel_preferred_dma_buf_formats_changed(toplevel);
+    },
+    // format_table
+    [](void* data, struct zwp_linux_dmabuf_feedback_v1*, int32_t fd, uint32_t size)
+    {
+        // The protocol specification is not clear about the ordering of the format_table and main_device
+        // events. Err on the safer side and allow any of them to create the pending feedback instance.
+        auto* priv = WPE_TOPLEVEL_WAYLAND(data)->priv;
+        if (!priv->pendingDMABufFeedback)
+            priv->pendingDMABufFeedback = makeUnique<DMABufFeedback>();
+
+        priv->pendingDMABufFeedback->formatTable = DMABufFeedback::FormatTable(size, fd);
+        close(fd);
+    },
+    // main_device
+    [](void* data, struct zwp_linux_dmabuf_feedback_v1*, struct wl_array* device)
+    {
+        auto* priv = WPE_TOPLEVEL_WAYLAND(data)->priv;
+        if (!priv->pendingDMABufFeedback)
+            priv->pendingDMABufFeedback = makeUnique<DMABufFeedback>();
+
+#if USE(LIBDRM)
+        memcpy(&priv->pendingDMABufFeedback->mainDevice, device->data, sizeof(dev_t));
+#endif
+    },
+    // tranche_done
+    [](void* data, struct zwp_linux_dmabuf_feedback_v1*)
+    {
+        auto* priv = WPE_TOPLEVEL_WAYLAND(data)->priv;
+        if (!priv->pendingDMABufFeedback)
+            return;
+
+        priv->pendingDMABufFeedback->tranches.append(WTFMove(priv->pendingDMABufFeedback->pendingTranche));
+    },
+    // tranche_target_device
+    [](void* data, struct zwp_linux_dmabuf_feedback_v1*, struct wl_array* device)
+    {
+#if USE(LIBDRM)
+        auto* priv = WPE_TOPLEVEL_WAYLAND(data)->priv;
+        if (!priv->pendingDMABufFeedback)
+            return;
+
+        memcpy(&priv->pendingDMABufFeedback->pendingTranche.targetDevice, device->data, sizeof(dev_t));
+#endif
+    },
+    // tranche_formats
+    [](void* data, struct zwp_linux_dmabuf_feedback_v1*, struct wl_array* indices)
+    {
+        auto* priv = WPE_TOPLEVEL_WAYLAND(data)->priv;
+        if (!priv->pendingDMABufFeedback)
+            return;
+
+        const char* end = static_cast<const char*>(indices->data) + indices->size;
+        for (uint16_t* index = static_cast<uint16_t*>(indices->data); reinterpret_cast<const char*>(index) < end; ++index)
+            priv->pendingDMABufFeedback->pendingTranche.formats.append(*index);
+    },
+    // tranche_flags
+    [](void* data, struct zwp_linux_dmabuf_feedback_v1*, uint32_t flags)
+    {
+        auto* priv = WPE_TOPLEVEL_WAYLAND(data)->priv;
+        if (priv->pendingDMABufFeedback)
+            priv->pendingDMABufFeedback->pendingTranche.flags |= flags;
+    }
+};
+
+static void wpeToplevelWaylandConstructed(GObject *object)
+{
+    G_OBJECT_CLASS(wpe_toplevel_wayland_parent_class)->constructed(object);
+
+    auto* toplevel = WPE_TOPLEVEL(object);
+    auto* display = WPE_DISPLAY_WAYLAND(wpe_toplevel_get_display(toplevel));
+    auto* priv = WPE_TOPLEVEL_WAYLAND(object)->priv;
+    auto* wlCompositor = wpe_display_wayland_get_wl_compositor(display);
+    priv->wlSurface = wl_compositor_create_surface(wlCompositor);
+    wl_surface_add_listener(priv->wlSurface, &surfaceListener, object);
+    if (auto* xdgWMBase = wpeDisplayWaylandGetXDGWMBase(display)) {
+        priv->xdgSurface = xdg_wm_base_get_xdg_surface(xdgWMBase, priv->wlSurface);
+        xdg_surface_add_listener(priv->xdgSurface, &xdgSurfaceListener, object);
+        if (auto* xdgToplevel = xdg_surface_get_toplevel(priv->xdgSurface)) {
+            priv->xdgToplevel = xdgToplevel;
+            xdg_toplevel_add_listener(priv->xdgToplevel, &xdgToplevelListener, object);
+            xdg_toplevel_set_title(priv->xdgToplevel, "WPEDMABuf"); // FIXME
+            wl_surface_commit(priv->wlSurface);
+        }
+    }
+
+    auto* dmabuf = wpeDisplayWaylandGetLinuxDMABuf(display);
+    if (dmabuf && zwp_linux_dmabuf_v1_get_version(dmabuf) >= ZWP_LINUX_DMABUF_V1_GET_SURFACE_FEEDBACK_SINCE_VERSION) {
+        priv->dmabufFeedback = zwp_linux_dmabuf_v1_get_surface_feedback(dmabuf, priv->wlSurface);
+        zwp_linux_dmabuf_feedback_v1_add_listener(priv->dmabufFeedback, &linuxDMABufFeedbackListener, object);
+    }
+
+    wl_display_roundtrip(wpe_display_wayland_get_wl_display(display));
+
+    // Set the first monitor as the default one until enter monitor is emitted.
+    if (wpe_display_get_n_monitors(WPE_DISPLAY(display))) {
+        priv->currentMonitor = wpe_display_get_monitor(WPE_DISPLAY(display), 0);
+        auto scale = wpe_monitor_get_scale(priv->currentMonitor.get());
+        if (wl_surface_get_version(priv->wlSurface) >= WL_SURFACE_SET_BUFFER_SCALE_SINCE_VERSION)
+            wl_surface_set_buffer_scale(priv->wlSurface, scale);
+        wpe_toplevel_scale_changed(toplevel, scale);
+    }
+}
+
+static void wpeToplevelWaylandDispose(GObject* object)
+{
+    auto* priv = WPE_TOPLEVEL_WAYLAND(object)->priv;
+    priv->currentMonitor = nullptr;
+    priv->monitors.clear();
+    g_clear_pointer(&priv->xdgToplevel, xdg_toplevel_destroy);
+    g_clear_pointer(&priv->dmabufFeedback, zwp_linux_dmabuf_feedback_v1_destroy);
+    g_clear_pointer(&priv->xdgSurface, xdg_surface_destroy);
+    g_clear_pointer(&priv->wlSurface, wl_surface_destroy);
+
+    G_OBJECT_CLASS(wpe_toplevel_wayland_parent_class)->dispose(object);
+}
+
+static WPEMonitor* wpeToplevelWaylandGetMonitor(WPEToplevel* toplevel)
+{
+    auto* priv = WPE_TOPLEVEL_WAYLAND(toplevel)->priv;
+    return priv->currentMonitor.get();
+}
+
+static gboolean wpeToplevelWaylandResize(WPEToplevel* toplevel, int width, int height)
+{
+    auto* priv = WPE_TOPLEVEL_WAYLAND(toplevel)->priv;
+    if (!priv->xdgToplevel)
+        return FALSE;
+
+    wpe_toplevel_resized(toplevel, width, height);
+    return TRUE;
+}
+
+static gboolean wpeToplevelWaylandSetFullscreen(WPEToplevel* toplevel, gboolean fullscreen)
+{
+    auto* priv = WPE_TOPLEVEL_WAYLAND(toplevel)->priv;
+    if (!priv->xdgToplevel)
+        return FALSE;
+
+    if (fullscreen) {
+        wpeToplevelWaylandSaveSize(toplevel);
+        xdg_toplevel_set_fullscreen(priv->xdgToplevel, nullptr);
+        return TRUE;
+    }
+
+    xdg_toplevel_unset_fullscreen(priv->xdgToplevel);
+    return TRUE;
+}
+
+static gboolean wpeToplevelWaylandSetMaximized(WPEToplevel* toplevel, gboolean maximized)
+{
+    auto* priv = WPE_TOPLEVEL_WAYLAND(toplevel)->priv;
+    if (!priv->xdgToplevel)
+        return FALSE;
+
+    if (maximized) {
+        wpeToplevelWaylandSaveSize(toplevel);
+        xdg_toplevel_set_maximized(priv->xdgToplevel);
+        return TRUE;
+    }
+
+    xdg_toplevel_unset_maximized(priv->xdgToplevel);
+    return TRUE;
+}
+
+static WPEBufferDMABufFormats* wpeToplevelWaylandGetPreferredDMABufFormats(WPEToplevel* toplevel)
+{
+    auto* priv = WPE_TOPLEVEL_WAYLAND(toplevel)->priv;
+    if (priv->preferredDMABufFormats)
+        return priv->preferredDMABufFormats.get();
+
+    if (!priv->committedDMABufFeedback)
+        return nullptr;
+
+    auto mainDevice = priv->committedDMABufFeedback->drmDevice();
+    auto* builder = wpe_buffer_dma_buf_formats_builder_new(mainDevice.data());
+    for (const auto& tranche : priv->committedDMABufFeedback->tranches) {
+        WPEBufferDMABufFormatUsage usage = tranche.flags & ZWP_LINUX_DMABUF_FEEDBACK_V1_TRANCHE_FLAGS_SCANOUT ? WPE_BUFFER_DMA_BUF_FORMAT_USAGE_SCANOUT : WPE_BUFFER_DMA_BUF_FORMAT_USAGE_RENDERING;
+        auto targetDevice = tranche.drmDevice();
+        wpe_buffer_dma_buf_formats_builder_append_group(builder, targetDevice.data(), usage);
+
+        for (const auto& format : tranche.formats) {
+            auto [fourcc, modifier] = priv->committedDMABufFeedback->format(format);
+            if (LIKELY(fourcc))
+                wpe_buffer_dma_buf_formats_builder_append_format(builder, fourcc, modifier);
+        }
+    }
+
+    priv->preferredDMABufFormats = adoptGRef(wpe_buffer_dma_buf_formats_builder_end(builder));
+    return priv->preferredDMABufFormats.get();
+}
+
+static void wpe_toplevel_wayland_class_init(WPEToplevelWaylandClass* toplevelWaylandClass)
+{
+    GObjectClass* objectClass = G_OBJECT_CLASS(toplevelWaylandClass);
+    objectClass->constructed = wpeToplevelWaylandConstructed;
+    objectClass->dispose = wpeToplevelWaylandDispose;
+
+    WPEToplevelClass* toplevelClass = WPE_TOPLEVEL_CLASS(toplevelWaylandClass);
+    toplevelClass->get_monitor = wpeToplevelWaylandGetMonitor;
+    toplevelClass->resize = wpeToplevelWaylandResize;
+    toplevelClass->set_fullscreen = wpeToplevelWaylandSetFullscreen;
+    toplevelClass->set_maximized = wpeToplevelWaylandSetMaximized;
+    toplevelClass->get_preferred_dma_buf_formats = wpeToplevelWaylandGetPreferredDMABufFormats;
+}
+
+static bool regionsEqual(WPERectangle* rectsA, unsigned rectsACount, WPERectangle* rectsB, unsigned rectsBCount)
+{
+    if (rectsACount != rectsBCount)
+        return false;
+
+    if (rectsA == rectsB)
+        return true;
+
+    if (!rectsA || !rectsB)
+        return false;
+
+    auto rectsEqual = [](const WPERectangle& rectA, const WPERectangle& rectB) -> bool {
+        return rectA.x == rectB.x
+            && rectA.y == rectB.y
+            && rectA.width == rectB.width
+            && rectA.height == rectB.height;
+    };
+
+    for (unsigned i = 0; i < rectsACount; ++i) {
+        if (!rectsEqual(rectsA[i], rectsB[i]))
+            return false;
+    }
+
+    return true;
+}
+
+void wpeToplevelWaylandSetOpaqueRectangles(WPEToplevelWayland* toplevel, WPERectangle* rects, unsigned rectsCount)
+{
+    auto* priv = toplevel->priv;
+    if (regionsEqual(priv->opaqueRegion.rects.data(), priv->opaqueRegion.rects.size(), rects, rectsCount))
+        return;
+
+    priv->opaqueRegion.rects.clear();
+    if (rects) {
+        priv->opaqueRegion.rects.reserveInitialCapacity(rectsCount);
+        for (unsigned i = 0; i < rectsCount; ++i)
+            priv->opaqueRegion.rects.append(rects[i]);
+    }
+    priv->opaqueRegion.dirty = true;
+}
+
+void wpeToplevelWaylandUpdateOpaqueRegion(WPEToplevelWayland* toplevel)
+{
+    auto* priv = toplevel->priv;
+    if (!priv->opaqueRegion.dirty)
+        return;
+
+    struct wl_region* region = nullptr;
+    if (!priv->opaqueRegion.rects.isEmpty()) {
+        auto* display = WPE_DISPLAY_WAYLAND(wpe_toplevel_get_display(WPE_TOPLEVEL(toplevel)));
+        auto* wlCompositor = wpe_display_wayland_get_wl_compositor(display);
+        region = wl_compositor_create_region(wlCompositor);
+        if (region) {
+            for (const auto& rect : priv->opaqueRegion.rects)
+                wl_region_add(region, rect.x, rect.y, rect.width, rect.height);
+        }
+    }
+
+    wl_surface_set_opaque_region(priv->wlSurface, region);
+    if (region)
+        wl_region_destroy(region);
+
+    priv->opaqueRegion.dirty = false;
+}
+
+static WPEView* wpeToplevelWaylandFindVisibleView(WPEToplevelWayland* toplevel)
+{
+    WPEView* view = nullptr;
+    wpe_toplevel_foreach_view(WPE_TOPLEVEL(toplevel), [](WPEToplevel*, WPEView* view, gpointer userData) -> gboolean {
+        if (wpe_view_get_mapped(view)) {
+            *static_cast<WPEView**>(userData) = view;
+            return TRUE;
+        }
+        return FALSE;
+    }, &view);
+    return view;
+}
+
+void wpeToplevelWaylandSetHasPointer(WPEToplevelWayland* toplevel, bool hasPointer)
+{
+    auto* priv = toplevel->priv;
+    priv->hasPointer = hasPointer;
+    if (hasPointer && !priv->visibleView)
+        priv->visibleView.reset(wpeToplevelWaylandFindVisibleView(toplevel));
+}
+
+WPEView* wpeToplevelWaylandGetVisibleViewUnderPointer(WPEToplevelWayland* toplevel)
+{
+    auto* priv = toplevel->priv;
+    return priv->hasPointer ? toplevel->priv->visibleView.get() : nullptr;
+}
+
+void wpeToplevelWaylandSetIsFocused(WPEToplevelWayland* toplevel, bool isFocused)
+{
+    auto* priv = toplevel->priv;
+    priv->isFocused = isFocused;
+    if (isFocused && !priv->visibleView)
+        priv->visibleView.reset(wpeToplevelWaylandFindVisibleView(toplevel));
+}
+
+WPEView* wpeToplevelWaylandGetVisibleFocusedView(WPEToplevelWayland* toplevel)
+{
+    auto* priv = toplevel->priv;
+    return priv->isFocused ? toplevel->priv->visibleView.get() : nullptr;
+}
+
+void wpeToplevelWaylandViewVisibilityChanged(WPEToplevelWayland* toplevel, WPEView* view)
+{
+    auto* priv = toplevel->priv;
+    auto* visibleView = wpeToplevelWaylandFindVisibleView(toplevel);
+    if (wpe_view_get_visible(view)) {
+        priv->visibleView.reset(visibleView);
+        if (priv->visibleView.get() != view)
+            return;
+
+        if (priv->hasPointer) {
+            if (auto* seat = wpeDisplayWaylandGetSeat(WPE_DISPLAY_WAYLAND(wpe_toplevel_get_display(WPE_TOPLEVEL(toplevel)))))
+                seat->emitPointerEnter(view);
+        }
+        if (priv->isFocused)
+            wpe_view_focus_in(view);
+    } else {
+        if (priv->visibleView && priv->visibleView.get() == view) {
+            if (priv->hasPointer) {
+                if (auto* seat = wpeDisplayWaylandGetSeat(WPE_DISPLAY_WAYLAND(wpe_toplevel_get_display(WPE_TOPLEVEL(toplevel)))))
+                    seat->emitPointerLeave(view);
+            }
+            if (priv->isFocused)
+                wpe_view_focus_out(view);
+        }
+        priv->visibleView.reset(visibleView);
+    }
+}
+
+/**
+ * wpe_toplevel_wayland_new:
+ * @display: a #WPEDisplayWayland
+ *
+ * Create a new #WPEToplevel on @display.
+ *
+ * Returns: (transfer full): a #WPEToplevel
+ */
+WPEToplevel* wpe_toplevel_wayland_new(WPEDisplayWayland* display)
+{
+    return WPE_TOPLEVEL(g_object_new(WPE_TYPE_TOPLEVEL_WAYLAND, "display", display, nullptr));
+}
+
+/**
+ * wpe_toplevel_wayland_get_wl_surface: (skip)
+ * @toplevel: a #WPEToplevelWayland
+ *
+ * Get the native Wayland surface of @toplevel
+ *
+ * Returns: (transfer none) (nullable): a Wayland `wl_surface`
+ */
+struct wl_surface* wpe_toplevel_wayland_get_wl_surface(WPEToplevelWayland* toplevel)
+{
+    g_return_val_if_fail(WPE_IS_TOPLEVEL_WAYLAND(toplevel), nullptr);
+
+    return toplevel->priv->wlSurface;
+}

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,34 +22,27 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef __WPE_PLATFORM_H__
-#define __WPE_PLATFORM_H__
 
-#define __WPE_PLATFORM_H_INSIDE__
+#ifndef WPEToplevelWayland_h
+#define WPEToplevelWayland_h
 
-#include <wpe/WPEEnumTypes.h>
-#include <wpe/WPEEvent.h>
-#include <wpe/WPEBuffer.h>
-#include <wpe/WPEBufferDMABuf.h>
-#include <wpe/WPEBufferDMABufFormats.h>
-#include <wpe/WPEBufferSHM.h>
-#include <wpe/WPEColor.h>
-#include <wpe/WPEConfig.h>
-#include <wpe/WPEDefines.h>
-#include <wpe/WPEDisplay.h>
-#include <wpe/WPEEGLError.h>
-#include <wpe/WPEInputMethodContext.h>
-#include <wpe/WPEKeymap.h>
-#include <wpe/WPEKeyUnicode.h>
-#include <wpe/WPEKeymapXKB.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEMonitor.h>
-#include <wpe/WPERectangle.h>
-#include <wpe/WPEToplevel.h>
-#include <wpe/WPEVersion.h>
-#include <wpe/WPEView.h>
+#if !defined(__WPE_WAYLAND_H_INSIDE__) && !defined(BUILDING_WEBKIT)
+#error "Only <wpe/wayland/wpe-wayland.h> can be included directly."
+#endif
 
-#undef __WPE_PLATFORM_H_INSIDE__
+#include <glib-object.h>
+#include <wayland-client.h>
+#include <wpe/wpe-platform.h>
+#include <wpe/wayland/WPEDisplayWayland.h>
 
-#endif /* __WPE_PLATFORM_H__ */
+G_BEGIN_DECLS
+
+#define WPE_TYPE_TOPLEVEL_WAYLAND (wpe_toplevel_wayland_get_type())
+WPE_API G_DECLARE_FINAL_TYPE (WPEToplevelWayland, wpe_toplevel_wayland, WPE, TOPLEVEL_WAYLAND, WPEToplevel)
+
+WPE_API WPEToplevel       *wpe_toplevel_wayland_new            (WPEDisplayWayland  *display);
+WPE_API struct wl_surface *wpe_toplevel_wayland_get_wl_surface (WPEToplevelWayland *toplevel);
+
+G_END_DECLS
+
+#endif /* WPEToplevelWayland_h */

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWaylandPrivate.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWaylandPrivate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,34 +22,15 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef __WPE_PLATFORM_H__
-#define __WPE_PLATFORM_H__
 
-#define __WPE_PLATFORM_H_INSIDE__
+#pragma once
 
-#include <wpe/WPEEnumTypes.h>
-#include <wpe/WPEEvent.h>
-#include <wpe/WPEBuffer.h>
-#include <wpe/WPEBufferDMABuf.h>
-#include <wpe/WPEBufferDMABufFormats.h>
-#include <wpe/WPEBufferSHM.h>
-#include <wpe/WPEColor.h>
-#include <wpe/WPEConfig.h>
-#include <wpe/WPEDefines.h>
-#include <wpe/WPEDisplay.h>
-#include <wpe/WPEEGLError.h>
-#include <wpe/WPEInputMethodContext.h>
-#include <wpe/WPEKeymap.h>
-#include <wpe/WPEKeyUnicode.h>
-#include <wpe/WPEKeymapXKB.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEMonitor.h>
-#include <wpe/WPERectangle.h>
-#include <wpe/WPEToplevel.h>
-#include <wpe/WPEVersion.h>
-#include <wpe/WPEView.h>
+#include "WPEToplevelWayland.h"
 
-#undef __WPE_PLATFORM_H_INSIDE__
-
-#endif /* __WPE_PLATFORM_H__ */
+void wpeToplevelWaylandSetOpaqueRectangles(WPEToplevelWayland*, WPERectangle*, unsigned);
+void wpeToplevelWaylandUpdateOpaqueRegion(WPEToplevelWayland*);
+void wpeToplevelWaylandSetHasPointer(WPEToplevelWayland*, bool);
+WPEView* wpeToplevelWaylandGetVisibleViewUnderPointer(WPEToplevelWayland*);
+void wpeToplevelWaylandSetIsFocused(WPEToplevelWayland*, bool);
+WPEView* wpeToplevelWaylandGetVisibleFocusedView(WPEToplevelWayland*);
+void wpeToplevelWaylandViewVisibilityChanged(WPEToplevelWayland*, WPEView*);

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp
@@ -28,20 +28,15 @@
 
 #include "WPEBufferDMABufFormats.h"
 #include "WPEDisplayWaylandPrivate.h"
+#include "WPEToplevelWaylandPrivate.h"
 #include "WPEWaylandSHMPool.h"
 #include "linux-dmabuf-unstable-v1-client-protocol.h"
-#include "xdg-shell-client-protocol.h"
-#include <fcntl.h>
 #include <gio/gio.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/Vector.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/WTFGType.h>
-#include <wtf/text/CString.h>
-#include <wtf/text/WTFString.h>
 
 // These includes need to be in this order because wayland-egl.h defines WL_EGL_PLATFORM
 // and egl.h checks that to decide whether it's Wayland platform.
@@ -49,518 +44,78 @@
 #include <wayland-egl.h>
 #include <epoxy/egl.h>
 
-#if USE(LIBDRM)
-#include <xf86drm.h>
-#endif
-
 #ifndef EGL_WL_create_wayland_buffer_from_image
 typedef struct wl_buffer *(EGLAPIENTRYP PFNEGLCREATEWAYLANDBUFFERFROMIMAGEWL)(EGLDisplay dpy, EGLImageKHR image);
 #endif
-
-struct DMABufFeedback {
-    WTF_MAKE_STRUCT_FAST_ALLOCATED;
-
-    struct FormatTable {
-        struct Data {
-            uint32_t format { 0 };
-            uint32_t padding { 0 };
-            uint64_t modifier { 0 };
-        };
-
-        FormatTable(const FormatTable&) = delete;
-        FormatTable& operator=(const FormatTable&) = delete;
-        FormatTable(FormatTable&& other)
-        {
-            *this = WTFMove(other);
-        }
-
-        FormatTable(unsigned size, Data* data)
-            : size(size)
-            , data(data)
-        {
-        }
-
-        explicit FormatTable() = default;
-        explicit FormatTable(uint32_t size, int fd)
-            : size(size)
-            , data(static_cast<FormatTable::Data*>(mmap(nullptr, size, PROT_READ, MAP_PRIVATE, fd, 0)))
-        {
-            if (data == MAP_FAILED) {
-                data = nullptr;
-                size = 0;
-            }
-        }
-
-        explicit operator bool() const
-        {
-            return size && data;
-        }
-
-        FormatTable& operator=(FormatTable&& other)
-        {
-            if (data != other.data) {
-                if (data)
-                    munmap(data, size);
-                data = std::exchange(other.data, nullptr);
-                size = std::exchange(other.size, 0);
-            }
-            return *this;
-        }
-
-        ~FormatTable()
-        {
-            if (data)
-                munmap(data, size);
-        }
-
-        unsigned size { 0 };
-        Data* data { nullptr };
-    };
-
-    DMABufFeedback()
-    {
-#if USE(LIBDRM)
-        memset(&mainDevice, 0, sizeof(dev_t));
-#endif
-    }
-
-    ~DMABufFeedback() = default;
-
-    DMABufFeedback(const DMABufFeedback&) = delete;
-    DMABufFeedback& operator=(const DMABufFeedback&) = delete;
-
-    DMABufFeedback(DMABufFeedback&& other)
-        : formatTable(WTFMove(other.formatTable))
-        , pendingTranche(WTFMove(other.pendingTranche))
-        , tranches(WTFMove(other.tranches))
-    {
-#if USE(LIBDRM)
-        memcpy(&mainDevice, &other.mainDevice, sizeof(dev_t));
-        memset(&other.mainDevice, 0, sizeof(dev_t));
-#endif
-    }
-
-#if USE(LIBDRM)
-    static CString drmDeviceForUsage(const dev_t* device, bool isScanout)
-    {
-        drmDevicePtr drmDevice;
-        if (drmGetDeviceFromDevId(*device, 0, &drmDevice))
-            return { };
-
-        CString returnValue;
-        if (isScanout) {
-            if (drmDevice->available_nodes & (1 << DRM_NODE_PRIMARY))
-                returnValue = drmDevice->nodes[DRM_NODE_PRIMARY];
-        } else {
-            if (drmDevice->available_nodes & (1 << DRM_NODE_RENDER))
-                returnValue = drmDevice->nodes[DRM_NODE_RENDER];
-            else if (drmDevice->available_nodes & (1 << DRM_NODE_PRIMARY))
-                returnValue = drmDevice->nodes[DRM_NODE_PRIMARY];
-        }
-
-        drmFreeDevice(&drmDevice);
-
-        return returnValue;
-    }
-#endif
-
-    CString drmDevice() const
-    {
-#if USE(LIBDRM)
-        return drmDeviceForUsage(&mainDevice, false);
-#else
-        return { };
-#endif
-    }
-
-    struct Tranche {
-        Tranche()
-        {
-#if USE(LIBDRM)
-            memset(&targetDevice, 0, sizeof(dev_t));
-#endif
-        }
-        ~Tranche() = default;
-        Tranche(const Tranche&) = delete;
-        Tranche& operator=(const Tranche&) = delete;
-        Tranche(Tranche&& other)
-            : flags(other.flags)
-            , formats(WTFMove(other.formats))
-        {
-            other.flags = 0;
-#if USE(LIBDRM)
-            memcpy(&targetDevice, &other.targetDevice, sizeof(dev_t));
-            memset(&other.targetDevice, 0, sizeof(dev_t));
-#endif
-        }
-
-        CString drmDevice() const
-        {
-#if USE(LIBDRM)
-            return drmDeviceForUsage(&targetDevice, flags & ZWP_LINUX_DMABUF_FEEDBACK_V1_TRANCHE_FLAGS_SCANOUT);
-#else
-            return { };
-#endif
-        }
-
-        uint32_t flags { 0 };
-        Vector<uint16_t> formats;
-#if USE(LIBDRM)
-        dev_t targetDevice;
-#endif
-    };
-
-    std::pair<uint32_t, uint64_t> format(uint16_t index)
-    {
-        ASSERT(index < formatTable.size);
-        if (UNLIKELY(index >= formatTable.size))
-            return { 0, 0 };
-
-        return { formatTable.data[index].format, formatTable.data[index].modifier };
-    }
-
-    FormatTable formatTable;
-    Tranche pendingTranche;
-    Vector<Tranche> tranches;
-#if USE(LIBDRM)
-    dev_t mainDevice;
-#endif
-};
 
 /**
  * WPEViewWayland:
  *
  */
 struct _WPEViewWaylandPrivate {
-    struct wl_surface* wlSurface;
-    struct xdg_surface* xdgSurface;
-    struct xdg_toplevel* xdgToplevel;
-    struct zwp_linux_dmabuf_feedback_v1* dmabufFeedback;
-    std::unique_ptr<DMABufFeedback> pendingDMABufFeedback;
-    std::unique_ptr<DMABufFeedback> committedDMABufFeedback;
-    GRefPtr<WPEBufferDMABufFormats> preferredDMABufFormats;
-
-    Vector<GRefPtr<WPEMonitor>, 1> monitors;
-    GRefPtr<WPEMonitor> currentMonitor;
-
     GRefPtr<WPEBuffer> buffer;
     struct wl_callback* frameCallback;
 
-    struct {
-        std::optional<uint32_t> width;
-        std::optional<uint32_t> height;
-        WPEViewState state { WPE_VIEW_STATE_NONE };
-    } pendingState;
-
-    struct {
-        std::optional<uint32_t> width;
-        std::optional<uint32_t> height;
-    } savedSize;
-
-    struct {
-        Vector<WPERectangle, 1> rects;
-        bool dirty;
-    } pendingOpaqueRegion;
+    Vector<WPERectangle, 1> opaqueRegion;
+    unsigned long resizedID;
 };
 WEBKIT_DEFINE_FINAL_TYPE(WPEViewWayland, wpe_view_wayland, WPE_TYPE_VIEW, WPEView)
-
-static void wpeViewWaylandSaveSize(WPEView* view)
-{
-    auto state = wpe_view_get_state(view);
-    if (state & (WPE_VIEW_STATE_FULLSCREEN | WPE_VIEW_STATE_MAXIMIZED))
-        return;
-
-    auto* priv = WPE_VIEW_WAYLAND(view)->priv;
-    priv->savedSize.width = wpe_view_get_width(view);
-    priv->savedSize.height = wpe_view_get_height(view);
-}
-
-const struct xdg_surface_listener xdgSurfaceListener = {
-    // configure
-    [](void* data, struct xdg_surface* surface, uint32_t serial)
-    {
-        auto* view = WPE_VIEW(data);
-        auto* priv = WPE_VIEW_WAYLAND(view)->priv;
-
-        bool isFixedSize = priv->pendingState.state & (WPE_VIEW_STATE_FULLSCREEN | WPE_VIEW_STATE_MAXIMIZED);
-        bool wasFixedSize = wpe_view_get_state(view) & (WPE_VIEW_STATE_FULLSCREEN | WPE_VIEW_STATE_MAXIMIZED);
-        auto width = priv->pendingState.width;
-        auto height = priv->pendingState.height;
-        bool useSavedSize = !width.has_value() && !height.has_value();
-        if (useSavedSize && !isFixedSize && wasFixedSize) {
-            width = priv->savedSize.width;
-            height = priv->savedSize.height;
-        }
-
-        if (width.has_value() && height.has_value()) {
-            if (!useSavedSize)
-                wpeViewWaylandSaveSize(view);
-            wpe_view_resized(view, width.value(), height.value());
-        }
-
-        wpe_view_state_changed(view, priv->pendingState.state);
-        priv->pendingState = { };
-        xdg_surface_ack_configure(surface, serial);
-    },
-};
-
-const struct xdg_toplevel_listener xdgToplevelListener = {
-    // configure
-    [](void* data, struct xdg_toplevel*, int32_t width, int32_t height, struct wl_array* states)
-    {
-        auto* view = WPE_VIEW_WAYLAND(data);
-        if (width && height) {
-            view->priv->pendingState.width = width;
-            view->priv->pendingState.height = height;
-        }
-
-        uint32_t pendingState = 0;
-        const char* end = static_cast<const char*>(states->data) + states->size;
-        for (uint32_t* state = static_cast<uint32_t*>(states->data); reinterpret_cast<const char*>(state) < end; ++state) {
-            switch (*state) {
-            case XDG_TOPLEVEL_STATE_FULLSCREEN:
-                pendingState |= WPE_VIEW_STATE_FULLSCREEN;
-                break;
-            case XDG_TOPLEVEL_STATE_MAXIMIZED:
-                pendingState |= WPE_VIEW_STATE_MAXIMIZED;
-                break;
-            default:
-                break;
-            }
-        }
-
-        view->priv->pendingState.state = static_cast<WPEViewState>(view->priv->pendingState.state | pendingState);
-    },
-    // close
-    [](void* data, struct xdg_toplevel*)
-    {
-        wpe_view_closed(WPE_VIEW(data));
-    },
-#ifdef XDG_TOPLEVEL_CONFIGURE_BOUNDS_SINCE_VERSION
-    // configure_bounds
-    [](void*, struct xdg_toplevel*, int32_t, int32_t)
-    {
-    },
-#endif
-#ifdef XDG_TOPLEVEL_WM_CAPABILITIES_SINCE_VERSION
-    // wm_capabilities
-    [](void*, struct xdg_toplevel*, struct wl_array*)
-    {
-    },
-#endif
-};
-
-static void wpeViewWaylandUpdateScale(WPEViewWayland* view)
-{
-    if (view->priv->monitors.isEmpty())
-        return;
-
-    double scale = 1;
-    for (const auto& monitor : view->priv->monitors)
-        scale = std::max(scale, wpe_monitor_get_scale(monitor.get()));
-
-    if (wl_surface_get_version(view->priv->wlSurface) >= WL_SURFACE_SET_BUFFER_SCALE_SINCE_VERSION)
-        wl_surface_set_buffer_scale(view->priv->wlSurface, scale);
-
-    wpe_view_scale_changed(WPE_VIEW(view), scale);
-}
-
-static const struct wl_surface_listener surfaceListener = {
-    // enter
-    [](void* data, struct wl_surface*, struct wl_output* wlOutput)
-    {
-        auto* view = WPE_VIEW_WAYLAND(data);
-        auto* monitor = wpeDisplayWaylandFindMonitor(WPE_DISPLAY_WAYLAND(wpe_view_get_display(WPE_VIEW(view))), wlOutput);
-        if (!monitor)
-            return;
-
-        // For now we just use the last entered monitor as current, but we could do someting smarter.
-        bool monitorChanged = false;
-        if (view->priv->currentMonitor.get() != monitor) {
-            view->priv->currentMonitor = monitor;
-            monitorChanged = true;
-        }
-        view->priv->monitors.append(monitor);
-        wpeViewWaylandUpdateScale(view);
-        if (monitorChanged) {
-            wpe_view_map(WPE_VIEW(view));
-            g_object_notify(G_OBJECT(view), "monitor");
-        }
-        g_signal_connect_object(monitor, "notify::scale", G_CALLBACK(+[](WPEViewWayland* view) {
-            wpeViewWaylandUpdateScale(view);
-        }), view, G_CONNECT_SWAPPED);
-    },
-    // leave
-    [](void* data, struct wl_surface*, struct wl_output* wlOutput)
-    {
-        auto* view = WPE_VIEW_WAYLAND(data);
-        auto* monitor = wpeDisplayWaylandFindMonitor(WPE_DISPLAY_WAYLAND(wpe_view_get_display(WPE_VIEW(view))), wlOutput);
-        if (!monitor)
-            return;
-
-        view->priv->monitors.removeLast(monitor);
-        if (!view->priv->monitors.isEmpty())
-            view->priv->currentMonitor = view->priv->monitors.last();
-        else
-            view->priv->currentMonitor = nullptr;
-        wpeViewWaylandUpdateScale(view);
-        if (!view->priv->currentMonitor)
-            wpe_view_unmap(WPE_VIEW(view));
-        g_object_notify(G_OBJECT(view), "monitor");
-        g_signal_handlers_disconnect_by_data(monitor, view);
-    },
-#ifdef WL_SURFACE_PREFERRED_BUFFER_SCALE_SINCE_VERSION
-    // preferred_buffer_scale
-    [](void*, struct wl_surface*, int /* factor */)
-    {
-    },
-#endif
-#ifdef WL_SURFACE_PREFERRED_BUFFER_TRANSFORM_SINCE_VERSION
-    // preferred_buffer_transform
-    [](void*, struct wl_surface*, uint32_t) {
-    },
-#endif
-};
-
-static const struct zwp_linux_dmabuf_feedback_v1_listener linuxDMABufFeedbackListener = {
-    // done
-    [](void* data, struct zwp_linux_dmabuf_feedback_v1*)
-    {
-        auto* view = WPE_VIEW_WAYLAND(data);
-        if (!view->priv->pendingDMABufFeedback)
-            return;
-
-        // The compositor might not have sent the formats table. In that case, try to reuse the previous
-        // one. Return early and skip emitting the signal if there is no usable formats table in the end.
-        if (!view->priv->pendingDMABufFeedback->formatTable) {
-            if (view->priv->committedDMABufFeedback && view->priv->committedDMABufFeedback->formatTable)
-                view->priv->pendingDMABufFeedback->formatTable = WTFMove(view->priv->committedDMABufFeedback->formatTable);
-            else {
-                view->priv->pendingDMABufFeedback.reset();
-                return;
-            }
-        }
-
-        view->priv->committedDMABufFeedback = WTFMove(view->priv->pendingDMABufFeedback);
-        view->priv->preferredDMABufFormats = nullptr;
-        g_signal_emit_by_name(view, "preferred-dma-buf-formats-changed");
-    },
-    // format_table
-    [](void* data, struct zwp_linux_dmabuf_feedback_v1*, int32_t fd, uint32_t size)
-    {
-        // The protocol specification is not clear about the ordering of the format_table and main_device
-        // events. Err on the safer side and allow any of them to create the pending feedback instance.
-        auto* priv = WPE_VIEW_WAYLAND(data)->priv;
-        if (!priv->pendingDMABufFeedback)
-            priv->pendingDMABufFeedback = makeUnique<DMABufFeedback>();
-
-        priv->pendingDMABufFeedback->formatTable = DMABufFeedback::FormatTable(size, fd);
-        close(fd);
-    },
-    // main_device
-    [](void* data, struct zwp_linux_dmabuf_feedback_v1*, struct wl_array* device)
-    {
-        auto* priv = WPE_VIEW_WAYLAND(data)->priv;
-        if (!priv->pendingDMABufFeedback)
-            priv->pendingDMABufFeedback = makeUnique<DMABufFeedback>();
-
-#if USE(LIBDRM)
-        memcpy(&priv->pendingDMABufFeedback->mainDevice, device->data, sizeof(dev_t));
-#endif
-    },
-    // tranche_done
-    [](void* data, struct zwp_linux_dmabuf_feedback_v1*)
-    {
-        auto* priv = WPE_VIEW_WAYLAND(data)->priv;
-        if (!priv->pendingDMABufFeedback)
-            return;
-
-        priv->pendingDMABufFeedback->tranches.append(WTFMove(priv->pendingDMABufFeedback->pendingTranche));
-    },
-    // tranche_target_device
-    [](void* data, struct zwp_linux_dmabuf_feedback_v1*, struct wl_array* device)
-    {
-#if USE(LIBDRM)
-        auto* priv = WPE_VIEW_WAYLAND(data)->priv;
-        if (!priv->pendingDMABufFeedback)
-            return;
-
-        memcpy(&priv->pendingDMABufFeedback->pendingTranche.targetDevice, device->data, sizeof(dev_t));
-#endif
-    },
-    // tranche_formats
-    [](void* data, struct zwp_linux_dmabuf_feedback_v1*, struct wl_array* indices)
-    {
-        auto* priv = WPE_VIEW_WAYLAND(data)->priv;
-        if (!priv->pendingDMABufFeedback)
-            return;
-
-        const char* end = static_cast<const char*>(indices->data) + indices->size;
-        for (uint16_t* index = static_cast<uint16_t*>(indices->data); reinterpret_cast<const char*>(index) < end; ++index)
-            priv->pendingDMABufFeedback->pendingTranche.formats.append(*index);
-    },
-    // tranche_flags
-    [](void* data, struct zwp_linux_dmabuf_feedback_v1*, uint32_t flags)
-    {
-        auto* priv = WPE_VIEW_WAYLAND(data)->priv;
-        if (priv->pendingDMABufFeedback)
-            priv->pendingDMABufFeedback->pendingTranche.flags |= flags;
-    }
-};
 
 static void wpeViewWaylandConstructed(GObject* object)
 {
     G_OBJECT_CLASS(wpe_view_wayland_parent_class)->constructed(object);
 
     auto* view = WPE_VIEW(object);
-    auto* display = WPE_DISPLAY_WAYLAND(wpe_view_get_display(view));
-    auto* priv = WPE_VIEW_WAYLAND(object)->priv;
-    auto* wlCompositor = wpe_display_wayland_get_wl_compositor(display);
-    priv->wlSurface = wl_compositor_create_surface(wlCompositor);
-    wl_surface_add_listener(priv->wlSurface, &surfaceListener, object);
-    if (auto* xdgWMBase = wpeDisplayWaylandGetXDGWMBase(display)) {
-        priv->xdgSurface = xdg_wm_base_get_xdg_surface(xdgWMBase, priv->wlSurface);
-        xdg_surface_add_listener(priv->xdgSurface, &xdgSurfaceListener, object);
-        if (auto* xdgToplevel = xdg_surface_get_toplevel(priv->xdgSurface)) {
-            priv->xdgToplevel = xdgToplevel;
-            xdg_toplevel_add_listener(priv->xdgToplevel, &xdgToplevelListener, object);
-            xdg_toplevel_set_title(priv->xdgToplevel, "WPEDMABuf"); // FIXME
-            wl_surface_commit(priv->wlSurface);
-        }
-    }
-
-    auto* dmabuf = wpeDisplayWaylandGetLinuxDMABuf(display);
-    if (dmabuf && zwp_linux_dmabuf_v1_get_version(dmabuf) >= ZWP_LINUX_DMABUF_V1_GET_SURFACE_FEEDBACK_SINCE_VERSION) {
-        priv->dmabufFeedback = zwp_linux_dmabuf_v1_get_surface_feedback(dmabuf, priv->wlSurface);
-        zwp_linux_dmabuf_feedback_v1_add_listener(priv->dmabufFeedback, &linuxDMABufFeedbackListener, object);
-    }
-
-    wl_display_roundtrip(wpe_display_wayland_get_wl_display(display));
-
-    // Set the first monitor as the default one until enter monitor is emitted.
-    if (wpe_display_get_n_monitors(WPE_DISPLAY(display))) {
-        priv->currentMonitor = wpe_display_get_monitor(WPE_DISPLAY(display), 0);
-        wpe_view_map(view);
-        auto scale = wpe_monitor_get_scale(priv->currentMonitor.get());
-        if (wl_surface_get_version(priv->wlSurface) >= WL_SURFACE_SET_BUFFER_SCALE_SINCE_VERSION)
-            wl_surface_set_buffer_scale(priv->wlSurface, scale);
-        wpe_view_scale_changed(view, scale);
-    }
-
+    auto* priv = WPE_VIEW_WAYLAND(view)->priv;
     // The web view default background color is opaque white, so set the whole view region as opaque initially.
-    priv->pendingOpaqueRegion.rects.append({ 0, 0, wpe_view_get_width(view), wpe_view_get_height(view) });
-    priv->pendingOpaqueRegion.dirty = true;
+    priv->opaqueRegion.append({ 0, 0, wpe_view_get_width(view), wpe_view_get_height(view) });
+
+    priv->resizedID = g_signal_connect(view, "resized", G_CALLBACK(+[](WPEView* view, gpointer) {
+        auto* priv = WPE_VIEW_WAYLAND(view)->priv;
+        priv->opaqueRegion.clear();
+        priv->opaqueRegion.append({ 0, 0, wpe_view_get_width(view), wpe_view_get_height(view) });
+        if (auto* toplevel = wpe_view_get_toplevel(view))
+            wpeToplevelWaylandSetOpaqueRectangles(WPE_TOPLEVEL_WAYLAND(toplevel), priv->opaqueRegion.data(), priv->opaqueRegion.size());
+    }), nullptr);
+
+    g_signal_connect(view, "notify::toplevel", G_CALLBACK(+[](WPEView* view, GParamSpec*, gpointer) {
+        auto* toplevel = wpe_view_get_toplevel(view);
+        if (!toplevel) {
+            wpe_view_unmap(view);
+            return;
+        }
+
+        int width;
+        int height;
+        wpe_toplevel_get_size(toplevel, &width, &height);
+        if (width && height)
+            wpe_view_resized(view, width, height);
+
+        auto* priv = WPE_VIEW_WAYLAND(view)->priv;
+        wpeToplevelWaylandSetOpaqueRectangles(WPE_TOPLEVEL_WAYLAND(toplevel), !priv->opaqueRegion.isEmpty() ? priv->opaqueRegion.data() : nullptr, priv->opaqueRegion.size());
+
+        wpe_view_map(view);
+    }), nullptr);
+
+    g_signal_connect(view, "notify::monitor", G_CALLBACK(+[](WPEView* view, GParamSpec*, gpointer) {
+        if (wpe_view_get_monitor(view))
+            wpe_view_map(view);
+        else
+            wpe_view_unmap(view);
+    }), nullptr);
+
+    g_signal_connect(view, "notify::visible", G_CALLBACK(+[](WPEView* view, GParamSpec*, gpointer) {
+        auto* toplevel = wpe_view_get_toplevel(view);
+        if (!toplevel)
+            return;
+
+        wpeToplevelWaylandViewVisibilityChanged(WPE_TOPLEVEL_WAYLAND(toplevel), view);
+    }), nullptr);
 }
 
 static void wpeViewWaylandDispose(GObject* object)
 {
     auto* priv = WPE_VIEW_WAYLAND(object)->priv;
-    priv->currentMonitor = nullptr;
-    priv->monitors.clear();
-    g_clear_pointer(&priv->xdgToplevel, xdg_toplevel_destroy);
-    g_clear_pointer(&priv->dmabufFeedback, zwp_linux_dmabuf_feedback_v1_destroy);
-    g_clear_pointer(&priv->xdgSurface, xdg_surface_destroy);
-    g_clear_pointer(&priv->wlSurface, wl_surface_destroy);
     g_clear_pointer(&priv->frameCallback, wl_callback_destroy);
 
     G_OBJECT_CLASS(wpe_view_wayland_parent_class)->dispose(object);
@@ -738,28 +293,13 @@ static gboolean wpeViewWaylandRenderBuffer(WPEView* view, WPEBuffer* buffer, con
     auto* priv = WPE_VIEW_WAYLAND(view)->priv;
     priv->buffer = buffer;
 
+    wpeToplevelWaylandUpdateOpaqueRegion(WPE_TOPLEVEL_WAYLAND(wpe_view_get_toplevel(view)));
+
     auto* wlSurface = wpe_view_wayland_get_wl_surface(WPE_VIEW_WAYLAND(view));
-    auto* wlCompositor = wpe_display_wayland_get_wl_compositor(WPE_DISPLAY_WAYLAND(wpe_view_get_display(view)));
-
-    if (priv->pendingOpaqueRegion.dirty) {
-        struct wl_region* region = nullptr;
-        if (!priv->pendingOpaqueRegion.rects.isEmpty()) {
-            region = wl_compositor_create_region(wlCompositor);
-            if (region) {
-                for (const auto& rect : priv->pendingOpaqueRegion.rects)
-                    wl_region_add(region, rect.x, rect.y, rect.width, rect.height);
-            }
-        }
-
-        wl_surface_set_opaque_region(wlSurface, region);
-        if (region)
-            wl_region_destroy(region);
-
-        priv->pendingOpaqueRegion.rects.clear();
-        priv->pendingOpaqueRegion.dirty = false;
-    }
-
     wl_surface_attach(wlSurface, wlBuffer, 0, 0);
+
+    auto* display = WPE_DISPLAY_WAYLAND(wpe_view_get_display(view));
+    auto* wlCompositor = wpe_display_wayland_get_wl_compositor(display);
     if (nDamageRects && LIKELY(wl_compositor_get_version(wlCompositor) >= 4)) {
         ASSERT(damageRects);
         for (unsigned i = 0; i < nDamageRects; ++i)
@@ -772,81 +312,6 @@ static gboolean wpeViewWaylandRenderBuffer(WPEView* view, WPEBuffer* buffer, con
     wl_surface_commit(wlSurface);
 
     return TRUE;
-}
-
-static WPEMonitor* wpeViewWaylandGetMonitor(WPEView* view)
-{
-    auto* priv = WPE_VIEW_WAYLAND(view)->priv;
-    return priv->currentMonitor.get();
-}
-
-static gboolean wpeViewWaylandResize(WPEView* view, int width, int height)
-{
-    auto* priv = WPE_VIEW_WAYLAND(view)->priv;
-    if (!priv->xdgToplevel)
-        return FALSE;
-
-    wpe_view_resized(view, width, height);
-    return TRUE;
-}
-
-static gboolean wpeViewWaylandSetFullscreen(WPEView* view, gboolean fullscreen)
-{
-    auto* priv = WPE_VIEW_WAYLAND(view)->priv;
-    if (!priv->xdgToplevel)
-        return FALSE;
-
-    if (fullscreen) {
-        wpeViewWaylandSaveSize(view);
-        xdg_toplevel_set_fullscreen(priv->xdgToplevel, nullptr);
-        return TRUE;
-    }
-
-    xdg_toplevel_unset_fullscreen(priv->xdgToplevel);
-    return TRUE;
-}
-
-static gboolean wpeViewWaylandSetMaximized(WPEView* view, gboolean maximized)
-{
-    auto* priv = WPE_VIEW_WAYLAND(view)->priv;
-    if (!priv->xdgToplevel)
-        return FALSE;
-
-    if (maximized) {
-        wpeViewWaylandSaveSize(view);
-        xdg_toplevel_set_maximized(priv->xdgToplevel);
-        return TRUE;
-    }
-
-    xdg_toplevel_unset_maximized(priv->xdgToplevel);
-    return TRUE;
-}
-
-static WPEBufferDMABufFormats* wpeViewWaylandGetPreferredDMABufFormats(WPEView* view)
-{
-    auto* priv = WPE_VIEW_WAYLAND(view)->priv;
-    if (priv->preferredDMABufFormats)
-        return priv->preferredDMABufFormats.get();
-
-    if (!priv->committedDMABufFeedback)
-        return nullptr;
-
-    auto mainDevice = priv->committedDMABufFeedback->drmDevice();
-    auto* builder = wpe_buffer_dma_buf_formats_builder_new(mainDevice.data());
-    for (const auto& tranche : priv->committedDMABufFeedback->tranches) {
-        WPEBufferDMABufFormatUsage usage = tranche.flags & ZWP_LINUX_DMABUF_FEEDBACK_V1_TRANCHE_FLAGS_SCANOUT ? WPE_BUFFER_DMA_BUF_FORMAT_USAGE_SCANOUT : WPE_BUFFER_DMA_BUF_FORMAT_USAGE_RENDERING;
-        auto targetDevice = tranche.drmDevice();
-        wpe_buffer_dma_buf_formats_builder_append_group(builder, targetDevice.data(), usage);
-
-        for (const auto& format : tranche.formats) {
-            auto [fourcc, modifier] = priv->committedDMABufFeedback->format(format);
-            if (LIKELY(fourcc))
-                wpe_buffer_dma_buf_formats_builder_append_format(builder, fourcc, modifier);
-        }
-    }
-
-    priv->preferredDMABufFormats = adoptGRef(wpe_buffer_dma_buf_formats_builder_end(builder));
-    return priv->preferredDMABufFormats.get();
 }
 
 static void wpeViewWaylandSetCursorFromName(WPEView* view, const char* name)
@@ -881,19 +346,26 @@ static void wpeViewWaylandSetCursorFromBytes(WPEView* view, GBytes* bytes, guint
 static void wpeViewWaylandSetOpaqueRectangles(WPEView* view, WPERectangle* rects, guint rectsCount)
 {
     auto* priv = WPE_VIEW_WAYLAND(view)->priv;
-    priv->pendingOpaqueRegion.rects.clear();
-    if (rects) {
-        priv->pendingOpaqueRegion.rects.reserveInitialCapacity(rectsCount);
-        for (unsigned i = 0; i < rectsCount; ++i)
-            priv->pendingOpaqueRegion.rects.append(rects[i]);
+    if (priv->resizedID) {
+        g_signal_handler_disconnect(view, priv->resizedID);
+        priv->resizedID = 0;
     }
-    priv->pendingOpaqueRegion.dirty = true;
+
+    priv->opaqueRegion.clear();
+    if (rects) {
+        priv->opaqueRegion.reserveInitialCapacity(rectsCount);
+        for (unsigned i = 0; i < rectsCount; ++i)
+            priv->opaqueRegion.append(rects[i]);
+    }
+    if (auto* toplevel = wpe_view_get_toplevel(view))
+        wpeToplevelWaylandSetOpaqueRectangles(WPE_TOPLEVEL_WAYLAND(toplevel), !priv->opaqueRegion.isEmpty() ? priv->opaqueRegion.data() : nullptr, priv->opaqueRegion.size());
 }
 
 static gboolean wpeViewWaylandCanBeMapped(WPEView* view)
 {
-    auto* priv = WPE_VIEW_WAYLAND(view)->priv;
-    return !!priv->currentMonitor.get();
+    if (auto* toplevel = wpe_view_get_toplevel(view))
+        return !!wpe_toplevel_get_monitor(toplevel);
+    return FALSE;
 }
 
 static void wpe_view_wayland_class_init(WPEViewWaylandClass* viewWaylandClass)
@@ -904,11 +376,6 @@ static void wpe_view_wayland_class_init(WPEViewWaylandClass* viewWaylandClass)
 
     WPEViewClass* viewClass = WPE_VIEW_CLASS(viewWaylandClass);
     viewClass->render_buffer = wpeViewWaylandRenderBuffer;
-    viewClass->get_monitor = wpeViewWaylandGetMonitor;
-    viewClass->resize = wpeViewWaylandResize;
-    viewClass->set_fullscreen = wpeViewWaylandSetFullscreen;
-    viewClass->set_maximized = wpeViewWaylandSetMaximized;
-    viewClass->get_preferred_dma_buf_formats = wpeViewWaylandGetPreferredDMABufFormats;
     viewClass->set_cursor_from_name = wpeViewWaylandSetCursorFromName;
     viewClass->set_cursor_from_bytes = wpeViewWaylandSetCursorFromBytes;
     viewClass->set_opaque_rectangles = wpeViewWaylandSetOpaqueRectangles;
@@ -942,5 +409,7 @@ struct wl_surface* wpe_view_wayland_get_wl_surface(WPEViewWayland* view)
 {
     g_return_val_if_fail(WPE_IS_VIEW_WAYLAND(view), nullptr);
 
-    return view->priv->wlSurface;
+    if (auto* toplevel = wpe_view_get_toplevel(WPE_VIEW(view)))
+        return wpe_toplevel_wayland_get_wl_surface(WPE_TOPLEVEL_WAYLAND(toplevel));
+    return nullptr;
 }

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.h
@@ -27,7 +27,7 @@
 
 #include "WPEEvent.h"
 #include "WPEKeymap.h"
-#include "WPEView.h"
+#include "WPEToplevelWayland.h"
 #include <wayland-client.h>
 #include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
@@ -50,6 +50,9 @@ public:
 
     void setCursor(struct wl_surface*, int32_t, int32_t);
 
+    void emitPointerEnter(WPEView*) const;
+    void emitPointerLeave(WPEView*) const;
+
 private:
     static const struct wl_seat_listener s_listener;
     static const struct wl_pointer_listener s_pointerListener;
@@ -67,7 +70,7 @@ private:
     struct {
         struct wl_pointer* object { nullptr };
         WPEInputSource source { WPE_INPUT_SOURCE_MOUSE };
-        GWeakPtr<WPEView> view;
+        GWeakPtr<WPEToplevelWayland> toplevel;
         double x { 0 };
         double y { 0 };
         uint32_t modifiers { 0 };
@@ -88,7 +91,7 @@ private:
     struct {
         struct wl_keyboard* object { nullptr };
         WPEInputSource source { WPE_INPUT_SOURCE_KEYBOARD };
-        GWeakPtr<WPEView> view;
+        GWeakPtr<WPEToplevelWayland> toplevel;
         uint32_t modifiers { 0 };
         uint32_t time { 0 };
 
@@ -111,7 +114,7 @@ private:
     struct {
         struct wl_touch* object { nullptr };
         WPEInputSource source { WPE_INPUT_SOURCE_TOUCHSCREEN };
-        GWeakPtr<WPEView> view;
+        GWeakPtr<WPEToplevelWayland> toplevel;
         HashMap<int32_t, std::pair<double, double>, IntHash<int32_t>, WTF::SignedWithZeroKeyHashTraits<int32_t>> points;
     } m_touch;
 };

--- a/Source/WebKit/WPEPlatform/wpe/wayland/wpe-wayland.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/wpe-wayland.h
@@ -29,6 +29,7 @@
 
 #include <wpe/wayland/WPEDisplayWayland.h>
 #include <wpe/wayland/WPEMonitorWayland.h>
+#include <wpe/wayland/WPEToplevelWayland.h>
 #include <wpe/wayland/WPEViewWayland.h>
 
 #undef __WPE_WAYLAND_H_INSIDE__

--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -157,20 +157,24 @@ static gboolean wpeViewEventCallback(WPEView* view, WPEEvent* event, WebKitWebVi
         }
 
         if (keyval == WPE_KEY_Up) {
-            if (wpe_view_get_state(view) & WPE_VIEW_STATE_MAXIMIZED)
-                wpe_view_unmaximize(view);
-            else
-                wpe_view_maximize(view);
-            return TRUE;
+            if (auto* toplevel = wpe_view_get_toplevel(view)) {
+                if (wpe_toplevel_get_state(toplevel) & WPE_TOPLEVEL_STATE_MAXIMIZED)
+                    wpe_toplevel_unmaximize(toplevel);
+                else
+                    wpe_toplevel_maximize(toplevel);
+                return TRUE;
+            }
         }
     }
 
     if (keyval == WPE_KEY_F11) {
-        if (wpe_view_get_state(view) & WPE_VIEW_STATE_FULLSCREEN)
-            wpe_view_unfullscreen(view);
-        else
-            wpe_view_fullscreen(view);
-        return TRUE;
+        if (auto* toplevel = wpe_view_get_toplevel(view)) {
+            if (wpe_toplevel_get_state(toplevel) & WPE_TOPLEVEL_STATE_FULLSCREEN)
+                wpe_toplevel_unfullscreen(toplevel);
+            else
+                wpe_toplevel_fullscreen(toplevel);
+            return TRUE;
+        }
     }
 
     return FALSE;

--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -172,14 +172,16 @@ _PATH_RULES_SPECIFIER = [
      ["-readability/parameter_name", "-readability/naming/acronym"]),
 
     ([
-        # The WPEViewQtQuick / WPEDisplayQtQuick follow GLib API conventions.
+        # The WPE QtQuick files follow GLib API conventions.
         os.path.join('Source', 'WebKit', 'UIProcess', 'API', 'wpe', 'qt6', 'WPEViewQtQuick.h'),
+        os.path.join('Source', 'WebKit', 'UIProcess', 'API', 'wpe', 'qt6', 'WPEToplevelQtQuick.h'),
         os.path.join('Source', 'WebKit', 'UIProcess', 'API', 'wpe', 'qt6', 'WPEDisplayQtQuick.h')],
      ["-build/header_guard", "-readability/naming/underscores", "-readability/parameter_name", "-whitespace/declaration", "-whitespace/parens"]),
 
     ([
-        # The WPEViewQtQuick / WPEDisplayQtQuick follow GLib API conventions.
+        # The WPE QtQuick files follow GLib API conventions.
         os.path.join('Source', 'WebKit', 'UIProcess', 'API', 'wpe', 'qt6', 'WPEViewQtQuick.cpp'),
+        os.path.join('Source', 'WebKit', 'UIProcess', 'API', 'wpe', 'qt6', 'WPEToplevelQtQuick.cpp'),
         os.path.join('Source', 'WebKit', 'UIProcess', 'API', 'wpe', 'qt6', 'WPEDisplayQtQuick.cpp')],
      ["-build/include_order", "-whitespace/parens"]),
 

--- a/Tools/WebKitTestRunner/wpe/PlatformWebViewClientWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/PlatformWebViewClientWPE.cpp
@@ -46,7 +46,7 @@ PlatformWebViewClientWPE::PlatformWebViewClientWPE(WKPageConfigurationRef config
 {
     m_view = WKViewCreate(m_display.get(), configuration);
     auto* wpeView = WKViewGetView(m_view);
-    wpe_view_resize(wpeView, 800, 600);
+    wpe_toplevel_resize(wpe_view_get_toplevel(wpeView), 800, 600);
     g_signal_connect(wpeView, "buffer-rendered", G_CALLBACK(+[](WPEView*, WPEBuffer* buffer, gpointer userData) {
         auto& view = *static_cast<PlatformWebViewClientWPE*>(userData);
         view.m_buffer = buffer;


### PR DESCRIPTION
#### af3cd7645c2f0124130279549f392f8c89501fcb
<pre>
[WPE] WPE Platform: add WPEToplevel
<a href="https://bugs.webkit.org/show_bug.cgi?id=275805">https://bugs.webkit.org/show_bug.cgi?id=275805</a>

Reviewed by Alejandro G. Castro.

Add a new class to handle platform toplevels. This will allow us to
support multiple views in the same toplevel, but for now only one is
supported.

* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp:
(WKWPE::m_backend):
(WKWPE::viewToplevelIsFullScreen):
(WKWPE::View::enterFullScreen):
(WKWPE::View::exitFullScreen):
* Source/WebKit/UIProcess/API/wpe/qt6/WPEDisplayQtQuick.cpp:
(wpeDisplayQtQuickCreateView):
* Source/WebKit/UIProcess/API/wpe/qt6/WPEToplevelQtQuick.cpp: Added.
(wpeToplevelQtQuickDispose):
(wpeToplevelQtQuickResize):
(wpe_toplevel_qtquick_class_init):
(wpe_toplevel_qtquick_new):
* Source/WebKit/UIProcess/API/wpe/qt6/WPEToplevelQtQuick.h: Copied from Source/WebKit/WPEPlatform/wpe/headless/wpe-headless.h.
* Source/WebKit/UIProcess/API/wpe/qt6/WPEViewQtQuick.cpp:
(wpe_view_qtquick_class_init):
(wpeViewQtQuickResize): Deleted.
* Source/WebKit/WPEPlatform/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp: Added.
(wpeToplevelGetProperty):
(wpe_toplevel_class_init):
(wpeToplevelAddView):
(wpeToplevelRemoveView):
(wpe_toplevel_get_display):
(wpe_toplevel_set_title):
(wpe_toplevel_get_max_views):
(wpe_toplevel_get_n_views):
(wpe_toplevel_foreach_view):
(wpe_toplevel_closed):
(wpe_toplevel_get_size):
(wpe_toplevel_resize):
(wpe_toplevel_resized):
(wpe_toplevel_get_state):
(wpe_toplevel_state_changed):
(wpe_toplevel_get_scale):
(wpe_toplevel_scale_changed):
(wpe_toplevel_get_monitor):
(wpe_toplevel_monitor_changed):
(wpe_toplevel_fullscreen):
(wpe_toplevel_unfullscreen):
(wpe_toplevel_maximize):
(wpe_toplevel_unmaximize):
(wpe_toplevel_get_preferred_dma_buf_formats):
(wpe_toplevel_preferred_dma_buf_formats_changed):
* Source/WebKit/WPEPlatform/wpe/WPEToplevel.h: Added.
* Source/WebKit/WPEPlatform/wpe/WPEToplevelPrivate.h: Copied from Source/WebKit/WPEPlatform/wpe/drm/wpe-drm.h.
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpeViewGetProperty):
(wpeViewDispose):
(wpe_view_class_init):
(wpeViewToplevelStateChanged):
(wpeViewScaleChanged):
(wpeViewMonitorChanged):
(wpeViewPreferredDMABufFormatsChanged):
(wpe_view_get_toplevel):
(wpe_view_set_toplevel):
(wpe_view_get_toplevel_state):
(wpe_view_get_monitor):
(wpe_view_get_preferred_dma_buf_formats):
(wpe_view_resize): Deleted.
(wpe_view_scale_changed): Deleted.
(wpe_view_get_state): Deleted.
(wpe_view_state_changed): Deleted.
(wpe_view_fullscreen): Deleted.
(wpe_view_unfullscreen): Deleted.
(wpe_view_maximize): Deleted.
(wpe_view_unmaximize): Deleted.
* Source/WebKit/WPEPlatform/wpe/WPEView.h:
* Source/WebKit/WPEPlatform/wpe/WPEViewPrivate.h: Copied from Source/WebKit/WPEPlatform/wpe/drm/wpe-drm.h.
* Source/WebKit/WPEPlatform/wpe/drm/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp:
(wpeDisplayDRMCreateView):
* Source/WebKit/WPEPlatform/wpe/drm/WPEToplevelDRM.cpp: Added.
(wpeToplevelDRMConstructed):
(wpeToplevelDRMGetMonitor):
(wpe_toplevel_drm_class_init):
(wpe_toplevel_drm_new):
* Source/WebKit/WPEPlatform/wpe/drm/WPEToplevelDRM.h: Copied from Source/WebKit/WPEPlatform/wpe/drm/wpe-drm.h.
* Source/WebKit/WPEPlatform/wpe/drm/WPEViewDRM.cpp:
(wpeViewDRMConstructed):
(wpe_view_drm_class_init):
(wpeViewDRMGetMonitor): Deleted.
* Source/WebKit/WPEPlatform/wpe/drm/wpe-drm.h:
* Source/WebKit/WPEPlatform/wpe/headless/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/headless/WPEDisplayHeadless.cpp:
(wpeDisplayHeadlessCreateView):
* Source/WebKit/WPEPlatform/wpe/headless/WPEToplevelHeadless.cpp: Added.
(wpeToplevelHeadlessResize):
(wpeToplevelHeadlessSetFullscreen):
(wpe_toplevel_headless_class_init):
(wpe_toplevel_headless_new):
* Source/WebKit/WPEPlatform/wpe/headless/WPEToplevelHeadless.h: Copied from Source/WebKit/WPEPlatform/wpe/headless/wpe-headless.h.
* Source/WebKit/WPEPlatform/wpe/headless/WPEViewHeadless.cpp:
(wpe_view_headless_class_init):
(wpeViewHeadlessResize): Deleted.
(wpeViewHeadlessSetFullscreen): Deleted.
* Source/WebKit/WPEPlatform/wpe/headless/wpe-headless.h:
* Source/WebKit/WPEPlatform/wpe/wayland/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp:
(wpeDisplayWaylandCreateView):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp: Added.
(DMABufFeedback::FormatTable::FormatTable):
(DMABufFeedback::FormatTable::operator bool const):
(DMABufFeedback::FormatTable::operator=):
(DMABufFeedback::FormatTable::~FormatTable):
(DMABufFeedback::DMABufFeedback):
(DMABufFeedback::drmDeviceForUsage):
(DMABufFeedback::drmDevice const):
(DMABufFeedback::Tranche::Tranche):
(DMABufFeedback::Tranche::drmDevice const):
(DMABufFeedback::format):
(wpeToplevelWaylandSaveSize):
(wpeToplevelWaylandResized):
(wpeToplevelWaylandConstructed):
(wpeToplevelWaylandDispose):
(wpeToplevelWaylandGetMonitor):
(wpeToplevelWaylandResize):
(wpeToplevelWaylandSetFullscreen):
(wpeToplevelWaylandSetMaximized):
(wpeToplevelWaylandGetPreferredDMABufFormats):
(wpe_toplevel_wayland_class_init):
(regionsEqual):
(wpeToplevelWaylandSetOpaqueRectangles):
(wpeToplevelWaylandUpdateOpaqueRegion):
(wpeToplevelWaylandFindVisibleView):
(wpeToplevelWaylandSetHasPointer):
(wpeToplevelWaylandGetVisibleViewUnderPointer):
(wpeToplevelWaylandSetIsFocused):
(wpeToplevelWaylandGetVisibleFocusedView):
(wpeToplevelWaylandViewVisibilityChanged):
(wpe_toplevel_wayland_new):
(wpe_toplevel_wayland_get_wl_surface):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.h: Copied from Source/WebKit/WPEPlatform/wpe/wayland/wpe-wayland.h.
* Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWaylandPrivate.h: Copied from Source/WebKit/WPEPlatform/wpe/headless/wpe-headless.h.
* Source/WebKit/WPEPlatform/wpe/wayland/WPEViewWayland.cpp:
(wpeViewWaylandConstructed):
(wpeViewWaylandDispose):
(wpeViewWaylandSetOpaqueRectangles):
(wpeViewWaylandCanBeMapped):
(wpe_view_wayland_class_init):
(wpe_view_wayland_get_wl_surface):
(): Deleted.
(DMABufFeedback::FormatTable::FormatTable): Deleted.
(DMABufFeedback::FormatTable::operator bool const): Deleted.
(DMABufFeedback::FormatTable::operator=): Deleted.
(DMABufFeedback::FormatTable::~FormatTable): Deleted.
(DMABufFeedback::DMABufFeedback): Deleted.
(DMABufFeedback::drmDeviceForUsage): Deleted.
(DMABufFeedback::drmDevice const): Deleted.
(DMABufFeedback::Tranche::Tranche): Deleted.
(DMABufFeedback::Tranche::drmDevice const): Deleted.
(DMABufFeedback::format): Deleted.
(wpeViewWaylandSaveSize): Deleted.
(wpeViewWaylandGetMonitor): Deleted.
(wpeViewWaylandResize): Deleted.
(wpeViewWaylandSetFullscreen): Deleted.
(wpeViewWaylandSetMaximized): Deleted.
(wpeViewWaylandGetPreferredDMABufFormats): Deleted.
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp:
(WPE::WaylandSeat::updateCursor):
(WPE::WaylandSeat::emitPointerEnter const):
(WPE::WaylandSeat::emitPointerLeave const):
(WPE::WaylandSeat::flushScrollEvent):
(WPE::WaylandSeat::handleKeyEvent):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.h:
* Source/WebKit/WPEPlatform/wpe/wayland/wpe-wayland.h:
* Source/WebKit/WPEPlatform/wpe/wpe-platform.h:
* Tools/MiniBrowser/wpe/main.cpp:
* Tools/Scripts/webkitpy/style/checker.py:
* Tools/WebKitTestRunner/wpe/PlatformWebViewClientWPE.cpp:
(WTR::PlatformWebViewClientWPE::PlatformWebViewClientWPE):

Canonical link: <a href="https://commits.webkit.org/280412@main">https://commits.webkit.org/280412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aec8b122e3a53663ec6d094c9645b52316da9530

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56569 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60180 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7010 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7201 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45821 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4902 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58599 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33748 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48820 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26682 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/56095 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30529 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6152 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6013 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6424 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61863 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/479 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/6528 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53080 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/481 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53021 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/414 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8404 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31723 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32810 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33894 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32556 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->