### PR TITLE
[Webpage Translation] Text fields are incorrectly translated after invoking AutoFill

### DIFF
--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -260,6 +260,8 @@ private:
 
 static bool shouldExtractValueForTextManipulation(const HTMLInputElement& input)
 {
+    // FIXME: Consider using `type()` instead of checking the attribute, so that plain text fields
+    // with and without an explicit `type="text"` behave consistently.
     if (input.isSearchField() || equalIgnoringASCIICase(input.attributeWithoutSynchronization(HTMLNames::typeAttr), InputTypeNames::text()))
         return !input.lastChangeWasUserEdit();
 
@@ -358,6 +360,15 @@ static bool isEnclosingItemBoundaryElement(const Element& element)
         return true;
 
     return false;
+}
+
+static bool shouldIgnoreNodeInTextField(const Node& node)
+{
+    RefPtr input = dynamicDowncast<HTMLInputElement>(node.shadowHost());
+    if (!input)
+        return false;
+
+    return input->lastChangeWasUserEdit() || input->isAutoFilled();
 }
 
 TextManipulationController::ManipulationUnit TextManipulationController::createUnit(const Vector<String>& text, Node& textNode)
@@ -590,13 +601,18 @@ void TextManipulationController::scheduleObservationUpdate()
         for (auto& text : controller->m_manipulatedNodesWithNewContent) {
             if (!controller->m_manipulatedNodes.contains(text))
                 continue;
+            if (shouldIgnoreNodeInTextField(text))
+                continue;
             controller->m_manipulatedNodes.remove(text);
             nodesToObserve.add(text);
         }
         controller->m_manipulatedNodesWithNewContent.clear();
 
-        for (auto& node : controller->m_addedOrNewlyRenderedNodes)
+        for (auto& node : controller->m_addedOrNewlyRenderedNodes) {
+            if (shouldIgnoreNodeInTextField(node))
+                continue;
             nodesToObserve.add(node);
+        }
         controller->m_addedOrNewlyRenderedNodes.clear();
 
         if (nodesToObserve.isEmpty())
@@ -805,6 +821,9 @@ auto TextManipulationController::replace(const ManipulationItemData& item, const
         m_manipulatedNodes.add(*element);
         return std::nullopt;
     }
+
+    if (RefPtr container = item.start.containerNode(); container && shouldIgnoreNodeInTextField(*container))
+        return ManipulationFailure::Type::ContentChanged;
 
     size_t currentTokenIndex = 0;
     HashMap<TextManipulationTokenIdentifier, TokenExchangeData> tokenExchangeMap;


### PR DESCRIPTION
#### 5387029f37335aefb7c6a2fa4fec42b58a0f1aef
<pre>
[Webpage Translation] Text fields are incorrectly translated after invoking AutoFill
<a href="https://bugs.webkit.org/show_bug.cgi?id=275878">https://bugs.webkit.org/show_bug.cgi?id=275878</a>
<a href="https://rdar.apple.com/130413693">rdar://130413693</a>

Reviewed by Abrar Rahman Protyasha.

Make a couple of minor adjustments to avoid extracting text within text fields, in the case where
the user has inserted text in those fields via AutoFill. See below for more details.

Test: TextManipulation.CompleteTextManipulationDoesNotFillAutoFilledField

* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::shouldExtractValueForTextManipulation):

Add a FIXME regarding how we directly check against for `type=&apos;text&apos;` instead of using the effective
`type()`.

(WebCore::shouldIgnoreNodeInTextField):

Add a helper function to check whether a node is inside of an AutoFilled or user-edited text field,
and deploy it in several places below.

(WebCore::TextManipulationController::scheduleObservationUpdate):

Check whether the node should be ignored, before observing it.

(WebCore::TextManipulationController::replace):

Run another check right before replacement, to ensure that we don&apos;t replace text in the node if:

1. An observation update runs.
2. The node is AutoFilled.
3. Replacement results arrive.

We bail early with `ContentChanged`, since the node has become AutoFilled in between the observation
and replacement.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextManipulation.mm:
(TestWebKitAPI::TEST(TextManipulation, CompleteTextManipulationDoesNotFillAutoFilledField)):

Add an API test to exercise the change.

Canonical link: <a href="https://commits.webkit.org/280362@main">https://commits.webkit.org/280362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64addd4b56b66b76dbce8c28173332fa629e5a88

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/59998 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6827 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58517 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43339 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45677 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4772 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33592 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48658 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26539 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30372 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5987 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5831 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6259 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61682 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/299 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6377 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52940 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/299 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48723 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/52825 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12486 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/266 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31544 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32630 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33713 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32377 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->