### PR TITLE
[GTK][WPE] Application ID is not used consistently

### DIFF
--- a/Source/WTF/wtf/PlatformGTK.cmake
+++ b/Source/WTF/wtf/PlatformGTK.cmake
@@ -4,6 +4,7 @@ list(APPEND WTF_SOURCES
     generic/MainThreadGeneric.cpp
     generic/WorkQueueGeneric.cpp
 
+    glib/Application.cpp
     glib/ChassisType.cpp
     glib/FileSystemGlib.cpp
     glib/GRefPtr.cpp
@@ -26,6 +27,7 @@ list(APPEND WTF_SOURCES
 )
 
 list(APPEND WTF_PUBLIC_HEADERS
+    glib/Application.h
     glib/ChassisType.h
     glib/GMutexLocker.h
     glib/GRefPtr.h

--- a/Source/WTF/wtf/PlatformWPE.cmake
+++ b/Source/WTF/wtf/PlatformWPE.cmake
@@ -3,6 +3,7 @@ list(APPEND WTF_SOURCES
     generic/MemoryFootprintGeneric.cpp
     generic/WorkQueueGeneric.cpp
 
+    glib/Application.cpp
     glib/ChassisType.cpp
     glib/FileSystemGlib.cpp
     glib/GRefPtr.cpp
@@ -29,6 +30,7 @@ list(APPEND WTF_SOURCES
 )
 
 list(APPEND WTF_PUBLIC_HEADERS
+    glib/Application.h
     glib/ChassisType.h
     glib/GMutexLocker.h
     glib/GRefPtr.h

--- a/Source/WTF/wtf/glib/Application.cpp
+++ b/Source/WTF/wtf/glib/Application.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "Application.h"
+
+#if USE(GLIB)
+#include <glib.h>
+#include <mutex>
+#include <wtf/FileSystem.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/UUID.h>
+#include <wtf/glib/GUniquePtr.h>
+#include <wtf/text/WTFString.h>
+
+namespace WTF {
+
+const CString& applicationID()
+{
+    static NeverDestroyed<CString> id;
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        if (auto* app = g_application_get_default()) {
+            if (const char* appID = g_application_get_application_id(app)) {
+                id.get() = appID;
+                return;
+            }
+        }
+
+        const char* programName = g_get_prgname();
+        if (programName && g_application_id_is_valid(programName)) {
+            id.get() = programName;
+            return;
+        }
+
+        // There must be some id for xdg-desktop-portal to function.
+        // xdg-desktop-portal uses this id for permissions.
+        // This creates a somewhat reliable id based on the executable path
+        // which will avoid potentially gaining permissions from another app
+        // and won't flood xdg-desktop-portal with new ids.
+        if (auto executablePath = FileSystem::currentExecutablePath(); !executablePath.isNull()) {
+            GUniquePtr<char> digest(g_compute_checksum_for_data(G_CHECKSUM_SHA256, reinterpret_cast<const uint8_t*>(executablePath.data()), executablePath.length()));
+            id.get() = makeString("org.webkit.app-"_s, span(digest.get())).utf8();
+            return;
+        }
+
+        // If it is not possible to obtain the executable path, generate a random identifier as a fallback.
+        auto uuid = WTF::UUID::createVersion4Weak();
+        id.get() = makeString("org.webkit.app-"_s, uuid.toString()).utf8();
+    });
+    return id.get();
+}
+
+} // namespace WTF
+
+#endif // USE(GLIB)

--- a/Source/WTF/wtf/glib/Application.h
+++ b/Source/WTF/wtf/glib/Application.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#if USE(GLIB)
+
+#include <wtf/text/CString.h>
+
+namespace WTF {
+
+WTF_EXPORT_PRIVATE const CString& applicationID();
+
+} // namespace WTF
+
+#endif // USE(GLIB)

--- a/Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.cpp
@@ -31,6 +31,7 @@
 #include <WebCore/PlatformDisplay.h>
 #include <gio/gunixinputstream.h>
 #include <wtf/UniStdExtras.h>
+#include <wtf/glib/Application.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/Sandbox.h>
@@ -74,12 +75,8 @@ std::optional<CString> XDGDBusProxy::dbusSessionProxy(const char* baseDirectory,
     });
 
 #if ENABLE(MEDIA_SESSION)
-    if (auto* app = g_application_get_default()) {
-        if (const char* appID = g_application_get_application_id(app)) {
-            auto mprisSessionID = makeString("--own=org.mpris.MediaPlayer2."_s, WTF::span(appID), ".Sandboxed.*"_s);
-            m_args.append(mprisSessionID.ascii().data());
-        }
-    }
+    auto mprisSessionID = makeString("--own=org.mpris.MediaPlayer2."_s, WTF::applicationID().span(), ".Sandboxed.*"_s);
+    m_args.append(mprisSessionID.ascii().data());
 #endif
 
     if (allowPortals == AllowPortals::Yes)

--- a/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.cpp
+++ b/Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.cpp
@@ -29,6 +29,7 @@
 #include <WebCore/GeolocationPositionData.h>
 #include <gio/gio.h>
 #include <glib/gi18n-lib.h>
+#include <wtf/glib/Application.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/Sandbox.h>
 #include <wtf/text/StringConcatenateNumbers.h>
@@ -400,15 +401,8 @@ void GeoclueGeolocationProvider::setupGeoclueClient(GRefPtr<GDBusProxy>&& proxy)
 
     // Geoclue2 requires the client to provide a desktop ID for security
     // reasons, which should identify the application requesting the location.
-    // We use the application ID configured for the default GApplication, and
-    // also fallback to our old behavior of using g_get_prgname().
-    const char* applicationID = nullptr;
-    if (auto* defaultApplication = g_application_get_default())
-        applicationID = g_application_get_application_id(defaultApplication);
-    if (!applicationID)
-        applicationID = g_get_prgname();
     g_dbus_proxy_call(m_geoclue.client.get(), "org.freedesktop.DBus.Properties.Set",
-        g_variant_new("(ssv)", "org.freedesktop.GeoClue2.Client", "DesktopId", g_variant_new_string(applicationID)),
+        g_variant_new("(ssv)", "org.freedesktop.GeoClue2.Client", "DesktopId", g_variant_new_string(WTF::applicationID().data())),
         G_DBUS_CALL_FLAGS_NONE, -1, nullptr, [](GObject* manager, GAsyncResult* result, gpointer userData) {
             GUniqueOutPtr<GError> error;
             GRefPtr<GVariant> returnValue = adoptGRef(g_dbus_proxy_call_finish(G_DBUS_PROXY(manager), result, &error.outPtr()));

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -34,6 +34,7 @@
 #include "WebProcessCreationParameters.h"
 #include <WebCore/PlatformDisplay.h>
 #include <wtf/FileSystem.h>
+#include <wtf/glib/Application.h>
 #include <wtf/glib/Sandbox.h>
 
 #if ENABLE(REMOTE_INSPECTOR)
@@ -133,9 +134,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
 
     parameters.disableFontHintingForTesting = m_configuration->disableFontHintingForTesting();
 
-    GApplication* app = g_application_get_default();
-    if (app)
-        parameters.applicationID = String::fromLatin1(g_application_get_application_id(app));
+    parameters.applicationID = String::fromUTF8(WTF::applicationID().span());
     parameters.applicationName = String::fromLatin1(g_get_application_name());
 
 #if ENABLE(REMOTE_INSPECTOR)


### PR DESCRIPTION
#### 696c432e7e05d6da4c0661ef7d891b6fd7007ef2
<pre>
[GTK][WPE] Application ID is not used consistently
<a href="https://bugs.webkit.org/show_bug.cgi?id=275946">https://bugs.webkit.org/show_bug.cgi?id=275946</a>

Reviewed by Michael Catanzaro.

We currently need the application ID from the bubblewrap sandbox,
notifications, geolocation provider, and it&apos;s sent to the web process
too. We are doing different things in all of those places. Add
WTF::applicationID() and use it everywhere to ensure we always get the
same value.

* Source/WTF/wtf/PlatformGTK.cmake:
* Source/WTF/wtf/PlatformWPE.cmake:
* Source/WTF/wtf/glib/Application.cpp: Added.
(WTF::applicationID):
* Source/WTF/wtf/glib/Application.h: Added.
* Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp:
(WebKit::createFlatpakInfo):
(WebKit::effectiveApplicationId): Deleted.
* Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.cpp:
(WebKit::XDGDBusProxy::dbusSessionProxy):
* Source/WebKit/UIProcess/Notifications/glib/NotificationService.cpp:
(WebKit::applicationIcon):
(WebKit::NotificationService::showNotification):
* Source/WebKit/UIProcess/geoclue/GeoclueGeolocationProvider.cpp:
(WebKit::GeoclueGeolocationProvider::setupGeoclueClient):
* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::WebProcessPool::platformInitializeWebProcess):

Canonical link: <a href="https://commits.webkit.org/280444@main">https://commits.webkit.org/280444@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/969d23f42a8c4b962ca57121048a340493b55c64

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56574 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35901 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60185 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7015 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7206 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45824 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4905 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48822 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26685 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30533 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6154 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6018 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/49666 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52490 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6426 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61868 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/55815 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6530 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53082 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/486 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48882 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53034 "Found 3 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/417 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/77576 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8424 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31728 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12856 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32815 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33899 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32561 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->