### PR TITLE
Use a const & when when getting tracks in minSizeForChild

### DIFF
--- a/PerformanceTests/Layout/auto-masonry-1000-columns-10000-items.html
+++ b/PerformanceTests/Layout/auto-masonry-1000-columns-10000-items.html
@@ -1,0 +1,40 @@
+<!-- webkit-test-runner [ MasonryEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<!-- This test focuses on testing the performance of large numbers of columns in CSS Masonry. -->
+<title>Masonry Test: 1,000 Columns and 10,000 Items</title>
+<script src="../resources/runner.js"></script>
+</head>
+
+<style>
+    grid {
+        display: grid;
+        grid-template-columns: repeat(1000, auto);
+        grid-template-rows: masonry;
+        gap: 5px;
+    }
+</style>
+
+<div id="testGrid"></div>
+
+<script>
+    // Construct the grid
+    grid = document.createElement("grid")
+    for (let i = 0; i < 10000; i++) {
+        let div = document.createElement("div");
+        div.innerText = i;
+        grid.appendChild(div);
+    }
+
+    function test() {
+        document.getElementById("testGrid").appendChild(grid);
+        document.body.offsetHeight;
+        document.getElementById("testGrid").removeChild(grid);
+        document.body.offsetHeight;
+    }
+
+    PerfTestRunner.measureRunsPerSecond({ run: test });
+</script>
+
+</html>

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -918,7 +918,7 @@ LayoutUnit GridTrackSizingAlgorithmStrategy::minSizeForChild(RenderBox& child) c
         const GridSpan& span = m_algorithm.m_renderGrid->gridSpanForChild(child, direction());
 
         LayoutUnit maxBreadth;
-        auto allTracks = m_algorithm.tracks(direction());
+        const auto& allTracks = m_algorithm.tracks(direction());
         bool allFixed = true;
         for (auto trackPosition : span) {
             const auto& trackSize = allTracks[trackPosition].cachedTrackSize();


### PR DESCRIPTION
#### 267c225fb2d3c6ba94a3426f442a6dda40eecb2d
<pre>
Use a const &amp; when when getting tracks in minSizeForChild
<a href="https://bugs.webkit.org/show_bug.cgi?id=275972">https://bugs.webkit.org/show_bug.cgi?id=275972</a>
<a href="https://rdar.apple.com/problem/130728344">rdar://problem/130728344</a>

Reviewed by Sammy Gill.

We are doing unnecessary copies of GridTracks when grabbing the allTracks.

Based on the microbenchmark I wrote it reduced masonry layout from ~1 minute to ~1 second.
Grid layout decreased from ~100 ms to ~30 ms.
Tested on M1 Ultra.

* PerformanceTests/Layout/auto-masonry-1000-columns-10000-items.html: Added.
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithmStrategy::minSizeForChild const):

Canonical link: <a href="https://commits.webkit.org/280473@main">https://commits.webkit.org/280473@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/436d641d1c8a8e775a0b7e1f0327addb13701c53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56716 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36044 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60331 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7159 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58843 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7349 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45950 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5026 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58746 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33882 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48955 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26807 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30662 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6286 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6162 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52611 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6557 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62014 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/629 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6657 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53212 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/632 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49010 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53231 "Found 3 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12548 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/540 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31873 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32958 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34043 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32704 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->