### PR TITLE
Drop MappedFileData::data() in favor of span()

### DIFF
--- a/Source/JavaScriptCore/runtime/CachePayload.cpp
+++ b/Source/JavaScriptCore/runtime/CachePayload.cpp
@@ -60,7 +60,7 @@ const uint8_t* CachePayload::data() const
 {
     return WTF::switchOn(m_data,
         [](const FileSystem::MappedFileData& data) {
-            return static_cast<const uint8_t*>(data.data());
+            return data.span().data();
         }, [](const std::pair<MallocPtr<uint8_t, VMMalloc>, size_t>& data) -> const uint8_t* {
             return data.first.get();
         }

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -254,9 +254,9 @@ public:
     MappedFileData& operator=(MappedFileData&&);
 
     explicit operator bool() const { return !!m_fileData; }
-    const void* data() const { return m_fileData; } // FIXME: Port callers to span() and remove.
     unsigned size() const { return m_fileSize; }
-    std::span<const uint8_t> span() const { return { static_cast<const uint8_t *>(data()), size() }; }
+    std::span<const uint8_t> span() const { return { static_cast<const uint8_t*>(m_fileData), size() }; }
+    std::span<uint8_t> mutableSpan() { return { static_cast<uint8_t*>(m_fileData), size() }; }
 
 #if PLATFORM(COCOA)
     void* leakHandle() { return std::exchange(m_fileData, nullptr); }

--- a/Source/WebCore/contentextensions/SerializedNFA.cpp
+++ b/Source/WebCore/contentextensions/SerializedNFA.cpp
@@ -106,7 +106,7 @@ SerializedNFA::SerializedNFA(FileSystem::MappedFileData&& file, Metadata&& metad
 template<typename T>
 const T* SerializedNFA::pointerAtOffsetInFile(size_t offset) const
 {
-    return reinterpret_cast<const T*>(static_cast<const uint8_t*>(m_file.data()) + offset);
+    return reinterpret_cast<const T*>(m_file.span().subspan(offset).data());
 }
 
 auto SerializedNFA::nodes() const -> const Range<ImmutableNFANode>

--- a/Source/WebCore/platform/SharedBuffer.cpp
+++ b/Source/WebCore/platform/SharedBuffer.cpp
@@ -616,7 +616,7 @@ const uint8_t* DataSegment::data() const
 #if USE(SKIA)
         [](const sk_sp<SkData>& data) -> const uint8_t* { return data->bytes(); },
 #endif
-        [](const FileSystem::MappedFileData& data) -> const uint8_t* { return static_cast<const uint8_t*>(data.data()); },
+        [](const FileSystem::MappedFileData& data) -> const uint8_t* { return data.span().data(); },
         [](const Provider& provider) -> const uint8_t* { return provider.data(); }
     );
     return std::visit(visitor, m_immutableData);

--- a/Source/WebCore/platform/network/BlobRegistryImpl.cpp
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.cpp
@@ -140,7 +140,7 @@ static FileSystem::MappedFileData storeInMappedFileData(const String& path, std:
         return { };
     FileSystem::deleteFile(path);
 
-    memcpy(const_cast<void*>(mappedFileData.data()), data.data(), data.size());
+    memcpySpan(mappedFileData.mutableSpan().first(data.size()), data);
 
     FileSystem::finalizeMappedFileData(mappedFileData, data.size());
     return mappedFileData;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataGLib.cpp
@@ -132,7 +132,7 @@ static void deleteMapWrapper(MapWrapper* wrapper)
 Data Data::adoptMap(FileSystem::MappedFileData&& mappedFile, FileSystem::PlatformFileHandle fd)
 {
     size_t size = mappedFile.size();
-    const void* map = mappedFile.data();
+    auto* map = mappedFile.span().data();
     ASSERT(map);
     ASSERT(map != MAP_FAILED);
     MapWrapper* wrapper = new MapWrapper { WTFMove(mappedFile), fd };

--- a/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/FileSystem.cpp
@@ -124,7 +124,7 @@ TEST_F(FileSystemTest, MappingExistingFile)
     EXPECT_TRUE(success);
     EXPECT_TRUE(!!mappedFileData);
     EXPECT_TRUE(mappedFileData.size() == strlen(FileSystemTestData));
-    EXPECT_TRUE(strnstr(FileSystemTestData, static_cast<const char*>(mappedFileData.data()), mappedFileData.size()));
+    EXPECT_TRUE(strnstr(FileSystemTestData, byteCast<char>(mappedFileData.span().data()), mappedFileData.size()));
 }
 
 TEST_F(FileSystemTest, MappingExistingEmptyFile)


### PR DESCRIPTION
#### 3e03e5b45afbf2b189c0df3282e6ea66c8866bda
<pre>
Drop MappedFileData::data() in favor of span()
<a href="https://bugs.webkit.org/show_bug.cgi?id=276045">https://bugs.webkit.org/show_bug.cgi?id=276045</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/runtime/CachePayload.cpp:
(JSC::CachePayload::data const):
* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::finalizeMappedFileData):
(WTF::FileSystemImpl::mapToFile):
* Source/WTF/wtf/FileSystem.h:
(WTF::FileSystemImpl::MappedFileData::operator bool const):
(WTF::FileSystemImpl::MappedFileData::span const):
(WTF::FileSystemImpl::MappedFileData::mutableSpan):
(WTF::FileSystemImpl::MappedFileData::data const): Deleted.
* Source/WebCore/contentextensions/SerializedNFA.cpp:
(WebCore::ContentExtensions::SerializedNFA::pointerAtOffsetInFile const):
* Source/WebCore/platform/SharedBuffer.cpp:
(WebCore::DataSegment::data const):
* Source/WebCore/platform/network/BlobRegistryImpl.cpp:
(WebCore::storeInMappedFileData):

Canonical link: <a href="https://commits.webkit.org/280517@main">https://commits.webkit.org/280517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af30450f595858c771644f622d68c96ec6be1c41

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60484 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7308 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58993 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43816 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7498 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46057 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5124 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33995 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26915 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30775 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6406 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6312 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/49957 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52726 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6677 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62166 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/56106 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/778 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6781 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53314 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/781 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49130 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53347 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/657 "Passed tests") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/77867 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8463 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32022 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/12904 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33107 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34192 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32853 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->