### PR TITLE
Drop StreamConnectionBuffer::data() in favor of span()

### DIFF
--- a/Source/WebKit/Platform/IPC/StreamClientConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamClientConnectionBuffer.h
@@ -43,7 +43,7 @@ public:
     enum class WakeUpServer : bool { No, Yes };
     WakeUpServer release(size_t writeSize);
     void resetClientOffset();
-    std::span<uint8_t> alignedSpan(size_t offset, size_t limit);
+    std::span<uint8_t> alignedMutableSpan(size_t offset, size_t limit);
     void setSemaphores(IPC::Semaphore&& wakeUp, IPC::Semaphore&& clientWait);
     bool hasSemaphores() const { return m_semaphores.has_value(); }
     void wakeUpServer();
@@ -53,7 +53,7 @@ private:
     static constexpr size_t messageAlignment = StreamConnectionEncoder::messageAlignment;
     explicit StreamClientConnectionBuffer(Ref<WebCore::SharedMemory>);
 
-    size_t size(size_t offset, size_t limit);
+    size_t size(size_t offset, size_t limit) const;
     size_t alignOffset(size_t offset) const { return StreamConnectionBuffer::alignOffset<messageAlignment>(offset, minimumMessageSize); }
     Atomic<ClientOffset>& sharedClientOffset() { return clientOffset(); }
     using ClientLimit = ServerOffset;
@@ -107,7 +107,7 @@ inline std::optional<std::span<uint8_t>> StreamClientConnectionBuffer::tryAcquir
 
     for (;;) {
         if (clientLimit != ClientLimit::clientIsWaitingTag) {
-            auto result = alignedSpan(m_clientOffset, toLimit(clientLimit));
+            auto result = alignedMutableSpan(m_clientOffset, toLimit(clientLimit));
             if (result.size() >= minimumMessageSize)
                 return result;
         }
@@ -120,7 +120,7 @@ inline std::optional<std::span<uint8_t>> StreamClientConnectionBuffer::tryAcquir
             clientLimit = sharedClientLimit().load(std::memory_order_acquire);
         } else
             clientLimit = oldClientLimit;
-        // The alignedSpan uses the minimumMessageSize to calculate the next beginning position in the buffer,
+        // The alignedMutableSpan uses the minimumMessageSize to calculate the next beginning position in the buffer,
         // and not the size. The size might be more or less what is needed, depending on where the reader is.
         // If there is no capacity for minimum message size, wait until more is available.
         // In the case where clientOffset < clientLimit we can arrive to a situation where
@@ -155,7 +155,7 @@ inline std::optional<std::span<uint8_t>> StreamClientConnectionBuffer::tryAcquir
     // In case the transaction was cancelled, undo the transaction marker.
     sharedClientLimit().store(static_cast<ClientLimit>(0), std::memory_order_release);
     m_clientOffset = 0;
-    return alignedSpan(m_clientOffset, 0);
+    return alignedMutableSpan(m_clientOffset, 0);
 }
 
 inline StreamClientConnectionBuffer::WakeUpServer StreamClientConnectionBuffer::release(size_t size)
@@ -177,7 +177,7 @@ inline void StreamClientConnectionBuffer::resetClientOffset()
     m_clientOffset = 0;
 }
 
-inline std::span<uint8_t> StreamClientConnectionBuffer::alignedSpan(size_t offset, size_t limit)
+inline std::span<uint8_t> StreamClientConnectionBuffer::alignedMutableSpan(size_t offset, size_t limit)
 {
     ASSERT(offset < dataSize());
     ASSERT(limit < dataSize());
@@ -190,10 +190,10 @@ inline std::span<uint8_t> StreamClientConnectionBuffer::alignedSpan(size_t offse
         if (aligned >= offset || aligned < limit)
             resultSize = size(aligned, limit);
     }
-    return { data() + aligned, resultSize };
+    return mutableSpan().subspan(aligned, resultSize);
 }
 
-inline size_t StreamClientConnectionBuffer::size(size_t offset, size_t limit)
+inline size_t StreamClientConnectionBuffer::size(size_t offset, size_t limit) const
 {
     if (!limit)
         return dataSize() - 1 - offset;

--- a/Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp
+++ b/Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp
@@ -53,9 +53,4 @@ std::span<uint8_t> StreamConnectionBuffer::headerForTesting()
     return m_sharedMemory->mutableSpan().first(headerSize());
 }
 
-std::span<uint8_t> StreamConnectionBuffer::dataForTesting()
-{
-    return { data(), m_sharedMemory->size() - headerSize() };
-}
-
 }

--- a/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
+++ b/Source/WebKit/Platform/IPC/StreamConnectionBuffer.h
@@ -110,13 +110,14 @@ public:
 
     Atomic<ClientOffset>& clientOffset() { return header().clientOffset; }
     Atomic<ServerOffset>& serverOffset() { return header().serverOffset; }
