### PR TITLE
[GStreamer] Use gstStructureGet helper in more places

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -1082,12 +1082,12 @@ int GStreamerMediaEndpoint::pickAvailablePayloadType()
             continue;
 
         gst_caps_foreach(codecPreferences.get(), reinterpret_cast<GstCapsForeachFunc>(+[](GstCapsFeatures*, GstStructure* structure, gpointer data) -> gboolean {
-            int payloadType;
-            if (!gst_structure_get_int(structure, "payload", &payloadType))
+            auto payloadType = gstStructureGet<int>(structure, "payload"_s);
+            if (!payloadType)
                 return TRUE;
 
             auto* holder = reinterpret_cast<PayloadTypeHolder*>(data);
-            holder->payloadType = std::max(holder->payloadType, payloadType);
+            holder->payloadType = std::max(holder->payloadType, *payloadType);
             return TRUE;
         }), holder);
     }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -732,9 +732,8 @@ GRefPtr<GstElement> createOptionalParserForFormat(GstBin* bin, const AtomString&
         // as the (as of writing) only one spec-defined format that has the "Generate Timestamps Flag" set
         // to false, i.e. is used without a demuxer, in "sequence" mode.
         // We need a parser to take care of extracting the frames from the byte stream.
-        int mpegversion = 0;
-        gst_structure_get_int(structure, "mpegversion", &mpegversion);
-        switch (mpegversion) {
+        int mpegVersion = gstStructureGet<int>(structure, "mpegversion"_s).value_or(0);
+        switch (mpegVersion) {
         case 1:
             // MPEG-1 Part 3 Audio (ISO 11172-3) Layer I -- MP1, archaic
             // MPEG-1 Part 3 Audio (ISO 11172-3) Layer II -- MP2, common in audio broadcasting, e.g. DVB

--- a/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp
@@ -278,15 +278,14 @@ static bool videoEncoderSetEncoder(WebKitVideoEncoder* self, EncoderId encoderId
 
     auto* structure = gst_caps_get_structure(encodedCaps.get(), 0);
     if (structure) {
-        int width;
-        if (gst_structure_get_int(structure, "width", &width) && width > MAX_WIDTH) {
-            GST_WARNING_OBJECT(self, "Encoded width (%d) is too high. Maximum allowed: %d.", width, MAX_WIDTH);
+        auto width = gstStructureGet<int>(structure, "width"_s);
+        if (width && *width > MAX_WIDTH) {
+            GST_WARNING_OBJECT(self, "Encoded width (%d) is too high. Maximum allowed: %d.", *width, MAX_WIDTH);
             return false;
         }
-
-        int height;
-        if (gst_structure_get_int(structure, "height", &height) && height > MAX_HEIGHT) {
-            GST_WARNING_OBJECT(self, "Encoded height (%d) is too high. Maximum allowed: %d.", height, MAX_HEIGHT);
+        auto height = gstStructureGet<int>(structure, "height"_s);
+        if (height && *height > MAX_HEIGHT) {
+            GST_WARNING_OBJECT(self, "Encoded height (%d) is too high. Maximum allowed: %d.", *height, MAX_HEIGHT);
             return false;
         }
     }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp
@@ -250,13 +250,14 @@ const GstStructure* GStreamerIncomingTrackProcessor::stats()
         return nullptr;
 
     m_stats.reset(gst_structure_new_empty("incoming-video-stats"));
-    uint64_t droppedVideoFrames = 0;
     GUniqueOutPtr<GstStructure> stats;
     g_object_get(m_fakeVideoSink.get(), "stats", &stats.outPtr(), nullptr);
-    if (!gst_structure_get_uint64(stats.get(), "dropped", &droppedVideoFrames))
+
+    auto droppedVideoFrames = gstStructureGet<uint64_t>(stats.get(), "dropped"_s);
+    if (!droppedVideoFrames)
         return m_stats.get();
 
-    gst_structure_set(m_stats.get(), "frames-decoded", G_TYPE_UINT64, m_decodedVideoFrames, "frames-dropped", G_TYPE_UINT64, droppedVideoFrames, nullptr);
+    gst_structure_set(m_stats.get(), "frames-decoded", G_TYPE_UINT64, m_decodedVideoFrames, "frames-dropped", G_TYPE_UINT64, *droppedVideoFrames, nullptr);
     if (!m_videoSize.isZero())
         gst_structure_set(m_stats.get(), "frame-width", G_TYPE_UINT, static_cast<unsigned>(m_videoSize.width()), "frame-height", G_TYPE_UINT, static_cast<unsigned>(m_videoSize.height()), nullptr);
     return m_stats.get();

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp
@@ -293,11 +293,8 @@ void GStreamerVideoCapturer::reconfigure()
 
     // If nothing has been specified by the user, we target at least an arbitrary resolution of 1920x1080@24fps.
     const GstStructure* capsStruct = gst_caps_get_structure(m_caps.get(), 0);
-    if (!gst_structure_get_int(capsStruct, "width", &selector.stopCondition.width))
-        selector.stopCondition.width = 1920;
-
-    if (!gst_structure_get_int(capsStruct, "height", &selector.stopCondition.height))
-        selector.stopCondition.height = 1080;
+    selector.stopCondition.width = gstStructureGet<int>(capsStruct, "width"_s).value_or(1920);
+    selector.stopCondition.height = gstStructureGet<int>(capsStruct, "height"_s).value_or(1080);
 
     int numerator = 0;
     int denominator = 1;


### PR DESCRIPTION
#### be64472d6f0a6e2415907fabe53ba7aa4fec261c
<pre>
[GStreamer] Use gstStructureGet helper in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=276063">https://bugs.webkit.org/show_bug.cgi?id=276063</a>

Reviewed by Xabier Rodriguez-Calvar.

Use the new helper instead of gst_structure_get_ functions when possible.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::pickAvailablePayloadType):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::getVideoSizeAndFormatFromCaps):
(WebCore::getVideoResolutionFromCaps):
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::createOptionalParserForFormat):
* Source/WebCore/platform/gstreamer/VideoEncoderPrivateGStreamer.cpp:
(videoEncoderSetEncoder):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerIncomingTrackProcessor.cpp:
(WebCore::GStreamerIncomingTrackProcessor::stats):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCapturer.cpp:
(WebCore::GStreamerVideoCapturer::reconfigure):

Canonical link: <a href="https://commits.webkit.org/280533@main">https://commits.webkit.org/280533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffeefd6aa3d40ed89bf1f420c5e5ee55fceb859a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60521 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7345 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59030 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43853 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7535 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46090 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5157 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34030 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26948 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30810 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6441 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6349 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6712 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62203 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/815 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6815 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53345 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/818 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53385 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12577 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/692 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32059 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33144 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34229 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32890 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->