### PR TITLE
[visionOS] Safari can crash when entering LinearMediaPlayer fullscreen

### DIFF
--- a/Source/WebCore/platform/audio/ios/AudioSessionIOS.mm
+++ b/Source/WebCore/platform/audio/ios/AudioSessionIOS.mm
@@ -385,6 +385,8 @@ void AudioSessionIOS::updateSpatialExperience()
         case AudioSession::SoundStageSize::Large:
             return AVAudioSessionSoundStageSizeLarge;
         };
+        ASSERT_NOT_REACHED();
+        return AVAudioSessionSoundStageSizeAutomatic;
     }();
     NSError *error = nil;
     AVAudioSession *session = [PAL::getAVAudioSessionClass() sharedInstance];

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -49,6 +49,7 @@ namespace WebCore {
 
 PlaybackSessionModelMediaElement::PlaybackSessionModelMediaElement()
     : EventListener(EventListener::CPPEventListenerType)
+    , m_soundStageSize { AudioSessionSoundStageSize::Automatic }
 {
 }
 


### PR DESCRIPTION
#### 23871b35678729fe1fa18102db9ac0de0160e5d5
<pre>
[visionOS] Safari can crash when entering LinearMediaPlayer fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=275881">https://bugs.webkit.org/show_bug.cgi?id=275881</a>
<a href="https://rdar.apple.com/130103538">rdar://130103538</a>

Reviewed by Alex Christensen.

There were two issues that could result in a UI process crash when
entering LinearMediaPlayer fullscreen:

1. PlaybackSessionModelMediaElement::m_soundStageSize was not initialized by its constructor. When
   entering LinearMediaKit fullscreen we change the sound stage size, which reads from this
   uninitialized value and attempts to send it from WebContent to GPU via IPC. CoreIPC detects the
   invalid value and terminates the WebContent process
2. When the UI process handles a WebContent process termination it calls
   PlaybackSessionManagerProxy::invalidate(), but the WebPageProxy has been destroyed in this case.
   PlaybackSessionManagerProxy stores a WeakPtr to the WebPageProxy but does not property null-check
   it in many places. This leads to the UI process crashing due to the WebContent process
   termination in (1).

Addressed (1) by initializing PlaybackSessionModelMediaElement::m_soundStageSize to
SoundStageSize::Automatic. Addressed (2) by storing PlaybackSessionManagerProxy::m_page in a RefPtr
and checking it for null before accessing it.

* Source/WebCore/platform/audio/ios/AudioSessionIOS.mm:
(WebCore::AudioSessionIOS::updateSpatialExperience):
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm:
(WebCore::PlaybackSessionModelMediaElement::PlaybackSessionModelMediaElement):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionManagerProxy::invalidate):
(WebKit::PlaybackSessionManagerProxy::createModelAndInterface):
(WebKit::PlaybackSessionManagerProxy::setUpPlaybackControlsManagerWithID):
(WebKit::PlaybackSessionManagerProxy::clearPlaybackControlsManager):
(WebKit::PlaybackSessionManagerProxy::currentTimeChanged):
(WebKit::PlaybackSessionManagerProxy::rateChanged):
(WebKit::PlaybackSessionManagerProxy::handleControlledElementIDResponse const):
(WebKit::PlaybackSessionManagerProxy::play):
(WebKit::PlaybackSessionManagerProxy::pause):
(WebKit::PlaybackSessionManagerProxy::togglePlayState):
(WebKit::PlaybackSessionManagerProxy::beginScrubbing):
(WebKit::PlaybackSessionManagerProxy::endScrubbing):
(WebKit::PlaybackSessionManagerProxy::seekToTime):
(WebKit::PlaybackSessionManagerProxy::fastSeek):
(WebKit::PlaybackSessionManagerProxy::beginScanningForward):
(WebKit::PlaybackSessionManagerProxy::beginScanningBackward):
(WebKit::PlaybackSessionManagerProxy::endScanning):
(WebKit::PlaybackSessionManagerProxy::setDefaultPlaybackRate):
(WebKit::PlaybackSessionManagerProxy::setPlaybackRate):
(WebKit::PlaybackSessionManagerProxy::selectAudioMediaOption):
(WebKit::PlaybackSessionManagerProxy::selectLegibleMediaOption):
(WebKit::PlaybackSessionManagerProxy::togglePictureInPicture):
(WebKit::PlaybackSessionManagerProxy::enterFullscreen):
(WebKit::PlaybackSessionManagerProxy::exitFullscreen):
(WebKit::PlaybackSessionManagerProxy::toggleInWindow):
(WebKit::PlaybackSessionManagerProxy::toggleMuted):
(WebKit::PlaybackSessionManagerProxy::setMuted):
(WebKit::PlaybackSessionManagerProxy::setVolume):
(WebKit::PlaybackSessionManagerProxy::setPlayingOnSecondScreen):
(WebKit::PlaybackSessionManagerProxy::sendRemoteCommand):
(WebKit::PlaybackSessionManagerProxy::setVideoReceiverEndpoint):
(WebKit::PlaybackSessionManagerProxy::uncacheVideoReceiverEndpoint):
(WebKit::PlaybackSessionManagerProxy::setSpatialTrackingLabel):
(WebKit::PlaybackSessionManagerProxy::setSoundStageSize):
(WebKit::PlaybackSessionManagerProxy::requestControlledElementID):

Canonical link: <a href="https://commits.webkit.org/280363@main">https://commits.webkit.org/280363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/295cfabbecaeb0a1edd19dbebc8cb922a8a930ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56393 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60000 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6829 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58519 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7023 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45678 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4773 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58422 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48661 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26540 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30370 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/5990 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5833 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6262 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61684 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/301 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6380 "Found 1 new test failure: fast/webgpu/texture-supports-blending.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52942 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/301 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48726 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52828 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12487 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/272 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31546 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32632 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33715 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32379 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->