### PR TITLE
Web Inspector: UAF needs to be prevented for RemoteConnectionToTarget::m_target member variable

### DIFF
--- a/Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.h
@@ -31,6 +31,7 @@
 #include "RemoteControllableTarget.h"
 #include <wtf/Lock.h>
 #include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/WeakPtr.h>
 
 #if PLATFORM(COCOA)
 #include <wtf/Function.h>
@@ -103,7 +104,7 @@ private:
     Lock m_queueMutex;
 #endif
 
-    RemoteControllableTarget* m_target { nullptr };
+    WeakPtr<RemoteControllableTarget> m_target;
     bool m_connected { false };
 
 #if PLATFORM(COCOA)

--- a/Source/JavaScriptCore/inspector/remote/RemoteControllableTarget.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteControllableTarget.h
@@ -28,6 +28,7 @@
 #if ENABLE(REMOTE_INSPECTOR)
 
 #include "JSExportMacros.h"
+#include <wtf/CanMakeWeakPtr.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/text/WTFString.h>
 
@@ -41,9 +42,12 @@ class FrontendChannel;
 
 using TargetID = unsigned;
 
-class JS_EXPORT_PRIVATE RemoteControllableTarget {
+class JS_EXPORT_PRIVATE RemoteControllableTarget : public CanMakeWeakPtr<RemoteControllableTarget> {
 public:
     virtual ~RemoteControllableTarget();
+
+    virtual void ref() const = 0;
+    virtual void deref() const = 0;
 
     void init();
     void update();

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspector.cpp
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspector.cpp
@@ -227,7 +227,7 @@ TargetListing RemoteInspector::listingForTarget(const RemoteControllableTarget& 
 
 void RemoteInspector::updateTargetListing(TargetID targetIdentifier)
 {
-    auto target = m_targetMap.get(targetIdentifier);
+    RefPtr<RemoteControllableTarget> target = m_targetMap.get(targetIdentifier).get();
     if (!target)
         return;
 

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
@@ -271,7 +271,7 @@ private:
     // from any thread.
     Lock m_mutex;
 
-    HashMap<TargetID, RemoteControllableTarget*> m_targetMap;
+    HashMap<TargetID, WeakPtr<RemoteControllableTarget>> m_targetMap;
     HashMap<TargetID, RefPtr<RemoteConnectionToTarget>> m_targetConnectionMap;
     HashMap<TargetID, TargetListing> m_targetListingMap;
 

--- a/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
+++ b/Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm
@@ -623,8 +623,8 @@ void RemoteInspector::receivedSetupMessage(NSDictionary *userInfo)
         return;
 
     // Attempt to create a connection. This may fail if the page already has an inspector or if it disallows inspection.
-    RemoteControllableTarget* target = findResult->value;
-    auto connectionToTarget = adoptRef(*new RemoteConnectionToTarget(target, connectionIdentifier, sender));
+    RefPtr<RemoteControllableTarget> target = findResult->value.get();
+    auto connectionToTarget = adoptRef(*new RemoteConnectionToTarget(target.get(), connectionIdentifier, sender));
 
     if (is<RemoteInspectionTarget>(target)) {
         bool isAutomaticInspection = m_pausedAutomaticInspectionCandidates.contains(target->targetIdentifier());
@@ -715,7 +715,7 @@ void RemoteInspector::receivedIndicateMessage(NSDictionary *userInfo)
         return;
 
     dispatchAsyncOnMainThreadWithWebThreadLockIfNeeded(^{
-        RemoteControllableTarget* target = nullptr;
+        RefPtr<RemoteControllableTarget> target;
         {
             Locker locker { m_mutex };
 
@@ -723,9 +723,9 @@ void RemoteInspector::receivedIndicateMessage(NSDictionary *userInfo)
             if (findResult == m_targetMap.end())
                 return;
 
-            target = findResult->value;
+            target = findResult->value.get();
         }
-        if (auto* inspectionTarget = dynamicDowncast<RemoteInspectionTarget>(target))
+        if (RefPtr inspectionTarget = dynamicDowncast<RemoteInspectionTarget>(target))
             inspectionTarget->setIndicating(indicateEnabled);
     });
 }

--- a/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp
+++ b/Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp
@@ -264,7 +264,7 @@ void RemoteInspector::receivedCloseMessage(TargetID targetIdentifier)
     RefPtr<RemoteConnectionToTarget> connectionToTarget;
     {
         Locker locker { m_mutex };
-        RemoteControllableTarget* target = m_targetMap.get(targetIdentifier);
+        RefPtr<RemoteControllableTarget> target = m_targetMap.get(targetIdentifier).get();
         if (!target)
             return;
 
@@ -278,15 +278,15 @@ void RemoteInspector::receivedCloseMessage(TargetID targetIdentifier)
 
 void RemoteInspector::setup(TargetID targetIdentifier)
 {
-    RemoteControllableTarget* target;
+    RefPtr<RemoteControllableTarget> target;
     {
         Locker locker { m_mutex };
-        target = m_targetMap.get(targetIdentifier);
+        target = m_targetMap.get(targetIdentifier).get();
         if (!target)
             return;
     }
 
-    auto connectionToTarget = adoptRef(*new RemoteConnectionToTarget(*target));
+    auto connectionToTarget = adoptRef(*new RemoteConnectionToTarget(target.get()));
     ASSERT(is<RemoteInspectionTarget>(target) || is<RemoteAutomationTarget>(target));
     if (!connectionToTarget->setup()) {
         connectionToTarget->close();

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp
@@ -228,15 +228,15 @@ void RemoteInspector::sendMessageToRemote(TargetID targetIdentifier, const Strin
 
 void RemoteInspector::setup(TargetID targetIdentifier)
 {
-    RemoteControllableTarget* target;
+    RefPtr<RemoteControllableTarget> target;
     {
         Locker locker { m_mutex };
-        target = m_targetMap.get(targetIdentifier);
+        target = m_targetMap.get(targetIdentifier).get();
         if (!target)
             return;
     }
 
-    auto connectionToTarget = adoptRef(*new RemoteConnectionToTarget(*target));
+    auto connectionToTarget = adoptRef(*new RemoteConnectionToTarget(target.get()));
     ASSERT(is<RemoteInspectionTarget>(target) || is<RemoteAutomationTarget>(target));
     if (!connectionToTarget->setup()) {
         connectionToTarget->close();
@@ -315,7 +315,7 @@ void RemoteInspector::frontendDidClose(const Event& event)
     RefPtr<RemoteConnectionToTarget> connectionToTarget;
     {
         Locker locker { m_mutex };
-        RemoteControllableTarget* target = m_targetMap.get(event.targetID.value());
+        RefPtr<RemoteControllableTarget> target = m_targetMap.get(event.targetID.value()).get();
         if (!target)
             return;
 

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -823,7 +823,7 @@ void JSGlobalObject::init(VM& vm)
 
 #if ENABLE(REMOTE_INSPECTOR)
     m_inspectorController = makeUnique<Inspector::JSGlobalObjectInspectorController>(*this);
-    m_inspectorDebuggable = makeUnique<JSGlobalObjectDebuggable>(*this);
+    m_inspectorDebuggable = JSGlobalObjectDebuggable::create(*this);
     m_inspectorDebuggable->init();
     m_consoleClient = m_inspectorController->consoleClient();
 #endif

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -421,7 +421,7 @@ public:
 #if ENABLE(REMOTE_INSPECTOR)
     // FIXME: <http://webkit.org/b/246237> Local inspection should be controlled by `inspectable` API.
     std::unique_ptr<Inspector::JSGlobalObjectInspectorController> m_inspectorController;
-    std::unique_ptr<JSGlobalObjectDebuggable> m_inspectorDebuggable;
+    RefPtr<JSGlobalObjectDebuggable> m_inspectorDebuggable;
 #endif
 
     Ref<WatchpointSet> m_masqueradesAsUndefinedWatchpointSet;

--- a/Source/WebCore/page/PageDebuggable.cpp
+++ b/Source/WebCore/page/PageDebuggable.cpp
@@ -44,6 +44,16 @@ PageDebuggable::PageDebuggable(Page& page)
 {
 }
 
+void PageDebuggable::ref() const
+{
+    m_page.ref();
+}
+
+void PageDebuggable::deref() const
+{
+    m_page.deref();
+}
+
 String PageDebuggable::name() const
 {
     RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());

--- a/Source/WebCore/page/PageDebuggable.h
+++ b/Source/WebCore/page/PageDebuggable.h
@@ -41,6 +41,9 @@ public:
     PageDebuggable(Page&);
     ~PageDebuggable() = default;
 
+    void ref() const final;
+    void deref() const final;
+
     Inspector::RemoteControllableTarget::Type type() const final { return Inspector::RemoteControllableTarget::Type::Page; }
 
     String name() const final;

--- a/Source/WebCore/workers/service/context/ServiceWorkerDebuggable.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerDebuggable.cpp
@@ -41,6 +41,16 @@ ServiceWorkerDebuggable::ServiceWorkerDebuggable(ServiceWorkerThreadProxy& servi
 {
 }
 
+void ServiceWorkerDebuggable::ref() const
+{
+    m_serviceWorkerThreadProxy.ref();
+}
+
+void ServiceWorkerDebuggable::deref() const
+{
+    m_serviceWorkerThreadProxy.deref();
+}
+
 void ServiceWorkerDebuggable::connect(FrontendChannel& channel, bool, bool)
 {
     m_serviceWorkerThreadProxy.inspectorProxy().connectToWorker(channel);

--- a/Source/WebCore/workers/service/context/ServiceWorkerDebuggable.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerDebuggable.h
@@ -42,6 +42,9 @@ public:
     ServiceWorkerDebuggable(ServiceWorkerThreadProxy&, const ServiceWorkerContextData&);
     ~ServiceWorkerDebuggable() = default;
 
+    void ref() const final;
+    void deref() const final;
+
     Inspector::RemoteControllableTarget::Type type() const final { return Inspector::RemoteControllableTarget::Type::ServiceWorker; }
 
     String name() const final { return "ServiceWorker"_s; }

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
@@ -68,7 +68,7 @@ ServiceWorkerThreadProxy::ServiceWorkerThreadProxy(Ref<Page>&& page, ServiceWork
     : m_page(WTFMove(page))
     , m_document(*dynamicDowncast<LocalFrame>(m_page->mainFrame())->document())
 #if ENABLE(REMOTE_INSPECTOR)
-    , m_remoteDebuggable(makeUnique<ServiceWorkerDebuggable>(*this, contextData))
+    , m_remoteDebuggable(makeUniqueWithoutRefCountedCheck<ServiceWorkerDebuggable>(*this, contextData))
 #endif
     , m_serviceWorkerThread(ServiceWorkerThread::create(WTFMove(contextData), WTFMove(workerData), WTFMove(userAgent), workerThreadMode, m_document->settingsValues(), *this, *this, *this, idbConnectionProxy(m_document), m_document->socketProvider(), WTFMove(notificationClient), m_page->sessionID(), m_document->noiseInjectionHashSalt(), m_document->advancedPrivacyProtections()))
     , m_cacheStorageProvider(cacheStorageProvider)

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -113,6 +113,9 @@ public:
     WebAutomationSession();
     ~WebAutomationSession();
 
+    void ref() const final { API::ObjectImpl<API::Object::Type::AutomationSession>::ref(); }
+    void deref() const final { API::ObjectImpl<API::Object::Type::AutomationSession>::deref(); }
+
     void setClient(std::unique_ptr<API::AutomationSessionClient>&&);
 
     void setSessionIdentifier(const String& sessionIdentifier) { m_sessionIdentifier = sessionIdentifier; }

--- a/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.cpp
@@ -41,6 +41,16 @@ WebPageDebuggable::WebPageDebuggable(WebPageProxy& page)
 {
 }
 
+void WebPageDebuggable::ref() const
+{
+    m_page.ref();
+}
+
+void WebPageDebuggable::deref() const
+{
+    m_page.deref();
+}
+
 String WebPageDebuggable::name() const
 {
     if (!m_page.mainFrame())

--- a/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h
@@ -29,6 +29,7 @@
 
 #include <JavaScriptCore/RemoteInspectionTarget.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/WeakRef.h>
 
 namespace WebKit {
 
@@ -40,6 +41,9 @@ class WebPageDebuggable final : public Inspector::RemoteInspectionTarget {
 public:
     WebPageDebuggable(WebPageProxy&);
     ~WebPageDebuggable() = default;
+
+    void ref() const final;
+    void deref() const final;
 
     Inspector::RemoteControllableTarget::Type type() const final { return Inspector::RemoteControllableTarget::Type::WebPage; }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -700,7 +700,7 @@ WebPageProxy::WebPageProxy(PageClient& pageClient, WebProcessProxy& process, Ref
 #endif
     , m_inspectorController(makeUnique<WebPageInspectorController>(*this))
 #if ENABLE(REMOTE_INSPECTOR)
-    , m_inspectorDebuggable(makeUnique<WebPageDebuggable>(*this))
+    , m_inspectorDebuggable(makeUniqueWithoutRefCountedCheck<WebPageDebuggable>(*this))
 #endif
     , m_corsDisablingPatterns(m_configuration->corsDisablingPatterns())
 #if ENABLE(APP_BOUND_DOMAINS)


### PR DESCRIPTION
#### 369df60d96b5c4c5eb4e2e3a1b39e838a15f49cf
<pre>
Web Inspector: UAF needs to be prevented for RemoteConnectionToTarget::m_target member variable
<a href="https://webkit.org/b/276192">https://webkit.org/b/276192</a>
<a href="https://rdar.apple.com/129782183">rdar://129782183</a>

Reviewed by NOBODY (OOPS!).

In the RemoteConnectionToTarget class, the member m_target used to be
stored as a raw pointer. This introduced a possible use-after-free bug
we&apos;re experiencing in RemoteConnectionToTarget::close when we try to
disconnect the target, which is done asynchronously and susceptible to
m_target already being freed elsewhere.

This patch fixes that by making m_target, along with other places where
instances of RemoteControllableTarget are stored as member variables,
use smart pointers instead.

I have preliminarily tested that this patch did not break things by:
   - Remote inspecting an iOS device from a Mac with this patch and
     seeing the remote inspector behave normally;
   - Running a short WebDriver automation script with Selenium in Python
     and seeing that it still works as usual and session closes without
     crashes.

* Source/JavaScriptCore/inspector/remote/RemoteControllableTarget.h:
   - Enables using smart pointers to instances of this class or its
     subclasses.

* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
   - This subclass of RemoteControllableTarget also inherits from
     API::ObjectImpl which already has its own lifetime management.
     Specifically, API::ObjectImpl already has non-trivial `ref` and
     and `deref` methods. We ensure that WebAutomationSession continues
     to exhibit behaviors from its other base class API::ObjectImpl
     instead.

* Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h:
* Source/WebKit/UIProcess/Inspector/WebPageDebuggable.cpp:
(WebKit::WebPageDebuggable::ref const):
(WebKit::WebPageDebuggable::deref const):
* Source/WebCore/page/PageDebuggable.h:
* Source/WebCore/page/PageDebuggable.cpp:
(WebCore::PageDebuggable::ref const):
(WebCore::PageDebuggable::deref const):
* Source/WebCore/workers/service/context/ServiceWorkerDebuggable.h:
* Source/WebCore/workers/service/context/ServiceWorkerDebuggable.cpp:
(WebCore::ServiceWorkerDebuggable::ref const):
(WebCore::ServiceWorkerDebuggable::deref const):
   - Redirect the `ref` and `deref` methods of these subclasses of
     RemoteControllableTarget to their unique owner objects instead.
     This way, we ensure these debuggable objects won&apos;t outlive their
     owners, since the debuggables maintain a strong ref to their
     owners. (For example, ServiceWorkerDebuggable has a member
     variable ServiceWorkerThreadProxy&amp; to its owner, so we make sure
     the proxy object&apos;s lifetime gets extended if needed when the
     debuggable gets strongly referred.)

* Source/WebKit/UIProcess/WebPageProxy.cpp:
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::ServiceWorkerThreadProxy::ServiceWorkerThreadProxy):
   - Since the debuggable objects now have `ref` and `deref` methods,
     use makeUniqueWithoutRefCountedCheck to create them instead.

* Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.h:
* Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.cpp:
(JSC::JSGlobalObjectDebuggable::create):
(JSC::JSGlobalObjectDebuggable::JSGlobalObjectDebuggable):
(JSC::JSGlobalObjectDebuggable::name const):
(JSC::JSGlobalObjectDebuggable::connect):
(JSC::JSGlobalObjectDebuggable::disconnect):
(JSC::JSGlobalObjectDebuggable::dispatchMessageFromRemote):
(JSC::JSGlobalObjectDebuggable::pauseWaitingForAutomaticInspection):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
   - Unlike the other subclasses of RemoteInspectionTarget,
     JSGlobalObjectDebuggable&apos;s owner JSGlobalObject doesn&apos;t have `ref`
     and `deref` methods to control its lifetime, so we can&apos;t use the
     similar &quot;redirecting&quot; strategy. We work around that by making
     the debuggable ref counted and, since the debuggable is now capable
     to outlive JSGlobalObject, use a JSC::Weak to prevent UAF.
   - Conform to the recommended pattern involving smart pointers and
     make a static `create` function to replace
     JSGlobalObjectDebuggable&apos;s public constructor.

* Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.h:
* Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.cpp:
(Inspector::RemoteConnectionToTarget::setup):
(Inspector::RemoteConnectionToTarget::sendMessageToTarget):
(Inspector::RemoteConnectionToTarget::close):
(Inspector::RemoteConnectionToTarget::targetIdentifier const):
(Inspector::RemoteConnectionToTarget::sendMessageToFrontend):
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteConnectionToTargetCocoa.mm:
(Inspector::RemoteConnectionToTarget::targetIdentifier const):
(Inspector::RemoteConnectionToTarget::setup):
(Inspector::RemoteConnectionToTarget::close):
(Inspector::RemoteConnectionToTarget::sendMessageToTarget):
(Inspector::RemoteConnectionToTarget::setupRunLoop):
   - Make the RemoteConnectionToTarget::m_target variable a WeakPtr
     and adapt to that change.

* Source/JavaScriptCore/inspector/remote/RemoteInspector.h:
* Source/JavaScriptCore/inspector/remote/RemoteInspector.cpp:
(Inspector::RemoteInspector::updateTargetListing):
* Source/JavaScriptCore/inspector/remote/cocoa/RemoteInspectorCocoa.mm:
(Inspector::RemoteInspector::receivedSetupMessage):
(Inspector::RemoteInspector::receivedIndicateMessage):
* Source/JavaScriptCore/inspector/remote/glib/RemoteInspectorGlib.cpp:
(Inspector::RemoteInspector::receivedCloseMessage):
(Inspector::RemoteInspector::setup):
* Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocket.cpp:
(Inspector::RemoteInspector::setup):
(Inspector::RemoteInspector::frontendDidClose):
   - For correctness, also make the other place where raw pointers to
     RemoteControllableTarget are used, namely the values in the
     RemoteInspector::m_targetMap, use WeakPtr too.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/369df60d96b5c4c5eb4e2e3a1b39e838a15f49cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37356 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10505 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61653 "Hash 369df60d for PR 30213 does not build (failure)") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8473 "Hash 369df60d for PR 30213 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60156 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8662 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/61653 "Hash 369df60d for PR 30213 does not build (failure)") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/59/builds/8473 "Hash 369df60d for PR 30213 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60058 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50158 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/61653 "Hash 369df60d for PR 30213 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31795 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7453 "Passed tests") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7477 "Hash 369df60d for PR 30213 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/51120 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53742 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7721 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63341 "Hash 369df60d for PR 30213 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/57270 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7792 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/63341 "Hash 369df60d for PR 30213 does not build (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1949 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50169 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/63341 "Hash 369df60d for PR 30213 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1665 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/79031 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33185 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13117 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34271 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35355 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34016 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->