### PR TITLE
[JSC] Add fpTempRegister to x64 macro assembler

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -2167,6 +2167,12 @@ public:
         store64(getCachedDataTempRegisterIDAndInvalidate(), dest);
     }
 
+    void transferVector(Address src, Address dest)
+    {
+        loadVector(src, fpTempRegister);
+        storeVector(fpTempRegister, dest);
+    }
+
     void transferPtr(Address src, Address dest)
     {
         transfer64(src, dest);
@@ -2182,6 +2188,12 @@ public:
     {
         load64(src, getCachedDataTempRegisterIDAndInvalidate());
         store64(getCachedDataTempRegisterIDAndInvalidate(), dest);
+    }
+
+    void transferVector(BaseIndex src, BaseIndex dest)
+    {
+        loadVector(src, fpTempRegister);
+        storeVector(fpTempRegister, dest);
     }
 
     void transferPtr(BaseIndex src, BaseIndex dest)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
@@ -1259,6 +1259,12 @@ public:
         store64(temp.data(), dest);
     }
 
+    void transferVector(Address src, Address dest)
+    {
+        loadVector(src, fpTempRegister);
+        storeVector(fpTempRegister, dest);
+    }
+
     void transferPtr(Address src, Address dest)
     {
         transfer64(src, dest);
@@ -1276,6 +1282,12 @@ public:
         auto temp = temps<Data>();
         load64(src, temp.data());
         store64(temp.data(), dest);
+    }
+
+    void transferVector(BaseIndex src, BaseIndex dest)
+    {
+        loadVector(src, fpTempRegister);
+        storeVector(fpTempRegister, dest);
     }
 
     void transferPtr(BaseIndex src, BaseIndex dest)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h
@@ -41,6 +41,7 @@ public:
 
     // Use this directly only if you're not generating code with it.
     static constexpr X86Registers::RegisterID s_scratchRegister = X86Registers::r11;
+    static constexpr X86Registers::XMMRegisterID fpTempRegister = X86Registers::xmm15;
 
     // Use this when generating code so that we get enforcement of the disallowing of scratch register
     // usage.
@@ -1811,7 +1812,12 @@ public:
             m_assembler.vdivsd_rrr(op2, op1, dest);
         else {
             // B := A / B is invalid.
-            ASSERT(op1 == dest || op2 != dest);
+            if (op1 != dest && op2 == dest) {
+                moveDouble(op2, fpTempRegister);
+                moveDouble(op1, dest);
+                divDouble(fpTempRegister, dest);
+                return;
+            }
             moveDouble(op1, dest);
             divDouble(op2, dest);
         }
@@ -1849,7 +1855,12 @@ public:
             m_assembler.vdivss_rrr(op2, op1, dest);
         else {
             // B := A / B is invalid.
-            ASSERT(op1 == dest || op2 != dest);
+            if (op1 != dest && op2 == dest) {
+                moveDouble(op2, fpTempRegister);
+                moveDouble(op1, dest);
+                divFloat(fpTempRegister, dest);
+                return;
+            }
             moveDouble(op1, dest);
             divFloat(op2, dest);
         }
@@ -1867,7 +1878,12 @@ public:
             m_assembler.vsubsd_rrr(op2, op1, dest);
         else {
             // B := A - B is invalid.
-            ASSERT(op1 == dest || op2 != dest);
+            if (op1 != dest && op2 == dest) {
+                moveDouble(op2, fpTempRegister);
+                moveDouble(op1, dest);
+                m_assembler.subsd_rr(fpTempRegister, dest);
+                return;
+            }
             moveDouble(op1, dest);
             m_assembler.subsd_rr(op2, dest);
         }
@@ -1911,7 +1927,12 @@ public:
             m_assembler.vsubss_rrr(op2, op1, dest);
         else {
             // B := A - B is invalid.
-            ASSERT(op1 == dest || op2 != dest);
+            if (op1 != dest && op2 == dest) {
+                moveDouble(op2, fpTempRegister);
+                moveDouble(op1, dest);
+                m_assembler.subss_rr(fpTempRegister, dest);
+                return;
+            }
             moveDouble(op1, dest);
             m_assembler.subss_rr(op2, dest);
         }

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -1276,6 +1276,12 @@ public:
         store64(scratchRegister(), dest);
     }
 
