### PR TITLE
WebGL context resize is more complex than needed

### DIFF
--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -603,7 +603,7 @@ void HTMLCanvasElement::reset()
 
     if (m_context) {
         if (auto* context = dynamicDowncast<GPUBasedCanvasRenderingContext>(*m_context))
-            context->reshape(width(), height(), oldSize.width(), oldSize.height());
+            context->reshape();
     }
 
     if (CheckedPtr canvasRenderer = dynamicDowncast<RenderHTMLCanvas>(renderer())) {

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -149,13 +149,11 @@ void OffscreenCanvas::setHeight(unsigned newHeight)
 
 void OffscreenCanvas::setSize(const IntSize& newSize)
 {
-    auto oldWidth = width();
-    auto oldHeight = height();
     CanvasBase::setSize(newSize);
     reset();
 
     if (RefPtr context = dynamicDowncast<GPUBasedCanvasRenderingContext>(m_context.get()))
-        context->reshape(width(), height(), oldWidth, oldHeight);
+        context->reshape();
 }
 
 #if ENABLE(WEBGL)

--- a/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
@@ -43,7 +43,7 @@ public:
     bool isGPUBased() const override { return true; }
     bool delegatesDisplay() const override { return true; }
 
-    virtual void reshape(int width, int height, int oldWidth, int oldHeight) = 0;
+    virtual void reshape() = 0;
 protected:
     explicit GPUBasedCanvasRenderingContext(CanvasBase&);
 

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -63,7 +63,7 @@ public:
     bool needsPreparationForDisplay() const override { return true; }
     void prepareForDisplay() override;
     ImageBufferPixelFormat pixelFormat() const override;
-    void reshape(int width, int height, int oldWidth, int oldHeight) override;
+    void reshape() override;
 
 
     RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) override;

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -151,18 +151,15 @@ GPUCanvasContextCocoa::GPUCanvasContextCocoa(CanvasBase& canvas, GPU& gpu)
 {
 }
 
-void GPUCanvasContextCocoa::reshape(int width, int height, int oldWidth, int oldHeight)
+void GPUCanvasContextCocoa::reshape()
 {
-    UNUSED_PARAM(oldWidth);
-    UNUSED_PARAM(oldHeight);
-
     if (auto* texture = m_currentTexture.get()) {
         texture->destroy();
         m_currentTexture = nullptr;
     }
-
-    m_width = static_cast<GPUIntegerCoordinate>(width);
-    m_height = static_cast<GPUIntegerCoordinate>(height);
+    auto newSize = canvasBase().size();
+    m_width = static_cast<GPUIntegerCoordinate>(newSize.width());
+    m_height = static_cast<GPUIntegerCoordinate>(newSize.height());
 
     auto configuration = WTFMove(m_configuration);
     m_configuration.reset();

--- a/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp
+++ b/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp
@@ -52,6 +52,11 @@ WebGLDefaultFramebuffer::WebGLDefaultFramebuffer(WebGLRenderingContextBase& cont
     }
 }
 
+IntSize WebGLDefaultFramebuffer::size() const
+{
+    return m_context.protectedGraphicsContextGL()->getInternalFramebufferSize();
+}
+
 void WebGLDefaultFramebuffer::reshape(IntSize size)
 {
     m_context.protectedGraphicsContextGL()->reshape(size.width(), size.height());

--- a/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.h
+++ b/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.h
@@ -42,6 +42,7 @@ public:
     PlatformGLObject object() const { return 0; }
     bool hasStencil() const { return m_hasStencil; }
     bool hasDepth() const { return m_hasDepth; }
+    IntSize size() const;
     void reshape(IntSize);
     GCGLbitfield dirtyBuffers() const { return m_dirtyBuffers; }
     void markBuffersClear(GCGLbitfield clearBuffers);

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -437,7 +437,7 @@ public:
 
     RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() override;
 
-    void reshape(int width, int height, int oldWidth, int oldHeight) override;
+    void reshape() override;
 
     RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) final;
 


### PR DESCRIPTION
#### 1b1a2082b238e1cb9d0ef1080d19f0ce5ca9a5fe
<pre>
WebGL context resize is more complex than needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=275902">https://bugs.webkit.org/show_bug.cgi?id=275902</a>
<a href="https://rdar.apple.com/130584997">rdar://130584997</a>

Reviewed by Said Abou-Hallawa and Dan Glastonbury.

Remove the old and new size parameters from
GPUBasedCanvasRenderingContext::reshape().
The new canvas size is available from the canvas element / offscreen
object, i.e. CanvasBase::size().
The old drawing buffer size should be the current context drawing size.
The new drawing buffer size should be derived from the new canvas size,
which is available.

This is preparation for all the CanvasRenderingContext types to get
reshape(). This is work towards making the rendering contexts manage
the drawing buffer and display buffer, instead of CanvasBase.

* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::reset):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::setSize):
* Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::reshape):
* Source/WebCore/html/canvas/WebGLDefaultFramebuffer.cpp:
(WebCore::WebGLDefaultFramebuffer::size const):
* Source/WebCore/html/canvas/WebGLDefaultFramebuffer.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::reshape):
(WebCore::WebGLRenderingContextBase::drawingBufferWidth const):
(WebCore::WebGLRenderingContextBase::drawingBufferHeight const):
(WebCore::WebGLRenderingContextBase::clampedCanvasSize):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:

Canonical link: <a href="https://commits.webkit.org/280419@main">https://commits.webkit.org/280419@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51794e72122836930e9431ec9dc3296403d30c7d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35899 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60183 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7013 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58699 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43522 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7204 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45822 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4903 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58602 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33749 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48821 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26683 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30530 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6153 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6016 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52488 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6425 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61866 "Failed to checkout and rebase branch from PR 30190") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/482 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6529 "Found 1 new test failure: fast/forms/form-submission-crash-4.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/61866 "Failed to checkout and rebase branch from PR 30190") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/484 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48881 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/61866 "Failed to checkout and rebase branch from PR 30190") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12525 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/415 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31726 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32813 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33897 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32559 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->