### PR TITLE
Get rid of makeTextFlow constructor

### DIFF
--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -699,7 +699,7 @@ static double lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis logicalA
     if (!style)
         return 0;
 
-    switch (mapLogicalAxisToPhysicalAxis(makeTextFlow(style->writingMode(), style->direction()), logicalAxis)) {
+    switch (mapLogicalAxisToPhysicalAxis({ style->blockFlowDirection(), style->direction() }, logicalAxis)) {
     case BoxAxis::Horizontal:
         return size.width();
 

--- a/Source/WebCore/css/process-css-properties.py
+++ b/Source/WebCore/css/process-css-properties.py
@@ -2614,7 +2614,7 @@ class GenerateCSSPropertyNames:
         to.write(f"{signature}")
         to.write(f"{{")
         with to.indent():
-            to.write(f"auto textflow = makeTextFlow(writingMode, direction);")
+            to.write(f"TextFlow flow {{ writingModeToBlockFlowDirection(writingMode), direction }};")
             to.write(f"switch (id) {{")
 
             for group_name, property_group in sorted(self.properties_and_descriptors.style_properties.logical_property_groups.items(), key=lambda x: x[0]):
@@ -2631,7 +2631,7 @@ class GenerateCSSPropertyNames:
                     to.write(f"case {property.id}: {{")
                     with to.indent():
                         to.write(f"static constexpr CSSPropertyID properties[{len(properties)}] = {{ {', '.join(properties)} }};")
-                        to.write(f"return properties[static_cast<size_t>(map{source_as_id}{kind_as_id}To{destination_as_id}{kind_as_id}(textflow, {resolver_enum}))];")
+                        to.write(f"return properties[static_cast<size_t>(map{source_as_id}{kind_as_id}To{destination_as_id}{kind_as_id}(flow, {resolver_enum}))];")
                     to.write(f"}}")
 
             to.write(f"default:")

--- a/Source/WebCore/platform/RectEdges.h
+++ b/Source/WebCore/platform/RectEdges.h
@@ -95,13 +95,13 @@ public:
 
     T& before(WritingMode writingMode) { return at(mapLogicalSideToPhysicalSide(writingMode, LogicalBoxSide::BlockStart)); }
     T& after(WritingMode writingMode) { return at(mapLogicalSideToPhysicalSide(writingMode, LogicalBoxSide::BlockEnd)); }
-    T& start(WritingMode writingMode, TextDirection direction = TextDirection::LTR) { return at(mapLogicalSideToPhysicalSide(makeTextFlow(writingMode, direction), LogicalBoxSide::InlineStart)); }
-    T& end(WritingMode writingMode, TextDirection direction = TextDirection::LTR) { return at(mapLogicalSideToPhysicalSide(makeTextFlow(writingMode, direction), LogicalBoxSide::InlineEnd)); }
+    T& start(WritingMode writingMode, TextDirection direction = TextDirection::LTR) { return at(mapLogicalSideToPhysicalSide({ writingModeToBlockFlowDirection(writingMode), direction }, LogicalBoxSide::InlineStart)); }
+    T& end(WritingMode writingMode, TextDirection direction = TextDirection::LTR) { return at(mapLogicalSideToPhysicalSide({ writingModeToBlockFlowDirection(writingMode), direction }, LogicalBoxSide::InlineEnd)); }
 
     const T& before(WritingMode writingMode) const { return at(mapLogicalSideToPhysicalSide(writingMode, LogicalBoxSide::BlockStart)); }
     const T& after(WritingMode writingMode) const { return at(mapLogicalSideToPhysicalSide(writingMode, LogicalBoxSide::BlockEnd)); }
-    const T& start(WritingMode writingMode, TextDirection direction = TextDirection::LTR) const { return at(mapLogicalSideToPhysicalSide(makeTextFlow(writingMode, direction), LogicalBoxSide::InlineStart)); }
-    const T& end(WritingMode writingMode, TextDirection direction = TextDirection::LTR) const { return at(mapLogicalSideToPhysicalSide(makeTextFlow(writingMode, direction), LogicalBoxSide::InlineEnd)); }
+    const T& start(WritingMode writingMode, TextDirection direction = TextDirection::LTR) const { return at(mapLogicalSideToPhysicalSide({ writingModeToBlockFlowDirection(writingMode), direction }, LogicalBoxSide::InlineStart)); }
+    const T& end(WritingMode writingMode, TextDirection direction = TextDirection::LTR) const { return at(mapLogicalSideToPhysicalSide({ writingModeToBlockFlowDirection(writingMode), direction }, LogicalBoxSide::InlineEnd)); }
 
     void setBefore(const T& before, WritingMode writingMode) { this->before(writingMode) = before; }
     void setAfter(const T& after, WritingMode writingMode) { this->after(writingMode) = after; }

--- a/Source/WebCore/platform/text/WritingMode.h
+++ b/Source/WebCore/platform/text/WritingMode.h
@@ -104,27 +104,16 @@ struct TextFlow {
     }
 };
 
-constexpr inline TextFlow makeTextFlow(WritingMode writingMode, TextDirection direction)
-{
-    auto textDirection = direction;
-
-    // FIXME: Remove this erronous logic and remove `makeTextFlow` helper (webkit.org/b/276028).
-    if (writingMode == WritingMode::SidewaysLr)
-        textDirection = direction == TextDirection::RTL ? TextDirection::LTR : TextDirection::RTL;
-
-    return { writingModeToBlockFlowDirection(writingMode), textDirection };
-}
-
 // Lines have vertical orientation; modes vertical-lr or vertical-rl.
 constexpr inline bool isVerticalWritingMode(WritingMode writingMode)
 {
-    return makeTextFlow(writingMode, TextDirection::LTR).isVertical();
+    return TextFlow { writingModeToBlockFlowDirection(writingMode), TextDirection::LTR }.isVertical();
 }
 
 // Block progression increases in the opposite direction to normal; modes vertical-rl or horizontal-bt.
 constexpr inline bool isFlippedWritingMode(WritingMode writingMode)
 {
-    return makeTextFlow(writingMode, TextDirection::LTR).isFlipped();
+    return TextFlow { writingModeToBlockFlowDirection(writingMode), TextDirection::LTR }.isFlipped();
 }
 
 // Lines have horizontal orientation; modes horizontal-tb or horizontal-bt.
@@ -136,7 +125,7 @@ constexpr inline bool isHorizontalWritingMode(WritingMode writingMode)
 // Bottom of the line occurs earlier in the block; modes vertical-lr or horizontal-bt.
 constexpr inline bool isFlippedLinesWritingMode(WritingMode writingMode)
 {
-    return makeTextFlow(writingMode, TextDirection::LTR).isFlippedLines();
+    return TextFlow { writingModeToBlockFlowDirection(writingMode), TextDirection::LTR }.isFlippedLines();
 }
 
 enum class LogicalBoxSide : uint8_t {
@@ -197,7 +186,7 @@ constexpr BoxSide mapLogicalSideToPhysicalSide(WritingMode writingMode, LogicalB
 {
     // Set the direction such that side is mirrored if isFlippedWritingMode() is true
     auto direction = isFlippedWritingMode(writingMode) ? TextDirection::RTL : TextDirection::LTR;
-    return mapLogicalSideToPhysicalSide(makeTextFlow(writingMode, direction), logicalSide);
+    return mapLogicalSideToPhysicalSide({ writingModeToBlockFlowDirection(writingMode), direction }, logicalSide);
 }
 
 constexpr LogicalBoxSide mapPhysicalSideToLogicalSide(TextFlow flow, BoxSide side)

--- a/Source/WebCore/rendering/RenderCounter.cpp
+++ b/Source/WebCore/rendering/RenderCounter.cpp
@@ -472,7 +472,7 @@ String RenderCounter::originalText() const
 
         if (m_counter.listStyleType().type == ListStyleType::Type::CounterStyle) {
             ASSERT(counterStyle());
-            return counterStyle()->text(value, makeTextFlow(style().writingMode(), style().direction()));
+            return counterStyle()->text(value, { style().blockFlowDirection(), style().direction() });
         }
 
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -313,7 +313,7 @@ void RenderListMarker::updateContent()
     case ListStyleType::Type::CounterStyle: {
         auto counter = counterStyle();
         ASSERT(counter);
-        auto text = makeString(counter->prefix().text, counter->text(m_listItem->value(), makeTextFlow(style().writingMode(), style().direction())));
+        auto text = makeString(counter->prefix().text, counter->text(m_listItem->value(), { style().blockFlowDirection(), style().direction() }));
         m_textWithSuffix = makeString(text, counter->suffix().text);
         m_textWithoutSuffixLength = text.length();
         m_textIsLeftToRightDirection = u_charDirection(text[0]) != U_RIGHT_TO_LEFT;


### PR DESCRIPTION
#### e6d038446cca9504ff6a728c2a5195482b8ddfec
<pre>
Get rid of makeTextFlow constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=276028">https://bugs.webkit.org/show_bug.cgi?id=276028</a>
<a href="https://rdar.apple.com/130808015">rdar://130808015</a>

Reviewed by Alan Baradlay.

Use TextFlow default constructor instead.

* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::lengthOfViewportPhysicalAxisForLogicalAxis):
* Source/WebCore/css/process-css-properties.py:
(GenerateCSSPropertyNames):
* Source/WebCore/platform/RectEdges.h:
(WebCore::RectEdges::start):
(WebCore::RectEdges::end):
(WebCore::RectEdges::start const):
(WebCore::RectEdges::end const):
* Source/WebCore/platform/text/WritingMode.h:
(WebCore::isVerticalWritingMode):
(WebCore::isFlippedWritingMode):
(WebCore::isFlippedLinesWritingMode):
(WebCore::mapLogicalSideToPhysicalSide):
(WebCore::makeTextFlow): Deleted.
(WebCore::mapPhysicalSideToLogicalSide): Deleted.
(WebCore::mapLogicalCornerToPhysicalCorner): Deleted.
(WebCore::mapPhysicalCornerToLogicalCorner): Deleted.
(WebCore::mapLogicalAxisToPhysicalAxis): Deleted.
(WebCore::mapPhysicalAxisToLogicalAxis): Deleted.
(WebCore::operator&lt;&lt;): Deleted.
* Source/WebCore/rendering/RenderCounter.cpp:
(WebCore::RenderCounter::originalText const):
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::updateContent):

Canonical link: <a href="https://commits.webkit.org/280500@main">https://commits.webkit.org/280500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42b6e6a78774c98b8bdb591023d2b2cc522c3e8a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60427 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7254 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58939 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46011 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5076 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26868 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30727 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6357 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6258 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52660 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62109 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/724 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6732 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53269 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/727 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49081 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53291 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12562 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/609 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31968 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33053 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34138 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32799 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->