### PR TITLE
[Writing Tools] Adopt new names for NS/UIWritingToolsAllowedInputOptions

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/WritingToolsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/WritingToolsSPI.h
@@ -41,12 +41,14 @@ constexpr auto PlatformWritingToolsBehaviorDefault = NSWritingToolsBehaviorDefau
 constexpr auto PlatformWritingToolsBehaviorLimited = NSWritingToolsBehaviorLimited;
 constexpr auto PlatformWritingToolsBehaviorComplete = NSWritingToolsBehaviorComplete;
 
-using PlatformWritingToolsAllowedInputOptions = NSWritingToolsAllowedInputOptions;
+// FIXME: (rdar://130540028) Remove uses of the old WritingToolsAllowedInputOptions API in favor of the new WritingToolsResultOptions API, and remove staging.
 
-constexpr auto PlatformWritingToolsAllowedInputOptionsPlainText = NSWritingToolsAllowedInputOptionsPlainText;
-constexpr auto PlatformWritingToolsAllowedInputOptionsRichText = NSWritingToolsAllowedInputOptionsRichText;
-constexpr auto PlatformWritingToolsAllowedInputOptionsList = NSWritingToolsAllowedInputOptionsList;
-constexpr auto PlatformWritingToolsAllowedInputOptionsTable = NSWritingToolsAllowedInputOptionsTable;
+using PlatformWritingToolsResultOptions = NSUInteger;
+
+constexpr auto PlatformWritingToolsResultPlainText = (PlatformWritingToolsResultOptions)(1 << 0);
+constexpr auto PlatformWritingToolsResultRichText = (PlatformWritingToolsResultOptions)(1 << 1);
+constexpr auto PlatformWritingToolsResultList = (PlatformWritingToolsResultOptions)(1 << 2);
+constexpr auto PlatformWritingToolsResultTable = (PlatformWritingToolsResultOptions)(1 << 3);
 
 #else
 
@@ -57,12 +59,14 @@ constexpr auto PlatformWritingToolsBehaviorDefault = UIWritingToolsBehaviorDefau
 constexpr auto PlatformWritingToolsBehaviorLimited = UIWritingToolsBehaviorLimited;
 constexpr auto PlatformWritingToolsBehaviorComplete = UIWritingToolsBehaviorComplete;
 
-using PlatformWritingToolsAllowedInputOptions = UIWritingToolsAllowedInputOptions;
+// FIXME: (rdar://130540028) Remove uses of the old WritingToolsAllowedInputOptions API in favor of the new WritingToolsResultOptions API, and remove staging.
 
-constexpr auto PlatformWritingToolsAllowedInputOptionsPlainText = UIWritingToolsAllowedInputOptionsPlainText;
-constexpr auto PlatformWritingToolsAllowedInputOptionsRichText = UIWritingToolsAllowedInputOptionsRichText;
-constexpr auto PlatformWritingToolsAllowedInputOptionsList = UIWritingToolsAllowedInputOptionsList;
-constexpr auto PlatformWritingToolsAllowedInputOptionsTable = UIWritingToolsAllowedInputOptionsTable;
+using PlatformWritingToolsResultOptions = NSUInteger;
+
+constexpr auto PlatformWritingToolsResultPlainText = (PlatformWritingToolsResultOptions)(1 << 0);
+constexpr auto PlatformWritingToolsResultRichText = (PlatformWritingToolsResultOptions)(1 << 1);
+constexpr auto PlatformWritingToolsResultList = (PlatformWritingToolsResultOptions)(1 << 2);
+constexpr auto PlatformWritingToolsResultTable = (PlatformWritingToolsResultOptions)(1 << 3);
 
 #endif
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2079,14 +2079,19 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
 
 #pragma mark - WTWritingToolsDelegate conformance
 
