### PR TITLE
Fixes flakiness of interaction-region tests with virtual keyboard usage

### DIFF
--- a/LayoutTests/interaction-region/text-input-focused-edited-empty.html
+++ b/LayoutTests/interaction-region/text-input-focused-edited-empty.html
@@ -26,13 +26,18 @@ if (window.testRunner) {
     element = document.querySelector("input");
 
     await UIHelper.activateElementAndWaitForInputSession(element);
-    await UIHelper.typeCharacter("a");
-    await UIHelper.typeCharacter("delete");
 
-    await UIHelper.animationFrame();
-    await UIHelper.ensureStablePresentationUpdate();
+    do {
+        await UIHelper.typeCharacter("a");
+        await UIHelper.animationFrame();
+        await UIHelper.ensureStablePresentationUpdate();
+    } while (element.value === "")
 
-    results.textContent = element.value;
+    do {
+        await UIHelper.typeCharacter("delete");
+        await UIHelper.animationFrame();
+        await UIHelper.ensureStablePresentationUpdate();
+    } while (element.value !== "")
 
     if (window.internals)
        results.textContent += internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
@@ -40,7 +45,7 @@ if (window.testRunner) {
     if (window.testRunner)
         testRunner.dumpAsText();
 
-    await UIHelper.waitForInputSessionToDismiss();
+    document.activeElement.blur();
 
     if (window.testRunner)
         testRunner.notifyDone();

--- a/LayoutTests/interaction-region/text-input-focused-edited-expected.txt
+++ b/LayoutTests/interaction-region/text-input-focused-edited-expected.txt
@@ -1,5 +1,4 @@
 
-A
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 768.00 1004.00)

--- a/LayoutTests/interaction-region/text-input-focused-edited.html
+++ b/LayoutTests/interaction-region/text-input-focused-edited.html
@@ -26,12 +26,12 @@ if (window.testRunner) {
     element = document.querySelector("input");
 
     await UIHelper.activateElementAndWaitForInputSession(element);
-    await UIHelper.typeCharacter("a");
 
-    await UIHelper.animationFrame();
-    await UIHelper.ensureStablePresentationUpdate();
-
-    results.textContent = element.value + "\n";
+    do {
+        await UIHelper.typeCharacter("a");
+        await UIHelper.animationFrame();
+        await UIHelper.ensureStablePresentationUpdate();
+    } while (element.value === "")
 
     if (window.internals)
        results.textContent += internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
@@ -39,7 +39,7 @@ if (window.testRunner) {
     if (window.testRunner)
         testRunner.dumpAsText();
 
-    await UIHelper.waitForInputSessionToDismiss();
+    document.activeElement.blur();
 
     if (window.testRunner)
         testRunner.notifyDone();

--- a/LayoutTests/interaction-region/textarea-focused-edited-empty.html
+++ b/LayoutTests/interaction-region/textarea-focused-edited-empty.html
@@ -25,13 +25,18 @@ if (window.testRunner) {
     element = document.querySelector("textarea");
 
     await UIHelper.activateElementAndWaitForInputSession(element);
-    await UIHelper.typeCharacter("a");
-    await UIHelper.typeCharacter("delete");
 
-    await UIHelper.animationFrame();
-    await UIHelper.ensureStablePresentationUpdate();
+    do {
+        await UIHelper.typeCharacter("a");
+        await UIHelper.animationFrame();
+        await UIHelper.ensureStablePresentationUpdate();
+    } while (element.value === "")
 
-    results.textContent = element.value;
+    do {
+        await UIHelper.typeCharacter("delete");
+        await UIHelper.animationFrame();
+        await UIHelper.ensureStablePresentationUpdate();
+    } while (element.value !== "")
 
     if (window.internals)
        results.textContent += internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
@@ -39,7 +44,7 @@ if (window.testRunner) {
     if (window.testRunner)
         testRunner.dumpAsText();
 
-    await UIHelper.waitForInputSessionToDismiss();
+    document.activeElement.blur();
 
     if (window.testRunner)
         testRunner.notifyDone();

--- a/LayoutTests/interaction-region/textarea-focused-edited-expected.txt
+++ b/LayoutTests/interaction-region/textarea-focused-edited-expected.txt
@@ -1,5 +1,4 @@
 
-A
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 768.00 1004.00)

--- a/LayoutTests/interaction-region/textarea-focused-edited.html
+++ b/LayoutTests/interaction-region/textarea-focused-edited.html
@@ -25,12 +25,12 @@ if (window.testRunner) {
     element = document.querySelector("textarea");
 
     await UIHelper.activateElementAndWaitForInputSession(element);
-    await UIHelper.typeCharacter("a");
 
-    await UIHelper.animationFrame();
-    await UIHelper.ensureStablePresentationUpdate();
-
-    results.textContent = element.value + "\n";
+    do {
+        await UIHelper.typeCharacter("a");
+        await UIHelper.animationFrame();
+        await UIHelper.ensureStablePresentationUpdate();
+    } while (element.value == "")
 
     if (window.internals)
        results.textContent += internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
@@ -38,7 +38,7 @@ if (window.testRunner) {
     if (window.testRunner)
         testRunner.dumpAsText();
 
-    await UIHelper.waitForInputSessionToDismiss();
+    document.activeElement.blur();
 
     if (window.testRunner)
         testRunner.notifyDone();

--- a/LayoutTests/platform/visionos/TestExpectations
+++ b/LayoutTests/platform/visionos/TestExpectations
@@ -142,8 +142,6 @@ fast/events/pointer/ios/tap-gives-pointerdown-pointerup.html [ Timeout ]
 
 webkit.org/b/275115 imported/w3c/web-platform-tests/webxr/getInputPose_pointer.https.html [ Skip ]
 
-webkit.org/b/275590 interaction-region/text-input-focused-edited-empty.html [ Pass Failure ]
-
 ### END OF Triaged failures
 ###################################################################################################
 


### PR DESCRIPTION
#### a44043d736635e7870d454f9a6cd5fce4d94825d
<pre>
Fixes flakiness of interaction-region tests with virtual keyboard usage
<a href="https://bugs.webkit.org/show_bug.cgi?id=275590">https://bugs.webkit.org/show_bug.cgi?id=275590</a>
<a href="https://rdar.apple.com/130034598">rdar://130034598</a>

Reviewed by Wenson Hsieh and Tim Horton.

When interaction-region tests run back-to-back in some cases virtual keyboard
input is not registered on the page that leads to flaky results. By adding
virtual keyboard call in a loop and validating element&apos;s value, tests act much
more consistently.

* LayoutTests/interaction-region/text-input-focused-edited-empty.html:
* LayoutTests/interaction-region/text-input-focused-edited-expected.txt:
* LayoutTests/interaction-region/text-input-focused-edited.html:
* LayoutTests/interaction-region/textarea-focused-edited-empty.html:
* LayoutTests/interaction-region/textarea-focused-edited-expected.txt:
* LayoutTests/interaction-region/textarea-focused-edited.html:
* LayoutTests/platform/visionos/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/280465@main">https://commits.webkit.org/280465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/001ee5b64e8fa81fa115657f37cf2e9bac3816a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56614 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60228 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7055 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7246 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45863 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4938 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48863 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26724 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30570 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6194 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6058 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52525 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6465 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61911 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/526 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6569 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53119 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/528 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48921 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53123 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12549 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/452 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31769 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32855 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33939 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32601 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->