### PR TITLE
`textarea` should not reset the caret position when it is focused by sequential focus navigation

### DIFF
--- a/LayoutTests/fast/forms/focus-selection-textarea-expected.txt
+++ b/LayoutTests/fast/forms/focus-selection-textarea-expected.txt
@@ -7,9 +7,7 @@ EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotificatio
 EDITING DELEGATE: shouldChangeSelectedDOMRange:(null) toDOMRange:range from 0 of DIV > #document-fragment to 0 of DIV > #document-fragment affinity:NSSelectionAffinityDownstream stillSelecting:FALSE
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
-EDITING DELEGATE: shouldChangeSelectedDOMRange:(null) toDOMRange:range from 5 of #text > BODY > HTML > #document to 5 of #text > BODY > HTML > #document affinity:NSSelectionAffinityDownstream stillSelecting:FALSE
-EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
-EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
+EDITING DELEGATE: shouldChangeSelectedDOMRange:(null) toDOMRange:range from 1 of #text > LABEL > BODY > HTML > #document to 1 of #text > LABEL > BODY > HTML > #document affinity:NSSelectionAffinityDownstream stillSelecting:FALSE
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
 EDITING DELEGATE: webViewDidChangeSelection:WebViewDidChangeSelectionNotification
@@ -36,8 +34,8 @@ This test checks whether the selection is restored, cleared, or set to the full 
 
 PASS first.selectionStart is 11
 PASS first.selectionEnd is 18
-FAIL first.selectionStart should be 11. Was 0.
-FAIL first.selectionEnd should be 18. Was 0.
+PASS first.selectionStart is 11
+PASS first.selectionEnd is 18
 PASS second.selectionStart is 11
 PASS second.selectionEnd is 18
 PASS second.selectionStart is 11
@@ -64,10 +62,13 @@ PASS seventh.selectionStart is 11
 PASS seventh.selectionEnd is 18
 PASS eighth.selectionStart is 11
 PASS eighth.selectionEnd is 18
-FAIL eighth.selectionStart should be 11. Was 0.
-FAIL eighth.selectionEnd should be 18. Was 0.
+PASS eighth.selectionStart is 11
+PASS eighth.selectionEnd is 18
 PASS ninth.selectionStart is 11
 PASS ninth.selectionEnd is 18
 PASS ninth.selectionStart is 11
 PASS ninth.selectionEnd is 18
+PASS successfullyParsed is true
+
+TEST COMPLETE
 

--- a/LayoutTests/fast/forms/focus-selection-textarea.html
+++ b/LayoutTests/fast/forms/focus-selection-textarea.html
@@ -1,5 +1,11 @@
+<style>
+body {
+    font-size: 10px;
+    font-family: monospace;
+}
+</style>
 <body onload="runTest()">
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 
 <script>
 async function runTest()

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1671,8 +1671,6 @@ webkit.org/b/179605 editing/execCommand/underline-selection-containing-image.htm
 
 webkit.org/b/181662 fast/forms/auto-fill-button/input-strong-password-viewable-baseline-alignment.html [ ImageOnlyFailure ]
 
