### PR TITLE
[WPE] WPE Platform: add wpe_input_method_context_filter_key_event

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/InputMethodFilter.h
+++ b/Source/WebKit/UIProcess/API/glib/InputMethodFilter.h
@@ -59,7 +59,11 @@ public:
 #if PLATFORM(GTK)
     using PlatformEventKey = GdkEvent;
 #elif PLATFORM(WPE)
-    using PlatformEventKey = struct wpe_input_keyboard_event;
+    using PlatformEventKey = void;
+
+#if ENABLE(WPE_PLATFORM)
+    void setUseWPEPlatformEvents(bool useWPEPlatformEvents) { m_useWPEPlatformEvents = useWPEPlatformEvents; }
+#endif
 #endif
     struct FilterResult {
         bool handled { false };
@@ -125,6 +129,10 @@ private:
         uint64_t cursorPosition;
         uint64_t selectionPosition;
     } m_surrounding;
+
+#if ENABLE(WPE_PLATFORM)
+    bool m_useWPEPlatformEvents { false };
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/glib/WebKitInputMethodContext.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitInputMethodContext.h.in
@@ -126,7 +126,7 @@ struct _WebKitInputMethodContextClass {
                                      GdkEventKey              *key_event);
 #elif PLATFORM(WPE)
     gboolean (* filter_key_event)   (WebKitInputMethodContext        *context,
-                                     struct wpe_input_keyboard_event *key_event);
+                                     gpointer                         key_event);
 #endif
     void     (* notify_focus_in)    (WebKitInputMethodContext *context);
     void     (* notify_focus_out)   (WebKitInputMethodContext *context);
@@ -184,7 +184,7 @@ webkit_input_method_context_filter_key_event   (WebKitInputMethodContext   *cont
 #elif PLATFORM(WPE)
 WEBKIT_API gboolean
 webkit_input_method_context_filter_key_event   (WebKitInputMethodContext        *context,
-                                                struct wpe_input_keyboard_event *key_event);
+                                                gpointer                         key_event);
 #endif
 
 WEBKIT_API void

--- a/Source/WebKit/UIProcess/API/wpe/InputMethodFilterWPE.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/InputMethodFilterWPE.cpp
@@ -24,6 +24,10 @@
 #include <WebCore/IntRect.h>
 #include <wpe/wpe.h>
 
