### PR TITLE
[WebXR] Fix MESSAGE_CHECK failure in PlatformXRSystem::RequestFrame()

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -350,11 +350,14 @@ void WebXRSession::shutdown(InitiatedBySystem initiatedBySystem)
 
     m_inputSources->clear();
 
+    RefPtr device = m_device.get();
     if (initiatedBySystem == InitiatedBySystem::Yes) {
         // If we get here, the session termination was triggered by the system rather than
         // via XRSession.end(). Since the system has completed the session shutdown, we can
         // immediately do the final cleanup.
         didCompleteShutdown();
+        if (device)
+            device->didCompleteShutdownTriggeredBySystem();
         return;
     }
 
@@ -364,7 +367,6 @@ void WebXRSession::shutdown(InitiatedBySystem initiatedBySystem)
     //  6.1. Releasing exclusive access to the XR device if session is an immersive session.
     //  6.2. Deallocating any graphics resources acquired by session for presentation to the XR device.
     //  6.3. Putting the XR device in a state such that a different source may be able to initiate a session with the same device if session is an immersive session.
-    auto device = m_device.get();
     if (device)
         device->shutDownTrackingAndRendering();
 

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -380,6 +380,7 @@ public:
 
     virtual void initializeTrackingAndRendering(const WebCore::SecurityOriginData&, SessionMode, const FeatureList&) = 0;
     virtual void shutDownTrackingAndRendering() = 0;
+    virtual void didCompleteShutdownTriggeredBySystem() { }
     TrackingAndRenderingClient* trackingAndRenderingClient() const { return m_trackingAndRenderingClient.get(); }
     void setTrackingAndRenderingClient(WeakPtr<TrackingAndRenderingClient>&& client) { m_trackingAndRenderingClient = WTFMove(client); }
 

--- a/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
+++ b/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
@@ -95,6 +95,12 @@ void XRDeviceProxy::shutDownTrackingAndRendering()
         m_xrSystem->shutDownTrackingAndRendering();
 }
 
+void XRDeviceProxy::didCompleteShutdownTriggeredBySystem()
+{
+    if (m_xrSystem)
+        m_xrSystem->didCompleteShutdownTriggeredBySystem();
+}
+
 Vector<PlatformXR::Device::ViewData> XRDeviceProxy::views(SessionMode mode) const
 {
     Vector<Device::ViewData> views;
@@ -110,6 +116,8 @@ void XRDeviceProxy::requestFrame(PlatformXR::Device::RequestFrameCallback&& call
 {
     if (m_xrSystem)
         m_xrSystem->requestFrame(WTFMove(callback));
+    else
+        callback({ });
 }
 
 std::optional<PlatformXR::LayerHandle> XRDeviceProxy::createLayerProjection(uint32_t width, uint32_t height, bool alpha)

--- a/Source/WebKit/Shared/XR/XRDeviceProxy.h
+++ b/Source/WebKit/Shared/XR/XRDeviceProxy.h
@@ -57,6 +57,7 @@ private:
     WebCore::IntSize recommendedResolution(PlatformXR::SessionMode) final { return m_recommendedResolution; }
     void initializeTrackingAndRendering(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList&) final;
     void shutDownTrackingAndRendering() final;
+    void didCompleteShutdownTriggeredBySystem() final;
     bool supportsSessionShutdownNotification() const final { return true; }
     void initializeReferenceSpace(PlatformXR::ReferenceSpaceType) final { }
     Vector<PlatformXR::Device::ViewData> views(PlatformXR::SessionMode) const final;

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
@@ -84,6 +84,7 @@ private:
     void shutDownTrackingAndRendering();
     void requestFrame(CompletionHandler<void(PlatformXR::FrameData&&)>&&);
     void submitFrame();
+    void didCompleteShutdownTriggeredBySystem();
 
     // PlatformXRCoordinatorSessionEventClient
     void sessionDidEnd(XRDeviceIdentifier) final;
@@ -96,11 +97,13 @@ private:
         Idle,
         RequestingPermissions,
         PermissionsGranted,
-        SessionRunning
+        SessionRunning,
+        SessionEndingFromWebContent,
+        SessionEndingFromSystem,
     };
     ImmersiveSessionState m_immersiveSessionState { ImmersiveSessionState::Idle };
     void setImmersiveSessionState(ImmersiveSessionState);
-    void invalidateImmersiveSessionState();
+    void invalidateImmersiveSessionState(ImmersiveSessionState nextSessionState = ImmersiveSessionState::Idle);
 
     WebPageProxy& m_page;
     std::unique_ptr<ProcessThrottler::ForegroundActivity> m_immersiveSessionActivity;

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in
@@ -32,6 +32,7 @@ messages -> PlatformXRSystem NotRefCounted {
     [EnabledIf='webXREnabled()'] ShutDownTrackingAndRendering()
     [EnabledIf='webXREnabled()'] RequestFrame() -> (struct PlatformXR::FrameData frameData)
     [EnabledIf='webXREnabled()'] SubmitFrame()
+    [EnabledIf='webXREnabled()'] DidCompleteShutdownTriggeredBySystem()
 }
 
 #endif

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp
@@ -86,6 +86,11 @@ void PlatformXRSystemProxy::shutDownTrackingAndRendering()
     m_page.send(Messages::PlatformXRSystem::ShutDownTrackingAndRendering());
 }
 