-webkit.org/b/182103 fast/forms/focus-selection-textarea.html [ Failure ]
-
 webkit.org/b/182763 accessibility/gtk/aria-activedescendant-changed-notification.html [ Failure ]
 
 webkit.org/b/183902 fast/dom/frame-loading-via-document-write.html [ Failure ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -823,9 +823,6 @@ webkit.org/b/140589 svg/text/text-text-06-t.svg [ Failure ]
 webkit.org/b/137098 svg/text/text-hkern.svg [ Failure ]
 webkit.org/b/137100 svg/text/text-vkern.svg [ Failure ]
 
-# Sometimes has an extra space at the end
-fast/forms/focus-selection-textarea.html [ Pass Failure ]
-
 # See also: rdar://problem/27356144
 webkit.org/b/142726 fast/images/animated-png.html [ Skip ]
 

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -229,14 +229,8 @@ void HTMLTextAreaElement::reset()
 
 void HTMLTextAreaElement::updateFocusAppearance(SelectionRestorationMode restorationMode, SelectionRevealMode revealMode)
 {
-    if (restorationMode == SelectionRestorationMode::RestoreOrSelectAll && hasCachedSelection())
+    if ((restorationMode == SelectionRestorationMode::RestoreOrSelectAll || restorationMode == SelectionRestorationMode::SelectAll)  && hasCachedSelection())
         restoreCachedSelection(revealMode, Element::defaultFocusTextStateChangeIntent());
-    else {
-        // If this is the first focus, set a caret at the beginning of the text.  
-        // This matches some browsers' behavior; see bug 11746 Comment #15.
-        // http://bugs.webkit.org/show_bug.cgi?id=11746#c15
-        setSelectionRange(0, 0, SelectionHasNoDirection, revealMode, Element::defaultFocusTextStateChangeIntent());
-    }
 }
 
 void HTMLTextAreaElement::defaultEventHandler(Event& event)

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestInputMethodContext.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestInputMethodContext.cpp
@@ -511,7 +511,7 @@ static void testWebKitInputMethodContextSimple(InputMethodTest* test, gconstpoin
     g_assert_false(test->m_events[2].isComposing);
     {
         auto editableValue = test->editableValue();
-        g_assert_cmpstr(editableValue.get(), ==, "a");
+        g_assert_cmpstr(editableValue.get(), ==, "");
     }
     test->resetEditable();
 
@@ -785,7 +785,7 @@ static void testWebKitInputMethodContextSurrounding(InputMethodTest* test, gcons
     test->keyStrokeAndWaitForEvents(KEY(a), 3);
     test->keyStrokeAndWaitForEvents(KEY(b), 6);
     test->keyStrokeAndWaitForEvents(KEY(c), 9);
-    g_assert_cmpstr(test->surroundingText(), ==, "abc");
+    g_assert_cmpstr(test->surroundingText(), ==, "");
     g_assert_cmpuint(test->surroundingCursorIndex(), ==, 3);
     g_assert_cmpuint(test->surroundingSelectionIndex(), ==, test->surroundingCursorIndex());
     test->m_events.clear();


### PR DESCRIPTION
#### ee45767afe32e10457fcd0eefceed9d28f454857
<pre>
`textarea` should not reset the caret position when it is focused by sequential focus navigation

<a href="https://bugs.webkit.org/show_bug.cgi?id=274367">https://bugs.webkit.org/show_bug.cgi?id=274367</a>
<a href="https://rdar.apple.com/problem/128762719">rdar://problem/128762719</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/281b9124b31f6aa3c8030f06d25bef969c3964d5">https://chromium.googlesource.com/chromium/src.git/+/281b9124b31f6aa3c8030f06d25bef969c3964d5</a>

We have reset it to the beginning of the `textarea` content and the
new behavior matches with other browsers.

* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::HTMLTextAreaElement::updateFocusAppearance):
* LayoutTests/fast/forms/focus-selection-textarea-expected.txt: Rebaselined
* LayoutTests/fast/forms/focus-selection-textarea.html: Updated (to reduce flakiness)
* LayoutTests/platform/gtk/TestExpectations: Removed Test Expectation
* LayoutTests/platform/mac/TestExpectations: Ditto
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestInputMethodContext.cpp:
(testWebKitInputMethodContextSimple):
(testWebKitInputMethodContextSurrounding):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fc8eaa2ac06c6d15615a00213b91139d454c5eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108914 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54376 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/105764 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23772 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31972 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78810 "Found 10 new test failures: fast/events/input-events-typing-data.html fast/events/inputText-never-fired-on-keydown-cancel.html fast/events/keypress-insert-tab.html fast/events/onchange-setvalue.html fast/shadow-dom/input-element-in-shadow.html imported/blink/fast/forms/textarea-placeholder-visibility-3.html imported/w3c/web-platform-tests/css/css-ui/user-select-none-on-input.html imported/w3c/web-platform-tests/html/semantics/forms/beforeinput.tentative.html imported/w3c/web-platform-tests/html/semantics/forms/input-change-event-properties.html imported/w3c/web-platform-tests/uievents/textInput/api.html (failure)") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106730 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18439 "Found 14 new test failures: editing/inserting/inserting-slash-inside-url-with-smart-link.html editing/pasteboard/copy-paste-pre-line-content.html editing/pasteboard/copy-paste-ruby-text-with-block.html editing/selection/ios/hide-selection-in-empty-overflow-hidden-container.html editing/selection/ios/hide-selection-in-textarea-with-transform.html editing/undo/5658727.html fast/forms/11423.html fast/forms/textarea-maxlength.html fast/forms/textarea-placeholder-visibility-1.html fast/forms/textarea-trailing-newline.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93566 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59144 "Found 5 new API test failures: /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/cancel-sequence, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/sequence, /WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/invalid-sequence (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18245 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11615 "Found 38 new test failures: accessibility/mac/replace-text-with-empty-range.html accessibility/mac/replace-text-with-range-value-change-notification.html accessibility/mac/selection-boundary-userinfo.html editing/deleting/delete-ligature-001.html editing/input/style-change-during-input.html editing/inserting/inserting-slash-inside-url-with-smart-link.html editing/inserting/smart-link-when-caret-is-moved-before-URL.html editing/mac/input/text-control-ime-input.html editing/mac/spelling/autocorrection-at-beginning-of-word-1.html editing/mac/spelling/autocorrection-at-beginning-of-word-2.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53752 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88027 "Found 1 new API test failure: TestWebKitAPI.EditorStateTests.ContentViewHasTextInTextarea (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11673 "Found 36 new test failures: accessibility/mac/replace-text-with-empty-range.html accessibility/mac/replace-text-with-range-value-change-notification.html accessibility/mac/selection-boundary-userinfo.html accessibility/mac/text-marker-from-typing-notification.html editing/deleting/delete-ligature-001.html editing/input/style-change-during-input.html editing/inserting/inserting-slash-inside-url-with-smart-link.html editing/inserting/smart-link-when-caret-is-moved-before-URL.html editing/mac/input/text-control-ime-input.html editing/mac/spelling/autocorrection-at-beginning-of-word-1.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111304 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30880 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22767 "Found 37 new test failures: accessibility/mac/replace-text-with-empty-range.html accessibility/mac/replace-text-with-range-value-change-notification.html accessibility/mac/selection-boundary-userinfo.html accessibility/mac/text-marker-from-typing-notification.html editing/deleting/delete-ligature-001.html editing/input/style-change-during-input.html editing/inserting/inserting-slash-inside-url-with-smart-link.html editing/inserting/smart-link-when-caret-is-moved-before-URL.html editing/mac/input/text-control-ime-input.html editing/mac/spelling/autocorrection-at-beginning-of-word-1.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87810 "Found 32 new test failures: compositing/patterns/direct-pattern-compositing-size.html editing/input/style-change-during-input.html editing/inserting/inserting-slash-inside-url-with-smart-link.html editing/pasteboard/copy-null-characters.html editing/pasteboard/copy-paste-pre-line-content.html editing/pasteboard/copy-paste-ruby-text-with-block.html editing/spelling/move-cursor-around-misspelled-word.html editing/spelling/spelling-attribute-change.html editing/spelling/spelling-hasspellingmarker.html editing/spelling/toggle-spellchecking.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31241 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89768 "Exiting early after 10 failures. 10 tests run. 1 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87460 "Found 6 new API test failures: /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/sequence, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/invalid-sequence, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/cancel-sequence, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/dom-input-element-is-user-edited (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32336 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10065 "Found 36 new test failures: accessibility/mac/replace-text-with-empty-range.html accessibility/mac/replace-text-with-range-value-change-notification.html accessibility/mac/selection-boundary-userinfo.html accessibility/mac/text-marker-from-typing-notification.html editing/deleting/delete-ligature-001.html editing/input/style-change-during-input.html editing/inserting/inserting-slash-inside-url-with-smart-link.html editing/inserting/smart-link-when-caret-is-moved-before-URL.html editing/mac/input/text-control-ime-input.html editing/mac/spelling/autocorrection-at-beginning-of-word-1.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25237 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30808 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36111 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30602 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33937 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32163 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->