### PR TITLE
[Writing Tools] Tapping on Restart after a Magic Rewrite duplicates the sentence

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1342,6 +1342,7 @@ editing/VisibleUnits.cpp
 editing/WebContentReader.cpp
 editing/WebCorePasteboardFileReader.cpp
 editing/WrapContentsInDummySpanCommand.cpp
+editing/WritingToolsCompositionCommand.cpp
 editing/markup.cpp
 fileapi/AsyncFileStream.cpp
 fileapi/Blob.cpp

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -1280,6 +1280,9 @@ void Editor::unappliedEditing(EditCommandComposition& composition)
     updateEditorUINowIfScheduled();
 
     m_alternativeTextController->respondToUnappliedEditing(&composition);
+#if ENABLE(WRITING_TOOLS)
+    protectedDocument()->page()->respondToUnappliedWritingToolsEditing(&composition);
+#endif
 
     m_lastEditCommand = nullptr;
     if (auto* client = this->client())
@@ -1303,6 +1306,10 @@ void Editor::reappliedEditing(EditCommandComposition& composition)
     dispatchInputEvents(composition.startingRootEditableElement(), composition.endingRootEditableElement(), "historyRedo"_s, IsInputMethodComposing::No);
     
     updateEditorUINowIfScheduled();
+
+#if ENABLE(WRITING_TOOLS)
+    protectedDocument()->page()->respondToReappliedWritingToolsEditing(&composition);
+#endif
 
     m_lastEditCommand = nullptr;
     if (auto* client = this->client())

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -1945,6 +1945,32 @@ std::optional<SimpleRange> rangeExpandedAroundPositionByCharacters(const Visible
     return makeSimpleRange(start, end);
 }
 
