### PR TITLE
[iOS] Crash when selecting <datalist> menu item

### DIFF
--- a/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
@@ -464,7 +464,22 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     [self _updateTextSuggestions];
 
-    if (![UIKeyboard isInHardwareKeyboardMode] && !(activationType == WebCore::DataListSuggestionActivationType::IndicatorClicked || activationType == WebCore::DataListSuggestionActivationType::DataListMayHaveChanged))
+    bool shouldShowOrUpdateSugggestions = [&] {
+#if USE(UICONTEXTMENU)
+        if (_suggestionsContextMenuPresenter)
+            return true;
+#endif
+
+        if ([UIKeyboard isInHardwareKeyboardMode])
+            return true;
+
+        if (activationType == WebCore::DataListSuggestionActivationType::IndicatorClicked || activationType == WebCore::DataListSuggestionActivationType::DataListMayHaveChanged)
+            return true;
+
+        return false;
+    }();
+
+    if (!shouldShowOrUpdateSugggestions)
         return;
 
     [self _showSuggestions];


### PR DESCRIPTION
#### 15238f5b3939caeecf4f8107c21e40ed7881b70f
<pre>
[iOS] Crash when selecting &lt;datalist&gt; menu item
<a href="https://bugs.webkit.org/show_bug.cgi?id=275826">https://bugs.webkit.org/show_bug.cgi?id=275826</a>
<a href="https://rdar.apple.com/130285494">rdar://130285494</a>

Reviewed by Richard Robinson and Tim Horton.

Crash data shows occassional crashes when tapping on a menu item that is part
of a &lt;datalist&gt; menu. The crash is a RELEASE_ASSERT due to attempted out of
bounds access into the suggestions array.

In general, the displayed menu is meant to mirror the suggestions array. The
crash implies that the suggestions array has been updated independently of the
menu.

From auditing the code there is currently one known area where the menu update
is may be elided when suggestions are updated.

Suggestion updates happen via `-[WKDataListSuggestionsDropdown updateWithInformation:]`.
That method calls `-[WKDataListSuggestionsDropdown _displayWithActivationType:]`.
When using a software keyboard, and the update is due to tapping on the input
or changing the text, menu presentation is elided. This logic exists so that
interacting with an &lt;input&gt; that has a &lt;datalist&gt; does not dismiss the keyboard
and present the menu. When using a software keyboard, the menu should only be
presented when tapping on the indicator.

However, as a speculative fix for the crash, if the menu is already presented,
simply update it.

* Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm:
(-[WKDataListSuggestionsDropdown _displayWithActivationType:]):

Canonical link: <a href="https://commits.webkit.org/280340@main">https://commits.webkit.org/280340@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c54d894cf340bb5b983ea6bdc82a26d7f41df037

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56268 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59874 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6704 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6898 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45557 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4662 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58297 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33480 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48545 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26433 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30259 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5708 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52268 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6147 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61557 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/176 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6274 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52836 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/176 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52713 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12474 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/157 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31421 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32507 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33590 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32254 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->