### PR TITLE
UIIntelligenceSupport context retrieval should avoid extracting text in password fields

### DIFF
--- a/LayoutTests/fast/text-extraction/avoid-extracting-password-fields-expected.txt
+++ b/LayoutTests/fast/text-extraction/avoid-extracting-password-fields-expected.txt
@@ -1,0 +1,10 @@
+
+(ROOT
+  (TEXT "\n1. Password field\n")
+  (TEXT "" {editable (secure)})
+  (TEXT "\n2. Text field (previously a password field)\n")
+  (TEXT "" {editable (secure)})
+  (TEXT "\n3. Password field (previously a text field)\n")
+  (TEXT "" {editable (secure)})
+  (TEXT "\n4. Plain text field\n")
+  (TEXT "fourth\n" {editable}))

--- a/LayoutTests/fast/text-extraction/avoid-extracting-password-fields.html
+++ b/LayoutTests/fast/text-extraction/avoid-extracting-password-fields.html
@@ -1,0 +1,32 @@
+<!-- webkit-test-runner [ textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body {
+    white-space: pre-wrap;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<div>1. Password field<br><input type="password" value="first" /></div>
+<div>2. Text field (previously a password field)<br><input id="originally-password-field" type="password" value="second" /></div>
+<div>3. Password field (previously a text field)<br><input id="originally-text-field" value="third" /></div>
+<div>4. Plain text field<br><input value="fourth" /></div>
+<script>
+addEventListener("load", async () => {
+    document.getElementById("originally-password-field").type = "text";
+    document.getElementById("originally-text-field").type = "password";
+
+    if (!window.testRunner)
+        return;
+
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+    document.body.textContent = await UIHelper.requestTextExtraction();
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### bd405371c620acba4b52f4cae521c98c02592156
<pre>
UIIntelligenceSupport context retrieval should avoid extracting text in password fields
<a href="https://bugs.webkit.org/show_bug.cgi?id=276022">https://bugs.webkit.org/show_bug.cgi?id=276022</a>
<a href="https://rdar.apple.com/129415710">rdar://129415710</a>

Reviewed by Richard Robinson.

Make a couple of minor adjustments to context retrieval:

1.  Consider text fields as secure for the purposes of context retrieval, if they were previously
    password fields.

2.  Skip extracting text inside password fields altogether (note that we still extract some metadata
    about the password field itself, such as the placeholder text).

* LayoutTests/fast/text-extraction/avoid-extracting-password-fields-expected.txt: Added.
* LayoutTests/fast/text-extraction/avoid-extracting-password-fields.html: Added.

Add a layout test to exercise the change.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::shouldTreatAsPasswordField):
(WebCore::TextExtraction::extractItemData):

See comments above.

Canonical link: <a href="https://commits.webkit.org/280487@main">https://commits.webkit.org/280487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d80c2989ba3c4cc1374ef2b8eb2fbf06fc6e2b8a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56771 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60386 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7214 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58898 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43722 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7404 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/45987 "Passed tests") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/5060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33923 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/49002 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26844 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30703 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6333 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6217 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6604 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62069 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/684 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6704 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53246 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/687 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49057 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/53266 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12557 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/585 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/44/builds/31928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33013 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/34098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32759 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->