### PR TITLE
execCommand("outdent") on a list containing a table duplicates the content

### DIFF
--- a/LayoutTests/editing/execCommand/indent-list-item-with-children-expected.txt
+++ b/LayoutTests/editing/execCommand/indent-list-item-with-children-expected.txt
@@ -1,0 +1,58 @@
+
+Indent With Children:
+| "\n    "
+| <ol>
+|   "\n        "
+|   <ol>
+|     <li>
+|       id="listItemBlock"
+|       "before"
+|       <div>
+|         "div1"
+|       <div>
+|         "div2"
+|       <div>
+|         "div3"
+|       "after"
+|     <li>
+|       id="listItemInline"
+|       "before"
+|       <span>
+|         "span1"
+|       <span>
+|         "span2"
+|       <span>
+|         "span3"
+|       "after"
+|     <li>
+|       id="listItemTable"
+|       "before"
+|       <table>
+|         border="1"
+|         cellpadding="2"
+|         cellspacing="2"
+|         <tbody>
+|           <tr>
+|             <td>
+|               <br>
+|       "after"
+|   "\n        "
+|   "\n        "
+|   "\n    "
+| "\n"
+
+Indent With Pre:
+| "\n"
+| <ol>
+|   "\n"
+|   <pre>
+|     <ul>
+|       <ul>
+|         <li>
+|           id="listItemPre"
+|           "<#selection-caret>hello"
+|           "\n"
+|           "world"
+|       "\n"
+|   "\n"
+| "\n"

--- a/LayoutTests/editing/execCommand/indent-list-item-with-children.html
+++ b/LayoutTests/editing/execCommand/indent-list-item-with-children.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/dump-as-markup.js"></script>
+</head>
+<body>
+<div contentEditable id="first">
+    <ol>
+        <li id="listItemBlock">before<div>div1</div><div>div2</div><div>div3</div>after</li>
+        <li id="listItemInline">before<span>span1</span><span>span2</span><span>span3</span>after</li>
+        <li id="listItemTable">before<table border="1" cellpadding="2" cellspacing="2"><tr><td><br/></td></tr></table>after</li>
+    </ol>
+</div>
+<div contentEditable id="second">
+<ol>
+<pre><ul><li id="listItemPre">hello
+world</li>
+</ul></pre>
+</ol>
+</div>
+<script>
+Markup.waitUntilDone();
+
+function indentListItem(item) {
+    window.getSelection().collapse(item, 0);
+    document.execCommand("indent");
+}
+
+Array.prototype.slice.call(document.getElementsByTagName('li')).forEach(indentListItem);
+Markup.dump(document.getElementById('first'), "Indent With Children");
+Markup.dump(document.getElementById('second'), "Indent With Pre");
+
+Markup.notifyDone();
+</script>
+</body>
+</html>

--- a/LayoutTests/editing/execCommand/indent-pre-list-expected.txt
+++ b/LayoutTests/editing/execCommand/indent-pre-list-expected.txt
@@ -36,7 +36,7 @@ yields:
 |     <ul>
 |       <li>
 |         "<#selection-anchor>hello"
-|       <li>
+|         "\n"
 |         "world<#selection-focus>"
 |     "\n"
 | "\n"

--- a/LayoutTests/imported/w3c/web-platform-tests/editing/run/indent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/editing/run/indent-expected.txt
@@ -807,7 +807,7 @@ PASS [["indent",""]] "<ol><li>foo</ol>[bar]" queryCommandState("indent") after
 PASS [["indent",""]] "<ol><li>foo</ol>[bar]" queryCommandValue("indent") after
 PASS [["indent",""]] "<ol><li>[foo]<br>bar<li>baz</ol>": execCommand("indent", false, "") return value
 PASS [["indent",""]] "<ol><li>[foo]<br>bar<li>baz</ol>" checks for modifications to non-editable content