+    void transferVector(Address src, Address dest)
+    {
+        loadVector(src, fpTempRegister);
+        storeVector(fpTempRegister, dest);
+    }
+
     void transferPtr(Address src, Address dest)
     {
         transfer64(src, dest);
@@ -1291,6 +1297,12 @@ public:
     {
         load64(src, scratchRegister());
         store64(scratchRegister(), dest);
+    }
+
+    void transferVector(BaseIndex src, BaseIndex dest)
+    {
+        loadVector(src, fpTempRegister);
+        storeVector(fpTempRegister, dest);
     }
 
     void transferPtr(BaseIndex src, BaseIndex dest)
@@ -1320,12 +1332,9 @@ public:
         if (reg1 == reg2)
             return;
 
-        // FIXME: This is kinda a hack since we don't use xmm7 as a temp.
-        ASSERT(reg1 != FPRegisterID::xmm7);
-        ASSERT(reg2 != FPRegisterID::xmm7);
-        moveDouble(reg1, FPRegisterID::xmm7);
+        moveDouble(reg1, fpTempRegister);
         moveDouble(reg2, reg1);
-        moveDouble(FPRegisterID::xmm7, reg2);
+        moveDouble(fpTempRegister, reg2);
     }
 
     void move32ToFloat(RegisterID src, FPRegisterID dest)

--- a/Source/JavaScriptCore/jit/FPRInfo.h
+++ b/Source/JavaScriptCore/jit/FPRInfo.h
@@ -40,26 +40,34 @@ static constexpr FPRReg InvalidFPRReg { FPRReg::InvalidFPRReg };
 class FPRInfo {
 public:
     typedef FPRReg RegisterType;
-    static constexpr unsigned numberOfRegisters = 6;
+    static constexpr unsigned numberOfRegisters = 15;
     static constexpr unsigned numberOfArgumentRegisters = is64Bit() ? 8 : 0;
 
     // Temporary registers.
+    // xmm15 is use by the MacroAssembler as fpTempRegister.
     static constexpr FPRReg fpRegT0 = X86Registers::xmm0;
     static constexpr FPRReg fpRegT1 = X86Registers::xmm1;
     static constexpr FPRReg fpRegT2 = X86Registers::xmm2;
     static constexpr FPRReg fpRegT3 = X86Registers::xmm3;
     static constexpr FPRReg fpRegT4 = X86Registers::xmm4;
     static constexpr FPRReg fpRegT5 = X86Registers::xmm5;
+    static constexpr FPRReg fpRegT6 = X86Registers::xmm6;
+    static constexpr FPRReg fpRegT7 = X86Registers::xmm7;
+    static constexpr FPRReg fpRegT8 = X86Registers::xmm8;
+    static constexpr FPRReg fpRegT9 = X86Registers::xmm9;
+    static constexpr FPRReg fpRegT10 = X86Registers::xmm10;
+    static constexpr FPRReg fpRegT11 = X86Registers::xmm11;
+    static constexpr FPRReg fpRegT12 = X86Registers::xmm12;
+    static constexpr FPRReg fpRegT13 = X86Registers::xmm13;
+    static constexpr FPRReg fpRegT14 = X86Registers::xmm14;
     static constexpr FPRReg argumentFPR0 = X86Registers::xmm0; // fpRegT0
     static constexpr FPRReg argumentFPR1 = X86Registers::xmm1; // fpRegT1
     static constexpr FPRReg argumentFPR2 = X86Registers::xmm2; // fpRegT2
     static constexpr FPRReg argumentFPR3 = X86Registers::xmm3; // fpRegT3
     static constexpr FPRReg argumentFPR4 = X86Registers::xmm4; // fpRegT4
     static constexpr FPRReg argumentFPR5 = X86Registers::xmm5; // fpRegT5
-    static constexpr FPRReg argumentFPR6 = X86Registers::xmm6;
-    static constexpr FPRReg argumentFPR7 = X86Registers::xmm7;
-    // On X86 the return will actually be on the x87 stack,
-    // so we'll copy to xmm0 for sanity!
+    static constexpr FPRReg argumentFPR6 = X86Registers::xmm6; // fpRegT6
+    static constexpr FPRReg argumentFPR7 = X86Registers::xmm7; // fpRegT7
     static constexpr FPRReg returnValueFPR = X86Registers::xmm0; // fpRegT0
 
     static constexpr FPRReg nonPreservedNonArgumentFPR0 = X86Registers::xmm8;
@@ -72,6 +80,16 @@ public:
     static_assert(X86Registers::xmm3 == 3);
     static_assert(X86Registers::xmm4 == 4);
     static_assert(X86Registers::xmm5 == 5);
+    static_assert(X86Registers::xmm6 == 6);
+    static_assert(X86Registers::xmm7 == 7);
+    static_assert(X86Registers::xmm8 == 8);
+    static_assert(X86Registers::xmm9 == 9);
+    static_assert(X86Registers::xmm10 == 10);
+    static_assert(X86Registers::xmm11 == 11);
+    static_assert(X86Registers::xmm12 == 12);
+    static_assert(X86Registers::xmm13 == 13);
+    static_assert(X86Registers::xmm14 == 14);
+    static_assert(X86Registers::xmm15 == 15);
     static FPRReg toRegister(unsigned index)
     {
         return (FPRReg)index;

--- a/Source/JavaScriptCore/jit/RegisterSet.cpp
+++ b/Source/JavaScriptCore/jit/RegisterSet.cpp
@@ -112,7 +112,9 @@ RegisterSet RegisterSetBuilder::macroClobberedGPRs()
 RegisterSet RegisterSetBuilder::macroClobberedFPRs()
 {
 #if CPU(X86_64)
-    return { };
+    RegisterSetBuilder builder;
+    builder.add(MacroAssembler::fpTempRegister, IgnoreVectors);
+    return builder.buildAndValidate();
 #elif CPU(ARM64)
     RegisterSetBuilder builder;
     builder.add(MacroAssembler::fpTempRegister, IgnoreVectors);

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -3000,10 +3000,9 @@ void BBQJIT::emitCatchImpl(ControlData& dataCatch, const TypeDefinition& excepti
             case TypeKind::Subfinal:
             case TypeKind::Array:
             case TypeKind::Struct:
-            case TypeKind::Func: {
+            case TypeKind::Func:
                 m_jit.transfer64(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), slot.asAddress());
                 break;
-            }
             case TypeKind::F32:
                 m_jit.transfer32(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), slot.asAddress());
                 break;
@@ -3011,8 +3010,7 @@ void BBQJIT::emitCatchImpl(ControlData& dataCatch, const TypeDefinition& excepti
                 m_jit.transfer64(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), slot.asAddress());
                 break;
             case TypeKind::V128:
-                m_jit.loadVector(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), wasmScratchFPR);
-                m_jit.storeVector(wasmScratchFPR, slot.asAddress());
+                m_jit.transferVector(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), slot.asAddress());
                 break;
             case TypeKind::Void:
                 RELEASE_ASSERT_NOT_REACHED();
