### PR TITLE
MarginTrim Remove Duplicate Stack Layers

### DIFF
--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -587,8 +587,17 @@ void LocalFrameViewLayoutContext::pushLayoutState(RenderElement& root)
 
 bool LocalFrameViewLayoutContext::pushLayoutState(RenderBox& renderer, const LayoutSize& offset, LayoutUnit pageHeight, bool pageHeightChanged)
 {
+    if (renderer.element()) {
+        WTF_ALWAYS_LOG("pushLayoutState: " << renderer.element());
+    }
+    
     // We push LayoutState even if layoutState is disabled because it stores layoutDelta too.
     auto* layoutState = this->layoutState();
+    
+    if (layoutState)
+        WTF_ALWAYS_LOG("layoutState->blockStartTrimming() " << layoutState->blockStartTrimming());
+    
+    
     if (!layoutState || !needsFullRepaint() || layoutState->isPaginated() || renderer.enclosingFragmentedFlow()
         || layoutState->lineGrid() || (renderer.style().lineGrid() != RenderStyle::initialLineGrid() && renderer.isRenderBlockFlow())) {
         m_layoutStateStack.append(makeUnique<RenderLayoutState>(m_layoutStateStack
@@ -596,6 +605,7 @@ bool LocalFrameViewLayoutContext::pushLayoutState(RenderBox& renderer, const Lay
             , offset
             , pageHeight
             , pageHeightChanged
+            , layoutState ? layoutState->blockStartTrimming() : false
             , layoutState ? layoutState->lineClamp() : std::nullopt
             , layoutState ? layoutState->textBoxTrim() : RenderLayoutState::TextBoxTrim()));
         return true;

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2949,6 +2949,8 @@ bool RenderBlock::updateFragmentRangeForBoxChild(const RenderBox& box) const
 
 void RenderBlock::setTrimmedMarginForChild(RenderBox &child, MarginTrimType marginTrimType)
 {
+    WTF_ALWAYS_LOG("setTrimmedMarginForChild: " << child.m_node << " " << marginTrimType);
+    
     switch (marginTrimType) {
     case MarginTrimType::BlockStart:
         setMarginBeforeForChild(child, 0_lu);

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -288,6 +288,7 @@ public:
 
     void removeFloatingObjects();
     void markAllDescendantsWithFloatsForLayout(RenderBox* floatToRemove = nullptr, bool inLayout = true);
+    void markAllDecendantsWithMarginTrim(RenderBox* box = nullptr);
     void markSiblingsWithFloatsForLayout(RenderBox* floatToRemove = nullptr);
 
     const FloatingObjectSet* floatingObjectSet() const { return m_floatingObjects ? &m_floatingObjects->set() : nullptr; }

--- a/Source/WebCore/rendering/RenderLayoutState.cpp
+++ b/Source/WebCore/rendering/RenderLayoutState.cpp
@@ -45,7 +45,7 @@ RenderLayoutState::RenderLayoutState(RenderElement& renderer)
 #if ASSERT_ENABLED
     , m_layoutDeltaXSaturated(false)
     , m_layoutDeltaYSaturated(false)
-    , m_blockStartTrimming(Vector<bool>(0))
+    , m_blockStartTrimming(false)
     , m_renderer(&renderer)
 #endif
 {
@@ -66,7 +66,7 @@ RenderLayoutState::RenderLayoutState(RenderElement& renderer)
     }
 }
 
-RenderLayoutState::RenderLayoutState(const LocalFrameViewLayoutContext::LayoutStateStack& layoutStateStack, RenderBox& renderer, const LayoutSize& offset, LayoutUnit pageLogicalHeight, bool pageLogicalHeightChanged, std::optional<LineClamp> lineClamp, std::optional<TextBoxTrim> textBoxTrim)
+RenderLayoutState::RenderLayoutState(const LocalFrameViewLayoutContext::LayoutStateStack& layoutStateStack, RenderBox& renderer, const LayoutSize& offset, LayoutUnit pageLogicalHeight, bool pageLogicalHeightChanged, bool blockStartTrimming, std::optional<LineClamp> lineClamp, std::optional<TextBoxTrim> textBoxTrim)
     : m_clipped(false)
     , m_isPaginated(false)
     , m_pageLogicalHeightChanged(false)
@@ -74,7 +74,7 @@ RenderLayoutState::RenderLayoutState(const LocalFrameViewLayoutContext::LayoutSt
     , m_layoutDeltaXSaturated(false)
     , m_layoutDeltaYSaturated(false)
 #endif
-    , m_blockStartTrimming(Vector<bool>(0))
+    , m_blockStartTrimming(blockStartTrimming)
     , m_lineClamp(lineClamp)
     , m_textBoxTrim(textBoxTrim)
 #if ASSERT_ENABLED

--- a/Source/WebCore/rendering/RenderLayoutState.h
+++ b/Source/WebCore/rendering/RenderLayoutState.h
@@ -62,10 +62,10 @@ public:
         , m_layoutDeltaXSaturated(false)
         , m_layoutDeltaYSaturated(false)
 #endif
-        , m_blockStartTrimming(Vector<bool>(0))
+        , m_blockStartTrimming(false)
     {
     }
-    RenderLayoutState(const LocalFrameViewLayoutContext::LayoutStateStack&, RenderBox&, const LayoutSize& offset, LayoutUnit pageHeight, bool pageHeightChanged, std::optional<LineClamp>, std::optional<TextBoxTrim>);
+    RenderLayoutState(const LocalFrameViewLayoutContext::LayoutStateStack&, RenderBox&, const LayoutSize& offset, LayoutUnit pageHeight, bool pageHeightChanged, bool blockStartTrimming, std::optional<LineClamp>, std::optional<TextBoxTrim>);
     explicit RenderLayoutState(RenderElement&);
 
     bool isPaginated() const { return m_isPaginated; }
@@ -113,12 +113,8 @@ public:
     void addTextBoxTrimEnd(const RenderBlockFlow& targetInlineFormattingContext);
     void resetTextBoxTrim() { m_textBoxTrim = { }; }
 
-    void pushBlockStartTrimming(bool blockStartTrimming) { m_blockStartTrimming.append(blockStartTrimming); }
-    std::optional<bool> blockStartTrimming() const { return m_blockStartTrimming.isEmpty() ? std::nullopt : std::optional(m_blockStartTrimming.last()); }
-    void popBlockStartTrimming() 
-    {
-        m_blockStartTrimming.removeLast(); 
-    }
+    void setBlockStartTrimming(bool blockStartTrimming) { m_blockStartTrimming = blockStartTrimming; }
+    bool blockStartTrimming() const { return m_blockStartTrimming; }
 
 private:
     void computeOffsets(const RenderLayoutState& ancestor, RenderBox&, LayoutSize offset);
@@ -138,7 +134,7 @@ private:
     bool m_layoutDeltaXSaturated : 1;
     bool m_layoutDeltaYSaturated : 1;
 #endif
-    Vector<bool> m_blockStartTrimming;
+    bool m_blockStartTrimming;
 
     // The current line grid that we're snapping to and the offset of the start of the grid.
     SingleThreadWeakPtr<RenderBlockFlow> m_lineGrid;

--- a/Tools/MiniBrowser/MiniBrowser.xcodeproj/xcshareddata/xcschemes/MiniBrowser.xcscheme
+++ b/Tools/MiniBrowser/MiniBrowser.xcodeproj/xcshareddata/xcschemes/MiniBrowser.xcscheme
@@ -50,6 +50,13 @@
             ReferencedContainer = "container:MiniBrowser.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "IDEPreferLogStreaming"
+            value = "Yes"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
#### 17854d3ebb861c89a123c4687e67b6ce7952b4ce
<pre>
MarginTrim Remove Duplicate Stack Layers
<a href="https://bugs.webkit.org/show_bug.cgi?id=275869">https://bugs.webkit.org/show_bug.cgi?id=275869</a>

Reviewed by NOBODY (OOPS!).

In draft status...

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::pushLayoutState):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::setTrimmedMarginForChild):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutBlock):
(WebCore::RenderBlockFlow::layoutInFlowChildren):
(WebCore::RenderBlockFlow::layoutBlockChildren):
(WebCore::RenderBlockFlow::markAllDecendantsWithMarginTrim):
(WebCore::RenderBlockFlow::layoutBlockChild):
(WebCore::RenderBlockFlow::collapseMarginsWithChildInfo):
(WebCore::RenderBlockFlow::styleDidChange):
* Source/WebCore/rendering/RenderBlockFlow.h:
* Source/WebCore/rendering/RenderLayoutState.cpp:
(WebCore::RenderLayoutState::RenderLayoutState):
* Source/WebCore/rendering/RenderLayoutState.h:
(WebCore::RenderLayoutState::RenderLayoutState):
(WebCore::RenderLayoutState::setBlockStartTrimming):
(WebCore::RenderLayoutState::blockStartTrimming const):
(WebCore::RenderLayoutState::pushBlockStartTrimming): Deleted.
(WebCore::RenderLayoutState::popBlockStartTrimming): Deleted.
* Tools/MiniBrowser/MiniBrowser.xcodeproj/xcshareddata/xcschemes/MiniBrowser.xcscheme:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17854d3ebb861c89a123c4687e67b6ce7952b4ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56368 "13 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35694 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59975 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6804 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/6998 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45660 "31 flakes 105 failures") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4750 "Found 17 new test failures: css3/calc/simple-calcs-prefixed.html css3/calc/simple-calcs.html editing/execCommand/delete-non-editable-range-crash.html editing/selection/move-by-character-brute-force.html fast/rendering/glyph-display-list-cache-crash.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-writing-modes-001.html jquery/attributes.html jquery/core.html jquery/event.html jquery/manipulation.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58397 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33569 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48639 "Found 1091 new API test failures: TestWebKitAPI.ProcessSwap.LockdownModeEnabledByDefaultThenOptOut, TestWebKitAPI.WebKit.CreateNewPageDelegateFrameLoadState, TestWebKitAPI.WebPushDTest.UnsubscribesOnPermissionReset, TestWebKitAPI.ProcessSwap.NavigatingCrossOriginFromCOOPSameOrigin, TestWebKitAPI.ProcessSwap.NoProcessSwapDueToRelatedView, TestWebKitAPI.ProcessSwap.MouseEventDuringCrossSiteProvisionalNavigation, TestWebKitAPI.ImmediateActionTests.ImmediateActionOverImageOverlay, TestWebKitAPI.SiteIsolation.DrawAfterNavigateToDomainAgain, TestWebKitAPI.TextManipulation.CompleteTextManipulationForNewlyDisplayedText, TestWebKitAPI.WebPushDPushNotificationEventTest.Basic ... (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26523 "Found 5 new API test failures: /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme, /WPE/TestWebKitWebView:/webkit/WebKitWebView/is-playing-audio, /WPE/TestBackForwardList:/webkit/BackForwardList/list-limit-and-cache, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-style-sheet (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30349 "4 new passes 14 flakes 23 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5969 "layout-tests (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5808 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52340 "Found 657 new API test failures: TestWebKitAPI.KeyboardInputTests.HasTextAfterFocusingTextField, TestWebKitAPI.ProcessSwap.NavigatingCrossOriginFromCOOPSameOrigin, TestWebKitAPI.IndexedDB.IndexedDBMultiProcess, TestWebKitAPI.WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGesturePushStateAfterEvaluateJS, TestWebKitAPI.ImageAnalysisTests.PerformRemoveBackground, TestWebKitAPI.ApplicationManifest.Basic, TestWebKitAPI.WKUserContentController.UserStyleSheetAffectingOnlySpecificWebViewSharedConfiguration, TestWebKitAPI.TextStyleFontSize.AfterCrash, TestWebKitAPI.URLSchemeHandler.Exceptions, TestWebKitAPI.NowPlayingMetadataObserver.VideoTitleUpdatedByMediaSession ... (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6241 "layout-tests (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61659 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/276 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6361 "layout-tests (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52919 "42 flakes 97 failures") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/276 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48705 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52802 "Found 7 new API test failures: /WebKitGTK/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/injected-style-sheet, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/custom-container-destroyed, /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/default, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/content-type, /WebKitGTK/TestBackForwardList:/webkit/BackForwardList/list-limit-and-cache, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/249 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31521 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32607 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33690 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32354 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->