### PR TITLE
Allow WebRTC network traffic on the interface used to load the document main resource even if it is not the default interface

### DIFF
--- a/LayoutTests/http/wpt/webrtc/resources/cacheable-iframe.py
+++ b/LayoutTests/http/wpt/webrtc/resources/cacheable-iframe.py
@@ -1,0 +1,4 @@
+def main(request, response):
+    response.headers.set(b"Cache-Control", b"max-age=31536000")
+    response.headers.set(b"Content-Type", b"text/html")
+    return "<html><body></body></html>"

--- a/LayoutTests/http/wpt/webrtc/rtcNetworkInterface-expected.txt
+++ b/LayoutTests/http/wpt/webrtc/rtcNetworkInterface-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Check rtc network interface detection
+

--- a/LayoutTests/http/wpt/webrtc/rtcNetworkInterface.html
+++ b/LayoutTests/http/wpt/webrtc/rtcNetworkInterface.html
@@ -1,0 +1,52 @@
+<!doctype html> <!-- webkit-test-runner [ EnumeratingVisibleNetworkInterfacesEnabled=true ] -->
+<document>
+<head>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+function with_iframe(url) {
+    return new Promise(function(resolve) {
+        var frame = document.createElement('iframe');
+        frame.src = url;
+        frame.onload = function() { resolve(frame); };
+        document.body.appendChild(frame);
+    });
+}
+
+async function testNetworkInterface(test, frame)
+{
+    await frame.contentWindow.navigator.mediaDevices.getUserMedia({ video: true });
+
+    const pc = new frame.contentWindow.RTCPeerConnection();
+    pc.createDataChannel("test");
+    pc.setLocalDescription();
+    await new Promise((resolve, reject) => {
+       pc.onicecandidate = e => {
+           if (!e.candidate)
+               resolve();
+       };
+       setTimeout(() => reject("end of candidate time out"), 5000);
+    });
+
+    return frame.contentWindow.internals ? frame.contentWindow.internals.rtcNetworkInterfaceName : "";
+}
+
+promise_test(async test => {
+    // Actual network load to get the iframe.
+    const frame1 = await with_iframe("resources/cacheable-iframe.py");
+    const rtcNetworkInterfaceName1 = await testNetworkInterface(test, frame1);
+
+    assert_greater_than(rtcNetworkInterfaceName1.length, 0, "test1");
+
+    // Get iframe content from the cache, no network load.
+    const frame2 = await with_iframe("resources/cacheable-iframe.py");
+    const rtcNetworkInterfaceName2 = await testNetworkInterface(test, frame2);
+
+    assert_equals(rtcNetworkInterfaceName2, rtcNetworkInterfaceName1, "test5");
+}, 'Check rtc network interface detection');
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1782,6 +1782,7 @@ webkit.org/b/264805 imported/w3c/web-platform-tests/websockets/basic-auth.any.wo
 
 media/audioSession [ Skip ]
 http/tests/webrtc/audioSessionInFrames.html [ Skip ]
