### PR TITLE
Add a WKWebView SPI to tell clients when a Now Playing session is active

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -662,6 +662,14 @@ void AudioContext::defaultDestinationWillBecomeConnected()
     m_canOverrideBackgroundPlaybackRestriction = true;
 }
 
+void AudioContext::isActiveNowPlayingSessionChanged()
+{
+    if (RefPtr document = this->document()) {
+        if (RefPtr page = document->protectedPage())
+            page->hasActiveNowPlayingSessionChanged();
+    }
+}
+
 #if !RELEASE_LOG_DISABLED
 const Logger& AudioContext::logger() const
 {

--- a/Source/WebCore/Modules/webaudio/AudioContext.h
+++ b/Source/WebCore/Modules/webaudio/AudioContext.h
@@ -138,6 +138,7 @@ private:
     bool isNowPlayingEligible() const final;
     std::optional<NowPlayingInfo> nowPlayingInfo() const final;
     WeakPtr<PlatformMediaSession> selectBestMediaSession(const Vector<WeakPtr<PlatformMediaSession>>&, PlatformMediaSession::PlaybackControlsPurpose) final;
+    void isActiveNowPlayingSessionChanged() final;
 
     // MediaCanStartListener.
     void mediaCanStart(Document&) final;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -9601,6 +9601,12 @@ String HTMLMediaElement::localizedSourceType() const
     return { };
 }
 
+void HTMLMediaElement::isActiveNowPlayingSessionChanged()
+{
+    if (RefPtr page = protectedDocument()->protectedPage())
+        page->hasActiveNowPlayingSessionChanged();
+}
+
 #if HAVE(SPATIAL_TRACKING_LABEL)
 void HTMLMediaElement::updateSpatialTrackingLabel()
 {

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -233,6 +233,8 @@ public:
 
     MediaSessionGroupIdentifier mediaSessionGroupIdentifier() const final;
 
+    void isActiveNowPlayingSessionChanged() final;
+
 // DOM API
 // error state
     WEBCORE_EXPORT MediaError* error() const;

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -677,6 +677,8 @@ public:
     virtual void addDestinationTextAnimation(const WritingTools::SessionID&, const CharacterRange&) { }
 #endif
 
+    virtual void hasActiveNowPlayingSessionChanged(bool) { }
+
     WEBCORE_EXPORT virtual ~ChromeClient();
 
 protected:

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -416,6 +416,7 @@ Page::Page(PageConfiguration&& pageConfiguration)
 #if ENABLE(WRITING_TOOLS)
     , m_writingToolsController(makeUniqueRef<WritingToolsController>(*this))
 #endif
+    , m_activeNowPlayingSessionUpdateTimer(*this, &Page::activeNowPlayingSessionUpdateTimerFired)
 {
     updateTimerThrottlingState();
 
@@ -4899,5 +4900,21 @@ void Page::writingToolsSessionDidReceiveAction(const WritingTools::Session& sess
     m_writingToolsController->writingToolsSessionDidReceiveAction(session, action);
 }
 #endif
+
+void Page::hasActiveNowPlayingSessionChanged()
+{
+    if (!m_activeNowPlayingSessionUpdateTimer.isActive())
+        m_activeNowPlayingSessionUpdateTimer.startOneShot(0_s);
+}
+
+void Page::activeNowPlayingSessionUpdateTimerFired()
+{
+    bool hasActiveNowPlayingSession = PlatformMediaSessionManager::sharedManager().hasActiveNowPlayingSessionInGroup(mediaSessionGroupIdentifier());
+    if (hasActiveNowPlayingSession == m_hasActiveNowPlayingSession)
+        return;
+
+    m_hasActiveNowPlayingSession = hasActiveNowPlayingSession;
+    chrome().client().hasActiveNowPlayingSessionChanged(hasActiveNowPlayingSession);
+}
 
 } // namespace WebCore

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1167,6 +1167,10 @@ public:
     WEBCORE_EXPORT std::optional<SimpleRange> contextRangeForSessionWithID(const WritingTools::SessionID&) const;
 #endif
 
+    bool hasActiveNowPlayingSession() const { return m_hasActiveNowPlayingSession; }
+    void hasActiveNowPlayingSessionChanged();
+    void activeNowPlayingSessionUpdateTimerFired();
+
 private:
     explicit Page(PageConfiguration&&);
 
@@ -1573,6 +1577,9 @@ private:
 #if ENABLE(WRITING_TOOLS)
     UniqueRef<WritingToolsController> m_writingToolsController;
 #endif
+
+    bool m_hasActiveNowPlayingSession { false };
+    Timer m_activeNowPlayingSessionUpdateTimer;
 }; // class Page
 
 inline Page* Frame::page() const