+void PlatformXRSystemProxy::didCompleteShutdownTriggeredBySystem()
+{
+    m_page.send(Messages::PlatformXRSystem::DidCompleteShutdownTriggeredBySystem());
+}
+
 void PlatformXRSystemProxy::requestFrame(PlatformXR::Device::RequestFrameCallback&& callback)
 {
     m_page.sendWithAsyncReply(Messages::PlatformXRSystem::RequestFrame(), WTFMove(callback));

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
@@ -58,6 +58,7 @@ public:
     void requestPermissionOnSessionFeatures(const WebCore::SecurityOriginData&, PlatformXR::SessionMode, const PlatformXR::Device::FeatureList& /* granted */, const PlatformXR::Device::FeatureList& /* consentRequired */, const PlatformXR::Device::FeatureList& /* consentOptional */, const PlatformXR::Device::FeatureList& /* requiredFeaturesRequested */, const PlatformXR::Device::FeatureList& /* optionalFeaturesRequested */,  CompletionHandler<void(std::optional<PlatformXR::Device::FeatureList>&&)>&&);
     void initializeTrackingAndRendering();
     void shutDownTrackingAndRendering();
+    void didCompleteShutdownTriggeredBySystem();
     void requestFrame(PlatformXR::Device::RequestFrameCallback&&);
     std::optional<PlatformXR::LayerHandle> createLayerProjection(uint32_t, uint32_t, bool);
     void submitFrame();


### PR DESCRIPTION
#### a3fcf4fdfbc19460ad56323d2c0dbb4c26906d2f
<pre>
[WebXR] Fix MESSAGE_CHECK failure in PlatformXRSystem::RequestFrame()
<a href="https://bugs.webkit.org/show_bug.cgi?id=275912">https://bugs.webkit.org/show_bug.cgi?id=275912</a>
<a href="https://rdar.apple.com/130300869">rdar://130300869</a>

Reviewed by Mike Wyrzykowski and Dan Glastonbury.

If the WebXR immersive session was triggered by the system, PlatformXRSystem::sessionDidEnd()
would be called on the UI process side first, which updated the session state to Idle.
However, during the short period when the UI process had handled the session end request but
the web process had not handled it yet, PlatformXRSystem::requestFrame() could still be called
on the UI process side, which would fail the m_immersiveSessionState == SessionRunning check.

To fix this, we introduce two new immersive session states: SessionEndingFromSystem and
SessionEndingFromWebContent. If PlatformXRSystem::sessionDidEnd() is called while the state
is SessionRunning, that means the session end request comes from the system and we&apos;ll update
the state to SessionEndingFromSystem. The message check in PlatformXRSystem::requestFrame()
has been updated to allow the state to be either SessionRunning and SessionEndingFromSystem,
but will skip the actual frame update if it&apos;s SessionEndingFromSystem. When the web process
has ended the XR session, it&apos;ll send the PlatformXRSystem::didCompleteShutdownTriggeredBySystem
message which will reset PlatformXRSystem::m_immersiveSessionState back to Idle.

If the session end request comes from XRSession.end(), then PlatformXRSystem::shutDownTrackingAndRendering()
will be called first when the state is SessionRunning, and the session state will be updated
to SessionEndingFromWebContent. After the system has finished the work to end the session,
PlatformXRSystem::sessionDidEnd() will be called which will update the session state to Idle.

* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::shutdown):
If the ending of the XR session is triggered by the system, call
PlatformXR::Device::didCompleteShutdownTriggeredBySystem() after
finishing the shutdown work.
* Source/WebCore/platform/xr/PlatformXR.h:
(PlatformXR::Device::didCompleteShutdownTriggeredBySystem):
* Source/WebKit/Shared/XR/XRDeviceProxy.cpp:
(WebKit::XRDeviceProxy::didCompleteShutdownTriggeredBySystem):
(WebKit::XRDeviceProxy::requestFrame):
Make sure the completion handler is always called.
* Source/WebKit/Shared/XR/XRDeviceProxy.h:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::shutDownTrackingAndRendering):
(WebKit::PlatformXRSystem::requestFrame):
Allow the session state to be either SessionRunning and SessionEndingFromSystem.
But skip the frame update if it&apos;s SessionEndingFromSystem.
Make sure the completion handler is called even if there&apos;s no xrCoordinator.
(WebKit::PlatformXRSystem::submitFrame):
Allow the session state to be either SessionRunning and SessionEndingFromSystem.
(WebKit::PlatformXRSystem::didCompleteShutdownTriggeredBySystem):
Make sure we&apos;ll only get here from handling a session end request from the system.
Reset the state back to Idle.
(WebKit::PlatformXRSystem::sessionDidEnd):
If this is called when the state is SessionRunning, the session is being ended
by the system so set the next state to be SessionEndingFromSystem. Otherwise,
reset it back to Idle.
(WebKit::PlatformXRSystem::invalidateImmersiveSessionState):
* Source/WebKit/UIProcess/XR/PlatformXRSystem.h:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.messages.in:
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp:
(WebKit::PlatformXRSystemProxy::didCompleteShutdownTriggeredBySystem):
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h:

Canonical link: <a href="https://commits.webkit.org/280392@main">https://commits.webkit.org/280392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a0a94f420f8d3c0a0fde6ae364ec19228927704

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/8959 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60094 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6923 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58613 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43435 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7119 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/45760 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4846 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33676 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48746 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26621 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30453 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6071 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5927 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6343 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61778 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/395 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6459 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53015 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/395 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48807 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52921 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12509 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/350 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/31640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32726 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33809 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32473 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->