### PR TITLE
AX: lineTextMarkerRangeForTextMarker fails on first character of line in Google Docs

### DIFF
--- a/LayoutTests/accessibility/mac/line-text-marker-range-for-text-marker-expected.txt
+++ b/LayoutTests/accessibility/mac/line-text-marker-range-for-text-marker-expected.txt
@@ -1,0 +1,8 @@
+This tests that when there are <br> elements with contenteditable=false in a contenteditable text area, we can get the correct range for a line.
+
+PASS: rangeStr === "First line of text"
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/line-text-marker-range-for-text-marker.html
+++ b/LayoutTests/accessibility/mac/line-text-marker-range-for-text-marker.html
@@ -1,0 +1,30 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="textcontrol" contenteditable="true">
+  First line of text
+  <span contenteditable="false"><br></span>
+  Second line of text
+</div>
+
+<script>
+let output = "This tests that when there are &lt;br&gt; elements with contenteditable=false in a contenteditable text area, we can get the correct range for a line.\n\n";
+
+if (window.accessibilityController) {
+  const textControl = accessibilityController.accessibleElementById("textcontrol");
+  const fullRange = textControl.textMarkerRangeForElement(textControl.childAtIndex(0));
+  const marker = textControl.startTextMarkerForTextMarkerRange(fullRange);
+  const range = textControl.lineTextMarkerRangeForTextMarker(marker);
+  var rangeStr = (textControl.stringForTextMarkerRange(range) + "").trim();
+  output += expect("rangeStr", '"First line of text"');
+  debug(output);
+  document.getElementById("textcontrol").hidden = true;
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -1637,7 +1637,9 @@ std::optional<SimpleRange> AccessibilityObject::rangeForCharacterRange(const Cha
 
 VisiblePositionRange AccessibilityObject::lineRangeForPosition(const VisiblePosition& visiblePosition) const
 {
-    return { startOfLine(visiblePosition), endOfLine(visiblePosition) };
+    VisiblePosition startPosition = startOfLine(visiblePosition);
+    VisiblePosition endPosition = nextLineEndPosition(startPosition);
+    return { startPosition, endPosition };
 }
 
 #if PLATFORM(MAC)


### PR DESCRIPTION
#### 69bf3ef0cfdc8cf5748d335c0652a704093630a8
<pre>
AX: lineTextMarkerRangeForTextMarker fails on first character of line in Google Docs
<a href="https://bugs.webkit.org/show_bug.cgi?id=275870">https://bugs.webkit.org/show_bug.cgi?id=275870</a>
<a href="https://rdar.apple.com/130529132">rdar://130529132</a>

Reviewed by Tyler Wilcock.

nextLineEndPosition has some workarounds for cases where the standard VisiblePosition
endOfLine function returns null. When computing AccessibilityObject::lineRangeForPosition
we should use that so that we&apos;re more likely to get a valid line.

* LayoutTests/accessibility/mac/line-text-marker-range-for-text-marker-expected.txt: Added.
* LayoutTests/accessibility/mac/line-text-marker-range-for-text-marker.html: Added.
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::lineRangeForPosition const):

Canonical link: <a href="https://commits.webkit.org/280426@main">https://commits.webkit.org/280426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/920ef6d325dc1d51cf1a710996905b873c29a996

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35925 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9071 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60212 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7039 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58725 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43548 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7230 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45846 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4925 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58628 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33773 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48845 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26707 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30554 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6177 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6042 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6448 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61895 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/510 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6554 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53105 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/512 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48904 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53098 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12524 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/437 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31753 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32839 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33923 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32585 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->