### PR TITLE
[WPE] WKWPE::View is refcounted

### DIFF
--- a/Source/WebKit/UIProcess/API/C/wpe/WKView.cpp
+++ b/Source/WebKit/UIProcess/API/C/wpe/WKView.cpp
@@ -38,13 +38,13 @@ using namespace WebKit;
 #if ENABLE(WPE_PLATFORM)
 WKViewRef WKViewCreate(WPEDisplay* display, WKPageConfigurationRef configuration)
 {
-    return toAPI(WKWPE::ViewPlatform::create(display, *toImpl(configuration)));
+    return toAPI(&WKWPE::ViewPlatform::create(display, *toImpl(configuration)).leakRef());
 }
 #endif
 
 WKViewRef WKViewCreateDeprecated(struct wpe_view_backend* backend, WKPageConfigurationRef configuration)
 {
-    return toAPI(WKWPE::ViewLegacy::create(backend, *toImpl(configuration)));
+    return toAPI(&WKWPE::ViewLegacy::create(backend, *toImpl(configuration)).leakRef());
 }
 
 WKPageRef WKViewGetPage(WKViewRef view)

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp
@@ -338,7 +338,7 @@ struct _WebKitWebViewPrivate {
 #if ENABLE(WPE_PLATFORM)
     GRefPtr<WPEDisplay> display;
 #endif
-    std::unique_ptr<WKWPE::View> view;
+    RefPtr<WKWPE::View> view;
     Vector<FrameDisplayedCallback> frameDisplayedCallbacks;
     bool inFrameDisplayed;
     HashSet<unsigned> frameDisplayedCallbacksToRemove;
@@ -838,13 +838,13 @@ static void webkitWebViewCreatePage(WebKitWebView* webView, Ref<API::PageConfigu
 #elif PLATFORM(WPE)
 #if ENABLE(WPE_PLATFORM)
     if (!webView->priv->backend) {
-        webView->priv->view.reset(WKWPE::ViewPlatform::create(webkit_web_view_get_display(webView), configuration.get()));
+        webView->priv->view = WKWPE::ViewPlatform::create(webkit_web_view_get_display(webView), configuration.get());
         if (auto* wpeView = webView->priv->view->wpeView())
             g_signal_connect_object(wpeView, "closed", G_CALLBACK(webkitWebViewClosePage), webView, G_CONNECT_SWAPPED);
         return;
     }
 #endif
-    webView->priv->view.reset(WKWPE::ViewLegacy::create(webkit_web_view_backend_get_wpe_backend(webView->priv->backend.get()), configuration.get()));
+    webView->priv->view = WKWPE::ViewLegacy::create(webkit_web_view_backend_get_wpe_backend(webView->priv->backend.get()), configuration.get());
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.h
@@ -38,9 +38,9 @@ namespace WKWPE {
 
 class ViewLegacy final : public View {
 public:
-    static View* create(struct wpe_view_backend* backend, const API::PageConfiguration& configuration)
+    static Ref<View> create(struct wpe_view_backend* backend, const API::PageConfiguration& configuration)
     {
-        return new ViewLegacy(backend, configuration);
+        return adoptRef(*new ViewLegacy(backend, configuration));
     }
     ~ViewLegacy();
 

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h
@@ -44,9 +44,9 @@ namespace WKWPE {
 
 class ViewPlatform final : public View {
 public:
-    static View* create(WPEDisplay* display, const API::PageConfiguration& configuration)
+    static Ref<View> create(WPEDisplay* display, const API::PageConfiguration& configuration)
     {
-        return new ViewPlatform(display, configuration);
+        return adoptRef(*new ViewPlatform(display, configuration));
     }
     ~ViewPlatform();
 

--- a/Tools/TestWebKitAPI/wpe/PlatformWebViewWPE.cpp
+++ b/Tools/TestWebKitAPI/wpe/PlatformWebViewWPE.cpp
@@ -64,6 +64,7 @@ PlatformWebView::PlatformWebView(WKPageRef relatedPage)
 
 PlatformWebView::~PlatformWebView()
 {
+    WKRelease(m_view);
     delete m_window;
 }
 

--- a/Tools/WebKitTestRunner/libwpe/PlatformWebViewClient.h
+++ b/Tools/WebKitTestRunner/libwpe/PlatformWebViewClient.h
@@ -33,7 +33,10 @@ namespace WTR {
 class PlatformWebViewClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    virtual ~PlatformWebViewClient() = default;
+    virtual ~PlatformWebViewClient()
+    {
+        WKRelease(m_view);
+    }
 
     virtual void addToWindow() = 0;
     virtual void removeFromWindow() = 0;


### PR DESCRIPTION
#### 8104e1d037fe1ef5d6824f8d893b5df6c2691452
<pre>
[WPE] WKWPE::View is refcounted
<a href="https://bugs.webkit.org/show_bug.cgi?id=276059">https://bugs.webkit.org/show_bug.cgi?id=276059</a>

Reviewed by Michael Catanzaro.

Create methods are returning a pointer, GLib API is using
std::unique_ptr and WKTR and API tests are leaking the view.

* Source/WebKit/UIProcess/API/C/wpe/WKView.cpp:
(WKViewCreate):
(WKViewCreateDeprecated):
* Source/WebKit/UIProcess/API/glib/WebKitWebView.cpp:
(webkitWebViewCreatePage):
* Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.h:
* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h:
* Tools/TestWebKitAPI/wpe/PlatformWebViewWPE.cpp:
(TestWebKitAPI::PlatformWebView::~PlatformWebView):
* Tools/WebKitTestRunner/libwpe/PlatformWebViewClient.h:
(WTR::PlatformWebViewClient::~PlatformWebViewClient):

Canonical link: <a href="https://commits.webkit.org/280568@main">https://commits.webkit.org/280568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d2bf793dfb50a49fdffa5aa7d3329f716e57596

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60616 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7439 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7629 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/46159 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 wincairo-tests~~](https://ews-build.webkit.org/#/builders/60/builds/5227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59026 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34111 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/49194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/27019 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/30891 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/6525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6444 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/6796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62297 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/909 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6900 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53416 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/912 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/49249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/53455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/769 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8492 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32153 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33238 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34323 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32984 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->