### PR TITLE
Use SystemV ABI for CSS Selector JIT on Windows

### DIFF
--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -884,7 +884,7 @@
 #endif
 
 /* CSS Selector JIT Compiler */
-#if !defined(ENABLE_CSS_SELECTOR_JIT) && ((CPU(X86_64) || CPU(ARM64)) && ENABLE(JIT) && (OS(DARWIN) || PLATFORM(GTK) || PLATFORM(WPE)))
+#if !defined(ENABLE_CSS_SELECTOR_JIT) && ((CPU(X86_64) || CPU(ARM64)) && ENABLE(JIT))
 #define ENABLE_CSS_SELECTOR_JIT 1
 #endif
 

--- a/Source/WebCore/cssjit/RegisterAllocator.h
+++ b/Source/WebCore/cssjit/RegisterAllocator.h
@@ -56,7 +56,6 @@ static const JSC::MacroAssembler::RegisterID calleeSavedRegisters[] = {
 };
 static const JSC::MacroAssembler::RegisterID tempRegister = JSC::ARM64Registers::x15;
 #elif CPU(X86_64)
-#if !OS(WINDOWS)
 static const JSC::MacroAssembler::RegisterID callerSavedRegisters[] = {
     JSC::X86Registers::eax,
     JSC::X86Registers::ecx,
@@ -73,24 +72,6 @@ static const JSC::MacroAssembler::RegisterID calleeSavedRegisters[] = {
     JSC::X86Registers::r14,
     JSC::X86Registers::r15
 };
-#else // OS(WINDOWS)
-static const JSC::MacroAssembler::RegisterID callerSavedRegisters[] = {
-    JSC::X86Registers::eax,
-    JSC::X86Registers::ecx,
-    JSC::X86Registers::edx,
-    JSC::X86Registers::r8,
-    JSC::X86Registers::r9,
-    JSC::X86Registers::r10,
-};
-static const JSC::MacroAssembler::RegisterID calleeSavedRegisters[] = {
-    JSC::X86Registers::esi,
-    JSC::X86Registers::edi,
-    JSC::X86Registers::r12,
-    JSC::X86Registers::r13,
-    JSC::X86Registers::r14,
-    JSC::X86Registers::r15
-};
-#endif // !OS(WINDOWS)
 #else
 #error RegisterAllocator has no defined registers for the architecture.
 #endif
@@ -207,13 +188,8 @@ public:
 #if CPU(ARM64)
         return registerID >= JSC::ARM64Registers::x0 && registerID <= JSC::ARM64Registers::x14;
 #elif CPU(X86_64)
-#if !OS(WINDOWS)
         return (registerID >= JSC::X86Registers::eax && registerID <= JSC::X86Registers::edx)
             || (registerID >= JSC::X86Registers::esi && registerID <= JSC::X86Registers::r10);
-#else
-        return (registerID >= JSC::X86Registers::eax && registerID <= JSC::X86Registers::edx)
-            || (registerID >= JSC::X86Registers::r8 && registerID <= JSC::X86Registers::r10);
-#endif
 #else
 #error RegisterAllocator does not define the valid caller saved register range for the current architecture.
 #endif

--- a/Source/WebCore/cssjit/SelectorCompiler.h
+++ b/Source/WebCore/cssjit/SelectorCompiler.h
@@ -56,7 +56,7 @@ inline unsigned ruleCollectorSimpleSelectorChecker(CompiledSelector& compiledSel
     if (JSC::Options::useJITCage())
         return JSC::vmEntryToCSSJIT(bitwise_cast<uintptr_t>(element), bitwise_cast<uintptr_t>(value), 0, compiledSelector.codeRef.code().taggedPtr());
 #endif
-    using RuleCollectorSimpleSelectorChecker = unsigned(*)(const Element*, unsigned*);
+    using RuleCollectorSimpleSelectorChecker = unsigned SYSV_ABI (*)(const Element*, unsigned*);
     return untagCFunctionPtr<RuleCollectorSimpleSelectorChecker, JSC::CSSSelectorPtrTag>(compiledSelector.codeRef.code().taggedPtr())(element, value);
 }
 
@@ -67,7 +67,7 @@ inline unsigned querySelectorSimpleSelectorChecker(CompiledSelector& compiledSel
     if (JSC::Options::useJITCage())
         return JSC::vmEntryToCSSJIT(bitwise_cast<uintptr_t>(element), 0, 0, compiledSelector.codeRef.code().taggedPtr());
 #endif
-    using QuerySelectorSimpleSelectorChecker = unsigned(*)(const Element*);
+    using QuerySelectorSimpleSelectorChecker = unsigned SYSV_ABI (*)(const Element*);
     return untagCFunctionPtr<QuerySelectorSimpleSelectorChecker, JSC::CSSSelectorPtrTag>(compiledSelector.codeRef.code().taggedPtr())(element);
 }
 
@@ -78,7 +78,7 @@ inline unsigned ruleCollectorSelectorCheckerWithCheckingContext(CompiledSelector
     if (JSC::Options::useJITCage())
         return JSC::vmEntryToCSSJIT(bitwise_cast<uintptr_t>(element), bitwise_cast<uintptr_t>(context), bitwise_cast<uintptr_t>(value), compiledSelector.codeRef.code().taggedPtr());
 #endif
-    using RuleCollectorSelectorCheckerWithCheckingContext = unsigned(*)(const Element*, SelectorChecker::CheckingContext*, unsigned*);
+    using RuleCollectorSelectorCheckerWithCheckingContext = unsigned SYSV_ABI (*)(const Element*, SelectorChecker::CheckingContext*, unsigned*);
     return untagCFunctionPtr<RuleCollectorSelectorCheckerWithCheckingContext, JSC::CSSSelectorPtrTag>(compiledSelector.codeRef.code().taggedPtr())(element, context, value);
 }
 
@@ -89,7 +89,7 @@ inline unsigned querySelectorSelectorCheckerWithCheckingContext(CompiledSelector
     if (JSC::Options::useJITCage())
         return JSC::vmEntryToCSSJIT(bitwise_cast<uintptr_t>(element), bitwise_cast<uintptr_t>(context), 0, compiledSelector.codeRef.code().taggedPtr());
 #endif
-    using QuerySelectorSelectorCheckerWithCheckingContext = unsigned(*)(const Element*, const SelectorChecker::CheckingContext*);
+    using QuerySelectorSelectorCheckerWithCheckingContext = unsigned SYSV_ABI (*)(const Element*, const SelectorChecker::CheckingContext*);
     return untagCFunctionPtr<QuerySelectorSelectorCheckerWithCheckingContext, JSC::CSSSelectorPtrTag>(compiledSelector.codeRef.code().taggedPtr())(element, context);
 }
 


### PR DESCRIPTION
#### d86cd42fe26d4de7a76887df7880adcee2ea7925
<pre>
Use SystemV ABI for CSS Selector JIT on Windows
<a href="https://bugs.webkit.org/show_bug.cgi?id=275971">https://bugs.webkit.org/show_bug.cgi?id=275971</a>

Reviewed by Yusuke Suzuki.

Dropped the OS and PLATFORM checks for CSS JIT in PlatformEnable.h, we
rely on whether JIT is enabled instead.

* Source/WTF/wtf/PlatformEnable.h:
* Source/WebCore/cssjit/RegisterAllocator.h:
(WebCore::RegisterAllocator::isCallerSavedRegister):
* Source/WebCore/cssjit/SelectorCompiler.h:
(WebCore::SelectorCompiler::ruleCollectorSimpleSelectorChecker):
(WebCore::SelectorCompiler::querySelectorSimpleSelectorChecker):
(WebCore::SelectorCompiler::ruleCollectorSelectorCheckerWithCheckingContext):
(WebCore::SelectorCompiler::querySelectorSelectorCheckerWithCheckingContext):

Canonical link: <a href="https://commits.webkit.org/280439@main">https://commits.webkit.org/280439@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37f126d30fe3c30d66819060688f59dc0c0b9dcf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56629 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/35956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9102 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60243 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7070 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58756 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43579 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7261 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/45874 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4952 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58659 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33807 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48879 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26734 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30587 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6210 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6073 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/49721 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61926 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/55870 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/541 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6582 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53134 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/543 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48937 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/53145 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/468 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/77631 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8419 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31784 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12863 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32870 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/33954 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32616 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->