### PR TITLE
Replace `WKBundlePageForceRepaint` in WebKitTestRunner

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -3302,3 +3302,9 @@ void WKPageFlushDeferredDidReceiveMouseEventForTesting(WKPageRef pageRef)
     if (auto* pageForTesting = toImpl(pageRef)->pageForTesting())
         pageForTesting->flushDeferredDidReceiveMouseEvent();
 }
+
+void WKPageForceRepaintForTesting(WKPageRef pageRef)
+{
+    if (auto* pageForTesting = toImpl(pageRef)->pageForTesting())
+        pageForTesting->updateRenderingWithForcedRepaint();
+}

--- a/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
@@ -218,6 +218,8 @@ WK_EXPORT void WKPageSetPermissionLevelForTesting(WKPageRef page, WKStringRef or
 
 WK_EXPORT void WKPageFlushDeferredDidReceiveMouseEventForTesting(WKPageRef page);
 
+WK_EXPORT void WKPageForceRepaintForTesting(WKPageRef page);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
@@ -198,7 +198,14 @@ void WebPageProxyTesting::setSystemCanPromptForGetDisplayMediaForTesting(bool ca
 void WebPageProxyTesting::flushDeferredDidReceiveMouseEvent()
 {
     m_page->forEachWebContentProcess([](auto& webProcess, auto pageID) {
-        [[maybe_unused]] auto sendResult = webProcess.sendSync(Messages::WebPageTesting::FlushDeferredDidReceiveMouseEvent(), pageID, Seconds::infinity());
+        webProcess.sendSync(Messages::WebPageTesting::FlushDeferredDidReceiveMouseEvent(), pageID, Seconds::infinity());
+    });
+}
+
+void WebPageProxyTesting::updateRenderingWithForcedRepaint()
+{
+    m_page->forEachWebContentProcess([](auto& webProcess, auto pageID) {
+        webProcess.sendSync(Messages::WebPageTesting::UpdateRenderingWithForcedRepaint(), pageID, Seconds::infinity());
     });
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.h
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.h
@@ -73,6 +73,8 @@ public:
 
     void flushDeferredDidReceiveMouseEvent();
 
+    void updateRenderingWithForcedRepaint();
+
 private:
     bool sendMessage(UniqueRef<IPC::Encoder>&&, OptionSet<IPC::SendOption>) final;
     bool sendMessageWithAsyncReply(UniqueRef<IPC::Encoder>&&, AsyncReplyHandler, OptionSet<IPC::SendOption>) final;

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WebPageTesting.h"
 
+#include "DrawingArea.h"
 #include "NotificationPermissionRequestManager.h"
 #include "PluginView.h"
 #include "WebNotificationClient.h"
@@ -106,6 +107,12 @@ void WebPageTesting::clearWheelEventTestMonitor()
 void WebPageTesting::flushDeferredDidReceiveMouseEvent(CompletionHandler<void()>&& completionHandler)
 {
     m_page->flushDeferredDidReceiveMouseEvent();
+    completionHandler();
+}
+
+void WebPageTesting::updateRenderingWithForcedRepaint(CompletionHandler<void()>&& completionHandler)
+{
+    m_page->updateRenderingWithForcedRepaintWithoutCallback();
     completionHandler();
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
@@ -61,6 +61,8 @@ private:
 
     void flushDeferredDidReceiveMouseEvent(CompletionHandler<void()>&&);
 
+    void updateRenderingWithForcedRepaint(CompletionHandler<void()>&&);
+
     const WebCore::PageIdentifier m_identifier;
     WeakRef<WebPage> m_page;
 };

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
@@ -33,4 +33,6 @@ messages -> WebPageTesting NotRefCounted {
     ClearWheelEventTestMonitor()
 
     FlushDeferredDidReceiveMouseEvent() -> () Synchronous
+
+    UpdateRenderingWithForcedRepaint() -> () Synchronous
 }

--- a/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp
@@ -342,8 +342,6 @@ void EventSendingController::scheduleAsynchronousKeyDown(JSStringRef key)
 
 void EventSendingController::mouseScrollBy(int x, int y)
 {
-    WKBundlePageForceRepaint(InjectedBundle::singleton().page()->page()); // Triggers a scrolling tree commit.
-
     auto body = adoptWK(WKMutableDictionaryCreate());
     setValue(body, "SubMessage", "MouseScrollBy");
     setValue(body, "X", adoptWK(WKDoubleCreate(x)));
@@ -394,8 +392,6 @@ void EventSendingController::mouseScrollByWithWheelAndMomentumPhases(int x, int 
         m_sentWheelPhaseEndOrCancel = true;
     if (momentum == 3 /* kCGMomentumScrollPhaseEnd */)
         m_sentWheelMomentumPhaseEnd = true;
-
-    WKBundlePageForceRepaint(InjectedBundle::singleton().page()->page()); // Triggers a scrolling tree commit.
 
     auto body = adoptWK(WKMutableDictionaryCreate());
     setValue(body, "SubMessage", "MouseScrollByWithWheelAndMomentumPhases");

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp
@@ -732,6 +732,11 @@ WKRetainPtr<WKStringRef> InjectedBundle::backgroundFetchState(WKStringRef identi
     return static_cast<WKStringRef>(result);
 }
 
+void InjectedBundle::forceRepaint()
+{
+    postSynchronousPageMessage("ForceRepaint");
+}
+
 void InjectedBundle::textDidChangeInTextField()
 {
     m_testRunner->textDidChangeInTextFieldCallback();

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h
@@ -152,6 +152,8 @@ public:
     WKRetainPtr<WKStringRef> lastUpdatedBackgroundFetchIdentifier() const;
     WKRetainPtr<WKStringRef> backgroundFetchState(WKStringRef);
 
+    void forceRepaint();
+
 private:
     InjectedBundle() = default;
     ~InjectedBundle();

--- a/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp
@@ -712,7 +712,7 @@ void InjectedBundlePage::dump(bool forceRepaint)
     if (forceRepaint) {
         // Force a paint before dumping. This matches DumpRenderTree on Windows. (DumpRenderTree on Mac
         // does this at a slightly different time.) See <http://webkit.org/b/55469> for details.
-        WKBundlePageForceRepaint(m_page);
+        injectedBundle.forceRepaint();
     }
     WKBundlePageFlushPendingEditorStateUpdate(m_page);
 
@@ -1630,10 +1630,8 @@ void InjectedBundlePage::frameDidChangeLocation(WKBundleFrameRef frame)
 
     injectedBundle.setTopLoadingFrame(nullptr);
 
-    if (injectedBundle.testRunner()->shouldDisplayOnLoadFinish()) {
-        if (auto page = InjectedBundle::singleton().page())
-            WKBundlePageForceRepaint(page->page());
-    }
+    if (injectedBundle.testRunner()->shouldDisplayOnLoadFinish())
+        injectedBundle.forceRepaint();
 
     if (injectedBundle.testRunner()->shouldWaitUntilDone())
         return;

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -90,13 +90,13 @@ static WKBundlePageRef page()
 
 void TestRunner::display()
 {
-    WKBundlePageForceRepaint(page());
+    postSynchronousPageMessage("ForceRepaint");
 }
 
 void TestRunner::displayAndTrackRepaints()
 {
     auto page = WTR::page();
-    WKBundlePageForceRepaint(page);
+    postSynchronousPageMessage("ForceRepaint");
     WKBundlePageSetTracksRepaints(page, true);
     WKBundlePageResetTrackedRepaints(page);
 }

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1922,11 +1922,13 @@ void TestController::didReceiveMessageFromInjectedBundle(WKStringRef messageName
         }
         
         if (WKStringIsEqualToUTF8CString(subMessageName, "MouseScrollBy")) {
+            WKPageForceRepaintForTesting(m_mainWebView->page());
             m_eventSenderProxy->mouseScrollBy(doubleValue(dictionary, "X"), doubleValue(dictionary, "Y"));
             return;
         }
 
         if (WKStringIsEqualToUTF8CString(subMessageName, "MouseScrollByWithWheelAndMomentumPhases")) {
+            WKPageForceRepaintForTesting(m_mainWebView->page());
             auto x = doubleValue(dictionary, "X");
             auto y = doubleValue(dictionary, "Y");
             auto phase = uint64Value(dictionary, "Phase");

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -1409,6 +1409,11 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
     if (WKStringIsEqualToUTF8CString(messageName, "IsCommandEnabled"))
         return adoptWK(WKBooleanCreate(WKPageIsEditingCommandEnabledForTesting(TestController::singleton().mainWebView()->page(), stringValue(messageBody))));
 
+    if (WKStringIsEqualToUTF8CString(messageName, "ForceRepaint")) {
+        WKPageForceRepaintForTesting(TestController::singleton().mainWebView()->page());
+        return nullptr;
+    }
+
     ASSERT_NOT_REACHED();
     return nullptr;
 }


### PR DESCRIPTION
#### 75403b60876a3180b571a4490fbbcc8d6a487f68
<pre>
Replace `WKBundlePageForceRepaint` in WebKitTestRunner
<a href="https://bugs.webkit.org/show_bug.cgi?id=275970">https://bugs.webkit.org/show_bug.cgi?id=275970</a>
<a href="https://rdar.apple.com/130705659">rdar://130705659</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageForceRepaintForTesting):
* Source/WebKit/UIProcess/API/C/WKPagePrivate.h:
* Source/WebKit/UIProcess/WebPageProxyTesting.cpp:
(WebKit::WebPageProxyTesting::flushDeferredDidReceiveMouseEvent):
(WebKit::WebPageProxyTesting::updateRenderingWithForcedRepaint):
* Source/WebKit/UIProcess/WebPageProxyTesting.h:
* Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp:
(WebKit::WebPageTesting::updateRenderingWithForcedRepaint):
* Source/WebKit/WebProcess/WebPage/WebPageTesting.h:
* Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in:
* Tools/WebKitTestRunner/InjectedBundle/EventSendingController.cpp:
(WTR::EventSendingController::mouseScrollBy):
(WTR::EventSendingController::mouseScrollByWithWheelAndMomentumPhases):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.cpp:
(WTR::InjectedBundle::forceRepaint):
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundle.h:
* Tools/WebKitTestRunner/InjectedBundle/InjectedBundlePage.cpp:
(WTR::InjectedBundlePage::dump):
(WTR::InjectedBundlePage::frameDidChangeLocation):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::display):
(WTR::TestRunner::displayAndTrackRepaints):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::didReceiveMessageFromInjectedBundle):
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75403b60876a3180b571a4490fbbcc8d6a487f68

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56677 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60291 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7118 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58804 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7309 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45912 "Passed tests") | [❌ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4989 "") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58707 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48918 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26771 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30624 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6249 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6121 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52567 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6521 "Found 1 new test failure: fast/scrolling/latching/latched-scroll-in-passive-region.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61974 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/589 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6622 "Found 1 new test failure: http/tests/site-isolation/key-events.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53170 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/591 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48976 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53185 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/508 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31832 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32918 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34002 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32664 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->