--- a/Source/WebCore/platform/audio/PlatformMediaSession.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.cpp
@@ -27,6 +27,7 @@
 #include "PlatformMediaSession.h"
 
 #if ENABLE(VIDEO) || ENABLE(WEB_AUDIO)
+
 #include "HTMLMediaElement.h"
 #include "Logging.h"
 #include "MediaPlayer.h"
@@ -479,6 +480,15 @@ WeakPtr<PlatformMediaSession> PlatformMediaSession::selectBestMediaSession(const
     return client().selectBestMediaSession(sessions, purpose);
 }
 
+void PlatformMediaSession::setActiveNowPlayingSession(bool isActiveNowPlayingSession)
+{
+    if (isActiveNowPlayingSession == m_isActiveNowPlayingSession)
+        return;
+
+    m_isActiveNowPlayingSession = isActiveNowPlayingSession;
+    client().isActiveNowPlayingSessionChanged();
+}
+
 #if !RELEASE_LOG_DISABLED
 const Logger& PlatformMediaSession::logger() const
 {
@@ -511,6 +521,6 @@ std::optional<NowPlayingInfo> PlatformMediaSessionClient::nowPlayingInfo() const
     return { };
 }
 
-}
+} // namespace WebCore
 
-#endif
+#endif // ENABLE(VIDEO) || ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -892,6 +892,17 @@ void PlatformMediaSessionManager::nowPlayingMetadataChanged(const NowPlayingMeta
     });
 }
 
+bool PlatformMediaSessionManager::hasActiveNowPlayingSessionInGroup(MediaSessionGroupIdentifier mediaSessionGroupIdentifier)
+{
+    bool hasActiveNowPlayingSession = false;
+
+    forEachSessionInGroup(mediaSessionGroupIdentifier, [&](auto& session) {
+        hasActiveNowPlayingSession |= session.isActiveNowPlayingSession();
+    });
+
+    return hasActiveNowPlayingSession;
+}
+
 #if !RELEASE_LOG_DISABLED
 WTFLogChannel& PlatformMediaSessionManager::logChannel() const
 {

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
@@ -196,6 +196,8 @@ public:
     WEBCORE_EXPORT void addNowPlayingMetadataObserver(const NowPlayingMetadataObserver&);
     WEBCORE_EXPORT void removeNowPlayingMetadataObserver(const NowPlayingMetadataObserver&);
 
+    bool hasActiveNowPlayingSessionInGroup(MediaSessionGroupIdentifier);
+
 protected:
     friend class PlatformMediaSession;
     static std::unique_ptr<PlatformMediaSessionManager> create();

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
@@ -84,6 +84,7 @@ public:
 protected:
     void scheduleSessionStatusUpdate() final;
     void updateNowPlayingInfo();
+    void updateActiveNowPlayingSession(CheckedPtr<PlatformMediaSession>);
 
     void removeSession(PlatformMediaSession&) final;
     void addSession(PlatformMediaSession&) final;
@@ -145,6 +146,6 @@ private:
     bool m_previousHadAudibleAudioOrVideoMediaType { false };
 };
 
-}
+} // namespace WebCore
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -475,6 +475,13 @@ WeakPtr<PlatformMediaSession> MediaSessionManagerCocoa::nowPlayingEligibleSessio
     }, PlatformMediaSession::PlaybackControlsPurpose::NowPlaying);
 }
 