-    uint8_t* data() const { return m_sharedMemory->mutableSpan().subspan(headerSize()).data(); }
+    std::span<const uint8_t> span() const { return m_sharedMemory->mutableSpan().subspan(headerSize()); }
+    std::span<uint8_t> mutableSpan() { return m_sharedMemory->mutableSpan().subspan(headerSize()); }
     size_t dataSize() const { return m_dataSize; }
 
     static constexpr size_t maximumSize() { return std::min(static_cast<size_t>(ClientOffset::serverIsSleepingTag), static_cast<size_t>(ClientOffset::serverIsSleepingTag)) - 1; }
 
     std::span<uint8_t> headerForTesting();
-    std::span<uint8_t> dataForTesting();
+    std::span<uint8_t> dataForTesting() { return mutableSpan(); }
 
     static constexpr bool sharedMemorySizeIsValid(size_t size) { return headerSize() < size && size <= headerSize() + maximumSize(); }
 

--- a/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionBufferTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/StreamConnectionBufferTests.cpp
@@ -36,7 +36,7 @@ TEST(StreamConnectionBufferTests, CreateWorks)
     auto buffer = IPC::StreamClientConnectionBuffer::create(8);
     ASSERT_TRUE(buffer.has_value());
     auto& b = *buffer;
-    EXPECT_NE(b.data(), nullptr);
+    EXPECT_NE(b.span().data(), nullptr);
     EXPECT_EQ(b.dataSize(), 256u);
     {
         auto server = IPC::StreamServerConnectionBuffer::map(b.createHandle());
@@ -46,7 +46,7 @@ TEST(StreamConnectionBufferTests, CreateWorks)
     auto buffer2 = IPC::StreamClientConnectionBuffer::create(24);
     ASSERT_TRUE(buffer2.has_value());
     auto& b2 = *buffer2;
-    EXPECT_NE(b2.data(), nullptr);
+    EXPECT_NE(b2.span().data(), nullptr);
     EXPECT_EQ(b2.dataSize(), 16777216u);
     {
         auto server = IPC::StreamServerConnectionBuffer::map(b2.createHandle());


### PR DESCRIPTION
#### 0941de69a7b9ddd103e8e7765d65b09bf2938801
<pre>
Drop StreamConnectionBuffer::data() in favor of span()
<a href="https://bugs.webkit.org/show_bug.cgi?id=275834">https://bugs.webkit.org/show_bug.cgi?id=275834</a>

Reviewed by Kimmo Kinnunen.

* Source/WebKit/Platform/IPC/StreamClientConnectionBuffer.h:
(IPC::StreamClientConnectionBuffer::tryAcquire):
(IPC::StreamClientConnectionBuffer::tryAcquireAll):
(IPC::StreamClientConnectionBuffer::alignedMutableSpan):
(IPC::StreamClientConnectionBuffer::size const):
(IPC::StreamClientConnectionBuffer::alignedSpan): Deleted.
(IPC::StreamClientConnectionBuffer::size): Deleted.
* Source/WebKit/Platform/IPC/StreamConnectionBuffer.cpp:
(IPC::StreamConnectionBuffer::dataForTesting): Deleted.
* Source/WebKit/Platform/IPC/StreamConnectionBuffer.h:
(IPC::StreamConnectionBuffer::span const):
(IPC::StreamConnectionBuffer::mutableSpan):
(IPC::StreamConnectionBuffer::dataForTesting):
(IPC::StreamConnectionBuffer::data const): Deleted.
* Source/WebKit/Platform/IPC/StreamServerConnectionBuffer.h:
(IPC::StreamServerConnectionBuffer::tryAcquire):
(IPC::StreamServerConnectionBuffer::acquireAll):
(IPC::StreamServerConnectionBuffer::alignedMutableSpan):
(IPC::StreamServerConnectionBuffer::size const):
(IPC::StreamServerConnectionBuffer::alignedSpan): Deleted.
(IPC::StreamServerConnectionBuffer::size): Deleted.
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionBufferTests.cpp:
(TestWebKitAPI::TEST(StreamConnectionBufferTests, CreateWorks)):

Canonical link: <a href="https://commits.webkit.org/280351@main">https://commits.webkit.org/280351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1872ed8c56522cb563ee885938e8e07b4e4a0848

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56284 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59891 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6720 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58410 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43232 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6914 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45573 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4677 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48561 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26447 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30273 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5891 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5724 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52278 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6163 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61574 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/192 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6290 "Found 1 new test failure: workers/wasm-hashset-many.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52849 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/192 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48627 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52727 "Found 1 new API test failure: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/select-all/non-editable (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/172 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8373 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31437 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32523 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33606 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32270 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->