### PR TITLE
[tvOS] Hide custom fullscreen controls when a video element is in element fullscreen

### DIFF
--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -193,8 +193,9 @@ void WebFullScreenManagerProxy::enterFullScreen(bool blocksReturnToFullscreenFro
     m_blocksReturnToFullscreenFromPictureInPicture = blocksReturnToFullscreenFromPictureInPicture;
 #if PLATFORM(IOS_FAMILY)
 
-#if PLATFORM(VISION)
+#if ENABLE(VIDEO_USES_ELEMENT_FULLSCREEN)
     m_isVideoElement = mediaDetails.type == FullScreenMediaDetails::Type::Video;
+#endif
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     if (mediaDetails.imageHandle) {
         auto sharedMemoryBuffer = SharedMemory::map(WTFMove(*mediaDetails.imageHandle), WebCore::SharedMemory::Protection::ReadOnly);
@@ -203,7 +204,6 @@ void WebFullScreenManagerProxy::enterFullScreen(bool blocksReturnToFullscreenFro
     }
     m_imageMIMEType = mediaDetails.mimeType;
 #endif // QUICKLOOK_FULLSCREEN
-#endif
 
     auto mediaDimensions = mediaDetails.mediaDimensions;
     m_client.enterFullScreen(mediaDimensions);

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -87,13 +87,13 @@ public:
 
     bool isFullScreen();
     bool blocksReturnToFullscreenFromPictureInPicture() const;
-#if PLATFORM(VISION)
+#if ENABLE(VIDEO_USES_ELEMENT_FULLSCREEN)
     bool isVideoElement() const { return m_isVideoElement; }
+#endif
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     bool isImageElement() const { return m_imageBuffer; }
     void prepareQuickLookImageURL(CompletionHandler<void(URL&&)>&&) const;
 #endif // QUICKLOOK_FULLSCREEN
-#endif
     void close();
 
     enum class FullscreenState : uint8_t {
@@ -140,13 +140,13 @@ private:
     WebFullScreenManagerProxyClient& m_client;
     FullscreenState m_fullscreenState { FullscreenState::NotInFullscreen };
     bool m_blocksReturnToFullscreenFromPictureInPicture { false };
-#if PLATFORM(VISION)
+#if ENABLE(VIDEO_USES_ELEMENT_FULLSCREEN)
     bool m_isVideoElement { false };
+#endif
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     String m_imageMIMEType;
     RefPtr<WebCore::SharedBuffer> m_imageBuffer;
 #endif // QUICKLOOK_FULLSCREEN
-#endif
     Vector<CompletionHandler<void()>> m_closeCompletionHandlers;
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setAnimatingViewAlpha:(CGFloat)alpha;
 - (void)setSupportedOrientations:(UIInterfaceOrientationMask)supportedOrientations;
 - (void)resetSupportedOrientations;
-#if PLATFORM(VISION)
+#if ENABLE(VIDEO_USES_ELEMENT_FULLSCREEN)
 - (void)hideCustomControls:(BOOL)hidden;
 #endif
 #if ENABLE(LINEAR_MEDIA_PLAYER)

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -160,9 +160,11 @@ private:
     CGFloat _nonZeroStatusBarHeight;
     std::optional<UIInterfaceOrientationMask> _supportedOrientations;
     BOOL _isShowingMenu;
+#if ENABLE(VIDEO_USES_ELEMENT_FULLSCREEN)
+    BOOL _shouldHideCustomControls;
+#endif
 #if PLATFORM(VISION)
     RetainPtr<WKExtrinsicButton> _moreActionsButton;
-    BOOL _shouldHideCustomControls;
     BOOL _isInteractingWithSystemChrome;
 #endif
 #if ENABLE(LINEAR_MEDIA_PLAYER)
@@ -200,8 +202,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _playbackClient.setParent(self);
     _valid = YES;
     _isShowingMenu = NO;
-#if PLATFORM(VISION)
+#if ENABLE(VIDEO_USES_ELEMENT_FULLSCREEN)
     _shouldHideCustomControls = NO;
+#endif
+#if PLATFORM(VISION)
     _isInteractingWithSystemChrome = NO;
 #endif
 
@@ -373,9 +377,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (auto page = [self._webView _page])
         isPiPEnabled = page->preferences().pictureInPictureAPIEnabled() && page->preferences().allowsPictureInPictureMediaPlayback();
     bool isPiPSupported = playbackSessionModel && playbackSessionModel->isPictureInPictureSupported();
-#if PLATFORM(VISION)
+#if ENABLE(VIDEO_USES_ELEMENT_FULLSCREEN)
     [_cancelButton setHidden:_shouldHideCustomControls];
+#endif
 
+#if PLATFORM(VISION)
     bool isDimmingEnabled = false;
     if (auto page = [self._webView _page])
         isDimmingEnabled = page->preferences().fullscreenSceneDimmingEnabled();
@@ -456,7 +462,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }];
 }
 
