### PR TITLE
[WPE] Create the WebPageProxy after initializing activity state flags

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
@@ -39,23 +39,10 @@ using namespace WebKit;
 
 namespace WKWPE {
 
-View::View(const API::PageConfiguration& baseConfiguration)
+View::View()
     : m_client(makeUnique<API::ViewClient>())
     , m_pageClient(makeUniqueWithoutRefCountedCheck<PageClientImpl>(*this))
 {
-    auto configuration = baseConfiguration.copy();
-    auto& preferences = configuration->preferences();
-    preferences.setAcceleratedCompositingEnabled(true);
-    preferences.setForceCompositingMode(true);
-    preferences.setThreadedScrollingEnabled(true);
-
-    auto& pool = configuration->processPool();
-    m_pageProxy = pool.createWebPage(*m_pageClient, WTFMove(configuration));
-
-#if ENABLE(MEMORY_SAMPLER)
-    if (getenv("WEBKIT_SAMPLE_MEMORY"))
-        pool.startMemorySampler(0);
-#endif
 }
 
 View::~View()
@@ -63,6 +50,17 @@ View::~View()
 #if USE(ATK)
     if (m_accessible)
         webkitWebViewAccessibleSetWebView(m_accessible.get(), nullptr);
+#endif
+}
+
+void View::createWebPage(const API::PageConfiguration& configuration)
+{
+    auto& pool = configuration.processPool();
+    m_pageProxy = pool.createWebPage(*m_pageClient, configuration.copy());
+
+#if ENABLE(MEMORY_SAMPLER)
+    if (getenv("WEBKIT_SAMPLE_MEMORY"))
+        pool.startMemorySampler(0);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
@@ -102,8 +102,9 @@ public:
     virtual void callAfterNextPresentationUpdate(CompletionHandler<void()>&&) = 0;
 
 protected:
-    explicit View(const API::PageConfiguration&);
+    View();
 
+    void createWebPage(const API::PageConfiguration&);
     void setSize(const WebCore::IntSize&);
 
     std::unique_ptr<API::ViewClient> m_client;

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp
@@ -51,9 +51,8 @@ static Vector<ViewLegacy*>& viewsVector()
     return vector;
 }
 
-ViewLegacy::ViewLegacy(struct wpe_view_backend* backend, const API::PageConfiguration& baseConfiguration)
-    : View(baseConfiguration)
-    , m_backend(backend)
+ViewLegacy::ViewLegacy(struct wpe_view_backend* backend, const API::PageConfiguration& configuration)
+    : m_backend(backend)
 #if ENABLE(TOUCH_EVENTS)
     , m_touchGestureController(makeUnique<TouchGestureController>())
 #endif
@@ -61,7 +60,9 @@ ViewLegacy::ViewLegacy(struct wpe_view_backend* backend, const API::PageConfigur
     ASSERT(m_backend);
 
     m_size = { 800, 600 };
-    setViewState({ WebCore::ActivityState::WindowIsActive, WebCore::ActivityState::IsFocused, WebCore::ActivityState::IsVisible, WebCore::ActivityState::IsInWindow });
+    m_viewStateFlags = { WebCore::ActivityState::WindowIsActive, WebCore::ActivityState::IsFocused, WebCore::ActivityState::IsVisible, WebCore::ActivityState::IsInWindow };
+
+    createWebPage(configuration);
 
     static struct wpe_view_backend_client s_backendClient = {
         // set_size

--- a/Source/WebKit/UIProcess/wpe/WebPreferencesWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/WebPreferencesWPE.cpp
@@ -30,6 +30,10 @@ namespace WebKit {
 
 void WebPreferences::platformInitializeStore()
 {
+    setAcceleratedCompositingEnabled(true);
+    setForceCompositingMode(true);
+    setThreadedScrollingEnabled(true);
+
 #if USE(SKIA)
     // FIXME: Expose this as a setting when we switch to Skia.
     static const char* disableAccelerated2DCanvas = getenv("WEBKIT_DISABLE_ACCELERATED_2D_CANVAS");


### PR DESCRIPTION
#### 6461ef8e6cca4c13ffd021cf66d35182a156255f
<pre>
[WPE] Create the WebPageProxy after initializing activity state flags
<a href="https://bugs.webkit.org/show_bug.cgi?id=276062">https://bugs.webkit.org/show_bug.cgi?id=276062</a>

Reviewed by Nikolas Zimmermann.

WebPageProxy queries the page client in the constructor to initialize
the activity flags. If we initialize the WKWPE::View flags before
creating the page we save an IPC message.

* Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp:
(WKWPE::View::View):
(WKWPE::View::createWebPage):
* Source/WebKit/UIProcess/API/wpe/WPEWebView.h:
* Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp:
(WKWPE::ViewLegacy::ViewLegacy):
* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp:
(WKWPE::ViewPlatform::ViewPlatform):
* Source/WebKit/UIProcess/wpe/WebPreferencesWPE.cpp:
(WebKit::WebPreferences::platformInitializeStore):

Canonical link: <a href="https://commits.webkit.org/280567@main">https://commits.webkit.org/280567@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c3ee221f66c8d514ff779a93def19cb4186603d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60507 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7331 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7521 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46079 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5147 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58918 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34017 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49096 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26937 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30797 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6335 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52757 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6698 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62189 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/801 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6803 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53333 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/804 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49151 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53369 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/679 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8491 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32045 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33130 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34215 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32876 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->