+void MediaSessionManagerCocoa::updateActiveNowPlayingSession(CheckedPtr<PlatformMediaSession> activeNowPlayingSession)
+{
+    forEachSession([&](auto& session) {
+        session.setActiveNowPlayingSession(&session == activeNowPlayingSession.get());
+    });
+}
+
 void MediaSessionManagerCocoa::updateNowPlayingInfo()
 {
     if (!isMediaRemoteFrameworkAvailable())
@@ -483,11 +490,11 @@ void MediaSessionManagerCocoa::updateNowPlayingInfo()
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
     std::optional<NowPlayingInfo> nowPlayingInfo;
-    if (auto session = nowPlayingEligibleSession())
+    CheckedPtr session = nowPlayingEligibleSession().get();
+    if (session)
         nowPlayingInfo = session->nowPlayingInfo();
 
     if (!nowPlayingInfo) {
-
         if (m_registeredAsNowPlayingApplication) {
             ALWAYS_LOG(LOGIDENTIFIER, "clearing now playing info");
             m_nowPlayingManager->clearNowPlayingInfo();
@@ -500,6 +507,7 @@ void MediaSessionManagerCocoa::updateNowPlayingInfo()
         m_lastUpdatedNowPlayingElapsedTime = NAN;
         m_lastUpdatedNowPlayingInfoUniqueIdentifier = { };
 
+        updateActiveNowPlayingSession(nullptr);
         return;
     }
 
@@ -519,6 +527,8 @@ void MediaSessionManagerCocoa::updateNowPlayingInfo()
         m_registeredAsNowPlayingApplication = true;
         providePresentingApplicationPIDIfNecessary();
     }
+
+    updateActiveNowPlayingSession(session);
 
     if (!m_nowPlayingInfo || nowPlayingInfo->metadata != m_nowPlayingInfo->metadata)
         nowPlayingMetadataChanged(nowPlayingInfo->metadata);

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
@@ -215,7 +215,7 @@ void MediaSessionManageriOS::activeVideoRouteDidChange(SupportsAirPlayVideo supp
     m_playbackTargetSupportsAirPlayVideo = supportsAirPlayVideo == SupportsAirPlayVideo::Yes;
 #endif
 
-    auto nowPlayingSession = nowPlayingEligibleSession();
+    CheckedPtr nowPlayingSession = nowPlayingEligibleSession().get();
     if (!nowPlayingSession)
         return;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -440,6 +440,8 @@ struct PerWebProcessState {
 - (WKPageRef)_pageForTesting;
 - (NakedPtr<WebKit::WebPageProxy>)_page;
 
+@property (nonatomic, setter=_setHasActiveNowPlayingSession:) BOOL _hasActiveNowPlayingSession;
+
 @end
 
 RetainPtr<NSError> nsErrorFromExceptionDetails(const WebCore::ExceptionDetails&);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -561,6 +561,8 @@ typedef NS_OPTIONS(NSUInteger, WKDisplayCaptureSurfaces) {
 
 @property (nonatomic, readonly) NSURL *_requiredWebExtensionBaseURL WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
+@property (nonatomic, readonly) BOOL _hasActiveNowPlayingSession WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 @end
 
 #if TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -131,6 +131,8 @@ public:
     void setGamepadsRecentlyAccessed(GamepadsRecentlyAccessed) final;
 #endif
 
+    void hasActiveNowPlayingSessionChanged(bool) final;
+
 protected:
     RetainPtr<WKWebView> webView() const { return m_webView.get(); }
 
@@ -138,4 +140,4 @@ protected:
     std::unique_ptr<WebCore::AlternativeTextUIController> m_alternativeTextUIController;
 };
 
-}
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -317,4 +317,14 @@ void PageClientImplCocoa::setGamepadsRecentlyAccessed(GamepadsRecentlyAccessed g
 }
 #endif
 
+void PageClientImplCocoa::hasActiveNowPlayingSessionChanged(bool hasActiveNowPlayingSession)
+{
+    if ([m_webView _hasActiveNowPlayingSession] == hasActiveNowPlayingSession)
+        return;
+
+    [m_webView willChangeValueForKey:@"_hasActiveNowPlayingSession"];
+    [m_webView _setHasActiveNowPlayingSession:hasActiveNowPlayingSession];
+    [m_webView didChangeValueForKey:@"_hasActiveNowPlayingSession"];
 }
+
+} // namespace WebKit

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -785,6 +785,8 @@ public:
     };
     virtual void setGamepadsRecentlyAccessed(GamepadsRecentlyAccessed) { }
 #endif
+
+    virtual void hasActiveNowPlayingSessionChanged(bool) { }
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6505,6 +6505,8 @@ void WebPageProxy::didCommitLoadForFrame(IPC::Connection& connection, FrameIdent
     if (frame->isMainFrame() && preferences().textExtractionEnabled())
         prepareTextExtractionSupportIfNeeded();
 #endif
+
+    protectedPageClient->hasActiveNowPlayingSessionChanged(false);
 }
 
 void WebPageProxy::setCrossSiteLoadWithLinkDecorationForTesting(const URL& fromURL, const URL& toURL, bool wasFiltered, CompletionHandler<void()>&& completionHandler)