-- (PlatformWritingToolsAllowedInputOptions)writingToolsAllowedInputOptions {
+- (PlatformWritingToolsResultOptions)allowedWritingToolsResultOptions
+{
     auto& editorState = _page->editorState();
     if (editorState.isContentEditable && !editorState.isContentRichlyEditable)
-        return PlatformWritingToolsAllowedInputOptionsPlainText;
+        return PlatformWritingToolsResultPlainText;
 
-    PlatformWritingToolsAllowedInputOptions listOption = (PlatformWritingToolsAllowedInputOptions)(1 << 2);
+    return PlatformWritingToolsResultPlainText | PlatformWritingToolsResultRichText | PlatformWritingToolsResultList | PlatformWritingToolsResultTable;
+}
 
-    return PlatformWritingToolsAllowedInputOptionsPlainText | PlatformWritingToolsAllowedInputOptionsRichText | listOption | PlatformWritingToolsAllowedInputOptionsTable;
+// FIXME: (rdar://130540028) Remove uses of the old WritingToolsAllowedInputOptions API in favor of the new WritingToolsResultOptions API, and remove staging.
+- (PlatformWritingToolsResultOptions)writingToolsAllowedInputOptions
+{
+    return [self allowedWritingToolsResultOptions];
 }
 
 - (PlatformWritingToolsBehavior)writingToolsBehavior

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -407,9 +407,13 @@ struct PerWebProcessState {
 - (void)_proofreadingSessionWithUUID:(NSUUID *)sessionUUID updateState:(WebCore::WritingTools::TextSuggestionState)state forSuggestionWithUUID:(NSUUID *)replacementUUID;
 
 #if PLATFORM(MAC)
-- (NSWritingToolsAllowedInputOptions)writingToolsAllowedInputOptions;
+// FIXME: (rdar://130540028) Remove uses of the old WritingToolsAllowedInputOptions API in favor of the new WritingToolsResultOptions API, and remove staging.
+- (PlatformWritingToolsResultOptions)writingToolsAllowedInputOptions;
+- (PlatformWritingToolsResultOptions)allowedWritingToolsResultOptions;
 #else
-- (UIWritingToolsAllowedInputOptions)writingToolsAllowedInputOptions;
+// FIXME: (rdar://130540028) Remove uses of the old WritingToolsAllowedInputOptions API in favor of the new WritingToolsResultOptions API, and remove staging.
+- (PlatformWritingToolsResultOptions)writingToolsAllowedInputOptions;
+- (PlatformWritingToolsResultOptions)allowedWritingToolsResultOptions;
 #endif
 
 #endif // ENABLE(WRITING_TOOLS)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -13259,9 +13259,15 @@ inline static NSString *extendSelectionCommand(UITextLayoutDirection direction)
 
 #if ENABLE(WRITING_TOOLS)
 
-- (UIWritingToolsAllowedInputOptions)writingToolsAllowedInputOptions
+// FIXME: (rdar://130540028) Remove uses of the old WritingToolsAllowedInputOptions API in favor of the new WritingToolsResultOptions API, and remove staging.
+- (PlatformWritingToolsResultOptions)writingToolsAllowedInputOptions
 {
-    return [_webView writingToolsAllowedInputOptions];
+    return [_webView allowedWritingToolsResultOptions];
+}
+
+- (PlatformWritingToolsResultOptions)allowedWritingToolsResultOptions
+{
+    return [_webView allowedWritingToolsResultOptions];
 }
 
 - (UIWritingToolsBehavior)writingToolsBehavior

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -106,6 +106,21 @@
 
 @end
 
+// FIXME: (rdar://130540028) Remove uses of the old WritingToolsAllowedInputOptions API in favor of the new WritingToolsResultOptions API, and remove staging.
+#if PLATFORM(IOS_FAMILY)
+@protocol UITextInput_Staging130540028 <UITextInput>
+
+- (PlatformWritingToolsResultOptions)allowedWritingToolsResultOptions;
+
+@end
+#else
+@protocol NSTextInputTraits_Staging130540028 <NSTextInputTraits>
+
+- (PlatformWritingToolsResultOptions)allowedWritingToolsResultOptions;
+
+@end
+#endif
+
 @interface WritingToolsWKWebView : TestWKWebView
 
 @end
@@ -171,12 +186,12 @@
 #endif
 }
 
-- (PlatformWritingToolsAllowedInputOptions)writingToolsAllowedInputOptionsForTesting
+- (PlatformWritingToolsResultOptions)allowedWritingToolsResultOptionsForTesting
 {
 #if PLATFORM(IOS_FAMILY)
-    return [(id<UITextInput>)[self textInputContentView] writingToolsAllowedInputOptions];
+    return [(id<UITextInput_Staging130540028>)[self textInputContentView] allowedWritingToolsResultOptions];
 #else
-    return [(id<NSTextInputTraits>)self writingToolsAllowedInputOptions];
+    return [(id<NSTextInputTraits_Staging130540028>)self allowedWritingToolsResultOptions];
 #endif
 }
 
@@ -1835,7 +1850,7 @@ TEST(WritingTools, AllowedInputOptionsNonEditable)
 {
     auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body></body>"]);
 
-    EXPECT_EQ(PlatformWritingToolsAllowedInputOptionsPlainText | PlatformWritingToolsAllowedInputOptionsRichText | PlatformWritingToolsAllowedInputOptionsList | PlatformWritingToolsAllowedInputOptionsTable, [webView writingToolsAllowedInputOptionsForTesting]);
+    EXPECT_EQ(PlatformWritingToolsResultPlainText | PlatformWritingToolsResultRichText | PlatformWritingToolsResultList | PlatformWritingToolsResultTable, [webView allowedWritingToolsResultOptionsForTesting]);
 }
 
 TEST(WritingTools, AllowedInputOptionsEditable)
@@ -1844,7 +1859,7 @@ TEST(WritingTools, AllowedInputOptionsEditable)
     [webView _setEditable:YES];
     [webView focusDocumentBodyAndSelectAll];
 
-    EXPECT_EQ(PlatformWritingToolsAllowedInputOptionsPlainText | PlatformWritingToolsAllowedInputOptionsRichText | PlatformWritingToolsAllowedInputOptionsList | PlatformWritingToolsAllowedInputOptionsTable, [webView writingToolsAllowedInputOptionsForTesting]);
+    EXPECT_EQ(PlatformWritingToolsResultPlainText | PlatformWritingToolsResultRichText | PlatformWritingToolsResultList | PlatformWritingToolsResultTable, [webView allowedWritingToolsResultOptionsForTesting]);
 }
 
 TEST(WritingTools, AllowedInputOptionsRichText)
