### PR TITLE
[run-benchmark] Driver for chrome on Linux should avoid showing things like sign-in screen or default-browser-check

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_chrome_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_chrome_driver.py
@@ -33,23 +33,24 @@ class LinuxChromeDriver(LinuxBrowserDriver):
     browser_name = 'chrome'
     process_search_list = ['chromium', 'chromium-browser', 'chrome', 'google-chrome']
 
+    def prepare_env(self, config):
+        super().prepare_env(config)
+        self._default_browser_arguments = ['--start-maximized', '--disable-extensions', '--no-first-run', '--no-default-browser-check']
+
     def launch_url(self, url, options, browser_build_path, browser_path):
-        self._default_browser_arguments = ['--temp-profile', '--start-maximized',
-                                   '--homepage', url]
-        super(LinuxChromeDriver, self).launch_url(url, options, browser_build_path, browser_path)
+        self._default_browser_arguments += ['--homepage', url]
+        super().launch_url(url, options, browser_build_path, browser_path)
 
     def launch_driver(self, url, options, browser_build_path):
         from selenium import webdriver
         from selenium.webdriver.chrome.options import Options
         options = Options()
-        options.add_argument("--disable-web-security")
-        options.add_argument("--user-data-dir")
-        options.add_argument("--disable-extensions")
-        options.add_argument("--start-maximized")
+        for option_switch in self._default_browser_arguments:
+            options.add_argument(option_switch)
         if browser_build_path:
             binary_path = os.path.join(browser_build_path, 'chromium-browser')
             options.binary_location = binary_path
         driver_executable = self.webdriver_binary_path
         driver = webdriver.Chrome(chrome_options=options, executable_path=driver_executable)
-        super(LinuxChromeDriver, self).launch_webdriver(url, driver)
+        super().launch_webdriver(url, driver)
         return driver


### PR DESCRIPTION
#### 7e644f3ca0fc7ad8ffaa74ac03565caaac7d6db9
<pre>
[run-benchmark] Driver for chrome on Linux should avoid showing things like sign-in screen or default-browser-check
<a href="https://bugs.webkit.org/show_bug.cgi?id=275959">https://bugs.webkit.org/show_bug.cgi?id=275959</a>

Reviewed by Nikolas Zimmermann.

This passes to the Chrome program the right switches so it avoids showing
any first-run screen like the default-browser-check or the offer to sign-in
into the Google services.

It also removes the --temp-profile switch which never was a real switch of
Chrome but one of the Chromium version shipped in Debian.
This was not needed in any case because the browser is already executed with
HOME=/tmp/randomDir

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_chrome_driver.py:
(LinuxChromeDriver.prepare_env):
(LinuxChromeDriver.launch_url):
(LinuxChromeDriver.launch_driver):

Canonical link: <a href="https://commits.webkit.org/280431@main">https://commits.webkit.org/280431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46be79402368dffdb86b1ad7574ddfd608a0d9b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56603 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60217 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7044 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43553 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7235 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45850 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4929 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33779 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48852 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26711 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/56129 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30560 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6184 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6047 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6455 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61900 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/515 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6559 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53109 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/517 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48911 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53106 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/444 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8414 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31758 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32844 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33928 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32590 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->