### PR TITLE
[Site Isolation] Avoid skipping code on out-of-process frames in more places

### DIFF
--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -264,14 +264,10 @@ const FeatureSchema& colorGamut()
         "color-gamut"_s,
         FixedVector { CSSValueSRGB, CSSValueP3, CSSValueRec2020 },
         [](auto& context) {
-            Ref frame = *context.document->frame();
-
             // FIXME: At some point we should start detecting displays that support more colors.
             MatchingIdentifiers identifiers { CSSValueSRGB };
-            if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame())) {
-                if (screenSupportsExtendedColor(localFrame->protectedView().get()))
-                    identifiers.append(CSSValueP3);
-            }
+            if (screenSupportsExtendedColor(context.document->protectedFrame()->mainFrame().protectedVirtualView().get()))
+                identifiers.append(CSSValueP3);
             return identifiers;
         }
     };

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -413,16 +413,9 @@ std::optional<URL> HTMLAnchorElement::attributionDestinationURLForPCM() const
 
 std::optional<RegistrableDomain> HTMLAnchorElement::mainDocumentRegistrableDomainForPCM() const
 {
-    if (auto frame = document().frame()) {
-
-        auto* localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame());
-        if (!localFrame)
-            return std::nullopt;
-
-        if (auto mainDocument = localFrame->document()) {
-            if (auto mainDocumentRegistrableDomain = RegistrableDomain { mainDocument->url() }; !mainDocumentRegistrableDomain.isEmpty())
-                return mainDocumentRegistrableDomain;
-        }
+    if (auto* page = document().page()) {
+        if (auto mainFrameURL = page->mainFrameURL(); !mainFrameURL.isEmpty())
+            return RegistrableDomain(mainFrameURL);
     }
 
     protectedDocument()->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, "Could not find a main document to use as source site for Private Click Measurement."_s);

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -963,7 +963,7 @@ void InspectorInstrumentation::takeHeapSnapshotImpl(InstrumentingAgents& instrum
         consoleAgent->takeHeapSnapshot(title);
 }
 
