### PR TITLE
Static analyzer bugs are missed due to truncated hash collisions

### DIFF
--- a/Tools/Scripts/build-and-analyze
+++ b/Tools/Scripts/build-and-analyze
@@ -95,6 +95,12 @@ def make_analyzer_flags(output_dir, args):
             'max-nodes={}'.format(args.analyzer_budget_max_nodes),
         ])
 
+    if args.only_smart_pointers:
+        analyzer_flags.extend([
+            '-analyzer-config',
+            'verbose-report-filename=true',
+        ])
+
     return ' '.join(analyzer_flags)
 
 

--- a/Tools/Scripts/compare-static-analysis-results
+++ b/Tools/Scripts/compare-static-analysis-results
@@ -83,14 +83,13 @@ def find_diff(args, file1, file2):
     return set(diff_new_from_baseline), set(diff_baseline_from_new)
 
 
-def create_filtered_results_dir(args, project, issues, category='StaticAnalyzerRegressions'):
+def create_filtered_results_dir(args, project, result_paths, category='StaticAnalyzerRegressions'):
     # Create symlinks to new issues only so that we can run scan-build to generate new index.html files
-    path_to_reports = os.path.abspath(f'{args.build_output}/{category}/{project}/StaticAnalyzerReports')
-    subprocess.run(['mkdir', '-p', path_to_reports])
-    for issue_hash in issues:
-        report = f"report-{issue_hash[:6]}.html"
-        path_to_report = f'{args.build_output}/StaticAnalyzer/{project}/StaticAnalyzerReports/{report}'
-        path_to_report_new = os.path.join(path_to_reports, report)
+    prefix_path = os.path.abspath(f'{args.build_output}/{category}/{project}/StaticAnalyzerReports')
+    subprocess.run(['mkdir', '-p', prefix_path])
+    for path_to_report in result_paths:
+        report = path_to_report.split('/')[-1]
+        path_to_report_new = os.path.join(prefix_path, report)
         subprocess.run(['ln', '-s', os.path.abspath(path_to_report), path_to_report_new])
     print('\n')
     path_to_project = f'{args.build_output}/{category}/{project}'
@@ -99,6 +98,7 @@ def create_filtered_results_dir(args, project, issues, category='StaticAnalyzerR
 
 def compare_project_results_to_expectations(args, new_path, project):
     unexpected_issues_total = set()
+    unexpected_result_paths_total = set()
     unexpected_buggy_files = set()
     unexpected_clean_files = set()
     project_results_passes = {}
@@ -113,10 +113,14 @@ def compare_project_results_to_expectations(args, new_path, project):
 
         # Get unexpected issues per checker
         unexpected_issues = set()
+        unexpected_result_paths = set()
+
         with open(f'{new_path}/issues_per_file.json') as f:
             issues_per_file = json.load(f)
         for file_name in buggy_files:
-            unexpected_issues.update(issues_per_file[checker][file_name])
+            unexpected_issues.update(list(issues_per_file[checker][file_name].keys()))
+            unexpected_result_paths.update(list(issues_per_file[checker][file_name].values()))
+        unexpected_result_paths_total.update(unexpected_result_paths)
         unexpected_issues_total.update(unexpected_issues)
 
         # Set up JSON object
@@ -146,7 +150,7 @@ def compare_project_results_to_expectations(args, new_path, project):
             print(f'    No unexpected results!')
 
     if unexpected_issues_total and args.scan_build:
-        create_filtered_results_dir(args, project, unexpected_issues_total, STATIC_ANALYZER_UNEXPECTED)
+        create_filtered_results_dir(args, project, unexpected_result_paths_total, STATIC_ANALYZER_UNEXPECTED)
 
     return unexpected_buggy_files, unexpected_clean_files, unexpected_issues_total, project_results_passes, project_results_failures
 

--- a/Tools/Scripts/generate-dirty-files
+++ b/Tools/Scripts/generate-dirty-files
@@ -108,8 +108,11 @@ def find_project_results(args, project, file_list, results_data):
         # Map filename to issues for each bug type
         file_dict = results_data.get(CHECKER_MAP[bug_type], {})
         if not file_name in file_dict:
-            file_dict[file_name] = []
-        file_dict[file_name].append(issue_hash)
+            file_dict[file_name] = {}
+
+        # Map issue to its report path
+        if not issue_hash in file_dict[file_name]:
+            file_dict[file_name][issue_hash] = result_file
         results_data[CHECKER_MAP[bug_type]] = file_dict
 
         output_file_name = os.path.abspath(f'{args.output_dir}/{project}/{CHECKER_MAP[bug_type]}Issues')


### PR DESCRIPTION
#### acf6ab78c5875e691a23dc8bd48198d257d72a7e
<pre>
Static analyzer bugs are missed due to truncated hash collisions
<a href="https://bugs.webkit.org/show_bug.cgi?id=275825">https://bugs.webkit.org/show_bug.cgi?id=275825</a>
<a href="https://rdar.apple.com/130445038">rdar://130445038</a>

Reviewed by Ryosuke Niwa.

Use verbose report filenames to prevent hash collisions. This uncovers thousands of bugs.

* Tools/Scripts/build-and-analyze:
(make_analyzer_flags):
- Adds &apos;verbose-report-filename=true&apos; to make command. This includes the filename in the report name to reduce collisions.

* Tools/Scripts/compare-static-analysis-results:
(find_diff):
(create_filtered_results_dir):
(compare_project_results_to_expectations):
- Generalize finding report paths from JSON. This will work for both short and verbose names.

* Tools/Scripts/generate-dirty-files:
(find_project_results):
- Map each issue to its report path.

Canonical link: <a href="https://commits.webkit.org/280345@main">https://commits.webkit.org/280345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49963ea7f1c1e4663f890056434d248b71dd257f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56364 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35690 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59971 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6800 "Built successfully") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/58490 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43312 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6994 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/45654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4748 "Passed tests") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/58393 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/33567 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48635 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/26518 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/30347 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5965 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5804 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6237 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61655 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/272 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/6358 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/52917 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/272 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48701 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/52800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/246 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8368 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31517 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32603 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33686 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32350 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->