### PR TITLE
Add style and layout interleaving for `anchor()`

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2499,6 +2499,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     storage/StorageType.h
     storage/StorageUtilities.h
 
+    style/AnchorPositionEvaluator.h
     style/PseudoElementIdentifier.h
     style/ScopedName.h
     style/StyleAppearance.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2937,6 +2937,7 @@ storage/StorageEventDispatcher.cpp
 storage/StorageMap.cpp
 storage/StorageNamespaceProvider.cpp
 storage/StorageUtilities.cpp
+style/AnchorPositionEvaluator.cpp
 style/AttributeChangeInvalidation.cpp
 style/ChildChangeInvalidation.cpp
 style/ClassChangeInvalidation.cpp

--- a/Source/WebCore/css/CSSAnchorValue.cpp
+++ b/Source/WebCore/css/CSSAnchorValue.cpp
@@ -30,6 +30,14 @@
 
 namespace WebCore {
 
+void CSSAnchorValue::collectAnchorNames(HashSet<String>& accumulator) const
+{
+    if (m_anchorElement)
+        accumulator.add(m_anchorElement->stringValue());
+    // FIXME: Support collecting anchor names from m_fallback
+}
+
+
 Ref<CSSAnchorValue> CSSAnchorValue::create(RefPtr<CSSPrimitiveValue>&& anchorElement, Ref<CSSValue>&& anchorSide, RefPtr<CSSPrimitiveValue>&& fallback)
 {
     return adoptRef(*new CSSAnchorValue(WTFMove(anchorElement), WTFMove(anchorSide), WTFMove(fallback)));

--- a/Source/WebCore/css/CSSAnchorValue.h
+++ b/Source/WebCore/css/CSSAnchorValue.h
@@ -26,11 +26,16 @@
 #pragma once
 
 #include "CSSValue.h"
+#include "Length.h"
 
 namespace WebCore {
 
+class Element;
+
 class CSSAnchorValue final : public CSSValue {
 public:
+    void collectAnchorNames(HashSet<String>& accumulator) const;
+
     static Ref<CSSAnchorValue> create(RefPtr<CSSPrimitiveValue>&& anchorElement, Ref<CSSValue>&& anchorSide, RefPtr<CSSPrimitiveValue>&& fallback);
 
     void collectComputedStyleDependencies(ComputedStyleDependencies&) const;

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -185,6 +185,8 @@ public:
 
     const CSSCalcValue* cssCalcValue() const { return isCalculated() ? m_value.calc : nullptr; }
 
+    const CSSAnchorValue* cssAnchorValue() const { return isAnchor() ? m_value.anchor : nullptr; }
+
     String customCSSText() const;
 
     bool equals(const CSSPrimitiveValue&) const;

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -4455,11 +4455,10 @@ RefPtr<CSSPrimitiveValue> consumeAnchor(CSSParserTokenRange& range, CSSParserMod
 {
     // https://drafts.csswg.org/css-anchor-position-1/#anchor-pos
     // <anchor()> = anchor( <anchor-element>? && <anchor-side>, <length-percentage>? )
-    auto rangeCopy = range;
-
-    if (rangeCopy.peek().type() != FunctionToken || range.peek().functionId() != CSSValueAnchor)
+    if (range.peek().type() != FunctionToken || range.peek().functionId() != CSSValueAnchor)
         return nullptr;
 
+    auto rangeCopy = range;
     auto args = consumeFunction(rangeCopy);
     if (!args.size())
         return nullptr;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2570,9 +2570,10 @@ void Document::resolveStyle(ResolveStyleType type)
         Style::TreeResolver resolver(*this, WTFMove(m_pendingRenderTreeUpdate));
         auto styleUpdate = resolver.resolve();
 
-        while (resolver.hasUnresolvedQueryContainers()) {
+        while (resolver.hasUnresolvedQueryContainers() || resolver.hasUnresolvedAnchorPositionedElements()) {
             if (styleUpdate) {
-                SetForScope resolvingContainerQueriesScope(m_isResolvingContainerQueries, true);
+                SetForScope resolvingContainerQueriesScope(m_isResolvingContainerQueries, resolver.hasUnresolvedQueryContainers());
+                SetForScope resolvingAnchorPositionedElementsScope(m_isResolvingAnchorPositionedElements, resolver.hasUnresolvedAnchorPositionedElements());
 
                 updateRenderTree(WTFMove(styleUpdate));
 
@@ -2995,6 +2996,15 @@ bool Document::isResolvingContainerQueriesForSelfOrAncestor() const
         return true;
     if (RefPtr owner = ownerElement())
         return owner->document().isResolvingContainerQueriesForSelfOrAncestor();
+    return false;
+}
+
+bool Document::isInStyleInterleavedLayoutForSelfOrAncestor() const
+{
+    if (isInStyleInterleavedLayout())
+        return true;
+    if (RefPtr owner = ownerElement())
+        return owner->document().isInStyleInterleavedLayoutForSelfOrAncestor();
     return false;
 }
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1542,6 +1542,8 @@ public:
     bool inRenderTreeUpdate() const { return m_inRenderTreeUpdate; }
     bool isResolvingContainerQueries() const { return m_isResolvingContainerQueries; }
     bool isResolvingContainerQueriesForSelfOrAncestor() const;
+    bool isInStyleInterleavedLayout() const { return m_isResolvingContainerQueries || m_isResolvingAnchorPositionedElements; };
+    bool isInStyleInterleavedLayoutForSelfOrAncestor() const;
     bool isResolvingTreeStyle() const { return m_isResolvingTreeStyle; }
     void setIsResolvingTreeStyle(bool);
 
@@ -2527,6 +2529,7 @@ private:
     bool m_inRenderTreeUpdate { false };
     bool m_isResolvingTreeStyle { false };
     bool m_isResolvingContainerQueries { false };
+    bool m_isResolvingAnchorPositionedElements { false };
 
     bool m_gotoAnchorNeededAfterStylesheetsLoad { false };
     TriState m_isDNSPrefetchEnabled { TriState::Indeterminate };

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2548,6 +2548,17 @@ void Element::invalidateForResumingQueryContainerResolution()
     markAncestorsForInvalidatedStyle();
 }
 
+void Element::invalidateAncestorsForAnchor()
+{
+    markAncestorsForInvalidatedStyle();
+}
+
+void Element::invalidateForResumingAnchorPositionedElementResolution()
+{
+    invalidateStyleInternal();
+    markAncestorsForInvalidatedStyle();
+}
+
 bool Element::needsUpdateQueryContainerDependentStyle() const
 {
     return hasElementStateFlag(ElementStateFlag::NeedsUpdateQueryContainerDependentStyle);

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -760,6 +760,8 @@ public:
     void invalidateStyleForSubtreeInternal();
     void invalidateForQueryContainerSizeChange();
     void invalidateForResumingQueryContainerResolution();
+    void invalidateAncestorsForAnchor();
+    void invalidateForResumingAnchorPositionedElementResolution();
 
     bool needsUpdateQueryContainerDependentStyle() const;
     void clearNeedsUpdateQueryContainerDependentStyle();

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -203,7 +203,7 @@ void LocalFrameViewLayoutContext::performLayout()
     {
         SetForScope layoutPhase(m_layoutPhase, LayoutPhase::InPreLayout);
 
-        if (!document()->isResolvingContainerQueriesForSelfOrAncestor()) {
+        if (!document()->isInStyleInterleavedLayoutForSelfOrAncestor()) {
             // If this is a new top-level layout and there are any remaining tasks from the previous layout, finish them now.
             if (!isLayoutNested() && m_postLayoutTaskTimer.isActive())
                 runPostLayoutTasks();
@@ -283,8 +283,8 @@ void LocalFrameViewLayoutContext::runOrScheduleAsynchronousTasks()
     if (m_postLayoutTaskTimer.isActive())
         return;
 
-    if (document()->isResolvingContainerQueries()) {
-        // We are doing layout from style resolution to resolve container queries.
+    if (document()->isInStyleInterleavedLayout()) {
+        // We are doing layout from style resolution to resolve container queries and/or anchor-positioned elements.
         m_postLayoutTaskTimer.startOneShot(0_s);
         return;
     }

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AnchorPositionEvaluator.h"
+
+#include "Document.h"
+#include "Element.h"
+#include "StyleScope.h"
+
+namespace WebCore::Style {
+
+Length AnchorPositionEvaluator::resolveAnchorValue(const CSSAnchorValue* anchorValue, const Element& element)
+{
+    auto& anchorPositionedStateMap = element.document().styleScope().anchorPositionedStateMap();
+
+    auto* anchorPositionedElementState = anchorPositionedStateMap.ensure(element, [&] {
+        return WTF::makeUnique<AnchorPositionedElementState>();
+    }).iterator->value.get();
+
+    if (!anchorPositionedElementState->finishedCollectingAnchorNames)
+        anchorValue->collectAnchorNames(anchorPositionedElementState->anchorNames);
+
+    if (!anchorPositionedElementState->readyToBeResolved)
+        return Length(0, LengthType::Fixed);
+
+    // FIXME: Actually resolve the value
+    anchorPositionedElementState->hasBeenResolved = true;
+    return Length(0, LengthType::Fixed);
+}
+
+}

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "CSSAnchorValue.h"
+#include "EventTarget.h"
+#include <memory>
+#include <wtf/WeakHashMap.h>
+
+namespace WebCore {
+
+class Element;
+
+namespace Style {
+
+struct AnchorPositionedElementState {
+    WTF_MAKE_FAST_ALLOCATED;
+public:
+    HashMap<String, Ref<Element>> anchorElements;
+    HashSet<String> anchorNames;
+    bool finishedCollectingAnchorNames { false };
+    bool readyToBeResolved { false };
+    bool hasBeenResolved { false };
+};
+
+using AnchorPositionedStateMap = WeakHashMap<Element, std::unique_ptr<AnchorPositionedElementState>, WeakPtrImplWithEventTargetData>;
+
+class AnchorPositionEvaluator {
+public:
+    static Length resolveAnchorValue(const CSSAnchorValue*, const Element&);
+};
+
+}
+}

--- a/Source/WebCore/style/MatchedDeclarationsCache.cpp
+++ b/Source/WebCore/style/MatchedDeclarationsCache.cpp
@@ -36,6 +36,7 @@
 #include "FontCascade.h"
 #include "RenderStyleInlines.h"
 #include "StyleResolver.h"
+#include "StyleScope.h"
 #include <wtf/text/StringHash.h>
 
 namespace WebCore {
@@ -78,6 +79,14 @@ bool MatchedDeclarationsCache::isCacheable(const Element& element, const RenderS
     if (style.writingMode() != RenderStyle::initialWritingMode() || style.direction() != RenderStyle::initialDirection())
         return false;
     if (style.usesContainerUnits())
+        return false;
+
+    // An anchor-positioned element needs to first be resolved in order to gather
+    // relevant anchor-names. Style & layout interleaving uses that information to find
+    // the relevant anchors that this element will be positioned relative to. Then, the
+    // anchor-positioned element will be resolved once again, this time with the anchor
+    // information needed to fully resolve the element.
+    if (element.document().styleScope().anchorPositionedStateMap().contains(element))
         return false;
 
     // Getting computed style after a font environment change but before full style resolution may involve styles with non-current fonts.

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include "AnchorPositionEvaluator.h"
 #include "BasicShapeFunctions.h"
 #include "CSSBasicShapes.h"
 #include "CSSCalcValue.h"
@@ -264,8 +265,10 @@ inline Length BuilderConverter::convertLength(const BuilderState& builderState, 
     if (primitiveValue.isCalculatedPercentageWithLength())
         return Length(primitiveValue.cssCalcValue()->createCalculationValue(conversionData));
 
-    if (primitiveValue.isAnchor())
-        return Length(0, LengthType::Fixed);
+    if (primitiveValue.isAnchor()) {
+        auto& anchorPositionedElement = *builderState.element();
+        return AnchorPositionEvaluator::resolveAnchorValue(primitiveValue.cssAnchorValue(), anchorPositionedElement);
+    }
 
     ASSERT_NOT_REACHED();
     return Length(0, LengthType::Fixed);

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -30,6 +30,7 @@
 #include "config.h"
 #include "StyleResolver.h"
 
+#include "AnchorPositionEvaluator.h"
 #include "BlendingKeyframes.h"
 #include "CSSCustomPropertyValue.h"
 #include "CSSFontSelector.h"

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include "AnchorPositionEvaluator.h"
 #include "LayoutSize.h"
 #include "StyleScopeOrdinal.h"
 #include "Timer.h"
@@ -155,6 +156,8 @@ public:
     const CSSCounterStyleRegistry& counterStyleRegistry() const { return m_counterStyleRegistry.get(); }
     CSSCounterStyleRegistry& counterStyleRegistry() { return m_counterStyleRegistry.get(); }
 
+    AnchorPositionedStateMap& anchorPositionedStateMap() { return m_anchorPositionedStateMap; }
+
 private:
     Scope& documentScope();
     bool isForUserAgentShadowTree() const;
@@ -248,6 +251,8 @@ private:
 
     // FIXME: These (and some things above) are only relevant for the root scope.
     HashMap<ResolverSharingKey, Ref<Resolver>> m_sharedShadowTreeResolvers;
+
+    AnchorPositionedStateMap m_anchorPositionedStateMap;
 };
 
 HTMLSlotElement* assignedSlotForScopeOrdinal(const Element&, ScopeOrdinal);

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "StyleTreeResolver.h"
 
+#include "AnchorPositionEvaluator.h"
 #include "CSSFontSelector.h"
 #include "ComposedTreeAncestorIterator.h"
 #include "ComposedTreeIterator.h"
@@ -874,6 +875,21 @@ void TreeResolver::popParent()
     if (!queryContainers.isEmpty() && queryContainers.last().ptr() == &parentElement)
         queryContainers.removeLast();
 
+    // If parentElement is a containing block that positions anchor-positioned elements,
+    // then try to find the relevant anchors for those anchor-positioned elements here.
+    if (m_canFindAnchorsForNextAnchorPositionedElement) {
+        const auto& unresolvedAnchorPositionedElements = m_unresolvedAnchorPositionedElementsForContainingBlock.get(parentElement);
+        if (!unresolvedAnchorPositionedElements.isEmpty()) {
+            // FIXME: Ideally we would style resolve the entire subtree rooted at each
+            // element in this vector. This may or may not be possible via refactoring.
+            // Otherwise, this approach can only style resolve one anchor-positioned
+            // element per iteration in style & layout interleaving.
+            auto anchorPositionedElement = unresolvedAnchorPositionedElements.at(0);
+            findAnchorsForAnchorPositionedElement(anchorPositionedElement, &parentElement);
+            m_canFindAnchorsForNextAnchorPositionedElement = false;
+        }
+    }
+
     m_parentStack.removeLast();
 }
 
@@ -1073,12 +1089,20 @@ void TreeResolver::resolveComposedTree()
 
         auto queryContainerAction = updateStateForQueryContainer(element, style, change, descendantsToResolve);
 
+        if (queryContainerAction == QueryContainerAction::Resolve)
+            m_canFindAnchorsForNextAnchorPositionedElement = false;
+
+        auto anchorPositionedElementAction = updateAnchorPositioningState(element, style);
+
         bool shouldIterateChildren = [&] {
             // display::none, no need to resolve descendants.
             if (!style)
                 return false;
             // Style resolution will be resumed after the container has been resolved.
             if (queryContainerAction == QueryContainerAction::Resolve)
+                return false;
+            // Style resolution will be resumed after the anchor-positioned element has been resolved.
+            if (anchorPositionedElementAction == AnchorPositionedElementAction::SkipDescendants)
                 return false;
             return element.childNeedsStyleRecalc() || descendantsToResolve != DescendantsToResolve::None;
         }();
@@ -1103,6 +1127,7 @@ void TreeResolver::resolveComposedTree()
     }
 
     popParentsToDepth(1);
+    updateAnchorPositioningStateInInitialContainingBlock();
 }
 
 const RenderStyle* TreeResolver::existingStyle(const Element& element)
@@ -1154,6 +1179,13 @@ std::unique_ptr<Update> TreeResolver::resolve()
 {
     m_hasUnresolvedQueryContainers = false;
 
+    m_anchorElements.clear();
+    m_unresolvedAnchorPositionedElementsForContainingBlock.clear();
+    m_unresolvedAnchorPositionedElementsForInitialContainingBlock.clear();
+    m_anchorsForAnchorName.clear();
+    m_hasUnresolvedAnchorPositionedElements = false;
+    m_canFindAnchorsForNextAnchorPositionedElement = true;
+
     Element* documentElement = m_document.documentElement();
     if (!documentElement) {
         m_document.styleScope().resolver();
@@ -1182,6 +1214,21 @@ std::unique_ptr<Update> TreeResolver::resolve()
             // Ensure that resumed resolution reaches the container.
             if (containerAndState.value)
                 containerAndState.key->invalidateForResumingQueryContainerResolution();
+        }
+    }
+
+    if (m_hasUnresolvedAnchorPositionedElements) {
+        // During each style resolution, we need to iterate through all anchors
+        // to efficiently find the most recent anchor element in DOM tree order
+        // at any point in time during style resolution.
+        for (auto& anchorElement : m_anchorElements)
+            anchorElement->invalidateAncestorsForAnchor();
+
+        // We also need to ensure that style resolution visits any unresolved
+        // anchor-positioned elements.
+        for (auto elementAndState : m_document.styleScope().anchorPositionedStateMap()) {
+            if (!elementAndState.value->hasBeenResolved)
+                elementAndState.key.invalidateForResumingAnchorPositionedElementResolution();
         }
     }
 
@@ -1263,6 +1310,126 @@ PostResolutionCallbackDisabler::~PostResolutionCallbackDisabler()
 bool postResolutionCallbacksAreSuspended()
 {
     return resolutionNestingDepth;
+}
+
+auto TreeResolver::updateAnchorPositioningState(Element& element, const RenderStyle* style) -> AnchorPositionedElementAction
+{
+    if (!style)
+        return AnchorPositionedElementAction::None;
+
+    // Maintain the list of anchors (in tree order) used for anchor-positioned elements
+    if (m_canFindAnchorsForNextAnchorPositionedElement) {
+        if (!style->anchorNames().isEmpty()) {
+            for (auto& anchorName : style->anchorNames()) {
+                m_anchorElements.add(element);
+                m_anchorsForAnchorName.ensure(anchorName, [&] {
+                    return Vector<Ref<Element>> { };
+                }).iterator->value.append(element);
+            }
+        }
+    }
+
+    // Check if this element is anchor-positioned
+    auto* anchorPositionedElementState = m_document.styleScope().anchorPositionedStateMap().get(element);
+    if (!anchorPositionedElementState)
+        return AnchorPositionedElementAction::None;
+
+    // Update state for anchor-positioned elements
+    m_hasUnresolvedAnchorPositionedElements = !anchorPositionedElementState->hasBeenResolved;
+    if (!element.renderer()) {
+        // We are seeing this anchor-positioned element for the first time during
+        // style & layout interleaving. Wait until we have relevant layout information
+        // before further processing this anchor-positioned element.
+        if (!style->positionAnchor().isNull())
+            anchorPositionedElementState->anchorNames.add(style->positionAnchor());
+        anchorPositionedElementState->finishedCollectingAnchorNames = true;
+        m_canFindAnchorsForNextAnchorPositionedElement = false;
+        return AnchorPositionedElementAction::SkipDescendants;
+    }
+
+    if (anchorPositionedElementState->hasBeenResolved)
+        return AnchorPositionedElementAction::None;
+
+    // Maintain the following invariant: if an anchor positioned element is marked ready to
+    // be resolved, it should have already been resolved by the resolveElement() call above.
+    ASSERT(!anchorPositionedElementState->readyToBeResolved);
+
+    // Defer the determination of anchors for anchor-positioned element to its
+    // containing block, where we have access to all the acceptable anchor elements.
+    // See: https://drafts.csswg.org/css-anchor-position-1/#acceptable-anchor-element
+    auto* containingBlock = element.renderer()->containingBlock()->element();
+
+    // Note: containingBlock is nullptr if and only if it is the initial containing block.
+    if (!containingBlock)
+        m_unresolvedAnchorPositionedElementsForInitialContainingBlock.append(element);
+    else {
+        m_unresolvedAnchorPositionedElementsForContainingBlock.ensure(*containingBlock, [&] {
+            return Vector<Ref<Element>> { };
+        }).iterator->value.append(element);
+    }
+
+    return AnchorPositionedElementAction::SkipDescendants;
+}
+
+// Precondition: containingBlock is nullptr if and only if containingBlock is the initial containing block.
+void TreeResolver::findAnchorsForAnchorPositionedElement(const Element& anchorPositionedElement, const Element* containingBlock)
+{
+    auto* anchorPositionedElementState = m_document.styleScope().anchorPositionedStateMap().get(anchorPositionedElement);
+    ASSERT(anchorPositionedElementState);
+
+    // Check if we have already found the anchors for this anchor-positioned element
+    if (anchorPositionedElementState->readyToBeResolved)
+        return;
+
+    for (auto& anchorName : anchorPositionedElementState->anchorNames) {
+        auto anchor = findLastAcceptableAnchorWithName(anchorName, containingBlock);
+        if (anchor.has_value())
+            anchorPositionedElementState->anchorElements.add(anchorName, anchor.value());
+    }
+
+    anchorPositionedElementState->readyToBeResolved = true;
+}
+
+static bool elementIsInContainingBlockChain(const Element& element, const Element& start)
+{
+    auto elementRenderer = element.renderer();
+    auto currentBlock = start.renderer();
+    while ((currentBlock = currentBlock->containingBlock())) {
+        if (elementRenderer == currentBlock)
+            return true;
+    }
+    return false;
+}
+
+// Precondition: containingBlock is nullptr if and only if containingBlock is the initial containing block.
+std::optional<Ref<Element>> TreeResolver::findLastAcceptableAnchorWithName(String anchorName, const Element* containingBlock)
+{
+    auto anchorsIt = m_anchorsForAnchorName.find(anchorName);
+    if (anchorsIt == m_anchorsForAnchorName.end())
+        return { };
+
+    for (auto& anchor : makeReversedRange(anchorsIt->value)) {
+        if (!containingBlock || elementIsInContainingBlockChain(*containingBlock, anchor))
+            return anchor;
+    }
+
+    return { };
+}
+
+void TreeResolver::updateAnchorPositioningStateInInitialContainingBlock()
+{
+    // Try to find the relevant anchors for those anchor-positioned elements that are
+    // positioned by the initial containing block.
+
+    // FIXME: Ideally we would style resolve the entire subtree rooted at each
+    // element in this vector. This may or may not be possible via refactoring.
+    // Otherwise, this approach can only style resolve one anchor-positioned
+    // element per iteration in style & layout interleaving.
+    if (!m_unresolvedAnchorPositionedElementsForInitialContainingBlock.isEmpty()) {
+        auto anchorPositionedElement = m_unresolvedAnchorPositionedElementsForInitialContainingBlock.at(0);
+        findAnchorsForAnchorPositionedElement(anchorPositionedElement, nullptr);
+        m_canFindAnchorsForNextAnchorPositionedElement = false;
+    }
 }
 
 }


### PR DESCRIPTION
#### 5f0104f4e2cd965e5622fb88090d7425bc464801
<pre>
Add style and layout interleaving for `anchor()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=275938">https://bugs.webkit.org/show_bug.cgi?id=275938</a>
<a href="https://rdar.apple.com/130642534">rdar://130642534</a>

Reviewed by Antti Koivisto.

This patch introduces an initial implementation of style and layout
interleaving for anchor positioning. For each anchor-positioned element,
we perform a layout to get its containing block, then bounce back to
style resolution to determine its anchors, and then finally attempt
to resolve the element with another style resolution.

The actual resolution of `anchor()` is not implemented yet, (this patch
is a precursor for its implementation). As a result, there are no
behavioral changes.

This patch also is not fully spec-compliant when finding anchors for
each anchor-positioned element. It only attempts to find the last
anchor element in tree order with a matching anchor name. Further
patches will build on this patch to correctly determine anchors and
actually resolve anchor-positioned elements.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSAnchorValue.cpp:
(WebCore::CSSAnchorValue::collectAnchorNames const):
* Source/WebCore/css/CSSAnchorValue.h:
* Source/WebCore/css/CSSPrimitiveValue.h:
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeAnchor):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resolveStyle):
(WebCore::Document::isInStyleInterleavedLayoutForSelfOrAncestor const):
* Source/WebCore/dom/Document.h:
(WebCore::Document::isInStyleInterleavedLayout const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::invalidateAncestorsForAnchor):
(WebCore::Element::invalidateForResumingAnchorPositionedElementResolution):
* Source/WebCore/dom/Element.h:
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::performLayout):
(WebCore::LocalFrameViewLayoutContext::runOrScheduleAsynchronousTasks):
* Source/WebCore/style/AnchorPositionEvaluator.cpp: Added.
(WebCore::Style::AnchorPositionEvaluator::resolveAnchorValue):
* Source/WebCore/style/AnchorPositionEvaluator.h: Added.
* Source/WebCore/style/MatchedDeclarationsCache.cpp:
(WebCore::Style::MatchedDeclarationsCache::isCacheable):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertLength):
* Source/WebCore/style/StyleResolver.cpp:
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::popParent):
(WebCore::Style::TreeResolver::resolveComposedTree):
(WebCore::Style::TreeResolver::resolve):
(WebCore::Style::TreeResolver::updateAnchorPositioningState):
(WebCore::Style::TreeResolver::findAnchorsForAnchorPositionedElement):
(WebCore::Style::elementIsInContainingBlockChain):
(WebCore::Style::TreeResolver::findLastAcceptableAnchorWithName):
(WebCore::Style::TreeResolver::updateAnchorPositioningStateInInitialContainingBlock):
* Source/WebCore/style/StyleTreeResolver.h:
(WebCore::Style::TreeResolver::hasUnresolvedAnchorPositionedElements const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:

Canonical link: <a href="https://commits.webkit.org/280543@main">https://commits.webkit.org/280543@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91748303d649265f705afaa17b528aea56a94115

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9389 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60535 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7358 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59043 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7548 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46100 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5168 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58945 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34041 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49120 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26958 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30821 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6451 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6363 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52781 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6722 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62216 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/828 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6828 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53357 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/831 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49175 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53401 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12580 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/702 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32072 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33157 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34242 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32903 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->