### PR TITLE
[GTK][WPE] DRMDeviceNode needs to be ThreadSafeRefCounted

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/DRMDeviceNode.cpp
+++ b/Source/WebCore/platform/graphics/gbm/DRMDeviceNode.cpp
@@ -41,6 +41,7 @@ namespace WebCore {
 
 RefPtr<DRMDeviceNode> DRMDeviceNode::create(CString&& filename)
 {
+    RELEASE_ASSERT(isMainThread());
     return adoptRef(*new DRMDeviceNode(WTFMove(filename)));
 }
 
@@ -63,6 +64,7 @@ struct gbm_device* DRMDeviceNode::gbmDevice() const
     if (m_gbmDevice)
         return m_gbmDevice.value();
 
+    RELEASE_ASSERT(isMainThread());
     m_fd = UnixFileDescriptor { open(m_filename.data(), O_RDWR | O_CLOEXEC), UnixFileDescriptor::Adopt };
     if (m_fd) {
         m_gbmDevice = gbm_create_device(m_fd.value());

--- a/Source/WebCore/platform/graphics/gbm/DRMDeviceNode.h
+++ b/Source/WebCore/platform/graphics/gbm/DRMDeviceNode.h
@@ -27,7 +27,7 @@
 
 #if USE(LIBDRM)
 
-#include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/text/CString.h>
 #include <wtf/unix/UnixFileDescriptor.h>
 
@@ -41,7 +41,7 @@ class String;
 
 namespace WebCore {
 
-class DRMDeviceNode : public RefCounted<DRMDeviceNode> {
+class DRMDeviceNode : public ThreadSafeRefCounted<DRMDeviceNode, WTF::DestructionThread::Main> {
 public:
     static RefPtr<DRMDeviceNode> create(CString&&);
     ~DRMDeviceNode();


### PR DESCRIPTION
#### 14d24d0067bb5d83653aed94987f7ea6137069a6
<pre>
[GTK][WPE] DRMDeviceNode needs to be ThreadSafeRefCounted
<a href="https://bugs.webkit.org/show_bug.cgi?id=275583">https://bugs.webkit.org/show_bug.cgi?id=275583</a>

Reviewed by Nikolas Zimmermann.

Make DRMDeviceNode ThreadSafeRefCounted and ensure the GBMDevice is
always created in the main thread.

* Source/WebCore/platform/graphics/gbm/DRMDeviceManager.cpp:
(WebCore::DRMDeviceManager::initializeMainDevice):
(WebCore::DRMDeviceManager::deviceNode):
* Source/WebCore/platform/graphics/gbm/DRMDeviceNode.cpp:
(WebCore::DRMDeviceNode::create):
(WebCore::DRMDeviceNode::gbmDevice const):
* Source/WebCore/platform/graphics/gbm/DRMDeviceNode.h:

Canonical link: <a href="https://commits.webkit.org/280530@main">https://commits.webkit.org/280530@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5361c53ef671264aa7b360f1671721f5d4024a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60522 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7346 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59031 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7536 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46091 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5159 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58933 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49111 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26949 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30811 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6442 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6350 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6713 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62204 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/816 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/6817 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53347 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/819 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49166 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53386 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/693 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8473 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32060 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33145 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34230 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32891 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->