### PR TITLE
Add a LowerInt64 B3 pass

### DIFF
--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -150,6 +150,7 @@ b3/B3InferSwitches.cpp
 b3/B3InsertionSet.cpp
 b3/B3Kind.cpp
 b3/B3LegalizeMemoryOffsets.cpp
+b3/B3LowerInt64.cpp
 b3/B3LowerMacros.cpp
 b3/B3LowerMacrosAfterOptimizations.cpp
 b3/B3LowerToAir.cpp

--- a/Source/JavaScriptCore/b3/B3Generate.cpp
+++ b/Source/JavaScriptCore/b3/B3Generate.cpp
@@ -39,6 +39,7 @@
 #include "B3HoistLoopInvariantValues.h"
 #include "B3InferSwitches.h"
 #include "B3LegalizeMemoryOffsets.h"
+#include "B3LowerInt64.h"
 #include "B3LowerMacros.h"
 #include "B3LowerMacrosAfterOptimizations.h"
 #include "B3LowerToAir.h"
@@ -102,6 +103,9 @@ void generateToAir(Procedure& procedure)
         reduceStrength(procedure);
     }
 
+#if USE(JSVALUE32_64)
+    lowerInt64(procedure);
+#endif
     // This puts the IR in quirks mode.
     lowerMacros(procedure);
 