@@ -10058,6 +10060,8 @@ void WebPageProxy::resetState(ResetStateReason resetStateReason)
 
     m_nowPlayingMetadataObservers.clear();
     m_nowPlayingMetadataObserverForTesting = nullptr;
+
+    protectedPageClient()->hasActiveNowPlayingSessionChanged(false);
 }
 
 void WebPageProxy::resetStateAfterProcessExited(ProcessTerminationReason terminationReason)
@@ -14366,6 +14370,11 @@ void WebPageProxy::setPermissionLevelForTesting(const String& origin, bool allow
     forEachWebContentProcess([&](auto& webProcess, auto pageID) {
         webProcess.send(Messages::WebPage::SetPermissionLevelForTesting(origin, allowed), pageID);
     });
+}
+
+void WebPageProxy::hasActiveNowPlayingSessionChanged(bool hasActiveNowPlayingSession)
+{
+    protectedPageClient()->hasActiveNowPlayingSessionChanged(hasActiveNowPlayingSession);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2486,6 +2486,8 @@ public:
     bool isEditingCommandEnabledForTesting(const String&);
     void setPermissionLevelForTesting(const String& origin, bool allowed);
 
+    void hasActiveNowPlayingSessionChanged(bool);
+
 private:
     std::optional<Vector<uint8_t>> getWebCryptoMasterKey();
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -647,4 +647,6 @@ CreateAppHighlightInSelectedRange)
 #if ENABLE(GAMEPAD)
     GamepadsRecentlyAccessed()
 #endif
+
+    HasActiveNowPlayingSessionChanged(bool hasActiveNowPlayingSessionChanged)
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1882,4 +1882,9 @@ void WebChromeClient::addDestinationTextAnimation(const WritingTools::Session::I
 
 #endif
 
+void WebChromeClient::hasActiveNowPlayingSessionChanged(bool hasActiveNowPlayingSession)
+{
+    protectedPage()->hasActiveNowPlayingSessionChanged(hasActiveNowPlayingSession);
+}
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -522,6 +522,8 @@ private:
     void addDestinationTextAnimation(const WebCore::WritingTools::SessionID&, const WebCore::CharacterRange&) final;
 #endif
 
+    void hasActiveNowPlayingSessionChanged(bool) final;
+
     mutable bool m_cachedMainFrameHasHorizontalScrollbar { false };
     mutable bool m_cachedMainFrameHasVerticalScrollbar { false };
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9721,6 +9721,11 @@ void WebPage::setPermissionLevelForTesting(const String& origin, bool allowed)
 #endif
 }
 
+void WebPage::hasActiveNowPlayingSessionChanged(bool hasActiveNowPlayingSession)
+{
+    send(Messages::WebPageProxy::HasActiveNowPlayingSessionChanged(hasActiveNowPlayingSession));
+}
+
 } // namespace WebKit
 
 #undef WEBPAGE_RELEASE_LOG

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1779,6 +1779,8 @@ public:
 
     void takeSnapshotForTargetedElement(WebCore::ElementIdentifier, WebCore::ScriptExecutionContextIdentifier, CompletionHandler<void(std::optional<WebCore::ShareableBitmapHandle>&&)>&&);
 
+    void hasActiveNowPlayingSessionChanged(bool);
+
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -943,6 +943,7 @@
 		A1FB504122A212A900D4D979 /* apple-pay-can-make-payments-with-active-card.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1FB504022A2128400D4D979 /* apple-pay-can-make-payments-with-active-card.html */; };
 		A1FB504322A213A300D4D979 /* apple-pay-can-make-payment.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1FB504222A2138F00D4D979 /* apple-pay-can-make-payment.html */; };
 		A1FB504522A2157100D4D979 /* apple-pay.js in Copy Resources */ = {isa = PBXBuildFile; fileRef = A1FB504422A2154B00D4D979 /* apple-pay.js */; };
+		A1FCFF2D2C292D0D0014463B /* NowPlayingSession.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1FCFF2C2C292A600014463B /* NowPlayingSession.mm */; };
 		A310827221F296FF00C28B97 /* FileSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A310827121F296EC00C28B97 /* FileSystem.cpp */; };
 		A57A34F216AF6B2B00C2501F /* PageVisibilityStateWithWindowChanges.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = A57A34F116AF69E200C2501F /* PageVisibilityStateWithWindowChanges.html */; };
 		A57D54F31F338C3600A97AA7 /* NeverDestroyed.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A57D54F21F338C3600A97AA7 /* NeverDestroyed.cpp */; };
