### PR TITLE
[JSC] Remove JSGlobalObject::hasVarDeclaration()

### DIFF
--- a/JSTests/stress/global-add-function-should-not-be-shadowed-by-lexical-bindings.js
+++ b/JSTests/stress/global-add-function-should-not-be-shadowed-by-lexical-bindings.js
@@ -15,4 +15,4 @@ function shouldThrow(func, errorMessage) {
 
 shouldThrow(() => {
     $.evalScript(`const shouldThrow = 42`);
-}, `SyntaxError: Can't create duplicate variable: 'shouldThrow'`);
+}, `SyntaxError: Can't create duplicate variable that shadows a global property: 'shouldThrow'`);

--- a/JSTests/stress/global-add-var-should-not-be-shadowed-by-lexical-bindings.js
+++ b/JSTests/stress/global-add-var-should-not-be-shadowed-by-lexical-bindings.js
@@ -15,4 +15,4 @@ var shouldThrow = function(func, errorMessage) {
 
 shouldThrow(() => {
     $.evalScript(`const shouldThrow = 42`);
-}, `SyntaxError: Can't create duplicate variable: 'shouldThrow'`);
+}, `SyntaxError: Can't create duplicate variable that shadows a global property: 'shouldThrow'`);

--- a/JSTests/stress/has-var-declaration.js
+++ b/JSTests/stress/has-var-declaration.js
@@ -3,39 +3,14 @@ function assert(x) {
         throw new Error("Bad assertion!");
 }
 
-function shouldThrow(func, expectedError) {
-    let errorThrown = false;
-    try {
-        func();
-    } catch (error) {
-        errorThrown = true;
-        if (error.toString() !== expectedError)
-            throw new Error(`Bad error: ${error}!`);
-    }
-    if (!errorThrown)
-        throw new Error("Didn't throw!");
-}
-
-
 eval("var theVar");
-shouldThrow(() => { $262.evalScript("let theVar = 1"); }, "SyntaxError: Can't create duplicate variable: 'theVar'");
-shouldThrow(() => { $262.evalScript("const theVar = 1"); }, "SyntaxError: Can't create duplicate variable: 'theVar'");
-delete globalThis.theVar;
 $262.evalScript("let theVar = 2");
 assert(theVar === 2);
 
-
 eval("function theTopLevelFunctionDeclaration() {}");
-shouldThrow(() => { $262.evalScript("let theTopLevelFunctionDeclaration = 3"); }, "SyntaxError: Can't create duplicate variable: 'theTopLevelFunctionDeclaration'");
-shouldThrow(() => { $262.evalScript("const theTopLevelFunctionDeclaration = 3"); }, "SyntaxError: Can't create duplicate variable: 'theTopLevelFunctionDeclaration'");
-delete globalThis.theTopLevelFunctionDeclaration;
 $262.evalScript("const theTopLevelFunctionDeclaration = 4");
 assert(theTopLevelFunctionDeclaration === 4);
 
-
 eval("if (true) { function theHoistedBlockLevelFunctionDeclaration() {} }");
-shouldThrow(() => { $262.evalScript("const theHoistedBlockLevelFunctionDeclaration = 5"); }, "SyntaxError: Can't create duplicate variable: 'theHoistedBlockLevelFunctionDeclaration'");
-shouldThrow(() => { $262.evalScript("let theHoistedBlockLevelFunctionDeclaration = 5"); }, "SyntaxError: Can't create duplicate variable: 'theHoistedBlockLevelFunctionDeclaration'");
-delete globalThis.theHoistedBlockLevelFunctionDeclaration;
 $262.evalScript("let theHoistedBlockLevelFunctionDeclaration = 6");
 assert(theHoistedBlockLevelFunctionDeclaration === 6);

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -5,8 +5,6 @@ test/annexB/language/comments/single-line-html-close-first-line-2.js:
   raw: Expected uncaught exception with name 'Test262Error' but given exception class is not defined
 test/annexB/language/comments/single-line-html-close-first-line-3.js:
   raw: Expected uncaught exception with name 'Test262Error' but given exception class is not defined
-test/annexB/language/eval-code/direct/script-decl-lex-no-collision.js:
-  default: "SyntaxError: Can't create duplicate variable: 'test262Fn'"
 test/annexB/language/function-code/block-decl-func-skip-arguments.js:
   default: 'Test262Error: Expected SameValue(«function arguments() {}», «[object Arguments]») to be true'
 test/built-ins/AsyncFromSyncIteratorPrototype/next/for-await-iterator-next-rejected-promise-close.js:

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -565,8 +565,6 @@ public:
     bool m_requiresTrustedTypes { true };
     bool m_needsSiteSpecificQuirks { false };
     unsigned m_globalLexicalBindingEpoch { 1 };
-    ScopeOffset m_lastStaticGlobalOffset;
-    IdentifierSet m_varNamesDeclaredViaEval;
     String m_evalDisabledErrorMessage;
     String m_webAssemblyDisabledErrorMessage;
     RuntimeFlags m_runtimeFlags;
@@ -647,9 +645,6 @@ public:
     JS_EXPORT_PRIVATE static bool getOwnPropertySlot(JSObject*, JSGlobalObject*, PropertyName, PropertySlot&);
     JS_EXPORT_PRIVATE static bool put(JSCell*, JSGlobalObject*, PropertyName, JSValue, PutPropertySlot&);
     JS_EXPORT_PRIVATE static bool defineOwnProperty(JSObject*, JSGlobalObject*, PropertyName, const PropertyDescriptor&, bool shouldThrow);
