### PR TITLE
[Writing Tools] Writing Tools context menu item may still show up even when using UIWritingToolsBehaviorNone

### DIFF
--- a/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h
@@ -42,7 +42,6 @@ WTF_EXTERN_C_END
 #import <UIKit/UIFont_Private.h>
 #import <UIKit/UIInterface_Private.h>
 #import <UIKit/UIPasteboard_Private.h>
-#import <UIKit/UIResponder_Private.h>
 #import <UIKit/UIScreen_Private.h>
 #import <UIKit/UITextEffectsWindow.h>
 #import <UIKit/UIViewController_Private.h>

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2085,9 +2085,20 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
     return PlatformWritingToolsAllowedInputOptionsPlainText | PlatformWritingToolsAllowedInputOptionsRichText | listOption | PlatformWritingToolsAllowedInputOptionsTable;
 }
 
-- (BOOL)wantsWritingToolsInlineEditing
+- (PlatformWritingToolsBehavior)writingToolsBehavior
 {
-    return [self _isEditable] || [_configuration writingToolsBehavior] == PlatformWritingToolsBehaviorComplete;
+    if ([self _isEditable])
+        return PlatformWritingToolsBehaviorComplete;
+
+    auto& editorState = _page->editorState();
+
+    if ([_configuration writingToolsBehavior] == PlatformWritingToolsBehaviorNone || editorState.selectionIsNone || editorState.isInPasswordField)
+        return PlatformWritingToolsBehaviorNone;
+
+    if ([_configuration writingToolsBehavior] == PlatformWritingToolsBehaviorComplete && editorState.isContentEditable)
+        return PlatformWritingToolsBehaviorComplete;
+
+    return PlatformWritingToolsBehaviorLimited;
 }
 
 - (void)willBeginWritingToolsSession:(WTSession *)session requestContexts:(void (^)(NSArray<WTContext *> *))completion

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -57,7 +57,7 @@
 #if PLATFORM(IOS_FAMILY)
 
 #if ENABLE(WRITING_TOOLS)
-#define WK_WEB_VIEW_PROTOCOLS <WKBEScrollViewDelegate, WTWritingToolsDelegate>
+#define WK_WEB_VIEW_PROTOCOLS <WKBEScrollViewDelegate, WTWritingToolsDelegate, UITextInputTraits>
 #else
 #define WK_WEB_VIEW_PROTOCOLS <WKBEScrollViewDelegate>
 #endif
@@ -67,7 +67,7 @@
 #if PLATFORM(MAC)
 
 #if ENABLE(WRITING_TOOLS)
-#define WK_WEB_VIEW_PROTOCOLS <WKShareSheetDelegate, WTWritingToolsDelegate>
+#define WK_WEB_VIEW_PROTOCOLS <WKShareSheetDelegate, WTWritingToolsDelegate, NSTextInputTraits>
 #else
 #define WK_WEB_VIEW_PROTOCOLS <WKShareSheetDelegate>
 #endif

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1239,13 +1239,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
 }
 
-#if ENABLE(WRITING_TOOLS)
-- (BOOL)_web_wantsWritingToolsInlineEditing
-{
-    return [self wantsWritingToolsInlineEditing];
-}
-#endif
-
 #if ENABLE(DRAG_SUPPORT)
 
 - (WKDragDestinationAction)_web_dragDestinationActionForDraggingInfo:(id <NSDraggingInfo>)draggingInfo

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -178,13 +178,6 @@ typedef std::pair<WebKit::InteractionInformationRequest, InteractionInformationC
 #define FOR_EACH_FIND_WKCONTENTVIEW_ACTION(M)
 #endif
 
-#if ENABLE(WRITING_TOOLS)
-#define FOR_EACH_UNIFIED_TEXT_REPLACEMENT_PRIVATE_WKCONTENTVIEW_ACTION(M) \
-    M(_startWritingTools)
-#else
-#define FOR_EACH_UNIFIED_TEXT_REPLACEMENT_PRIVATE_WKCONTENTVIEW_ACTION(M)
-#endif
-
 #define FOR_EACH_WKCONTENTVIEW_ACTION(M) \
     FOR_EACH_INSERT_TEXT_FROM_CAMERA_WKCONTENTVIEW_ACTION(M) \
     FOR_EACH_FIND_WKCONTENTVIEW_ACTION(M) \
