### PR TITLE
MediaStreamTrackPrivate::clone should use toDataHolder

### DIFF
--- a/LayoutTests/fast/mediastream/clone-track-in-worker-expected.txt
+++ b/LayoutTests/fast/mediastream/clone-track-in-worker-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Get deviceId on worker cloned track
+

--- a/LayoutTests/fast/mediastream/clone-track-in-worker.html
+++ b/LayoutTests/fast/mediastream/clone-track-in-worker.html
@@ -1,0 +1,36 @@
+<html>
+<body>
+<script src="../../resources/gc.js"></script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+promise_test(async test => {
+    const worker = new Worker(URL.createObjectURL(new Blob([`
+        self.onmessage = e => {
+            self.onmessage = null;
+
+            const track = e.data;
+            const clone = track.clone();
+            const deviceId = clone.getSettings().deviceId;
+
+            [][deviceId];  // Atomize it.
+
+            self.deviceId = deviceId;
+            self.postMessage("PASS");
+        };
+    `])));
+
+    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+
+    const track = stream.getAudioTracks()[0];
+    worker.postMessage(track, [track]);
+
+    assert_equals(await new Promise(resolve => worker.onmessage = e => resolve(e.data)), "PASS");
+
+    worker.terminate();
+
+    gc();
+}, "Get deviceId on worker cloned track");
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
@@ -157,7 +157,8 @@ public:
     void initializeSettings(RealtimeMediaSourceSettings&& settings) { m_settings = WTFMove(settings); }
     void initializeCapabilities(RealtimeMediaSourceCapabilities&& capabilities) { m_capabilities = WTFMove(capabilities); }
 
-    UniqueRef<MediaStreamTrackDataHolder> toDataHolder();
+    enum class ShouldClone : bool { No, Yes };
+    UniqueRef<MediaStreamTrackDataHolder> toDataHolder(ShouldClone = ShouldClone::No);
 
 private:
     MediaStreamTrackPrivate(Ref<const Logger>&&, Ref<RealtimeMediaSource>&&, String&& id, std::function<void(Function<void()>&&)>&&);


### PR DESCRIPTION
#### ff1c06111b4475d741a31938f0c2cb9f792b66e9
<pre>
MediaStreamTrackPrivate::clone should use toDataHolder
<a href="https://bugs.webkit.org/show_bug.cgi?id=275841">https://bugs.webkit.org/show_bug.cgi?id=275841</a>
<a href="https://rdar.apple.com/130262516">rdar://130262516</a>

Reviewed by Eric Carlson.

* LayoutTests/fast/mediastream/clone-track-in-worker-expected.txt: Added.
* LayoutTests/fast/mediastream/clone-track-in-worker.html: Added.
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp:
(WebCore::MediaStreamTrackPrivate::clone):
(WebCore::MediaStreamTrackPrivate::toDataHolder):
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h:

Canonical link: <a href="https://commits.webkit.org/280350@main">https://commits.webkit.org/280350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba62923bfe5f4da58f5e42867cb2c36662382ba1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35688 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59969 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6798 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58488 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43310 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45651 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4745 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33565 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48632 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26515 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30345 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5962 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5802 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52336 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61653 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/270 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6356 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52914 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/270 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48698 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52797 "Found 1 new API test failure: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/cut-copy-paste/non-editable (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/244 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8372 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31515 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32601 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33684 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32348 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->