### PR TITLE
[WPE] WPE Platform: copy toplevel views values to a vector when iterating them

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp
@@ -200,8 +200,8 @@ void wpe_toplevel_foreach_view(WPEToplevel* toplevel, WPEToplevelForeachViewFunc
 {
     g_return_if_fail(WPE_IS_TOPLEVEL(toplevel));
 
-    for (auto* view : toplevel->priv->views) {
-        if (func(toplevel, view, userData))
+    for (auto& view : copyToVectorOf<GRefPtr<WPEView>>(toplevel->priv->views)) {
+        if (func(toplevel, view.get(), userData))
             return;
     }
 }
@@ -223,8 +223,8 @@ void wpe_toplevel_closed(WPEToplevel* toplevel)
         return;
 
     toplevel->priv->closed = true;
-    for (auto* view : toplevel->priv->views)
-        wpe_view_closed(view);
+    for (auto& view : copyToVectorOf<GRefPtr<WPEView>>(toplevel->priv->views))
+        wpe_view_closed(view.get());
 }
 
 /**
@@ -321,8 +321,8 @@ void wpe_toplevel_state_changed(WPEToplevel* toplevel, WPEToplevelState state)
         return;
 
     toplevel->priv->state = state;
-    for (auto* view : toplevel->priv->views)
-        wpeViewToplevelStateChanged(view, state);
+    for (auto& view : copyToVectorOf<GRefPtr<WPEView>>(toplevel->priv->views))
+        wpeViewToplevelStateChanged(view.get(), state);
 }
 
 /**
@@ -359,8 +359,8 @@ void wpe_toplevel_scale_changed(WPEToplevel* toplevel, gdouble scale)
         return;
 
     toplevel->priv->scale = scale;
-    for (auto* view : toplevel->priv->views)
-        wpeViewScaleChanged(view, scale);
+    for (auto& view : copyToVectorOf<GRefPtr<WPEView>>(toplevel->priv->views))
+        wpeViewScaleChanged(view.get(), scale);
 }
 
 /**
@@ -392,8 +392,8 @@ void wpe_toplevel_monitor_changed(WPEToplevel* toplevel)
 {
     g_return_if_fail(WPE_IS_TOPLEVEL(toplevel));
 
-    for (auto* view : toplevel->priv->views)
-        wpeViewMonitorChanged(view);
+    for (auto& view : copyToVectorOf<GRefPtr<WPEView>>(toplevel->priv->views))
+        wpeViewMonitorChanged(view.get());
 }
 
 /**
@@ -528,6 +528,6 @@ void wpe_toplevel_preferred_dma_buf_formats_changed(WPEToplevel* toplevel)
 {
     g_return_if_fail(WPE_IS_TOPLEVEL(toplevel));
 
-    for (auto* view : toplevel->priv->views)
-        wpeViewPreferredDMABufFormatsChanged(view);
+    for (auto& view : copyToVectorOf<GRefPtr<WPEView>>(toplevel->priv->views))
+        wpeViewPreferredDMABufFormatsChanged(view.get());
 }


### PR DESCRIPTION
#### 35cb1751bf8f1f7efc59fe033cf8a95ad5803c05
<pre>
[WPE] WPE Platform: copy toplevel views values to a vector when iterating them
<a href="https://bugs.webkit.org/show_bug.cgi?id=276071">https://bugs.webkit.org/show_bug.cgi?id=276071</a>

Reviewed by Nikolas Zimmermann.

We iterate the toplevel views to notify them about changes, that can
emit signals and that could destroy the view causing the map to change
while being iterated.

* Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp:
(wpe_toplevel_foreach_view):
(wpe_toplevel_closed):
(wpe_toplevel_state_changed):
(wpe_toplevel_scale_changed):
(wpe_toplevel_monitor_changed):
(wpe_toplevel_preferred_dma_buf_formats_changed):

Canonical link: <a href="https://commits.webkit.org/280566@main">https://commits.webkit.org/280566@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49b89e0cdbb780e1cbac67bc8ab87b664c1b2c37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56904 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9378 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60523 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7347 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7537 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46092 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5160 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34032 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49112 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26950 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30812 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6351 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52770 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6714 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62205 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/817 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6818 "Found 1 new test failure: webaudio/Panner/PannerNode-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53348 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/820 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49167 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53387 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/694 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8490 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32061 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33146 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34231 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32892 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->