### PR TITLE
Upstream RuntimeApplicationChecks

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.cpp
@@ -206,6 +206,23 @@ static SDKAlignedBehaviors computeSDKAlignedBehaviors()
         disableBehavior(SDKAlignedBehavior::ThrowIfCanDeclareGlobalFunctionFails);
     }
 
+    if (linkedBefore(dyld_spring_2024_os_versions, DYLD_IOS_VERSION_17_4, DYLD_MACOSX_VERSION_14_4)) {
+        disableBehavior(SDKAlignedBehavior::AsyncFragmentNavigationPolicyDecision);
+        disableBehavior(SDKAlignedBehavior::DoNotLoadStyleSheetIfHTTPStatusIsNotOK);
+        disableBehavior(SDKAlignedBehavior::ScrollViewSubclassImplementsAddGestureRecognizer);
+    }
+
+    if (linkedBefore(dyld_fall_2024_os_versions, DYLD_IOS_VERSION_18_0, DYLD_MACOSX_VERSION_15_0)) {
+        disableBehavior(SDKAlignedBehavior::FullySuspendsBackgroundContentImmediately);
+        disableBehavior(SDKAlignedBehavior::NoGetElementsByNameQuirk);
+        disableBehavior(SDKAlignedBehavior::ApplicationStateTrackerDoesNotObserveWindow);
+        disableBehavior(SDKAlignedBehavior::ThrowOnKVCInstanceVariableAccess);
+        disableBehavior(SDKAlignedBehavior::BlockOptionallyBlockableMixedContent);
+        disableBehavior(SDKAlignedBehavior::LaxCookieSameSiteAttribute);
+        disableBehavior(SDKAlignedBehavior::UseCFNetworkNetworkLoader);
+        disableBehavior(SDKAlignedBehavior::BrowsingContextControllerSPIAccessRemoved);
+    }
+
     disableAdditionalSDKAlignedBehaviors(behaviors);
 
     return behaviors;

--- a/Source/WTF/wtf/spi/darwin/dyldSPI.h
+++ b/Source/WTF/wtf/spi/darwin/dyldSPI.h
@@ -93,6 +93,14 @@
 #define DYLD_IOS_VERSION_17_2 0x00110200
 #endif
 
+#ifndef DYLD_IOS_VERSION_17_4
+#define DYLD_IOS_VERSION_17_4 0x00110400
+#endif
+
+#ifndef DYLD_IOS_VERSION_18_0
+#define DYLD_IOS_VERSION_18_0 0x00120000
+#endif
+
 #ifndef DYLD_MACOSX_VERSION_10_13
 #define DYLD_MACOSX_VERSION_10_13 0x000A0D00
 #endif
@@ -145,6 +153,14 @@
 #define DYLD_MACOSX_VERSION_14_2 0x000e0200
 #endif
 
+#ifndef DYLD_MACOSX_VERSION_14_4
+#define DYLD_MACOSX_VERSION_14_4 0x000e0400
+#endif
+
+#ifndef DYLD_MACOSX_VERSION_15_0
+#define DYLD_MACOSX_VERSION_15_0 0x000f0000
+#endif
+
 #else
 
 typedef uint32_t dyld_platform_t;
@@ -177,6 +193,8 @@ typedef struct {
 #define DYLD_IOS_VERSION_16_4 0x00100400
 #define DYLD_IOS_VERSION_17_0 0x00110000
 #define DYLD_IOS_VERSION_17_2 0x00110200
+#define DYLD_IOS_VERSION_17_4 0x00110400
+#define DYLD_IOS_VERSION_18_0 0x00120000
 
 #define DYLD_MACOSX_VERSION_10_10 0x000A0A00
 #define DYLD_MACOSX_VERSION_10_11 0x000A0B00
@@ -196,6 +214,8 @@ typedef struct {
 #define DYLD_MACOSX_VERSION_13_3 0x000d0300
 #define DYLD_MACOSX_VERSION_14_0 0x000e0000
 #define DYLD_MACOSX_VERSION_14_2 0x000e0200
+#define DYLD_MACOSX_VERSION_14_4 0x000e0400
+#define DYLD_MACOSX_VERSION_15_0 0x000f0000
 
 #endif
 
@@ -283,6 +303,14 @@ WTF_EXTERN_C_BEGIN
 
 #ifndef dyld_2023_SU_C_os_versions
 #define dyld_2023_SU_C_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
+#endif
+
+#ifndef dyld_spring_2024_os_versions
+#define dyld_spring_2024_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
+#endif
+
+#ifndef dyld_fall_2024_os_versions
+#define dyld_fall_2024_os_versions ({ (dyld_build_version_t) { 0, 0 }; })
 #endif
 
 uint32_t dyld_get_program_sdk_version();


### PR DESCRIPTION
#### 0b32918091ebd1b742ebb57201d49c86a4e0f575
<pre>
Upstream RuntimeApplicationChecks
<a href="https://bugs.webkit.org/show_bug.cgi?id=275933">https://bugs.webkit.org/show_bug.cgi?id=275933</a>
<a href="https://rdar.apple.com/130634399">rdar://130634399</a>

Reviewed by Aditya Keerthi.

This commit upstreams RuntimeApplicationChecks corresponding to
iOS 17.4/18 and macOS 14.4/15.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.cpp:
(WTF::computeSDKAlignedBehaviors):
* Source/WTF/wtf/spi/darwin/dyldSPI.h:

Canonical link: <a href="https://commits.webkit.org/280410@main">https://commits.webkit.org/280410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70933776e0556fa14d7823217e6554ad12b76b5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56551 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9024 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60162 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/6992 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7183 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45806 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4885 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58581 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33734 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48804 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26667 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30515 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6137 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/5995 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/49643 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6409 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61845 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/55792 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/461 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6513 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53065 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/463 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48865 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/52985 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12513 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/402 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/77553 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31705 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12854 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32792 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33876 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32538 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->