### PR TITLE
[WPE] Add --size / --maximized / --fullscreen parameters to MiniBrowser

### DIFF
--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Igalia S.L.
+ * Copyright (C) 2018, 2024 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -58,11 +58,50 @@ static char* timeZone;
 static const char* featureList = nullptr;
 static gboolean enableITP;
 static gboolean printVersion;
+static guint windowWidth = 0;
+static guint windowHeight = 0;
+static guint defaultWindowWidthLegacyAPI = 1280;
+static guint defaultWindowHeightLegacyAPI = 720;
 static GHashTable* openViews;
 #if ENABLE_WPE_PLATFORM
+static gboolean windowMaximized;
+static gboolean windowFullscreen;
 static gboolean useWPEPlatformAPI;
 static const char* defaultWindowTitle = "WPEWebKit MiniBrowser";
 #endif
+
+static gboolean parseWindowSize(const char*, const char* value, gpointer, GError** error)
+{
+    if (!value)
+        return FALSE;
+
+    g_auto(GStrv) windowSizes = g_strsplit(value, "x", 2);
+    if (!windowSizes || !windowSizes[0] || !windowSizes[1]) {
+        g_set_error(error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED, "Failed to parse --size command line argument \"%s\" - use \"<size>x<height>\" without any additional whitespace.", value);
+        return FALSE;
+    }
+
+    guint64 parsedWidth = 0;
+    if (!g_ascii_string_to_unsigned(windowSizes[0], 10, 0, G_MAXUINT, &parsedWidth, nullptr)) {
+        g_set_error(error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED, "Failed to parse window width as unsigned integer from string \"%s\"", windowSizes[0]);
+        return FALSE;
+    }
+
+    guint64 parsedHeight = 0;
+    if (!g_ascii_string_to_unsigned(windowSizes[1], 10, 0, G_MAXUINT, &parsedHeight, nullptr)) {
+        g_set_error(error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED, "Failed to parse window height as unsigned integer from string \"%s\"", windowSizes[1]);
+        return FALSE;
+    }
+
+    if (!parsedWidth || !parsedHeight) {
+        g_set_error(error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED, "Window width/height needs to be larger than zero.");
+        return FALSE;
+    }
+
+    windowWidth = static_cast<guint>(parsedWidth);
+    windowHeight = static_cast<guint>(parsedHeight);
+    return TRUE;
+}
 
 static const GOptionEntry commandLineOptions[] =
 {
@@ -81,7 +120,10 @@ static const GOptionEntry commandLineOptions[] =
     { "features", 'F', 0, G_OPTION_ARG_STRING, &featureList, "Enable or disable WebKit features (hint: pass 'help' for a list)", "FEATURE-LIST" },
 #if ENABLE_WPE_PLATFORM
     { "use-wpe-platform-api", 0, 0, G_OPTION_ARG_NONE, &useWPEPlatformAPI, "Use the WPE platform API", nullptr },
+    { "maximized", 'm', 0, G_OPTION_ARG_NONE, &windowMaximized, "Start with maximized window", nullptr },
+    { "fullscreen", 'f', 0, G_OPTION_ARG_NONE, &windowFullscreen, "Start with fullscreen window", nullptr },
 #endif
+    { "size", 's', 0, G_OPTION_ARG_CALLBACK, reinterpret_cast<gpointer>(parseWindowSize), "Specify the window size to use, e.g. --size=\"800x600\"", nullptr },
     { "version", 'v', 0, G_OPTION_ARG_NONE, &printVersion, "Print the WPE version", nullptr },
     { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &uriArguments, nullptr, "[URL]" },
     { nullptr, 0, 0, G_OPTION_ARG_NONE, nullptr, nullptr, nullptr }
@@ -239,8 +281,7 @@ static void webViewClose(WebKitWebView* webView, gpointer user_data)
 
 static WebKitWebView* createWebView(WebKitWebView* webView, WebKitNavigationAction*, gpointer user_data)
 {
-
-    auto backend = createViewBackend(1280, 720);
+    auto backend = createViewBackend(defaultWindowWidthLegacyAPI, defaultWindowHeightLegacyAPI);
     WebKitWebViewBackend* viewBackend = nullptr;
     if (backend) {
         struct wpe_view_backend* wpeBackend = backend->backend();
@@ -503,8 +544,15 @@ static void activate(GApplication* application, WPEToolingBackends::ViewBackend*
 
 #if ENABLE_WPE_PLATFORM
     if (auto* wpeView = webkit_web_view_get_wpe_view(webView)) {
+        auto* wpeToplevel = wpe_view_get_toplevel(wpeView);
+        if (windowWidth > 0 && windowHeight > 0)
+            wpe_toplevel_resize(wpeToplevel, windowWidth, windowHeight);
+        if (windowMaximized)
+            wpe_toplevel_maximize(wpeToplevel);
+        if (windowFullscreen)
+            wpe_toplevel_fullscreen(wpeToplevel);
         g_signal_connect(wpeView, "event", G_CALLBACK(wpeViewEventCallback), webView);
-        wpe_toplevel_set_title(wpe_view_get_toplevel(wpeView), defaultWindowTitle);
+        wpe_toplevel_set_title(wpeToplevel, defaultWindowTitle);
         g_signal_connect(webView, "notify::title", G_CALLBACK(webViewTitleChanged), wpeView);
     }
 #endif
@@ -595,11 +643,35 @@ int main(int argc, char *argv[])
         return 0;
     }
 
-    auto backend = createViewBackend(1280, 720);
+    bool setDefaultWindowSize = true;
+
+#if ENABLE_WPE_PLATFORM
+    if (useWPEPlatformAPI)
+        setDefaultWindowSize = false;
+
+    if (windowMaximized && windowFullscreen) {
+        g_printerr("You cannot specify both --maximized and --fullscreen, these options are mutually exclusive.");
+        return 1;
+    }
+
+    if ((windowMaximized || windowFullscreen) && !useWPEPlatformAPI) {
+        g_printerr("You cannot specify either --maximized or --fullscreen, without enabling the new WPE API (--use-wpe-platform-api).");
+        return 1;
+    }
+
+#endif
+
+    if (setDefaultWindowSize) {
+        // Default values used in old API, for legacy reasons.
+        windowWidth = defaultWindowWidthLegacyAPI;
+        windowHeight = defaultWindowHeightLegacyAPI;
+    }
+
+    auto backend = createViewBackend(windowWidth, windowHeight);
     if (backend) {
         struct wpe_view_backend* wpeBackend = backend->backend();
         if (!wpeBackend) {
-            g_warning("Failed to create WPE view backend");
+            g_printerr("Failed to create WPE view backend");
             return 1;
         }
     }


### PR DESCRIPTION
#### d72f4bd734ae263071bcd38db5ded174974a5bd4
<pre>
[WPE] Add --size / --maximized / --fullscreen parameters to MiniBrowser
<a href="https://bugs.webkit.org/show_bug.cgi?id=276072">https://bugs.webkit.org/show_bug.cgi?id=276072</a>

Reviewed by Carlos Garcia Campos.

Add --size parameter to MiniBrowser to specify the window width/height
as command line argument. This is necessary for our plans to switch WPE
perf bot testing to use MiniBrowser+new API instead of cog+old API.

Furthermore add --maximized / --fullscreen parameters supported only
within the new WPE platform API, which start MiniBrowser either
maximized or in fullscreen mode.

Doesn&apos;t affect any tests.

* Tools/MiniBrowser/wpe/main.cpp:
(parseWindowSize):
(createWebView):
(activate):
(main):

Canonical link: <a href="https://commits.webkit.org/280571@main">https://commits.webkit.org/280571@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aed8fa7ba1522a778b96642b499027289a5d4912

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57005 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36333 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60625 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7448 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59133 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43956 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7638 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46168 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5235 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59035 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34120 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49203 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27028 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30900 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6534 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6453 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52859 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6805 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62306 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/918 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6909 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53426 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/921 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49258 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53467 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12599 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/779 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32162 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33247 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34332 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32993 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->