@@ -221,7 +214,6 @@ typedef std::pair<WebKit::InteractionInformationRequest, InteractionInformationC
     M(makeTextWritingDirectionRightToLeft)
 
 #define FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(M) \
-    FOR_EACH_UNIFIED_TEXT_REPLACEMENT_PRIVATE_WKCONTENTVIEW_ACTION(M) \
     M(_alignCenter) \
     M(_alignJustified) \
     M(_alignLeft) \

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -4435,11 +4435,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (action == @selector(cut:))
         return !editorState.isInPasswordField && editorState.isContentEditable && editorState.selectionIsRange;
 
-#if ENABLE(WRITING_TOOLS)
-    if (action == @selector(_startWritingTools:))
-        return _page->configuration().writingToolsBehavior() != WebCore::WritingTools::Behavior::None && [super canPerformAction:action withSender:sender];
-#endif
-
     if (action == @selector(paste:) || action == @selector(_pasteAsQuotation:) || action == @selector(_pasteAndMatchStyle:) || action == @selector(pasteAndMatchStyle:)) {
         if (editorState.selectionIsNone || !editorState.isContentEditable)
             return NO;
@@ -4730,13 +4725,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
     [self lookupForWebView:sender];
 }
-
-#if ENABLE(WRITING_TOOLS)
-- (void)_startWritingToolsForWebView:(id)sender
-{
-    [super _startWritingTools:sender];
-}
-#endif
 
 - (void)accessibilityRetrieveSpeakSelectionContent
 {
@@ -6933,11 +6921,6 @@ static UITextAutocapitalizationType toUITextAutocapitalize(WebCore::Autocapitali
         return _focusedElementInformation.isWritingSuggestionsEnabled;
     }();
     traits.inlinePredictionType = allowsInlinePredictions ? UITextInlinePredictionTypeDefault : UITextInlinePredictionTypeNo;
-#endif
-
-#if ENABLE(WRITING_TOOLS)
-    auto behavior = WebKit::convertToPlatformWritingToolsBehavior(_page->configuration().writingToolsBehavior());
-    [traits setWritingToolsBehavior:behavior];
 #endif
 
     [self _updateTextInputTraitsForInteractionTintColor];
@@ -13195,9 +13178,9 @@ inline static NSString *extendSelectionCommand(UITextLayoutDirection direction)
     return [_webView writingToolsAllowedInputOptions];
 }
 
-- (BOOL)wantsWritingToolsInlineEditing
+- (UIWritingToolsBehavior)writingToolsBehavior
 {
-    return [_webView wantsWritingToolsInlineEditing];
+    return [_webView writingToolsBehavior];
 }
 
 - (void)willBeginWritingToolsSession:(WTSession *)session requestContexts:(void (^)(NSArray<WTContext *> *))completion

--- a/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.h
+++ b/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.h
@@ -59,10 +59,6 @@
 @property (nonatomic, strong) UIColor *selectionHandleColor;
 @property (nonatomic, strong) UIColor *selectionHighlightColor;
 
-#if ENABLE(WRITING_TOOLS)
-@property UIWritingToolsBehavior writingToolsBehavior;
-#endif
-
 - (void)setSelectionColorsToMatchTintColor:(UIColor *)tintColor;
 - (void)restoreDefaultValues;
 

--- a/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.mm
+++ b/Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.mm
@@ -130,18 +130,7 @@
     self.insertionPointColor = nil;
     self.selectionHandleColor = nil;
     self.selectionHighlightColor = nil;
-
-#if ENABLE(WRITING_TOOLS)
-    [self restoreDefaultWritingToolsBehaviorValue];
-#endif
 }
-
-#if ENABLE(WRITING_TOOLS)
-- (void)restoreDefaultWritingToolsBehaviorValue
-{
-    self.writingToolsBehavior = UIWritingToolsBehaviorLimited;
-}
-#endif
 
 @end
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -165,10 +165,6 @@ enum class ReplacementBehavior : uint8_t;
 - (void)_didHandleAcceptedCandidate;
 - (void)_didUpdateCandidateListVisibility:(BOOL)visible;
 
