### PR TITLE
[css-transitions] `display` transition to `none` does not work on Chrome for Developers blog

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/CSSTransition-not-canceling.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/CSSTransition-not-canceling.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Setting "display: none" with "display" set to transition using "display 100s allow-discrete" does not cancel running transitions
+PASS Setting "display: none" with "display" set to transition using "display 100s, all allow-discrete 100s" does not cancel running transitions
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/CSSTransition-not-canceling.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/CSSTransition-not-canceling.tentative.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Not canceling a CSS transition</title>
+<link rel="help" href="https://drafts.csswg.org/css-transitions/#starting">
+<!-- TODO: Add a more specific link for this once it is specified. -->
+<link rel="help" href="https://drafts.csswg.org/css-transitions-2/#csstransition">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/helper.js"></script>
+<div id="log"></div>
+<script>
+'use strict';
+
+const runDisplayNoneTransitionTest = displayTransitionStyle => {
+    promise_test(async t => {
+      const div = addDiv(t, { style: 'margin-left: 0px' });
+      getComputedStyle(div).marginLeft;
+
+      div.style.transition = 'margin-left 100s';
+      div.style.marginLeft = '1000px';
+
+      const transition = div.getAnimations()[0];
+      await transition.ready;
+      await waitForFrame();
+
+      assert_not_equals(getComputedStyle(div).marginLeft, '1000px',
+                        'transform style is animated before setting "display: none"');
+
+      div.style.transition = `${div.style.transition}, ${displayTransitionStyle}`;
+      div.style.display = 'none';
+
+      assert_not_equals(getComputedStyle(div).marginLeft, '1000px',
+                        'transform style is animated after setting "display: none"');
+    }, `Setting "display: none" with "display" set to transition using "${displayTransitionStyle}" does not cancel running transitions`);
+};
+
+runDisplayNoneTransitionTest('display 100s allow-discrete');
+runDisplayNoneTransitionTest('display 100s, all allow-discrete 100s');
+
+</script>


### PR DESCRIPTION
#### 268a017af767eade0ec58b3d1ce5965fa3136220
<pre>
[css-transitions] `display` transition to `none` does not work on Chrome for Developers blog
<a href="https://bugs.webkit.org/show_bug.cgi?id=275994">https://bugs.webkit.org/show_bug.cgi?id=275994</a>

Reviewed by Tim Nguyen.

Historically, setting `display: none` on an element would cancel any running transition. However,
with the addition of `transition-behavior: allow-discrete` and the fact `display` supports discrete
animation, setting `display: none` if that value is being transitioned should not cancel running
transitions.

On top of that, after canceling running transitions, we&apos;d bail out of considering any further transition,
so we would fail to transition the `display` value itself.

We now correctly handle this case by checking in `Styleable::updateCSSTransitions()` whether setting
`display: none` will yield a transition before canceling running transitions and bailing out of that
method.

This was not covered by existing WPT tests, as noted in <a href="https://github.com/web-platform-tests/wpt/issues/46753">https://github.com/web-platform-tests/wpt/issues/46753</a>,
so we&apos;re adding a new WPT test that checks that we do not cancel running transitions when setting
`display: none` when `display` is getting transitioned.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/CSSTransition-not-canceling.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/CSSTransition-not-canceling.tentative.html: Added.
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::updateCSSTransitions const):

Canonical link: <a href="https://commits.webkit.org/280512@main">https://commits.webkit.org/280512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db4a6b480379f3d2ece2faa35f6ed9859fe7571d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60477 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7304 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/58989 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46050 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5120 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58891 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/33991 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49071 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26908 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30771 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6402 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6308 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52717 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6673 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62159 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/774 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6777 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53307 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/777 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49126 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53339 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/653 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8459 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32018 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33103 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34188 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32849 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->