### PR TITLE
[Win] Fix Popup Width mistakenly bounded by select element width

### DIFF
--- a/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp
+++ b/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp
@@ -407,7 +407,7 @@ void WebPopupMenuProxyWin::calculatePositionAndSize(const IntRect& rect)
     int clientInsetLeftInDevicePixel = m_data.m_clientInsetLeft * deviceScaleFactor;
     int clientInsetRightInDevicePixel = m_data.m_clientInsetRight * deviceScaleFactor;
     // The popup should be at least as wide as the control on the page
-    popupWidth = std::max(rectInScreenCoords.width() - clientInsetLeftInDevicePixel - clientInsetRightInDevicePixel, popupRect.width());
+    popupWidth = std::max(rectInScreenCoords.width() - clientInsetLeftInDevicePixel - clientInsetRightInDevicePixel, popupWidth);
     popupRect.setWidth(popupWidth);
 
     // Adjust X


### PR DESCRIPTION
#### 2e5519674a0fb5a08822e51875f861b64e265493
<pre>
[Win] Fix Popup Width mistakenly bounded by select element width
<a href="https://bugs.webkit.org/show_bug.cgi?id=275894">https://bugs.webkit.org/show_bug.cgi?id=275894</a>

Reviewed by Fujii Hironori.

PopupWidth should be bigger value of select&apos;s item width or select
width. This fixes wrong variable use to achieve that behavior.

Canonical link: <a href="https://commits.webkit.org/280368@main">https://commits.webkit.org/280368@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca67c41a5d7253695d3bfea70f3a6e99078f8c8d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60050 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6879 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43391 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7073 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45715 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4807 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33633 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48705 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26577 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30410 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5883 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61734 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/351 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6418 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/52977 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/351 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48766 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52869 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/310 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8381 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31596 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32682 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33765 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32429 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->