### PR TITLE
[tvOS] Add fullscreen and mute buttons to media controls

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.css
@@ -31,6 +31,27 @@
     background-color: transparent;
 }
 
+.media-controls.fullscreen.tvos > .controls-bar {
+    --tvos-controls-top-margin: 32px;
+    --tvos-controls-horizontal-margin: 24px;
+}
+
+.media-controls.fullscreen.tvos.uses-ltr-user-interface-layout-direction > .controls-bar.top-left,
+.media-controls.fullscreen.tvos:not(.uses-ltr-user-interface-layout-direction) > .controls-bar.top-right {
+    position: absolute;
+    left: var(--tvos-controls-horizontal-margin);
+    right: auto;
+    top: var(--tvos-controls-top-margin);
+}
+
+.media-controls.fullscreen.tvos.uses-ltr-user-interface-layout-direction > .controls-bar.top-right,
+.media-controls.fullscreen.tvos:not(.uses-ltr-user-interface-layout-direction) > .controls-bar.top-left {
+    position: absolute;
+    left: auto;
+    right: var(--tvos-controls-horizontal-margin);
+    top: var(--tvos-controls-top-margin);
+}
+
 .media-controls.fullscreen.tvos > .controls-bar.center {
     position: absolute;
     top: 50%;

--- a/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.js
@@ -25,6 +25,7 @@
 
 class TVOSMediaControls extends MediaControls
 {
+    static topButtonsScaleFactor = 1;
     static backForwardButtonScaleFactor = 2;
     static playPauseButtonScaleFactor = 3;
     static centerControlsBarButtonMargin = 48;
@@ -40,11 +41,25 @@ class TVOSMediaControls extends MediaControls
 
         this.skipBackButton = new SkipBackButton(this);
         this.skipForwardButton = new SkipForwardButton(this);
+        
+        this.topLeftControlsBar = new ControlsBar("top-left");
+        this._topLeftControlsBarContainer = this.topLeftControlsBar.addChild(new ButtonsContainer);
+
+        this.topRightControlsBar = new ControlsBar("top-right");
+        this._topRightControlsBarContainer = this.topRightControlsBar.addChild(new ButtonsContainer);
 
         this.centerControlsBar = new ControlsBar("center");
         this._centerControlsBarContainer = this.centerControlsBar.addChild(new ButtonsContainer);
 
         this.showsStartButton = false;
+
+        for (let clickEvent of ["click", "mousedown", "mouseup", "pointerdown", "pointerup"]) {
+            this.element.addEventListener(clickEvent, (event) => {
+                event.stopPropagation();
+            });
+        }
+
+        this._isInitialized = true
     }
 
     // Protected
@@ -53,24 +68,51 @@ class TVOSMediaControls extends MediaControls
     {
         super.layout();
 
-        if (!this.centerControlsBar)
+        if (!this._isInitialized)
             return;
 
+        this.fullscreenButton.scaleFactor = TVOSMediaControls.topButtonsScaleFactor;
+        this.muteButton.scaleFactor = TVOSMediaControls.topButtonsScaleFactor;
         this.playPauseButton.scaleFactor = TVOSMediaControls.playPauseButtonScaleFactor;
         this.skipForwardButton.scaleFactor = TVOSMediaControls.backForwardButtonScaleFactor;
         this.skipBackButton.scaleFactor = TVOSMediaControls.backForwardButtonScaleFactor;
+
+        this._topLeftControlsBarContainer.children = this._topLeftContainerButtons();
+        this._topLeftControlsBarContainer.layout();
+
+        this._topRightControlsBarContainer.children = this._topRightContainerButtons();
+        this._topRightControlsBarContainer.layout();
 
         this._centerControlsBarContainer.children = this._centerContainerButtons();
         this._centerControlsBarContainer.buttonMargin = TVOSMediaControls.centerControlsBarButtonMargin;
         this._centerControlsBarContainer.layout();
 
+        this.topLeftControlsBar.with = this._topLeftControlsBarContainer.width;
+        this.topRightControlsBar.width = this._topRightControlsBarContainer.width;
         this.centerControlsBar.width = this._centerControlsBarContainer.width;
+        
+        this.topLeftControlsBar.visible = this._topLeftControlsBarContainer.children.some(button => button.visible);
+        this.topRightControlsBar.visible = this._topRightControlsBarContainer.children.some(button => button.visible);
         this.centerControlsBar.visible = this._centerControlsBarContainer.children.some(button => button.visible);
 
-        this.children = [this.centerControlsBar];
+        this.children = [this.topLeftControlsBar, this.topRightControlsBar, this.centerControlsBar];
     }
 
     // Private
+
+    _topLeftContainerButtons()
+    {
+        if (this.usesLTRUserInterfaceLayoutDirection)
+            return [this.fullscreenButton];
+        return [this.muteButton];
+    }
+
+    _topRightContainerButtons()
+    {
+        if (this.usesLTRUserInterfaceLayoutDirection)
+            return [this.muteButton];
+        return [this.fullscreenButton];
+    }
 
     _centerContainerButtons()
     {


### PR DESCRIPTION
#### c14581bf13cf3821605eec78f683c5a0e6856292
<pre>
[tvOS] Add fullscreen and mute buttons to media controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=275886">https://bugs.webkit.org/show_bug.cgi?id=275886</a>

Reviewed by Eric Carlson.

Added top-left and top-right button containers with buttons to toggle fullscreen and mute. While
here, also stopped pointer events from propagating to the underlying video element.

* Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.css:
(.media-controls.fullscreen.tvos &gt; .controls-bar):
(.media-controls.fullscreen.tvos.uses-ltr-user-interface-layout-direction &gt; .controls-bar.top-left,):
(.media-controls.fullscreen.tvos.uses-ltr-user-interface-layout-direction &gt; .controls-bar.top-right,):
* Source/WebCore/Modules/modern-media-controls/controls/tvos-media-controls.js:
(TVOSMediaControls.prototype.layout):
(TVOSMediaControls.prototype._topLeftContainerButtons):
(TVOSMediaControls.prototype._topRightContainerButtons):

Canonical link: <a href="https://commits.webkit.org/280364@main">https://commits.webkit.org/280364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aca776768c65c5b59e443c0604a1d352ab3811d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8884 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60019 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6848 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58538 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7042 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45693 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4787 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58441 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26555 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30387 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6004 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5852 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52369 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61703 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/320 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6395 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52955 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/320 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48740 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52850 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12488 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/289 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31565 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32651 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33734 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32398 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->