+http/wpt/webrtc/rtcNetworkInterface.html [ Failure ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of Media-related bugs

--- a/Source/WebCore/Modules/mediastream/RTCNetworkManager.h
+++ b/Source/WebCore/Modules/mediastream/RTCNetworkManager.h
@@ -36,6 +36,7 @@ public:
     virtual void close() = 0;
     virtual void setICECandidateFiltering(bool) = 0;
     virtual void unregisterMDNSNames() = 0;
+    virtual const String& interfaceNameForTesting() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
@@ -385,6 +385,7 @@ typedef NS_ENUM(NSInteger, NSURLSessionCompanionProxyPreference) {
 @property (assign, readonly) NSInteger _responseHeaderBytesReceived;
 @property (assign, readonly) int64_t _responseBodyBytesReceived;
 @property (assign, readonly) int64_t _responseBodyBytesDecoded;
+@property (nullable, copy, readonly) NSString* _interfaceName;
 #if HAVE(NETWORK_CONNECTION_PRIVACY_STANCE)
 @property (assign, readonly) nw_connection_privacy_stance_t _privacyStance;
 #endif

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -176,6 +176,7 @@
 #include "PseudoElement.h"
 #include "PushSubscription.h"
 #include "PushSubscriptionData.h"
+#include "RTCNetworkManager.h"
 #include "RTCRtpSFrameTransform.h"
 #include "Range.h"
 #include "ReadableStream.h"
@@ -6109,7 +6110,19 @@ bool Internals::shouldAudioTrackPlay(const AudioTrack& track)
         return false;
     return downcast<AudioTrackPrivateMediaStream>(track.privateTrack()).shouldPlay();
 }
-#endif
+#endif // ENABLE(MEDIA_STREAM)
+
+#if ENABLE(WEB_RTC)
+String Internals::rtcNetworkInterfaceName() const
+{
+    RefPtr document = contextDocument();
+    RefPtr rtcNetworkManager = document ? document->rtcNetworkManager() : nullptr;
+    if (!rtcNetworkManager)
+        return { };
+
+    return rtcNetworkManager->interfaceNameForTesting();
+}
+#endif // ENABLE(WEB_RTC)
 
 bool Internals::isHardwareVP9DecoderExpected()
 {

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -984,6 +984,9 @@ public:
     bool isMediaStreamTrackPowerEfficient(const MediaStreamTrack&) const;
     bool isMockRealtimeMediaSourceCenterEnabled();
     bool shouldAudioTrackPlay(const AudioTrack&);
+#endif // ENABLE(MEDIA_STREAM)
+#if ENABLE(WEB_RTC)
+    String rtcNetworkInterfaceName() const;
 #endif
 
     bool isHardwareVP9DecoderExpected();

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1107,6 +1107,8 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     [Conditional=MEDIA_STREAM] boolean isMockRealtimeMediaSourceCenterEnabled();
     [Conditional=MEDIA_STREAM] boolean shouldAudioTrackPlay(AudioTrack track);
 
+    [Conditional=WEB_RTC] readonly attribute DOMString rtcNetworkInterfaceName;
+
     boolean isHardwareVP9DecoderExpected();
 
     DOMString documentIdentifier(Document document);

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
@@ -339,6 +339,18 @@ void NetworkRTCProvider::stopResolver(LibWebRTCResolverIdentifier identifier)
     WebCore::stopResolveDNS(identifier.toUInt64());
 }
 
+#if PLATFORM(COCOA)
+void NetworkRTCProvider::getInterfaceName(URL&& url, WebPageProxyIdentifier pageIdentifier, bool isFirstParty, bool isRelayDisabled, WebCore::RegistrableDomain&& domain, CompletionHandler<void(String&&)>&& completionHandler)
+{
+    if (!url.protocolIsInHTTPFamily()) {
+        completionHandler({ });
+        return;
+    }
+
+    NetworkRTCTCPSocketCocoa::getInterfaceName(*this, url, attributedBundleIdentifierFromPageIdentifier(pageIdentifier), isFirstParty, isRelayDisabled, domain, WTFMove(completionHandler));
+}
+#endif
+
 void NetworkRTCProvider::callOnRTCNetworkThread(Function<void()>&& callback)
 {
     m_rtcNetworkThread.PostTask(WTFMove(callback));

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
@@ -137,6 +137,7 @@ private:
 
     void createResolver(LibWebRTCResolverIdentifier, String&&);
     void stopResolver(LibWebRTCResolverIdentifier);
+    void getInterfaceName(URL&&, WebPageProxyIdentifier, bool isFirstParty, bool isRelayDisabled, WebCore::RegistrableDomain&&, CompletionHandler<void(String&&)>&&);
 
     void addSocket(WebCore::LibWebRTCSocketIdentifier, std::unique_ptr<Socket>&&);
 

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.messages.in
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.messages.in
@@ -27,15 +27,19 @@ messages -> NetworkRTCProvider {
     CreateClientTCPSocket(WebCore::LibWebRTCSocketIdentifier identifier, WebKit::RTC::Network::SocketAddress localAddress, WebKit::RTC::Network::SocketAddress remoteAddress, String userAgent, int options, WebKit::WebPageProxyIdentifier pageIdentifier, bool isFirstParty, bool isRelayDisabled, WebCore::RegistrableDomain domain)
     WrapNewTCPConnection(WebCore::LibWebRTCSocketIdentifier identifier, WebCore::LibWebRTCSocketIdentifier newConnectionSocketIdentifier)
 
-    void SetPlatformTCPSocketsEnabled(bool enabled)
-    void SetPlatformUDPSocketsEnabled(bool enabled)
+    SetPlatformTCPSocketsEnabled(bool enabled)
+    SetPlatformUDPSocketsEnabled(bool enabled)
 
     CreateResolver(WebKit::LibWebRTCResolverIdentifier identifier, String address)
     StopResolver(WebKit::LibWebRTCResolverIdentifier identifier)
 
-    void SendToSocket(WebCore::LibWebRTCSocketIdentifier identifier, std::span<const uint8_t> data, WebKit::RTC::Network::SocketAddress address, struct WebKit::RTCPacketOptions options)
-    void CloseSocket(WebCore::LibWebRTCSocketIdentifier identifier)
-    void SetSocketOption(WebCore::LibWebRTCSocketIdentifier identifier, int option, int value)
+#if PLATFORM(COCOA)
+    GetInterfaceName(URL url, WebKit::WebPageProxyIdentifier pageIdentifier, bool isFirstParty, bool isRelayDisabled, WebCore::RegistrableDomain domain) -> (String interfaceName) async
+#endif
+
+    SendToSocket(WebCore::LibWebRTCSocketIdentifier identifier, std::span<const uint8_t> data, WebKit::RTC::Network::SocketAddress address, struct WebKit::RTCPacketOptions options)
+    CloseSocket(WebCore::LibWebRTCSocketIdentifier identifier)
+    SetSocketOption(WebCore::LibWebRTCSocketIdentifier identifier, int option, int value)
 }
 
 #endif // USE(LIBWEBRTC)

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.h
@@ -53,6 +53,8 @@ public:
 
     NetworkRTCTCPSocketCocoa(WebCore::LibWebRTCSocketIdentifier, NetworkRTCProvider&, const rtc::SocketAddress&, int options, const String& attributedBundleIdentifier, bool isFirstParty, bool isRelayDisabled, const WebCore::RegistrableDomain&, Ref<IPC::Connection>&&);
 
+    static void getInterfaceName(NetworkRTCProvider&, const URL&, const String& attributedBundleIdentifier, bool isFirstParty, bool isRelayDisabled, const WebCore::RegistrableDomain&, CompletionHandler<void(String&&)>&&);
+
 private:
     // NetworkRTCProvider::Socket.
     WebCore::LibWebRTCSocketIdentifier identifier() const final { return m_identifier; }

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.h
@@ -53,6 +53,7 @@ private:
     void setICECandidateFiltering(bool doFiltering) final { m_useMDNSCandidates = doFiltering; }
     void unregisterMDNSNames() final;
     void close() final;
+    const String& interfaceNameForTesting() const final;
 
     // webrtc::NetworkManagerBase
     void StartUpdating() final;
@@ -78,6 +79,7 @@ private:
 #endif
     bool m_enableEnumeratingAllNetworkInterfaces { false };
     bool m_enableEnumeratingVisibleNetworkInterfaces { false };
+    bool m_hasQueriedInterface { false };
     HashSet<String> m_allowedInterfaces;
 };
 


### PR DESCRIPTION
#### b5877b229ffa2ae13da637a0fd8910e30ffafc29
<pre>
Allow WebRTC network traffic on the interface used to load the document main resource even if it is not the default interface
<a href="https://bugs.webkit.org/show_bug.cgi?id=275986">https://bugs.webkit.org/show_bug.cgi?id=275986</a>
<a href="https://rdar.apple.com/problem/130748643">rdar://problem/130748643</a>

Reviewed by Eric Carlson.

With split VPN, HTTP trafic may go through either default interface or the VPN interface.
But WebRTC UDP traffic will only go through the default interface as we do not enumerate all interfaces even post getUserMedia.

To improve the support of split VPN, we use the following heuristic:
- We continue allow using the default network interface.
- We get the interface that would be used to create a TCP connection to the document&apos;s host.

In case of no VPN, or full VPN, the same interface will be used.
In case of split VPN, two interfaces may be used.
This only happens post getUserMedia and is controlled by EnumeratingVisibleNetworkInterfacesEnabled flag.

* LayoutTests/http/wpt/webrtc/resources/cacheable-iframe.py: Added.
(main):
* LayoutTests/http/wpt/webrtc/rtcNetworkInterface-expected.txt: Added.
* LayoutTests/http/wpt/webrtc/rtcNetworkInterface.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediastream/RTCNetworkManager.h:
* Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::rtcNetworkInterfaceName const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp:
(WebKit::NetworkRTCProvider::getInterfaceName):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.messages.in:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCTCPSocketCocoa.mm:
(WebKit::createNWConnection):
(WebKit::NetworkRTCTCPSocketCocoa::NetworkRTCTCPSocketCocoa):
(WebKit::NetworkRTCTCPSocketCocoa::getInterfaceName):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp:
(WebKit::LibWebRTCNetworkManager::networksChanged):
(WebKit::LibWebRTCNetworkManager::interfaceNameForTesting const):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCNetworkManager.h:

Canonical link: <a href="https://commits.webkit.org/280535@main">https://commits.webkit.org/280535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/001d15f0a71843d42a96c5c8b51212919f6ce348

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36227 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60518 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7342 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43850 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7532 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46088 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5155 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58929 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34029 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49109 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26946 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30809 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6440 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6346 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6711 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62200 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/812 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6813 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53342 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/815 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49164 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53382 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12579 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/691 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32056 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33141 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34226 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32887 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->