### PR TITLE
[GStreamer] Support for serializing uint64_t values to JSON

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp
@@ -51,14 +51,14 @@ void GStreamerTest::TearDownTestSuite()
 
 TEST_F(GStreamerTest, gstStructureGetters)
 {
-    GUniquePtr<GstStructure> structure(gst_structure_new("foo", "int-val", G_TYPE_INT, -5, "int64-val", G_TYPE_INT64, -10, "uint-val", G_TYPE_UINT, 5, "uint64-val", G_TYPE_UINT64, 10, "double-val", G_TYPE_DOUBLE, 1.0, nullptr));
+    GUniquePtr<GstStructure> structure(gst_structure_new("foo", "int-val", G_TYPE_INT, -5, "int64-val", G_TYPE_INT64, -10, "uint-val", G_TYPE_UINT, 5, "uint64-val", G_TYPE_UINT64, 18014398509481982, "double-val", G_TYPE_DOUBLE, 1.0, nullptr));
     ASSERT_EQ(gstStructureGet<int>(structure.get(), "int-val"_s), -5);
     ASSERT_TRUE(!gstStructureGet<int>(structure.get(), "int-val-noexist"_s).has_value());
     ASSERT_EQ(gstStructureGet<int64_t>(structure.get(), "int64-val"_s), -10);
     ASSERT_TRUE(!gstStructureGet<int64_t>(structure.get(), "int64-val-noexist"_s).has_value());
     ASSERT_EQ(gstStructureGet<unsigned>(structure.get(), "uint-val"_s), 5);
     ASSERT_TRUE(!gstStructureGet<unsigned>(structure.get(), "uint-val-noexist"_s).has_value());
-    ASSERT_EQ(gstStructureGet<uint64_t>(structure.get(), "uint64-val"_s), 10);
+    ASSERT_EQ(gstStructureGet<uint64_t>(structure.get(), "uint64-val"_s), 18014398509481982);
     ASSERT_TRUE(!gstStructureGet<uint64_t>(structure.get(), "uint64-val-noexist"_s).has_value());
     ASSERT_EQ(gstStructureGet<double>(structure.get(), "double-val"_s), 1.0);
     ASSERT_TRUE(!gstStructureGet<double>(structure.get(), "double-val-noexist"_s).has_value());
@@ -66,14 +66,14 @@ TEST_F(GStreamerTest, gstStructureGetters)
 
 TEST_F(GStreamerTest, gstStructureJSONSerializing)
 {
-    GUniquePtr<GstStructure> structure(gst_structure_new("foo", "int-val", G_TYPE_INT, 5, "str-val", G_TYPE_STRING, "foo", "bool-val", G_TYPE_BOOLEAN, TRUE, nullptr));
+    GUniquePtr<GstStructure> structure(gst_structure_new("foo", "int-val", G_TYPE_INT, 5, "str-val", G_TYPE_STRING, "foo", "bool-val", G_TYPE_BOOLEAN, TRUE, "uint64-val", G_TYPE_UINT64, 18014398509481982, nullptr));
     auto jsonString = gstStructureToJSONString(structure.get());
-    ASSERT_EQ(jsonString, "{\"int-val\":5,\"str-val\":\"foo\",\"bool-val\":1}"_s);
+    ASSERT_EQ(jsonString, "{\"int-val\":5,\"str-val\":\"foo\",\"bool-val\":1,\"uint64-val\":{\"$bigint\":\"18014398509481982\"}}"_s);
 
     GUniquePtr<GstStructure> innerStructure(gst_structure_new("bar", "boo", G_TYPE_BOOLEAN, FALSE, "double-val", G_TYPE_DOUBLE, 2.42, nullptr));
     gst_structure_set(structure.get(), "inner", GST_TYPE_STRUCTURE, innerStructure.get(), nullptr);
     jsonString = gstStructureToJSONString(structure.get());
-    ASSERT_EQ(jsonString, "{\"int-val\":5,\"str-val\":\"foo\",\"bool-val\":1,\"inner\":{\"boo\":0,\"double-val\":2.42}}"_s);
+    ASSERT_EQ(jsonString, "{\"int-val\":5,\"str-val\":\"foo\",\"bool-val\":1,\"uint64-val\":{\"$bigint\":\"18014398509481982\"},\"inner\":{\"boo\":0,\"double-val\":2.42}}"_s);
 
     GUniquePtr<GstStructure> structureWithList(gst_structure_new_from_string("foo, words=(string){ hello, world }"));
     jsonString = gstStructureToJSONString(structureWithList.get());


### PR DESCRIPTION
#### 87ee5e0693a006bda3b05bfc7f47fdaaafd4dd99
<pre>
[GStreamer] Support for serializing uint64_t values to JSON
<a href="https://bugs.webkit.org/show_bug.cgi?id=276068">https://bugs.webkit.org/show_bug.cgi?id=276068</a>

Reviewed by Xabier Rodriguez-Calvar.

BigInt is not officially supported in JSON, so the workaround is to serialize to a string. See:
<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#use_within_json">https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#use_within_json</a>

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::gstStructureValueToJSON):
* Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp:
(TestWebKitAPI::TEST_F):

Canonical link: <a href="https://commits.webkit.org/280531@main">https://commits.webkit.org/280531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ea294bc4f60fc2ec995ec8c272ee4c702c934c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36224 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60515 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7339 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59024 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43847 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7529 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46084 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5152 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58926 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34024 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49104 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26942 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30804 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6435 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6343 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52761 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6706 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62197 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/809 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6810 "Found 18 new test failures: imported/w3c/web-platform-tests/css/css-logical/logical-box-border-color.html imported/w3c/web-platform-tests/css/css-logical/logical-box-border-radius.html imported/w3c/web-platform-tests/css/css-logical/logical-box-border-shorthands.html imported/w3c/web-platform-tests/css/css-logical/logical-box-border-style.html imported/w3c/web-platform-tests/css/css-logical/logical-box-border-width.html imported/w3c/web-platform-tests/css/css-logical/logical-box-inset.html imported/w3c/web-platform-tests/css/css-logical/logical-box-margin.html imported/w3c/web-platform-tests/css/css-logical/logical-box-padding.html imported/w3c/web-platform-tests/css/css-writing-modes/logical-physical-mapping-001.html imported/w3c/web-platform-tests/svg/import/metadata-example-01-t-manual.svg ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53339 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/812 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49159 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53378 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12575 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/686 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32053 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33138 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34223 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32884 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->