### PR TITLE
Add missing `required` for RTCCodecStats dictionary in RTCStatsReport.idl

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCStatsReport.h
+++ b/Source/WebCore/Modules/mediastream/RTCStatsReport.h
@@ -397,7 +397,7 @@ public:
         CodecStats(const GstStructure*);
 #endif
 
-        std::optional<uint32_t> payloadType;
+        uint32_t payloadType { 0 };
         String transportId;
         String mimeType;
         std::optional<uint32_t> clockRate;

--- a/Source/WebCore/Modules/mediastream/RTCStatsReport.idl
+++ b/Source/WebCore/Modules/mediastream/RTCStatsReport.idl
@@ -205,12 +205,14 @@ enum RTCCodecType {
     "decode"
 };
 
+// https://w3c.github.io/webrtc-stats/#dom-rtccodecstats
+
 [
     JSGenerateToJSObject
 ] dictionary RTCCodecStats : RTCStats {
-    unsigned long payloadType;
-    DOMString transportId;
-    DOMString mimeType;
+    required unsigned long payloadType;
+    required DOMString transportId;
+    required DOMString mimeType;
     unsigned long clockRate;
     unsigned long channels;
     DOMString sdpFmtpLine;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
@@ -69,9 +69,11 @@ RTCStatsReport::SentRtpStreamStats::SentRtpStreamStats(Type type, const GstStruc
 RTCStatsReport::CodecStats::CodecStats(const GstStructure* structure)
     : Stats(Type::Codec, structure)
 {
-    payloadType = gstStructureGet<unsigned>(structure, "payload-type"_s);
     clockRate = gstStructureGet<unsigned>(structure, "clock-rate"_s);
     channels = gstStructureGet<unsigned>(structure, "channels"_s);
+
+    if (auto value = gstStructureGet<unsigned>(structure, "payload-type"_s))
+        payloadType = *value;
 
     if (const char* gstSdpFmtpLine = gst_structure_get_string(structure, "sdp-fmtp-line"))
         sdpFmtpLine = String::fromLatin1(gstSdpFmtpLine);


### PR DESCRIPTION
#### 89f95d2d94f9d1659c4a4243861bf740cfa77b8c
<pre>
Add missing `required` for RTCCodecStats dictionary in RTCStatsReport.idl

<a href="https://bugs.webkit.org/show_bug.cgi?id=274026">https://bugs.webkit.org/show_bug.cgi?id=274026</a>
<a href="https://rdar.apple.com/problem/128306882">rdar://problem/128306882</a>

Reviewed by Youenn Fablet and Philippe Normand.

This patch aligns &apos;RTCCodecStats&apos; as per web specification [1]:

[1] <a href="https://w3c.github.io/webrtc-stats/#dom-rtccodecstats">https://w3c.github.io/webrtc-stats/#dom-rtccodecstats</a>

WebKit was missing `required` for &apos;payloadType&apos;, &apos;transportId&apos; and
&apos;mimeType&apos; and this patch adds it.

* Source/WebCore/Modules/mediastream/RTCStatsReport.h:
* Source/WebCore/Modules/mediastream/RTCStatsReport.idl:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
(WebCore::RTCStatsReport::CodecStats::CodecStats):

Canonical link: <a href="https://commits.webkit.org/280815@main">https://commits.webkit.org/280815@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6e3bd7a4b7559fb6b713c4fb6cb944b1a8b6925

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57727 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/37055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/10203 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/61349 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/8172 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59855 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44691 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/8360 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46771 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5793 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59757 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34753 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49878 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27596 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/31524 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/7170 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/7176 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/53474 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/7441 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/63031 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/1641 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/7518 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53991 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/1647 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49889 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/54108 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12770 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/1386 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32884 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33970 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/35054 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33715 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->