### PR TITLE
Drop AudioArray::data() in favor of span()

### DIFF
--- a/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
@@ -136,7 +136,7 @@ AudioBuffer::AudioBuffer(AudioBus& bus)
             return;
         }
 
-        channelDataArray->setRange(bus.channel(i)->data(), m_originalLength, 0);
+        channelDataArray->setRange(bus.channel(i)->span().data(), m_originalLength, 0);
         channels.append(WTFMove(channelDataArray));
     }
 

--- a/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp
@@ -136,7 +136,7 @@ void AudioBufferSourceNode::process(size_t framesToProcess)
     }
 
     for (unsigned i = 0; i < outputBus.numberOfChannels(); ++i)
-        m_destinationChannels[i] = outputBus.channel(i)->mutableData();
+        m_destinationChannels[i] = outputBus.channel(i)->mutableSpan().data();
 
     // Render by reading directly from the buffer.
     if (!renderFromBuffer(&outputBus, quantumFrameOffset, bufferFramesToProcess, startFrameOffset)) {

--- a/Source/WebCore/Modules/webaudio/AudioListener.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioListener.cpp
@@ -109,17 +109,17 @@ void AudioListener::updateValuesIfNeeded(size_t framesToProcess)
         ASSERT(framesToProcess <= m_upYValues.size());
         ASSERT(framesToProcess <= m_upZValues.size());
 
-        positionX().calculateSampleAccurateValues(m_positionXValues.data(), framesToProcess);
-        positionY().calculateSampleAccurateValues(m_positionYValues.data(), framesToProcess);
-        positionZ().calculateSampleAccurateValues(m_positionZValues.data(), framesToProcess);
+        positionX().calculateSampleAccurateValues(m_positionXValues.mutableSpan().data(), framesToProcess);
+        positionY().calculateSampleAccurateValues(m_positionYValues.mutableSpan().data(), framesToProcess);
+        positionZ().calculateSampleAccurateValues(m_positionZValues.mutableSpan().data(), framesToProcess);
 
-        forwardX().calculateSampleAccurateValues(m_forwardXValues.data(), framesToProcess);
-        forwardY().calculateSampleAccurateValues(m_forwardYValues.data(), framesToProcess);
-        forwardZ().calculateSampleAccurateValues(m_forwardZValues.data(), framesToProcess);
+        forwardX().calculateSampleAccurateValues(m_forwardXValues.mutableSpan().data(), framesToProcess);
+        forwardY().calculateSampleAccurateValues(m_forwardYValues.mutableSpan().data(), framesToProcess);
+        forwardZ().calculateSampleAccurateValues(m_forwardZValues.mutableSpan().data(), framesToProcess);
 
-        upX().calculateSampleAccurateValues(m_upXValues.data(), framesToProcess);
-        upY().calculateSampleAccurateValues(m_upYValues.data(), framesToProcess);
-        upZ().calculateSampleAccurateValues(m_upZValues.data(), framesToProcess);
+        upX().calculateSampleAccurateValues(m_upXValues.mutableSpan().data(), framesToProcess);
+        upY().calculateSampleAccurateValues(m_upYValues.mutableSpan().data(), framesToProcess);
+        upZ().calculateSampleAccurateValues(m_upZValues.mutableSpan().data(), framesToProcess);
     }
 }
 
@@ -140,55 +140,55 @@ void AudioListener::updateDirtyState()
 const float* AudioListener::positionXValues(size_t framesToProcess)
 {
     updateValuesIfNeeded(framesToProcess);
-    return m_positionXValues.data();
+    return m_positionXValues.span().data();
 }
 
 const float* AudioListener::positionYValues(size_t framesToProcess)
 {
     updateValuesIfNeeded(framesToProcess);
-    return m_positionYValues.data();
+    return m_positionYValues.span().data();
 }
 
 const float* AudioListener::positionZValues(size_t framesToProcess)
 {
     updateValuesIfNeeded(framesToProcess);
-    return m_positionZValues.data();
+    return m_positionZValues.span().data();
 }
 
 const float* AudioListener::forwardXValues(size_t framesToProcess)
 {
     updateValuesIfNeeded(framesToProcess);
-    return m_forwardXValues.data();
+    return m_forwardXValues.span().data();
 }
 
 const float* AudioListener::forwardYValues(size_t framesToProcess)
 {
     updateValuesIfNeeded(framesToProcess);
-    return m_forwardYValues.data();
+    return m_forwardYValues.span().data();
 }
 
 const float* AudioListener::forwardZValues(size_t framesToProcess)
 {
     updateValuesIfNeeded(framesToProcess);
-    return m_forwardZValues.data();
+    return m_forwardZValues.span().data();
 }
 
 const float* AudioListener::upXValues(size_t framesToProcess)
 {
     updateValuesIfNeeded(framesToProcess);
-    return m_upXValues.data();
+    return m_upXValues.span().data();
 }
 
 const float* AudioListener::upYValues(size_t framesToProcess)
 {
     updateValuesIfNeeded(framesToProcess);
-    return m_upYValues.data();
+    return m_upYValues.span().data();
 }
 
 const float* AudioListener::upZValues(size_t framesToProcess)
 {
     updateValuesIfNeeded(framesToProcess);
-    return m_upZValues.data();
+    return m_upZValues.span().data();
 }
 
 ExceptionOr<void> AudioListener::setPosition(float x, float y, float z)

--- a/Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.cpp
@@ -115,7 +115,7 @@ void AudioScheduledSourceNode::updateSchedulingInfo(size_t quantumFrameSize, Aud
     // Zero any initial frames representing silence leading up to a rendering start time in the middle of the quantum.
     if (quantumFrameOffset) {
         for (unsigned i = 0; i < outputBus.numberOfChannels(); ++i)
-            memset(outputBus.channel(i)->mutableData(), 0, sizeof(float) * quantumFrameOffset);
+            memsetSpan(outputBus.channel(i)->mutableSpan().first(quantumFrameOffset), 0);
     }
 
     // Handle silence after we're done playing.
@@ -137,7 +137,7 @@ void AudioScheduledSourceNode::updateSchedulingInfo(size_t quantumFrameSize, Aud
                 nonSilentFramesToProcess -= framesToZero;
 
             for (unsigned i = 0; i < outputBus.numberOfChannels(); ++i)
-                memset(outputBus.channel(i)->mutableData() + zeroStartFrame, 0, sizeof(float) * framesToZero);
+                memsetSpan(outputBus.channel(i)->mutableSpan().subspan(zeroStartFrame, framesToZero), 0);
         }
 
         finish();

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
@@ -221,7 +221,7 @@ void AudioWorkletNode::process(size_t framesToProcess)
             if (auto& input = m_inputs[inputIndex]) {
                 for (unsigned channelIndex = 0; channelIndex < input->numberOfChannels(); ++channelIndex) {
                     auto* channel = input->channel(channelIndex);
-                    AudioUtilities::applyNoise(channel->mutableData(), channel->length(), 0.01);
+                    AudioUtilities::applyNoise(channel->mutableSpan().data(), channel->length(), 0.01);
                 }
             }
         }
@@ -232,9 +232,9 @@ void AudioWorkletNode::process(size_t framesToProcess)
         ASSERT(paramValues);
         RELEASE_ASSERT(paramValues->size() >= framesToProcess);
         if (audioParam->hasSampleAccurateValues() && audioParam->automationRate() == AutomationRate::ARate)
-            audioParam->calculateSampleAccurateValues(paramValues->data(), framesToProcess);
+            audioParam->calculateSampleAccurateValues(paramValues->mutableSpan().data(), framesToProcess);
         else
-            std::fill_n(paramValues->data(), framesToProcess, audioParam->finalValue());
+            std::fill_n(paramValues->mutableSpan().data(), framesToProcess, audioParam->finalValue());
     }
 
     bool threwException = false;

--- a/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
@@ -87,7 +87,7 @@ static JSObject* constructFrozenKeyValueObject(VM& vm, JSGlobalObject& globalObj
         PutPropertySlot slot(object, false, PutPropertySlot::PutById);
         // Per the specification, if the value is constant, we pass the JS an array with length 1, with the array item being the constant.
         unsigned jsArraySize = pair.value->containsConstantValue() ? 1 : pair.value->size();
-        object->putInline(&globalObject, Identifier::fromString(vm, pair.key), constructJSFloat32Array(globalObject, jsArraySize, pair.value->data()), slot);
+        object->putInline(&globalObject, Identifier::fromString(vm, pair.key), constructJSFloat32Array(globalObject, jsArraySize, pair.value->span().data()), slot);
     }
     JSC::objectConstructorFreeze(&globalObject, object);
     EXCEPTION_ASSERT_UNUSED(scope, !scope.exception());
@@ -103,7 +103,7 @@ static JSArray* constructFrozenJSArray(VM& vm, JSGlobalObject& globalObject, JSC
     auto* channelsData = JSArray::create(vm, globalObject.originalArrayStructureForIndexingType(ArrayWithContiguous), numberOfChannels);
     for (unsigned j = 0; j < numberOfChannels; ++j) {
         auto* channel = bus->channel(j);
-        channelsData->setIndexQuickly(vm, j, constructJSFloat32Array(globalObject, channel->length(), shouldPopulateWithBusData == ShouldPopulateWithBusData::Yes ? channel->data() : nullptr));
+        channelsData->setIndexQuickly(vm, j, constructJSFloat32Array(globalObject, channel->length(), shouldPopulateWithBusData == ShouldPopulateWithBusData::Yes ? channel->span().data() : nullptr));
     }
     JSC::objectConstructorFreeze(&globalObject, channelsData);
     EXCEPTION_ASSERT_UNUSED(scope, !scope.exception());
@@ -136,7 +136,7 @@ static void copyDataFromJSArrayToBuses(JSGlobalObject& globalObject, const JSArr
             auto* channel = bus->channel(j);
             auto* jsChannelData = jsDynamicCast<JSFloat32Array*>(channelsArray->getIndex(&globalObject, j));
             if (LIKELY(jsChannelData && jsChannelData->length() == channel->length()))
-                memcpy(channel->mutableData(), jsChannelData->typedVector(), sizeof(float) * channel->length());
+                memcpy(channel->mutableSpan().data(), jsChannelData->typedVector(), sizeof(float) * channel->length());
             else
                 channel->zero();
         }
@@ -159,7 +159,7 @@ static bool copyDataFromBusesToJSArray(JSGlobalObject& globalObject, const Vecto
             auto* jsChannelArray = jsDynamicCast<JSFloat32Array*>(jsChannelsArray->getIndex(&globalObject, channelIndex));
             if (!jsChannelArray || jsChannelArray->length() != channel->length())
                 return false;
-            memcpy(jsChannelArray->typedVector(), channel->mutableData(), sizeof(float) * jsChannelArray->length());
+            memcpy(jsChannelArray->typedVector(), channel->mutableSpan().data(), sizeof(float) * jsChannelArray->length());
         }
     }
     return true;
@@ -177,7 +177,7 @@ static bool copyDataFromParameterMapToJSObject(VM& vm, JSGlobalObject& globalObj
         unsigned expectedLength = pair.value->containsConstantValue() ? 1 : pair.value->size();
         if (jsTypedArray->length() != expectedLength)
             return false;
-        memcpy(jsTypedArray->typedVector(), pair.value->data(), sizeof(float) * jsTypedArray->length());
+        memcpy(jsTypedArray->typedVector(), pair.value->span().data(), sizeof(float) * jsTypedArray->length());
     }
     return true;
 }

--- a/Source/WebCore/Modules/webaudio/BiquadProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/BiquadProcessor.cpp
@@ -103,7 +103,7 @@ void BiquadProcessor::process(const AudioBus* source, AudioBus* destination, siz
             
     // For each channel of our input, process using the corresponding BiquadDSPKernel into the output channel.
     for (unsigned i = 0; i < m_kernels.size(); ++i)
-        m_kernels[i]->process(source->channel(i)->data(), destination->channel(i)->mutableData(), framesToProcess);
+        m_kernels[i]->process(source->channel(i)->span().data(), destination->channel(i)->mutableSpan().data(), framesToProcess);
 }
 
 void BiquadProcessor::processOnlyAudioParams(size_t framesToProcess)

