### PR TITLE
[css-writing-modes] Refactor TextFlow to be a struct instead of an enum

### DIFF
--- a/Source/WebCore/css/CSSCounterStyle.cpp
+++ b/Source/WebCore/css/CSSCounterStyle.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2022-2024 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -238,40 +238,30 @@ static String counterForSystemCJK(int number, const std::array<UChar, 17>& table
     return std::span<const UChar> { characters, length };
 }
 
-String CSSCounterStyle::counterForSystemDisclosureClosed(TextFlow textFlow)
+String CSSCounterStyle::counterForSystemDisclosureClosed(TextFlow flow)
 {
-    switch (textFlow) {
-    case TextFlow::InlineEastBlockSouth:
-    case TextFlow::InlineEastBlockNorth:
-        return span(blackRightPointingSmallTriangle);
-    case TextFlow::InlineWestBlockSouth:
-    case TextFlow::InlineWestBlockNorth:
-        return span(blackLeftPointingSmallTriangle);
-    case TextFlow::InlineSouthBlockEast:
-    case TextFlow::InlineNorthBlockEast:
-        return span(blackDownPointingSmallTriangle);
-    case TextFlow::InlineSouthBlockWest:
-    case TextFlow::InlineNorthBlockWest:
-        return span(blackUpPointingSmallTriangle);
+    switch (flow.blockDirection) {
+    case BlockFlowDirection::TopToBottom:
+    case BlockFlowDirection::BottomToTop:
+        return span(flow.textDirection == TextDirection::LTR ? blackRightPointingSmallTriangle : blackLeftPointingSmallTriangle);
+    case BlockFlowDirection::LeftToRight:
+    case BlockFlowDirection::RightToLeft:
+        return span(flow.textDirection == TextDirection::LTR ? blackDownPointingSmallTriangle : blackUpPointingSmallTriangle);
     }
     ASSERT_NOT_REACHED();
     return { };
 }
 
-String CSSCounterStyle::counterForSystemDisclosureOpen(TextFlow textFlow)
+String CSSCounterStyle::counterForSystemDisclosureOpen(TextFlow flow)
 {
-    switch (textFlow) {
-    case TextFlow::InlineEastBlockSouth:
-    case TextFlow::InlineWestBlockSouth:
+    switch (flow.blockDirection) {
+    case BlockFlowDirection::TopToBottom:
         return span(blackDownPointingSmallTriangle);
-    case TextFlow::InlineEastBlockNorth:
-    case TextFlow::InlineWestBlockNorth:
+    case BlockFlowDirection::BottomToTop:
         return span(blackUpPointingSmallTriangle);
-    case TextFlow::InlineSouthBlockEast:
-    case TextFlow::InlineSouthBlockWest:
+    case BlockFlowDirection::LeftToRight:
         return span(blackRightPointingSmallTriangle);
-    case TextFlow::InlineNorthBlockEast:
-    case TextFlow::InlineNorthBlockWest:
+    case BlockFlowDirection::RightToLeft:
         return span(blackLeftPointingSmallTriangle);
     }
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/css/CSSCounterStyle.h
+++ b/Source/WebCore/css/CSSCounterStyle.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2022-2024 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -45,7 +45,7 @@ public:
             && m_predefinedCounterStyle == other.m_predefinedCounterStyle;
     }
 
-    String text(int, TextFlow = TextFlow::InlineEastBlockSouth);
+    String text(int, TextFlow);
     const CSSCounterStyleDescriptors::Name& name() const { return m_descriptors.m_name; }
     CSSCounterStyleDescriptors::System system() const { return m_descriptors.m_system; }
     const CSSCounterStyleDescriptors::NegativeSymbols& negative() const { return m_descriptors.m_negativeSymbols; }

--- a/Source/WebCore/platform/text/WritingMode.h
+++ b/Source/WebCore/platform/text/WritingMode.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012, Google Inc. All rights reserved.
- * Copyright (C) 2015, Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -75,66 +75,56 @@ constexpr inline BlockFlowDirection writingModeToBlockFlowDirection(WritingMode 
     return BlockFlowDirection::TopToBottom;
 }
 
-constexpr unsigned makeTextFlowInitalizer(BlockFlowDirection blockFlow, TextDirection direction)
-{
-    return static_cast<unsigned>(blockFlow) << 1 | static_cast<unsigned>(direction);
-}
-
 // Define the text flow in terms of the writing mode and the text direction. The first
 // part is the block flow direction and the second part is the inline base direction.
-enum TextFlow {
-    InlineEastBlockSouth = makeTextFlowInitalizer(BlockFlowDirection::TopToBottom, TextDirection::LTR),
-    InlineWestBlockSouth = makeTextFlowInitalizer(BlockFlowDirection::TopToBottom, TextDirection::RTL),
-    InlineEastBlockNorth = makeTextFlowInitalizer(BlockFlowDirection::BottomToTop, TextDirection::LTR),
-    InlineWestBlockNorth = makeTextFlowInitalizer(BlockFlowDirection::BottomToTop, TextDirection::RTL),
-    InlineSouthBlockEast = makeTextFlowInitalizer(BlockFlowDirection::LeftToRight, TextDirection::LTR),
-    InlineSouthBlockWest = makeTextFlowInitalizer(BlockFlowDirection::LeftToRight, TextDirection::RTL),
-    InlineNorthBlockEast = makeTextFlowInitalizer(BlockFlowDirection::RightToLeft, TextDirection::LTR),
-    InlineNorthBlockWest = makeTextFlowInitalizer(BlockFlowDirection::RightToLeft, TextDirection::RTL)
+struct TextFlow {
+    BlockFlowDirection blockDirection;
+    TextDirection textDirection;
+
+    constexpr inline bool isReversed()
+    {
+        return textDirection == TextDirection::RTL;
+    }
+
+    constexpr inline bool isFlipped()
+    {
+        return blockDirection == BlockFlowDirection::BottomToTop
+            || blockDirection == BlockFlowDirection::RightToLeft;
+    }
+
+    constexpr inline bool isVertical()
+    {
+        return blockDirection == BlockFlowDirection::LeftToRight
+            || blockDirection == BlockFlowDirection::RightToLeft;
+    }
+
+    constexpr inline bool isFlippedLines()
+    {
+        return isFlipped() != isVertical();
+    }
 };
 
 constexpr inline TextFlow makeTextFlow(WritingMode writingMode, TextDirection direction)
 {
-    TextDirection inlineBaseDirection = direction;
+    auto textDirection = direction;
+
+    // FIXME: Remove this erronous logic and remove `makeTextFlow` helper (webkit.org/b/276028).
     if (writingMode == WritingMode::SidewaysLr)
-        inlineBaseDirection = direction == TextDirection::RTL ? TextDirection::LTR : TextDirection::RTL;
-    return static_cast<TextFlow>(makeTextFlowInitalizer(writingModeToBlockFlowDirection(writingMode), inlineBaseDirection));
-}
+        textDirection = direction == TextDirection::RTL ? TextDirection::LTR : TextDirection::RTL;
 
-constexpr unsigned TextFlowReversedMask = 1;
-constexpr unsigned TextFlowFlippedMask = 1 << 1;
-constexpr unsigned TextFlowVerticalMask = 1 << 2;
-
-constexpr inline bool isReversedTextFlow(TextFlow textflow)
-{
-    return textflow & TextFlowReversedMask;
-}
-
-constexpr inline bool isFlippedTextFlow(TextFlow textflow)
-{
-    return textflow & TextFlowFlippedMask;
-}
-
-constexpr inline bool isVerticalTextFlow(TextFlow textflow)
-{
-    return textflow & TextFlowVerticalMask;
-}
-
-constexpr inline bool isFlippedLinesTextFlow(TextFlow textflow)
-{
-    return isFlippedTextFlow(textflow) != isVerticalTextFlow(textflow);
+    return { writingModeToBlockFlowDirection(writingMode), textDirection };
 }
 
 // Lines have vertical orientation; modes vertical-lr or vertical-rl.
 constexpr inline bool isVerticalWritingMode(WritingMode writingMode)
 {
-    return isVerticalTextFlow(makeTextFlow(writingMode, TextDirection::LTR));
+    return makeTextFlow(writingMode, TextDirection::LTR).isVertical();
 }
 
 // Block progression increases in the opposite direction to normal; modes vertical-rl or horizontal-bt.
 constexpr inline bool isFlippedWritingMode(WritingMode writingMode)
 {
-    return isFlippedTextFlow(makeTextFlow(writingMode, TextDirection::LTR));
+    return makeTextFlow(writingMode, TextDirection::LTR).isFlipped();
 }
 
 // Lines have horizontal orientation; modes horizontal-tb or horizontal-bt.
@@ -146,7 +136,7 @@ constexpr inline bool isHorizontalWritingMode(WritingMode writingMode)
 // Bottom of the line occurs earlier in the block; modes vertical-lr or horizontal-bt.
 constexpr inline bool isFlippedLinesWritingMode(WritingMode writingMode)
 {
-    return isFlippedLinesTextFlow(makeTextFlow(writingMode, TextDirection::LTR));
+    return makeTextFlow(writingMode, TextDirection::LTR).isFlippedLines();
 }
 
 enum class LogicalBoxSide : uint8_t {
@@ -192,12 +182,12 @@ enum class BoxAxis : uint8_t {
 
 constexpr std::array<BoxSide, 4> allBoxSides = { BoxSide::Top, BoxSide::Right, BoxSide::Bottom, BoxSide::Left };
 
-constexpr BoxSide mapLogicalSideToPhysicalSide(TextFlow textflow, LogicalBoxSide logicalSide)
+constexpr BoxSide mapLogicalSideToPhysicalSide(TextFlow flow, LogicalBoxSide logicalSide)
 {
     bool isBlock = logicalSide == LogicalBoxSide::BlockStart || logicalSide == LogicalBoxSide::BlockEnd;
     bool isStart = logicalSide == LogicalBoxSide::BlockStart || logicalSide == LogicalBoxSide::InlineStart;
-    bool isNormalStart = isStart != (isBlock ? isFlippedTextFlow(textflow) : isReversedTextFlow(textflow));
-    bool isVertical = isBlock != isVerticalTextFlow(textflow);
+    bool isNormalStart = isStart != (isBlock ? flow.isFlipped() : flow.isReversed());
+    bool isVertical = isBlock != flow.isVertical();
     if (isVertical)
         return isNormalStart ? BoxSide::Top : BoxSide::Bottom;
     return isNormalStart ? BoxSide::Left : BoxSide::Right;
@@ -206,30 +196,30 @@ constexpr BoxSide mapLogicalSideToPhysicalSide(TextFlow textflow, LogicalBoxSide
 constexpr BoxSide mapLogicalSideToPhysicalSide(WritingMode writingMode, LogicalBoxSide logicalSide)
 {
     // Set the direction such that side is mirrored if isFlippedWritingMode() is true
-    TextDirection direction = isFlippedWritingMode(writingMode) ? TextDirection::RTL : TextDirection::LTR;
+    auto direction = isFlippedWritingMode(writingMode) ? TextDirection::RTL : TextDirection::LTR;
     return mapLogicalSideToPhysicalSide(makeTextFlow(writingMode, direction), logicalSide);
 }
 
-constexpr LogicalBoxSide mapPhysicalSideToLogicalSide(TextFlow textflow, BoxSide side)
+constexpr LogicalBoxSide mapPhysicalSideToLogicalSide(TextFlow flow, BoxSide side)
 {
     bool isNormalStart = side == BoxSide::Top || side == BoxSide::Left;
     bool isVertical = side == BoxSide::Top || side == BoxSide::Bottom;
-    bool isBlock = isVertical != isVerticalTextFlow(textflow);
+    bool isBlock = isVertical != flow.isVertical();
     if (isBlock) {
-        bool isBlockStart = isNormalStart != isFlippedTextFlow(textflow);
+        bool isBlockStart = isNormalStart != flow.isFlipped();
         return isBlockStart ? LogicalBoxSide::BlockStart : LogicalBoxSide::BlockEnd;
     }
-    bool isInlineStart = isNormalStart != isReversedTextFlow(textflow);
+    bool isInlineStart = isNormalStart != flow.isReversed();
     return isInlineStart ? LogicalBoxSide::InlineStart : LogicalBoxSide::InlineEnd;
 }
 
-constexpr BoxCorner mapLogicalCornerToPhysicalCorner(TextFlow textflow, LogicalBoxCorner logicalBoxCorner)
+constexpr BoxCorner mapLogicalCornerToPhysicalCorner(TextFlow flow, LogicalBoxCorner logicalBoxCorner)
 {
     bool isBlockStart = logicalBoxCorner == LogicalBoxCorner::StartStart || logicalBoxCorner == LogicalBoxCorner::StartEnd;
     bool isInlineStart = logicalBoxCorner == LogicalBoxCorner::StartStart || logicalBoxCorner == LogicalBoxCorner::EndStart;
-    bool isNormalBlockStart = isBlockStart != isFlippedTextFlow(textflow);
-    bool isNormalInlineStart = isInlineStart != isReversedTextFlow(textflow);
-    bool usingVerticalTextFlow = isVerticalTextFlow(textflow);
+    bool isNormalBlockStart = isBlockStart != flow.isFlipped();
+    bool isNormalInlineStart = isInlineStart != flow.isReversed();
+    bool usingVerticalTextFlow = flow.isVertical();
     bool isTop = usingVerticalTextFlow ? isNormalInlineStart : isNormalBlockStart;
     bool isLeft = usingVerticalTextFlow ? isNormalBlockStart : isNormalInlineStart;
     if (isTop)
@@ -237,32 +227,57 @@ constexpr BoxCorner mapLogicalCornerToPhysicalCorner(TextFlow textflow, LogicalB
     return isLeft ? BoxCorner::BottomLeft : BoxCorner::BottomRight;
 }
 
-constexpr LogicalBoxCorner mapPhysicalCornerToLogicalCorner(TextFlow textflow, BoxCorner boxCorner)
+constexpr LogicalBoxCorner mapPhysicalCornerToLogicalCorner(TextFlow flow, BoxCorner boxCorner)
 {
     bool isTop = boxCorner == BoxCorner::TopLeft || boxCorner == BoxCorner::TopRight;
     bool isLeft = boxCorner == BoxCorner::TopLeft || boxCorner == BoxCorner::BottomLeft;
-    bool usingVerticalTextFlow = isVerticalTextFlow(textflow);
+    bool usingVerticalTextFlow = flow.isVertical();
     bool isNormalBlockStart = usingVerticalTextFlow ? isLeft : isTop;
     bool isNormalInlineStart = usingVerticalTextFlow ? isTop : isLeft;
-    bool isBlockStart = isNormalBlockStart != isFlippedTextFlow(textflow);
-    bool isInlineStart = isNormalInlineStart != isReversedTextFlow(textflow);
+    bool isBlockStart = isNormalBlockStart != flow.isFlipped();
+    bool isInlineStart = isNormalInlineStart != flow.isReversed();
     if (isBlockStart)
         return isInlineStart ? LogicalBoxCorner::StartStart : LogicalBoxCorner::StartEnd;
     return isInlineStart ? LogicalBoxCorner::EndStart : LogicalBoxCorner::EndEnd;
 }
 
-constexpr BoxAxis mapLogicalAxisToPhysicalAxis(TextFlow textflow, LogicalBoxAxis logicalAxis)
+constexpr BoxAxis mapLogicalAxisToPhysicalAxis(TextFlow flow, LogicalBoxAxis logicalAxis)
 {
     bool isBlock = logicalAxis == LogicalBoxAxis::Block;
-    bool isVertical = isBlock != isVerticalTextFlow(textflow);
+    bool isVertical = isBlock != flow.isVertical();
     return isVertical ? BoxAxis::Vertical : BoxAxis::Horizontal;
 }
 
-constexpr LogicalBoxAxis mapPhysicalAxisToLogicalAxis(TextFlow textflow, BoxAxis axis)
+constexpr LogicalBoxAxis mapPhysicalAxisToLogicalAxis(TextFlow flow, BoxAxis axis)
 {
     bool isVertical = axis == BoxAxis::Vertical;
-    bool isBlock = isVertical != isVerticalTextFlow(textflow);
+    bool isBlock = isVertical != flow.isVertical();
     return isBlock ? LogicalBoxAxis::Block : LogicalBoxAxis::Inline;
+}
+
+inline TextStream& operator<<(TextStream& stream, BlockFlowDirection blockFlow)
+{
+    switch (blockFlow) {
+    case BlockFlowDirection::TopToBottom:
+        stream << "top-to-bottom";
+        break;
+    case BlockFlowDirection::BottomToTop:
+        stream << "bottom-to-top";
+        break;
+    case BlockFlowDirection::LeftToRight:
+        stream << "left-to-right";
+        break;
+    case BlockFlowDirection::RightToLeft:
+        stream << "right-to-left";
+        break;
+    }
+    return stream;
+}
+
+inline TextStream& operator<<(TextStream& stream, TextFlow flow)
+{
+    stream << "(" << flow.blockDirection << ", " << flow.textDirection << ")";
+    return stream;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderCounter.cpp
+++ b/Source/WebCore/rendering/RenderCounter.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2004 Allan Sandfeld Jensen (kde@carewolf.com)
- * Copyright (C) 2006-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -466,13 +466,13 @@ String RenderCounter::originalText() const
     RefPtr child = m_counterNode.get();
     int value = child->actsAsReset() ? child->value() : child->countInParent();
 
-    auto counterText = [this](int value) {
-        if (this->m_counter.listStyleType().type == ListStyleType::Type::None)
+    auto counterText = [&](int value) {
+        if (m_counter.listStyleType().type == ListStyleType::Type::None)
             return emptyString();
 
-        if (this->m_counter.listStyleType().type == ListStyleType::Type::CounterStyle) {
-            ASSERT(this->counterStyle());
-            return this->counterStyle()->text(value, makeTextFlow(this->style().writingMode(), this->style().direction()));
+        if (m_counter.listStyleType().type == ListStyleType::Type::CounterStyle) {
+            ASSERT(counterStyle());
+            return counterStyle()->text(value, makeTextFlow(style().writingMode(), style().direction()));
         }
 
         ASSERT_NOT_REACHED();

--- a/Tools/TestWebKitAPI/Tests/WebCore/WritingModeTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/WritingModeTests.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2022 Igalia S.L.
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -36,27 +37,34 @@ using namespace WebCore;
 
 namespace TestWebKitAPI {
 
-constexpr std::array<TextFlow, 8> allTextFlows = {
-    InlineEastBlockSouth,
-    InlineWestBlockSouth,
-    InlineEastBlockNorth,
-    InlineWestBlockNorth,
-    InlineSouthBlockEast,
-    InlineSouthBlockWest,
-    InlineNorthBlockEast,
-    InlineNorthBlockWest,
+constexpr std::array<TextFlow, 8> flows = {
+    TextFlow { BlockFlowDirection::TopToBottom, TextDirection::LTR },
+    TextFlow { BlockFlowDirection::TopToBottom, TextDirection::RTL },
+    TextFlow { BlockFlowDirection::BottomToTop, TextDirection::LTR },
+    TextFlow { BlockFlowDirection::BottomToTop, TextDirection::RTL },
+    TextFlow { BlockFlowDirection::LeftToRight, TextDirection::LTR },
+    TextFlow { BlockFlowDirection::LeftToRight, TextDirection::RTL },
+    TextFlow { BlockFlowDirection::RightToLeft, TextDirection::LTR },
+    TextFlow { BlockFlowDirection::RightToLeft, TextDirection::RTL }
 };
+
+inline std::string textFlowString(TextFlow flow)
+{
+    TextStream stream;
+    stream << flow;
+    return stream.release().utf8().toStdString();
+}
 
 TEST(WritingMode, LogicalBoxSide)
 {
     auto mapBackAndForth = [](TextFlow textFlow, LogicalBoxSide logicalSide) {
         return mapPhysicalSideToLogicalSide(textFlow, mapLogicalSideToPhysicalSide(textFlow, logicalSide));
     };
-    for (TextFlow textFlow : allTextFlows) {
-        EXPECT_EQ(mapBackAndForth(textFlow, LogicalBoxSide::BlockStart), LogicalBoxSide::BlockStart) << "with textFlow=" << textFlow;
-        EXPECT_EQ(mapBackAndForth(textFlow, LogicalBoxSide::BlockEnd), LogicalBoxSide::BlockEnd) << "with textFlow=" << textFlow;
-        EXPECT_EQ(mapBackAndForth(textFlow, LogicalBoxSide::InlineStart), LogicalBoxSide::InlineStart) << "with textFlow=" << textFlow;
-        EXPECT_EQ(mapBackAndForth(textFlow, LogicalBoxSide::InlineEnd), LogicalBoxSide::InlineEnd) << "with textFlow=" << textFlow;
+    for (auto flow : flows) {
+        EXPECT_EQ(mapBackAndForth(flow, LogicalBoxSide::BlockStart), LogicalBoxSide::BlockStart) << "with flow=" << textFlowString(flow);
+        EXPECT_EQ(mapBackAndForth(flow, LogicalBoxSide::BlockEnd), LogicalBoxSide::BlockEnd) << "with flow=" << textFlowString(flow);
+        EXPECT_EQ(mapBackAndForth(flow, LogicalBoxSide::InlineStart), LogicalBoxSide::InlineStart) << "with flow=" << textFlowString(flow);
+        EXPECT_EQ(mapBackAndForth(flow, LogicalBoxSide::InlineEnd), LogicalBoxSide::InlineEnd) << "with flow=" << textFlowString(flow);
     }
 }
 
@@ -65,11 +73,11 @@ TEST(WritingMode, BoxSide)
     auto mapBackAndForth = [](TextFlow textFlow, BoxSide side) {
         return mapLogicalSideToPhysicalSide(textFlow, mapPhysicalSideToLogicalSide(textFlow, side));
     };
-    for (TextFlow textFlow : allTextFlows) {
-        EXPECT_EQ(mapBackAndForth(textFlow, BoxSide::Top), BoxSide::Top) << "with textFlow=" << textFlow;
-        EXPECT_EQ(mapBackAndForth(textFlow, BoxSide::Right), BoxSide::Right) << "with textFlow=" << textFlow;
-        EXPECT_EQ(mapBackAndForth(textFlow, BoxSide::Bottom), BoxSide::Bottom) << "with textFlow=" << textFlow;
-        EXPECT_EQ(mapBackAndForth(textFlow, BoxSide::Left), BoxSide::Left) << "with textFlow=" << textFlow;
+    for (auto flow : flows) {
+        EXPECT_EQ(mapBackAndForth(flow, BoxSide::Top), BoxSide::Top) << "with flow=" << textFlowString(flow);
+        EXPECT_EQ(mapBackAndForth(flow, BoxSide::Right), BoxSide::Right) << "with flow=" << textFlowString(flow);
+        EXPECT_EQ(mapBackAndForth(flow, BoxSide::Bottom), BoxSide::Bottom) << "with flow=" << textFlowString(flow);
+        EXPECT_EQ(mapBackAndForth(flow, BoxSide::Left), BoxSide::Left) << "with flow=" << textFlowString(flow);
     }
 }
 
@@ -78,11 +86,11 @@ TEST(WritingMode, LogicalBoxCorner)
     auto mapBackAndForth = [](TextFlow textFlow, LogicalBoxCorner logicalCorner) {
         return mapPhysicalCornerToLogicalCorner(textFlow, mapLogicalCornerToPhysicalCorner(textFlow, logicalCorner));
     };
-    for (TextFlow textFlow : allTextFlows) {
-        EXPECT_EQ(mapBackAndForth(textFlow, LogicalBoxCorner::StartStart), LogicalBoxCorner::StartStart) << "with textFlow=" << textFlow;
-        EXPECT_EQ(mapBackAndForth(textFlow, LogicalBoxCorner::StartEnd), LogicalBoxCorner::StartEnd) << "with textFlow=" << textFlow;
-        EXPECT_EQ(mapBackAndForth(textFlow, LogicalBoxCorner::EndStart), LogicalBoxCorner::EndStart) << "with textFlow=" << textFlow;
-        EXPECT_EQ(mapBackAndForth(textFlow, LogicalBoxCorner::EndEnd), LogicalBoxCorner::EndEnd) << "with textFlow=" << textFlow;
+    for (auto flow : flows) {
+        EXPECT_EQ(mapBackAndForth(flow, LogicalBoxCorner::StartStart), LogicalBoxCorner::StartStart) << "with flow=" << textFlowString(flow);
+        EXPECT_EQ(mapBackAndForth(flow, LogicalBoxCorner::StartEnd), LogicalBoxCorner::StartEnd) << "with flow=" << textFlowString(flow);
+        EXPECT_EQ(mapBackAndForth(flow, LogicalBoxCorner::EndStart), LogicalBoxCorner::EndStart) << "with flow=" << textFlowString(flow);
+        EXPECT_EQ(mapBackAndForth(flow, LogicalBoxCorner::EndEnd), LogicalBoxCorner::EndEnd) << "with flow=" << textFlowString(flow);
     }
 }
 
@@ -91,11 +99,11 @@ TEST(WritingMode, BoxCorner)
     auto mapBackAndForth = [](TextFlow textFlow, BoxCorner corner) {
         return mapLogicalCornerToPhysicalCorner(textFlow, mapPhysicalCornerToLogicalCorner(textFlow, corner));
     };
-    for (TextFlow textFlow : allTextFlows) {
-        EXPECT_EQ(mapBackAndForth(textFlow, BoxCorner::TopLeft), BoxCorner::TopLeft) << "with textFlow=" << textFlow;
-        EXPECT_EQ(mapBackAndForth(textFlow, BoxCorner::TopRight), BoxCorner::TopRight) << "with textFlow=" << textFlow;
-        EXPECT_EQ(mapBackAndForth(textFlow, BoxCorner::BottomRight), BoxCorner::BottomRight) << "with textFlow=" << textFlow;
-        EXPECT_EQ(mapBackAndForth(textFlow, BoxCorner::BottomLeft), BoxCorner::BottomLeft) << "with textFlow=" << textFlow;
+    for (auto flow : flows) {
+        EXPECT_EQ(mapBackAndForth(flow, BoxCorner::TopLeft), BoxCorner::TopLeft) << "with flow=" << textFlowString(flow);
+        EXPECT_EQ(mapBackAndForth(flow, BoxCorner::TopRight), BoxCorner::TopRight) << "with flow=" << textFlowString(flow);
+        EXPECT_EQ(mapBackAndForth(flow, BoxCorner::BottomRight), BoxCorner::BottomRight) << "with flow=" << textFlowString(flow);
+        EXPECT_EQ(mapBackAndForth(flow, BoxCorner::BottomLeft), BoxCorner::BottomLeft) << "with flow=" << textFlowString(flow);
     }
 }
 
@@ -104,9 +112,9 @@ TEST(WritingMode, LogicalBoxAxis)
     auto mapBackAndForth = [](TextFlow textFlow, LogicalBoxAxis logicalAxis) {
         return mapPhysicalAxisToLogicalAxis(textFlow, mapLogicalAxisToPhysicalAxis(textFlow, logicalAxis));
     };
-    for (TextFlow textFlow : allTextFlows) {
-        EXPECT_EQ(mapBackAndForth(textFlow, LogicalBoxAxis::Block), LogicalBoxAxis::Block) << "with textFlow=" << textFlow;
-        EXPECT_EQ(mapBackAndForth(textFlow, LogicalBoxAxis::Inline), LogicalBoxAxis::Inline) << "with textFlow=" << textFlow;
+    for (auto flow : flows) {
+        EXPECT_EQ(mapBackAndForth(flow, LogicalBoxAxis::Block), LogicalBoxAxis::Block) << "with flow=" << textFlowString(flow);
+        EXPECT_EQ(mapBackAndForth(flow, LogicalBoxAxis::Inline), LogicalBoxAxis::Inline) << "with flow=" << textFlowString(flow);
     }
 }
 
@@ -115,9 +123,9 @@ TEST(WritingMode, BoxAxis)
     auto mapBackAndForth = [](TextFlow textFlow, BoxAxis axis) {
         return mapLogicalAxisToPhysicalAxis(textFlow, mapPhysicalAxisToLogicalAxis(textFlow, axis));
     };
-    for (TextFlow textFlow : allTextFlows) {
-        EXPECT_EQ(mapBackAndForth(textFlow, BoxAxis::Horizontal), BoxAxis::Horizontal) << "with textFlow=" << textFlow;
-        EXPECT_EQ(mapBackAndForth(textFlow, BoxAxis::Vertical), BoxAxis::Vertical) << "with textFlow=" << textFlow;
+    for (auto flow : flows) {
+        EXPECT_EQ(mapBackAndForth(flow, BoxAxis::Horizontal), BoxAxis::Horizontal) << "with flow=" << textFlowString(flow);
+        EXPECT_EQ(mapBackAndForth(flow, BoxAxis::Vertical), BoxAxis::Vertical) << "with flow=" << textFlowString(flow);
     }
 }
 


### PR DESCRIPTION
#### a760ea6009c1bed9b6bba2e890f6fa1a1fcf3d60
<pre>
[css-writing-modes] Refactor TextFlow to be a struct instead of an enum
<a href="https://bugs.webkit.org/show_bug.cgi?id=275966">https://bugs.webkit.org/show_bug.cgi?id=275966</a>
<a href="https://rdar.apple.com/130787071">rdar://130787071</a>

Reviewed by Alan Baradlay.

Names like InlineEastBlockSouth / InlineWestBlockSouth / etc. are quite confusing.
Refactor TextFlow to be a struct instead.

* Source/WebCore/css/CSSCounterStyle.cpp:
(WebCore::CSSCounterStyle::counterForSystemDisclosureClosed):
(WebCore::CSSCounterStyle::counterForSystemDisclosureOpen):
* Source/WebCore/css/CSSCounterStyle.h:
* Source/WebCore/platform/text/WritingMode.h:
(WebCore::TextFlow::isReversed):
(WebCore::TextFlow::isFlipped):
(WebCore::TextFlow::isVertical):
(WebCore::TextFlow::isFlippedLines):
(WebCore::makeTextFlow):
(WebCore::isVerticalWritingMode):
(WebCore::isFlippedWritingMode):
(WebCore::isFlippedLinesWritingMode):
(WebCore::mapLogicalSideToPhysicalSide):
(WebCore::mapPhysicalSideToLogicalSide):
(WebCore::mapLogicalCornerToPhysicalCorner):
(WebCore::mapPhysicalCornerToLogicalCorner):
(WebCore::mapLogicalAxisToPhysicalAxis):
(WebCore::mapPhysicalAxisToLogicalAxis):
(WebCore::operator&lt;&lt;):
(WebCore::makeTextFlowInitalizer): Deleted.
(): Deleted.
(WebCore::isReversedTextFlow): Deleted.
(WebCore::isFlippedTextFlow): Deleted.
(WebCore::isVerticalTextFlow): Deleted.
(WebCore::isFlippedLinesTextFlow): Deleted.
* Source/WebCore/rendering/RenderCounter.cpp:
(WebCore::RenderCounter::originalText const):
* Tools/TestWebKitAPI/Tests/WebCore/WritingModeTests.cpp:

Canonical link: <a href="https://commits.webkit.org/280494@main">https://commits.webkit.org/280494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2301b49771a6eda64f5cff09cfeff4a59a7fbb07

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56801 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9275 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60417 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7244 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58929 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43752 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7434 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46005 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5071 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58831 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33943 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49020 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26862 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30723 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6351 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6248 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52653 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62099 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/714 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6727 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53266 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/717 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49075 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53288 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12559 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/605 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31958 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33043 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34128 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32789 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->