-void InspectorInstrumentation::startConsoleTimingImpl(InstrumentingAgents& instrumentingAgents, LocalFrame& frame, JSC::JSGlobalObject* exec, const String& label)
+void InspectorInstrumentation::startConsoleTimingImpl(InstrumentingAgents& instrumentingAgents, Frame& frame, JSC::JSGlobalObject* exec, const String& label)
 {
     if (LIKELY(!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()))
         return;
@@ -992,7 +992,7 @@ void InspectorInstrumentation::logConsoleTimingImpl(InstrumentingAgents& instrum
         consoleAgent->logTiming(exec, label, WTFMove(arguments));
 }
 
-void InspectorInstrumentation::stopConsoleTimingImpl(InstrumentingAgents& instrumentingAgents, LocalFrame& frame, JSC::JSGlobalObject* exec, const String& label)
+void InspectorInstrumentation::stopConsoleTimingImpl(InstrumentingAgents& instrumentingAgents, Frame& frame, JSC::JSGlobalObject* exec, const String& label)
 {
     if (LIKELY(!instrumentingAgents.inspectorEnvironment().developerExtrasEnabled()))
         return;
@@ -1012,7 +1012,7 @@ void InspectorInstrumentation::stopConsoleTimingImpl(InstrumentingAgents& instru
         consoleAgent->stopTiming(exec, label);
 }
 
-void InspectorInstrumentation::consoleTimeStampImpl(InstrumentingAgents& instrumentingAgents, LocalFrame& frame, Ref<ScriptArguments>&& arguments)
+void InspectorInstrumentation::consoleTimeStampImpl(InstrumentingAgents& instrumentingAgents, Frame& frame, Ref<ScriptArguments>&& arguments)
 {
     if (auto* timelineAgent = instrumentingAgents.trackingTimelineAgent()) {
         String message;

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -234,7 +234,7 @@ public:
     static void loaderDetachedFromFrame(LocalFrame&, DocumentLoader&);
     static void frameStartedLoading(LocalFrame&);
     static void frameStoppedLoading(LocalFrame&);
-    static void didCompleteRenderingFrame(LocalFrame&);
+    static void didCompleteRenderingFrame(Frame&);
     static void frameScheduledNavigation(Frame&, Seconds delay);
     static void frameClearedScheduledNavigation(Frame&);
     static void accessibilitySettingsDidChange(Page&);
@@ -257,14 +257,14 @@ public:
     static void consoleCountReset(Page&, JSC::JSGlobalObject*, const String& label);
     static void consoleCountReset(WorkerOrWorkletGlobalScope&, JSC::JSGlobalObject*, const String& label);
 
-    static void takeHeapSnapshot(LocalFrame&, const String& title);
-    static void startConsoleTiming(LocalFrame&, JSC::JSGlobalObject*, const String& label);
+    static void takeHeapSnapshot(Frame&, const String& title);
+    static void startConsoleTiming(Frame&, JSC::JSGlobalObject*, const String& label);
     static void startConsoleTiming(WorkerOrWorkletGlobalScope&, JSC::JSGlobalObject*, const String& label);
-    static void logConsoleTiming(LocalFrame&, JSC::JSGlobalObject*, const String& label, Ref<Inspector::ScriptArguments>&&);
+    static void logConsoleTiming(Frame&, JSC::JSGlobalObject*, const String& label, Ref<Inspector::ScriptArguments>&&);
     static void logConsoleTiming(WorkerOrWorkletGlobalScope&, JSC::JSGlobalObject*, const String& label, Ref<Inspector::ScriptArguments>&&);
-    static void stopConsoleTiming(LocalFrame&, JSC::JSGlobalObject*, const String& label);
+    static void stopConsoleTiming(Frame&, JSC::JSGlobalObject*, const String& label);
     static void stopConsoleTiming(WorkerOrWorkletGlobalScope&, JSC::JSGlobalObject*, const String& label);
-    static void consoleTimeStamp(LocalFrame&, Ref<Inspector::ScriptArguments>&&);
+    static void consoleTimeStamp(Frame&, Ref<Inspector::ScriptArguments>&&);
     static void startProfiling(Page&, JSC::JSGlobalObject*, const String& title);
     static void stopProfiling(Page&, JSC::JSGlobalObject*, const String& title);
     static void consoleStartRecordingCanvas(CanvasRenderingContext&, JSC::JSGlobalObject&, JSC::JSObject* options);
@@ -469,12 +469,12 @@ private:
     static void consoleCountImpl(InstrumentingAgents&, JSC::JSGlobalObject*, const String& label);
     static void consoleCountResetImpl(InstrumentingAgents&, JSC::JSGlobalObject*, const String& label);
     static void takeHeapSnapshotImpl(InstrumentingAgents&, const String& title);
-    static void startConsoleTimingImpl(InstrumentingAgents&, LocalFrame&, JSC::JSGlobalObject*, const String& label);
+    static void startConsoleTimingImpl(InstrumentingAgents&, Frame&, JSC::JSGlobalObject*, const String& label);
     static void startConsoleTimingImpl(InstrumentingAgents&, JSC::JSGlobalObject*, const String& label);
     static void logConsoleTimingImpl(InstrumentingAgents&, JSC::JSGlobalObject*, const String& label, Ref<Inspector::ScriptArguments>&&);
-    static void stopConsoleTimingImpl(InstrumentingAgents&, LocalFrame&, JSC::JSGlobalObject*, const String& label);
+    static void stopConsoleTimingImpl(InstrumentingAgents&, Frame&, JSC::JSGlobalObject*, const String& label);
     static void stopConsoleTimingImpl(InstrumentingAgents&, JSC::JSGlobalObject*, const String& label);
-    static void consoleTimeStampImpl(InstrumentingAgents&, LocalFrame&, Ref<Inspector::ScriptArguments>&&);
+    static void consoleTimeStampImpl(InstrumentingAgents&, Frame&, Ref<Inspector::ScriptArguments>&&);
     static void startProfilingImpl(InstrumentingAgents&, JSC::JSGlobalObject*, const String& title);
     static void stopProfilingImpl(InstrumentingAgents&, JSC::JSGlobalObject*, const String& title);
     static void consoleStartRecordingCanvasImpl(InstrumentingAgents&, CanvasRenderingContext&, JSC::JSGlobalObject&, JSC::JSObject* options);
@@ -1276,7 +1276,7 @@ inline void InspectorInstrumentation::frameStartedLoading(LocalFrame& frame)
         frameStartedLoadingImpl(*agents, frame);
 }
 
-inline void InspectorInstrumentation::didCompleteRenderingFrame(LocalFrame& frame)
+inline void InspectorInstrumentation::didCompleteRenderingFrame(Frame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(frame))
@@ -1620,14 +1620,14 @@ inline void InspectorInstrumentation::consoleCountReset(WorkerOrWorkletGlobalSco
     consoleCountResetImpl(instrumentingAgents(globalScope), state, label);
 }
 
-inline void InspectorInstrumentation::takeHeapSnapshot(LocalFrame& frame, const String& title)
+inline void InspectorInstrumentation::takeHeapSnapshot(Frame& frame, const String& title)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(frame))
         takeHeapSnapshotImpl(*agents, title);
 }
 
-inline void InspectorInstrumentation::startConsoleTiming(LocalFrame& frame, JSC::JSGlobalObject* exec, const String& label)
+inline void InspectorInstrumentation::startConsoleTiming(Frame& frame, JSC::JSGlobalObject* exec, const String& label)
 {
     if (auto* agents = instrumentingAgents(frame))
         startConsoleTimingImpl(*agents, frame, exec, label);
@@ -1638,7 +1638,7 @@ inline void InspectorInstrumentation::startConsoleTiming(WorkerOrWorkletGlobalSc
     startConsoleTimingImpl(instrumentingAgents(globalScope), exec, label);
 }
 
-inline void InspectorInstrumentation::logConsoleTiming(LocalFrame& frame, JSC::JSGlobalObject* exec, const String& label, Ref<Inspector::ScriptArguments>&& arguments)
+inline void InspectorInstrumentation::logConsoleTiming(Frame& frame, JSC::JSGlobalObject* exec, const String& label, Ref<Inspector::ScriptArguments>&& arguments)
 {
     if (auto* agents = instrumentingAgents(frame))
         logConsoleTimingImpl(*agents, exec, label, WTFMove(arguments));
@@ -1649,7 +1649,7 @@ inline void InspectorInstrumentation::logConsoleTiming(WorkerOrWorkletGlobalScop
     logConsoleTimingImpl(instrumentingAgents(globalScope), exec, label, WTFMove(arguments));
 }
 
-inline void InspectorInstrumentation::stopConsoleTiming(LocalFrame& frame, JSC::JSGlobalObject* exec, const String& label)
+inline void InspectorInstrumentation::stopConsoleTiming(Frame& frame, JSC::JSGlobalObject* exec, const String& label)
 {
     if (auto* agents = instrumentingAgents(frame))
         stopConsoleTimingImpl(*agents, frame, exec, label);
@@ -1660,7 +1660,7 @@ inline void InspectorInstrumentation::stopConsoleTiming(WorkerOrWorkletGlobalSco
     stopConsoleTimingImpl(instrumentingAgents(globalScope), exec, label);
 }
 
-inline void InspectorInstrumentation::consoleTimeStamp(LocalFrame& frame, Ref<Inspector::ScriptArguments>&& arguments)
+inline void InspectorInstrumentation::consoleTimeStamp(Frame& frame, Ref<Inspector::ScriptArguments>&& arguments)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (auto* agents = instrumentingAgents(frame))

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -840,11 +840,8 @@ void InspectorOverlay::drawPaintRects(GraphicsContext& context, const Deque<Time
 
 void InspectorOverlay::drawBounds(GraphicsContext& context, const InspectorOverlay::Highlight::Bounds& bounds)
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
-    if (!localMainFrame)
-        return;
-
-    auto* pageView = localMainFrame->view();
+    Ref mainFrame = m_page.mainFrame();
+    RefPtr pageView = mainFrame->virtualView();
     FloatSize viewportSize = pageView->sizeForVisibleContent();
     FloatSize contentInset(0, pageView->topContentInset(ScrollView::TopContentInsetType::WebCoreOrPlatformContentInset));
 
@@ -1242,12 +1239,8 @@ Path InspectorOverlay::drawElementTitle(GraphicsContext& context, Node& node, co
         }
     }
 
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
-    if (!localMainFrame)
-        return { };
-
-    auto* pageView = localMainFrame->view();
-
+    Ref mainFrame = m_page.mainFrame();
+    RefPtr pageView = mainFrame->virtualView();
     FloatSize viewportSize = pageView->sizeForVisibleContent();
     FloatSize contentInset(0, pageView->topContentInset(ScrollView::TopContentInsetType::WebCoreOrPlatformContentInset));
     if (m_showRulers || m_showRulersForNodeHighlight)

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp
@@ -475,22 +475,22 @@ void InspectorTimelineAgent::didEvaluateScript(LocalFrame&)
     didCompleteCurrentRecord(TimelineRecordType::EvaluateScript);
 }
 
-void InspectorTimelineAgent::didTimeStamp(LocalFrame& frame, const String& message)
+void InspectorTimelineAgent::didTimeStamp(Frame& frame, const String& message)
 {
     appendRecord(TimelineRecordFactory::createTimeStampData(message), TimelineRecordType::TimeStamp, true, &frame);
 }
 
-void InspectorTimelineAgent::time(LocalFrame& frame, const String& message)
+void InspectorTimelineAgent::time(Frame& frame, const String& message)
 {
     appendRecord(TimelineRecordFactory::createTimeStampData(message), TimelineRecordType::Time, true, &frame);
 }
 
-void InspectorTimelineAgent::timeEnd(LocalFrame& frame, const String& message)
+void InspectorTimelineAgent::timeEnd(Frame& frame, const String& message)
 {
     appendRecord(TimelineRecordFactory::createTimeStampData(message), TimelineRecordType::TimeEnd, true, &frame);
 }
 
-void InspectorTimelineAgent::didPerformanceMark(const String& label, std::optional<MonotonicTime> timeInMonotonicTime, LocalFrame* frame)
+void InspectorTimelineAgent::didPerformanceMark(const String& label, std::optional<MonotonicTime> timeInMonotonicTime, Frame* frame)
 {
     std::optional<double> timestamp;
     if (timeInMonotonicTime) {
@@ -797,7 +797,7 @@ void InspectorTimelineAgent::addRecordToTimeline(Ref<JSON::Object>&& record, Tim
     }
 }
 
-void InspectorTimelineAgent::setFrameIdentifier(JSON::Object* record, LocalFrame* frame)
+void InspectorTimelineAgent::setFrameIdentifier(JSON::Object* record, Frame* frame)
 {
     if (!frame)
         return;
@@ -835,7 +835,7 @@ void InspectorTimelineAgent::didCompleteCurrentRecord(TimelineRecordType type)
     }
 }
 
-void InspectorTimelineAgent::appendRecord(Ref<JSON::Object>&& data, TimelineRecordType type, bool captureCallStack, LocalFrame* frame, std::optional<double> startTime)
+void InspectorTimelineAgent::appendRecord(Ref<JSON::Object>&& data, TimelineRecordType type, bool captureCallStack, Frame* frame, std::optional<double> startTime)
 {
     Ref<JSON::Object> record = TimelineRecordFactory::createGenericRecord(startTime.value_or(timestamp()), captureCallStack ? m_maxCallStackDepth : 0);
     record->setObject("data"_s, WTFMove(data));

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.h
@@ -46,6 +46,7 @@ namespace WebCore {
 
 class Event;
 class FloatQuad;
+class Frame;
 class LocalFrame;
 class RenderObject;
 class RunLoopObserver;
@@ -126,16 +127,16 @@ public:
     void willRecalculateStyle(LocalFrame*);
     void didRecalculateStyle();
     void didScheduleStyleRecalculation(LocalFrame*);
-    void didTimeStamp(LocalFrame&, const String&);
-    void didPerformanceMark(const String&, std::optional<MonotonicTime>, LocalFrame*);
+    void didTimeStamp(Frame&, const String&);
+    void didPerformanceMark(const String&, std::optional<MonotonicTime>, Frame*);
     void didRequestAnimationFrame(int callbackId, LocalFrame*);
     void didCancelAnimationFrame(int callbackId, LocalFrame*);
     void willFireAnimationFrame(int callbackId, LocalFrame*);
     void didFireAnimationFrame();
     void willFireObserverCallback(const String& callbackType, LocalFrame*);
     void didFireObserverCallback();
-    void time(LocalFrame&, const String&);
-    void timeEnd(LocalFrame&, const String&);
+    void time(Frame&, const String&);
+    void timeEnd(Frame&, const String&);
     void mainFrameStartedLoading();
     void mainFrameNavigated();
     void didCompleteRenderingFrame();
@@ -184,13 +185,13 @@ private:
     std::optional<double> timestampFromMonotonicTime(MonotonicTime);
 
     void sendEvent(Ref<JSON::Object>&&);
-    void appendRecord(Ref<JSON::Object>&& data, TimelineRecordType, bool captureCallStack, LocalFrame*, std::optional<double> startTime = std::nullopt);
+    void appendRecord(Ref<JSON::Object>&& data, TimelineRecordType, bool captureCallStack, Frame*, std::optional<double> startTime = std::nullopt);
     void pushCurrentRecord(Ref<JSON::Object>&&, TimelineRecordType, bool captureCallStack, LocalFrame*, std::optional<double> startTime = std::nullopt);
     void pushCurrentRecord(const TimelineRecordEntry& record) { m_recordStack.append(record); }
 
     TimelineRecordEntry createRecordEntry(Ref<JSON::Object>&& data, TimelineRecordType, bool captureCallStack, LocalFrame*, std::optional<double> startTime = std::nullopt);
 
-    void setFrameIdentifier(JSON::Object* record, LocalFrame*);
+    void setFrameIdentifier(JSON::Object* record, Frame*);
 
     void didCompleteRecordEntry(const TimelineRecordEntry&);
     void didCompleteCurrentRecord(TimelineRecordType);

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1081,8 +1081,7 @@ bool DocumentLoader::disallowWebArchive() const
 
 #if ENABLE(WEB_ARCHIVE)
     // On purpose of maintaining existing tests.
-    auto* localFrame = dynamicDowncast<LocalFrame>(frame()->mainFrame());
-    bool alwaysAllowLocalWebArchive = localFrame && localFrame->settings().alwaysAllowLocalWebarchive();
+    bool alwaysAllowLocalWebArchive = frame()->mainFrame().settings().alwaysAllowLocalWebarchive();
 #else
     bool alwaysAllowLocalWebArchive { false };
 #endif

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2768,8 +2768,7 @@ void FrameLoader::checkLoadCompleteForThisFrame(LoadWillContinueInAnotherProcess
         if (RefPtr page = m_frame->page()) {
             if (isBackForwardLoadType(loadType())) {
                 // Reset the back forward list to the last committed history item at the top level.
-                if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame()))
-                    item = localMainFrame->history().currentItem();
+                item = page->mainFrame().history().currentItem();
             }
         }
 
@@ -3479,8 +3478,8 @@ ResourceLoaderIdentifier FrameLoader::loadResourceSynchronously(const ResourceRe
         initialRequest.setHTTPReferrer(referrer);
     addHTTPOriginIfNeeded(initialRequest, outgoingOrigin());
 
-    if (RefPtr localFrame = dynamicDowncast<LocalFrame>(m_frame->mainFrame()))
-        initialRequest.setFirstPartyForCookies(localFrame->loader().documentLoader()->request().url());
+    if (auto* page = m_frame->page())
+        initialRequest.setFirstPartyForCookies(page->mainFrameURL());
     
     updateRequestAndAddExtraFields(initialRequest, IsMainResource::No);
 
@@ -3909,10 +3908,8 @@ void FrameLoader::continueLoadAfterNavigationPolicy(const ResourceRequest& reque
         // we only do this when punting a navigation for the target frame or top-level frame.  
         if ((isTargetItem || frame->isMainFrame()) && isBackForwardLoadType(policyChecker().loadType())) {
             if (RefPtr page = frame->page()) {
-                if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame->mainFrame())) {
-                    if (RefPtr resetItem = localFrame->history().currentItem())
-                        page->backForward().setCurrentItem(*resetItem);
-                }
+                if (RefPtr resetItem = frame->mainFrame().history().currentItem())
+                    page->backForward().setCurrentItem(*resetItem);
             }
         }
         return;

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -308,10 +308,7 @@ public:
         
         // go(i!=0) from a frame navigates into the history of the frame only,
         // in both IE and NS (but not in Mozilla). We can't easily do that.
-        RefPtr localMainFrame = dynamicDowncast<LocalFrame>(page->mainFrame());
-        if (!localMainFrame)
-            return;
-        page->goToItem(*localMainFrame, m_historyItem, FrameLoadType::IndexedBackForward, ShouldTreatAsContinuingLoad::No);
+        page->goToItem(page->mainFrame(), m_historyItem, FrameLoadType::IndexedBackForward, ShouldTreatAsContinuingLoad::No);
     }
 
 private:

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -352,12 +352,10 @@ void Chrome::setStatusbarText(LocalFrame& frame, const String& status)
 
 void Chrome::mouseDidMoveOverElement(const HitTestResult& result, OptionSet<PlatformEventModifier> modifiers)
 {
-    RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame());
-    if (!localMainFrame)
-        return;
-
-    if (result.innerNode() && result.innerNode()->document().isDNSPrefetchEnabled())
-        localMainFrame->checkedLoader()->client().prefetchDNS(result.absoluteLinkURL().host().toString());
+    if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame())) {
+        if (result.innerNode() && result.innerNode()->document().isDNSPrefetchEnabled())
+            localMainFrame->checkedLoader()->client().prefetchDNS(result.absoluteLinkURL().host().toString());
+    }
 
     String toolTip;
     TextDirection toolTipDirection;

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1304,14 +1304,10 @@ void LocalFrame::didAccessWindowProxyPropertyViaOpener(WindowProxyProperty prope
     if (origin.isNull() || origin.isOpaque())
         return;
 
-    if (!opener())
+    if (!opener() || !opener()->page())
         return;
 
-    auto openerMainFrame = dynamicDowncast<LocalFrame>(opener()->mainFrame());
-    if (!openerMainFrame)
-        return;
-
-    auto openerMainFrameOrigin = SecurityOriginData::fromFrame(openerMainFrame);
+    auto openerMainFrameOrigin = opener()->page()->mainFrameOrigin().data();
     if (openerMainFrameOrigin.isNull() || openerMainFrameOrigin.isOpaque())
         return;
 

--- a/Source/WebCore/page/PageConsoleClient.cpp
+++ b/Source/WebCore/page/PageConsoleClient.cpp
@@ -241,32 +241,27 @@ void PageConsoleClient::profileEnd(JSC::JSGlobalObject* lexicalGlobalObject, con
 
 void PageConsoleClient::takeHeapSnapshot(JSC::JSGlobalObject*, const String& title)
 {
-    if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame()))
-        InspectorInstrumentation::takeHeapSnapshot(*localMainFrame, title);
+    InspectorInstrumentation::takeHeapSnapshot(m_page->mainFrame(), title);
 }
 
 void PageConsoleClient::time(JSC::JSGlobalObject* lexicalGlobalObject, const String& label)
 {
-    if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame()))
-        InspectorInstrumentation::startConsoleTiming(*localMainFrame, lexicalGlobalObject, label);
+    InspectorInstrumentation::startConsoleTiming(m_page->mainFrame(), lexicalGlobalObject, label);
 }
 
 void PageConsoleClient::timeLog(JSC::JSGlobalObject* lexicalGlobalObject, const String& label, Ref<ScriptArguments>&& arguments)
 {
-    if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame()))
-        InspectorInstrumentation::logConsoleTiming(*localMainFrame, lexicalGlobalObject, label, WTFMove(arguments));
+    InspectorInstrumentation::logConsoleTiming(m_page->mainFrame(), lexicalGlobalObject, label, WTFMove(arguments));
 }
 
 void PageConsoleClient::timeEnd(JSC::JSGlobalObject* lexicalGlobalObject, const String& label)
 {
-    if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame()))
-        InspectorInstrumentation::stopConsoleTiming(*localMainFrame, lexicalGlobalObject, label);
+    InspectorInstrumentation::stopConsoleTiming(m_page->mainFrame(), lexicalGlobalObject, label);
 }
 
 void PageConsoleClient::timeStamp(JSC::JSGlobalObject*, Ref<ScriptArguments>&& arguments)
 {
-    if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame()))
-        InspectorInstrumentation::consoleTimeStamp(*localMainFrame, WTFMove(arguments));
+    InspectorInstrumentation::consoleTimeStamp(m_page->mainFrame(), WTFMove(arguments));
 }
 
 static JSC::JSObject* objectArgumentAt(ScriptArguments& arguments, unsigned index)