--- a/Source/JavaScriptCore/b3/B3LowerInt64.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerInt64.cpp
@@ -1,0 +1,700 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "B3LowerInt64.h"
+
+#if USE(JSVALUE32_64) && ENABLE(B3_JIT)
+#include "B3BasicBlock.h"
+#include "B3BlockInsertionSet.h"
+#include "B3InsertionSet.h"
+#include "B3InsertionSetInlines.h"
+#include "B3PhaseScope.h"
+#include "B3Procedure.h"
+#include "B3StackmapGenerationParams.h"
+#include "B3Value.h"
+
+namespace JSC {
+namespace B3 {
+
+namespace B3LowerInt64Internal {
+static constexpr bool verbose = false;
+}
+
+namespace {
+class LowerInt64 {
+public:
+    LowerInt64(Procedure& proc)
+        : m_proc(proc)
+        , m_zero(m_proc.addIntConstant(Origin(), Int32, 0))
+        , m_insertionSet(proc)
+        , m_blockInsertionSet(proc)
+    {
+    }
+
+    bool run()
+    {
+        const Vector<BasicBlock*> blocksInPreOrder = m_proc.blocksInPreOrder();
+
+        // Create 2 Int32 Identity Values for every Int64 value, so we always
+        // have the replacement of an Int64 available. We can then change what
+        // the Identity references in the lowering loop below.
+        for (BasicBlock *block : blocksInPreOrder) {
+            m_block = block;
+            for (m_index = 0; m_index < m_block->size(); ++m_index) {
+                m_value = m_block->at(m_index);
+                Value* hi;
+                Value* lo;
+                dataLogLnIf(B3LowerInt64Internal::verbose, "B3LowerInt64: prep for ", deepDump(m_value));
+                if ((m_value->type() == Int64) && (m_value->opcode() == Phi)) {
+                    // Upsilon expects the target of a ->setPhi() to be a Phi,
+                    // not an identity, so do the (trivial) lowering here.
+                    hi = insert<Value>(m_index + 1, Phi, Int32, m_value->origin());
+                    lo = insert<Value>(m_index + 1, Phi, Int32, m_value->origin());
+                } else if (m_value->type() == Int64 || (m_value->opcode() == Upsilon && m_value->child(0)->type() == Int64)) {
+                    hi = insert<Value>(m_index + 1, Identity, m_value->origin(), m_zero);
+                    lo = insert<Value>(m_index + 1, Identity, m_value->origin(), m_zero);
+                } else
+                    continue;
+                m_syntheticValues.add(hi);
+                m_syntheticValues.add(lo);
+                dataLogLnIf(B3LowerInt64Internal::verbose, "Map ", *m_value, " -> (", deepDump(hi), ", ", deepDump(lo), ")");
+                m_mapping.add(m_value, std::pair<Value*, Value*> { hi, lo });
+            }
+            m_changed |= !m_insertionSet.isEmpty();
+            m_insertionSet.execute(m_block);
+        }
+
+        // Lower every Int64 node. This might insert new blocks, but those
+        // blocks don't need any lowering.
+        for (BasicBlock *block : blocksInPreOrder) {
+            m_block = block;
+            processCurrentBlock();
+            m_changed |= !m_insertionSet.isEmpty();
+            m_insertionSet.execute(m_block);
+            m_changed |= m_blockInsertionSet.execute();
+        }
+
+        m_proc.deleteValue(m_zero);
+        if (m_changed) {
+            m_proc.resetReachability();
+            m_proc.invalidateCFG();
+        }
+        return m_changed;
+    }
+private:
+    void setMapping(Value* value, Value* hi, Value* lo)
+    {
+        std::pair<Value*, Value*> m = getMapping(value);
+        ASSERT(m.first->opcode() == Identity);
+        ASSERT(m.second->opcode() == Identity);
+        ASSERT(m.first->child(0) == m_zero);
+        ASSERT(m.second->child(0) == m_zero);
+        m.first->child(0) = hi;
+        m.second->child(0) = lo;
+    }
+
+    std::pair<Value*, Value*> getMapping(Value* value)
+    {
+        RELEASE_ASSERT(m_mapping.contains(value));
+        return m_mapping.get(value);
+    }
+
+    void processCurrentBlock()
+    {
+        for (m_index = 0; m_index < m_block->size(); ++m_index) {
+            m_value = m_block->at(m_index);
+            if (m_value->opcode() == Identity && m_syntheticValues.contains(m_value))
+                continue;
+            dataLogLnIf(B3LowerInt64Internal::verbose, "LowerInt64: ", deepDump(m_value));
+            processValue();
+        }
+    }
+
+    Value* valueLo(Value* value)
+    {
+        return insert<Value>(m_index, Trunc, m_origin, value);
+    }
+
+    Value* valueHi(Value* value)
+    {
+        return insert<Value>(m_index, TruncHigh, m_origin, value);
+    }
+
+    Value* valueHiLo(Value* hi, Value* lo)
+    {
+        return insert<Value>(m_index, Stitch, m_origin, hi, lo);
+    }
+
+    void valueReplaced()
+    {
+        m_value->replaceWithBottom(m_insertionSet, m_index);
+    }
+
+    template<typename ValueType, typename... Arguments>
+    ValueType* insert(size_t index, Arguments... arguments)
+    {
+        return m_insertionSet.insert<ValueType>(index, arguments...);
+    }
+
+    template<typename ValueType, typename... Arguments>
+    ValueType* appendToBlock(BasicBlock* block, Arguments... arguments)
+    {
+        return block->appendNew<ValueType>(m_proc, arguments...);
+    }
+
+    BasicBlock* splitForward()
+    {
+        return m_blockInsertionSet.splitForward(m_block, m_index, &m_insertionSet);
+    }
+
+    std::pair<UpsilonValue*, UpsilonValue*> shiftBelow32(BasicBlock* block, Opcode opcode, std::pair<Value*, Value*> input, Value* maskedShift)
+    {
+        Value* outputHi;
+        Value* outputLo;
+        Value* shiftComplement = appendToBlock<Value>(block, Sub, m_origin, appendToBlock<Const32Value>(block, m_origin, 32), maskedShift);
+        Value* inputHi = input.first;
+        Value* inputLo = input.second;
+
+        if (opcode == SShr) {
+            Value* shiftedLo = appendToBlock<Value>(block, ZShr, m_origin, inputLo, maskedShift);
+            Value* shiftedIntoLoFromHi = appendToBlock<Value>(block, Shl, m_origin, inputHi, shiftComplement);
+            outputLo = appendToBlock<Value>(block, BitOr, m_origin, shiftedLo, shiftedIntoLoFromHi);
+            outputHi = appendToBlock<Value>(block, SShr, m_origin, inputHi, maskedShift);
+        } else if (opcode == ZShr) {
+            Value* shiftedLo = appendToBlock<Value>(block, ZShr, m_origin, inputLo, maskedShift);
+            Value* shiftedIntoLoFromHi = appendToBlock<Value>(block, Shl, m_origin, inputHi, shiftComplement);
+            outputLo = appendToBlock<Value>(block, BitOr, m_origin, shiftedLo, shiftedIntoLoFromHi);
+            outputHi = appendToBlock<Value>(block, ZShr, m_origin, inputHi, maskedShift);
+        } else {
+            RELEASE_ASSERT(opcode == Shl);
+            outputLo = appendToBlock<Value>(block, Shl, m_origin, inputLo, maskedShift);
+            Value* shiftedHi = appendToBlock<Value>(block, Shl, m_origin, inputHi, maskedShift);
+            Value* shiftedIntoHiFromLo = appendToBlock<Value>(block, ZShr, m_origin, inputLo, shiftComplement);
+            outputHi = appendToBlock<Value>(block, BitOr, m_origin, shiftedHi, shiftedIntoHiFromLo);
+        }
+        auto ret = std::pair { appendToBlock<UpsilonValue>(block, m_origin, outputHi), appendToBlock<UpsilonValue>(block, m_origin, outputLo) };
+        appendToBlock<Value>(block, Jump, m_origin);
+        return ret;
+    }
+
+    std::pair<UpsilonValue*, UpsilonValue*> shiftAboveEquals32(BasicBlock* block, Opcode opcode, std::pair<Value*, Value*> input, Value* maskedShift)
+    {
+        Value* outputHi;
+        Value* outputLo;
+        Value* shift = appendToBlock<Value>(block, Sub, m_origin, maskedShift, appendToBlock<Const32Value>(block, m_origin, 32));
+        if (opcode == SShr) {
+            outputLo = appendToBlock<Value>(block, SShr, m_origin, input.first, shift);
+            outputHi = appendToBlock<Value>(block, SShr, m_origin, input.first, appendToBlock<Const32Value>(block, m_origin, 31));
+        } else if (opcode == ZShr) {
+            outputLo = appendToBlock<Value>(block, ZShr, m_origin, input.first, shift);
+            outputHi = appendToBlock<Const32Value>(block, m_origin, 0);
+        } else {
+            RELEASE_ASSERT(opcode == Shl);
+            outputHi = appendToBlock<Value>(block, Shl, m_origin, input.second, shift);
+            outputLo = appendToBlock<Const32Value>(block, m_origin, 0);
+        }
+        auto ret = std::pair { appendToBlock<UpsilonValue>(block, m_origin, outputHi), appendToBlock<UpsilonValue>(block, m_origin, outputLo) };
+        appendToBlock<Value>(block, Jump, m_origin);
+        return ret;
+    }
+
+    void processValue()
+    {
+        switch (m_value->opcode()) {
+        case BitOr:
+        case BitXor:
+        case BitAnd: {
+            if (m_value->type() != Int64)
+                return;
+            auto left = getMapping(m_value->child(0));
+            auto right = getMapping(m_value->child(1));
+            Value* hi = insert<Value>(m_index, m_value->opcode(), m_origin, left.first, right.first);
+            Value* lo = insert<Value>(m_index, m_value->opcode(), m_origin, left.second, right.second);
+            setMapping(m_value, hi, lo);
+            valueReplaced();
+            return;
+        }
+        case Const64: {
+            Value* hi = insert<Const32Value>(m_index, m_origin, (m_value->asInt() >> 32) & 0xffffffff);
+            Value* lo = insert<Const32Value>(m_index, m_origin, m_value->asInt() & 0xffffffff);
+            setMapping(m_value, hi, lo);
+            valueReplaced();
+            return;
+        }
+        case Phi : {
+            return;
+        }
+        case Upsilon: {
+            if (m_value->child(0)->type() != Int64)
+                return;
+            auto phi = getMapping(m_value->as<UpsilonValue>()->phi());
+            auto input = getMapping(m_value->child(0));
+            UpsilonValue* hi = insert<UpsilonValue>(m_index, m_origin, input.first);
+            hi->setPhi(phi.first);
+            UpsilonValue* lo = insert<UpsilonValue>(m_index, m_origin, input.second);
+            lo->setPhi(phi.second);
+            setMapping(m_value, hi, lo);
+            valueReplaced();
+            return;
+        }
+        case CCall: {
+            bool hasInt64Arg = false;
+            for (size_t index = 0; index < m_value->numChildren(); ++index) {
+                if (m_value->child(index)->type() != Int64)
+                    continue;
+                hasInt64Arg = true;
+            }
+            if (!hasInt64Arg && m_value->type() != Int64)
+                return;
+            CCallValue* cCall = insert<CCallValue>(m_index, m_value->type(), m_origin, m_value->child(0));
+            cCall->effects = m_value->effects();
+            Vector<Value*> args;
+            RELEASE_ASSERT(cCall->numChildren() == 1);
+            for (size_t index = 1; index < m_value->numChildren(); ++index) {
+                Value* child = m_value->child(index);
+                if (child->type() != Int64)
+                    args.append(child);
+                else {
+                    auto childParts = getMapping(child);
+                    args.append(valueHiLo(childParts.first, childParts.second));
+                }
+            }
+            cCall->appendArgs(args);
+            m_value->replaceWithIdentity(cCall);
+            if (m_value->type() == Int64)
+                setMapping(m_value, valueHi(m_value), valueLo(m_value));
+            return;
+        }
+        case Check: {
+            bool hasInt64Arg = false;
+            for (size_t index = 0; index < m_value->numChildren(); ++index) {
+                if (m_value->child(index)->type() != Int64)
+                    continue;
+                hasInt64Arg = true;
+            }
+            if (!hasInt64Arg && m_value->type() != Int64)
+                return;
+
+            CheckValue* originalCheck = m_value->as<CheckValue>();
+            // Putting together Int64 values with valueHiLo needs to preceed the
+            // insertion of the PatchpointValue.
+            Vector<Value*> args;
+            for (size_t index = 0; index < m_value->numChildren(); ++index) {
+                Value* child = m_value->child(index);
+                if (child->type() == Int64) {
+                    auto childParts = getMapping(child);
+                    // The rep should have been correctly assigned when the
+                    // Patchpoint was created, here we simply piece together the
+                    // 64-bit value that it expects.
+                    args.append(valueHiLo(childParts.first, childParts.second));
+                } else
+                    args.append(child);
+            }
+            CheckValue* check;
+            if (m_value->kind() == Check) {
+                RELEASE_ASSERT(m_value->numChildren() == 1);
+                check = insert<CheckValue>(m_index, m_value->kind(), m_origin, m_value->child(0));
+            } else {
+                RELEASE_ASSERT(m_value->numChildren() == 2);
+                check = insert<CheckValue>(m_index, m_value->kind(), m_origin, m_value->child(0), m_value->child(1));
+            }
+            check->clobberEarly(originalCheck->earlyClobbered());
+            check->clobberLate(originalCheck->lateClobbered());
+            // XXX: m_usedRegisters?
+            check->setGenerator(originalCheck->generator());
+            const Vector<ValueRep>& reps = originalCheck->reps();
+            for (size_t index = 0; index < m_value->numChildren(); ++index)
+                check->append(args[index], reps[index]);
+            m_value->replaceWithIdentity(check);
+            if (m_value->type() == Int64)
+                setMapping(m_value, valueHi(m_value), valueLo(m_value));
+            return;
+        }
+        case Patchpoint: {
+            bool hasInt64Arg = false;
+            for (size_t index = 0; index < m_value->numChildren(); ++index) {
+                if (m_value->child(index)->type() != Int64)
+                    continue;
+                hasInt64Arg = true;
+            }
+            if (!hasInt64Arg && m_value->type() != Int64)
+                return;
+            PatchpointValue* originalPatchpoint = m_value->as<PatchpointValue>();
+
+            // Putting together Int64 values with valueHiLo needs to preceed the
+            // insertion of the PatchpointValue.
+            Vector<Value*> args;
+            for (size_t index = 0; index < originalPatchpoint->numChildren(); ++index) {
+                Value* child = originalPatchpoint->child(index);
+                if (child->type() == Int64) {
+                    auto childParts = getMapping(child);
+                    // The rep should have been correctly assigned when the
+                    // Patchpoint was created, here we simply piece together the
+                    // 64-bit value that it expects.
+                    args.append(valueHiLo(childParts.first, childParts.second));
+                } else
+                    args.append(child);
+            }
+            PatchpointValue* patchpoint = insert<PatchpointValue>(m_index, originalPatchpoint->type(), m_origin);
+            patchpoint->clobberEarly(originalPatchpoint->earlyClobbered());
+            patchpoint->clobberLate(originalPatchpoint->lateClobbered());
+            // XXX: m_usedRegisters?
+            patchpoint->effects = originalPatchpoint->effects;
+            patchpoint->resultConstraints = originalPatchpoint->resultConstraints;
+            patchpoint->numGPScratchRegisters = originalPatchpoint->numGPScratchRegisters;
+            patchpoint->numFPScratchRegisters = originalPatchpoint->numFPScratchRegisters;
+            patchpoint->setGenerator(originalPatchpoint->generator());
+            const Vector<ValueRep>& reps = originalPatchpoint->reps();
+            for (size_t index = 0; index < originalPatchpoint->numChildren(); ++index)
+                patchpoint->append(args[index], reps[index]);
+            m_value->replaceWithIdentity(patchpoint);
+            if (m_value->type() == Int64)
+                setMapping(m_value, valueHi(m_value), valueLo(m_value));
+            return;
+        }
+        case Add:
+        case Sub: {
+            if (m_value->type() != Int64)
+                return;
+            auto left = getMapping(m_value->child(0));
+            auto right = getMapping(m_value->child(1));
+            Value* stitchedLeft = valueHiLo(left.first, left.second);
+            Value* stitchedRight = valueHiLo(right.first, right.second);
+            Value* stitched = insert<Value>(m_index, m_value->opcode(), m_origin, stitchedLeft, stitchedRight);
+            m_value->replaceWithIdentity(stitched);
+            setMapping(m_value, valueHi(stitched), valueLo(stitched));
+            return;
+        }
+
+        case Branch: {
+            if (m_value->child(0)->type() != Int64)
+                return;
+            std::pair<Value*, Value*> input = getMapping(m_value->child(0));
+            Value* testValue = insert<Value>(m_index, BitOr, m_origin, input.first, input.second);
+            Value* branchValue = insert<Value>(m_index, Branch, m_origin, testValue);
+            m_value->replaceWithIdentity(branchValue);
+            return;
+        }
+        case Equal:
+        case NotEqual: {
+            if (m_value->child(0)->type() != Int64)
+                return;
+            auto left = getMapping(m_value->child(0));
+            auto right = getMapping(m_value->child(1));
+            Value* highComparison = insert<Value>(m_index, m_value->opcode(), m_origin, left.first, right.first);
+            Value* lowComparison = insert<Value>(m_index, m_value->opcode(), m_origin, left.second, right.second);
+            Opcode combineOpcode = m_value->opcode() == Equal ? BitAnd : BitOr;
+            Value* result = insert<Value>(m_index, combineOpcode, m_origin, highComparison, lowComparison);
+            m_value->replaceWithIdentity(result);
+            return;
+        }
+
+        // To verify the lowering of the comparisons, you can use Z3:
+        // (declare-const left (_ BitVec 64))
+        // (declare-const right (_ BitVec 64))
+        // (define-fun low ((x (_ BitVec 64))) (_ BitVec 32)
+        //   ((_ extract 31 0) x))
+        // (define-fun high ((x (_ BitVec 64))) (_ BitVec 32)
+        //   ((_ extract 63 32) x))
+
+        // ;; Below
+        // (push)
+        // (assert
+        //   (not
+        //    (= (bvult left right)
+        //       (or (bvult (high left) (high right))
+        //           (and (= (high left) (high right))
+        //                (bvult (low left) (low right)))))))
+        // (check-sat)
+        // (pop)
+
+        // ;; Above
+        // (push)
+        // (assert
+        //   (not
+        //    (= (bvugt left right)
+        //       (or (bvugt (high left) (high right))
+        //        (and (= (high left) (high right))
+        //             (bvugt (low left) (low right)))))))
+        // (check-sat)
+        // (pop)
+        case Below:
+        case Above: {
+            if (m_value->child(0)->type() != Int64)
+                return;
+            auto left = getMapping(m_value->child(0));
+            auto right = getMapping(m_value->child(1));
+            Value* highComparison = insert<Value>(m_index, m_value->opcode(), m_origin, left.first, right.first);
+            Value* highEquality = insert<Value>(m_index, Equal, m_origin, left.first, right.first);
+            Value* lowComparison = insert<Value>(m_index, m_value->opcode(), m_origin, left.second, right.second);
+            Value* result = insert<Value>(m_index, BitOr, m_origin, highComparison, insert<Value>(m_index, BitAnd, m_origin, highEquality, lowComparison));
+            m_value->replaceWithIdentity(result);
+            return;
+        }
+        // ;; BelowEqual
+        // (push)
+        // (assert
+        //   (not
+        //    (= (bvule left right)
+        //       (or (bvult (high left) (high right))
+        //        (and (= (high left) (high right))
+        //             (bvule (low left) (low right)))))))
+        // (check-sat)
+        // (pop)
+
+        // ;; AboveEqual
+        // (push)
+        // (assert
+        //   (not
+        //    (= (bvuge left right)
+        //       (or (bvugt (high left) (high right))
+        //        (and (= (high left) (high right))
+        //             (bvuge (low left) (low right)))))))
+        // (check-sat)
+        // (pop)
+        case BelowEqual:
+        case AboveEqual: {
+            if (m_value->child(0)->type() != Int64)
+                return;
+            auto left = getMapping(m_value->child(0));
+            auto right = getMapping(m_value->child(1));
+            Opcode highComparisonOpcode = m_value->opcode() == BelowEqual ? Below : Above;
+            Value* highComparison = insert<Value>(m_index, highComparisonOpcode, m_origin, left.first, right.first);
+            Value* highEquality = insert<Value>(m_index, Equal, m_origin, left.first, right.first);
+            Value* lowComparison = insert<Value>(m_index, m_value->opcode(), m_origin, left.second, right.second);
+            Value* result = insert<Value>(m_index, BitOr, m_origin, highComparison, insert<Value>(m_index, BitAnd, m_origin, highEquality, lowComparison));
+            m_value->replaceWithIdentity(result);
+            return;
+        }
+
+        // ;; JSC LessThan
+        // (push)
+        // (assert
+        //   (not
+        //    (= (bvslt left right)
+        //       (or (bvslt (high left) (high right))
+        //        (and (= (high left) (high right))
+        //             (bvult (low left) (low right)))))))
+        // (check-sat)
+        // (pop)
+
+        // ;; JSC GreaterThan: signed comparison
+        // (push)
+        // (assert
+        //   (not
+        //    (= (bvsgt left right)
+        //       (or (bvsgt (high left) (high right))
+        //        (and (= (high left) (high right))
+        //             (bvugt (low left) (low right)))))))
+        // (check-sat)
+        // (pop)
+        case LessThan:
+        case GreaterThan: {
+            if (m_value->child(0)->type() != Int64)
+                return;
+            auto left = getMapping(m_value->child(0));
+            auto right = getMapping(m_value->child(1));
+            Value* highComparison = insert<Value>(m_index, m_value->opcode(), m_origin, left.first, right.first);
+            Value* highEquality = insert<Value>(m_index, Equal, m_origin, left.first, right.first);
+            Opcode lowComparisonOpcode = m_value->opcode() == LessThan ? Below : Above;
+            Value* lowComparison = insert<Value>(m_index, lowComparisonOpcode, m_origin, left.second, right.second);
+            Value* result = insert<Value>(m_index, BitOr, m_origin, highComparison, insert<Value>(m_index, BitAnd, m_origin, highEquality, lowComparison));
+            m_value->replaceWithIdentity(result);
+            return;
+        }
+
+        // ;; LessEqual
+        // (push)
+        // (assert
+        //   (not
+        //    (= (bvsle left right)
+        //       (or (bvslt (high left) (high right))
+        //        (and (= (high left) (high right))
+        //             (bvule (low left) (low right)))))))
+        // (check-sat)
+        // (pop)
+
+        // ;; GreaterEqual
+        // (push)
+        // (assert
+        //   (not
+        //    (= (bvsge left right)
+        //       (or (bvsgt (high left) (high right))
+        //        (and (= (high left) (high right))
+        //             (bvuge (low left) (low right)))))))
+        // (check-sat)
+        // (pop)
+        case LessEqual:
+        case GreaterEqual: {
+            if (m_value->child(0)->type() != Int64)
+                return;
+            auto left = getMapping(m_value->child(0));
+            auto right = getMapping(m_value->child(1));
+            Opcode highComparisonOpcode = m_value->opcode() == LessEqual ? LessThan : GreaterThan;
+            Value* highComparison = insert<Value>(m_index, highComparisonOpcode, m_origin, left.first, right.first);
+            Value* highEquality = insert<Value>(m_index, Equal, m_origin, left.first, right.first);
+            Opcode lowComparisonOpcode = m_value->opcode() == LessEqual ? BelowEqual : AboveEqual;
+            Value* lowComparison = insert<Value>(m_index, lowComparisonOpcode, m_origin, left.second, right.second);
+            Value* result = insert<Value>(m_index, BitOr, m_origin, highComparison, insert<Value>(m_index, BitAnd, m_origin, highEquality, lowComparison));
+            m_value->replaceWithIdentity(result);
+            return;
+        }
+
+        case Return: {
+            if (!m_value->numChildren() || m_value->child(0)->type() != Int64)
+                return;
+            std::pair<Value*, Value*> retValue = getMapping(m_value->child(0));
+            PatchpointValue* patchpoint = insert<PatchpointValue>(m_index, Void, m_origin);
+            patchpoint->effects = Effects::none();
+            patchpoint->effects.terminal = true;
+            patchpoint->append(retValue.first, ValueRep::reg(GPRInfo::returnValueGPR2));
+            patchpoint->append(retValue.second, ValueRep::reg(GPRInfo::returnValueGPR));
+            patchpoint->setGenerator([] (CCallHelpers& jit, const StackmapGenerationParams& params) {
+                params.context().code->emitEpilogue(jit);
+            });
+            m_value->replaceWithIdentity(patchpoint);
+            return;
+        }
+        case SShr:
+        case Shl:
+        case ZShr: {
+            if (m_value->type() != Int64)
+                return;
+            auto input = getMapping(m_value->child(0));
+            Value* shiftAmount = m_value->child(1);
+            BasicBlock* before = splitForward();
+            BasicBlock* check = m_blockInsertionSet.insertBefore(m_block);
+            BasicBlock* aboveOrEquals32 = m_blockInsertionSet.insertBefore(m_block);
+            BasicBlock* below32 = m_blockInsertionSet.insertBefore(m_block);
+            BasicBlock* shiftIsZero = m_blockInsertionSet.insertBefore(m_block);
+
+            Value* maskedShift = appendToBlock<Value>(before, B3::BitAnd, m_origin, shiftAmount, before->replaceLastWithNew<Const32Value>(m_proc, m_origin, 63));
+            appendToBlock<Value>(before, Branch, m_origin, maskedShift);
+            before->setSuccessors(check, shiftIsZero);
+            Value* constant32 = appendToBlock<Const32Value>(check, m_origin, 32);
+            appendToBlock<Value>(check, Branch, m_origin, appendToBlock<Value>(check, Below, m_origin, maskedShift, constant32));
+            check->setSuccessors(below32, aboveOrEquals32);
+
+            std::pair<UpsilonValue*, UpsilonValue*> resultBelow32 = shiftBelow32(below32, m_value->opcode(), input, maskedShift);
+            below32->setSuccessors(m_block);
+
+            std::pair<UpsilonValue*, UpsilonValue*> resultAboveOrEquals32 = shiftAboveEquals32(aboveOrEquals32, m_value->opcode(), input, maskedShift);
+            aboveOrEquals32->setSuccessors(m_block);
+
+            std::pair<UpsilonValue*, UpsilonValue*> resultShiftIsZero = std::pair {
+                appendToBlock<UpsilonValue>(shiftIsZero, m_origin, input.first),
+                appendToBlock<UpsilonValue>(shiftIsZero, m_origin, input.second)
+            };
+            appendToBlock<Value>(shiftIsZero, Jump, m_origin);
+            shiftIsZero->setSuccessors(m_block);
+
+            std::pair<Value*, Value*> phis = std::pair {
+                insert<Value>(m_index, Phi, Int32, m_origin),
+                insert<Value>(m_index, Phi, Int32, m_origin)
+            };
+            resultBelow32.first->setPhi(phis.first);
+            resultBelow32.second->setPhi(phis.second);
+
+            resultAboveOrEquals32.first->setPhi(phis.first);
+            resultAboveOrEquals32.second->setPhi(phis.second);
+
+            resultShiftIsZero.first->setPhi(phis.first);
+            resultShiftIsZero.second->setPhi(phis.second);
+
+            setMapping(m_value, phis.first, phis.second);
+            before->updatePredecessorsAfter();
+            return;
+        }
+        case Const32:
+        case FramePointer:
+        case ArgumentReg:
+        case Jump:
+            return;
+        case Trunc: {
+            auto input = getMapping(m_value->child(0));
+            m_value->replaceWithIdentity(input.second);
+            return;
+        }
+        case ZExt32: {
+            Value* hi = insert<Const32Value>(m_index, m_origin, 0);
+            setMapping(m_value, hi, m_value->child(0));
+            valueReplaced();
+            return;
+        }
+        case Load: {
+            if (m_value->type() != Int64)
+                return;
+            MemoryValue* memory = m_value->as<MemoryValue>();
+            if (memory->range() != HeapRange::top())
+                RELEASE_ASSERT_NOT_REACHED(); // XXX: TBD
+            if (memory->fenceRange() != HeapRange())
+                RELEASE_ASSERT_NOT_REACHED(); // XXX: TBD
+            MemoryValue* hi = insert<MemoryValue>(m_index, Load, Int32, m_origin, memory->child(0));
+            // XXX: overflow!
+            hi->setOffset(memory->offset() + bytesForWidth(Width32));
+            // Assumes little-endian arch.
+            MemoryValue* lo = insert<MemoryValue>(m_index, Load, Int32, m_origin, memory->child(0));
+            lo->setOffset(memory->offset());
+            setMapping(m_value, hi, lo);
+            valueReplaced();
+            return;
+        }
+        case Store: {
+            if (m_value->child(0)->type() != Int64)
+                return;
+            RELEASE_ASSERT_NOT_REACHED(); // XXX: TBD
+        }
+        default: {
+            dataLogLn("Cannot lower ", deepDump(m_value));
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+        }
+    }
+    Procedure& m_proc;
+    Value* m_zero;
+    BasicBlock* m_block;
+    Value* m_value;
+    unsigned m_index;
+    Origin m_origin;
+    InsertionSet m_insertionSet;
+    BlockInsertionSet m_blockInsertionSet;
+    bool m_changed;
+    HashMap<Value*, std::pair<Value*, Value*>> m_mapping;
+    HashSet<Value*> m_syntheticValues;
+};
+
+} // anonymous namespace
+
+bool lowerInt64(Procedure& proc)
+{
+    PhaseScope phaseScope(proc, "B3::lowerInt64"_s);
+    LowerInt64 lowerInt64(proc);
+    return lowerInt64.run();
+}
+
+} // B3
+} // JSC
+#endif // USE(JSVALUE32_64) && ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3LowerInt64.h
+++ b/Source/JavaScriptCore/b3/B3LowerInt64.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(B3_JIT)
+
+namespace JSC { namespace B3 {
+
+class Procedure;
+
+// Lowers operations on 64-bit Ints to 32-bit ones.
+bool lowerInt64(Procedure&);
+
+} } // namespace JSC::B3
+
+#endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp
@@ -265,6 +265,12 @@ private:
     {
         switch (value->opcode()) {
         case Trunc:
+            // Copy propagation returns the tmp of a child for the tmp of a
+            // parent, but that could result in a wide tmp for an Int32.
+            // XXX: be smarter and resolve to the low Tmp
+            if (value->type().kind() == Int32)
+                return false;
+            FALLTHROUGH;
         case Identity:
         case Opaque:
             return true;
@@ -962,9 +968,6 @@ private:
     {
         Air::Opcode opcode = opcodeForType(opcode32, opcode64, opcodeDouble, opcodeFloat, value->type());
 
-        if (appendUnOp32_64(opcode32, value))
-            return;
-
         Tmp result = tmp(m_value);
 
         // Two operand forms like:
@@ -1053,8 +1056,6 @@ private:
     {
         Air::Opcode opcode = opcodeForType(opcode32, opcode64, opcodeDouble, opcodeFloat, left->type());
 
-        if ((m_value->type() == Int64) && appendBinOp32_64(opcode32, opcode64, left, right))
-            return;
         Tmp result = tmp(m_value);
 
         // Three-operand forms like:
@@ -1195,209 +1196,11 @@ private:
             append(kind, std::forward<Arguments>(arguments)...);
     }
 
-    bool appendLoad32_64(MemoryValue *memory)
-    {
-        if (memory->hasFence())
-            return false; // XXX: To be implemented
-        auto* base = memory->lastChild();
-        auto highBytes = effectiveAddr(base, memory->offset() + 4, Width32);
-        auto lowBytes = effectiveAddr(base, memory->offset(), Width32);
-        auto destTmp = someTmp(m_value);
-        append(trappingInst(m_value, Air::Move32, m_value, highBytes, hiTmp(destTmp)));
-        append(trappingInst(m_value, Air::Move32, m_value, lowBytes, loTmp(destTmp)));
-        return true;
-    }
-
-    bool appendUnOp32_64(Air::Opcode opcode32, Value *value)
-    {
-        using namespace Air;
-        ASSERT(m_value->type() == Int64);
-        if (opcode32 == Move32) {
-            auto resultTmp = someTmp(m_value);
-            append(Move, tmp(value), loTmp(resultTmp));
-            append(Move, Arg::imm(0), hiTmp(resultTmp));
-            return true;
-        }
-        return false;
-    }
-
-    bool opcodeIsNaturallyParallel(Air::Opcode opcode)
-    {
-        switch (opcode) {
-        case Air::And64:
-        case Air::Or64:
-        case Air::Xor64:
-        case Air::Not64:
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    bool appendBinOp32_64(Air::Opcode opcode32, Air::Opcode opcode64, Value *left, Value* right)
-    {
-        ASSERT(m_value->type() == Int64);
-
-        if (isValidForm(opcode64, Arg::Tmp, Arg::Tmp, Arg::Tmp, Arg::Tmp, Arg::Tmp, Arg::Tmp)) {
-            LogicalTmp leftTmp = someTmp(left);
-            LogicalTmp rightTmp = someTmp(right);
-            LogicalTmp resultTmp = someTmp(m_value);
-            append(opcode64,
-                   hiTmp(leftTmp), loTmp(leftTmp),
-                   hiTmp(rightTmp), loTmp(rightTmp),
-                   hiTmp(resultTmp), loTmp(resultTmp));
-            return true;
-        }
-        if ((left->type() == Int64)
-            && (right->type() == Int64)
-            && opcodeIsNaturallyParallel(opcode64)
-            && isValidForm(opcode32, Arg::Tmp, Arg::Tmp, Arg::Tmp)) {
-                auto leftTmp = someTmp(left);
-                auto rightTmp = someTmp(right);
-                auto resultTmp = someTmp(m_value);
-                append(opcode32, loTmp(leftTmp), loTmp(rightTmp), loTmp(resultTmp));
-                append(opcode32, hiTmp(leftTmp), hiTmp(rightTmp), hiTmp(resultTmp));
-                return true;
-        }
-        return false;
-    }
-
-    void appendShiftMask(Air::BasicBlock *block, Tmp amountTmp, LogicalTmp valueTmp, LogicalTmp resultTmp, Arg tmpShift, bool needMask)
-    {
-        using namespace Air;
-        appendToBlock(block, Move, amountTmp, tmpShift);
-        appendToBlock(block, Move, hiTmp(valueTmp), hiTmp(resultTmp));
-        appendToBlock(block, Move, loTmp(valueTmp), loTmp(resultTmp));
-        if (needMask)
-            appendToBlock(block, And32, Arg::imm(63), tmpShift, tmpShift);
-    }
-
-    void appendShiftBelow32(Air::BasicBlock *block, Air::Opcode opcode, LogicalTmp valueTmp, LogicalTmp resultTmp, Arg tmpShift)
-    {
-        using namespace Air;
-        Tmp tmpComplementShift = tmpForType(Int32);
-
-        appendToBlock(block, Move, Arg::imm(32), tmpComplementShift);
-        appendToBlock(block, Sub32, tmpShift, tmpComplementShift);
-        if (opcode == Rshift32) {
-            appendToBlock(block, Urshift32, loTmp(valueTmp), tmpShift, loTmp(resultTmp));
-            appendToBlock(block, Lshift32, hiTmp(valueTmp), tmpComplementShift, tmpComplementShift);
-            appendToBlock(block, Or32, tmpComplementShift, loTmp(resultTmp));
-            appendToBlock(block, Rshift32, hiTmp(valueTmp), tmpShift, hiTmp(resultTmp));
-        } else if (opcode == Urshift32) {
-            appendToBlock(block, Urshift32, loTmp(valueTmp), tmpShift, loTmp(resultTmp));
-            appendToBlock(block, Lshift32, hiTmp(valueTmp), tmpComplementShift, tmpComplementShift);
-            appendToBlock(block, Or32, tmpComplementShift, loTmp(resultTmp));
-            appendToBlock(block, Urshift32, hiTmp(valueTmp), tmpShift, hiTmp(resultTmp));
-        } else { // Lshift32
-            appendToBlock(block, Lshift32, hiTmp(valueTmp), tmpShift, hiTmp(resultTmp));
-            appendToBlock(block, Urshift32, loTmp(valueTmp), tmpComplementShift, tmpComplementShift);
-            appendToBlock(block, Or32, tmpComplementShift, hiTmp(resultTmp));
-            appendToBlock(block, Lshift32, loTmp(valueTmp), tmpShift, loTmp(resultTmp));
-        }
-    }
-
-    void appendShiftAboveEquals32(Air::BasicBlock *block, Air::Opcode opcode, LogicalTmp valueTmp, LogicalTmp resultTmp, Arg tmpShift)
-    {
-        using namespace Air;
-        appendToBlock(block, Sub32, tmpShift, Arg::imm(32), tmpShift);
-        if (opcode == Rshift32) {
-            appendToBlock(block, Rshift32, hiTmp(valueTmp), tmpShift, loTmp(resultTmp));
-            appendToBlock(block, Rshift32, hiTmp(valueTmp), Arg::imm(31), hiTmp(resultTmp));
-        } else if (opcode == Urshift32) {
-            appendToBlock(block, Urshift32, hiTmp(valueTmp), tmpShift, loTmp(resultTmp));
-            appendToBlock(block, Move, Arg::imm(0), hiTmp(resultTmp));
-        } else { // Lshift32
-            appendToBlock(block, Lshift32, loTmp(valueTmp), tmpShift, hiTmp(resultTmp));
-            appendToBlock(block, Move, Arg::imm(0), loTmp(resultTmp));
-        }
-    }
-
-    bool appendShift32_64(Air::Opcode opcode, Value* value, Value* amount)
-    {
-        using namespace Air;
-        auto valueTmp = someTmp(value);
-        Tmp amountTmp;
-        if (amount->type().kind() == Int64)
-            amountTmp = loTmp(someTmp(amount));
-        else {
-            ASSERT(amount->type().kind() == Int32);
-            amountTmp = singularTmp(someTmp(amount));
-        }
-        auto resultTmp = someTmp(m_value);
-        Tmp tmpShift = tmpForType(Int32);
-        if ((value->type() == Int64) && imm(amount) && amount->hasInt()) {
-            uint32_t amountInt = amount->asInt() & 0x3f;
-            // XXX: this only avoids blowing up the CFG by creating
-            // extra blocks that test a constant; it still puts the shift in
-            // a register (i.e. not an immediate) and treats it as a runtime
-            // value.
-            if (!amountInt) {
-                append(Move, loTmp(valueTmp), loTmp(resultTmp));
-                append(Move, hiTmp(valueTmp), hiTmp(resultTmp));
-                return true;
-            }
-            if (amountInt == 32) {
-                if (opcode == Urshift32) {
-                    append(Move, hiTmp(valueTmp), loTmp(resultTmp));
-                    append(Move, Arg::imm(0), hiTmp(resultTmp));
-                    return true;
-                } else if (opcode == Lshift32) {
-                    append(Move, loTmp(valueTmp), hiTmp(resultTmp));
-                    append(Move, Arg::imm(0), loTmp(resultTmp));
-                    return true;
-                }
-            }
-            appendShiftMask(nullptr, amountTmp, valueTmp, resultTmp, tmpShift, false);
-            if (amountInt < 32) {
-                appendShiftBelow32(nullptr, opcode, valueTmp, resultTmp, tmpShift);
-                return true;
-            }
-            appendShiftAboveEquals32(nullptr, opcode, valueTmp, resultTmp, tmpShift);
-            return true;
-        }
-        if ((value->type() == Int64)
-            && isValidForm(opcode, Arg::Tmp, Arg::Tmp, Arg::Tmp)) {
-            Air::BasicBlock* beginBlock;
-            Air::BasicBlock* doneBlock;
-            Air::BasicBlock* maskBlock = newBlock();
-            Air::BasicBlock* check = newBlock();
-            Air::BasicBlock* aboveOrEquals32 = newBlock();
-            Air::BasicBlock* below32 = newBlock();
-
-            splitBlock(beginBlock, doneBlock);
-
-            append(Air::Jump);
-            beginBlock->setSuccessors(maskBlock);
-            maskBlock->setSuccessors(doneBlock, check);
-            check->setSuccessors(below32, aboveOrEquals32);
-            below32->setSuccessors(doneBlock);
-            aboveOrEquals32->setSuccessors(doneBlock);
-
-            appendShiftMask(maskBlock, amountTmp, valueTmp, resultTmp, tmpShift, true);
-            maskBlock->append(BranchTest32, m_value, Arg::resCond(MacroAssembler::Zero), tmpShift, tmpShift);
-
-            check->append(Branch32, m_value, Arg::relCond(MacroAssembler::Below), tmpShift, Arg::imm(32));
-
-            appendShiftAboveEquals32(aboveOrEquals32, opcode, valueTmp, resultTmp, tmpShift);
-            aboveOrEquals32->append(Air::Jump, m_value);
-
-            appendShiftBelow32(below32, opcode, valueTmp, resultTmp, tmpShift);
-            below32->append(Air::Jump, m_value);
-
-            return true;
-        }
-        return false;
-    }
-
     template<Air::Opcode opcode32, Air::Opcode opcode64>
     void appendShift(Value* value, Value* amount)
     {
         using namespace Air;
         Air::Opcode opcode = opcodeForType(opcode32, opcode64, value->type());
-
-        if ((m_value->type() == Int64) && appendShift32_64(opcode32, value, amount))
-            return;
 
         if (imm(amount)) {
             if (isValidForm(opcode, Arg::Tmp, Arg::Imm, Arg::Tmp)) {
@@ -3214,8 +3017,6 @@ private:
 
         case Load: {
             MemoryValue* memory = m_value->as<MemoryValue>();
-                if ((memory->type() == Int64) && appendLoad32_64(memory))
-                    return;
             Air::Kind kind = moveForType(memory->type());
             if (memory->hasFence()) {
                 if (isX86())
@@ -3340,6 +3141,14 @@ private:
                 return;
             Value* left = m_value->child(0);
             Value* right = m_value->child(1);
+
+            if (m_value->type() == Int64 && isValidForm(Add64, Arg::Tmp, Arg::Tmp, Arg::Tmp, Arg::Tmp, Arg::Tmp, Arg::Tmp)) {
+                auto leftArg = someArg(left);
+                auto rightArg = someArg(right);
+                auto result = someArg(m_value);
+                append(Add64, leftArg.tmpHi(), leftArg.tmpLo(), rightArg.tmpHi(), rightArg.tmpLo(), result.tmpHi(), result.tmpLo());
+                return;
+            }
 
             auto tryMultiplyAdd = [&] () -> bool {
                 if (imm(right) && !m_valueToTmp[right])
@@ -4757,10 +4566,28 @@ private:
         }
 
         case Trunc: {
+            if (m_value->type() == Int32) {
+                auto input = someArg(m_value->child(0));
+                append(Move, input.tmpLo(), tmp(m_value));
+                return;
+            }
             ASSERT(tmp(m_value->child(0)) == tmp(m_value));
             return;
         }
+        case TruncHigh: {
+            RELEASE_ASSERT(m_value->type() == Int32);
+            auto input = someArg(m_value->child(0));
+            append(Move, input.tmpHi(), tmp(m_value));
+            return;
+        }
 
+        case Stitch: {
+            RELEASE_ASSERT(m_value->type() == Int64);
+            auto result = someArg(m_value);
+            append(Move, tmp(m_value->child(0)), result.tmpHi());
+            append(Move, tmp(m_value->child(1)), result.tmpLo());
+            return;
+        }
         case SExt8: {
             appendUnOp<SignExtend8To32, Air::Oops>(m_value->child(0));
             return;

--- a/Source/JavaScriptCore/b3/B3Opcode.cpp
+++ b/Source/JavaScriptCore/b3/B3Opcode.cpp
@@ -234,6 +234,12 @@ void printInternal(PrintStream& out, Opcode opcode)
     case Trunc:
         out.print("Trunc");
         return;
+    case TruncHigh:
+        out.print("TruncHigh");
+        return;
+    case Stitch:
+        out.print("Stitch");
+        return;
     case IToD:
         out.print("IToD");
         return;

--- a/Source/JavaScriptCore/b3/B3Opcode.h
+++ b/Source/JavaScriptCore/b3/B3Opcode.h
@@ -128,6 +128,11 @@ enum Opcode : uint8_t {
     ZExt32,
     // Does a bitwise truncation of Int64->Int32 and Double->Float:
     Trunc,
+    // On JSVALUE32_64 platforms only: gets the high 32-bits of an Int64.
+    TruncHigh,
+    // On JSVALUE32_64 platforms only: puts together an Int32 from two Int32s.
+    // High bits come from the first child.
+    Stitch,
     // Takes ints and returns floating point value. Note that we don't currently provide the opposite operation,
     // because double-to-int conversions have weirdly different semantics on different platforms. Use
     // a patchpoint if you need to do that.

--- a/Source/JavaScriptCore/b3/B3StackmapSpecial.cpp
+++ b/Source/JavaScriptCore/b3/B3StackmapSpecial.cpp
@@ -293,7 +293,7 @@ bool StackmapSpecial::isArgValidForRep(Air::Code& code, const Air::Arg& arg, con
     case ValueRep::SomeRegisterPairWithClobber:
     case ValueRep::SomeEarlyRegisterPair:
     case ValueRep::SomeLateRegisterPair:
-        return arg.isTmp();
+        return arg.isTmpPair();
     case ValueRep::LateRegisterPair:
     case ValueRep::RegisterPair:
         return arg == Arg(Tmp(rep.regHi()), Tmp(rep.regLo()));

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -300,6 +300,20 @@ public:
                     || (value->type() == Float && value->child(0)->type() == Double),
                     ("At ", *value));
                 break;
+            case TruncHigh:
+                VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
+                VALIDATE(value->numChildren() == 1, ("At ", *value));
+                VALIDATE(
+                    (value->type() == Int32 && value->child(0)->type() == Int64),
+                    ("At ", *value));
+                break;
+            case Stitch:
+                VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
+                VALIDATE(value->numChildren() == 2, ("At ", *value));
+                VALIDATE(value->type() == Int64, ("At ", *value));
+                VALIDATE(value->child(0)->type() == Int32, ("At ", *value));
+                VALIDATE(value->child(1)->type() == Int32, ("At ", *value));
+                break;
             case Abs:
             case Ceil:
             case Floor:

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -661,6 +661,8 @@ Effects Value::effects() const
     case SExt32:
     case ZExt32:
     case Trunc:
+    case TruncHigh:
+    case Stitch:
     case IToD:
     case IToF:
     case FloatToDouble:
@@ -872,6 +874,7 @@ ValueKey Value::key() const
     case ZExt32:
     case Clz:
     case Trunc:
+    case TruncHigh:
     case IToD:
     case IToF:
     case FloatToDouble:
@@ -910,6 +913,7 @@ ValueKey Value::key() const
     case CheckAdd:
     case CheckSub:
     case CheckMul:
+    case Stitch:
         return ValueKey(kind(), type(), child(0), child(1));
     case Select:
         return ValueKey(kind(), type(), child(0), child(1), child(2));
@@ -1101,6 +1105,7 @@ Type Value::typeFor(Kind kind, Value* firstChild, Value* secondChild)
     case AboveEqual:
     case BelowEqual:
     case EqualOrUnordered:
+    case TruncHigh:
         return Int32;
     case Trunc:
         return firstChild->type() == Int64 ? Int32 : Float;
@@ -1108,6 +1113,7 @@ Type Value::typeFor(Kind kind, Value* firstChild, Value* secondChild)
     case SExt16To64:
     case SExt32:
     case ZExt32:
+    case Stitch:
         return Int64;
     case FloatToDouble:
     case IToD:

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -424,6 +424,7 @@ protected:
         case SExt8:
         case SExt16:
         case Trunc:
+        case TruncHigh:
         case SExt8To64:
         case SExt16To64:
         case SExt32:
@@ -542,6 +543,7 @@ protected:
         case VectorMulByElement:
         case VectorShiftByVector:
         case VectorRelaxedSwizzle:
+        case Stitch:
             return 2 * sizeof(Value*);
         case Select:
         case AtomicWeakCAS:
@@ -664,6 +666,7 @@ private:
         case SExt8:
         case SExt16:
         case Trunc:
+        case TruncHigh:
         case SExt8To64:
         case SExt16To64:
         case SExt32:
@@ -764,6 +767,7 @@ private:
         case VectorMulByElement:
         case VectorShiftByVector:
         case VectorRelaxedSwizzle:
+        case Stitch:
             if (UNLIKELY(numArgs != 2))
                 badKind(kind, numArgs);
             return Two;

--- a/Source/JavaScriptCore/b3/B3ValueInlines.h
+++ b/Source/JavaScriptCore/b3/B3ValueInlines.h
@@ -75,6 +75,8 @@ namespace JSC { namespace B3 {
     case SExt8: \
     case SExt16: \
     case Trunc: \
+    case TruncHigh: \
+    case Stitch: \
     case SExt8To64: \
     case SExt16To64: \
     case SExt32: \

--- a/Source/JavaScriptCore/b3/B3ValueRep.h
+++ b/Source/JavaScriptCore/b3/B3ValueRep.h
@@ -129,7 +129,22 @@ public:
     ValueRep(Kind kind)
         : m_kind(kind)
     {
-        ASSERT(kind == WarmAny || kind == ColdAny || kind == LateColdAny || kind == SomeRegister || kind == SomeRegisterWithClobber || kind == SomeEarlyRegister || kind == SomeLateRegister);
+        ASSERT(kind == WarmAny
+            || kind == ColdAny
+            || kind == LateColdAny
+            || kind == SomeRegister
+            || kind == SomeRegisterWithClobber
+            || kind == SomeEarlyRegister
+            || kind == SomeLateRegister
+#if USE(JSVALUE32_64)
+            || kind == SomeRegisterPair
+            || kind == SomeRegisterPairWithClobber
+            || kind == SomeEarlyRegisterPair
+            || kind == SomeLateRegisterPair
+            || kind == RegisterPair
+            || kind == LateRegisterPair
+#endif
+        );
     }
 
 #if ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -159,7 +159,7 @@ x86: Add16 U:G:16, UD:G:16
 # change anything to disrupt the carry flag between the two adc instructions;
 # so, for now, they are fused as this Add64
 
-32: Add64 U:G:32, U:G:32, U:G:32, U:G:32, D:G:32, D:G:32
+32: Add64 U:G:32, U:G:32, U:G:32, U:G:32, D:G:32, ED:G:32
     Tmp, Tmp, Tmp, Tmp, Tmp, Tmp
 
 AddDouble U:F:64, U:F:64, D:F:64
@@ -211,7 +211,7 @@ arm64: Sub64 U:G:64, U:G:64, D:G:64
     Tmp, Imm, Tmp
 
 # note see note above, on Add64
-32: Sub64 U:G:32, U:G:32, U:G:32, U:G:32, D:G:32, D:G:32
+32: Sub64 U:G:32, U:G:32, U:G:32, U:G:32, D:G:32, ED:G:32
     Tmp, Tmp, Tmp, Tmp, Tmp, Tmp
 
 SubDouble U:F:64, U:F:64, D:F:64


### PR DESCRIPTION
#### e4b1106bc45645cdf986bb2b174622b82c8b03bd
<pre>
Add a LowerInt64 B3 pass
<a href="https://bugs.webkit.org/show_bug.cgi?id=275988">https://bugs.webkit.org/show_bug.cgi?id=275988</a>

Reviewed by Yusuke Suzuki and Justin Michaud.

Base infrastructure and partial implementation of a lowering pass for
Int64 values on 32-bits.

Crucially, this doesn&apos;t lower Patchpoints/CCalls and Add/Sub on Int64
values.  The former would, at the moment, complicate the generic paths
that simultaneously iterate over B3 Values and Air args. The latter
(Add/Sub) is lowered to the pre-existing Add64/Sub64 Air forms, which
avoids the need to track the carry bit.

Since we need to interface with the above values that use Int64s, this
patch also introduces two new B3 opcodes (that are only used on
32-bits):

- TruncHigh: extracts the high Int32 of an Int64 value.
- Stitch: creates an Int64 out of two Int32 values.

They need to be defined on 64-bits too because B3ValueInlines.h
references opcodes in a macro definition.

This removes the previously added lowering code to
B3LowerToAir32_64.cpp. It implements enough ops in B3LowerInt64.cpp to
keep i64-call.js and cc-int-to-int.js working with OMG on ARMv7.

It also fixes a bug in the Air forms for Add64/Sub64.

* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/b3/B3Generate.cpp:
(JSC::B3::generateToAir):
* Source/JavaScriptCore/b3/B3LowerInt64.cpp: Added.
(JSC::B3::lowerInt64):
* Source/JavaScriptCore/b3/B3LowerInt64.h: Added.
* Source/JavaScriptCore/b3/B3LowerToAir32_64.cpp:
* Source/JavaScriptCore/b3/B3Opcode.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/b3/B3Opcode.h:
* Source/JavaScriptCore/b3/B3StackmapSpecial.cpp:
(JSC::B3::StackmapSpecial::isArgValidForRep):
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::effects const):
(JSC::B3::Value::key const):
(JSC::B3::Value::typeFor):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/B3ValueInlines.h:
* Source/JavaScriptCore/b3/B3ValueRep.h:
(JSC::B3::ValueRep::ValueRep):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:

Canonical link: <a href="https://commits.webkit.org/280764@main">https://commits.webkit.org/280764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b971006fbf5341a164bbc5a1c508e4ce73da6c48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61088 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7911 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8099 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46537 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5604 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34525 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49638 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27401 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31306 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6941 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6914 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/50558 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53283 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62767 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/56708 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1379 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7306 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53796 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1385 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49664 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53891 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12726 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1179 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/78469 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32623 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13016 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33708 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34793 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33454 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->