+#if ENABLE(WPE_PLATFORM)
+#include <wpe/wpe-platform.h>
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -34,7 +38,14 @@ IntRect InputMethodFilter::platformTransformCursorRectToViewCoordinates(const In
 
 bool InputMethodFilter::platformEventKeyIsKeyPress(PlatformEventKey* event) const
 {
-    return event->pressed;
+#if ENABLE(WPE_PLATFORM)
+    if (m_useWPEPlatformEvents) {
+        auto* wpe_platform_event = static_cast<WPEEvent*>(event);
+        return wpe_event_get_event_type(wpe_platform_event) == WPE_EVENT_KEYBOARD_KEY_DOWN;
+    }
+#endif
+    auto* wpe_event = static_cast<struct wpe_input_keyboard_event*>(event);
+    return wpe_event->pressed;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/API/wpe/WebKitInputMethodContextImplWPE.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitInputMethodContextImplWPE.cpp
@@ -138,6 +138,13 @@ static void webkitInputMethodContextImplWPEGetPreedit(WebKitInputMethodContext* 
         *cursorOffset = clampTo<unsigned>(offset);
 }
 
+static gboolean webkitInputMethodContextImplWPEFilterKeyEvent(WebKitInputMethodContext* context, void* keyEvent)
+{
+    auto* priv = WEBKIT_INPUT_METHOD_CONTEXT_IMPL_WPE(context)->priv;
+    auto* wpeEvent = static_cast<WPEEvent*>(keyEvent);
+    return wpe_input_method_context_filter_key_event(priv->context.get(), wpeEvent);
+}
+
 static void webkitInputMethodContextImplWPENotifyFocusIn(WebKitInputMethodContext* context)
 {
     auto* priv = WEBKIT_INPUT_METHOD_CONTEXT_IMPL_WPE(context)->priv;
@@ -172,6 +179,7 @@ static void webkit_input_method_context_impl_wpe_class_init(WebKitInputMethodCon
 {
     auto* imClass = WEBKIT_INPUT_METHOD_CONTEXT_CLASS(klass);
     imClass->get_preedit = webkitInputMethodContextImplWPEGetPreedit;
+    imClass->filter_key_event = webkitInputMethodContextImplWPEFilterKeyEvent;
     imClass->notify_focus_in = webkitInputMethodContextImplWPENotifyFocusIn;
     imClass->notify_focus_out = webkitInputMethodContextImplWPENotifyFocusOut;
     imClass->notify_cursor_area = webkitInputMethodContextImplWPENotifyCursorArea;

--- a/Source/WebKit/UIProcess/API/wpe/WebKitInputMethodContextWPE.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WebKitInputMethodContextWPE.cpp
@@ -60,7 +60,7 @@ void webkit_input_method_underline_set_color(WebKitInputMethodUnderline* underli
  *
  * Since: 2.28
  */
-gboolean webkit_input_method_context_filter_key_event(WebKitInputMethodContext* context, struct wpe_input_keyboard_event* keyEvent)
+gboolean webkit_input_method_context_filter_key_event(WebKitInputMethodContext* context, void* keyEvent)
 {
     g_return_val_if_fail(WEBKIT_IS_INPUT_METHOD_CONTEXT(context), FALSE);
     g_return_val_if_fail(keyEvent, FALSE);

--- a/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.cpp
@@ -411,6 +411,27 @@ void wpe_input_method_context_get_preedit_string(WPEInputMethodContext* context,
 }
 
 /**
+ * wpe_input_method_context_filter_key_event:
+ * @context: a #WPEInputMethodContext
+ * @event: the key event
+ *
+ * Allow an input method to internally handle key press and release
+ * events. If this function returns %TRUE, then no further processing
+ * should be done for this key event.
+ *
+ * Returns: %TRUE if the input method handled the key event.
+ **/
+gboolean wpe_input_method_context_filter_key_event(WPEInputMethodContext* context, WPEEvent* event)
+{
+    g_return_val_if_fail(WPE_IS_INPUT_METHOD_CONTEXT(context), false);
+
+    auto* imeClass = WPE_INPUT_METHOD_CONTEXT_GET_CLASS(context);
+    if (imeClass->filter_key_event)
+        return imeClass->filter_key_event(context, event);
+    return FALSE;
+}
+
+/**
  * wpe_input_method_context_focus_in:
  * @context: a #WPEInputMethodContext
  *

--- a/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h
@@ -41,6 +41,7 @@ G_BEGIN_DECLS
 WPE_DECLARE_DERIVABLE_TYPE (WPEInputMethodContext, wpe_input_method_context, WPE, INPUT_METHOD_CONTEXT, GObject)
 
 typedef struct _WPEDisplay WPEDisplay;
+typedef struct _WPEEvent WPEEvent;
 typedef struct _WPEView WPEView;
 
 /**
@@ -133,6 +134,8 @@ struct _WPEInputMethodContextClass
                                      gchar                 **text,
                                      GList                 **underlines,
                                      guint                 *cursor_offset);
+    gboolean (* filter_key_event)   (WPEInputMethodContext *context,
+			                         WPEEvent              *event);
     void     (* focus_in)           (WPEInputMethodContext *context);
     void     (* focus_out)          (WPEInputMethodContext *context);
     void     (* set_cursor_area)    (WPEInputMethodContext *context,
@@ -157,6 +160,8 @@ WPE_API void                     wpe_input_method_context_get_preedit_string (WP
                                                                               char                    **text,
                                                                               GList                   **underlines,
                                                                               guint                   *cursor_offset);
+WPE_API gboolean                 wpe_input_method_context_filter_key_event   (WPEInputMethodContext   *context,
+                                                                              WPEEvent                *event);
 WPE_API void                     wpe_input_method_context_focus_in           (WPEInputMethodContext   *context);
 WPE_API void                     wpe_input_method_context_focus_out          (WPEInputMethodContext   *context);
 WPE_API void                     wpe_input_method_context_set_cursor_area    (WPEInputMethodContext   *context,

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestInputMethodContext.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestInputMethodContext.cpp
@@ -35,7 +35,7 @@ using PlatformEventKey = GdkEventKey;
 #define CONTROL_MASK GDK_CONTROL_MASK
 #define SHIFT_MASK GDK_SHIFT_MASK
 #elif PLATFORM(WPE)
-using PlatformEventKey = struct wpe_input_keyboard_event;
+using PlatformEventKey = void;
 #define KEY(x) WPE_KEY_##x
 #define CONTROL_MASK wpe_input_keyboard_modifier_control
 #define SHIFT_MASK wpe_input_keyboard_modifier_shift
@@ -112,9 +112,10 @@ static gboolean webkitInputMethodContextMockFilterKeyEvent(WebKitInputMethodCont
 #endif
     gunichar character = gdk_keyval_to_unicode(keyval);
 #elif PLATFORM(WPE)
-    uint32_t state = keyEvent->modifiers;
-    uint32_t keyval = keyEvent->key_code;
-    bool isKeyPress = keyEvent->pressed;
+    struct wpe_input_keyboard_event* wpeKeyEvent = static_cast<struct wpe_input_keyboard_event*>(keyEvent);
+    uint32_t state = wpeKeyEvent->modifiers;
+    uint32_t keyval = wpeKeyEvent->key_code;
+    bool isKeyPress = wpeKeyEvent->pressed;
     gunichar character = wpe_key_code_to_unicode(keyval);
 #endif
     bool isControl = state & CONTROL_MASK;


### PR DESCRIPTION
#### f3070e7128adc401c89b6b7fc843194dffb7c3d8
<pre>
[WPE] WPE Platform: add wpe_input_method_context_filter_key_event
<a href="https://bugs.webkit.org/show_bug.cgi?id=275893">https://bugs.webkit.org/show_bug.cgi?id=275893</a>

Reviewed by Carlos Garcia Campos.

Add missing wpe_input_method_context_filter_key_event to
WPEPlatform

* Source/WebKit/UIProcess/API/glib/InputMethodFilter.h:
(WebKit::InputMethodFilter::setUseWPEPlatformEvents):
* Source/WebKit/UIProcess/API/glib/WebKitInputMethodContext.h.in:
* Source/WebKit/UIProcess/API/wpe/InputMethodFilterWPE.cpp:
(WebKit::InputMethodFilter::platformEventKeyIsKeyPress const):
* Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp:
(WKWPE::m_backend):
* Source/WebKit/UIProcess/API/wpe/WebKitInputMethodContextImplWPE.cpp:
(webkitInputMethodContextImplWPEFilterKeyEvent):
(webkit_input_method_context_impl_wpe_class_init):
* Source/WebKit/UIProcess/API/wpe/WebKitInputMethodContextWPE.cpp:
(webkit_input_method_context_filter_key_event):
* Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.cpp:
(wpe_input_method_context_filter_key_event):
* Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestInputMethodContext.cpp:
(webkitInputMethodContextMockFilterKeyEvent):

Canonical link: <a href="https://commits.webkit.org/280448@main">https://commits.webkit.org/280448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b31aba3fe66b80060c2343839bfb2593c56271d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60290 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7117 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58803 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7308 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/45911 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4986 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58706 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33843 "Found 60 new test failures: accessibility/accessibility-node-reparent.html accessibility/ancestor-computation.html accessibility/announcement-notification.html accessibility/aria-braillelabel.html accessibility/aria-brailleroledescription.html accessibility/aria-checked-mixed-value.html accessibility/aria-current-state-changed-notification.html accessibility/aria-current.html accessibility/aria-describedby-on-input.html accessibility/aria-description.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48916 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26770 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30622 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6247 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6120 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52565 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6519 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61973 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/588 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6620 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/590 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48974 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53184 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/507 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8427 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31831 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32917 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34001 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32663 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->