--- a/Source/WebCore/page/ResourceUsageOverlay.cpp
+++ b/Source/WebCore/page/ResourceUsageOverlay.cpp
@@ -58,16 +58,10 @@ ResourceUsageOverlay::~ResourceUsageOverlay()
 
 void ResourceUsageOverlay::initialize()
 {
-    auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());
-    if (!localMainFrame)
+    auto* frameView = m_page.mainFrame().virtualView();
+    if (!frameView)
         return;
-
-    if (!localMainFrame->view())
-        return;
-
-    auto& frameView = *localMainFrame->view();
-
-    IntRect initialRect(frameView.width() / 2 - normalWidth / 2, frameView.height() - normalHeight - 20, normalWidth, normalHeight);
+    IntRect initialRect(frameView->width() / 2 - normalWidth / 2, frameView->height() - normalHeight - 20, normalWidth, normalHeight);
 
 #if PLATFORM(IOS_FAMILY)
     // FIXME: The overlay should be stuck to the viewport instead of moving along with the page.

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3210,10 +3210,8 @@ void WebPage::pageDidScroll()
 
     m_pageScrolledHysteresis.impulse();
 
-    if (RefPtr localMainFrame = dynamicDowncast<LocalFrame>(m_page->mainFrame())) {
-        auto scrollPosition = localMainFrame->view()->scrollPosition();
-        send(Messages::WebPageProxy::PageDidScroll(scrollPosition));
-    }
+    if (RefPtr view = m_page->protectedMainFrame()->virtualView())
+        send(Messages::WebPageProxy::PageDidScroll(view->scrollPosition()));
 }
 
 void WebPage::pageStoppedScrolling()


