### PR TITLE
[Cocoa] Clean up AVFoundation MIME type code

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -886,21 +886,6 @@ bool MediaPlayerPrivateAVFoundation::canSaveMediaData() const
     return true;
 }
 
-bool MediaPlayerPrivateAVFoundation::isUnsupportedMIMEType(const String& type)
-{
-    String lowerCaseType = type.convertToASCIILowercase();
-
-    // AVFoundation will return non-video MIME types which it claims to support, but which we
-    // do not support in the <video> element. Reject all non video/, audio/, and application/ types.
-    if (!lowerCaseType.startsWith("video/"_s) && !lowerCaseType.startsWith("audio/"_s) && !lowerCaseType.startsWith("application/"_s))
-        return true;
-
-    // Reject types we know AVFoundation does not support that sites commonly ask about.
-    static constexpr ComparableASCIILiteral unsupportedTypesArray[] = { "application/ogg", "audio/ogg", "audio/webm", "video/h264", "video/ogg", "video/webm", "video/x-flv", "video/x-webm" };
-    static constexpr SortedArraySet unsupportedTypesSet { unsupportedTypesArray };
-    return unsupportedTypesSet.contains(lowerCaseType);
-}
-
 bool MediaPlayerPrivateAVFoundation::shouldEnableInheritURIQueryComponent() const
 {
     static NeverDestroyed<const AtomString> iTunesInheritsURIQueryComponent(MAKE_STATIC_STRING_IMPL("x-itunes-inherit-uri-query-component"));
@@ -922,43 +907,6 @@ WTFLogChannel& MediaPlayerPrivateAVFoundation::logChannel() const
 }
 #endif
 
-const HashSet<String>& MediaPlayerPrivateAVFoundation::staticMIMETypeList()
-{
-    static NeverDestroyed cache = HashSet<String> {
-        "application/vnd.apple.mpegurl"_s,
-        "application/x-mpegurl"_s,
-        "audio/3gpp"_s,
-        "audio/aac"_s,
-        "audio/aacp"_s,
-        "audio/aiff"_s,
-        "audio/basic"_s,
-        "audio/mp3"_s,
-        "audio/mp4"_s,
-        "audio/mpeg"_s,
-        "audio/mpeg3"_s,
-        "audio/mpegurl"_s,
-        "audio/mpg"_s,
-        "audio/vnd.wave"_s,
-        "audio/wav"_s,
-        "audio/wave"_s,
-        "audio/x-aac"_s,
-        "audio/x-aiff"_s,
-        "audio/x-m4a"_s,
-        "audio/x-mpegurl"_s,
-        "audio/x-wav"_s,
-        "video/3gpp"_s,
-        "video/3gpp2"_s,
-        "video/mp4"_s,
-        "video/mpeg"_s,
-        "video/mpeg2"_s,
-        "video/mpg"_s,
-        "video/quicktime"_s,
-        "video/x-m4v"_s,
-        "video/x-mpeg"_s,
-        "video/x-mpg"_s,
-    };
-    return cache;
-}
 
 String convertEnumerationToString(MediaPlayerPrivateAVFoundation::MediaRenderingMode enumerationValue)
 {

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -277,9 +277,6 @@ protected:
 
     virtual bool isHLS() const { return false; }
 
-    static bool isUnsupportedMIMEType(const String&);
-    static const HashSet<String>& staticMIMETypeList();
-
     void updateStates();
 
     void setHasVideo(bool);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.mm
@@ -145,7 +145,7 @@ bool AVAssetMIMETypeCache::isUnsupportedContainerType(const String& type)
         return true;
 
     // Reject types we know AVFoundation does not support that sites commonly ask about.
-    static constexpr ComparableASCIILiteral unsupportedTypesArray[] = { "application/ogg", "audio/ogg", "video/h264", "video/ogg", "video/x-flv" };
+    static constexpr ComparableASCIILiteral unsupportedTypesArray[] = { "video/h264", "video/x-flv" };
     static constexpr SortedArraySet unsupportedTypesSet { unsupportedTypesArray };
     return unsupportedTypesSet.contains(lowerCaseType);
 }


### PR DESCRIPTION
#### f3fe7d5be8193ca15e0446e97fd5e0235756a9b3
<pre>
[Cocoa] Clean up AVFoundation MIME type code
<a href="https://bugs.webkit.org/show_bug.cgi?id=275867">https://bugs.webkit.org/show_bug.cgi?id=275867</a>
<a href="https://rdar.apple.com/128759015">rdar://128759015</a>

Reviewed by Andy Estes.

Remove some unused MIME type code from MediaPlayerPrivateAVFoundation.cpp. Remove
ogg from the MIME types rejected without consulting AVFoundation.

* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
(WebCore::MediaPlayerPrivateAVFoundation::isUnsupportedMIMEType): Deleted.
(WebCore::MediaPlayerPrivateAVFoundation::staticMIMETypeList): Deleted.
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AVAssetMIMETypeCache.mm:
(WebCore::AVAssetMIMETypeCache::isUnsupportedContainerType):

Canonical link: <a href="https://commits.webkit.org/280418@main">https://commits.webkit.org/280418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4c7e31ab3e3d280368b01cde68876620a1c11d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60203 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7030 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58716 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43539 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7221 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45840 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4919 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58619 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33766 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/48838 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26701 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30547 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6170 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6033 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6441 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61885 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/501 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6547 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53098 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/502 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53085 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12523 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/431 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31744 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32830 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33914 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32576 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->