### PR TITLE
Add test for position outside string in findWordBoundary

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/TextBoundaries.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/TextBoundaries.cpp
@@ -37,7 +37,35 @@ TEST(TextBoundariesTest, FindWordBoundaryEmpty)
 
     WebCore::findWordBoundary(stringView, 0, &start, &end);
 
-    ASSERT(!start);
-    ASSERT(!end);
+    EXPECT_EQ(start, 0);
+    EXPECT_EQ(end, 0);
+}
+
+TEST(TextBoundariesTest, FindWordBoundaryPositionTooBig)
+{
+    WTF::String aString("Hello World"_s);
+    WTF::StringView stringView(aString);
+    int start = -1;
+    int end = -1;
+
+    WebCore::findWordBoundary(stringView, aString.length(), &start, &end);
+
+    EXPECT_EQ(start >= 0 && start < static_cast<int>(stringView.length()), true);
+    EXPECT_EQ(end >= 0 && end < static_cast<int>(stringView.length()), true);
+    EXPECT_EQ(start <= end, true);
+}
+
+TEST(TextBoundariesTest, FindWordBoundaryPositionTooSmall)
+{
+    WTF::String aString("Hello World"_s);
+    WTF::StringView stringView(aString);
+    int start = -1;
+    int end = -1;
+
+    WebCore::findWordBoundary(stringView, -1, &start, &end);
+
+    EXPECT_EQ(start >= 0 && start < static_cast<int>(stringView.length()), true);
+    EXPECT_EQ(end >= 0 && end < static_cast<int>(stringView.length()), true);
+    EXPECT_EQ(start <= end, true);
 }
 }


### PR DESCRIPTION
#### 3a4912d38e7fd3078773805a15c08729e4c43220
<pre>
Add test for position outside string in findWordBoundary
<a href="https://bugs.webkit.org/show_bug.cgi?id=276002">https://bugs.webkit.org/show_bug.cgi?id=276002</a>
<a href="https://rdar.apple.com/130331432">rdar://130331432</a>

Reviewed by NOBODY (OOPS!).

Checks the output to make sure it is in-range, even if the input is nonsense.

* Tools/TestWebKitAPI/Tests/WebCore/TextBoundaries.cpp:
(TestWebKitAPI::TEST(TextBoundariesTest, FindWordBoundaryEmpty)):
(TestWebKitAPI::TEST(TextBoundariesTest, FindWordBoundaryPositionTooBig)):
(TestWebKitAPI::TEST(TextBoundariesTest, FindWordBoundaryPositionTooSmall)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a4912d38e7fd3078773805a15c08729e4c43220

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56963 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36291 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9438 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60583 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7406 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59091 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43914 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7596 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46130 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5200 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58993 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34082 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49159 "Found 2 new API test failures: TestWebKitAPI.TextBoundariesTest.FindWordBoundaryPositionTooSmall, TestWebKitAPI.TextBoundariesTest.FindWordBoundaryPositionTooBig (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26989 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30862 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6490 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6411 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52824 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6761 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62264 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/876 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6866 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53387 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49214 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53429 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/741 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32120 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33205 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34290 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32951 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->