@@ -3186,6 +3187,7 @@
 		A1FB504022A2128400D4D979 /* apple-pay-can-make-payments-with-active-card.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "apple-pay-can-make-payments-with-active-card.html"; sourceTree = "<group>"; };
 		A1FB504222A2138F00D4D979 /* apple-pay-can-make-payment.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "apple-pay-can-make-payment.html"; sourceTree = "<group>"; };
 		A1FB504422A2154B00D4D979 /* apple-pay.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = "apple-pay.js"; sourceTree = "<group>"; };
+		A1FCFF2C2C292A600014463B /* NowPlayingSession.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NowPlayingSession.mm; sourceTree = "<group>"; };
 		A1FDFD2E19C288BB005148A4 /* WKImageCreateCGImageCrash.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKImageCreateCGImageCrash.cpp; sourceTree = "<group>"; };
 		A310827121F296EC00C28B97 /* FileSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FileSystem.cpp; sourceTree = "<group>"; };
 		A57A34EF16AF677200C2501F /* PageVisibilityStateWithWindowChanges.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PageVisibilityStateWithWindowChanges.mm; sourceTree = "<group>"; };
@@ -4211,6 +4213,7 @@
 				CD2D0D19213465560018C784 /* NowPlaying.mm */,
 				2ECFF5541D9B12F800B55394 /* NowPlayingControlsTests.mm */,
 				A198D0A12BC64D8E0058BBEB /* NowPlayingMetadataObserver.mm */,
+				A1FCFF2C2C292A600014463B /* NowPlayingSession.mm */,
 				958B70E026C46EDC00B2022B /* NSAttributedStringWebKitAdditions.mm */,
 				A10F047C1E3AD29C00C95E19 /* NSFileManagerExtras.mm */,
 				F4EB4E8F2328AC3000574DAB /* NSItemProviderAdditions.h */,
@@ -6757,6 +6760,7 @@
 				83F22C6420B355F80034277E /* NoPolicyDelegateResponse.mm in Sources */,
 				5159F267260D43E300B2DA3C /* NowPlayingInfoTests.cpp in Sources */,
 				A198D0A22BC64D8E0058BBEB /* NowPlayingMetadataObserver.mm in Sources */,
