### PR TITLE
[WGSL] Struct offset can overflow

### DIFF
--- a/Source/WebGPU/WGSL/AttributeValidator.cpp
+++ b/Source/WebGPU/WGSL/AttributeValidator.cpp
@@ -305,7 +305,14 @@ void AttributeValidator::visit(AST::Structure& structure)
         }
 
         unsigned currentSize = UNLIKELY(size.hasOverflowed()) ? std::numeric_limits<unsigned>::max() : size.value();
-        unsigned offset = UNLIKELY(size.hasOverflowed()) ? currentSize : WTF::roundUpToMultipleOf(*fieldAlignment, currentSize);
+        unsigned offset;
+        if (UNLIKELY(size.hasOverflowed()))
+            offset = currentSize;
+        else {
+            CheckedUint32 checkedOffset = WTF::roundUpToMultipleOf(*fieldAlignment, static_cast<uint64_t>(currentSize));
+            offset = UNLIKELY(checkedOffset.hasOverflowed()) ? std::numeric_limits<unsigned>::max() : checkedOffset.value();
+        }
+
         member.m_offset = offset;
 
         alignment = std::max(alignment, *fieldAlignment);

--- a/Source/WebGPU/WGSL/tests/valid/struct.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/struct.wgsl
@@ -5,7 +5,13 @@ struct S {
     @align(16) y: i32,
 }
 
-struct T{ x:array<i32,4294063007u> }
+struct T { x:array<i32,4294063007u> }
+
+struct U {
+    w: array< array<f32,1-2*4u>, 15095094>,
+    ram_shadow: u32,
+    o: u32,
+}
 
 fn testStructConstructor() -> i32
 {


### PR DESCRIPTION
#### 2b4f5ef73598b70e32abd9def228f9d9f25462aa
<pre>
[WGSL] Struct offset can overflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=275850">https://bugs.webkit.org/show_bug.cgi?id=275850</a>
<a href="https://rdar.apple.com/130092379">rdar://130092379</a>

Reviewed by Mike Wyrzykowski.

We fixed a similar issue with the struct size overflowing in 279809@main, but I missed
that the same could happen to the offset. The issue was that all the operations were
already using Checked types, except rounding up the offset to the required alignment,
which is where the overflow happened.

* Source/WebGPU/WGSL/AttributeValidator.cpp:
(WGSL::AttributeValidator::visit):
* Source/WebGPU/WGSL/tests/valid/struct.wgsl:

Canonical link: <a href="https://commits.webkit.org/280370@main">https://commits.webkit.org/280370@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a0d49f27d06d62a910c208524d1fc2d562d8ad9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59930 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6759 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43271 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6953 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45618 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4713 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33529 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48596 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26484 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30308 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5763 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52308 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6198 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61614 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/231 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6324 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/dedicated-worker/mediasource-worker-detach-element.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52883 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/231 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48662 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52767 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12492 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/208 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31476 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32562 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33645 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32309 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->