-FAIL [["indent",""]] "<ol><li>[foo]<br>bar<li>baz</ol>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ol><ol><li>foo<br>bar</li></ol><li>baz</li></ol>" but got "<ol><ol><li>foo</li></ol><li>bar</li><li>baz</li></ol>"
+PASS [["indent",""]] "<ol><li>[foo]<br>bar<li>baz</ol>" compare innerHTML
 PASS [["indent",""]] "<ol><li>[foo]<br>bar<li>baz</ol>" queryCommandIndeterm("indent") before
 PASS [["indent",""]] "<ol><li>[foo]<br>bar<li>baz</ol>" queryCommandState("indent") before
 PASS [["indent",""]] "<ol><li>[foo]<br>bar<li>baz</ol>" queryCommandValue("indent") before
@@ -816,7 +816,7 @@ PASS [["indent",""]] "<ol><li>[foo]<br>bar<li>baz</ol>" queryCommandState("inden
 PASS [["indent",""]] "<ol><li>[foo]<br>bar<li>baz</ol>" queryCommandValue("indent") after
 PASS [["indent",""]] "<ol><li>foo<br>[bar]<li>baz</ol>": execCommand("indent", false, "") return value
 PASS [["indent",""]] "<ol><li>foo<br>[bar]<li>baz</ol>" checks for modifications to non-editable content
-FAIL [["indent",""]] "<ol><li>foo<br>[bar]<li>baz</ol>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ol><ol><li>foo<br>bar</li></ol><li>baz</li></ol>" but got "<ol><ol><li>bar</li></ol><li>foo<br></li><li>baz</li></ol>"
+FAIL [["indent",""]] "<ol><li>foo<br>[bar]<li>baz</ol>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ol><ol><li>foo<br>bar</li></ol><li>baz</li></ol>" but got "<ol><ol><li>bar</li></ol><li>baz</li></ol>"
 PASS [["indent",""]] "<ol><li>foo<br>[bar]<li>baz</ol>" queryCommandIndeterm("indent") before
 PASS [["indent",""]] "<ol><li>foo<br>[bar]<li>baz</ol>" queryCommandState("indent") before
 PASS [["indent",""]] "<ol><li>foo<br>[bar]<li>baz</ol>" queryCommandValue("indent") before
@@ -906,7 +906,7 @@ PASS [["indent",""]] "<ol><li>foo</li><ol><li>b[a]r</ol><li>baz</ol>" queryComma
 PASS [["indent",""]] "<ol><li>foo</li><ol><li>b[a]r</ol><li>baz</ol>" queryCommandValue("indent") after
 PASS [["indent",""]] "<ol><li>foo{<ol><li>bar</ol>}<li>baz</ol>": execCommand("indent", false, "") return value
 PASS [["indent",""]] "<ol><li>foo{<ol><li>bar</ol>}<li>baz</ol>" checks for modifications to non-editable content
-FAIL [["indent",""]] "<ol><li>foo{<ol><li>bar</ol>}<li>baz</ol>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ol><li>foo</li><ol><ol><li>bar</li></ol></ol><li>baz</li></ol>" but got "<ol><ol><li>foo</li></ol><li><ol><ol><li>bar</li></ol></ol></li><li>baz</li></ol>"
+FAIL [["indent",""]] "<ol><li>foo{<ol><li>bar</ol>}<li>baz</ol>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ol><li>foo</li><ol><ol><li>bar</li></ol></ol><li>baz</li></ol>" but got "<ol><ol><li>foo<ol><li>bar</li></ol></li></ol><li>baz</li></ol>"
 PASS [["indent",""]] "<ol><li>foo{<ol><li>bar</ol>}<li>baz</ol>" queryCommandIndeterm("indent") before
 PASS [["indent",""]] "<ol><li>foo{<ol><li>bar</ol>}<li>baz</ol>" queryCommandState("indent") before
 PASS [["indent",""]] "<ol><li>foo{<ol><li>bar</ol>}<li>baz</ol>" queryCommandValue("indent") before
@@ -924,7 +924,7 @@ PASS [["indent",""]] "<ol><li>foo</li>{<ol><li>bar</ol>}<li>baz</ol>" queryComma
 PASS [["indent",""]] "<ol><li>foo</li>{<ol><li>bar</ol>}<li>baz</ol>" queryCommandValue("indent") after
 PASS [["indent",""]] "<ol><li>[foo]<ol><li>bar</ol><li>baz</ol>": execCommand("indent", false, "") return value
 PASS [["indent",""]] "<ol><li>[foo]<ol><li>bar</ol><li>baz</ol>" checks for modifications to non-editable content
-FAIL [["indent",""]] "<ol><li>[foo]<ol><li>bar</ol><li>baz</ol>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ol><ol><li>foo</li><li>bar</li></ol><li>baz</li></ol>" but got "<ol><ol><li>foo</li></ol><li><ol><li>bar</li></ol></li><li>baz</li></ol>"
+FAIL [["indent",""]] "<ol><li>[foo]<ol><li>bar</ol><li>baz</ol>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ol><ol><li>foo</li><li>bar</li></ol><li>baz</li></ol>" but got "<ol><ol><li>foo<ol><li>bar</li></ol></li></ol><li>baz</li></ol>"
 PASS [["indent",""]] "<ol><li>[foo]<ol><li>bar</ol><li>baz</ol>" queryCommandIndeterm("indent") before
 PASS [["indent",""]] "<ol><li>[foo]<ol><li>bar</ol><li>baz</ol>" queryCommandState("indent") before
 PASS [["indent",""]] "<ol><li>[foo]<ol><li>bar</ol><li>baz</ol>" queryCommandValue("indent") before
@@ -942,7 +942,7 @@ PASS [["indent",""]] "<ol><li>[foo]</li><ol><li>bar</ol><li>baz</ol>" queryComma
 PASS [["indent",""]] "<ol><li>[foo]</li><ol><li>bar</ol><li>baz</ol>" queryCommandValue("indent") after
 PASS [["indent",""]] "<ol><li>foo<li>[bar]<ol><li>baz</ol><li>quz</ol>": execCommand("indent", false, "") return value
 PASS [["indent",""]] "<ol><li>foo<li>[bar]<ol><li>baz</ol><li>quz</ol>" checks for modifications to non-editable content
-FAIL [["indent",""]] "<ol><li>foo<li>[bar]<ol><li>baz</ol><li>quz</ol>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ol><li>foo</li><ol><li>bar</li><li>baz</li></ol><li>quz</li></ol>" but got "<ol><li>foo</li><ol><li>bar</li></ol><li><ol><li>baz</li></ol></li><li>quz</li></ol>"
+FAIL [["indent",""]] "<ol><li>foo<li>[bar]<ol><li>baz</ol><li>quz</ol>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ol><li>foo</li><ol><li>bar</li><li>baz</li></ol><li>quz</li></ol>" but got "<ol><li>foo</li><ol><li>bar<ol><li>baz</li></ol></li></ol><li>quz</li></ol>"
 PASS [["indent",""]] "<ol><li>foo<li>[bar]<ol><li>baz</ol><li>quz</ol>" queryCommandIndeterm("indent") before
 PASS [["indent",""]] "<ol><li>foo<li>[bar]<ol><li>baz</ol><li>quz</ol>" queryCommandState("indent") before
 PASS [["indent",""]] "<ol><li>foo<li>[bar]<ol><li>baz</ol><li>quz</ol>" queryCommandValue("indent") before
@@ -1032,7 +1032,7 @@ PASS [["indent",""]] "<ol><li>foo<li>b[ar<li>baz]</ol>" queryCommandState("inden
 PASS [["indent",""]] "<ol><li>foo<li>b[ar<li>baz]</ol>" queryCommandValue("indent") after
 PASS [["indent",""]] "<ol><li>[foo<ol><li>bar]</ol><li>baz</ol>": execCommand("indent", false, "") return value
 PASS [["indent",""]] "<ol><li>[foo<ol><li>bar]</ol><li>baz</ol>" checks for modifications to non-editable content
-FAIL [["indent",""]] "<ol><li>[foo<ol><li>bar]</ol><li>baz</ol>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ol><ol><li>foo</li><ol><li>bar</li></ol></ol><li>baz</li></ol>" but got "<ol><ol><li>foo</li></ol><li><ol><ol><li>bar</li></ol></ol></li><li>baz</li></ol>"
+FAIL [["indent",""]] "<ol><li>[foo<ol><li>bar]</ol><li>baz</ol>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ol><ol><li>foo</li><ol><li>bar</li></ol></ol><li>baz</li></ol>" but got "<ol><ol><li>foo<ol><li>bar</li></ol></li></ol><li>baz</li></ol>"
 PASS [["indent",""]] "<ol><li>[foo<ol><li>bar]</ol><li>baz</ol>" queryCommandIndeterm("indent") before
 PASS [["indent",""]] "<ol><li>[foo<ol><li>bar]</ol><li>baz</ol>" queryCommandState("indent") before
 PASS [["indent",""]] "<ol><li>[foo<ol><li>bar]</ol><li>baz</ol>" queryCommandValue("indent") before
@@ -1068,7 +1068,7 @@ PASS [["indent",""]] "<ol><li>foo</li><ol><li>b[ar</ol><li>b]az</ol>" queryComma
 PASS [["indent",""]] "<ol><li>foo</li><ol><li>b[ar</ol><li>b]az</ol>" queryCommandValue("indent") after
 PASS [["indent",""]] "<ol><li>[foo<ol><li>bar</ol><li>baz]</ol><p>extra": execCommand("indent", false, "") return value
 PASS [["indent",""]] "<ol><li>[foo<ol><li>bar</ol><li>baz]</ol><p>extra" checks for modifications to non-editable content
-FAIL [["indent",""]] "<ol><li>[foo<ol><li>bar</ol><li>baz]</ol><p>extra" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<blockquote><ol><li>foo</li><ol><li>bar</li></ol><li>baz</li></ol></blockquote><p>extra</p>" but got "<ol><ol><li>foo</li></ol><li><ol><ol><li>bar</li></ol></ol></li><ol><li>baz</li></ol></ol><p>extra</p>"
+FAIL [["indent",""]] "<ol><li>[foo<ol><li>bar</ol><li>baz]</ol><p>extra" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<blockquote><ol><li>foo</li><ol><li>bar</li></ol><li>baz</li></ol></blockquote><p>extra</p>" but got "<ol><ol><li>foo<ol><li>bar</li></ol></li></ol><li>baz</li></ol><p>extra</p>"
 PASS [["indent",""]] "<ol><li>[foo<ol><li>bar</ol><li>baz]</ol><p>extra" queryCommandIndeterm("indent") before
 PASS [["indent",""]] "<ol><li>[foo<ol><li>bar</ol><li>baz]</ol><p>extra" queryCommandState("indent") before
 PASS [["indent",""]] "<ol><li>[foo<ol><li>bar</ol><li>baz]</ol><p>extra" queryCommandValue("indent") before
@@ -1086,7 +1086,7 @@ PASS [["indent",""]] "<ol><li>[foo</li><ol><li>bar</ol><li>baz]</ol><p>extra" qu
 PASS [["indent",""]] "<ol><li>[foo</li><ol><li>bar</ol><li>baz]</ol><p>extra" queryCommandValue("indent") after
 PASS [["indent",""]] "<ol><li>[foo]<ol><li>bar</ol>baz</ol>": execCommand("indent", false, "") return value
 PASS [["indent",""]] "<ol><li>[foo]<ol><li>bar</ol>baz</ol>" checks for modifications to non-editable content
-FAIL [["indent",""]] "<ol><li>[foo]<ol><li>bar</ol>baz</ol>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ol><ol><li>foo</li><li>bar</li></ol><li>baz</li></ol>" but got "<ol><ol><li>foo</li></ol><li><ol><li>bar</li></ol>baz</li></ol>"
+FAIL [["indent",""]] "<ol><li>[foo]<ol><li>bar</ol>baz</ol>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ol><ol><li>foo</li><li>bar</li></ol><li>baz</li></ol>" but got "<ol><ol><li>foo<ol><li>bar</li></ol>baz</li></ol></ol>"
 PASS [["indent",""]] "<ol><li>[foo]<ol><li>bar</ol>baz</ol>" queryCommandIndeterm("indent") before
 PASS [["indent",""]] "<ol><li>[foo]<ol><li>bar</ol>baz</ol>" queryCommandState("indent") before
 PASS [["indent",""]] "<ol><li>[foo]<ol><li>bar</ol>baz</ol>" queryCommandValue("indent") before
@@ -1104,7 +1104,7 @@ PASS [["indent",""]] "<ol><li>foo<ol><li>[bar]</ol>baz</ol>" queryCommandState("
 PASS [["indent",""]] "<ol><li>foo<ol><li>[bar]</ol>baz</ol>" queryCommandValue("indent") after
 PASS [["indent",""]] "<ol><li>foo<ol><li>bar</ol>[baz]</ol>": execCommand("indent", false, "") return value
 PASS [["indent",""]] "<ol><li>foo<ol><li>bar</ol>[baz]</ol>" checks for modifications to non-editable content
-FAIL [["indent",""]] "<ol><li>foo<ol><li>bar</ol>[baz]</ol>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ol><li>foo</li><ol><li>bar</li><li>baz</li></ol></ol>" but got "<ol><ol><li>baz</li></ol><li>foo<ol><li>bar</li></ol></li></ol>"
+FAIL [["indent",""]] "<ol><li>foo<ol><li>bar</ol>[baz]</ol>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ol><li>foo</li><ol><li>bar</li><li>baz</li></ol></ol>" but got "<ol><ol><li>baz</li></ol></ol>"
 PASS [["indent",""]] "<ol><li>foo<ol><li>bar</ol>[baz]</ol>" queryCommandIndeterm("indent") before
 PASS [["indent",""]] "<ol><li>foo<ol><li>bar</ol>[baz]</ol>" queryCommandState("indent") before
 PASS [["indent",""]] "<ol><li>foo<ol><li>bar</ol>[baz]</ol>" queryCommandValue("indent") before
@@ -1113,7 +1113,7 @@ PASS [["indent",""]] "<ol><li>foo<ol><li>bar</ol>[baz]</ol>" queryCommandState("
 PASS [["indent",""]] "<ol><li>foo<ol><li>bar</ol>[baz]</ol>" queryCommandValue("indent") after
 PASS [["indent",""]] "<ol><li>[foo<ol><li>bar]</ol>baz</ol>": execCommand("indent", false, "") return value
 PASS [["indent",""]] "<ol><li>[foo<ol><li>bar]</ol>baz</ol>" checks for modifications to non-editable content
-FAIL [["indent",""]] "<ol><li>[foo<ol><li>bar]</ol>baz</ol>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ol><ol><li>foo</li><ol><li>bar</li></ol></ol><li>baz</li></ol>" but got "<ol><ol><li>foo</li></ol><li><ol><ol><li>bar</li></ol></ol>baz</li></ol>"
+FAIL [["indent",""]] "<ol><li>[foo<ol><li>bar]</ol>baz</ol>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ol><ol><li>foo</li><ol><li>bar</li></ol></ol><li>baz</li></ol>" but got "<ol><ol><li>foo<ol><li>bar</li></ol>baz</li></ol></ol>"
 PASS [["indent",""]] "<ol><li>[foo<ol><li>bar]</ol>baz</ol>" queryCommandIndeterm("indent") before
 PASS [["indent",""]] "<ol><li>[foo<ol><li>bar]</ol>baz</ol>" queryCommandState("indent") before
 PASS [["indent",""]] "<ol><li>[foo<ol><li>bar]</ol>baz</ol>" queryCommandValue("indent") before
@@ -1266,7 +1266,7 @@ PASS [["indent",""]] "<ol><li>foo<li>[bar]</li> <ol> <li>baz</ol></ol>" queryCom
 PASS [["indent",""]] "<ol><li>foo<li>[bar]</li> <ol> <li>baz</ol></ol>" queryCommandValue("indent") after
 PASS [["indent",""]] "<ol><li>foo<li>[bar] <ol><li>baz</ol></ol>": execCommand("indent", false, "") return value
 PASS [["indent",""]] "<ol><li>foo<li>[bar] <ol><li>baz</ol></ol>" checks for modifications to non-editable content
-FAIL [["indent",""]] "<ol><li>foo<li>[bar] <ol><li>baz</ol></ol>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ol><li>foo</li><ol><li>bar </li><li>baz</li></ol></ol>" but got "<ol><li>foo</li><ol><li>bar </li></ol><li><ol><li>baz</li></ol></li></ol>"
+FAIL [["indent",""]] "<ol><li>foo<li>[bar] <ol><li>baz</ol></ol>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ol><li>foo</li><ol><li>bar </li><li>baz</li></ol></ol>" but got "<ol><li>foo</li><ol><li>bar <ol><li>baz</li></ol></li></ol></ol>"
 PASS [["indent",""]] "<ol><li>foo<li>[bar] <ol><li>baz</ol></ol>" queryCommandIndeterm("indent") before
 PASS [["indent",""]] "<ol><li>foo<li>[bar] <ol><li>baz</ol></ol>" queryCommandState("indent") before
 PASS [["indent",""]] "<ol><li>foo<li>[bar] <ol><li>baz</ol></ol>" queryCommandValue("indent") before
@@ -1275,7 +1275,7 @@ PASS [["indent",""]] "<ol><li>foo<li>[bar] <ol><li>baz</ol></ol>" queryCommandSt
 PASS [["indent",""]] "<ol><li>foo<li>[bar] <ol><li>baz</ol></ol>" queryCommandValue("indent") after
 PASS [["indent",""]] "<ol><li>foo<li>[bar]<ol> <li>baz</ol></ol>": execCommand("indent", false, "") return value
 PASS [["indent",""]] "<ol><li>foo<li>[bar]<ol> <li>baz</ol></ol>" checks for modifications to non-editable content
-FAIL [["indent",""]] "<ol><li>foo<li>[bar]<ol> <li>baz</ol></ol>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ol><li>foo</li><ol><li>bar</li> <li>baz</li></ol></ol>" but got "<ol><li>foo</li><ol><li>bar</li></ol><li><ol> <li>baz</li></ol></li></ol>"
+FAIL [["indent",""]] "<ol><li>foo<li>[bar]<ol> <li>baz</ol></ol>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ol><li>foo</li><ol><li>bar</li> <li>baz</li></ol></ol>" but got "<ol><li>foo</li><ol><li>bar<ol> <li>baz</li></ol></li></ol></ol>"
 PASS [["indent",""]] "<ol><li>foo<li>[bar]<ol> <li>baz</ol></ol>" queryCommandIndeterm("indent") before
 PASS [["indent",""]] "<ol><li>foo<li>[bar]<ol> <li>baz</ol></ol>" queryCommandState("indent") before
 PASS [["indent",""]] "<ol><li>foo<li>[bar]<ol> <li>baz</ol></ol>" queryCommandValue("indent") before
@@ -1284,7 +1284,7 @@ PASS [["indent",""]] "<ol><li>foo<li>[bar]<ol> <li>baz</ol></ol>" queryCommandSt
 PASS [["indent",""]] "<ol><li>foo<li>[bar]<ol> <li>baz</ol></ol>" queryCommandValue("indent") after
 PASS [["indent",""]] "<ol><li>foo<li>[bar] <ol> <li>baz</ol></ol>": execCommand("indent", false, "") return value
 PASS [["indent",""]] "<ol><li>foo<li>[bar] <ol> <li>baz</ol></ol>" checks for modifications to non-editable content
-FAIL [["indent",""]] "<ol><li>foo<li>[bar] <ol> <li>baz</ol></ol>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ol><li>foo</li><ol><li>bar </li> <li>baz</li></ol></ol>" but got "<ol><li>foo</li><ol><li>bar </li></ol><li><ol> <li>baz</li></ol></li></ol>"
+FAIL [["indent",""]] "<ol><li>foo<li>[bar] <ol> <li>baz</ol></ol>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ol><li>foo</li><ol><li>bar </li> <li>baz</li></ol></ol>" but got "<ol><li>foo</li><ol><li>bar <ol> <li>baz</li></ol></li></ol></ol>"
 PASS [["indent",""]] "<ol><li>foo<li>[bar] <ol> <li>baz</ol></ol>" queryCommandIndeterm("indent") before
 PASS [["indent",""]] "<ol><li>foo<li>[bar] <ol> <li>baz</ol></ol>" queryCommandState("indent") before
 PASS [["indent",""]] "<ol><li>foo<li>[bar] <ol> <li>baz</ol></ol>" queryCommandValue("indent") before
@@ -1293,7 +1293,7 @@ PASS [["indent",""]] "<ol><li>foo<li>[bar] <ol> <li>baz</ol></ol>" queryCommandS
 PASS [["indent",""]] "<ol><li>foo<li>[bar] <ol> <li>baz</ol></ol>" queryCommandValue("indent") after
 PASS [["indent",""]] "<ul><li>a<br>{<br>}</li><li>b</li></ul>": execCommand("indent", false, "") return value
 PASS [["indent",""]] "<ul><li>a<br>{<br>}</li><li>b</li></ul>" checks for modifications to non-editable content
-FAIL [["indent",""]] "<ul><li>a<br>{<br>}</li><li>b</li></ul>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ul><ul><li>a<br><br></li></ul><li>b</li></ul>" but got "<ul><ul><li><br></li></ul><li>a<br></li><li>b</li></ul>"
+FAIL [["indent",""]] "<ul><li>a<br>{<br>}</li><li>b</li></ul>" compare innerHTML assert_equals: Unexpected innerHTML (after normalizing inline style) expected "<ul><ul><li>a<br><br></li></ul><li>b</li></ul>" but got "<ul><ul><li><br></li></ul><li>b</li></ul>"
 PASS [["indent",""]] "<ul><li>a<br>{<br>}</li><li>b</li></ul>" queryCommandIndeterm("indent") before
 PASS [["indent",""]] "<ul><li>a<br>{<br>}</li><li>b</li></ul>" queryCommandState("indent") before
 PASS [["indent",""]] "<ul><li>a<br>{<br>}</li><li>b</li></ul>" queryCommandValue("indent") before

--- a/Source/WebCore/editing/IndentOutdentCommand.cpp
+++ b/Source/WebCore/editing/IndentOutdentCommand.cpp
@@ -82,7 +82,15 @@ bool IndentOutdentCommand::tryIndentingAsListItem(const Position& start, const P
         newList = HTMLOListElement::create(protectedDocument());
     insertNodeBefore(*newList, *selectedListItem);
 
-    moveParagraphWithClones(start, end, newList.get(), selectedListItem.get());
+    // We should clone all the children of the list item for indenting purposes. However, in case the current
+    // selection does not encompass all its children, we need to explicitally handle the same. The original
+    // list item too would require proper deletion in that case.
+    if (end.anchorNode() == selectedListItem.get() || end.anchorNode()->isDescendantOf(selectedListItem->lastChild()))
+        moveParagraphWithClones(start, end, newList.get(), selectedListItem.get());
+    else {
+        moveParagraphWithClones(start, positionAfterNode(selectedListItem->lastChild()), newList.get(), selectedListItem.get());
+        removeNode(*selectedListItem);
+    }
 
     if (canMergeLists(previousList.get(), newList.get()))
         mergeIdenticalElements(*previousList, *newList);

--- a/Source/WebCore/editing/IndentOutdentCommand.cpp
+++ b/Source/WebCore/editing/IndentOutdentCommand.cpp
@@ -83,7 +83,15 @@ bool IndentOutdentCommand::tryIndentingAsListItem(const Position& start, const P
         newList = HTMLOListElement::create(document());
     insertNodeBefore(*newList, *selectedListItem);
 
-    moveParagraphWithClones(start, end, newList.get(), selectedListItem.get());
+    // We should clone all the children of the list item for indenting purposes. However, in case the current
+    // selection does not encompass all its children, we need to explicitally handle the same. The original
+    // list item too would require proper deletion in that case.
+    if (end.anchorNode() == selectedListItem.get() || end.anchorNode()->isDescendantOf(selectedListItem->lastChild()))
+        moveParagraphWithClones(start, end, newList.get(), selectedListItem.get());
+    else {
+        moveParagraphWithClones(start, positionAfterNode(selectedListItem->lastChild()), newList.get(), selectedListItem.get());
+        removeNode(*selectedListItem);
+    }
 
     if (canMergeLists(previousList.get(), newList.get()))
         mergeIdenticalElements(*previousList, *newList);


### PR DESCRIPTION
#### 376c0503ca4634a5c9cf39447bb1b8da599a800a
<pre>
execCommand(&quot;outdent&quot;) on a list containing a table duplicates the content

<a href="https://bugs.webkit.org/show_bug.cgi?id=24249">https://bugs.webkit.org/show_bug.cgi?id=24249</a>
<a href="https://rdar.apple.com/problem/129093516">rdar://problem/129093516</a>

Reviewed by NOBODY (OOPS!).

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/0cd4b3864db4fc9c0abfeeee0775c5fcbbca0184">https://chromium.googlesource.com/chromium/blink/+/0cd4b3864db4fc9c0abfeeee0775c5fcbbca0184</a>

This patch is for cases of indent/outdent for &apos;li&apos; elements containing children
spanning across multiple lines (paragraphs).
For such cases the selection only encompasses children contained within the
first paragraph (within the li), thereby causing incorrect behavior when indenting.
Thus we need to ensure while inserting a new li element and cloning the original,
that all the children are considered.

With this change, an existing test: indent-pre-list.html fails because of the
previous incorrect behavior. Two &apos;li`s&apos; were created for the indented &apos;li&apos;
with the text contained within the first paragraph forming the first and the
remaining content moving to the second &apos;li&apos; element.

This has now been fixed resulting in only a single indented &apos;li&apos;.

* Source/WebCore/editing/IndentOutdentCommand.cpp:
(WebCore::IndentOutdentCommand::tryIndentingAsListItem):
* LayoutTests/editing/execCommand/indent-pre-list-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/editing/run/indent-expected.txt:
* LayoutTests/editing/execCommand/indent-list-item-with-children.html: Add Test Case
* LayoutTests/editing/execCommand/indent-list-item-with-children-expected.txt: Add Test Case Expectation
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/376c0503ca4634a5c9cf39447bb1b8da599a800a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/178553 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/52491 "Hash 376c0503 for PR 30111 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46286 "Hash 376c0503 for PR 30111 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188169 "Hash 376c0503 for PR 30111 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/141802 "Hash 376c0503 for PR 30111 does not build (failure)") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/36e92bfa-c64c-4628-a0e0-0050330866cb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180416 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/53785 "Hash 376c0503 for PR 30111 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52201 "Hash 376c0503 for PR 30111 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/188169 "Hash 376c0503 for PR 30111 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/141802 "Hash 376c0503 for PR 30111 does not build (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/34545a6b-744a-47dc-aff2-6aa15cc79223) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/181510 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/53785 "Hash 376c0503 for PR 30111 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/46286 "Hash 376c0503 for PR 30111 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/188169 "Hash 376c0503 for PR 30111 does not build (failure)") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bf94a0f2-183e-440f-a6dc-175a12ccb1af) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/53785 "Hash 376c0503 for PR 30111 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/52201 "Hash 376c0503 for PR 30111 does not build (failure)") | [❌ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/5/builds/188169 "Hash 376c0503 for PR 30111 does not build (failure)") | | 
| [❌ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/168/builds/46286 "Hash 376c0503 for PR 30111 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/53785 "Hash 376c0503 for PR 30111 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/46286 "Hash 376c0503 for PR 30111 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/36624 "Hash 376c0503 for PR 30111 does not build (failure)") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45091 "Failed to build and analyze WebKit") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/52201 "Hash 376c0503 for PR 30111 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/190596 "Hash 376c0503 for PR 30111 does not build (failure)") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52160 "Hash 376c0503 for PR 30111 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/46286 "Hash 376c0503 for PR 30111 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/190596 "Hash 376c0503 for PR 30111 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/52841 "Hash 376c0503 for PR 30111 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/46286 "Hash 376c0503 for PR 30111 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/190596 "Hash 376c0503 for PR 30111 does not build (failure)") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/52841 "Hash 376c0503 for PR 30111 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125108 "Failed to build and analyze WebKit") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/119744 "Hash 376c0503 for PR 30111 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51359 "Hash 376c0503 for PR 30111 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/46286 "Hash 376c0503 for PR 30111 does not build (failure)") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/50744 "Hash 376c0503 for PR 30111 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/50984 "Hash 376c0503 for PR 30111 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/50806 "Hash 376c0503 for PR 30111 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->