### PR TITLE
[GStreamer] Use ASCIILiteral in registry scanner

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -245,9 +245,9 @@ GList* GStreamerRegistryScanner::ElementFactories::factory(GStreamerRegistryScan
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::ElementFactories::hasElementForMediaType(ElementFactories::Type factoryType, const char* capsString, ElementFactories::CheckHardwareClassifier shouldCheckHardwareClassifier, std::optional<Vector<String>> disallowedList) const
+GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::ElementFactories::hasElementForMediaType(ElementFactories::Type factoryType, const ASCIILiteral& capsString, ElementFactories::CheckHardwareClassifier shouldCheckHardwareClassifier, std::optional<Vector<String>> disallowedList) const
 {
-    GRefPtr<GstCaps> caps = adoptGRef(gst_caps_from_string(capsString));
+    GRefPtr<GstCaps> caps = adoptGRef(gst_caps_from_string(capsString.characters()));
     if (!caps)
         return { };
 
@@ -435,7 +435,7 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
 {
     m_decoderCodecMap.clear();
     m_decoderMimeTypeSet.clear();
-    if (auto result = factories.hasElementForMediaType(ElementFactories::Type::AudioDecoder, "audio/mpeg, mpegversion=(int)4")) {
+    if (auto result = factories.hasElementForMediaType(ElementFactories::Type::AudioDecoder, "audio/mpeg, mpegversion=(int)4"_s)) {
         m_decoderMimeTypeSet.add(AtomString("audio/aac"_s));
         m_decoderMimeTypeSet.add(AtomString("audio/mp4"_s));
         m_decoderMimeTypeSet.add(AtomString("audio/x-m4a"_s));
@@ -445,23 +445,23 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
         m_decoderCodecMap.add(AtomString("mp4a*"_s), result);
     }
 
-    auto opusSupported = factories.hasElementForMediaType(ElementFactories::Type::AudioDecoder, "audio/x-opus");
-    if (opusSupported && (!m_isMediaSource || factories.hasElementForMediaType(ElementFactories::Type::AudioParser, "audio/x-opus"))) {
+    auto opusSupported = factories.hasElementForMediaType(ElementFactories::Type::AudioDecoder, "audio/x-opus"_s);
+    if (opusSupported && (!m_isMediaSource || factories.hasElementForMediaType(ElementFactories::Type::AudioParser, "audio/x-opus"_s))) {
         m_decoderMimeTypeSet.add(AtomString("audio/opus"_s));
         m_decoderCodecMap.add(AtomString("opus"_s), opusSupported);
         m_decoderCodecMap.add(AtomString("x-opus"_s), opusSupported);
     }
 
-    auto vorbisSupported = factories.hasElementForMediaType(ElementFactories::Type::AudioDecoder, "audio/x-vorbis");
-    if (vorbisSupported && (!m_isMediaSource || factories.hasElementForMediaType(ElementFactories::Type::AudioParser, "audio/x-vorbis"))) {
+    auto vorbisSupported = factories.hasElementForMediaType(ElementFactories::Type::AudioDecoder, "audio/x-vorbis"_s);
+    if (vorbisSupported && (!m_isMediaSource || factories.hasElementForMediaType(ElementFactories::Type::AudioParser, "audio/x-vorbis"_s))) {
         m_decoderCodecMap.add(AtomString("vorbis"_s), vorbisSupported);
         m_decoderCodecMap.add(AtomString("x-vorbis"_s), vorbisSupported);
     }
 
-    bool matroskaSupported = factories.hasElementForMediaType(ElementFactories::Type::Demuxer, "video/x-matroska");
+    bool matroskaSupported = factories.hasElementForMediaType(ElementFactories::Type::Demuxer, "video/x-matroska"_s);
     if (matroskaSupported) {
-        auto vp8DecoderAvailable = factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-vp8", ElementFactories::CheckHardwareClassifier::Yes, { { "vp8alphadecodebin"_s } });
-        auto vp9DecoderAvailable = factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-vp9", ElementFactories::CheckHardwareClassifier::Yes, { { "vp9alphadecodebin"_s } });
+        auto vp8DecoderAvailable = factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-vp8"_s, ElementFactories::CheckHardwareClassifier::Yes, { { "vp8alphadecodebin"_s } });
+        auto vp9DecoderAvailable = factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-vp9"_s, ElementFactories::CheckHardwareClassifier::Yes, { { "vp9alphadecodebin"_s } });
 
         if (vp8DecoderAvailable || vp9DecoderAvailable)
             m_decoderMimeTypeSet.add(AtomString("video/webm"_s));
@@ -483,31 +483,28 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
 
     bool shouldAddMP4Container = false;
 
-    auto h264DecoderAvailable = factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-h264, profile=(string){ constrained-baseline, baseline, high }", ElementFactories::CheckHardwareClassifier::Yes);
+    auto h264DecoderAvailable = factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-h264, profile=(string){ constrained-baseline, baseline, high }"_s, ElementFactories::CheckHardwareClassifier::Yes);
     auto h264AllFormatsDecoderAvailable = GStreamerRegistryScanner::RegistryLookupResult::merge(
-        factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-h264, profile=(string){ constrained-baseline, baseline, high }, stream-format=(string)avc", ElementFactories::CheckHardwareClassifier::Yes),
-        factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-h264, profile=(string){ constrained-baseline, baseline, high }, stream-format=(string)byte-stream", ElementFactories::CheckHardwareClassifier::Yes)
-    );
+        factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-h264, profile=(string){ constrained-baseline, baseline, high }, stream-format=(string)avc"_s, ElementFactories::CheckHardwareClassifier::Yes),
+        factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-h264, profile=(string){ constrained-baseline, baseline, high }, stream-format=(string)byte-stream"_s, ElementFactories::CheckHardwareClassifier::Yes));
     auto needsH264Parse = h264DecoderAvailable != h264AllFormatsDecoderAvailable;
 
-    if (h264DecoderAvailable && (!needsH264Parse || factories.hasElementForMediaType(ElementFactories::Type::VideoParser, "video/x-h264"))) {
+    if (h264DecoderAvailable && (!needsH264Parse || factories.hasElementForMediaType(ElementFactories::Type::VideoParser, "video/x-h264"_s))) {
         shouldAddMP4Container = true;
         m_decoderCodecMap.add(AtomString("x-h264"_s), h264DecoderAvailable);
         m_decoderCodecMap.add(AtomString("avc*"_s), h264DecoderAvailable);
         m_decoderCodecMap.add(AtomString("mp4v*"_s), h264DecoderAvailable);
     }
 
-    auto h265DecoderAvailable = factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-h265", ElementFactories::CheckHardwareClassifier::Yes);
+    auto h265DecoderAvailable = factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-h265"_s, ElementFactories::CheckHardwareClassifier::Yes);
     auto h265AllFormatsDecoderAvailable = GStreamerRegistryScanner::RegistryLookupResult::merge(
-        factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-h265, stream-format=(string)byte-stream", ElementFactories::CheckHardwareClassifier::Yes),
+        factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-h265, stream-format=(string)byte-stream"_s, ElementFactories::CheckHardwareClassifier::Yes),
         GStreamerRegistryScanner::RegistryLookupResult::merge(
-            factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-h265, stream-format=(string)hev1", ElementFactories::CheckHardwareClassifier::Yes),
-            factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-h265, stream-format=(string)hvc1", ElementFactories::CheckHardwareClassifier::Yes)
-        )
-    );
+            factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-h265, stream-format=(string)hev1"_s, ElementFactories::CheckHardwareClassifier::Yes),
+            factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-h265, stream-format=(string)hvc1"_s, ElementFactories::CheckHardwareClassifier::Yes)));
     auto needsH265Parse = h265DecoderAvailable != h265AllFormatsDecoderAvailable;
 
-    if (h265DecoderAvailable && (!needsH265Parse || factories.hasElementForMediaType(ElementFactories::Type::VideoParser, "video/x-h265"))) {
+    if (h265DecoderAvailable && (!needsH265Parse || factories.hasElementForMediaType(ElementFactories::Type::VideoParser, "video/x-h265"_s))) {
         shouldAddMP4Container = true;
         m_decoderCodecMap.add(AtomString("x-h265"_s), h265DecoderAvailable);
         m_decoderCodecMap.add(AtomString("hvc1*"_s), h265DecoderAvailable);
@@ -519,7 +516,7 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
         m_decoderMimeTypeSet.add(AtomString("video/x-m4v"_s));
     }
 
-    auto av1DecoderAvailable = factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-av1", ElementFactories::CheckHardwareClassifier::Yes);
+    auto av1DecoderAvailable = factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-av1"_s, ElementFactories::CheckHardwareClassifier::Yes);
     if ((matroskaSupported || isContainerTypeSupported(Configuration::Decoding, "video/mp4"_s)) && av1DecoderAvailable) {
         m_decoderCodecMap.add(AtomString("av01*"_s), av1DecoderAvailable);
         m_decoderCodecMap.add(AtomString("av1"_s), av1DecoderAvailable);
@@ -527,9 +524,9 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
     }
 
     Vector<GstCapsWebKitMapping> mseCompatibleMapping = {
-        { ElementFactories::Type::AudioDecoder, "audio/x-ac3", { }, { "x-ac3"_s, "ac-3"_s, "ac3"_s } },
-        { ElementFactories::Type::AudioDecoder, "audio/x-eac3", { "audio/x-ac3"_s },  { "x-eac3"_s, "ec3"_s, "ec-3"_s, "eac3"_s } },
-        { ElementFactories::Type::AudioDecoder, "audio/x-flac", { "audio/x-flac"_s, "audio/flac"_s }, {"x-flac"_s, "flac"_s, "fLaC"_s } },
+        { ElementFactories::Type::AudioDecoder, "audio/x-ac3"_s, { }, { "x-ac3"_s, "ac-3"_s, "ac3"_s } },
+        { ElementFactories::Type::AudioDecoder, "audio/x-eac3"_s, { "audio/x-ac3"_s }, { "x-eac3"_s, "ec3"_s, "ec-3"_s, "eac3"_s } },
+        { ElementFactories::Type::AudioDecoder, "audio/x-flac"_s, { "audio/x-flac"_s, "audio/flac"_s }, { "x-flac"_s, "flac"_s, "fLaC"_s } },
     };
     fillMimeTypeSetFromCapsMapping(factories, mseCompatibleMapping);
 
@@ -539,43 +536,43 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
     // The mime-types initialized below are not supported by the MSE backend.
 
     Vector<GstCapsWebKitMapping> mapping = {
-        { ElementFactories::Type::AudioDecoder, "audio/midi", { "audio/midi"_s, "audio/riff-midi"_s }, { } },
-        { ElementFactories::Type::AudioDecoder, "audio/x-dts", { }, { } },
-        { ElementFactories::Type::AudioDecoder, "audio/x-sbc", { }, { } },
-        { ElementFactories::Type::AudioDecoder, "audio/x-sid", { }, { } },
-        { ElementFactories::Type::AudioDecoder, "audio/x-alaw", { }, { "alaw"_s } },
-        { ElementFactories::Type::AudioDecoder, "audio/x-mulaw", { }, { "ulaw"_s } },
-        { ElementFactories::Type::AudioDecoder, "audio/x-speex", { "audio/speex"_s, "audio/x-speex"_s }, { } },
-        { ElementFactories::Type::AudioDecoder, "audio/x-wavpack", { "audio/x-wavpack"_s }, { } },
-        { ElementFactories::Type::VideoDecoder, "video/mpeg, mpegversion=(int){1,2}, systemstream=(boolean)false", { "video/mpeg"_s }, { "mpeg"_s } },
-        { ElementFactories::Type::VideoDecoder, "video/mpegts", { }, { } },
-        { ElementFactories::Type::VideoDecoder, "video/x-dirac", { }, { } },
-        { ElementFactories::Type::VideoDecoder, "video/x-flash-video", { "video/flv"_s, "video/x-flv"_s }, { } },
-        { ElementFactories::Type::VideoDecoder, "video/x-h263", { }, { } },
-        { ElementFactories::Type::VideoDecoder, "video/x-msvideocodec", { "video/x-msvideo"_s }, { } },
-        { ElementFactories::Type::Demuxer, "application/vnd.rn-realmedia", { }, { } },
-        { ElementFactories::Type::Demuxer, "application/x-3gp", { }, { } },
-        { ElementFactories::Type::Demuxer, "application/x-pn-realaudio", { }, { } },
-        { ElementFactories::Type::Demuxer, "audio/x-aiff", { }, { } },
-        { ElementFactories::Type::Demuxer, "audio/x-wav", { "audio/x-wav"_s, "audio/wav"_s, "audio/vnd.wave"_s }, { "1"_s } },
-        { ElementFactories::Type::Demuxer, "video/quicktime", { }, { } },
-        { ElementFactories::Type::Demuxer, "video/quicktime, variant=(string)3gpp", { "video/3gpp"_s }, { } },
-        { ElementFactories::Type::Demuxer, "video/x-ms-asf", { }, { } },
+        { ElementFactories::Type::AudioDecoder, "audio/midi"_s, { "audio/midi"_s, "audio/riff-midi"_s }, { } },
+        { ElementFactories::Type::AudioDecoder, "audio/x-dts"_s, { }, { } },
+        { ElementFactories::Type::AudioDecoder, "audio/x-sbc"_s, { }, { } },
+        { ElementFactories::Type::AudioDecoder, "audio/x-sid"_s, { }, { } },
+        { ElementFactories::Type::AudioDecoder, "audio/x-alaw"_s, { }, { "alaw"_s } },
+        { ElementFactories::Type::AudioDecoder, "audio/x-mulaw"_s, { }, { "ulaw"_s } },
+        { ElementFactories::Type::AudioDecoder, "audio/x-speex"_s, { "audio/speex"_s, "audio/x-speex"_s }, { } },
+        { ElementFactories::Type::AudioDecoder, "audio/x-wavpack"_s, { "audio/x-wavpack"_s }, { } },
+        { ElementFactories::Type::VideoDecoder, "video/mpeg, mpegversion=(int){1,2}, systemstream=(boolean)false"_s, { "video/mpeg"_s }, { "mpeg"_s } },
+        { ElementFactories::Type::VideoDecoder, "video/mpegts"_s, { }, { } },
+        { ElementFactories::Type::VideoDecoder, "video/x-dirac"_s, { }, { } },
+        { ElementFactories::Type::VideoDecoder, "video/x-flash-video"_s, { "video/flv"_s, "video/x-flv"_s }, { } },
+        { ElementFactories::Type::VideoDecoder, "video/x-h263"_s, { }, { } },
+        { ElementFactories::Type::VideoDecoder, "video/x-msvideocodec"_s, { "video/x-msvideo"_s }, { } },
+        { ElementFactories::Type::Demuxer, "application/vnd.rn-realmedia"_s, { }, { } },
+        { ElementFactories::Type::Demuxer, "application/x-3gp"_s, { }, { } },
+        { ElementFactories::Type::Demuxer, "application/x-pn-realaudio"_s, { }, { } },
+        { ElementFactories::Type::Demuxer, "audio/x-aiff"_s, { }, { } },
+        { ElementFactories::Type::Demuxer, "audio/x-wav"_s, { "audio/x-wav"_s, "audio/wav"_s, "audio/vnd.wave"_s }, { "1"_s } },
+        { ElementFactories::Type::Demuxer, "video/quicktime"_s, { }, { } },
+        { ElementFactories::Type::Demuxer, "video/quicktime, variant=(string)3gpp"_s, { "video/3gpp"_s }, { } },
+        { ElementFactories::Type::Demuxer, "video/x-ms-asf"_s, { }, { } },
     };
 
     if (const char* hlsSupport = g_getenv("WEBKIT_GST_ENABLE_HLS_SUPPORT")) {
         if (!g_strcmp0(hlsSupport, "1"))
-            mapping.append({ ElementFactories::Type::Demuxer, "application/x-hls", { "application/vnd.apple.mpegurl"_s, "application/x-mpegurl"_s }, { } });
+            mapping.append({ ElementFactories::Type::Demuxer, "application/x-hls"_s, { "application/vnd.apple.mpegurl"_s, "application/x-mpegurl"_s }, { } });
     }
 
     if (const char* dashSupport = g_getenv("WEBKIT_GST_ENABLE_DASH_SUPPORT")) {
         if (!g_strcmp0(dashSupport, "1"))
-            mapping.append({ ElementFactories::Type::Demuxer, "application/dash+xml", { }, { } });
+            mapping.append({ ElementFactories::Type::Demuxer, "application/dash+xml"_s, { }, { } });
     }
 
     fillMimeTypeSetFromCapsMapping(factories, mapping);
 
-    if (factories.hasElementForMediaType(ElementFactories::Type::Demuxer, "application/ogg")) {
+    if (factories.hasElementForMediaType(ElementFactories::Type::Demuxer, "application/ogg"_s)) {
         m_decoderMimeTypeSet.add(AtomString("application/ogg"_s));
 
         if (vorbisSupported) {
@@ -583,19 +580,19 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
             m_decoderMimeTypeSet.add(AtomString("audio/x-vorbis+ogg"_s));
         }
 
-        if (auto result = factories.hasElementForMediaType(ElementFactories::Type::AudioDecoder, "audio/x-speex")) {
+        if (auto result = factories.hasElementForMediaType(ElementFactories::Type::AudioDecoder, "audio/x-speex"_s)) {
             m_decoderMimeTypeSet.add(AtomString("audio/ogg"_s));
             m_decoderCodecMap.add(AtomString("speex"_s), result);
         }
 
-        if (auto result = factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-theora")) {
+        if (auto result = factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-theora"_s)) {
             m_decoderMimeTypeSet.add(AtomString("video/ogg"_s));
             m_decoderCodecMap.add(AtomString("theora"_s), result);
         }
     }
 
     bool audioMpegSupported = false;
-    if (auto result = factories.hasElementForMediaType(ElementFactories::Type::AudioDecoder, "audio/mpeg, mpegversion=(int)1, layer=(int)[1, 3]")) {
+    if (auto result = factories.hasElementForMediaType(ElementFactories::Type::AudioDecoder, "audio/mpeg, mpegversion=(int)1, layer=(int)[1, 3]"_s)) {
         audioMpegSupported = true;
         m_decoderMimeTypeSet.add(AtomString("audio/mp1"_s));
         m_decoderMimeTypeSet.add(AtomString("audio/mp3"_s));
@@ -604,7 +601,7 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
         m_decoderCodecMap.add(AtomString("mp3"_s), result);
     }
 
-    if (factories.hasElementForMediaType(ElementFactories::Type::AudioDecoder, "audio/mpeg, mpegversion=(int)2")) {
+    if (factories.hasElementForMediaType(ElementFactories::Type::AudioDecoder, "audio/mpeg, mpegversion=(int)2"_s)) {
         audioMpegSupported = true;
         m_decoderMimeTypeSet.add(AtomString("audio/mp2"_s));
     }
@@ -618,7 +615,7 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
     if (matroskaSupported) {
         m_decoderMimeTypeSet.add(AtomString("video/x-matroska"_s));
 
-        if (factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-vp10"))
+        if (factories.hasElementForMediaType(ElementFactories::Type::VideoDecoder, "video/x-vp10"_s))
             m_decoderMimeTypeSet.add(AtomString("video/webm"_s));
     }
 }
@@ -632,52 +629,52 @@ void GStreamerRegistryScanner::initializeEncoders(const GStreamerRegistryScanner
     m_encoderCodecMap.clear();
     m_encoderMimeTypeSet.clear();
 
-    auto aacSupported = factories.hasElementForMediaType(ElementFactories::Type::AudioEncoder, "audio/mpeg, mpegversion=(int)4");
-    if (auto result = factories.hasElementForMediaType(ElementFactories::Type::AudioEncoder, "audio/mpeg, mpegversion=(int)4")) {
+    auto aacSupported = factories.hasElementForMediaType(ElementFactories::Type::AudioEncoder, "audio/mpeg, mpegversion=(int)4"_s);
+    if (auto result = factories.hasElementForMediaType(ElementFactories::Type::AudioEncoder, "audio/mpeg, mpegversion=(int)4"_s)) {
         m_encoderCodecMap.add(AtomString("mpeg"_s), result);
         m_encoderCodecMap.add(AtomString("mp4a*"_s), result);
     }
 
-    if (auto alawSupported = factories.hasElementForMediaType(ElementFactories::Type::AudioEncoder, "audio/x-alaw"))
+    if (auto alawSupported = factories.hasElementForMediaType(ElementFactories::Type::AudioEncoder, "audio/x-alaw"_s))
         m_encoderCodecMap.add(AtomString("alaw"_s), alawSupported);
 
-    if (auto ulawSupported = factories.hasElementForMediaType(ElementFactories::Type::AudioEncoder, "audio/x-mulaw"))
+    if (auto ulawSupported = factories.hasElementForMediaType(ElementFactories::Type::AudioEncoder, "audio/x-mulaw"_s))
         m_encoderCodecMap.add(AtomString("ulaw"_s), ulawSupported);
 
-    if (auto flacSupported = factories.hasElementForMediaType(ElementFactories::Type::AudioEncoder, "audio/x-flac"))
+    if (auto flacSupported = factories.hasElementForMediaType(ElementFactories::Type::AudioEncoder, "audio/x-flac"_s))
         m_encoderCodecMap.add(AtomString("flac"_s), flacSupported);
 
-    if (auto mp3Supported = factories.hasElementForMediaType(ElementFactories::Type::AudioEncoder, "audio/mpeg, mpegversion=(int)1, layer=(int)3"))
+    if (auto mp3Supported = factories.hasElementForMediaType(ElementFactories::Type::AudioEncoder, "audio/mpeg, mpegversion=(int)1, layer=(int)3"_s))
         m_encoderCodecMap.add(AtomString("mp3"_s), mp3Supported);
 
-    auto opusSupported = factories.hasElementForMediaType(ElementFactories::Type::AudioEncoder, "audio/x-opus");
+    auto opusSupported = factories.hasElementForMediaType(ElementFactories::Type::AudioEncoder, "audio/x-opus"_s);
     if (opusSupported) {
         m_encoderCodecMap.add(AtomString("opus"_s), opusSupported);
         m_encoderCodecMap.add(AtomString("x-opus"_s), opusSupported);
     }
 
-    auto vorbisSupported = factories.hasElementForMediaType(ElementFactories::Type::AudioEncoder, "audio/x-vorbis");
+    auto vorbisSupported = factories.hasElementForMediaType(ElementFactories::Type::AudioEncoder, "audio/x-vorbis"_s);
     if (vorbisSupported) {
         m_encoderCodecMap.add(AtomString("vorbis"_s), vorbisSupported);
         m_encoderCodecMap.add(AtomString("x-vorbis"_s), vorbisSupported);
     }
 
     Vector<String> av1EncodersDisallowedList { "av1enc"_s };
-    auto av1EncoderAvailable = factories.hasElementForMediaType(ElementFactories::Type::VideoEncoder, "video/x-av1", ElementFactories::CheckHardwareClassifier::Yes, std::make_optional(WTFMove(av1EncodersDisallowedList)));
+    auto av1EncoderAvailable = factories.hasElementForMediaType(ElementFactories::Type::VideoEncoder, "video/x-av1"_s, ElementFactories::CheckHardwareClassifier::Yes, std::make_optional(WTFMove(av1EncodersDisallowedList)));
     if (av1EncoderAvailable) {
         m_encoderCodecMap.add(AtomString("av01*"_s), av1EncoderAvailable);
         m_encoderCodecMap.add(AtomString("av1"_s), av1EncoderAvailable);
         m_encoderCodecMap.add(AtomString("x-av1"_s), av1EncoderAvailable);
     }
 
-    auto vp8EncoderAvailable = factories.hasElementForMediaType(ElementFactories::Type::VideoEncoder, "video/x-vp8", ElementFactories::CheckHardwareClassifier::Yes);
+    auto vp8EncoderAvailable = factories.hasElementForMediaType(ElementFactories::Type::VideoEncoder, "video/x-vp8"_s, ElementFactories::CheckHardwareClassifier::Yes);
     if (vp8EncoderAvailable) {
         m_encoderCodecMap.add(AtomString("vp8"_s), vp8EncoderAvailable);
         m_encoderCodecMap.add(AtomString("x-vp8"_s), vp8EncoderAvailable);
         m_encoderCodecMap.add(AtomString("vp8.0"_s), vp8EncoderAvailable);
     }
 
-    auto vp9EncoderAvailable = factories.hasElementForMediaType(ElementFactories::Type::VideoEncoder, "video/x-vp9", ElementFactories::CheckHardwareClassifier::Yes);
+    auto vp9EncoderAvailable = factories.hasElementForMediaType(ElementFactories::Type::VideoEncoder, "video/x-vp9"_s, ElementFactories::CheckHardwareClassifier::Yes);
     if (vp9EncoderAvailable) {
         m_encoderCodecMap.add(AtomString("vp9"_s), vp9EncoderAvailable);
         m_encoderCodecMap.add(AtomString("x-vp9"_s), vp9EncoderAvailable);
@@ -685,19 +682,19 @@ void GStreamerRegistryScanner::initializeEncoders(const GStreamerRegistryScanner
         m_encoderCodecMap.add(AtomString("vp09*"_s), vp9EncoderAvailable);
     }
 
-    if (factories.hasElementForMediaType(ElementFactories::Type::Muxer, "video/webm") && (vp8EncoderAvailable || vp9EncoderAvailable || av1EncoderAvailable))
+    if (factories.hasElementForMediaType(ElementFactories::Type::Muxer, "video/webm"_s) && (vp8EncoderAvailable || vp9EncoderAvailable || av1EncoderAvailable))
         m_encoderMimeTypeSet.add(AtomString("video/webm"_s));
 
-    if (factories.hasElementForMediaType(ElementFactories::Type::Muxer, "audio/webm")) {
+    if (factories.hasElementForMediaType(ElementFactories::Type::Muxer, "audio/webm"_s)) {
         if (opusSupported)
             m_encoderMimeTypeSet.add(AtomString("audio/opus"_s));
         m_encoderMimeTypeSet.add(AtomString("audio/webm"_s));
     }
 
-    if (factories.hasElementForMediaType(ElementFactories::Type::Muxer, "audio/ogg") && (vorbisSupported || opusSupported))
+    if (factories.hasElementForMediaType(ElementFactories::Type::Muxer, "audio/ogg"_s) && (vorbisSupported || opusSupported))
         m_encoderMimeTypeSet.add(AtomString("audio/ogg"_s));
 
-    auto h264EncoderAvailable = factories.hasElementForMediaType(ElementFactories::Type::VideoEncoder, "video/x-h264, profile=(string){ constrained-baseline, baseline, high }", ElementFactories::CheckHardwareClassifier::Yes);
+    auto h264EncoderAvailable = factories.hasElementForMediaType(ElementFactories::Type::VideoEncoder, "video/x-h264, profile=(string){ constrained-baseline, baseline, high }"_s, ElementFactories::CheckHardwareClassifier::Yes);
     if (h264EncoderAvailable) {
         m_encoderCodecMap.add(AtomString("h264"_s), h264EncoderAvailable);
         m_encoderCodecMap.add(AtomString("x-h264"_s), h264EncoderAvailable);
@@ -705,13 +702,13 @@ void GStreamerRegistryScanner::initializeEncoders(const GStreamerRegistryScanner
         m_encoderCodecMap.add(AtomString("mp4v*"_s), h264EncoderAvailable);
     }
 
-    auto h265EncoderAvailable = factories.hasElementForMediaType(ElementFactories::Type::VideoEncoder, "video/x-h265, profile=(string){ main, high }", ElementFactories::CheckHardwareClassifier::Yes);
+    auto h265EncoderAvailable = factories.hasElementForMediaType(ElementFactories::Type::VideoEncoder, "video/x-h265, profile=(string){ main, high }"_s, ElementFactories::CheckHardwareClassifier::Yes);
     if (h265EncoderAvailable) {
         m_encoderCodecMap.add(AtomString("hev1*"_s), h265EncoderAvailable);
         m_encoderCodecMap.add(AtomString("hvc1*"_s), h265EncoderAvailable);
     }
 
-    if (factories.hasElementForMediaType(ElementFactories::Type::Muxer, "video/quicktime")) {
+    if (factories.hasElementForMediaType(ElementFactories::Type::Muxer, "video/quicktime"_s)) {
         if (opusSupported)
             m_encoderMimeTypeSet.add(AtomString("audio/opus"_s));
         if (aacSupported) {
@@ -1052,16 +1049,16 @@ void GStreamerRegistryScanner::fillAudioRtpCapabilities(Configuration configurat
     }
 
     auto factories = ElementFactories({ codecElement, rtpElement });
-    if (factories.hasElementForMediaType(codecElement, "audio/x-opus") && factories.hasElementForMediaType(rtpElement, "audio/x-opus"))
+    if (factories.hasElementForMediaType(codecElement, "audio/x-opus"_s) && factories.hasElementForMediaType(rtpElement, "audio/x-opus"_s))
         capabilities.codecs.append({ .mimeType = "audio/opus"_s, .clockRate = 48000, .channels = 2, .sdpFmtpLine = "minptime=10;useinbandfec=1"_s });
 
-    if (factories.hasElementForMediaType(codecElement, "audio/G722") && factories.hasElementForMediaType(rtpElement, "audio/G722"))
+    if (factories.hasElementForMediaType(codecElement, "audio/G722"_s) && factories.hasElementForMediaType(rtpElement, "audio/G722"_s))
         capabilities.codecs.append({ .mimeType = "audio/G722"_s, .clockRate = 8000, .channels = 1, .sdpFmtpLine = emptyString() });
 
-    if (factories.hasElementForMediaType(codecElement, "audio/x-mulaw") && factories.hasElementForMediaType(rtpElement, "audio/x-mulaw"))
+    if (factories.hasElementForMediaType(codecElement, "audio/x-mulaw"_s) && factories.hasElementForMediaType(rtpElement, "audio/x-mulaw"_s))
         capabilities.codecs.append({ .mimeType = "audio/PCMU"_s, .clockRate = 8000, .channels = 1, .sdpFmtpLine = emptyString() });
 
-    if (factories.hasElementForMediaType(codecElement, "audio/x-alaw") && factories.hasElementForMediaType(rtpElement, "audio/x-alaw"))
+    if (factories.hasElementForMediaType(codecElement, "audio/x-alaw"_s) && factories.hasElementForMediaType(rtpElement, "audio/x-alaw"_s))
         capabilities.codecs.append({ .mimeType = "audio/PCMA"_s, .clockRate = 8000, .channels = 1, .sdpFmtpLine = emptyString() });
 }
 
@@ -1083,8 +1080,8 @@ void GStreamerRegistryScanner::fillVideoRtpCapabilities(Configuration configurat
     }
 
     auto factories = ElementFactories({ codecElement, rtpElement });
-    auto codecLookupResult = factories.hasElementForMediaType(codecElement, "video/x-h264");
-    if (codecLookupResult && factories.hasElementForMediaType(rtpElement, "video/x-h264")) {
+    auto codecLookupResult = factories.hasElementForMediaType(codecElement, "video/x-h264"_s);
+    if (codecLookupResult && factories.hasElementForMediaType(rtpElement, "video/x-h264"_s)) {
         GRefPtr<GstElement> element;
         if (configuration == Configuration::Decoding)
             element = gst_element_factory_create(codecLookupResult.factory.get(), nullptr);
@@ -1123,18 +1120,18 @@ void GStreamerRegistryScanner::fillVideoRtpCapabilities(Configuration configurat
         }
     }
 
-    if (factories.hasElementForMediaType(codecElement, "video/x-h265") && factories.hasElementForMediaType(rtpElement, "video/x-h265")) {
+    if (factories.hasElementForMediaType(codecElement, "video/x-h265"_s) && factories.hasElementForMediaType(rtpElement, "video/x-h265"_s)) {
         // FIXME: Probe for video/H265 encoder capabilities.
         capabilities.codecs.append({ .mimeType = "video/H265"_s, .clockRate = 90000, .channels = { }, .sdpFmtpLine = { } });
     }
 
-    if (factories.hasElementForMediaType(codecElement, "video/x-av1") && factories.hasElementForMediaType(rtpElement, "video/x-av1"))
+    if (factories.hasElementForMediaType(codecElement, "video/x-av1"_s) && factories.hasElementForMediaType(rtpElement, "video/x-av1"_s))
         capabilities.codecs.append({ .mimeType = "video/AV1"_s, .clockRate = 90000, .channels = { }, .sdpFmtpLine = { } });
 
-    if (factories.hasElementForMediaType(codecElement, "video/x-vp8") && factories.hasElementForMediaType(rtpElement, "video/x-vp8"))
+    if (factories.hasElementForMediaType(codecElement, "video/x-vp8"_s) && factories.hasElementForMediaType(rtpElement, "video/x-vp8"_s))
         capabilities.codecs.append({ .mimeType = "video/VP8"_s, .clockRate = 90000, .channels = { }, .sdpFmtpLine = { } });
 
-    if (factories.hasElementForMediaType(codecElement, "video/x-vp9") && factories.hasElementForMediaType(rtpElement, "video/x-vp9")) {
+    if (factories.hasElementForMediaType(codecElement, "video/x-vp9"_s) && factories.hasElementForMediaType(rtpElement, "video/x-vp9"_s)) {
         // FIXME: Profile levels are hardcoded here for the time being. It might be a good idea to
         // actually probe those on the selected encoder.
         capabilities.codecs.append({ .mimeType = "video/VP9"_s, .clockRate = 90000, .channels = { }, .sdpFmtpLine = "profile-id=0"_s });

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h
@@ -139,7 +139,7 @@ protected:
         GList* factory(Type) const;
 
         enum class CheckHardwareClassifier : bool { No, Yes };
-        RegistryLookupResult hasElementForMediaType(Type, const char* capsString, CheckHardwareClassifier = CheckHardwareClassifier::No, std::optional<Vector<String>> disallowedList = std::nullopt) const;
+        RegistryLookupResult hasElementForMediaType(Type, const ASCIILiteral& capsString, CheckHardwareClassifier = CheckHardwareClassifier::No, std::optional<Vector<String>> disallowedList = std::nullopt) const;
         RegistryLookupResult hasElementForCaps(Type, const GRefPtr<GstCaps>&, CheckHardwareClassifier = CheckHardwareClassifier::No, std::optional<Vector<String>> disallowedList = std::nullopt) const;
 
         GList* audioDecoderFactories { nullptr };
@@ -162,7 +162,7 @@ protected:
 
     struct GstCapsWebKitMapping {
         ElementFactories::Type elementType;
-        const char* capsString;
+        ASCIILiteral capsString;
         Vector<AtomString> webkitMimeTypes;
         Vector<AtomString> webkitCodecPatterns;
     };


### PR DESCRIPTION
#### 59b02eee1fcfe02ef18314b534ad1c54866518a0
<pre>
[GStreamer] Use ASCIILiteral in registry scanner
<a href="https://bugs.webkit.org/show_bug.cgi?id=276061">https://bugs.webkit.org/show_bug.cgi?id=276061</a>

Reviewed by Xabier Rodriguez-Calvar.

Replace const char* usage in hasElementForMediaType with an ASCIILiteral.

* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
(WebCore::GStreamerRegistryScanner::ElementFactories::hasElementForMediaType const):
(WebCore::GStreamerRegistryScanner::initializeDecoders):
(WebCore::GStreamerRegistryScanner::initializeEncoders):
(WebCore::GStreamerRegistryScanner::fillAudioRtpCapabilities):
(WebCore::GStreamerRegistryScanner::fillVideoRtpCapabilities):
* Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.h:

Canonical link: <a href="https://commits.webkit.org/280532@main">https://commits.webkit.org/280532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ca751cafdfed475cfb3dfaed61a1ff5599c8e19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36229 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9375 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60520 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7344 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59029 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7534 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46089 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5158 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58931 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34028 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49108 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26947 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30808 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6439 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6348 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6710 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62202 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/814 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6816 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53344 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/817 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49163 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53384 "Found 4 new API test failures: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure, /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/proxy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12576 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/690 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32058 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33143 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34228 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32889 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->