### PR TITLE
[GLib] Add GUniqueOutPtr<T>::reset(T*)

### DIFF
--- a/Source/WTF/wtf/glib/GUniquePtr.h
+++ b/Source/WTF/wtf/glib/GUniquePtr.h
@@ -124,15 +124,14 @@ public:
     typedef T* GUniqueOutPtr::*UnspecifiedBoolType;
     operator UnspecifiedBoolType() const { return m_ptr ? &GUniqueOutPtr::m_ptr : 0; }
 
-private:
-    void reset()
+    void reset(T* newPtr = nullptr)
     {
-        if (m_ptr) {
+        if (m_ptr)
             GUniquePtr<T> deletePtr(m_ptr);
-            m_ptr = nullptr;
-        }
+        m_ptr = newPtr;
     }
 
+private:
     T* m_ptr;
 };
 

--- a/Tools/TestWebKitAPI/Tests/WTF/glib/GUniquePtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/glib/GUniquePtr.cpp
@@ -190,6 +190,18 @@ TEST(WTF_GUniquePtr, OutPtr)
     }
     ASSERT_STREQ(actual.str().c_str(), takeLogStr().c_str());
     actual.str("");
+
+    {
+        GUniqueOutPtr<char> a;
+        returnOutChar(&a.outPtr());
+        actual << "g_free(" << a.get() << ");";
+        a.reset(g_strdup("b"));
+        ASSERT_STREQ(actual.str().c_str(), takeLogStr().c_str());
+        actual.str("");
+        actual << "g_free(" << a.get() << ");";
+    }
+    ASSERT_STREQ(actual.str().c_str(), takeLogStr().c_str());
+    actual.str("");
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 703b824a230887c8f2c5c84a30ae95eb3ea2ba62
<pre>
[GLib] Add GUniqueOutPtr&lt;T&gt;::reset(T*)
<a href="https://bugs.webkit.org/show_bug.cgi?id=275812">https://bugs.webkit.org/show_bug.cgi?id=275812</a>

Reviewed by NOBODY (OOPS!).

Make GUniqueOutPtr&lt;T&gt;::reset() public and add support
to take in a new pointer, freeing and replacing the previous
pointer. This enables GUniqueOutPtr to be used similar to
std::unique_ptr:

GUniqueOutPtr&lt;char&gt; a;
returnOutChar(&amp;a.outPtr());
a.reset(g_strdup(&quot;b&quot;));
// ^ would have to a.outPtr() = g_strdup(&quot;b&quot;) before this patch.

A case is added to GUniqueOutPtr&apos;s unit test.

* Source/WTF/wtf/glib/GUniquePtr.h:
(WTF::GUniqueOutPtr::reset):
* Tools/TestWebKitAPI/Tests/WTF/glib/GUniquePtr.cpp:
(TestWebKitAPI::TEST(WTF_GUniquePtr, OutPtr)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/703b824a230887c8f2c5c84a30ae95eb3ea2ba62

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59835 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6665 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58355 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6859 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45519 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4634 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58258 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33442 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48511 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26403 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30222 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5842 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5669 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/49307 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52237 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61518 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/55466 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/137 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6238 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52805 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/137 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48578 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52686 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/121 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/77226 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31382 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12796 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32468 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33551 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32215 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->