-    JS_EXPORT_PRIVATE static bool deleteProperty(JSCell*, JSGlobalObject*, PropertyName, DeletePropertySlot&);
-
-    bool hasVarDeclaration(const RefPtr<UniquedStringImpl>&);
 
     bool canDeclareGlobalFunction(const Identifier&);
     template<BindingCreationContext> void createGlobalFunctionBinding(const Identifier&);

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -450,16 +450,6 @@ inline JSScope* JSGlobalObject::globalScope()
     return m_globalLexicalEnvironment.get();
 }
 
-// https://tc39.es/ecma262/#sec-hasvardeclaration
-inline bool JSGlobalObject::hasVarDeclaration(const RefPtr<UniquedStringImpl>& ident)
-{
-    SymbolTableEntry entry = symbolTable()->get(ident.get());
-    if (!entry.isNull() && entry.scopeOffset() > m_lastStaticGlobalOffset)
-        return true;
-
-    return m_varNamesDeclaredViaEval.contains(ident);
-}
-
 // https://tc39.es/ecma262/#sec-candeclareglobalvar
 inline bool JSGlobalObject::canDeclareGlobalVar(const Identifier& ident)
 {
@@ -486,10 +476,8 @@ inline void JSGlobalObject::createGlobalVarBinding(const Identifier& ident)
     ASSERT(isStructureExtensible());
     if constexpr (context == BindingCreationContext::Global)
         addSymbolTableEntry(ident);
-    else {
+    else
         putDirect(vm, ident, jsUndefined());
-        m_varNamesDeclaredViaEval.add(ident.impl());
-    }
 }
 
 inline InlineWatchpointSet& JSGlobalObject::typedArraySpeciesWatchpointSet(TypedArrayType type)

--- a/Source/JavaScriptCore/runtime/ProgramExecutable.cpp
+++ b/Source/JavaScriptCore/runtime/ProgramExecutable.cpp
@@ -119,9 +119,6 @@ JSObject* ProgramExecutable::initializeGlobalProperties(VM& vm, JSGlobalObject* 
         // Check if any new "let"/"const"/"class" will shadow any pre-existing global property names (with configurable = false), or "var"/"let"/"const" variables.
         // It's an error to introduce a shadow.
         for (auto& entry : lexicalDeclarations) {
-            if (globalObject->hasVarDeclaration(entry.key))
-                return createErrorForDuplicateGlobalVariableDeclaration(globalObject, entry.key.get());
-
             if (hasGlobalLexicalDeclarations) {
                 bool hasProperty = globalLexicalEnvironment->hasProperty(globalObject, entry.key.get());
                 throwScope.assertNoExceptionExceptTermination();


### PR DESCRIPTION
#### 775c66f97c1049f8e75d9715fb0a684ba71e8dda
<pre>
[JSC] Remove JSGlobalObject::hasVarDeclaration()
<a href="https://bugs.webkit.org/show_bug.cgi?id=275821">https://bugs.webkit.org/show_bug.cgi?id=275821</a>
&lt;<a href="https://rdar.apple.com/problem/130438575">rdar://problem/130438575</a>&gt;

Reviewed by Justin Michaud and Yijia Huang.

This change implements stage 3 proposal [1] to remove [[VarNames]] from global object,
which purpose was to prevent redeclaration of `var` and `function` bindings that were
declared via eval().

However, those bindings are configurable and thus still were redeclarable following `delete`.
The proposal simplified both mental model of redeclaration constraints and its implementation.

This patch effectively reverts [2] and aligns JSC with V8.

[1]: <a href="https://github.com/tc39/proposal-redeclarable-global-eval-vars">https://github.com/tc39/proposal-redeclarable-global-eval-vars</a>
[2]: <a href="https://github.com/WebKit/WebKit/pull/17662">https://github.com/WebKit/WebKit/pull/17662</a>

* JSTests/stress/global-add-function-should-not-be-shadowed-by-lexical-bindings.js:
* JSTests/stress/global-add-var-should-not-be-shadowed-by-lexical-bindings.js:
* JSTests/stress/has-var-declaration.js:
* JSTests/test262/expectations.yaml: Mark 1 test as passing.
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::createGlobalFunctionBinding):
(JSC::JSGlobalObject::addStaticGlobals):
(JSC::JSGlobalObject::deleteProperty): Deleted.
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h:
(JSC::JSGlobalObject::createGlobalVarBinding):
(JSC::JSGlobalObject::hasVarDeclaration): Deleted.
* Source/JavaScriptCore/runtime/ProgramExecutable.cpp:
(JSC::ProgramExecutable::initializeGlobalProperties):

Canonical link: <a href="https://commits.webkit.org/280316@main">https://commits.webkit.org/280316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/881534fc693cfe200038a1778728eac7c27bf401

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59856 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6686 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43198 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6880 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45538 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4648 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58279 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33461 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48530 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26419 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5860 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5690 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/49328 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52253 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6132 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61539 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/55487 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/158 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6258 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52823 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/158 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48596 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52701 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/141 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/77247 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8351 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31403 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12802 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32489 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33572 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32236 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->