### PR TITLE
Ignore notify_register fault from LaunchServices

### DIFF
--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -296,6 +296,7 @@ function notify_entitlements()
             "com.apple.accessibility.cache.switch.control"
             "com.apple.accessibility.cache.vot"
             "com.apple.accessibility.cache.zoom"
+            "com.apple.coreservices.launchservices.session.*"
         )
 
         for NOTIFICATION in ${FORWARDED_NOTIFICATIONS[*]}; do
@@ -676,7 +677,12 @@ fi
 rm -f "${WK_PROCESSED_XCENT_FILE}"
 plistbuddy Clear dict
 
-# Simulator entitlements should be added to Resources/ios/XPCService-ios-simulator.entitlements
+# Simulator entitlements should be added to one or more of:
+#
+#  - Resources/ios/XPCService-embedded-simulator.entitlements
+#  - Shared/AuxiliaryProcessExtensions/GPUProcessExtension.entitlements
+#  - Shared/AuxiliaryProcessExtensions/NetworkingProcessExtension.entitlements
+#  - Shared/AuxiliaryProcessExtensions/WebContentProcessExtension.entitlements
 if [[ "${WK_PLATFORM_NAME}" =~ .*simulator ]]
 then
     exit 0


### PR DESCRIPTION
#### 2bb75ce8fab58c07779265cf2030e16004a40c03
<pre>
Ignore notify_register fault from LaunchServices
<a href="https://bugs.webkit.org/show_bug.cgi?id=275815">https://bugs.webkit.org/show_bug.cgi?id=275815</a>
<a href="https://rdar.apple.com/129022920">rdar://129022920</a>

Reviewed by Per Arne Vollan.

On Mac, we are getting spurious os_log_faults because LaunchServices is registering for a notifyd
notification with the prefix `com.apple.coreservices.launchservices.session` and this isn&apos;t on the
list of allowlisted notification prefixes for that process.

WebContent actually blocks connections to LaunchServices at runtime (via a call to
`_LSSetApplicationLaunchServicesServerConnectionStatus`), so we actually don&apos;t care or need LS to
get those notifications. The issue is that call has to happen late in WebContent initialization and
by that time LS has already registered for that notification.

To fix this, notifyd now allows us to specify prefixes in the notification allowlist. Since we don&apos;t
care about this notification being forwarded to the WebContent process, add it to the list of
non-forwarded entitled notifications.

* Source/WebKit/Scripts/process-entitlements.sh:

Canonical link: <a href="https://commits.webkit.org/280315@main">https://commits.webkit.org/280315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/074b291e642b0c5082adab5a4821c0ab03719342

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59838 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6668 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45518 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4637 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33443 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48512 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26401 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/55758 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30223 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5672 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52239 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61521 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/140 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52806 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/140 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48579 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52683 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12463 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/122 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31385 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32471 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33554 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32218 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->