+				A1FCFF2D2C292D0D0014463B /* NowPlayingSession.mm in Sources */,
 				F442851D2140DF2900CCDA22 /* NSFontPanelTesting.mm in Sources */,
 				F472874727816BCE003EBE7F /* NSResponderTests.mm in Sources */,
 				2D70059921EDA4D0003463CB /* OffscreenWindow.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlayingSession.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlayingSession.mm
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "PlatformUtilities.h"
+#import "TestWKWebView.h"
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WebKit.h>
+
+static NSString * const nowPlayingSessionKeyPath = @"_hasActiveNowPlayingSession";
+static bool hasActiveNowPlayingSessionChanged;
+
+@interface NowPlayingSessionObserver : NSObject
+@end
+
+@implementation NowPlayingSessionObserver
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSString *, id> *)change context:(void *)context
+{
+    ASSERT([keyPath isEqualToString:nowPlayingSessionKeyPath]);
+    ASSERT([object isKindOfClass:WKWebView.class]);
+    hasActiveNowPlayingSessionChanged = true;
+}
+
+TEST(NowPlayingSession, NoSession)
+{
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320)]);
+    ASSERT_FALSE([webView _hasActiveNowPlayingSession]);
+}
+
+TEST(NowPlayingSession, HasSession)
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
+    ASSERT_FALSE([webView _hasActiveNowPlayingSession]);
+
+    auto observer = adoptNS([[NowPlayingSessionObserver alloc] init]);
+    [webView addObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath options:NSKeyValueObservingOptionNew context:nil];
+
+    [webView loadTestPageNamed:@"large-video-test-now-playing"];
+    [webView waitForMessage:@"playing"];
+
+    if (!hasActiveNowPlayingSessionChanged)
+        TestWebKitAPI::Util::run(&hasActiveNowPlayingSessionChanged);
+
+    ASSERT_TRUE([webView _hasActiveNowPlayingSession]);
+}
+
+TEST(NowPlayingSession, NavigateAfterHasSession)
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 480, 320) configuration:configuration.get()]);
+    ASSERT_FALSE([webView _hasActiveNowPlayingSession]);
+
+    auto observer = adoptNS([[NowPlayingSessionObserver alloc] init]);
+    [webView addObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath options:NSKeyValueObservingOptionNew context:nil];
+
+    [webView loadTestPageNamed:@"large-video-test-now-playing"];
+    [webView waitForMessage:@"playing"];
+
+    if (!hasActiveNowPlayingSessionChanged)
+        TestWebKitAPI::Util::run(&hasActiveNowPlayingSessionChanged);
+
+    ASSERT_TRUE([webView _hasActiveNowPlayingSession]);
+
+    hasActiveNowPlayingSessionChanged = false;
+    [webView loadTestPageNamed:@"simple"];
+
+    if (!hasActiveNowPlayingSessionChanged)
+        TestWebKitAPI::Util::run(&hasActiveNowPlayingSessionChanged);
+
+    ASSERT_FALSE([webView _hasActiveNowPlayingSession]);
+}
+
+@end


### PR DESCRIPTION
#### e9ca870925506eabe4eb1434e3eac47c30da6e9c
<pre>
Add a WKWebView SPI to tell clients when a Now Playing session is active
<a href="https://bugs.webkit.org/show_bug.cgi?id=275814">https://bugs.webkit.org/show_bug.cgi?id=275814</a>
<a href="https://rdar.apple.com/129366857">rdar://129366857</a>

Reviewed by Eric Carlson.

Added a boolean -_hasActiveNowPlayingSession property to WKWebView that indicates when the web view
has an active Now Playing session. The property is key-value observable. This is achieved by teching
MediaSessionManagerCocoa to set a isActiveNowPlayingSession boolean on each PlatformMediaSession
when updating Now Playing information. PlatformMediaSession notifies its client when this value
changes, ultimately telling Page to set a 0-delay timer to check whether the Page has an active
Now Playing session (the timer coalesces updates in the case where one PlatformMediaSession becomes
inactive and another becomes active). When the timer fires, Page asks PlatformMediaSessionManager if
any media session in the page&apos;s media session group identifier has an active Now Playing session. If
this computed value changes then a message is sent to WebPageProxy that ultimately changes the value
of -_hasActiveNowPlayingSession.

Added API tests.

* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::isActiveNowPlayingSessionChanged):
* Source/WebCore/Modules/webaudio/AudioContext.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::isActiveNowPlayingSessionChanged):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::hasActiveNowPlayingSessionChanged):
* Source/WebCore/page/Page.cpp:
(WebCore::m_activeNowPlayingSessionUpdateTimer):
(WebCore::Page::hasActiveNowPlayingSessionChanged):
(WebCore::Page::activeNowPlayingSessionUpdateTimerFired):
(WebCore::m_writingToolsController): Deleted.
* Source/WebCore/page/Page.h:
(WebCore::Page::hasActiveNowPlayingSession const):
* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::PlatformMediaSession::setActiveNowPlayingSession):
* Source/WebCore/platform/audio/PlatformMediaSession.h:
(WebCore::PlatformMediaSession::isActiveNowPlayingSession const):
* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::hasActiveNowPlayingSessionInGroup):
* Source/WebCore/platform/audio/PlatformMediaSessionManager.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::updateActiveNowPlayingSession):
(WebCore::MediaSessionManagerCocoa::updateNowPlayingInfo):
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm:
(WebCore::MediaSessionManageriOS::activeVideoRouteDidChange):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::hasActiveNowPlayingSessionChanged):
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::hasActiveNowPlayingSessionChanged):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::resetState):
(WebKit::WebPageProxy::hasActiveNowPlayingSessionChanged):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::hasActiveNowPlayingSessionChanged):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::hasActiveNowPlayingSessionChanged):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlayingSession.mm: Added.
(-[NowPlayingSessionObserver observeValueForKeyPath:ofObject:change:context:]):
(TEST(NowPlayingSession, NoSession)):
(TEST(NowPlayingSession, HasSession)):
(TEST(NowPlayingSession, NavigateAfterHasSession)):

Canonical link: <a href="https://commits.webkit.org/280318@main">https://commits.webkit.org/280318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aae2b4c1f75ad4794e92ca08e8ff61172bc653ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56273 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59879 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6709 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58399 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43221 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45562 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4669 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33483 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48549 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26437 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30262 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5879 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5713 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6151 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61562 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/181 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6280 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52838 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/181 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48615 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52715 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12465 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/162 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31426 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32512 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33595 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32259 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->