### PR TITLE
[libpas] pas_segregated_heap_ensure_size_directory_for_size/check_medium_directories assert fail due to creating overlapping directories

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_bitfit_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_bitfit_heap.c
@@ -84,7 +84,8 @@ pas_bitfit_variant_selection pas_bitfit_heap_select_variant(size_t requested_obj
             continue;
 
         if (verbose)
-            pas_log("max object size = %zu\n", page_config.base.max_object_size);
+            pas_log("max object size = %zu min align = %zu\n",
+                    page_config.base.max_object_size, pas_page_base_config_min_align(page_config.base));
 
         PAS_ASSERT(
             page_config.base.max_object_size

--- a/Source/bmalloc/libpas/src/test/BmallocTests.cpp
+++ b/Source/bmalloc/libpas/src/test/BmallocTests.cpp
@@ -25,6 +25,7 @@
 
 #include "TestHarness.h"
 #include "bmalloc_heap.h"
+#include "bmalloc_heap_config.h"
 
 #include <cstdlib>
 
@@ -45,10 +46,29 @@ void testBmallocDeallocate()
     bmalloc_deallocate(mem);
 }
 
+void testBmallocForceBitfitAfterAlloc()
+{
+    void* mem0 = bmalloc_try_allocate(28616, pas_non_compact_allocation_mode);
+    CHECK(mem0);
+
+    void* mem1 = bmalloc_try_allocate(20768, pas_non_compact_allocation_mode);
+    CHECK(mem1);
+
+    // Simulate entering mini mode by forcing bitfit only.
+    bmalloc_intrinsic_runtime_config.base.max_segregated_object_size = 0;
+    bmalloc_intrinsic_runtime_config.base.max_bitfit_object_size = UINT_MAX;
+    bmalloc_primitive_runtime_config.base.max_segregated_object_size = 0;
+    bmalloc_primitive_runtime_config.base.max_bitfit_object_size = UINT_MAX;
+
+    void* mem2 = bmalloc_try_allocate(20648, pas_non_compact_allocation_mode);
+    CHECK(mem2);
+}
+
 } // anonymous namespace
 
 void addBmallocTests()
 {
     ADD_TEST(testBmallocAllocate());
     ADD_TEST(testBmallocDeallocate());
+    ADD_TEST(testBmallocForceBitfitAfterAlloc());
 }


### PR DESCRIPTION
#### c6894f128e9bac5871ad6e72574a9f60102974e0
<pre>
[libpas] pas_segregated_heap_ensure_size_directory_for_size/check_medium_directories assert fail due to creating overlapping directories
<a href="https://bugs.webkit.org/show_bug.cgi?id=275820">https://bugs.webkit.org/show_bug.cgi?id=275820</a>
<a href="https://rdar.apple.com/129774839">rdar://129774839</a>

Reviewed by Yusuke Suzuki.

There are some edge cases that can cause pas_segregated_heap_ensure_size_directory_for_size()
to create a new directory that overlaps the next largest directory, i.e.
the new directory&apos;s object_size index is greater than the next largest&apos;s
min_index. One case in which this can occur is after entering mini mode,
which forces bitfit. A side effect of that is that the &quot;ideal object size&quot;
computation changes, which can lead to this overlap.

There are three possible solutions:
1. Extend the directory for the next largest size class (candidate) down
to the new install_index. However, after this solution can lead to
pathologically large directories if given the a particular sequence of
allocates. This is because then the candidate is extended based on the
min_index, which then could continue decreasing after each allocate.
Normally, size classes are extended based only on the candidate&apos;s
object_size, which doesn&apos;t change once the directory is created.

2. Trim the lower bound of the next biggest directory (candidate) if the
new directory would overlap the candidate min_index. This appears to be
unsafe if the candidate is bitfit given the comment in the code that does
similar trimming for result.
       /* Bitfit size directories claim super high alignment, so they should never get replaced. This is a
           hard requirement, since:

           - pas_bitfit_size_class is allocated as part of the pas_segregated_size_directory.
           - We cannot add duplicate bitfit_size_classes, so if we ever tried to replace a
             segregated_size_directory with another one of the same size, and they both had bitfit_size_classes,
             then we&apos;d be in trouble. */
        PAS_ASSERT(!pas_segregated_size_directory_is_bitfit(result));

3. Cap the new directory&apos;s object_size at the next largest directories
min_index. Bumping of the new directory&apos;s object_size to the ideal
object size appears to be an optimization and so it is safe to not do
this if it would create overlapping directories.

Some of the existing libpas chaos test cases do hit this case, but it
goes unnoticed because the overlapping directories are small, not medium.
The assert that made this problem apparent is only for medium directories
(to verify their index can be binary searched). While this doesn&apos;t cause
an assert with small directories, it seems that overlapping directories
should not be allowed for small directories either as it can lead to
inconsistencies. For example, if the index tables need to be
dematerialized we may index to a different set of directories then were
indexed previously.

So I&apos;ve added a libpas test case that does trigger the medium director
assert without this fix.

* Source/bmalloc/libpas/src/libpas/pas_bitfit_heap.c:
(pas_bitfit_heap_select_variant):
* Source/bmalloc/libpas/src/libpas/pas_segregated_heap.c:
(pas_segregated_heap_ensure_size_directory_for_size):
* Source/bmalloc/libpas/src/test/BmallocTests.cpp:
(std::testBmallocForceBitfitAfterAlloc):
(addBmallocTests):

Canonical link: <a href="https://commits.webkit.org/280317@main">https://commits.webkit.org/280317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00d8b7ee107c6dcb0286c402679f7d124d50c527

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56275 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59881 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6711 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6905 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/45568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4667 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58304 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33484 "Found 60 new test failures: accessibility/accessibility-node-reparent.html accessibility/ancestor-computation.html accessibility/announcement-notification.html accessibility/aria-braillelabel.html accessibility/aria-brailleroledescription.html accessibility/aria-checked-mixed-value.html accessibility/aria-current-state-changed-notification.html accessibility/aria-current.html accessibility/aria-describedby-on-input.html accessibility/aria-description.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48552 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/26443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30263 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5882 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5715 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/49353 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6154 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61564 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/55512 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/183 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6281 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52839 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/183 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48618 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/52716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/163 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/77272 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8352 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31428 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12810 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32514 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33597 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32261 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->