### PR TITLE
@supports(background-attachment:fixed) should return false on iOS

### DIFF
--- a/LayoutTests/fast/css/fixed-background-support-disabled-expected.txt
+++ b/LayoutTests/fast/css/fixed-background-support-disabled-expected.txt
@@ -1,0 +1,14 @@
+Tests that background-attachment:fixed returns NO to @supports() when CSSFixedBackgroundSupportEnabled is disabled
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS 'backgroundAttachment' in document.documentElement.style is true
+PASS 'background-attachment' in getComputedStyle(document.documentElement) is true
+PASS CSS.supports('background-attachment:fixed') is false
+PASS CSS.supports('background-attachment:scroll') is true
+PASS CSS.supports('background-attachment:local') is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/fixed-background-support-disabled.html
+++ b/LayoutTests/fast/css/fixed-background-support-disabled.html
@@ -1,0 +1,26 @@
+<!-- webkit-test-runner [ CSSFixedBackgroundSupportEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+if (window.internals)
+    internals.settings.setCSSFixedBackgroundSupportEnabled(false);
+
+description("Tests that background-attachment:fixed returns NO to @supports() when CSSFixedBackgroundSupportEnabled is disabled");
+
+shouldBeTrue("'backgroundAttachment' in document.documentElement.style");
+shouldBeTrue("'background-attachment' in getComputedStyle(document.documentElement)");
+
+// Make sure @supports(background-attachment:fixed) returns NO when CSSFixedBackgroundSupportEnabled is disabled.
+shouldBeFalse("CSS.supports('background-attachment:fixed')");
+
+// Make sure the flag does not impact the other kinds of background-attachment.
+shouldBeTrue("CSS.supports('background-attachment:scroll')");
+shouldBeTrue("CSS.supports('background-attachment:local')");
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/css/fixed-background-support-enabled-expected.txt
+++ b/LayoutTests/fast/css/fixed-background-support-enabled-expected.txt
@@ -1,0 +1,14 @@
+Tests that background-attachment:fixed returns YES to @supports() when CSSFixedBackgroundSupportEnabled is enabled
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS 'backgroundAttachment' in document.documentElement.style is true
+PASS 'background-attachment' in getComputedStyle(document.documentElement) is true
+PASS CSS.supports('background-attachment:fixed') is true
+PASS CSS.supports('background-attachment:scroll') is true
+PASS CSS.supports('background-attachment:local') is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/fixed-background-support-enabled.html
+++ b/LayoutTests/fast/css/fixed-background-support-enabled.html
@@ -1,0 +1,23 @@
+<!-- webkit-test-runner [ CSSFixedBackgroundSupportEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+if (window.internals)
+    internals.settings.setCSSFixedBackgroundSupportEnabled(true);
+
+description("Tests that background-attachment:fixed returns YES to @supports() when CSSFixedBackgroundSupportEnabled is enabled");
+
+shouldBeTrue("'backgroundAttachment' in document.documentElement.style");
+shouldBeTrue("'background-attachment' in getComputedStyle(document.documentElement)");
+
+shouldBeTrue("CSS.supports('background-attachment:fixed')");
+shouldBeTrue("CSS.supports('background-attachment:scroll')");
+shouldBeTrue("CSS.supports('background-attachment:local')");
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -1610,8 +1610,8 @@
         "background-attachment": {
             "values": [
                 "scroll",
-                "fixed",
-                "local"
+                "local",
+                "fixed"
             ],
             "codegen-properties": {
                 "name-for-methods": "Attachment",
@@ -10521,13 +10521,6 @@
                 "url": "https://www.w3.org/TR/css-shapes-1/#typedef-shape-radius"
             }
         },
-        "<attachment>": {
-            "grammar": "scroll | fixed | local",
-            "specification": {
-                "category": "css-backgrounds",
-                "url": "https://www.w3.org/TR/css-backgrounds-3/#background-attachment"
-            }
-        },
         "<blend-mode>": {
             "grammar": "normal | multiply | screen | overlay | darken | lighten | color-dodge | color-burn | hard-light | soft-light | difference | exclusion | hue | saturation | color | luminosity",
             "exported": true,
@@ -10630,14 +10623,6 @@
             "specification": {
                 "category": "css-compositing",
                 "url": "https://www.w3.org/TR/compositing-1/#propdef-background-blend-mode"
-            }
-        },
-        "<single-background-attachment>": {
-            "grammar": "<attachment>",
-            "exported": true,
-            "specification": {
-                "category": "css-backgrounds",
-                "url": "https://www.w3.org/TR/css-backgrounds-3/#background-attachment"
             }
         },
         "<single-background-clip>": {

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -89,6 +89,7 @@ CSSParserContext::CSSParserContext(const Document& document, const URL& sheetBas
     , transformStyleOptimized3DEnabled { document.settings().cssTransformStyleOptimized3DEnabled() }
 #endif
     , masonryEnabled { document.settings().masonryEnabled() }
+    , cssFixedBackgroundSupportEnabled { document.settings().cssFixedBackgroundSupportEnabled() }
     , cssNestingEnabled { document.settings().cssNestingEnabled() }
     , cssPaintingAPIEnabled { document.settings().cssPaintingAPIEnabled() }
     , cssScopeAtRuleEnabled { document.settings().cssScopeAtRuleEnabled() }
@@ -127,29 +128,30 @@ void add(Hasher& hasher, const CSSParserContext& context)
 #if ENABLE(CSS_TRANSFORM_STYLE_OPTIMIZED_3D)
         | context.transformStyleOptimized3DEnabled          << 6
 #endif
-        | context.masonryEnabled                            << 7
-        | context.cssNestingEnabled                         << 8
-        | context.cssPaintingAPIEnabled                     << 9
-        | context.cssScopeAtRuleEnabled                     << 10
-        | context.cssShapeFunctionEnabled                   << 11
-        | context.cssTextUnderlinePositionLeftRightEnabled  << 12
-        | context.cssBackgroundClipBorderAreaEnabled        << 13
-        | context.cssWordBreakAutoPhraseEnabled             << 14
-        | context.popoverAttributeEnabled                   << 15
-        | context.sidewaysWritingModesEnabled               << 16
-        | context.cssTextWrapPrettyEnabled                  << 17
-        | context.highlightAPIEnabled                       << 18
-        | context.grammarAndSpellingPseudoElementsEnabled   << 19
-        | context.customStateSetEnabled                     << 20
-        | context.thumbAndTrackPseudoElementsEnabled        << 21
+        | context.cssFixedBackgroundSupportEnabled          << 7
+        | context.masonryEnabled                            << 8
+        | context.cssNestingEnabled                         << 9
+        | context.cssPaintingAPIEnabled                     << 10
+        | context.cssScopeAtRuleEnabled                     << 11
+        | context.cssShapeFunctionEnabled                   << 12
+        | context.cssTextUnderlinePositionLeftRightEnabled  << 13
+        | context.cssBackgroundClipBorderAreaEnabled        << 14
+        | context.cssWordBreakAutoPhraseEnabled             << 15
+        | context.popoverAttributeEnabled                   << 16
+        | context.sidewaysWritingModesEnabled               << 17
+        | context.cssTextWrapPrettyEnabled                  << 18
+        | context.highlightAPIEnabled                       << 19
+        | context.grammarAndSpellingPseudoElementsEnabled   << 20
+        | context.customStateSetEnabled                     << 21
+        | context.thumbAndTrackPseudoElementsEnabled        << 22
 #if ENABLE(SERVICE_CONTROLS)
-        | context.imageControlsEnabled                      << 22
+        | context.imageControlsEnabled                      << 23
 #endif
-        | context.colorLayersEnabled                        << 23
-        | context.lightDarkEnabled                          << 24
-        | context.targetTextPseudoElementEnabled            << 25
-        | context.viewTransitionTypesEnabled                << 26
-        | (uint32_t)context.mode                            << 27; // This is multiple bits, so keep it last.
+        | context.colorLayersEnabled                        << 24
+        | context.lightDarkEnabled                          << 25
+        | context.targetTextPseudoElementEnabled            << 26
+        | context.viewTransitionTypesEnabled                << 27
+        | (uint32_t)context.mode                            << 28; // This is multiple bits, so keep it last.
     add(hasher, context.baseURL, context.charset, context.propertySettings, bits);
 }
 

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -81,6 +81,7 @@ struct CSSParserContext {
     bool transformStyleOptimized3DEnabled : 1 { false };
 #endif
     bool masonryEnabled : 1 { false };
+    bool cssFixedBackgroundSupportEnabled : 1 { false };
     bool cssNestingEnabled : 1 { false };
     bool cssPaintingAPIEnabled : 1 { false };
     bool cssScopeAtRuleEnabled : 1 { false };

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -1871,7 +1871,7 @@ static RefPtr<CSSValue> consumeBackgroundComponent(CSSPropertyID property, CSSPa
     case CSSPropertyBackgroundBlendMode:
         return CSSPropertyParsing::consumeSingleBackgroundBlendMode(range);
     case CSSPropertyBackgroundAttachment:
-        return CSSPropertyParsing::consumeSingleBackgroundAttachment(range);
+        return consumeSingleBackgroundAttachment(range, context, FromShorthand::Yes);
     case CSSPropertyBackgroundOrigin:
         return CSSPropertyParsing::consumeSingleBackgroundOrigin(range);
     case CSSPropertyBackgroundImage:

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -2909,6 +2909,23 @@ RefPtr<CSSValue> consumeRepeatStyle(CSSParserTokenRange& range, const CSSParserC
     return CSSBackgroundRepeatValue::create(*value1, *value2);
 }
 
+RefPtr<CSSValue> consumeSingleBackgroundAttachment(CSSParserTokenRange& range, const CSSParserContext& context, FromShorthand fromShorthand)
+{
+    // https://www.w3.org/TR/css-backgrounds-3/#background-attachment
+    switch (auto keyword = range.peek().id(); keyword) {
+    case CSSValueScroll:
+    case CSSValueLocal:
+    case CSSValueFixed:
+        if (!context.cssFixedBackgroundSupportEnabled && keyword == CSSValueFixed && fromShorthand == FromShorthand::No)
+            return nullptr;
+        range.consumeIncludingWhitespace();
+        return CSSPrimitiveValue::create(keyword);
+    default:
+        return nullptr;
+    }
+    return nullptr;
+}
+
 RefPtr<CSSValue> consumeSingleBackgroundClip(CSSParserTokenRange& range, const CSSParserContext& context)
 {
     switch (auto keyword = range.peek().id(); keyword) {

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -142,6 +142,8 @@ RefPtr<CSSValue> consumeBorderImageWidth(CSSPropertyID, CSSParserTokenRange&);
 bool consumeBorderImageComponents(CSSPropertyID, CSSParserTokenRange&, const CSSParserContext&, RefPtr<CSSValue>&, RefPtr<CSSValue>&, RefPtr<CSSValue>&, RefPtr<CSSValue>&, RefPtr<CSSValue>&);
 RefPtr<CSSValue> consumeWebkitBorderImage(CSSPropertyID, CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeReflect(CSSParserTokenRange&, const CSSParserContext&);
+enum class FromShorthand : bool { No, Yes };
+RefPtr<CSSValue> consumeSingleBackgroundAttachment(CSSParserTokenRange&, const CSSParserContext&, FromShorthand = FromShorthand::No);
 RefPtr<CSSValue> consumeSingleBackgroundClip(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeBackgroundClip(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeBackgroundSize(CSSPropertyID, CSSParserTokenRange&, CSSParserMode);

--- a/Source/WebCore/page/Settings.yaml
+++ b/Source/WebCore/page/Settings.yaml
@@ -61,6 +61,13 @@ BackgroundShouldExtendBeyondPage:
     WebCore:
       default: false
 
+CSSFixedBackgroundSupportEnabled:
+  type: bool
+  defaultValue:
+    WebCore:
+      PLATFORM(IOS_FAMILY): false
+      default: true
+
 ClientCoordinatesRelativeToLayoutViewport:
   type: bool
   webcoreOnChange: setNeedsRecalcStyleInAllFrames
@@ -110,13 +117,6 @@ EditingBehaviorType:
       OS(WINDOWS): EditingBehaviorType::Windows
       OS(UNIX): EditingBehaviorType::Unix
       default: EditingBehaviorType::Mac
-
-FixedBackgroundsPaintRelativeToDocument:
-  type: bool
-  defaultValue:
-    WebCore:
-      PLATFORM(IOS_FAMILY): true
-      default: false
 
 FixedElementsLayoutRelativeToFrame:
   type: bool

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -587,7 +587,7 @@ BackgroundImageGeometry BackgroundPainter::calculateBackgroundImageGeometry(cons
     } else {
         LayoutRect viewportRect;
         float topContentInset = 0;
-        if (renderer.settings().fixedBackgroundsPaintRelativeToDocument())
+        if (!renderer.settings().cssFixedBackgroundSupportEnabled())
             viewportRect = view.unscaledDocumentRect();
         else {
             LocalFrameView& frameView = view.frameView();

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -948,7 +948,7 @@ void RenderElement::styleWillChange(StyleDifference diff, const RenderStyle& new
     }
 
     bool newStyleSlowScroll = false;
-    if (newStyle.hasAnyFixedBackground() && !settings().fixedBackgroundsPaintRelativeToDocument()) {
+    if (newStyle.hasAnyFixedBackground() && settings().cssFixedBackgroundSupportEnabled()) {
         newStyleSlowScroll = true;
         bool drawsRootBackground = isDocumentElementRenderer() || (isBody() && !rendererHasBackground(document().documentElement()->renderer()));
         if (drawsRootBackground && newStyle.hasEntirelyFixedBackground() && view().compositor().supportsFixedRootBackgroundCompositing())
@@ -1127,7 +1127,7 @@ void RenderElement::willBeDestroyed()
     if (!renderTreeBeingDestroyed() && element())
         document().contentChangeObserver().rendererWillBeDestroyed(*element());
 #endif
-    if (m_style.hasAnyFixedBackground() && !settings().fixedBackgroundsPaintRelativeToDocument())
+    if (m_style.hasAnyFixedBackground() && settings().cssFixedBackgroundSupportEnabled())
         view().protectedFrameView()->removeSlowRepaintObject(*this);
 
     unregisterForVisibleInViewportCallback();

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -4250,7 +4250,7 @@ bool RenderLayerCompositor::needsFixedRootBackgroundLayer(const RenderLayer& lay
     if (!layer.isRenderViewLayer())
         return false;
 
-    if (m_renderView.settings().fixedBackgroundsPaintRelativeToDocument())
+    if (!m_renderView.settings().cssFixedBackgroundSupportEnabled())
         return false;
 
     return supportsFixedRootBackgroundCompositing() && m_renderView.rootBackgroundIsEntirelyFixed();
@@ -5617,7 +5617,7 @@ void RenderLayerCompositor::updateSynchronousScrollingNodes()
     if (!hasCoordinatedScrolling())
         return;
 
-    if (m_renderView.settings().fixedBackgroundsPaintRelativeToDocument())
+    if (!m_renderView.settings().cssFixedBackgroundSupportEnabled())
         return;
 
     auto scrollingCoordinator = this->scrollingCoordinator();


### PR DESCRIPTION
#### 240b0227399a2330bc1704680c2dd2f1769a96b3
<pre>
@supports(background-attachment:fixed) should return false on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=196327">https://bugs.webkit.org/show_bug.cgi?id=196327</a>
<a href="https://rdar.apple.com/95035888">rdar://95035888</a>

Reviewed by NOBODY (OOPS!).

Properly gate support for background-attachment:fixed property on iOS.

Rename the settings flag for support from fixedBackgroundsPaintRelativeToDocument to cssFixedBackgroundSupportEnabled and flip flag for iOS.
This gives a clearer idea to what the flag is gating, and properly returns false when @supports(background-attachment:fixed) is resolved on iOS.

Write custom CSS parser to properly plumb the support across the codebase.

Added tests to verify this functionality.

  * LayoutTests/fast/css/fixed-background-support-disabled-expected.txt: Added.
  * LayoutTests/fast/css/fixed-background-support-disabled.html: Added.
  * LayoutTests/fast/css/fixed-background-support-enabled-expected.txt: Added.
  * LayoutTests/fast/css/fixed-background-support-enabled.html: Added.
  * Source/WebCore/css/CSSProperties.json:
  * Source/WebCore/css/parser/CSSParserContext.cpp:
  (WebCore::add):
  * Source/WebCore/css/parser/CSSParserContext.h:
  * Source/WebCore/css/parser/CSSPropertyParser.cpp:
  (WebCore::consumeBackgroundComponent):
  * Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
  (WebCore::CSSPropertyParserHelpers::consumeSingleBackgroundAttachment):
  * Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
  * Source/WebCore/page/Settings.yaml:
  * Source/WebCore/rendering/BackgroundPainter.cpp:
  (WebCore::BackgroundPainter::calculateBackgroundImageGeometry):
  * Source/WebCore/rendering/RenderElement.cpp:
  (WebCore::RenderElement::styleWillChange):
  (WebCore::RenderElement::willBeDestroyed):
  * Source/WebCore/rendering/RenderLayerCompositor.cpp:
  (WebCore::RenderLayerCompositor::needsFixedRootBackgroundLayer const):
  (WebCore::RenderLayerCompositor::updateSynchronousScrollingNodes):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/240b0227399a2330bc1704680c2dd2f1769a96b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/63811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/43168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/16408 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/67832 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/14419 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/65931 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/50858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/14699 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/51418 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/9970 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/66880 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/39985 "Found 2 new test failures: fast/backgrounds/multiple-backgrounds-computed-style.html fast/css/getComputedStyle/getComputedStyle-background-shorthand.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/55243 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/32035 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/36671 "Found 15 new test failures: imported/w3c/web-platform-tests/css/css-backgrounds/animations/discrete-no-interpolation.html imported/w3c/web-platform-tests/css/css-backgrounds/background-origin-006.html imported/w3c/web-platform-tests/css/css-backgrounds/inheritance.sub.html imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-attachment-computed.html imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-attachment-valid.html imported/w3c/web-platform-tests/css/css-backgrounds/parsing/background-computed.html imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer.html imported/w3c/web-platform-tests/css/css-pseudo/first-letter-allowed-properties.html imported/w3c/web-platform-tests/css/css-pseudo/first-line-allowed-properties.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/background-attachment.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/12624 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/13292 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/58641 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/12951 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/69528 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/7758 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/12494 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/58741 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/7791 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/55339 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/58885 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/6451 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/38988 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/40067 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/41250 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/39810 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->