### PR TITLE
REGRESSION (279977@main): [ macOS ] TestWebKitAPI.WebKitLegacy.MediaPlaybackSleepAssertion is a flaky failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/mac/MediaPlaybackSleepAssertion.html
+++ b/Tools/TestWebKitAPI/Tests/mac/MediaPlaybackSleepAssertion.html
@@ -9,15 +9,16 @@
 
         function startTest() {
             var video = document.querySelector('video');
-            video.addEventListener('playing', onplaying);
+            video.addEventListener('timeupdate', onplaybackstarted);
             video.addEventListener('pause', onpause);
             video.addEventListener('webkitcurrentplaybacktargetiswirelesschanged', oncurrentplaybacktargetiswirelesschanged);
             window.location = 'callback:loaded';
         }
 
-        function onplaying(event) {
+        function onplaybackstarted(event) {
             var video = event.target;
-            window.location = 'callback:playing';
+            if (video.currentTime > 0 && !video.paused)
+                window.location = 'callback:playing';
         }
 
         function onpause(event) {


### PR DESCRIPTION
#### 99e94b10377c114f50e450119fa3115882099130
<pre>
REGRESSION (279977@main): [ macOS ] TestWebKitAPI.WebKitLegacy.MediaPlaybackSleepAssertion is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=275750">https://bugs.webkit.org/show_bug.cgi?id=275750</a>
<a href="https://rdar.apple.com/130299367">rdar://130299367</a>

Reviewed by Eric Carlson.

The API test checks that as soon as we call `video.play()` the display sleep
assertion will be held.
However, following 279977@main we only do so if the media element is actually
playing. At the time play() is called, playback doesn&apos;t start synchronously and
will occur shortly after.
So instead we wait until the current time has progressed slightly to check
the display assertion.

* Tools/TestWebKitAPI/Tests/mac/MediaPlaybackSleepAssertion.html:

Canonical link: <a href="https://commits.webkit.org/280463@main">https://commits.webkit.org/280463@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08c733a76034a95aab8da474daff7cf8c1cbc35b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60292 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7119 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58805 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7310 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45916 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/4988 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58708 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48917 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26775 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30625 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6253 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6122 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52568 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6520 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/61975 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/590 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6621 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53171 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/592 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/48975 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53192 "Found 1 new API test failure: /WebKitGTK/TestSSL:/webkit/WebKitWebView/tls-http-auth (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12545 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/506 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31833 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32919 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34003 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32665 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->