@@ -1852,7 +1867,7 @@ TEST(WritingTools, AllowedInputOptionsRichText)
     auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
-    EXPECT_EQ(PlatformWritingToolsAllowedInputOptionsPlainText | PlatformWritingToolsAllowedInputOptionsRichText | PlatformWritingToolsAllowedInputOptionsList | PlatformWritingToolsAllowedInputOptionsTable, [webView writingToolsAllowedInputOptionsForTesting]);
+    EXPECT_EQ(PlatformWritingToolsResultPlainText | PlatformWritingToolsResultRichText | PlatformWritingToolsResultList | PlatformWritingToolsResultTable, [webView allowedWritingToolsResultOptionsForTesting]);
 }
 
 TEST(WritingTools, AllowedInputOptionsPlainText)
@@ -1860,7 +1875,7 @@ TEST(WritingTools, AllowedInputOptionsPlainText)
     auto webView = adoptNS([[WritingToolsWKWebView alloc] initWithHTMLString:@"<body contenteditable=\"plaintext-only\"></body>"]);
     [webView focusDocumentBodyAndSelectAll];
 
-    EXPECT_EQ(PlatformWritingToolsAllowedInputOptionsPlainText, [webView writingToolsAllowedInputOptionsForTesting]);
+    EXPECT_EQ(PlatformWritingToolsResultPlainText, [webView allowedWritingToolsResultOptionsForTesting]);
 }
 
 TEST(WritingTools, EphemeralSessionWithDifferingTextLengths)


### PR DESCRIPTION
#### 785069e5ddf2eedf46d6c7aeabe4ff61b60fc918
<pre>
[Writing Tools] Adopt new names for NS/UIWritingToolsAllowedInputOptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=275935">https://bugs.webkit.org/show_bug.cgi?id=275935</a>
<a href="https://rdar.apple.com/130540106">rdar://130540106</a>

Reviewed by Tim Horton and Abrar Rahman Protyasha.

Temporarily add staging declarations for the new API and remove uses of the old API, while still
retaining equal functionality for both APIs.

* Source/WebCore/PAL/pal/spi/cocoa/WritingToolsSPI.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView allowedWritingToolsResultOptions]):
(-[WKWebView writingToolsAllowedInputOptions]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView writingToolsAllowedInputOptions]):
(-[WKContentView allowedWritingToolsResultOptions]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(-[WritingToolsWKWebView allowedWritingToolsResultOptionsForTesting]):
(TEST(WritingTools, AllowedInputOptionsNonEditable)):
(TEST(WritingTools, AllowedInputOptionsEditable)):
(TEST(WritingTools, AllowedInputOptionsRichText)):
(TEST(WritingTools, AllowedInputOptionsPlainText)):
(-[WritingToolsWKWebView writingToolsAllowedInputOptionsForTesting]): Deleted.

Canonical link: <a href="https://commits.webkit.org/280945@main">https://commits.webkit.org/280945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29e063be0b5fc72547094b5bccefc6681b4982b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58101 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10581 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61726 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8546 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/60229 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45065 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8737 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/47072 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6087 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60131 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35094 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27906 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31857 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7523 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7550 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53804 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/7791 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63427 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7850 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/54341 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2022 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50239 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54446 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1724 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8670 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33258 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/34344 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35428 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34089 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->