### PR TITLE
[WGSL] Pointer rewriting causes variables to have the wrong type

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTVariable.h
+++ b/Source/WebGPU/WGSL/AST/ASTVariable.h
@@ -78,9 +78,7 @@ public:
     Expression* maybeReferenceType() { return m_referenceType; }
     const Type* storeType() const
     {
-        if (m_type)
-            return m_type->inferredType();
-        return m_initializer->inferredType();
+        return m_storeType;
     }
 
     std::optional<AddressSpace> addressSpace() const { return m_addressSpace; }
@@ -106,6 +104,10 @@ private:
         , m_role(role)
     {
         ASSERT(m_type || m_initializer);
+        if (m_type)
+            m_storeType = m_type->inferredType();
+        else
+            m_storeType = m_initializer->inferredType();
     }
 
     Identifier m_name;
@@ -121,6 +123,7 @@ private:
     Expression::Ptr m_referenceType { nullptr };
 
     // Computed properties
+    const Type* m_storeType { nullptr };
     std::optional<AddressSpace> m_addressSpace;
     std::optional<AccessMode> m_accessMode;
 

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -642,6 +642,8 @@ void TypeChecker::visit(AST::Variable& variable)
     if (variable.flavor() != AST::VariableFlavor::Const || result == m_types.bottomType())
         value = nullptr;
 
+    variable.m_storeType = result;
+
     if (variable.flavor() == AST::VariableFlavor::Var) {
         result = m_types.referenceType(*variable.addressSpace(), result, *variable.accessMode());
         auto* typeName = variable.maybeTypeName();

--- a/Source/WebGPU/WGSL/tests/valid/fuzz-130092499.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/fuzz-130092499.wgsl
@@ -1,0 +1,10 @@
+// RUN: %metal main
+
+@compute @workgroup_size(1)
+fn main() 
+{
+    var x = 1;
+    {
+        var x=*&x;
+    }
+}


### PR DESCRIPTION
#### 82a09825dd6e6bc0b87a6e2847d735282b60d6cc
<pre>
[WGSL] Pointer rewriting causes variables to have the wrong type
<a href="https://bugs.webkit.org/show_bug.cgi?id=275816">https://bugs.webkit.org/show_bug.cgi?id=275816</a>
<a href="https://rdar.apple.com/130092499">rdar://130092499</a>

Reviewed by Mike Wyrzykowski.

The type checker can update the type of a variable&apos;s initializer expression to satisfy
the constraints on initializers, in this case a variable cannot have a reference type,
so it updates the expression to have the reference&apos;s underlying type (e.g. i32&amp; becomes
i32). However, during pointer rewriting the initializer expression can change, erasing
the type coercion. To fix that, we now save the computed &quot;store type&quot; for the variable
in the AST::Variable node itself, so that it&apos;s preserved even if the initializer changes.

* Source/WebGPU/WGSL/AST/ASTVariable.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/valid/fuzz-130092499.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/280330@main">https://commits.webkit.org/280330@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b52c674b015c883295dbde5e167ef4ce62995bf1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59841 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6671 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43183 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6865 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45520 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4638 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33447 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26404 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30227 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5675 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52242 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6119 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61524 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/143 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6244 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52807 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/143 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48583 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52684 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12469 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/124 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31388 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32474 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33557 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32221 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->