--- a/Source/WebCore/Modules/webaudio/ConstantSourceNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ConstantSourceNode.cpp
@@ -81,10 +81,10 @@ void ConstantSourceNode::process(size_t framesToProcess)
     
     bool isSampleAccurate = m_offset->hasSampleAccurateValues();
     if (isSampleAccurate && m_offset->automationRate() == AutomationRate::ARate) {
-        float* offsets = m_sampleAccurateValues.data();
+        float* offsets = m_sampleAccurateValues.mutableSpan().data();
         m_offset->calculateSampleAccurateValues(offsets, framesToProcess);
         if (nonSilentFramesToProcess > 0) {
-            memcpy(outputBus.channel(0)->mutableData() + quantumFrameOffset, offsets + quantumFrameOffset, nonSilentFramesToProcess * sizeof(*offsets));
+            memcpy(outputBus.channel(0)->mutableSpan().subspan(quantumFrameOffset).data(), offsets + quantumFrameOffset, nonSilentFramesToProcess * sizeof(*offsets));
             outputBus.clearSilentFlag();
         } else
             outputBus.zero();
@@ -95,7 +95,7 @@ void ConstantSourceNode::process(size_t framesToProcess)
     if (!value)
         outputBus.zero();
     else {
-        float* dest = outputBus.channel(0)->mutableData();
+        float* dest = outputBus.channel(0)->mutableSpan().data();
         std::fill_n(dest + quantumFrameOffset, nonSilentFramesToProcess, value);
         outputBus.clearSilentFlag();
     }

--- a/Source/WebCore/Modules/webaudio/DelayDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/DelayDSPKernel.cpp
@@ -114,9 +114,9 @@ void DelayDSPKernel::process(const float* source, float* destination, size_t fra
 void DelayDSPKernel::processARate(const float* source, float* destination, size_t framesToProcess)
 {
     size_t bufferLength = m_buffer.size();
-    auto* buffer = m_buffer.data();
+    auto* buffer = m_buffer.mutableSpan().data();
 
-    delayProcessor()->delayTime().calculateSampleAccurateValues(m_delayTimes.data(), framesToProcess);
+    delayProcessor()->delayTime().calculateSampleAccurateValues(m_delayTimes.mutableSpan().data(), framesToProcess);
 
     copyToCircularBuffer(buffer, m_writeIndex, bufferLength, source, framesToProcess);
 
@@ -150,7 +150,7 @@ void DelayDSPKernel::processARate(const float* source, float* destination, size_
 void DelayDSPKernel::processKRate(const float* source, float* destination, size_t framesToProcess)
 {
     size_t bufferLength = m_buffer.size();
-    auto* buffer = m_buffer.data();
+    auto* buffer = m_buffer.mutableSpan().data();
 
     double delayTime = delayProcessor() ? delayProcessor()->delayTime().finalValue() : m_desiredDelayFrames / sampleRate();
     // Make sure the delay time is in a valid range.
@@ -192,7 +192,7 @@ void DelayDSPKernel::processKRate(const float* source, float* destination, size_
     ASSERT(framesToProcess <= m_tempBuffer.size());
 
     size_t readIndex2 = (readIndex1 + 1) % bufferLength;
-    auto* sample2 = m_tempBuffer.data();
+    auto* sample2 = m_tempBuffer.mutableSpan().data();
 
     readPointer = &buffer[readIndex2];
     remainder = positiveSubtract(bufferEnd, readPointer);

--- a/Source/WebCore/Modules/webaudio/GainNode.cpp
+++ b/Source/WebCore/Modules/webaudio/GainNode.cpp
@@ -80,7 +80,7 @@ void GainNode::process(size_t framesToProcess)
             // Apply sample-accurate gain scaling for precise envelopes, grain windows, etc.
             ASSERT(framesToProcess <= m_sampleAccurateGainValues.size());
             if (framesToProcess <= m_sampleAccurateGainValues.size()) {
-                float* gainValues = m_sampleAccurateGainValues.data();
+                float* gainValues = m_sampleAccurateGainValues.mutableSpan().data();
                 gain().calculateSampleAccurateValues(gainValues, framesToProcess);
                 outputBus->copyWithSampleAccurateGainValuesFrom(*inputBus, gainValues, framesToProcess);
             }

--- a/Source/WebCore/Modules/webaudio/IIRProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/IIRProcessor.cpp
@@ -92,7 +92,7 @@ void IIRProcessor::process(const AudioBus* source, AudioBus* destination, size_t
     // For each channel of our input, process using the corresponding IIRDSPKernel
     // into the output channel.
     for (size_t i = 0; i < m_kernels.size(); ++i)
-        m_kernels[i]->process(source->channel(i)->data(), destination->channel(i)->mutableData(), framesToProcess);
+        m_kernels[i]->process(source->channel(i)->span().data(), destination->channel(i)->mutableSpan().data(), framesToProcess);
 }
 
 void IIRProcessor::getFrequencyResponse(unsigned length, const float* frequencyHz, float* magResponse, float* phaseResponse)

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceCocoa.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceCocoa.cpp
@@ -59,7 +59,7 @@ static inline void copyChannelData(AudioChannel& channel, AudioBuffer& buffer, s
         memset(buffer.mData, 0, buffer.mDataByteSize);
         return;
     }
-    memcpy(buffer.mData, channel.data(), buffer.mDataByteSize);
+    memcpy(buffer.mData, channel.span().data(), buffer.mDataByteSize);
 }
 
 void MediaStreamAudioSource::consumeAudio(AudioBus& bus, size_t numberOfFrames)

--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp
@@ -41,7 +41,7 @@ static void copyBusData(AudioBus& bus, GstBuffer* buffer, bool isMuted)
     for (size_t channelIndex = 0; channelIndex < bus.numberOfChannels(); ++channelIndex) {
         const auto& channel = *bus.channel(channelIndex);
         auto dataSize = sizeof(float) * channel.length();
-        memcpy(mappedBuffer.data() + offset, channel.data(), dataSize);
+        memcpy(mappedBuffer.data() + offset, channel.span().data(), dataSize);
         offset += dataSize;
     }
 }

--- a/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.cpp
@@ -185,7 +185,7 @@ auto OfflineAudioDestinationNode::renderOnAudioThread() -> RenderResult
         size_t framesAvailableToCopy = std::min(m_framesToProcess, AudioUtilities::renderQuantumSize);
         
         for (unsigned channelIndex = 0; channelIndex < numberOfChannels; ++channelIndex) {
-            const float* source = m_renderBus->channel(channelIndex)->data();
+            const float* source = m_renderBus->channel(channelIndex)->span().data();
             float* destination = m_renderTarget->channelData(channelIndex)->data();
             memcpy(destination + m_destinationOffset, source, sizeof(float) * framesAvailableToCopy);
         }

--- a/Source/WebCore/Modules/webaudio/OscillatorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/OscillatorNode.cpp
@@ -130,7 +130,7 @@ bool OscillatorNode::calculateSampleAccuratePhaseIncrements(size_t framesToProce
 
     bool hasSampleAccurateValues = false;
     bool hasFrequencyChanges = false;
-    float* phaseIncrements = m_phaseIncrements.data();
+    float* phaseIncrements = m_phaseIncrements.mutableSpan().data();
 
     float finalScale = m_periodicWave->rateScale();
 
@@ -150,7 +150,7 @@ bool OscillatorNode::calculateSampleAccuratePhaseIncrements(size_t framesToProce
         hasSampleAccurateValues = true;
 
         // Get the sample-accurate detune values.
-        float* detuneValues = hasFrequencyChanges ? m_detuneValues.data() : phaseIncrements;
+        float* detuneValues = hasFrequencyChanges ? m_detuneValues.mutableSpan().data() : phaseIncrements;
         m_detune->calculateSampleAccurateValues(detuneValues, framesToProcess);
 
         // Convert from cents to rate scalar.
@@ -375,7 +375,7 @@ void OscillatorNode::process(size_t framesToProcess)
         return;
     }
 
-    float* destP = outputBus.channel(0)->mutableData();
+    float* destP = outputBus.channel(0)->mutableSpan().data();
 
     ASSERT(quantumFrameOffset <= framesToProcess);
 
@@ -399,7 +399,7 @@ void OscillatorNode::process(size_t framesToProcess)
         m_periodicWave->waveDataForFundamentalFrequency(frequency, lowerWaveData, higherWaveData, tableInterpolationFactor);
     }
 
-    float* phaseIncrements = m_phaseIncrements.data();
+    float* phaseIncrements = m_phaseIncrements.mutableSpan().data();
 
     // Start rendering at the correct offset.
     destP += quantumFrameOffset;

--- a/Source/WebCore/Modules/webaudio/PeriodicWave.cpp
+++ b/Source/WebCore/Modules/webaudio/PeriodicWave.cpp
@@ -154,8 +154,8 @@ void PeriodicWave::waveDataForFundamentalFrequency(float fundamentalFrequency, f
     unsigned rangeIndex1 = static_cast<unsigned>(pitchRange);
     unsigned rangeIndex2 = rangeIndex1 < m_numberOfRanges - 1 ? rangeIndex1 + 1 : rangeIndex1;
 
-    lowerWaveData = m_bandLimitedTables[rangeIndex2]->data();
-    higherWaveData = m_bandLimitedTables[rangeIndex1]->data();
+    lowerWaveData = m_bandLimitedTables[rangeIndex2]->mutableSpan().data();
+    higherWaveData = m_bandLimitedTables[rangeIndex1]->mutableSpan().data();
     
     // Ranges from 0 -> 1 to interpolate between lower -> higher.
     tableInterpolationFactor = pitchRange - rangeIndex1;
@@ -204,8 +204,8 @@ void PeriodicWave::createBandLimitedTables(const float* realData, const float* i
         RELEASE_ASSERT(imagP.size() >= numberOfComponents);
 
         // Copy from loaded frequency data and scale.
-        VectorMath::multiplyByScalar(realData, fftSize, realP.data(), numberOfComponents);
-        VectorMath::multiplyByScalar(imagData, -static_cast<float>(fftSize), imagP.data(), numberOfComponents);
+        VectorMath::multiplyByScalar(realData, fftSize, realP.mutableSpan().data(), numberOfComponents);
+        VectorMath::multiplyByScalar(imagData, -static_cast<float>(fftSize), imagP.mutableSpan().data(), numberOfComponents);
 
         // Find the starting bin where we should start culling.
         // We need to clear out the highest frequencies to band-limit the waveform.
@@ -230,7 +230,7 @@ void PeriodicWave::createBandLimitedTables(const float* realData, const float* i
         m_bandLimitedTables.append(makeUnique<AudioFloatArray>(waveSize));
 
         // Apply an inverse FFT to generate the time-domain table data.
-        float* data = m_bandLimitedTables[rangeIndex]->data();
+        float* data = m_bandLimitedTables[rangeIndex]->mutableSpan().data();
         frame.doInverseFFT(data);
 
         // For the first range (which has the highest power), calculate its peak value then compute normalization scale.
@@ -255,8 +255,8 @@ void PeriodicWave::generateBasicWaveform(Type shape)
 
     AudioFloatArray real(halfSize);
     AudioFloatArray imag(halfSize);
-    float* realP = real.data();
-    float* imagP = imag.data();
+    float* realP = real.mutableSpan().data();
+    float* imagP = imag.mutableSpan().data();
 
     // Clear DC and Nyquist.
     realP[0] = 0;

--- a/Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp
+++ b/Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp
@@ -87,13 +87,13 @@ void RealtimeAnalyser::writeInput(AudioBus* bus, size_t framesToProcess)
         return;    
     
     // Perform real-time analysis
-    float* dest = m_inputBuffer.data() + m_writeIndex;
+    auto dest = m_inputBuffer.mutableSpan().subspan(m_writeIndex, framesToProcess);
 
     // Clear the bus and downmix the input according to the down mixing rules.
     // Then save the result in the m_inputBuffer at the appropriate place.
     m_downmixBus->zero();
     m_downmixBus->sumFrom(*bus);
-    memcpy(dest, m_downmixBus->channel(0)->data(), sizeof(float) * framesToProcess);
+    memcpySpan(dest, m_downmixBus->channel(0)->span().first(framesToProcess));
 
     m_writeIndex += framesToProcess;
     if (m_writeIndex >= InputBufferSize)
@@ -137,23 +137,23 @@ void RealtimeAnalyser::doFFTAnalysisIfNecessary()
     size_t fftSize = this->fftSize();
     
     AudioFloatArray temporaryBuffer(fftSize);
-    float* inputBuffer = m_inputBuffer.data();
-    float* tempP = temporaryBuffer.data();
+    auto inputBuffer = m_inputBuffer.span();
+    auto tempP = temporaryBuffer.mutableSpan();
 
     // Take the previous fftSize values from the input buffer and copy into the temporary buffer.
     unsigned writeIndex = m_writeIndex;
     if (writeIndex < fftSize) {
-        memcpy(tempP, inputBuffer + writeIndex - fftSize + InputBufferSize, sizeof(*tempP) * (fftSize - writeIndex));
-        memcpy(tempP + fftSize - writeIndex, inputBuffer, sizeof(*tempP) * writeIndex);
+        memcpySpan(tempP.first(fftSize - writeIndex), inputBuffer.subspan(writeIndex - fftSize + InputBufferSize, fftSize - writeIndex));
+        memcpySpan(tempP.subspan(fftSize - writeIndex, writeIndex), inputBuffer.first(writeIndex));
     } else 
-        memcpy(tempP, inputBuffer + writeIndex - fftSize, sizeof(*tempP) * fftSize);
+        memcpySpan(tempP.first(fftSize), inputBuffer.subspan(writeIndex - fftSize, fftSize));
 
     
     // Window the input samples.
-    applyWindow(tempP, fftSize);
+    applyWindow(tempP.data(), fftSize);
     
     // Do the analysis.
-    m_analysisFrame->doFFT(tempP);
+    m_analysisFrame->doFFT(tempP.data());
 
     auto& realP = m_analysisFrame->realData();
     auto& imagP = m_analysisFrame->imagData();
@@ -170,7 +170,7 @@ void RealtimeAnalyser::doFFTAnalysisIfNecessary()
     k = std::min(1.0, k);    
     
     // Convert the analysis data from complex to magnitude and average with the previous result.
-    float* destination = magnitudeBuffer().data();
+    auto destination = magnitudeBuffer().mutableSpan();
     size_t n = magnitudeBuffer().size();
     for (size_t i = 0; i < n; ++i) {
         std::complex<double> c(realP[i], imagP[i]);
@@ -179,7 +179,7 @@ void RealtimeAnalyser::doFFTAnalysisIfNecessary()
     }
 
     if (m_noiseInjectionPolicy == NoiseInjectionPolicy::Minimal)
-        AudioUtilities::applyNoise(destination, n, 0.25);
+        AudioUtilities::applyNoise(destination.data(), n, 0.25);
 }
 
 void RealtimeAnalyser::getFloatFrequencyData(Float32Array& destinationArray)
@@ -190,7 +190,7 @@ void RealtimeAnalyser::getFloatFrequencyData(Float32Array& destinationArray)
     
     // Convert from linear magnitude to floating-point decibels.
     size_t length = std::min<size_t>(magnitudeBuffer().size(), destinationArray.length());
-    VectorMath::linearToDecibels(magnitudeBuffer().data(), destinationArray.data(), length);
+    VectorMath::linearToDecibels(magnitudeBuffer().mutableSpan().data(), destinationArray.data(), length);
 }
 
 void RealtimeAnalyser::getByteFrequencyData(Uint8Array& destinationArray)
@@ -207,8 +207,8 @@ void RealtimeAnalyser::getByteFrequencyData(Uint8Array& destinationArray)
         const double rangeScaleFactor = m_maxDecibels == m_minDecibels ? 1 : 1 / (m_maxDecibels - m_minDecibels);
         const double minDecibels = m_minDecibels;
 
-        const float* source = magnitudeBuffer().data();
-        unsigned char* destination = destinationArray.data();
+        auto source = magnitudeBuffer().span();
+        auto destination = destinationArray.mutableSpan();
         
         for (size_t i = 0; i < length; ++i) {
             float linearValue = source[i];
@@ -241,8 +241,8 @@ void RealtimeAnalyser::getFloatTimeDomainData(Float32Array& destinationArray)
         if (!isInputBufferGood)
             return;
         
-        float* inputBuffer = m_inputBuffer.data();
-        float* destination = destinationArray.data();
+        auto inputBuffer = m_inputBuffer.span();
+        auto destination = destinationArray.mutableSpan();
         
         unsigned writeIndex = m_writeIndex;
         
@@ -266,7 +266,7 @@ void RealtimeAnalyser::getByteTimeDomainData(Uint8Array& destinationArray)
         if (!isInputBufferGood)
             return;
 
-        float* inputBuffer = m_inputBuffer.data();        
+        auto inputBuffer = m_inputBuffer.span();
         unsigned char* destination = destinationArray.data();
         
         unsigned writeIndex = m_writeIndex;

--- a/Source/WebCore/Modules/webaudio/ScriptProcessorNode.cpp
+++ b/Source/WebCore/Modules/webaudio/ScriptProcessorNode.cpp
@@ -195,7 +195,7 @@ void ScriptProcessorNode::process(size_t framesToProcess)
 
     // Copy from the output buffer to the output. 
     for (unsigned i = 0; i < numberOfOutputChannels; ++i)
-        memcpy(outputBus->channel(i)->mutableData(), outputBuffer->rawChannelData(i) + m_bufferReadWriteIndex, sizeof(float) * framesToProcess);
+        memcpy(outputBus->channel(i)->mutableSpan().data(), outputBuffer->rawChannelData(i) + m_bufferReadWriteIndex, sizeof(float) * framesToProcess);
 
     // Update the buffering index.
     m_bufferReadWriteIndex = (m_bufferReadWriteIndex + framesToProcess) % bufferSize();

--- a/Source/WebCore/Modules/webaudio/StereoPannerNode.cpp
+++ b/Source/WebCore/Modules/webaudio/StereoPannerNode.cpp
@@ -82,7 +82,7 @@ void StereoPannerNode::process(size_t framesToProcess)
     }
 
     if (m_pan->hasSampleAccurateValues() && m_pan->automationRate() == AutomationRate::ARate) {
-        float* panValues = m_sampleAccurateValues.data();
+        float* panValues = m_sampleAccurateValues.mutableSpan().data();
         m_pan->calculateSampleAccurateValues(panValues, framesToProcess);
         StereoPanner::panWithSampleAccurateValues(source, destination, panValues, framesToProcess);
         return;

--- a/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.cpp
+++ b/Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.cpp
@@ -124,7 +124,7 @@ void WaveShaperDSPKernel::processCurve2x(const float* source, float* destination
     if (!isSafe)
         return;
 
-    float* tempP = m_tempBuffer->data();
+    float* tempP = m_tempBuffer->mutableSpan().data();
 
     m_upSampler->process(source, tempP, framesToProcess);
 
@@ -141,8 +141,8 @@ void WaveShaperDSPKernel::processCurve4x(const float* source, float* destination
     if (!isSafe)
         return;
 
-    float* tempP = m_tempBuffer->data();
-    float* tempP2 = m_tempBuffer2->data();
+    float* tempP = m_tempBuffer->mutableSpan().data();
+    float* tempP2 = m_tempBuffer2->mutableSpan().data();
 
     m_upSampler->process(source, tempP, framesToProcess);
     m_upSampler2->process(tempP, tempP2, framesToProcess * 2);

--- a/Source/WebCore/Modules/webaudio/WaveShaperProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/WaveShaperProcessor.cpp
@@ -95,7 +95,7 @@ void WaveShaperProcessor::process(const AudioBus* source, AudioBus* destination,
 
     // For each channel of our input, process using the corresponding WaveShaperDSPKernel into the output channel.
     for (size_t i = 0; i < m_kernels.size(); ++i)
-        static_cast<WaveShaperDSPKernel&>(*m_kernels[i]).process(source->channel(i)->data(), destination->channel(i)->mutableData(), framesToProcess);
+        static_cast<WaveShaperDSPKernel&>(*m_kernels[i]).process(source->channel(i)->span().data(), destination->channel(i)->mutableSpan().data(), framesToProcess);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/AudioArray.h
+++ b/Source/WebCore/platform/audio/AudioArray.h
@@ -33,6 +33,7 @@
 #include <string.h>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/FastMalloc.h>
+#include <wtf/StdLibExtras.h>
 
 namespace WebCore {
 
@@ -73,10 +74,8 @@ public:
         zero();
     }
 
-    std::span<T> span() { return { data(), size() }; }
-    std::span<const T> span() const { return { data(), size() }; }
-    T* data() { return m_allocation; }
-    const T* data() const { return m_allocation; }
+    std::span<T> mutableSpan() { return { m_allocation, size() }; }
+    std::span<const T> span() const { return { m_allocation, size() }; }
     size_t size() const { return m_size; }
     bool isEmpty() const { return !m_size; }
 
@@ -84,16 +83,14 @@ public:
     {
         // Note that although it is a size_t, m_size is now guaranteed to be
         // no greater than max unsigned. This guarantee is enforced in resize().
-        ASSERT_WITH_SECURITY_IMPLICATION(i < size());
-        return data()[i];
+        return mutableSpan()[i];
     }
 
     const T& at(size_t i) const
     {
         // Note that although it is a size_t, m_size is now guaranteed to be
         // no greater than max unsigned. This guarantee is enforced in resize().
-        RELEASE_ASSERT(i < size());
-        return data()[i];
+        return span()[i];
     }
 
     T& operator[](size_t i) { return at(i); }
@@ -102,7 +99,7 @@ public:
     void zero()
     {
         // This multiplication is made safe by the check in resize().
-        memset(this->data(), 0, sizeof(T) * this->size());
+        memsetSpan(mutableSpan(), 0);
     }
 
     void zeroRange(unsigned start, unsigned end)
@@ -114,7 +111,7 @@ public:
 
         // This expression cannot overflow because end - start cannot be
         // greater than m_size, which is safe due to the check in resize().
-        memset(this->data() + start, 0, sizeof(T) * (end - start));
+        memsetSpan(mutableSpan().subspan(start, end - start), 0);
     }
 
     void copyToRange(const T* sourceData, unsigned start, unsigned end)
@@ -126,16 +123,16 @@ public:
 
         // This expression cannot overflow because end - start cannot be
         // greater than m_size, which is safe due to the check in resize().
-        memcpy(this->data() + start, sourceData, sizeof(T) * (end - start));
+        memcpySpan(mutableSpan().subspan(start, end - start), std::span { sourceData, end - start });
     }
 
     bool containsConstantValue() const
     {
         if (m_size <= 1)
             return true;
-        float constant = data()[0];
-        for (unsigned i = 1; i < m_size; ++i) {
-            if (data()[i] != constant)
+        float constant = span().front();
+        for (auto value : span().subspan(1)) {
+            if (value != constant)
                 return false;
         }
         return true;

--- a/Source/WebCore/platform/audio/AudioBus.cpp
+++ b/Source/WebCore/platform/audio/AudioBus.cpp
@@ -309,21 +309,21 @@ void AudioBus::speakersSumFromByDownMixing(const AudioBus& sourceBus)
         // Handle stereo -> mono case. output += 0.5 * (input.L + input.R).
         AudioBus& sourceBusSafe = const_cast<AudioBus&>(sourceBus);
 
-        const float* sourceL = sourceBusSafe.channelByType(ChannelLeft)->data();
-        const float* sourceR = sourceBusSafe.channelByType(ChannelRight)->data();
+        const float* sourceL = sourceBusSafe.channelByType(ChannelLeft)->span().data();
+        const float* sourceR = sourceBusSafe.channelByType(ChannelRight)->span().data();
 
-        float* destination = channelByType(ChannelLeft)->mutableData();
+        float* destination = channelByType(ChannelLeft)->mutableSpan().data();
         VectorMath::multiplyByScalarThenAddToOutput(sourceL, 0.5, destination, length());
         VectorMath::multiplyByScalarThenAddToOutput(sourceR, 0.5, destination, length());
     } else if (numberOfSourceChannels == 4 && numberOfDestinationChannels == 1) {
         // Down-mixing: 4 -> 1
         // output = 0.25 * (input.L + input.R + input.SL + input.SR)
-        auto* sourceL = sourceBus.channelByType(ChannelLeft)->data();
-        auto* sourceR = sourceBus.channelByType(ChannelRight)->data();
-        auto* sourceSL = sourceBus.channelByType(ChannelSurroundLeft)->data();
-        auto* sourceSR = sourceBus.channelByType(ChannelSurroundRight)->data();
+        auto* sourceL = sourceBus.channelByType(ChannelLeft)->span().data();
+        auto* sourceR = sourceBus.channelByType(ChannelRight)->span().data();
+        auto* sourceSL = sourceBus.channelByType(ChannelSurroundLeft)->span().data();
+        auto* sourceSR = sourceBus.channelByType(ChannelSurroundRight)->span().data();
 
-        auto* destination = channelByType(ChannelLeft)->mutableData();
+        auto* destination = channelByType(ChannelLeft)->mutableSpan().data();
 
         VectorMath::multiplyByScalarThenAddToOutput(sourceL, 0.25, destination, length());
         VectorMath::multiplyByScalarThenAddToOutput(sourceR, 0.25, destination, length());
@@ -332,13 +332,13 @@ void AudioBus::speakersSumFromByDownMixing(const AudioBus& sourceBus)
     } else if (numberOfSourceChannels == 6 && numberOfDestinationChannels == 1) {
         // Down-mixing: 5.1 -> 1
         // output = sqrt(1/2) * (input.L + input.R) + input.C + 0.5 * (input.SL + input.SR)
-        auto* sourceL = sourceBus.channelByType(ChannelLeft)->data();
-        auto* sourceR = sourceBus.channelByType(ChannelRight)->data();
-        auto* sourceC = sourceBus.channelByType(ChannelCenter)->data();
-        auto* sourceSL = sourceBus.channelByType(ChannelSurroundLeft)->data();
-        auto* sourceSR = sourceBus.channelByType(ChannelSurroundRight)->data();
+        auto* sourceL = sourceBus.channelByType(ChannelLeft)->span().data();
+        auto* sourceR = sourceBus.channelByType(ChannelRight)->span().data();
+        auto* sourceC = sourceBus.channelByType(ChannelCenter)->span().data();
+        auto* sourceSL = sourceBus.channelByType(ChannelSurroundLeft)->span().data();
+        auto* sourceSR = sourceBus.channelByType(ChannelSurroundRight)->span().data();
 
-        auto* destination = channelByType(ChannelLeft)->mutableData();
+        auto* destination = channelByType(ChannelLeft)->mutableSpan().data();
         float scaleSqrtHalf = sqrtf(0.5);
 
         VectorMath::multiplyByScalarThenAddToOutput(sourceL, scaleSqrtHalf, destination, length());
@@ -350,13 +350,13 @@ void AudioBus::speakersSumFromByDownMixing(const AudioBus& sourceBus)
         // Down-mixing: 4 -> 2
         // output.L = 0.5 * (input.L + input.SL)
         // output.R = 0.5 * (input.R + input.SR)
-        auto* sourceL = sourceBus.channelByType(ChannelLeft)->data();
-        auto* sourceR = sourceBus.channelByType(ChannelRight)->data();
-        auto* sourceSL = sourceBus.channelByType(ChannelSurroundLeft)->data();
-        auto* sourceSR = sourceBus.channelByType(ChannelSurroundRight)->data();
+        auto* sourceL = sourceBus.channelByType(ChannelLeft)->span().data();
+        auto* sourceR = sourceBus.channelByType(ChannelRight)->span().data();
+        auto* sourceSL = sourceBus.channelByType(ChannelSurroundLeft)->span().data();
+        auto* sourceSR = sourceBus.channelByType(ChannelSurroundRight)->span().data();
 
-        auto* destinationL = channelByType(ChannelLeft)->mutableData();
-        auto* destinationR = channelByType(ChannelRight)->mutableData();
+        auto* destinationL = channelByType(ChannelLeft)->mutableSpan().data();
+        auto* destinationR = channelByType(ChannelRight)->mutableSpan().data();
 
         VectorMath::multiplyByScalarThenAddToOutput(sourceL, 0.5, destinationL, length());
         VectorMath::multiplyByScalarThenAddToOutput(sourceSL, 0.5, destinationL, length());
@@ -366,14 +366,14 @@ void AudioBus::speakersSumFromByDownMixing(const AudioBus& sourceBus)
         // Down-mixing: 5.1 -> 2
         // output.L = input.L + sqrt(1/2) * (input.C + input.SL)
         // output.R = input.R + sqrt(1/2) * (input.C + input.SR)
-        auto* sourceL = sourceBus.channelByType(ChannelLeft)->data();
-        auto* sourceR = sourceBus.channelByType(ChannelRight)->data();
-        auto* sourceC = sourceBus.channelByType(ChannelCenter)->data();
-        auto* sourceSL = sourceBus.channelByType(ChannelSurroundLeft)->data();
-        auto* sourceSR = sourceBus.channelByType(ChannelSurroundRight)->data();
+        auto* sourceL = sourceBus.channelByType(ChannelLeft)->span().data();
+        auto* sourceR = sourceBus.channelByType(ChannelRight)->span().data();
+        auto* sourceC = sourceBus.channelByType(ChannelCenter)->span().data();
+        auto* sourceSL = sourceBus.channelByType(ChannelSurroundLeft)->span().data();
+        auto* sourceSR = sourceBus.channelByType(ChannelSurroundRight)->span().data();
 
-        float* destinationL = channelByType(ChannelLeft)->mutableData();
-        float* destinationR = channelByType(ChannelRight)->mutableData();
+        float* destinationL = channelByType(ChannelLeft)->mutableSpan().data();
+        float* destinationR = channelByType(ChannelRight)->mutableSpan().data();
         float scaleSqrtHalf = sqrtf(0.5);
 
         VectorMath::add(sourceL, destinationL, destinationL, length());
@@ -388,12 +388,12 @@ void AudioBus::speakersSumFromByDownMixing(const AudioBus& sourceBus)
         // output.R = input.R + sqrt(1/2) * input.C
         // output.SL = input.SL
         // output.SR = input.SR
-        auto* sourceL = sourceBus.channelByType(ChannelLeft)->data();
-        auto* sourceR = sourceBus.channelByType(ChannelRight)->data();
-        auto* sourceC = sourceBus.channelByType(ChannelCenter)->data();
+        auto* sourceL = sourceBus.channelByType(ChannelLeft)->span().data();
+        auto* sourceR = sourceBus.channelByType(ChannelRight)->span().data();
+        auto* sourceC = sourceBus.channelByType(ChannelCenter)->span().data();
 
-        auto* destinationL = channelByType(ChannelLeft)->mutableData();
-        auto* destinationR = channelByType(ChannelRight)->mutableData();
+        auto* destinationL = channelByType(ChannelLeft)->mutableSpan().data();
+        auto* destinationR = channelByType(ChannelRight)->mutableSpan().data();
         auto scaleSqrtHalf = sqrtf(0.5);
 
         VectorMath::add(sourceL, destinationL, destinationL, length());
@@ -451,8 +451,8 @@ void AudioBus::copyWithGainFrom(const AudioBus& sourceBus, float gain)
     float* destinations[MaxBusChannels];
 
     for (unsigned i = 0; i < numberOfChannels; ++i) {
-        sources[i] = sourceBusSafe.channel(i)->data();
-        destinations[i] = channel(i)->mutableData();
+        sources[i] = sourceBusSafe.channel(i)->span().data();
+        destinations[i] = channel(i)->mutableSpan().data();
     }
 
     unsigned framesToProcess = length();
@@ -490,11 +490,11 @@ void AudioBus::copyWithSampleAccurateGainValuesFrom(const AudioBus &sourceBus, f
     }
 
     // We handle both the 1 -> N and N -> N case here.
-    const float* source = sourceBus.channel(0)->data();
+    const float* source = sourceBus.channel(0)->span().data();
     for (unsigned channelIndex = 0; channelIndex < numberOfChannels(); ++channelIndex) {
         if (sourceBus.numberOfChannels() == numberOfChannels())
-            source = sourceBus.channel(channelIndex)->data();
-        float* destination = channel(channelIndex)->mutableData();
+            source = sourceBus.channel(channelIndex)->span().data();
+        float* destination = channel(channelIndex)->mutableSpan().data();
         VectorMath::multiply(source, gainValues, destination, numberOfGainValues);
     }
 }
@@ -574,9 +574,9 @@ RefPtr<AudioBus> AudioBus::createByMixingToMono(const AudioBus* sourceBus)
             unsigned n = sourceBus->length();
             RefPtr<AudioBus> destinationBus = create(1, n);
 
-            const float* sourceL = sourceBus->channel(0)->data();
-            const float* sourceR = sourceBus->channel(1)->data();
-            float* destination = destinationBus->channel(0)->mutableData();
+            const float* sourceL = sourceBus->channel(0)->span().data();
+            const float* sourceR = sourceBus->channel(1)->span().data();
+            float* destination = destinationBus->channel(0)->mutableSpan().data();
         
             // Do the mono mixdown.
             VectorMath::addVectorsThenMultiplyByScalar(sourceL, sourceR, 0.5, destination, n);

--- a/Source/WebCore/platform/audio/AudioDSPKernelProcessor.cpp
+++ b/Source/WebCore/platform/audio/AudioDSPKernelProcessor.cpp
@@ -91,7 +91,7 @@ void AudioDSPKernelProcessor::process(const AudioBus* source, AudioBus* destinat
         return;
         
     for (unsigned i = 0; i < m_kernels.size(); ++i)
-        m_kernels[i]->process(source->channel(i)->data(), destination->channel(i)->mutableData(), framesToProcess);
+        m_kernels[i]->process(source->channel(i)->span().data(), destination->channel(i)->mutableSpan().data(), framesToProcess);
 }
 
 void AudioDSPKernelProcessor::processOnlyAudioParams(size_t framesToProcess)

--- a/Source/WebCore/platform/audio/AudioResampler.cpp
+++ b/Source/WebCore/platform/audio/AudioResampler.cpp
@@ -98,7 +98,7 @@ void AudioResampler::process(AudioSourceProvider* provider, AudioBus* destinatio
     // Now that we have the source data, resample each channel into the destination bus.
     // FIXME: optimize for the common stereo case where it's faster to process both left/right channels in the same inner loop.
     for (unsigned i = 0; i < numberOfChannels; ++i) {
-        float* destination = destinationBus->channel(i)->mutableData();
+        float* destination = destinationBus->channel(i)->mutableSpan().data();
         m_kernels[i]->process(destination, framesToProcess);
     }
 }

--- a/Source/WebCore/platform/audio/AudioResamplerKernel.cpp
+++ b/Source/WebCore/platform/audio/AudioResamplerKernel.cpp
@@ -65,14 +65,14 @@ float* AudioResamplerKernel::getSourcePointer(size_t framesToProcess, size_t* nu
     if (!isGood)
         return 0;
 
-    return m_sourceBuffer.data() + m_fillIndex;
+    return m_sourceBuffer.mutableSpan().subspan(m_fillIndex).data();
 }
 
 void AudioResamplerKernel::process(float* destination, size_t framesToProcess)
 {
     ASSERT(framesToProcess <= AudioUtilities::renderQuantumSize);
 
-    float* source = m_sourceBuffer.data();
+    float* source = m_sourceBuffer.mutableSpan().data();
     
     double rate = this->rate();
     rate = std::max(0.0, rate);

--- a/Source/WebCore/platform/audio/Biquad.cpp
+++ b/Source/WebCore/platform/audio/Biquad.cpp
@@ -82,11 +82,11 @@ void Biquad::process(const float* sourceP, float* destP, size_t framesToProcess)
         double y1 = m_y1;
         double y2 = m_y2;
 
-        auto* b0 = m_b0.data();
-        auto* b1 = m_b1.data();
-        auto* b2 = m_b2.data();
-        auto* a1 = m_a1.data();
-        auto* a2 = m_a2.data();
+        auto b0 = m_b0.span();
+        auto b1 = m_b1.span();
+        auto b2 = m_b2.span();
+        auto a1 = m_a1.span();
+        auto a2 = m_a2.span();
 
         for (size_t k = 0; k < n; ++k) {
             // FIXME: this can be optimized by pipelining the multiply adds...
@@ -121,8 +121,8 @@ void Biquad::process(const float* sourceP, float* destP, size_t framesToProcess)
     }
 
 #if USE(ACCELERATE)
-    auto* inputP = m_inputBuffer.data();
-    auto* outputP = m_outputBuffer.data();
+    auto inputP = m_inputBuffer.mutableSpan();
+    auto outputP = m_outputBuffer.mutableSpan();
 
     // Set up filter state. This is needed in case we're switching from
     // filtering with variable coefficients (i.e., with automations) to
@@ -198,8 +198,8 @@ void Biquad::processFast(const float* sourceP, float* destP, size_t framesToProc
     filterCoefficients[3] = m_a1[0];
     filterCoefficients[4] = m_a2[0];
 
-    double* inputP = m_inputBuffer.data();
-    double* outputP = m_outputBuffer.data();
+    double* inputP = m_inputBuffer.mutableSpan().data();
+    double* outputP = m_outputBuffer.mutableSpan().data();
 
     double* input2P = inputP + 2;
     double* output2P = outputP + 2;
@@ -246,11 +246,11 @@ void Biquad::reset()
 {
 #if USE(ACCELERATE)
     // Two extra samples for filter history
-    double* inputP = m_inputBuffer.data();
+    auto inputP = m_inputBuffer.mutableSpan();
     inputP[0] = 0;
     inputP[1] = 0;
 
-    double* outputP = m_outputBuffer.data();
+    auto outputP = m_outputBuffer.mutableSpan();
     outputP[0] = 0;
     outputP[1] = 0;
 #endif

--- a/Source/WebCore/platform/audio/DirectConvolver.cpp
+++ b/Source/WebCore/platform/audio/DirectConvolver.cpp
@@ -58,15 +58,15 @@ void DirectConvolver::process(AudioFloatArray* convolutionKernel, const float* s
     if (kernelSize > m_inputBlockSize)
         return;
 
-    float* kernelP = convolutionKernel->data();
+    float* kernelP = convolutionKernel->mutableSpan().data();
 
     // Sanity check
-    bool isCopyGood = kernelP && sourceP && destP && m_buffer.data();
+    bool isCopyGood = kernelP && sourceP && destP && m_buffer.span().data();
     ASSERT(isCopyGood);
     if (!isCopyGood)
         return;
 
-    float* inputP = m_buffer.data() + m_inputBlockSize;
+    float* inputP = m_buffer.mutableSpan().subspan(m_inputBlockSize).data();
 
     // Copy samples to 2nd half of input buffer.
     memcpy(inputP, sourceP, sizeof(float) * framesToProcess);
@@ -346,7 +346,7 @@ void DirectConvolver::process(AudioFloatArray* convolutionKernel, const float* s
 #endif // USE(ACCELERATE)
 
     // Copy 2nd half of input buffer to 1st half.
-    memcpy(m_buffer.data(), inputP, sizeof(float) * framesToProcess);
+    memcpy(m_buffer.mutableSpan().data(), inputP, sizeof(float) * framesToProcess);
 }
 
 void DirectConvolver::reset()

--- a/Source/WebCore/platform/audio/DownSampler.cpp
+++ b/Source/WebCore/platform/audio/DownSampler.cpp
@@ -106,12 +106,12 @@ void DownSampler::process(const float* sourceP, float* destP, size_t sourceFrame
     if (!isInputBufferGood)
         return;
 
-    float* inputP = m_inputBuffer.data() + sourceFramesToProcess;
+    float* inputP = m_inputBuffer.mutableSpan().subspan(sourceFramesToProcess).data();
     memcpy(inputP, sourceP, sizeof(float) * sourceFramesToProcess);
 
     // Copy the odd sample-frames from sourceP, delayed by one sample-frame (destination sample-rate)
     // to match shifting forward in time in m_reducedKernel.
-    float* oddSamplesP = m_tempBuffer.data();
+    float* oddSamplesP = m_tempBuffer.mutableSpan().data();
     for (unsigned i = 0; i < destFramesToProcess; ++i)
         oddSamplesP[i] = *((inputP - 1) + i * 2);
 
@@ -128,7 +128,7 @@ void DownSampler::process(const float* sourceP, float* destP, size_t sourceFrame
         destP[i] += 0.5 * *((inputP - halfSize) + i * 2);
 
     // Copy 2nd half of input buffer to 1st half.
-    memcpy(m_inputBuffer.data(), inputP, sizeof(float) * sourceFramesToProcess);
+    memcpy(m_inputBuffer.mutableSpan().data(), inputP, sizeof(float) * sourceFramesToProcess);
 }
 
 void DownSampler::reset()

--- a/Source/WebCore/platform/audio/DynamicsCompressor.cpp
+++ b/Source/WebCore/platform/audio/DynamicsCompressor.cpp
@@ -105,10 +105,10 @@ void DynamicsCompressor::process(const AudioBus* sourceBus, AudioBus* destinatio
 
     switch (numberOfChannels) {
     case 2: // stereo
-        m_sourceChannels[0] = sourceBus->channel(0)->data();
+        m_sourceChannels[0] = sourceBus->channel(0)->span().data();
 
         if (numberOfSourceChannels > 1)
-            m_sourceChannels[1] = sourceBus->channel(1)->data();
+            m_sourceChannels[1] = sourceBus->channel(1)->span().data();
         else
             // Simply duplicate mono channel input data to right channel for stereo processing.
             m_sourceChannels[1] = m_sourceChannels[0];
@@ -122,7 +122,7 @@ void DynamicsCompressor::process(const AudioBus* sourceBus, AudioBus* destinatio
     }
 
     for (unsigned i = 0; i < numberOfChannels; ++i)
-        m_destinationChannels[i] = destinationBus->channel(i)->mutableData();
+        m_destinationChannels[i] = destinationBus->channel(i)->mutableSpan().data();
 
     float dbThreshold = parameterValue(ParamThreshold);
     float dbKnee = parameterValue(ParamKnee);

--- a/Source/WebCore/platform/audio/DynamicsCompressorKernel.cpp
+++ b/Source/WebCore/platform/audio/DynamicsCompressorKernel.cpp
@@ -358,7 +358,7 @@ void DynamicsCompressorKernel::process(const float* sourceChannels[],
 
                 // Predelay signal, computing compression amount from un-delayed version.
                 for (unsigned i = 0; i < numberOfChannels; ++i) {
-                    float* delayBuffer = m_preDelayBuffers[i]->data();
+                    float* delayBuffer = m_preDelayBuffers[i]->mutableSpan().data();
                     float undelayedSource = sourceChannels[i][frameIndex];
                     delayBuffer[preDelayWriteIndex] = undelayedSource;
 
@@ -424,7 +424,7 @@ void DynamicsCompressorKernel::process(const float* sourceChannels[],
 
                 // Apply final gain.
                 for (unsigned i = 0; i < numberOfChannels; ++i) {
-                    float* delayBuffer = m_preDelayBuffers[i]->data();
+                    float* delayBuffer = m_preDelayBuffers[i]->mutableSpan().data();
                     destinationChannels[i][frameIndex] = delayBuffer[preDelayReadIndex] * totalGain;
                 }
 

--- a/Source/WebCore/platform/audio/EqualPowerPanner.cpp
+++ b/Source/WebCore/platform/audio/EqualPowerPanner.cpp
@@ -91,10 +91,10 @@ void EqualPowerPanner::pan(double azimuth, double /*elevation*/, const AudioBus*
     if (!isOutputSafe)
         return;
 
-    const float* sourceL = inputBus->channel(0)->data();                               
-    const float* sourceR = numberOfInputChannels > 1 ? inputBus->channel(1)->data() : sourceL;
-    float* destinationL = outputBus->channelByType(AudioBus::ChannelLeft)->mutableData();
-    float* destinationR = outputBus->channelByType(AudioBus::ChannelRight)->mutableData();
+    const float* sourceL = inputBus->channel(0)->span().data();
+    const float* sourceR = numberOfInputChannels > 1 ? inputBus->channel(1)->span().data() : sourceL;
+    float* destinationL = outputBus->channelByType(AudioBus::ChannelLeft)->mutableSpan().data();
+    float* destinationR = outputBus->channelByType(AudioBus::ChannelRight)->mutableSpan().data();
     
     if (!sourceL || !sourceR || !destinationL || !destinationR)
         return;
@@ -156,10 +156,10 @@ void EqualPowerPanner::panWithSampleAccurateValues(double* azimuth, double*, con
     ASSERT(outputBus->numberOfChannels() == 2u);
     ASSERT(framesToProcess <= outputBus->length());
 
-    const float* sourceL = inputBus->channel(0)->data();
-    const float* sourceR = numberOfInputChannels > 1 ? inputBus->channel(1)->data() : sourceL;
-    float* destinationL = outputBus->channelByType(AudioBus::ChannelLeft)->mutableData();
-    float* destinationR = outputBus->channelByType(AudioBus::ChannelRight)->mutableData();
+    const float* sourceL = inputBus->channel(0)->span().data();
+    const float* sourceR = numberOfInputChannels > 1 ? inputBus->channel(1)->span().data() : sourceL;
+    float* destinationL = outputBus->channelByType(AudioBus::ChannelLeft)->mutableSpan().data();
+    float* destinationR = outputBus->channelByType(AudioBus::ChannelRight)->mutableSpan().data();
 
     ASSERT(sourceL);
     ASSERT(sourceR);

--- a/Source/WebCore/platform/audio/FFTFrame.cpp
+++ b/Source/WebCore/platform/audio/FFTFrame.cpp
@@ -50,7 +50,7 @@ void FFTFrame::doPaddedFFT(const float* data, size_t dataSize)
     paddedResponse.copyToRange(data, 0, dataSize);
 
     // Get the frequency-domain version of padded response
-    doFFT(paddedResponse.data());
+    doFFT(paddedResponse.span().data());
 }
 
 std::unique_ptr<FFTFrame> FFTFrame::createInterpolatedFrame(const FFTFrame& frame1, const FFTFrame& frame2, double x)
@@ -62,11 +62,11 @@ std::unique_ptr<FFTFrame> FFTFrame::createInterpolatedFrame(const FFTFrame& fram
     // In the time-domain, the 2nd half of the response must be zero, to avoid circular convolution aliasing...
     int fftSize = newFrame->fftSize();
     AudioFloatArray buffer(fftSize);
-    newFrame->doInverseFFT(buffer.data());
+    newFrame->doInverseFFT(buffer.mutableSpan().data());
     buffer.zeroRange(fftSize / 2, fftSize);
 
     // Put back into frequency domain.
-    newFrame->doFFT(buffer.data());
+    newFrame->doFFT(buffer.span().data());
 
     return newFrame;
 }
@@ -175,8 +175,8 @@ void FFTFrame::interpolateFrequencyComponents(const FFTFrame& frame1, const FFTF
 
 void FFTFrame::scaleFFT(float factor)
 {
-    VectorMath::multiplyByScalar(realData().data(), factor, realData().data(), realData().size());
-    VectorMath::multiplyByScalar(imagData().data(), factor, imagData().data(), realData().size());
+    VectorMath::multiplyByScalar(realData().span().data(), factor, realData().mutableSpan().data(), realData().size());
+    VectorMath::multiplyByScalar(imagData().span().data(), factor, imagData().mutableSpan().data(), realData().size());
 }
 
 void FFTFrame::multiply(const FFTFrame& frame)
@@ -200,7 +200,7 @@ void FFTFrame::multiply(const FFTFrame& frame)
     float imag0 = imagP1[0];
 
     // Complex multiply
-    VectorMath::multiplyComplex(realP1.data(), imagP1.data(), realP2.data(), imagP2.data(), realP1.data(), imagP1.data(), halfSize);
+    VectorMath::multiplyComplex(realP1.span().data(), imagP1.span().data(), realP2.span().data(), imagP2.span().data(), realP1.mutableSpan().data(), imagP1.mutableSpan().data(), halfSize);
 
     // Multiply the packed DC/nyquist component
     realP1[0] = real0 * realP2[0];

--- a/Source/WebCore/platform/audio/HRTFKernel.cpp
+++ b/Source/WebCore/platform/audio/HRTFKernel.cpp
@@ -48,7 +48,7 @@ static float extractAverageGroupDelay(AudioChannel* channel, size_t analysisFFTS
 {
     ASSERT(channel);
         
-    float* impulseP = channel->mutableData();
+    float* impulseP = channel->mutableSpan().data();
     
     bool isSizeGood = channel->length() >= analysisFFTSize;
     ASSERT(isSizeGood);
@@ -75,7 +75,7 @@ HRTFKernel::HRTFKernel(AudioChannel* channel, size_t fftSize, float sampleRate)
     // Determine the leading delay (average group delay) for the response.
     m_frameDelay = extractAverageGroupDelay(channel, fftSize / 2);
 
-    float* impulseResponse = channel->mutableData();
+    float* impulseResponse = channel->mutableSpan().data();
     size_t responseLength = channel->length();
 
     // We need to truncate to fit into 1/2 the FFT size (with zero padding) in order to do proper convolution.
@@ -107,7 +107,7 @@ std::unique_ptr<AudioChannel> HRTFKernel::createImpulseResponse()
 
     // Add leading delay back in.
     fftFrame.addConstantGroupDelay(m_frameDelay);
-    fftFrame.doInverseFFT(channel->mutableData());
+    fftFrame.doInverseFFT(channel->mutableSpan().data());
 
     return channel;
 }

--- a/Source/WebCore/platform/audio/HRTFPanner.cpp
+++ b/Source/WebCore/platform/audio/HRTFPanner.cpp
@@ -168,10 +168,10 @@ void HRTFPanner::pan(double desiredAzimuth, double elevation, const AudioBus* in
     const AudioChannel* inputChannelR = numInputChannels > 1 ? inputBus->channelByType(AudioBus::ChannelRight) : 0;
 
     // Get source and destination pointers.
-    const float* sourceL = inputChannelL->data();
-    const float* sourceR = numInputChannels > 1 ? inputChannelR->data() : sourceL;
-    float* destinationL = outputBus->channelByType(AudioBus::ChannelLeft)->mutableData();
-    float* destinationR = outputBus->channelByType(AudioBus::ChannelRight)->mutableData();
+    const float* sourceL = inputChannelL->span().data();
+    const float* sourceR = numInputChannels > 1 ? inputChannelR->span().data() : sourceL;
+    float* destinationL = outputBus->channelByType(AudioBus::ChannelLeft)->mutableSpan().data();
+    float* destinationR = outputBus->channelByType(AudioBus::ChannelRight)->mutableSpan().data();
 
     double azimuthBlend;
     int desiredAzimuthIndex = calculateDesiredAzimuthIndexAndBlend(azimuth, azimuthBlend);
@@ -259,10 +259,10 @@ void HRTFPanner::pan(double desiredAzimuth, double elevation, const AudioBus* in
         bool needsCrossfading = m_crossfadeIncr;
         
         // Have the convolvers render directly to the final destination if we're not cross-fading.
-        float* convolutionDestinationL1 = needsCrossfading ? m_tempL1.data() : segmentDestinationL;
-        float* convolutionDestinationR1 = needsCrossfading ? m_tempR1.data() : segmentDestinationR;
-        float* convolutionDestinationL2 = needsCrossfading ? m_tempL2.data() : segmentDestinationL;
-        float* convolutionDestinationR2 = needsCrossfading ? m_tempR2.data() : segmentDestinationR;
+        float* convolutionDestinationL1 = needsCrossfading ? m_tempL1.mutableSpan().data() : segmentDestinationL;
+        float* convolutionDestinationR1 = needsCrossfading ? m_tempR1.mutableSpan().data() : segmentDestinationR;
+        float* convolutionDestinationL2 = needsCrossfading ? m_tempL2.mutableSpan().data() : segmentDestinationL;
+        float* convolutionDestinationR2 = needsCrossfading ? m_tempR2.mutableSpan().data() : segmentDestinationR;
 
         // Now do the convolutions.
         // Note that we avoid doing convolutions on both sets of convolvers if we're not currently cross-fading.

--- a/Source/WebCore/platform/audio/IIRFilter.cpp
+++ b/Source/WebCore/platform/audio/IIRFilter.cpp
@@ -201,16 +201,16 @@ double IIRFilter::tailTime(double sampleRate, bool isFilterStable)
     input[0] = 1;
 
     // Process the first block and get the max magnitude of the output.
-    process(input.data(), output.data(), AudioUtilities::renderQuantumSize);
-    magnitudes[0] = VectorMath::maximumMagnitude(output.data(), AudioUtilities::renderQuantumSize);
+    process(input.span().data(), output.mutableSpan().data(), AudioUtilities::renderQuantumSize);
+    magnitudes[0] = VectorMath::maximumMagnitude(output.span().data(), AudioUtilities::renderQuantumSize);
 
     // Process the rest of the signal, getting the max magnitude of the
     // output for each block.
     input[0] = 0;
 
     for (int k = 1; k < numberOfBlocks; ++k) {
-        process(input.data(), output.data(), AudioUtilities::renderQuantumSize);
-        magnitudes[k] = VectorMath::maximumMagnitude(output.data(), AudioUtilities::renderQuantumSize);
+        process(input.span().data(), output.mutableSpan().data(), AudioUtilities::renderQuantumSize);
+        magnitudes[k] = VectorMath::maximumMagnitude(output.span().data(), AudioUtilities::renderQuantumSize);
     }
 
     // Done computing the impulse response; reset the state so the actual node

--- a/Source/WebCore/platform/audio/MultiChannelResampler.cpp
+++ b/Source/WebCore/platform/audio/MultiChannelResampler.cpp
@@ -50,7 +50,7 @@ MultiChannelResampler::MultiChannelResampler(double scaleFactor, unsigned number
         m_channelsMemory = Vector<std::unique_ptr<AudioFloatArray>>(numberOfChannels - 1, [&](size_t i) {
             size_t channelIndex = i + 1;
             auto floatArray = makeUnique<AudioFloatArray>(requestFrames);
-            m_multiChannelBus->setChannelMemory(channelIndex, floatArray->data(), requestFrames);
+            m_multiChannelBus->setChannelMemory(channelIndex, floatArray->mutableSpan().data(), requestFrames);
             return floatArray;
         });
     }

--- a/Source/WebCore/platform/audio/PushPullFIFO.cpp
+++ b/Source/WebCore/platform/audio/PushPullFIFO.cpp
@@ -52,8 +52,8 @@ void PushPullFIFO::push(const AudioBus* inputBus)
     const size_t remainder = m_fifoLength - m_indexWrite;
 
     for (unsigned i = 0; i < m_fifoBus->numberOfChannels(); ++i) {
-        float* fifoBusChannel = m_fifoBus->channel(i)->mutableData();
-        const float* inputBusChannel = inputBus->channel(i)->data();
+        float* fifoBusChannel = m_fifoBus->channel(i)->mutableSpan().data();
+        const float* inputBusChannel = inputBus->channel(i)->span().data();
         if (remainder >= inputBusLength) {
             // The remainder is big enough for the input data.
             memcpy(fifoBusChannel + m_indexWrite, inputBusChannel, inputBusLength * sizeof(*fifoBusChannel));
@@ -90,8 +90,8 @@ size_t PushPullFIFO::pull(AudioBus* outputBus, size_t framesRequested)
     const size_t framesToFill = std::min(m_framesAvailable, framesRequested);
 
     for (unsigned i = 0; i < m_fifoBus->numberOfChannels(); ++i) {
-        const float* fifoBusChannel = m_fifoBus->channel(i)->data();
-        float* outputBusChannel = outputBus->channel(i)->mutableData();
+        const float* fifoBusChannel = m_fifoBus->channel(i)->span().data();
+        float* outputBusChannel = outputBus->channel(i)->mutableSpan().data();
 
         // Fill up the output bus with the available frames first.
         if (remainder >= framesToFill) {

--- a/Source/WebCore/platform/audio/Reverb.cpp
+++ b/Source/WebCore/platform/audio/Reverb.cpp
@@ -57,7 +57,7 @@ static float calculateNormalizationScale(AudioBus* response)
     float power = 0;
 
     for (size_t i = 0; i < numberOfChannels; ++i)
-        power += VectorMath::sumOfSquares(response->channel(i)->data(), length);
+        power += VectorMath::sumOfSquares(response->channel(i)->span().data(), length);
 
     power = sqrt(power / (numberOfChannels * length));
 

--- a/Source/WebCore/platform/audio/ReverbAccumulationBuffer.cpp
+++ b/Source/WebCore/platform/audio/ReverbAccumulationBuffer.cpp
@@ -56,7 +56,7 @@ void ReverbAccumulationBuffer::readAndClear(float* destination, size_t numberOfF
     size_t numberOfFrames1 = std::min(numberOfFrames, framesAvailable);
     size_t numberOfFrames2 = numberOfFrames - numberOfFrames1;
 
-    float* source = m_buffer.data();
+    float* source = m_buffer.mutableSpan().data();
     memcpy(destination, source + m_readIndex, sizeof(float) * numberOfFrames1);
     memset(source + m_readIndex, 0, sizeof(float) * numberOfFrames1);
 
@@ -89,7 +89,7 @@ int ReverbAccumulationBuffer::accumulate(float* source, size_t numberOfFrames, i
     size_t numberOfFrames1 = std::min(numberOfFrames, framesAvailable);
     size_t numberOfFrames2 = numberOfFrames - numberOfFrames1;
 
-    float* destination = m_buffer.data();
+    float* destination = m_buffer.mutableSpan().data();
 
     bool isSafe = writeIndex <= bufferLength && numberOfFrames1 + writeIndex <= bufferLength && numberOfFrames2 <= bufferLength;
     ASSERT(isSafe);

--- a/Source/WebCore/platform/audio/ReverbConvolver.cpp
+++ b/Source/WebCore/platform/audio/ReverbConvolver.cpp
@@ -70,7 +70,7 @@ ReverbConvolver::ReverbConvolver(AudioChannel* impulseResponse, size_t renderSli
     // Otherwise, assume we're being run from a command-line tool.
     bool hasRealtimeConstraint = useBackgroundThreads;
 
-    const float* response = impulseResponse->data();
+    const float* response = impulseResponse->span().data();
     size_t totalResponseLength = impulseResponse->length();
 
     // The total latency is zero because the direct-convolution is used in the leading portion.
@@ -174,8 +174,8 @@ void ReverbConvolver::process(const AudioChannel* sourceChannel, AudioChannel* d
     if (!isSafe)
         return;
         
-    const float* source = sourceChannel->data();
-    float* destination = destinationChannel->mutableData();
+    const float* source = sourceChannel->span().data();
+    float* destination = destinationChannel->mutableSpan().data();
     bool isDataSafe = source && destination;
     ASSERT(isDataSafe);
     if (!isDataSafe)

--- a/Source/WebCore/platform/audio/ReverbConvolverStage.cpp
+++ b/Source/WebCore/platform/audio/ReverbConvolverStage.cpp
@@ -69,7 +69,7 @@ ReverbConvolverStage::ReverbConvolverStage(const float* impulseResponse, size_t,
         m_directKernel->copyToRange(impulseResponse, 0, stageLength);
         // Account for the normalization (if any) of the convolver node.
         if (scale != 1)
-            VectorMath::multiplyByScalar(m_directKernel->data(), scale, m_directKernel->data(), stageLength);
+            VectorMath::multiplyByScalar(m_directKernel->span().data(), scale, m_directKernel->mutableSpan().data(), stageLength);
         m_directConvolver = makeUnique<DirectConvolver>(renderSliceSize);
     }
 
@@ -130,14 +130,14 @@ void ReverbConvolverStage::process(const float* source, size_t framesToProcess)
 
         isTemporaryBufferSafe = framesToProcess <= m_temporaryBuffer.size();
 
-        preDelayedDestination = m_preDelayBuffer.data() + m_preReadWriteIndex;
+        preDelayedDestination = m_preDelayBuffer.mutableSpan().subspan(m_preReadWriteIndex).data();
         preDelayedSource = preDelayedDestination;
-        temporaryBuffer = m_temporaryBuffer.data();        
+        temporaryBuffer = m_temporaryBuffer.mutableSpan().data();
     } else {
         // Zero delay
         preDelayedDestination = 0;
         preDelayedSource = source;
-        temporaryBuffer = m_preDelayBuffer.data();
+        temporaryBuffer = m_preDelayBuffer.mutableSpan().data();
         
         isTemporaryBufferSafe = framesToProcess <= m_preDelayBuffer.size();
     }

--- a/Source/WebCore/platform/audio/ReverbInputBuffer.cpp
+++ b/Source/WebCore/platform/audio/ReverbInputBuffer.cpp
@@ -47,7 +47,7 @@ void ReverbInputBuffer::write(const float* sourceP, size_t numberOfFrames)
     if (!isCopySafe)
         return;
         
-    memcpy(m_buffer.data() + m_writeIndex, sourceP, sizeof(float) * numberOfFrames);
+    memcpy(m_buffer.mutableSpan().subspan(m_writeIndex).data(), sourceP, sizeof(float) * numberOfFrames);
 
     m_writeIndex += numberOfFrames;
     ASSERT(m_writeIndex <= bufferLength);
@@ -65,10 +65,10 @@ float* ReverbInputBuffer::directReadFrom(int* readIndex, size_t numberOfFrames)
         // Should never happen in practice but return pointer to start of buffer (avoid crash)
         if (readIndex)
             *readIndex = 0;
-        return m_buffer.data();
+        return m_buffer.mutableSpan().data();
     }
         
-    float* sourceP = m_buffer.data();
+    float* sourceP = m_buffer.mutableSpan().data();
     float* p = sourceP + *readIndex;
 
     // Update readIndex

--- a/Source/WebCore/platform/audio/SincResampler.cpp
+++ b/Source/WebCore/platform/audio/SincResampler.cpp
@@ -132,8 +132,8 @@ SincResampler::SincResampler(double scaleFactor, unsigned requestFrames, Functio
     , m_requestFrames(requestFrames)
     , m_provideInput(WTFMove(provideInput))
     , m_inputBuffer(m_requestFrames + kernelSize) // See input buffer layout above.
-    , m_r1(m_inputBuffer.data(), m_inputBuffer.size())
-    , m_r2(m_inputBuffer.span().subspan(kernelSize / 2))
+    , m_r1(m_inputBuffer.mutableSpan())
+    , m_r2(m_inputBuffer.mutableSpan().subspan(kernelSize / 2))
 {
     ASSERT(m_provideInput);
     ASSERT(m_requestFrames > 0);
@@ -146,14 +146,14 @@ void SincResampler::updateRegions(bool isSecondLoad)
 {
     // Setup various region pointers in the buffer (see diagram above). If we're
     // on the second load we need to slide m_r0 to the right by kernelSize / 2.
-    m_r0 = m_inputBuffer.span().subspan(isSecondLoad ? kernelSize : kernelSize / 2);
+    m_r0 = m_inputBuffer.mutableSpan().subspan(isSecondLoad ? kernelSize : kernelSize / 2);
     m_r3 = m_r0.subspan(m_requestFrames - kernelSize);
     m_r4 = m_r0.subspan(m_requestFrames - kernelSize / 2);
     m_blockSize = std::distance(m_r2.begin(), m_r4.begin());
     m_chunkSize = calculateChunkSize(m_blockSize, m_scaleFactor);
 
     // m_r1 at the beginning of the buffer.
-    ASSERT(m_r1.data() == m_inputBuffer.data());
+    ASSERT(m_r1.data() == m_inputBuffer.span().data());
     // m_r1 left of m_r2, m_r4 left of m_r3 and size correct.
     ASSERT(std::distance(m_r1.begin(), m_r2.begin()) == std::distance(m_r3.begin(), m_r4.begin()));
     // m_r2 left of r3.

--- a/Source/WebCore/platform/audio/StereoPanner.cpp
+++ b/Source/WebCore/platform/audio/StereoPanner.cpp
@@ -51,10 +51,10 @@ void panWithSampleAccurateValues(const AudioBus* inputBus, AudioBus* outputBus, 
     if (!isOutputSafe)
         return;
     
-    const float* sourceL = inputBus->channel(0)->data();
-    const float* sourceR = numberOfInputChannels > 1 ? inputBus->channel(1)->data() : sourceL;
-    float* destinationL = outputBus->channelByType(AudioBus::ChannelLeft)->mutableData();
-    float* destinationR = outputBus->channelByType(AudioBus::ChannelRight)->mutableData();
+    const float* sourceL = inputBus->channel(0)->span().data();
+    const float* sourceR = numberOfInputChannels > 1 ? inputBus->channel(1)->span().data() : sourceL;
+    float* destinationL = outputBus->channelByType(AudioBus::ChannelLeft)->mutableSpan().data();
+    float* destinationR = outputBus->channelByType(AudioBus::ChannelRight)->mutableSpan().data();
     
     if (!sourceL || !sourceR || !destinationL || !destinationR)
         return;
@@ -111,10 +111,10 @@ void panToTargetValue(const AudioBus* inputBus, AudioBus* outputBus, float panVa
     if (!isOutputSafe)
         return;
     
-    const float* sourceL = inputBus->channel(0)->data();
-    const float* sourceR = numberOfInputChannels > 1 ? inputBus->channel(1)->data() : sourceL;
-    float* destinationL = outputBus->channelByType(AudioBus::ChannelLeft)->mutableData();
-    float* destinationR = outputBus->channelByType(AudioBus::ChannelRight)->mutableData();
+    const float* sourceL = inputBus->channel(0)->span().data();
+    const float* sourceR = numberOfInputChannels > 1 ? inputBus->channel(1)->span().data() : sourceL;
+    float* destinationL = outputBus->channelByType(AudioBus::ChannelLeft)->mutableSpan().data();
+    float* destinationR = outputBus->channelByType(AudioBus::ChannelRight)->mutableSpan().data();
     
     if (!sourceL || !sourceR || !destinationL || !destinationR)
         return;

--- a/Source/WebCore/platform/audio/UpSampler.cpp
+++ b/Source/WebCore/platform/audio/UpSampler.cpp
@@ -97,7 +97,7 @@ void UpSampler::process(const float* sourceP, float* destP, size_t sourceFramesT
     if (!isInputBufferGood)
         return;
 
-    float* inputP = m_inputBuffer.data() + sourceFramesToProcess;
+    float* inputP = m_inputBuffer.mutableSpan().subspan(sourceFramesToProcess).data();
     memcpy(inputP, sourceP, sizeof(float) * sourceFramesToProcess);
 
     // Copy even sample-frames 0,2,4,6... (delayed by the linear phase delay) directly into destP.
@@ -105,14 +105,14 @@ void UpSampler::process(const float* sourceP, float* destP, size_t sourceFramesT
         destP[i * 2] = *((inputP - halfSize) + i);
 
     // Compute odd sample-frames 1,3,5,7...
-    float* oddSamplesP = m_tempBuffer.data();
+    float* oddSamplesP = m_tempBuffer.mutableSpan().data();
     m_convolver.process(&m_kernel, sourceP, oddSamplesP, sourceFramesToProcess);
 
     for (unsigned i = 0; i < sourceFramesToProcess; ++i)
         destP[i * 2 + 1] = oddSamplesP[i];
 
     // Copy 2nd half of input buffer to 1st half.
-    memcpy(m_inputBuffer.data(), inputP, sizeof(float) * sourceFramesToProcess);
+    memcpy(m_inputBuffer.mutableSpan().data(), inputP, sizeof(float) * sourceFramesToProcess);
 }
 
 void UpSampler::reset()

--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
@@ -577,11 +577,11 @@ RefPtr<AudioBus> AudioFileReader::createBus(float sampleRate, bool mixToMono)
 
         bufferList->mBuffers[0].mNumberChannels = 1;
         bufferList->mBuffers[0].mDataByteSize = bufferSize;
-        bufferList->mBuffers[0].mData = leftChannel.data();
+        bufferList->mBuffers[0].mData = leftChannel.mutableSpan().data();
 
         bufferList->mBuffers[1].mNumberChannels = 1;
         bufferList->mBuffers[1].mDataByteSize = bufferSize;
-        bufferList->mBuffers[1].mData = rightChannel.data();
+        bufferList->mBuffers[1].mData = rightChannel.mutableSpan().data();
     } else {
         RELEASE_ASSERT(!mixToMono || numberOfChannels == 1);
 
@@ -590,7 +590,7 @@ RefPtr<AudioBus> AudioFileReader::createBus(float sampleRate, bool mixToMono)
             audioBus->channel(i)->zero();
             bufferList->mBuffers[i].mNumberChannels = 1;
             bufferList->mBuffers[i].mDataByteSize = bufferSize;
-            bufferList->mBuffers[i].mData = audioBus->channel(i)->mutableData();
+            bufferList->mBuffers[i].mData = audioBus->channel(i)->mutableSpan().data();
             ASSERT(bufferList->mBuffers[i].mData);
         }
     }
@@ -637,7 +637,7 @@ RefPtr<AudioBus> AudioFileReader::createBus(float sampleRate, bool mixToMono)
 
     if (mixToMono && numberOfChannels == 2) {
         // Mix stereo down to mono
-        float* destL = audioBus->channel(0)->mutableData();
+        auto destL = audioBus->channel(0)->mutableSpan();
         for (size_t i = 0; i < numberOfFrames; ++i)
             destL[i] = 0.5f * (leftChannel[i] + rightChannel[i]);
     }

--- a/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioFileReaderGStreamer.cpp
@@ -112,7 +112,7 @@ int decodebinAutoplugSelectCallback(GstElement*, GstPad*, GstCaps*, GstElementFa
 
 static void copyGstreamerBuffersToAudioChannel(const GRefPtr<GstBufferList>& buffers, AudioChannel* audioChannel)
 {
-    float* destination = audioChannel->mutableData();
+    float* destination = audioChannel->mutableSpan().data();
     unsigned bufferCount = gst_buffer_list_length(buffers.get());
     for (unsigned i = 0; i < bufferCount; ++i) {
         GstBuffer* buffer = gst_buffer_list_get(buffers.get(), i);

--- a/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioSourceProviderGStreamer.cpp
@@ -77,7 +77,7 @@ static void copyGStreamerBuffersToAudioChannel(GstAdapter* adapter, AudioBus* bu
     GST_TRACE("%zu samples available for channel %d (%zu frames requested)", available, channelNumber, framesToProcess);
     size_t bytes = framesToProcess * sizeof(float);
     if (available >= bytes) {
-        gst_adapter_copy(adapter, bus->channel(channelNumber)->mutableData(), 0, bytes);
+        gst_adapter_copy(adapter, bus->channel(channelNumber)->mutableSpan().data(), 0, bytes);
         gst_adapter_flush(adapter, bytes);
     } else
         bus->zero();

--- a/Source/WebCore/platform/audio/gstreamer/FFTFrameGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/FFTFrameGStreamer.cpp
@@ -79,8 +79,8 @@ FFTFrame::FFTFrame(const FFTFrame& frame)
     m_inverseFft = gst_fft_f32_new(fftLength, TRUE);
 
     // Copy/setup frame data.
-    memcpy(realData().data(), frame.realData().data(), sizeof(float) * realData().size());
-    memcpy(imagData().data(), frame.imagData().data(), sizeof(float) * imagData().size());
+    memcpySpan(realData().mutableSpan(), frame.realData().span());
+    memcpySpan(imagData().mutableSpan(), frame.imagData().span());
 }
 
 void FFTFrame::initialize()
@@ -103,8 +103,8 @@ void FFTFrame::doFFT(const float* data)
 {
     gst_fft_f32_fft(m_fft, data, m_complexData.get());
 
-    float* imagData = m_imagData.data();
-    float* realData = m_realData.data();
+    auto imagData = m_imagData.mutableSpan();
+    auto realData = m_realData.mutableSpan();
     for (unsigned i = 0; i < unpackedFFTDataSize(m_FFTSize); ++i) {
         imagData[i] = m_complexData[i].i;
         realData[i] = m_complexData[i].r;
@@ -114,8 +114,8 @@ void FFTFrame::doFFT(const float* data)
 void FFTFrame::doInverseFFT(float* data)
 {
     //  Merge the real and imaginary vectors to complex vector.
-    float* realData = m_realData.data();
-    float* imagData = m_imagData.data();
+    auto realData = m_realData.span();
+    auto imagData = m_imagData.span();
 
     for (size_t i = 0; i < unpackedFFTDataSize(m_FFTSize); ++i) {
         m_complexData[i].i = imagData[i];

--- a/Source/WebCore/platform/audio/mac/FFTFrameMac.cpp
+++ b/Source/WebCore/platform/audio/mac/FFTFrameMac.cpp
@@ -70,8 +70,8 @@ FFTFrame::FFTFrame(unsigned fftSize)
     m_FFTSetup = fftSetupForSize(fftSize);
 
     // Setup frame data
-    m_frame.realp = m_realData.data();
-    m_frame.imagp = m_imagData.data();
+    m_frame.realp = m_realData.mutableSpan().data();
+    m_frame.imagp = m_imagData.mutableSpan().data();
 }
 
 // Creates a blank/empty frame (interpolate() must later be called)
@@ -94,12 +94,12 @@ FFTFrame::FFTFrame(const FFTFrame& frame)
     , m_imagData(frame.m_FFTSize)
 {
     // Setup frame data
-    m_frame.realp = m_realData.data();
-    m_frame.imagp = m_imagData.data();
+    m_frame.realp = m_realData.mutableSpan().data();
+    m_frame.imagp = m_imagData.mutableSpan().data();
 
     // Copy/setup frame data
-    memcpy(realData().data(), frame.m_frame.realp, sizeof(float) * realData().size());
-    memcpy(imagData().data(), frame.m_frame.imagp, sizeof(float) * imagData().size());
+    memcpy(realData().mutableSpan().data(), frame.m_frame.realp, sizeof(float) * realData().size());
+    memcpy(imagData().mutableSpan().data(), frame.m_frame.imagp, sizeof(float) * imagData().size());
 }
 
 FFTFrame::~FFTFrame() = default;
@@ -118,8 +118,8 @@ void FFTFrame::doFFT(const float* data)
     // (See https://developer.apple.com/library/archive/documentation/Performance/Conceptual/vDSP_Programming_Guide/UsingFourierTransforms/UsingFourierTransforms.html#//apple_ref/doc/uid/TP40005147-CH3-SW5)
     // In the case of a Real forward Transform like above: RFimp = RFmath * 2 so we need to divide the output
     // by 2 to get the correct value.
-    VectorMath::multiplyByScalar(realData().data(), 0.5, realData().data(), halfSize);
-    VectorMath::multiplyByScalar(imagData().data(), 0.5, imagData().data(), halfSize);
+    VectorMath::multiplyByScalar(realData().span().data(), 0.5, realData().mutableSpan().data(), halfSize);
+    VectorMath::multiplyByScalar(imagData().span().data(), 0.5, imagData().mutableSpan().data(), halfSize);
 }
 
 void FFTFrame::doInverseFFT(float* data)

--- a/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
@@ -137,7 +137,7 @@ void AudioSourceProviderAVFObjC::provideInput(AudioBus* bus, size_t framesToProc
     for (unsigned i = 0; i < m_list->mNumberBuffers; ++i) {
         AudioChannel* channel = bus->channel(i);
         m_list->mBuffers[i].mNumberChannels = 1;
-        m_list->mBuffers[i].mData = channel->mutableData();
+        m_list->mBuffers[i].mData = channel->mutableSpan().data();
         m_list->mBuffers[i].mDataByteSize = channel->length() * sizeof(float);
     }
 

--- a/Source/WebCore/platform/mediastream/mac/WebAudioSourceProviderCocoa.mm
+++ b/Source/WebCore/platform/mediastream/mac/WebAudioSourceProviderCocoa.mm
@@ -93,7 +93,7 @@ void WebAudioSourceProviderCocoa::provideInput(AudioBus* bus, size_t framesToPro
         }
         auto* buffer = m_audioBufferList->buffer(i);
         buffer->mNumberChannels = 1;
-        buffer->mData = channel.mutableData();
+        buffer->mData = channel.mutableSpan().data();
         buffer->mDataByteSize = channel.length() * sizeof(float);
     }
 


### PR DESCRIPTION
#### 34084452dcecee993a49c0708573ca71d025fc59
<pre>
Drop AudioArray::data() in favor of span()
<a href="https://bugs.webkit.org/show_bug.cgi?id=276036">https://bugs.webkit.org/show_bug.cgi?id=276036</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/webaudio/AudioBuffer.cpp:
(WebCore::AudioBuffer::AudioBuffer):
* Source/WebCore/Modules/webaudio/AudioBufferSourceNode.cpp:
(WebCore::AudioBufferSourceNode::process):
* Source/WebCore/Modules/webaudio/AudioListener.cpp:
(WebCore::AudioListener::updateValuesIfNeeded):
(WebCore::AudioListener::positionXValues):
(WebCore::AudioListener::positionYValues):
(WebCore::AudioListener::positionZValues):
(WebCore::AudioListener::forwardXValues):
(WebCore::AudioListener::forwardYValues):
(WebCore::AudioListener::forwardZValues):
(WebCore::AudioListener::upXValues):
(WebCore::AudioListener::upYValues):
(WebCore::AudioListener::upZValues):
* Source/WebCore/Modules/webaudio/AudioScheduledSourceNode.cpp:
(WebCore::AudioScheduledSourceNode::updateSchedulingInfo):
* Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp:
(WebCore::AudioWorkletNode::process):
* Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp:
(WebCore::constructFrozenKeyValueObject):
(WebCore::constructFrozenJSArray):
(WebCore::copyDataFromJSArrayToBuses):
(WebCore::copyDataFromBusesToJSArray):
(WebCore::copyDataFromParameterMapToJSObject):
* Source/WebCore/Modules/webaudio/BiquadProcessor.cpp:
(WebCore::BiquadProcessor::process):
* Source/WebCore/Modules/webaudio/ConstantSourceNode.cpp:
(WebCore::ConstantSourceNode::process):
* Source/WebCore/Modules/webaudio/DelayDSPKernel.cpp:
(WebCore::DelayDSPKernel::processARate):
(WebCore::DelayDSPKernel::processKRate):
* Source/WebCore/Modules/webaudio/GainNode.cpp:
(WebCore::GainNode::process):
* Source/WebCore/Modules/webaudio/IIRProcessor.cpp:
(WebCore::IIRProcessor::process):
* Source/WebCore/Modules/webaudio/MediaStreamAudioSourceCocoa.cpp:
(WebCore::copyChannelData):
* Source/WebCore/Modules/webaudio/OfflineAudioDestinationNode.cpp:
(WebCore::OfflineAudioDestinationNode::renderOnAudioThread):
* Source/WebCore/Modules/webaudio/OscillatorNode.cpp:
(WebCore::OscillatorNode::calculateSampleAccuratePhaseIncrements):
(WebCore::OscillatorNode::process):
* Source/WebCore/Modules/webaudio/PeriodicWave.cpp:
(WebCore::PeriodicWave::waveDataForFundamentalFrequency):
(WebCore::PeriodicWave::createBandLimitedTables):
(WebCore::PeriodicWave::generateBasicWaveform):
* Source/WebCore/Modules/webaudio/RealtimeAnalyser.cpp:
(WebCore::RealtimeAnalyser::writeInput):
(WebCore::RealtimeAnalyser::doFFTAnalysisIfNecessary):
(WebCore::RealtimeAnalyser::getFloatFrequencyData):
(WebCore::RealtimeAnalyser::getByteFrequencyData):
(WebCore::RealtimeAnalyser::getFloatTimeDomainData):
(WebCore::RealtimeAnalyser::getByteTimeDomainData):
* Source/WebCore/Modules/webaudio/ScriptProcessorNode.cpp:
(WebCore::ScriptProcessorNode::process):
* Source/WebCore/Modules/webaudio/StereoPannerNode.cpp:
(WebCore::StereoPannerNode::process):
* Source/WebCore/Modules/webaudio/WaveShaperDSPKernel.cpp:
(WebCore::WaveShaperDSPKernel::processCurve2x):
(WebCore::WaveShaperDSPKernel::processCurve4x):
* Source/WebCore/Modules/webaudio/WaveShaperProcessor.cpp:
(WebCore::WaveShaperProcessor::process):
* Source/WebCore/platform/audio/AudioArray.h:
(WebCore::AudioArray::mutableSpan):
(WebCore::AudioArray::span const):
(WebCore::AudioArray::at):
(WebCore::AudioArray::at const):
(WebCore::AudioArray::zero):
(WebCore::AudioArray::zeroRange):
(WebCore::AudioArray::copyToRange):
(WebCore::AudioArray::containsConstantValue const):
(WebCore::AudioArray::span): Deleted.
(WebCore::AudioArray::data): Deleted.
(WebCore::AudioArray::data const): Deleted.
* Source/WebCore/platform/audio/AudioBus.cpp:
(WebCore::AudioBus::speakersSumFromByDownMixing):
(WebCore::AudioBus::copyWithGainFrom):
(WebCore::AudioBus::copyWithSampleAccurateGainValuesFrom):
(WebCore::AudioBus::createByMixingToMono):
* Source/WebCore/platform/audio/AudioChannel.cpp:
(WebCore::AudioChannel::scale):
(WebCore::AudioChannel::copyFrom):
(WebCore::AudioChannel::copyFromRange):
(WebCore::AudioChannel::sumFrom):
(WebCore::AudioChannel::maxAbsValue const):
* Source/WebCore/platform/audio/AudioChannel.h:
* Source/WebCore/platform/audio/AudioDSPKernelProcessor.cpp:
(WebCore::AudioDSPKernelProcessor::process):
* Source/WebCore/platform/audio/AudioResampler.cpp:
(WebCore::AudioResampler::process):
* Source/WebCore/platform/audio/AudioResamplerKernel.cpp:
(WebCore::AudioResamplerKernel::getSourcePointer):
(WebCore::AudioResamplerKernel::process):
* Source/WebCore/platform/audio/Biquad.cpp:
(WebCore::Biquad::process):
(WebCore::Biquad::processFast):
(WebCore::Biquad::reset):
* Source/WebCore/platform/audio/DirectConvolver.cpp:
(WebCore::DirectConvolver::process):
* Source/WebCore/platform/audio/DownSampler.cpp:
(WebCore::DownSampler::process):
* Source/WebCore/platform/audio/DynamicsCompressor.cpp:
(WebCore::DynamicsCompressor::process):
* Source/WebCore/platform/audio/DynamicsCompressorKernel.cpp:
(WebCore::DynamicsCompressorKernel::process):
* Source/WebCore/platform/audio/EqualPowerPanner.cpp:
(WebCore::EqualPowerPanner::pan):
(WebCore::EqualPowerPanner::panWithSampleAccurateValues):
* Source/WebCore/platform/audio/FFTConvolver.cpp:
(WebCore::FFTConvolver::process):
* Source/WebCore/platform/audio/FFTFrame.cpp:
(WebCore::FFTFrame::doPaddedFFT):
(WebCore::FFTFrame::createInterpolatedFrame):
(WebCore::FFTFrame::scaleFFT):
(WebCore::FFTFrame::multiply):
* Source/WebCore/platform/audio/HRTFKernel.cpp:
(WebCore::extractAverageGroupDelay):
(WebCore::HRTFKernel::HRTFKernel):
(WebCore::HRTFKernel::createImpulseResponse):
* Source/WebCore/platform/audio/HRTFPanner.cpp:
(WebCore::HRTFPanner::pan):
* Source/WebCore/platform/audio/IIRFilter.cpp:
(WebCore::IIRFilter::tailTime):
* Source/WebCore/platform/audio/MultiChannelResampler.cpp:
(WebCore::MultiChannelResampler::MultiChannelResampler):
* Source/WebCore/platform/audio/PushPullFIFO.cpp:
(WebCore::PushPullFIFO::push):
(WebCore::PushPullFIFO::pull):
* Source/WebCore/platform/audio/Reverb.cpp:
(WebCore::calculateNormalizationScale):
* Source/WebCore/platform/audio/ReverbAccumulationBuffer.cpp:
(WebCore::ReverbAccumulationBuffer::readAndClear):
(WebCore::ReverbAccumulationBuffer::accumulate):
* Source/WebCore/platform/audio/ReverbConvolver.cpp:
(WebCore::ReverbConvolver::ReverbConvolver):
(WebCore::ReverbConvolver::process):
* Source/WebCore/platform/audio/ReverbConvolverStage.cpp:
(WebCore::ReverbConvolverStage::ReverbConvolverStage):
(WebCore::ReverbConvolverStage::process):
* Source/WebCore/platform/audio/ReverbInputBuffer.cpp:
(WebCore::ReverbInputBuffer::write):
(WebCore::ReverbInputBuffer::directReadFrom):
* Source/WebCore/platform/audio/SincResampler.cpp:
(WebCore::SincResampler::SincResampler):
(WebCore::SincResampler::updateRegions):
* Source/WebCore/platform/audio/StereoPanner.cpp:
(WebCore::StereoPanner::panWithSampleAccurateValues):
(WebCore::StereoPanner::panToTargetValue):
* Source/WebCore/platform/audio/UpSampler.cpp:
(WebCore::UpSampler::process):
* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp:
(WebCore::AudioFileReader::createBus):
* Source/WebCore/platform/audio/mac/FFTFrameMac.cpp:
(WebCore::FFTFrame::FFTFrame):
(WebCore::FFTFrame::doFFT):
* Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm:
(WebCore::AudioSourceProviderAVFObjC::provideInput):
* Source/WebCore/platform/mediastream/mac/WebAudioSourceProviderCocoa.mm:
(WebCore::WebAudioSourceProviderCocoa::provideInput):

Canonical link: <a href="https://commits.webkit.org/280514@main">https://commits.webkit.org/280514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30092fda980677c4811c8cfcff71c064987f02d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9307 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60449 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7276 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58961 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7466 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46029 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5096 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58863 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33967 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49047 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26887 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30747 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6378 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6280 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52684 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6649 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62131 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/746 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6755 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53286 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/749 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49102 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53312 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/629 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8461 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/31990 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33075 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34160 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32821 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->