### PR TITLE
libpas: PGM allow keeping metadata for freed memory objects

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
@@ -77,6 +77,9 @@ struct pas_pgm_storage {
      */
     bool right_align;
 
+    // Mark if the physical memory is freed
+    bool free_status;
+
     pas_large_heap* large_heap;
 };
 
@@ -88,6 +91,9 @@ struct pas_pgm_storage {
  * including guard pages and wasted memory
  */
 #define PAS_PGM_MAX_VIRTUAL_MEMORY (1024 * 1024 * 1024)
+
+/* Total MAX_PGM_HASH_ENTRIES {0 - (MAX_PGM_HASH_ENTRIES - 1)} PGM entries are allowed for which metadata is kept alive */
+#define MAX_PGM_HASH_ENTRIES    10
 
 extern PAS_API pas_ptr_hash_map pas_pgm_hash_map;
 extern PAS_API pas_ptr_hash_map_in_flux_stash pas_pgm_hash_map_in_flux_stash;
@@ -109,6 +115,7 @@ void pas_probabilistic_guard_malloc_deallocate(void* memory);
 
 size_t pas_probabilistic_guard_malloc_get_free_virtual_memory(void);
 size_t pas_probabilistic_guard_malloc_get_free_wasted_memory(void);
+pas_ptr_hash_map_entry** pas_probabilistic_guard_malloc_get_metadata_array(void);
 
 bool pas_probabilistic_guard_malloc_check_exists(uintptr_t mem);
 


### PR DESCRIPTION
#### 7e5820bc252f8faea158012d0a92464001848407
<pre>
libpas: PGM allow keeping metadata for freed memory objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=276003">https://bugs.webkit.org/show_bug.cgi?id=276003</a>
<a href="https://rdar.apple.com/129454965">rdar://129454965</a>

Reviewed by Keith Miller.

Keeping PGM metadata for freed objects in order to differentiate OOB and UAF scenarios.

* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
(pas_probabilistic_guard_malloc_deallocate):
(pas_probabilistic_guard_malloc_remove_metadata):
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h:
* Source/bmalloc/libpas/src/libpas/pas_report_crash.c:
(pas_report_crash_extract_pgm_failure):
* Source/bmalloc/libpas/src/test/PGMTests.cpp:
(testPGMMetaData):

Canonical link: <a href="https://commits.webkit.org/281209@main">https://commits.webkit.org/281209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/212491f7544e096be7c0284584362b876ab1d158

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/58818 "26 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/38146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/11308 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/62450 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/9262 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/45854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/9462 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/47575 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/6594 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/60849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/35760 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/50861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/28445 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/32517 "") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/8152 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/8266 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/51911 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/54447 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/8432 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/64151 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/58060 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/2731 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/8416 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/54898 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/2740 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/50888 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54991 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13089 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/2288 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/79821 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/33976 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/13805 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/35060 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/36145 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/34806 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->