-#if PLATFORM(VISION)
+#if ENABLE(VIDEO_USES_ELEMENT_FULLSCREEN)
 
 - (void)hideCustomControls:(BOOL)hidden
 {
@@ -466,6 +472,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _shouldHideCustomControls = hidden;
     [self videoControlsManagerDidChange];
 }
+
+#endif
+
+#if PLATFORM(VISION)
 
 - (void)_didBeginInteractionWithSystemChrome:(NSNotificationCenter *)notification
 {

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -942,7 +942,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
     [_fullscreenViewController setModalPresentationCapturesStatusBarAppearance:YES];
     [_fullscreenViewController setDelegate:self];
     _fullscreenViewController.get().view.frame = _rootViewController.get().view.bounds;
-#if PLATFORM(VISION)
+#if ENABLE(VIDEO_USES_ELEMENT_FULLSCREEN)
     [_fullscreenViewController hideCustomControls:manager->isVideoElement()];
 #endif
     [self _updateLocationInfo];

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -274,13 +274,15 @@ void WebFullScreenManager::enterFullScreenForElement(WebCore::Element* element, 
 #if ENABLE(VIDEO)
     updateMainVideoElement();
 
-#if PLATFORM(VISION)
+#if ENABLE(VIDEO_USES_ELEMENT_FULLSCREEN)
     if (m_mainVideoElement) {
         bool fullscreenElementIsVideoElement = is<HTMLVideoElement>(element);
 
         auto mainVideoElementSize = [&]() -> FloatSize {
+#if PLATFORM(VISION)
             if (!fullscreenElementIsVideoElement && element->document().quirks().shouldDisableFullscreenVideoAspectRatioAdaptiveSizing())
                 return { };
+#endif
             return FloatSize(m_mainVideoElement->videoWidth(), m_mainVideoElement->videoHeight());
         }();
 


### PR DESCRIPTION
#### f4043d01a8ce50588522034ce58ab83fbdb0d5cd
<pre>
[tvOS] Hide custom fullscreen controls when a video element is in element fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=275887">https://bugs.webkit.org/show_bug.cgi?id=275887</a>
<a href="https://rdar.apple.com/130560759">rdar://130560759</a>

Reviewed by Aditya Keerthi and Eric Carlson.

Replaced PLATFORM(VISION) checks with ENABLE(VIDEO_USES_ELEMENT_FULLSCREEN) to enable the ability to
hide custom fullscreen controls when a video element is in element fullscreen on tvOS.

* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::enterFullScreen):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController initWithWebView:]):
(-[WKFullScreenViewController videoControlsManagerDidChange]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController enterFullScreen:]):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::enterFullScreenForElement):

Canonical link: <a href="https://commits.webkit.org/280379@main">https://commits.webkit.org/280379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2ecced8c92189bf2e18ed0dafe164199ff7f70e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35747 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60028 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6857 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43369 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7051 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45699 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4792 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33614 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48683 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26561 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30391 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5861 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52373 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6280 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61712 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/329 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6401 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52960 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/329 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52846 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12500 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/291 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31574 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32660 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33743 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32407 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->