### PR TITLE
Use smart pointers when accessing FrameView in RenderView

### DIFF
--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -383,7 +383,8 @@ RenderWidget::ChildWidgetState RenderWidget::updateWidgetPosition()
 
 IntRect RenderWidget::windowClipRect() const
 {
-    return intersection(view().frameView().contentsToWindow(m_clipRect), view().frameView().windowClipRect());
+    Ref frameView = view().frameView();
+    return intersection(frameView->contentsToWindow(m_clipRect), frameView->windowClipRect());
 }
 
 void RenderWidget::setSelectionState(HighlightState state)
@@ -469,7 +470,7 @@ RenderBox* RenderWidget::embeddedContentBox() const
 {
     if (!is<RenderEmbeddedObject>(this))
         return nullptr;
-    auto* frameView = dynamicDowncast<LocalFrameView>(widget());
+    RefPtr frameView = dynamicDowncast<LocalFrameView>(widget());
     return frameView ? frameView->embeddedContentBox() : nullptr;
 }
 


### PR DESCRIPTION
#### 727b904797aef856aedb8800c6d583ecdaa6e1f4
<pre>
Use smart pointers when accessing FrameView in RenderView
<a href="https://bugs.webkit.org/show_bug.cgi?id=275848">https://bugs.webkit.org/show_bug.cgi?id=275848</a>

Reviewed by Ryosuke Niwa.

Use smart pointers when accessing FrameView based
on [alpha.webkit.UncountedCallArgsChecker] and
[alpha.webkit.NoUncountedMemberChecker] warnings.

* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::styleDidChange):
(WebCore::RenderView::availableLogicalHeight const):
(WebCore::RenderView::pageOrViewLogicalHeight const):
(WebCore::RenderView::clientLogicalWidthForFixedPosition const):
(WebCore::RenderView::clientLogicalHeightForFixedPosition const):
(WebCore::RenderView::mapLocalToContainer const):
(WebCore::RenderView::pushMappingToContainer const):
(WebCore::RenderView::mapAbsoluteToLocalPoint const):
(WebCore::RenderView::requiresColumns const):
(WebCore::RenderView::computeColumnCountAndWidth):
(WebCore::RenderView::paint):
(WebCore::RenderView::paintBoxDecorations):
(WebCore::RenderView::repaintViewRectangle const):
(WebCore::RenderView::flushAccumulatedRepaintRegion const):
(WebCore::RenderView::computeVisibleRectsInContainer const):
(WebCore::RenderView::isScrollableOrRubberbandableBox const):
(WebCore::RenderView::shouldUsePrintingLayout const):
(WebCore::RenderView::viewRect const):
(WebCore::RenderView::backgroundRect const):
(WebCore::RenderView::viewHeight const):
(WebCore::RenderView::viewWidth const):
(WebCore::RenderView::zoomFactor const):
(WebCore::RenderView::sizeForCSSSmallViewportUnits const):
(WebCore::RenderView::sizeForCSSLargeViewportUnits const):
(WebCore::RenderView::sizeForCSSDynamicViewportUnits const):
(WebCore::RenderView::sizeForCSSDefaultViewportUnits const):
* Source/WebCore/rendering/RenderWidget.cpp:
(WebCore::RenderWidget::windowClipRect const):
(WebCore::RenderWidget::embeddedContentBox const):

Canonical link: <a href="https://commits.webkit.org/282975@main">https://commits.webkit.org/282975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/495aea9208fb7db8dd9731cc3f71075c97e43309

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/62144 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/41498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/14736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/66124 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/12689 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/64263 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/49184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/13029 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/50079 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/8779 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/65213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/38542 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/53823 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/30884 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/35214 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/11085 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/11620 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/56954 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/11390 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/67853 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/6087 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/11158 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/57458 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/6113 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/53796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/57683 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/14298 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/5022 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/37298 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/38382 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/39478 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/38127 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->