### PR TITLE
[WPE] WPE Platform: implement WPE_TOPLEVEL_STATE_ACTIVE

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEToplevelDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEToplevelDRM.cpp
@@ -49,7 +49,7 @@ static void wpeToplevelDRMConstructed(GObject* object)
     double scale = wpe_monitor_get_scale(monitor);
     wpe_toplevel_resized(toplevel, mode->hdisplay / scale, mode->vdisplay / scale);
     wpe_toplevel_scale_changed(toplevel, scale);
-    wpe_toplevel_state_changed(toplevel, WPE_TOPLEVEL_STATE_FULLSCREEN);
+    wpe_toplevel_state_changed(toplevel, static_cast<WPEToplevelState>(WPE_TOPLEVEL_STATE_FULLSCREEN | WPE_TOPLEVEL_STATE_ACTIVE));
 }
 
 static WPEMonitor* wpeToplevelDRMGetMonitor(WPEToplevel* toplevel)

--- a/Source/WebKit/WPEPlatform/wpe/headless/WPEToplevelHeadless.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/headless/WPEToplevelHeadless.cpp
@@ -36,6 +36,13 @@ struct _WPEToplevelHeadlessPrivate {
 };
 WEBKIT_DEFINE_FINAL_TYPE(WPEToplevelHeadless, wpe_toplevel_headless, WPE_TYPE_TOPLEVEL, WPEToplevel)
 
+static void wpeToplevelHeadlessConstructed(GObject* object)
+{
+    G_OBJECT_CLASS(wpe_toplevel_headless_parent_class)->constructed(object);
+
+    wpe_toplevel_state_changed(WPE_TOPLEVEL(object), WPE_TOPLEVEL_STATE_ACTIVE);
+}
+
 static gboolean wpeToplevelHeadlessResize(WPEToplevel* toplevel, int width, int height)
 {
     wpe_toplevel_resized(toplevel, width, height);
@@ -61,6 +68,9 @@ static gboolean wpeToplevelHeadlessSetFullscreen(WPEToplevel* toplevel, gboolean
 
 static void wpe_toplevel_headless_class_init(WPEToplevelHeadlessClass* toplevelHeadlessClass)
 {
+    GObjectClass* objectClass = G_OBJECT_CLASS(toplevelHeadlessClass);
+    objectClass->constructed = wpeToplevelHeadlessConstructed;
+
     WPEToplevelClass* toplevelClass = WPE_TOPLEVEL_CLASS(toplevelHeadlessClass);
     toplevelClass->resize = wpeToplevelHeadlessResize;
     toplevelClass->set_fullscreen = wpeToplevelHeadlessSetFullscreen;

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp
@@ -328,6 +328,9 @@ const struct xdg_toplevel_listener xdgToplevelListener = {
             case XDG_TOPLEVEL_STATE_MAXIMIZED:
                 pendingState |= WPE_TOPLEVEL_STATE_MAXIMIZED;
                 break;
+            case XDG_TOPLEVEL_STATE_ACTIVATED:
+                pendingState |= WPE_TOPLEVEL_STATE_ACTIVE;
+                break;
             default:
                 break;
             }


### PR DESCRIPTION
#### a9708dce12751c5fe67c32c195f9d2aca105ecbe
<pre>
[WPE] WPE Platform: implement WPE_TOPLEVEL_STATE_ACTIVE
<a href="https://bugs.webkit.org/show_bug.cgi?id=275949">https://bugs.webkit.org/show_bug.cgi?id=275949</a>

Reviewed by Nikolas Zimmermann.

* Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp:
(WKWPE::m_backend):
* Source/WebKit/WPEPlatform/wpe/drm/WPEToplevelDRM.cpp:
(wpeToplevelDRMConstructed):
* Source/WebKit/WPEPlatform/wpe/headless/WPEToplevelHeadless.cpp:
(wpeToplevelHeadlessConstructed):
(wpe_toplevel_headless_class_init):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEToplevelWayland.cpp:

Canonical link: <a href="https://commits.webkit.org/280447@main">https://commits.webkit.org/280447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a382ad45ed81c140d00eb5bf29d31a2e9c70d0b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36006 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60293 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7120 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7311 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/45913 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4990 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58709 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/33848 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48920 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26772 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30627 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6123 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6523 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61976 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/591 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/6623 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53172 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/593 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48978 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/53187 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/510 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8426 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31834 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32920 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34004 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32666 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->