### PR TITLE
[WebXR] Break reference cycle between WebXRSession and WebXRWebGLLayer

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -120,7 +120,7 @@ ExceptionOr<void> WebXRSession::updateRenderState(const XRRenderStateInit& newSt
 
     // 3. If newState's baseLayer was created with an XRSession other than session,
     //    throw an InvalidStateError and abort these steps.
-    if (newState.baseLayer && &newState.baseLayer->session() != this)
+    if (newState.baseLayer && newState.baseLayer->session() != this)
         return Exception { ExceptionCode::InvalidStateError };
 
     // 4. If newState's inlineVerticalFieldOfView is set and session is an immersive session,

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp
@@ -170,11 +170,6 @@ WebXRWebGLLayer::~WebXRWebGLLayer()
     auto canvasElement = canvas();
     if (canvasElement)
         canvasElement->removeObserver(*this);
-    if (m_framebuffer) {
-        auto device = m_session->device();
-        if (device)
-            device->deleteLayer(m_framebuffer->handle());
-    }
 }
 
 bool WebXRWebGLLayer::antialias() const
@@ -220,7 +215,7 @@ ExceptionOr<RefPtr<WebXRViewport>> WebXRWebGLLayer::getViewport(WebXRView& view)
     // 1. Let session be view’s session.
     // 2. Let frame be session’s animation frame.
     // 3. If session is not equal to layer’s session, throw an InvalidStateError and abort these steps.
-    if (&view.frame().session() != m_session.ptr())
+    if (&view.frame().session() != m_session.get())
         return Exception { ExceptionCode::InvalidStateError };
 
     // 4. If frame’s active boolean is false, throw an InvalidStateError and abort these steps.
@@ -272,8 +267,16 @@ HTMLCanvasElement* WebXRWebGLLayer::canvas() const
 void WebXRWebGLLayer::sessionEnded()
 {
 #if PLATFORM(COCOA)
-    if (m_framebuffer)
-        m_framebuffer->releaseAllDisplayAttachments();
+    ASSERT(m_session);
+
+    if (m_framebuffer) {
+        auto device = m_session->device();
+        if (device)
+            device->deleteLayer(m_framebuffer->handle());
+        m_framebuffer = nullptr;
+    }
+
+    m_session = nullptr;
 #endif
 }
 
@@ -311,6 +314,8 @@ void WebXRWebGLLayer::canvasResized(CanvasBase&)
 // https://immersive-web.github.io/webxr/#xrview-obtain-a-scaled-viewport
 void WebXRWebGLLayer::computeViewports()
 {
+    ASSERT(m_session);
+
     auto roundDown = [](IntSize size, double scale) -> IntSize {
         // Round down to integer value and ensure that the value is not zero.
         size.scale(scale);

--- a/Source/WebCore/Modules/webxr/WebXRWebGLLayer.h
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLLayer.h
@@ -76,7 +76,7 @@ public:
 
     static double getNativeFramebufferScaleFactor(const WebXRSession&);
 
-    const WebXRSession& session() { return m_session; }
+    const WebXRSession* session() { return m_session.get(); }
 
     bool isCompositionEnabled() const { return m_isCompositionEnabled; }
 
@@ -98,7 +98,7 @@ private:
     void canvasChanged(CanvasBase&, const FloatRect&) final { };
     void canvasResized(CanvasBase&) final;
     void canvasDestroyed(CanvasBase&) final { };
-    Ref<WebXRSession> m_session;
+    RefPtr<WebXRSession> m_session;
     WebXRRenderingContext m_context;
 
     struct ViewportData {


### PR DESCRIPTION
#### 69417c74f50df92ca17087e97ef3780abcfc378f
<pre>
[WebXR] Break reference cycle between WebXRSession and WebXRWebGLLayer
<a href="https://bugs.webkit.org/show_bug.cgi?id=276008">https://bugs.webkit.org/show_bug.cgi?id=276008</a>
<a href="https://rdar.apple.com/130776295">rdar://130776295</a>

Reviewed by Mike Wyrzykowski.

There is a strong refptr loop between WebXRSession and WebXRWebGLLayer (via
WebXRRenderState), that causes the this 3 objects to never be freed when exiting
a VR immersive session. Since graphics resources related to
WebXROpaqueFramebuffer were being released into it&apos;s destructor, this was
resulting in accumulation of thousands of leaked textures in GPU process,
causing out of OOM.

This patch makes use of the sessionEnded() method to free use graphics resources
associated with WebXRWebGLayer an break the cycle between WebXRSession &amp;
WebXRWebGLLayer, allowing the JS garbage collector to eventually free those
objects.

WebXRWebGLLayer::m_session has been changed from a Ref&lt;&gt; to RefPtr&lt;&gt;. The null
case is used to signal that the layer&apos;s session has ended and is no longer
viable.

* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::updateRenderState):
* Source/WebCore/Modules/webxr/WebXRWebGLLayer.cpp:
(WebCore::WebXRWebGLLayer::~WebXRWebGLLayer):
(WebCore::WebXRWebGLLayer::getViewport):
(WebCore::WebXRWebGLLayer::sessionEnded):
(WebCore::WebXRWebGLLayer::computeViewports):
* Source/WebCore/Modules/webxr/WebXRWebGLLayer.h:
(WebCore::WebXRWebGLLayer::session):

Canonical link: <a href="https://commits.webkit.org/280486@main">https://commits.webkit.org/280486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bf20740c1a60631f33398eb8953643a28595066

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60349 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7177 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58861 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43685 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7367 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45973 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5040 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33895 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/48969 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26830 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30675 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6300 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6180 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52619 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6571 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62032 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/647 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6672 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53228 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/650 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49024 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53252 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12556 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/556 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31891 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/32976 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34061 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32722 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->