### PR TITLE
[GStreamer][WebRTC] Log stats type as lower case in JSON

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -971,6 +971,44 @@ GstElement* makeGStreamerBin(const char* description, bool ghostUnlinkedPads)
     return bin;
 }
 
+#if USE(GSTREAMER_WEBRTC)
+static ASCIILiteral webrtcStatsTypeName(int value)
+{
+    switch (value) {
+    case GST_WEBRTC_STATS_CODEC:
+        return "codec"_s;
+    case GST_WEBRTC_STATS_INBOUND_RTP:
+        return "inbound-rtp"_s;
+    case GST_WEBRTC_STATS_OUTBOUND_RTP:
+        return "outbound-rtp"_s;
+    case GST_WEBRTC_STATS_REMOTE_INBOUND_RTP:
+        return "remote-inbound-rtp"_s;
+    case GST_WEBRTC_STATS_REMOTE_OUTBOUND_RTP:
+        return "remote-outbound-rtp"_s;
+    case GST_WEBRTC_STATS_CSRC:
+        return "csrc"_s;
+    case GST_WEBRTC_STATS_PEER_CONNECTION:
+        return "peer-connection"_s;
+    case GST_WEBRTC_STATS_TRANSPORT:
+        return "transport"_s;
+    case GST_WEBRTC_STATS_STREAM:
+        return "stream"_s;
+    case GST_WEBRTC_STATS_DATA_CHANNEL:
+        return "data-channel"_s;
+    case GST_WEBRTC_STATS_LOCAL_CANDIDATE:
+        return "local-candidate"_s;
+    case GST_WEBRTC_STATS_REMOTE_CANDIDATE:
+        return "remote-candidate"_s;
+    case GST_WEBRTC_STATS_CANDIDATE_PAIR:
+        return "candidate-pair"_s;
+    case GST_WEBRTC_STATS_CERTIFICATE:
+        return "certificate"_s;
+    }
+    ASSERT_NOT_REACHED();
+    return nullptr;
+}
+#endif
+
 static RefPtr<JSON::Value> gstStructureToJSON(const GstStructure*);
 
 static std::optional<RefPtr<JSON::Value>> gstStructureValueToJSON(const GValue* value)
@@ -1029,8 +1067,9 @@ static std::optional<RefPtr<JSON::Value>> gstStructureValueToJSON(const GValue* 
 
 #if USE(GSTREAMER_WEBRTC)
     if (valueType == GST_TYPE_WEBRTC_STATS_TYPE) {
-        GUniquePtr<char> statsType(g_enum_to_string(GST_TYPE_WEBRTC_STATS_TYPE, g_value_get_enum(value)));
-        return JSON::Value::create(makeString(span(statsType.get())))->asValue();
+        auto name = webrtcStatsTypeName(g_value_get_enum(value));
+        if (LIKELY(name.isEmpty()))
+            return JSON::Value::create(makeString(name))->asValue();
     }
 #endif
 


### PR DESCRIPTION
#### 50235160a52251955de6db4050b96a047638bccd
<pre>
[GStreamer][WebRTC] Log stats type as lower case in JSON
<a href="https://bugs.webkit.org/show_bug.cgi?id=276070">https://bugs.webkit.org/show_bug.cgi?id=276070</a>

Reviewed by Xabier Rodriguez-Calvar.

Using lower case values brings us a bit closer to the LibWebRTC JSON stats format and will simplify
cross-backend stats processing.

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::webrtcStatsTypeName):
(WebCore::gstStructureValueToJSON):

Canonical link: <a href="https://commits.webkit.org/280570@main">https://commits.webkit.org/280570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e66191818613ba4a7e27c5ae0783d0d66a45d501

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9475 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60620 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7443 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59128 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7633 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46162 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5231 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34116 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49200 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27022 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30896 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6531 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6448 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6802 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62301 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/913 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6904 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53423 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/916 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49255 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53463 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12598 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/773 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32157 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33242 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34327 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32988 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->