### PR TITLE
Not possible to hide media controls by tapping on IOS

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/auto-hide-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/auto-hide-controller.js
@@ -35,7 +35,6 @@ class AutoHideController
         this._pointerIdentifiersPreventingAutoHide = new Set;
         this._pointerIdentifiersPreventingAutoHideForHover = new Set;
 
-        this._mediaControls.element.addEventListener("mousemove", this);
         this._mediaControls.element.addEventListener("pointermove", this);
         this._mediaControls.element.addEventListener("pointerdown", this);
         this._mediaControls.element.addEventListener("pointerup", this);
@@ -91,8 +90,6 @@ class AutoHideController
             return;
 
         switch (event.type) {
-        case "mousemove":
-                this._mediaControls.faded = false;
         case "pointermove":
             // If the pointer is a mouse (supports hover), immediately show the controls.
             if (event.pointerType === "mouse")

--- a/Source/WebCore/Modules/modern-media-controls/controls/macos-fullscreen-media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/macos-fullscreen-media-controls.js
@@ -77,6 +77,7 @@ class MacOSFullscreenMediaControls extends MediaControls
 
         this.bottomControlsBar.element.addEventListener("mousedown", this);
         this.bottomControlsBar.element.addEventListener("click", this);
+        this.element.addEventListener("mousemove", this);
 
         this._backgroundClickDelegateNotifier = new BackgroundClickDelegateNotifier(this);
     }
@@ -181,6 +182,11 @@ class MacOSFullscreenMediaControls extends MediaControls
 
     _handleMousemove(event)
     {
+        if (!this._lastDragPoint) {
+            this.faded = false;
+            return;
+        }
+
         event.preventDefault();
 
         const currentDragPoint = this._pointForEvent(event);


### PR DESCRIPTION
#### c8dab5a83f57e9b3c3da7d831193db6595e83369
<pre>
Not possible to hide media controls by tapping on IOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=275998">https://bugs.webkit.org/show_bug.cgi?id=275998</a>
<a href="https://rdar.apple.com/130624835">rdar://130624835</a>

Reviewed by Andy Estes and Antoine Quint.

<a href="https://commits.webkit.org/280221@main">https://commits.webkit.org/280221@main</a> caused tapping on the negative space on a video in iOS Safari
to not produce the expected behavior of hiding the controls. To fix this, this patch reverts
the changes made to auto-hide-controller.js and moves the behavior to the Mac specific
macos-fullscreen-media-controls.js.

* Source/WebCore/Modules/modern-media-controls/controls/auto-hide-controller.js:
(AutoHideController):
(AutoHideController.prototype.handleEvent):
* Source/WebCore/Modules/modern-media-controls/controls/macos-fullscreen-media-controls.js:

Canonical link: <a href="https://commits.webkit.org/280625@main">https://commits.webkit.org/280625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81a9de0b86f3595ecc06ff575d90e50aa4b2c5d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9550 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60695 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7518 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59203 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7708 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46221 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5289 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34181 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49264 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27082 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30962 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6596 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6523 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52916 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6866 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62376 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/988 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6969 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53480 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/992 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49319 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53529 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/837 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8519 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32232 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33317 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34402 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33063 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->