@@ -4445,11 +4443,8 @@ void BBQJIT::emitMoveMemory(TypeKind type, Location src, Location dst)
         m_jit.transfer32(src.asAddress(), dst.asAddress());
         break;
     case TypeKind::I64:
-        m_jit.transfer64(src.asAddress(), dst.asAddress());
-        break;
     case TypeKind::F64:
-        m_jit.loadDouble(src.asAddress(), wasmScratchFPR);
-        m_jit.storeDouble(wasmScratchFPR, dst.asAddress());
+        m_jit.transfer64(src.asAddress(), dst.asAddress());
         break;
     case TypeKind::Externref:
     case TypeKind::Ref:
@@ -4464,13 +4459,9 @@ void BBQJIT::emitMoveMemory(TypeKind type, Location src, Location dst)
     case TypeKind::Nullexternref:
         m_jit.transfer64(src.asAddress(), dst.asAddress());
         break;
-    case TypeKind::V128: {
-        Address srcAddress = src.asAddress();
-        Address dstAddress = dst.asAddress();
-        m_jit.loadVector(srcAddress, wasmScratchFPR);
-        m_jit.storeVector(wasmScratchFPR, dstAddress);
+    case TypeKind::V128:
+        m_jit.transferVector(src.asAddress(), dst.asAddress());
         break;
-    }
     default:
         RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Unimplemented type kind move.");
     }


### PR DESCRIPTION
#### 2fdb35959e51641413e88e0eb9d47fb134f46b01
<pre>
[JSC] Add fpTempRegister to x64 macro assembler
<a href="https://bugs.webkit.org/show_bug.cgi?id=275596">https://bugs.webkit.org/show_bug.cgi?id=275596</a>
<a href="https://rdar.apple.com/130468600">rdar://130468600</a>

Reviewed by Yijia Huang.

And use it in some weird places.
Also, by using this, we add transferVector and use it in WasmBBQJIT.

* Source/JavaScriptCore/assembler/MacroAssemblerX86Common.h:
(JSC::MacroAssemblerX86Common::divDouble):
(JSC::MacroAssemblerX86Common::divFloat):
(JSC::MacroAssemblerX86Common::subDouble):
(JSC::MacroAssemblerX86Common::subFloat):
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
(JSC::MacroAssemblerX86_64::swapDouble):
* Source/JavaScriptCore/jit/FPRInfo.h:
* Source/JavaScriptCore/jit/RegisterSet.cpp:
(JSC::RegisterSetBuilder::macroClobberedFPRs):

Canonical link: <a href="https://commits.webkit.org/280495@main">https://commits.webkit.org/280495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae994b0977bf09aa6402af87f5cbdf313a689e51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56797 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60413 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7240 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7430 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46003 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5068 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58827 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33938 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49017 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26860 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30718 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6348 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6244 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/49889 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52650 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62095 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/56038 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/710 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6723 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53261 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/713 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53283 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/601 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/77799 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8451 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31954 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12895 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33039 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34124 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32785 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->