### PR TITLE
[tvOS] Enforce `object-fit: contain` for videos in element fullscreen

### DIFF
--- a/Source/WebCore/css/fullscreen.css
+++ b/Source/WebCore/css/fullscreen.css
@@ -54,6 +54,17 @@ video:fullscreen {
     -webkit-cursor-visibility: auto-hide;
 }
 
+#if defined(WTF_PLATFORM_APPLETV) && WTF_PLATFORM_APPLETV
+video:fullscreen {
+    /*
+     * FIXME: Adding !important improves compatibility when placing video elements in element
+     * fullscreen on tvOS, but we should add an -internal pseudo-class to contain styles that are
+     * specific to video using element fullscreen.
+     */
+    object-fit: contain !important;
+}
+#endif
+
 img:fullscreen {
     width: auto;
     height: 100%;


### PR DESCRIPTION
#### 8b5dbfa6c16adb0ab4110a48bc8c2930bce1f1fd
<pre>
[tvOS] Enforce `object-fit: contain` for videos in element fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=275889">https://bugs.webkit.org/show_bug.cgi?id=275889</a>
<a href="https://rdar.apple.com/130561454">rdar://130561454</a>

Reviewed by Eric Carlson.

Adding !important to `object-fit: contain` in fullscreen.css improves compatibility when placing
video elements in element fullscreen on tvOS. While ultimately we should add an internal
pseudo-class that selects a video in element fullscreen, for now this change modifies the definition
of the Fullscreen API UA stylesheet on tvOS.

* Source/WebCore/css/fullscreen.css:

Canonical link: <a href="https://commits.webkit.org/280382@main">https://commits.webkit.org/280382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e88e8ff12f466f6bd94007d9c91cea7709c3d34

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56470 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8942 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60077 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6906 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58596 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7102 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45743 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4832 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33664 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48731 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26605 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30441 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6056 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5910 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61761 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/378 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6443 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53001 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/378 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48792 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52904 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/12502 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/335 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8383 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31623 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32709 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33792 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32456 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->