+std::optional<SimpleRange> rangeExpandedAroundRangeByCharacters(const VisibleSelection& selection, uint64_t numberOfCharactersToExpandBackwards, uint64_t numberOfCharactersToExpandForwards)
+{
+    auto range = selection.firstRange();
+    if (!range)
+        return std::nullopt;
+
+    auto extendedPosition = [](const BoundaryPoint& point, uint64_t characterCount, SelectionDirection direction) {
+        auto visiblePosition = VisiblePosition { makeContainerOffsetPosition(point) };
+
+        for (uint64_t i = 0; i < characterCount; ++i) {
+            auto nextVisiblePosition = positionOfNextBoundaryOfGranularity(visiblePosition, TextGranularity::CharacterGranularity, direction);
+            if (nextVisiblePosition.isNull())
+                break;
+
+            visiblePosition = nextVisiblePosition;
+        }
+
+        return visiblePosition;
+    };
+
+    auto start = extendedPosition(range->start, numberOfCharactersToExpandBackwards, SelectionDirection::Backward);
+    auto end = extendedPosition(range->end, numberOfCharactersToExpandForwards, SelectionDirection::Forward);
+
+    return makeSimpleRange(start, end);
+}
+
 std::pair<VisiblePosition, WithinWordBoundary> wordBoundaryForPositionWithoutCrossingLine(const VisiblePosition& position)
 {
     if (atBoundaryOfGranularity(position, TextGranularity::LineGranularity, SelectionDirection::Forward))

--- a/Source/WebCore/editing/VisibleUnits.h
+++ b/Source/WebCore/editing/VisibleUnits.h
@@ -107,6 +107,7 @@ WEBCORE_EXPORT std::optional<SimpleRange> wordRangeFromPosition(const VisiblePos
 WEBCORE_EXPORT VisiblePosition closestWordBoundaryForPosition(const VisiblePosition& position);
 WEBCORE_EXPORT void charactersAroundPosition(const VisiblePosition&, char32_t& oneAfter, char32_t& oneBefore, char32_t& twoBefore);
 WEBCORE_EXPORT std::optional<SimpleRange> rangeExpandedAroundPositionByCharacters(const VisiblePosition&, int numberOfCharactersToExpand);
+WEBCORE_EXPORT std::optional<SimpleRange> rangeExpandedAroundRangeByCharacters(const VisibleSelection&, uint64_t numberOfCharactersToExpandBackwards, uint64_t numberOfCharactersToExpandForwards);
 WEBCORE_EXPORT std::optional<SimpleRange> rangeExpandedByCharactersInDirectionAtWordBoundary(const VisiblePosition&, int numberOfCharactersToExpand, SelectionDirection);
 enum class WithinWordBoundary : bool { No, Yes };
 WEBCORE_EXPORT std::pair<VisiblePosition, WithinWordBoundary> wordBoundaryForPositionWithoutCrossingLine(const VisiblePosition&);

--- a/Source/WebCore/editing/WritingToolsCompositionCommand.cpp
+++ b/Source/WebCore/editing/WritingToolsCompositionCommand.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WritingToolsCompositionCommand.h"
+
+#include "FrameSelection.h"
+#include "ReplaceSelectionCommand.h"
+#include "TextIterator.h"
+
+namespace WebCore {
+
+WritingToolsCompositionCommand::WritingToolsCompositionCommand(Ref<Document>&& document, const SimpleRange& endingContextRange)
+    : CompositeEditCommand(WTFMove(document), EditAction::InsertReplacement)
+    , m_endingContextRange(endingContextRange)
+{
+}
+
+void WritingToolsCompositionCommand::replaceContentsOfRangeWithFragment(RefPtr<DocumentFragment>&& fragment, const SimpleRange& range, MatchStyle matchStyle, State state)
+{
+    if (endingSelection().isNoneOrOrphaned() || !endingSelection().isContentEditable())
+        return;
+
+    auto contextRange = m_endingContextRange;
+
+    auto contextRangeCount = characterCount(contextRange);
+    auto resolvedCharacterRange = characterRange(contextRange, range);
+
+    OptionSet<ReplaceSelectionCommand::CommandOption> options { ReplaceSelectionCommand::PreventNesting, ReplaceSelectionCommand::SanitizeFragment, ReplaceSelectionCommand::SelectReplacement };
+    if (matchStyle == MatchStyle::Yes)
+        options.add(ReplaceSelectionCommand::MatchStyle);
+
+    applyCommandToComposite(ReplaceSelectionCommand::create(protectedDocument(), WTFMove(fragment), options, EditAction::InsertReplacement), range);
+
+    protectedDocument()->selection().setSelection(endingSelection());
+
+    if (state == State::Complete) {
+        // When the command is signaled to be "complete", this commits the entire command as a whole to the undo/redo stack.
+        this->apply();
+    }
+
+    // Restore the context range to what it previously was, while taking into account the newly replaced contents.
+    auto newContextRange = rangeExpandedAroundRangeByCharacters(endingSelection(), resolvedCharacterRange.location, contextRangeCount - (resolvedCharacterRange.location + resolvedCharacterRange.length));
+    if (!newContextRange) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    m_endingContextRange = *newContextRange;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/editing/WritingToolsCompositionCommand.h
+++ b/Source/WebCore/editing/WritingToolsCompositionCommand.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CompositeEditCommand.h"
+
+namespace WebCore {
+
+struct AttributedString;
+
+// A Writing Tools Composition command is essentially a wrapper around a group of Replace Selection commands,
+// which can be undone/redone as a whole.
+//
+// It also maintains an associated context range that persists after each constituent command.
+class WritingToolsCompositionCommand : public CompositeEditCommand {
+public:
+    enum class MatchStyle: bool {
+        No, Yes
+    };
+
+    enum class State: uint8_t {
+        InProgress,
+        Complete
+    };
+
+    static Ref<WritingToolsCompositionCommand> create(Ref<Document>&& document, const SimpleRange& endingContextRange)
+    {
+        return adoptRef(*new WritingToolsCompositionCommand(WTFMove(document), endingContextRange));
+    }
+
+    // This method is used to add each "piece" (aka Replace selection command) of the Writing Tools composition command.
+    void replaceContentsOfRangeWithFragment(RefPtr<DocumentFragment>&&, const SimpleRange&, MatchStyle, State);
+
+    SimpleRange endingContextRange() const { return m_endingContextRange; }
+
+private:
+    WritingToolsCompositionCommand(Ref<Document>&&, const SimpleRange&);
+
+    void doApply() override { }
+
+    SimpleRange m_endingContextRange;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4890,6 +4890,16 @@ void Page::updateStateForSelectedSuggestionIfNeeded()
     m_writingToolsController->updateStateForSelectedSuggestionIfNeeded();
 }
 
+void Page::respondToUnappliedWritingToolsEditing(EditCommandComposition* command)
+{
+    m_writingToolsController->respondToUnappliedEditing(command);
+}
+
+void Page::respondToReappliedWritingToolsEditing(EditCommandComposition* command)
+{
+    m_writingToolsController->respondToReappliedEditing(command);
+}
+
 std::optional<SimpleRange> Page::contextRangeForSessionWithID(const WritingTools::Session::ID& sessionID) const
 {
     return m_writingToolsController->contextRangeForSessionWithID(sessionID);

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -100,6 +100,7 @@ class BadgeClient;
 class BroadcastChannelRegistry;
 class CacheStorageProvider;
 class Chrome;
+class CompositeEditCommand;
 class ContextMenuController;
 class CookieJar;
 class CryptoClient;
@@ -110,6 +111,7 @@ class DiagnosticLoggingClient;
 class DragCaretController;
 class DragController;
 class EditorClient;
+class EditCommandComposition;
 class ElementTargetingController;
 class Element;
 class FocusController;
@@ -1163,6 +1165,9 @@ public:
     WEBCORE_EXPORT void writingToolsSessionDidReceiveAction(const WritingTools::Session&, WritingTools::Action);
 
     WEBCORE_EXPORT void updateStateForSelectedSuggestionIfNeeded();
+
+    void respondToUnappliedWritingToolsEditing(EditCommandComposition*);
+    void respondToReappliedWritingToolsEditing(EditCommandComposition*);
 
     WEBCORE_EXPORT std::optional<SimpleRange> contextRangeForSessionWithID(const WritingTools::SessionID&) const;
 #endif


### PR DESCRIPTION
#### 405782ff2e808caa3d518d03fc5de7b15de8098b
<pre>
[Writing Tools] Tapping on Restart after a Magic Rewrite duplicates the sentence
<a href="https://bugs.webkit.org/show_bug.cgi?id=275818">https://bugs.webkit.org/show_bug.cgi?id=275818</a>
<a href="https://rdar.apple.com/130065512">rdar://130065512</a>

Reviewed by Aditya Keerthi.

In the existing implementation of Rewrite/Composition, there were two fundamental issues:

* The stateful context range must always be up-to-date, which was a fragile architecture as it relied
upon it being updated with every different type of replacement operation.

* While undo/redo happened to work for trivial cases, the WritingToolsController was not aware of these
changes happening, which would also put the context range out of date. Additionally, each individual ReplaceSelectionCommand
was being undone or redone at a time, instead of the entire set of constituent commands belong to a particular composition.

To fix this, introduce a new specialized type of edit command specifically designed for rewrites and compositions,
and have it encapsulate both a group of ReplaceSelectionCommands as well as its corresponding context range.
This facilitates the ability to undo/redo a group of commands at once, and also ensures that the context range is always correct
for a given command.

To ensure that the right command is always being used, an undo and redo stack are now used to store the commands,
and a given command moves from one stack to the other when it is undone or redone. This also allows the &quot;show original&quot;
and &quot;show rewritten&quot; commands to function by simply undo-ing or redo-ing all the commands.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::unappliedEditing):
(WebCore::Editor::reappliedEditing):
* Source/WebCore/editing/VisibleUnits.cpp:
(WebCore::rangeExpandedAroundRangeByCharacters):
* Source/WebCore/editing/VisibleUnits.h:
* Source/WebCore/editing/WritingToolsCompositionCommand.cpp: Added.
(WebCore::WritingToolsCompositionCommand::WritingToolsCompositionCommand):
(WebCore::WritingToolsCompositionCommand::replaceFragment):
(WebCore::WritingToolsCompositionCommand::doApply):
* Source/WebCore/editing/WritingToolsCompositionCommand.h: Added.
(WebCore::WritingToolsCompositionCommand::create):
(WebCore::WritingToolsCompositionCommand::endingContextRange const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::respondToUnappliedWritingToolsEditing):
(WebCore::Page::respondToReappliedWritingToolsEditing):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/writing-tools/WritingToolsController.h:
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::WritingToolsController::WritingToolsController):
(WebCore::WritingToolsController::willBeginWritingToolsSession):
(WebCore::WritingToolsController::compositionSessionDidReceiveTextWithReplacementRange):
(WebCore::WritingToolsController::writingToolsSessionDidReceiveAction&lt;WritingTools::Session::Type::Composition&gt;):
(WebCore::WritingToolsController::respondToUnappliedEditing):
(WebCore::WritingToolsController::respondToReappliedEditing):
(WebCore::WritingToolsController::contextRangeForSessionWithID const):
(WebCore::WritingToolsController::replaceContentsOfRangeInSession):
(WebCore::WritingToolsController::replaceContentsOfRangeInSessionInternal): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(TEST(WritingTools, CompositionWithUndo)):
(TEST(WritingTools, CompositionWithMultipleUndosAndRestarts)):
(TEST(WritingTools, CompositionWithUndoAndRestart)):
(TEST(WritingTools, Composition)):
(TEST(WritingTools, CompositionRevert)):
(TEST(WritingTools, CompositionWithMultipleChunks)):
(TEST(WritingTools, ContextRangeFromCaretSelection)):
(TEST(WritingTools, ContextRangeFromRangeSelection)):

Canonical link: <a href="https://commits.webkit.org/280437@main">https://commits.webkit.org/280437@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14f2b5d7f3ba032df95caa246d8e07b425ad0004

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56622 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60236 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7063 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58749 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43572 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7254 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/45867 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4944 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58652 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/33802 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48869 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/30582 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6200 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6066 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61919 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/534 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6578 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53131 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/536 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48927 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/53141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/461 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8418 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31777 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32863 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33947 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32609 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->