### PR DESCRIPTION
#### a368459ce9a9e6b637a366dd90ba655f57031e23
<pre>
[Site Isolation] Avoid skipping code on out-of-process frames in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=276020">https://bugs.webkit.org/show_bug.cgi?id=276020</a>
<a href="https://rdar.apple.com/130784398">rdar://130784398</a>

Reviewed by Sihui Liu and Alex Christensen.

* Source/WebCore/css/query/MediaQueryFeatures.cpp:
(WebCore::MQ::Features::colorGamut):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::mainDocumentRegistrableDomainForPCM const):
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::startConsoleTimingImpl):
(WebCore::InspectorInstrumentation::stopConsoleTimingImpl):
(WebCore::InspectorInstrumentation::consoleTimeStampImpl):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::didCompleteRenderingFrame):
(WebCore::InspectorInstrumentation::takeHeapSnapshot):
(WebCore::InspectorInstrumentation::startConsoleTiming):
(WebCore::InspectorInstrumentation::logConsoleTiming):
(WebCore::InspectorInstrumentation::stopConsoleTiming):
(WebCore::InspectorInstrumentation::consoleTimeStamp):
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::InspectorOverlay::drawBounds):
(WebCore::InspectorOverlay::drawElementTitle):
* Source/WebCore/inspector/agents/InspectorTimelineAgent.cpp:
(WebCore::InspectorTimelineAgent::didTimeStamp):
(WebCore::InspectorTimelineAgent::time):
(WebCore::InspectorTimelineAgent::timeEnd):
(WebCore::InspectorTimelineAgent::didPerformanceMark):
(WebCore::InspectorTimelineAgent::setFrameIdentifier):
(WebCore::InspectorTimelineAgent::appendRecord):
* Source/WebCore/inspector/agents/InspectorTimelineAgent.h:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::disallowWebArchive const):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::checkLoadCompleteForThisFrame):
(WebCore::FrameLoader::loadResourceSynchronously):
(WebCore::FrameLoader::continueLoadAfterNavigationPolicy):
* Source/WebCore/loader/NavigationScheduler.cpp:
* Source/WebCore/page/Chrome.cpp:
(WebCore::Chrome::mouseDidMoveOverElement):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::didAccessWindowProxyPropertyViaOpener):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::windowScreenDidChange):
(WebCore::Page::didCompleteRenderingFrame):
(WebCore::Page::setSessionID):
(WebCore::dispatchPrintEvent):
(WebCore::Page::dispatchBeforePrintEvent):
(WebCore::Page::dispatchAfterPrintEvent):
* Source/WebCore/page/PageConsoleClient.cpp:
(WebCore::PageConsoleClient::takeHeapSnapshot):
(WebCore::PageConsoleClient::time):
(WebCore::PageConsoleClient::timeLog):
(WebCore::PageConsoleClient::timeEnd):
(WebCore::PageConsoleClient::timeStamp):
* Source/WebCore/page/ResourceUsageOverlay.cpp:
(WebCore::ResourceUsageOverlay::initialize):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::pageDidScroll):

Canonical link: <a href="https://commits.webkit.org/280558@main">https://commits.webkit.org/280558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce9dd3ed22c50627d006572905aa735ffd358367

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60570 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7393 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59078 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43901 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7583 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46123 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5193 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58980 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34068 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49140 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26981 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30848 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6471 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6398 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52809 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62251 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/863 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6854 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53380 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/866 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49195 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53422 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/727 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8484 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32107 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33192 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34277 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32938 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->