-#if ENABLE(WRITING_TOOLS)
-- (BOOL)_web_wantsWritingToolsInlineEditing;
-#endif
-
 @end
 
 namespace WebCore {
@@ -714,10 +710,6 @@ public:
 #if HAVE(TRANSLATION_UI_SERVICES) && ENABLE(CONTEXT_MENUS)
     bool canHandleContextMenuTranslation() const;
     void handleContextMenuTranslation(const WebCore::TranslationContextMenuInfo&);
-#endif
-
-#if ENABLE(WRITING_TOOLS)
-    WebCore::WritingTools::Behavior writingToolsBehavior() const;
 #endif
 
 #if ENABLE(WRITING_TOOLS) && ENABLE(CONTEXT_MENUS)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2787,7 +2787,7 @@ void WebViewImpl::selectionDidChange()
 #endif
 
 #if ENABLE(WRITING_TOOLS)
-    if ([m_view _web_wantsWritingToolsInlineEditing]) {
+    if (isEditable() || m_page->configuration().writingToolsBehavior() == WebCore::WritingTools::Behavior::Complete) {
         auto isRange = m_page->editorState().hasPostLayoutData() && m_page->editorState().selectionIsRange;
         auto selectionRect = isRange ? m_page->editorState().postLayoutData->selectionBoundingRect : IntRect { };
 


### PR DESCRIPTION
#### 63d8246828b2162cb11803da40cb479eca9922b1
<pre>
[Writing Tools] Writing Tools context menu item may still show up even when using UIWritingToolsBehaviorNone
<a href="https://bugs.webkit.org/show_bug.cgi?id=276040">https://bugs.webkit.org/show_bug.cgi?id=276040</a>
<a href="https://rdar.apple.com/130825002">rdar://130825002</a>

Reviewed by Wenson Hsieh.

Implement the `writingToolsBehavior` property of the `{UI|NS}TextInputTraits` protocol on WKContentViewInteraction and WKWebView,
rather than set it on the `writingToolsBehavior` property on the UITextInputTraits object itself on iOS.

This also has the advantage of unifying the behavior across the platforms.

* Source/WebCore/PAL/pal/spi/ios/UIKitSPI.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView writingToolsBehavior]):
(-[WKWebView wantsWritingToolsInlineEditing]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _web_wantsWritingToolsInlineEditing]): Deleted.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView canPerformActionForWebView:withSender:]):
(-[WKContentView _updateTextInputTraits:]):
(-[WKContentView writingToolsBehavior]):
(-[WKContentView _startWritingToolsForWebView:]): Deleted.
(-[WKContentView wantsWritingToolsInlineEditing]): Deleted.
* Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.h:
* Source/WebKit/UIProcess/ios/WKExtendedTextInputTraits.mm:
(-[WKExtendedTextInputTraits restoreDefaultValues]):
(-[WKExtendedTextInputTraits restoreDefaultWritingToolsBehaviorValue]): Deleted.
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::selectionDidChange):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(-[WritingToolsWKWebView writingToolsBehaviorForTesting]):
(TEST(WritingTools, WantsInlineEditing)):
(TEST(WritingTools, WritingToolsBehaviorNonEditableWithSelection)):
(TEST(WritingTools, WritingToolsBehaviorWithNoSelection)):
(TEST(WritingTools, WritingToolsBehaviorEditableWithSelection)):
(TEST(WritingTools, APIWithBehaviorNone)):
(TEST(WritingTools, APIWithBehaviorDefault)):
(TEST(WritingTools, APIWithBehaviorComplete)):
(TEST(WritingTools, ShowAffordance)):
(TEST(WritingTools, ShowAffordanceForMultipleLines)):

Canonical link: <a href="https://commits.webkit.org/280518@main">https://commits.webkit.org/280518@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4adc6ef635eeeaac96fcccaa10ec398df3e2e01a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60486 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7310 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58995 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43818 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7500 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46059 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5126 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58897 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/47/builds/33997 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49077 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26917 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30777 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/6408 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6314 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52733 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6679 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62168 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/780 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/6783 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53316 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/783 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49132 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/53351 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/659 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8464 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32024 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33109 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34194 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32855 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->