### PR TITLE
[WGSL] Compound assignments incorrectly (un)pack the assignee

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -62,6 +62,7 @@ public:
     void visit(AST::AssignmentStatement&) override;
     void visit(AST::VariableStatement&) override;
     void visit(AST::PhonyAssignmentStatement&) override;
+    void visit(AST::CompoundAssignmentStatement&) override;
 
     void visit(AST::Expression&) override;
 
@@ -361,6 +362,13 @@ void RewriteGlobalVariables::visit(AST::CompoundStatement& statement)
         m_shaderModule.insert(statement.statements(), insertion.index + offset, AST::Statement::Ref(*insertion.statement));
         ++offset;
     }
+}
+
+void RewriteGlobalVariables::visit(AST::CompoundAssignmentStatement& statement)
+{
+    Packing lhsPacking = pack(Packing::Either, statement.leftExpression());
+    ASSERT(lhsPacking != Packing::Either);
+    pack(lhsPacking, statement.rightExpression());
 }
 
 void RewriteGlobalVariables::visit(AST::AssignmentStatement& statement)

--- a/Source/WebGPU/WGSL/tests/valid/fuzz-130082002.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/fuzz-130082002.wgsl
@@ -1,0 +1,8 @@
+// RUN: %metal-compile main
+
+@group(0) @binding(0) var<storage, read_write> b: vec3f;
+
+@compute @workgroup_size(1)
+fn main() {
+  b += vec3();
+}


### PR DESCRIPTION
#### c49e508c6e3f5fc1f557e88df625c6e2d23af986
<pre>
[WGSL] Compound assignments incorrectly (un)pack the assignee
<a href="https://bugs.webkit.org/show_bug.cgi?id=275855">https://bugs.webkit.org/show_bug.cgi?id=275855</a>
<a href="https://rdar.apple.com/130082002">rdar://130082002</a>

Reviewed by Mike Wyrzykowski.

The default behavior in the global rewriter is that all expressions get unpack,
any exceptions need to be handled manually, as we do for assignments. However,
the rewriter was missing an entry for compound assignments (e.g. x += y).

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::visit):
* Source/WebGPU/WGSL/tests/valid/fuzz-130082002.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/280371@main">https://commits.webkit.org/280371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a40675c8843ad48de5f3ad05c9bb135da91b5c10

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56331 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59938 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6767 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43279 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6961 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45627 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4719 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58360 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48604 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26490 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30316 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5771 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52316 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6206 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61622 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/239 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6330 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52889 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/239 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48670 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52773 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12493 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/217 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31484 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32570 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33653 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32317 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->