### PR TITLE
COOP noopener-allow-popups

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/resources/reporting-common.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/resources/reporting-common.js
@@ -353,14 +353,33 @@ const receiveReport = async function(uuid, type) {
   }
 }
 
-// Build a set of 'Cross-Origin-Opener-Policy' and
-// 'Cross-Origin-Opener-Policy-Report-Only' headers.
 const coopHeaders = function (uuid) {
+  // Use a custom function instead of convertToWPTHeaderPipe(), to avoid
+  // encoding double quotes as %22, which messes with the reporting endpoint
+  // registration.
+  let getHeader = (uuid, coop_value, is_report_only) => {
+    const header_name =
+      is_report_only ?
+      "Cross-Origin-Opener-Policy-Report-Only":
+      "Cross-Origin-Opener-Policy";
+    return `|header(${header_name},${coop_value}%3Breport-to="${uuid}")`;
+  }
+
   return {
-    coopSameOriginHeader: `|header(Cross-Origin-Opener-Policy,same-origin%3Breport-to="${uuid}")`,
-    coopSameOriginAllowPopupsHeader: `|header(Cross-Origin-Opener-Policy,same-origin-allow-popups%3Breport-to="${uuid}")`,
-    coopReportOnlySameOriginHeader: `|header(Cross-Origin-Opener-Policy-Report-Only,same-origin%3Breport-to="${uuid}")`,
-    coopReportOnlySameOriginAllowPopupsHeader: `|header(Cross-Origin-Opener-Policy-Report-Only,same-origin-allow-popups%3Breport-to="${uuid}")`
+    coopSameOriginHeader:
+        getHeader(uuid, "same-origin", is_report_only = false),
+    coopSameOriginAllowPopupsHeader:
+        getHeader(uuid, "same-origin-allow-popups", is_report_only = false),
+    coopRestrictPropertiesHeader:
+        getHeader(uuid, "restrict-properties", is_report_only = false),
+    coopReportOnlySameOriginHeader:
+        getHeader(uuid, "same-origin", is_report_only = true),
+    coopReportOnlySameOriginAllowPopupsHeader:
+        getHeader(uuid, "same-origin-allow-popups", is_report_only = true),
+    coopReportOnlyRestrictPropertiesHeader:
+        getHeader(uuid, "restrict-properties", is_report_only = true),
+    coopReportOnlyNoopenerAllowPopupsHeader:
+        getHeader(uuid, "noopener-allow-popups", is_report_only = true),
   };
 }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/tentative/access-to-noopener-page-from-no-coop-ro.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/tentative/access-to-noopener-page-from-no-coop-ro.https-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL access-to-coop-page-from-opener, noopener-allow-popups assert_equals: expected (string) "coop" but got (undefined) undefined
+FAIL access-to-coop-page-from-opener, noopener-allow-popups + redirect assert_equals: expected (string) "coop" but got (undefined) undefined
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/tentative/access-to-noopener-page-from-no-coop-ro.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/tentative/access-to-noopener-page-from-no-coop-ro.https.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<title>
+  COOP reports are sent when the openee used COOP-RO+COEP and then its
+  same-origin opener tries to access it.
+</title>
+<meta name=timeout content=long>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src=/common/get-host-info.sub.js></script>
+<script src="/common/utils.js"></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/html/cross-origin-opener-policy/reporting/resources/reporting-common.js"></script>
+<script src="/html/cross-origin-opener-policy/reporting/resources/try-access.js"></script>
+<script>
+
+const directory = "/html/cross-origin-opener-policy";
+const redirect_path = directory + "/resources/redirect.py?";
+const same_origin = get_host_info().HTTPS_ORIGIN;
+
+let runTest = (openee_redirect, name) => promise_test(async t => {
+  const report_token = token();
+  const openee_token = token();
+  const opener_token = token(); // The current test window.
+
+  const opener_url = location.href;
+
+  const reportTo = reportToHeaders(report_token);
+  const openee_url = same_origin + executor_path + reportTo.header +
+    reportTo.coopReportOnlyNoopenerAllowPopupsHeader + coep_header +
+    `&uuid=${openee_token}`;
+  const openee_redirect_url = same_origin + redirect_path + openee_url
+  const openee_requested_url = openee_redirect ? openee_redirect_url
+                                               : openee_url;
+
+
+  const openee = window.open(openee_requested_url);
+  t.add_cleanup(() => send(openee_token, "window.close()"))
+
+  // 1. Make sure the new document to be loaded.
+  send(openee_token, `
+    send("${opener_token}", "Ready");
+  `);
+  let reply = await receive(opener_token);
+  assert_equals(reply, "Ready");
+
+  // 2. Try to access the openee. A report is sent, because of COOP-RO+COEP.
+  tryAccess(openee);
+
+  // 3. Check a report is sent to the openee.
+  let report =
+    await receiveReport(report_token, "access-to-coop-page-from-opener");
+  assert_equals(report.type, "coop");
+  assert_equals(report.url, openee_url.replace(/"/g, '%22'));
+  assert_equals(report.body.disposition, "reporting");
+  assert_equals(report.body.effectivePolicy, "noopener-allow-popups");
+  assert_equals(report.body.property, "blur");
+  assert_source_location_missing(report);
+  assert_equals(report.body.openerURL, opener_url);
+  assert_equals(report.body.openeeURL, undefined);
+  assert_equals(report.body.otherDocumentURL, undefined);
+  assert_equals(report.body.referrer, opener_url);
+  assert_equals(report.body.initialPopupURL, undefined);
+}, name);
+
+runTest(false, "access-to-coop-page-from-opener, noopener-allow-popups");
+runTest(true , "access-to-coop-page-from-opener, noopener-allow-popups + redirect");
+
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/resources/noopener-helper.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/resources/noopener-helper.js
@@ -1,0 +1,159 @@
+const executor_path = '/common/dispatcher/executor.html?pipe=';
+const coop_header = policy => {
+  return `|header(Cross-Origin-Opener-Policy,${policy})`;
+};
+
+function getExecutorPath(uuid, origin, coop_header) {
+  return origin.origin + executor_path + coop_header + `&uuid=${uuid}`;
+}
+
+const test_noopener_opening_popup =
+  (opener_coop, openee_coop, origin, opener_expectation) => {
+  promise_test(async t => {
+    // Set up dispatcher communications.
+    const popup_token = token();
+    const reply_token = token();
+    const popup_reply_token = token();
+    const popup_openee_token = token();
+
+    const popup_url = getExecutorPath(
+        popup_token, SAME_ORIGIN, coop_header(opener_coop));
+
+    // We open a popup and then ping it, it will respond after loading.
+    const popup = window.open(popup_url);
+    t.add_cleanup(() => send(popup_token, 'window.close()'));
+    send(popup_token, `send('${reply_token}', 'Popup loaded');`);
+    assert_equals(await receive(reply_token), 'Popup loaded');
+
+    if (opener_coop == 'noopener-allow-popups') {
+        // Assert that we can't script the popup.
+        assert_true(popup.closed, 'Opener popup.closed');
+    }
+
+    // Ensure that the popup has no access to its opener.
+    send(popup_token, `
+        let openerDOMAccessAllowed = false;
+        try {
+            openerDOMAccessAllowed = !!self.opener.document.URL;
+        } catch(ex) {
+        }
+        const payload = {
+            opener: !!self.opener,
+            openerDOMAccess: openerDOMAccessAllowed
+        };
+        send('${reply_token}', JSON.stringify(payload));
+    `);
+    let payload = JSON.parse(await receive(reply_token));
+    if (opener_coop == 'noopener-allow-popups') {
+        assert_false(payload.opener, 'popup opener');
+        assert_false(payload.openerDOMAccess, 'popup DOM access');
+    }
+
+    // Open another popup from inside the popup, and wait for it to
+    // load.
+    const popup_openee_url = getExecutorPath(
+        popup_openee_token, origin, coop_header(openee_coop));
+    send(popup_token, `
+        window.openee = open("${popup_openee_url}");
+        await receive('${popup_reply_token}');
+        const payload = {
+            openee: !!window.openee,
+            closed: window.openee.closed
+        };
+        send('${reply_token}', JSON.stringify(payload));
+    `);
+    t.add_cleanup(() => send(popup_token, 'window.openee && window.openee.close()'));
+    // Notify the popup that its openee was loaded.
+    send(popup_openee_token, `send('${popup_reply_token}', 'popup openee opened');`);
+
+    // Assert that the popup has access to its openee.
+    payload = JSON.parse(await receive(reply_token));
+    assert_true(payload.openee, 'popup openee');
+
+    // Assert that the openee has access to its popup opener.
+    send(popup_openee_token, `
+        let openerDOMAccessAllowed = false;
+        try {
+            openerDOMAccessAllowed = !!self.opener.document.URL;
+        } catch(ex) {
+        }
+        const payload = {
+            opener: !!self.opener,
+            openerDOMAccess: openerDOMAccessAllowed
+        };
+        send('${reply_token}', JSON.stringify(payload));
+    `);
+    payload = JSON.parse(await receive(reply_token));
+    if (opener_expectation) {
+        assert_true(payload.opener, 'Opener is not null');
+        assert_true(payload.openerDOMAccess, 'No DOM access');
+    } else {
+        assert_false(payload.opener, 'Opener is null');
+        assert_false(payload.openerDOMAccess, 'No DOM access');
+    }
+  },
+  'noopener-allow-popups ensures that the opener cannot script the openee,' +
+      ' but further popups with no COOP can access their opener: ' +
+      opener_coop + '/' + openee_coop + ':' + origin == SAME_ORIGIN);
+};
+
+const test_noopener_navigating_away = (popup_coop) => {
+  promise_test(
+      async t => {
+        // Set up dispatcher communications.
+        const popup_token = token();
+        const reply_token = token();
+        const popup_reply_token = token();
+        const popup_second_token = token();
+
+        const popup_url =
+            getExecutorPath(popup_token, SAME_ORIGIN, coop_header(popup_coop));
+
+        // We open a popup and then ping it, it will respond after loading.
+        const popup = window.open(popup_url);
+        send(popup_token, `send('${reply_token}', 'Popup loaded');`);
+        assert_equals(await receive(reply_token), 'Popup loaded');
+        t.add_cleanup(() => send(popup_token, 'window.close()'));
+
+        // Assert that we can script the popup.
+        assert_not_equals(popup.window, null);
+        assert_false(popup.closed, 'popup closed');
+
+        // Ensure that the popup has no access to its opener.
+        send(popup_token, `
+        let openerDOMAccessAllowed = false;
+        try {
+            openerDOMAccessAllowed = !!self.opener.document.URL;
+        } catch(ex) {
+        }
+        const payload = {
+            opener: !!self.opener,
+            openerDOMAccess: openerDOMAccessAllowed
+        };
+        send('${reply_token}', JSON.stringify(payload));
+        `);
+        let payload = JSON.parse(await receive(reply_token));
+        assert_true(payload.opener, 'popup opener');
+        assert_true(payload.openerDOMAccess, 'popup DOM access');
+
+        // Navigate the popup
+        const popup_second_url = getExecutorPath(
+            popup_second_token, SAME_ORIGIN,
+            coop_header('noopener-allow-popups'));
+
+        send(popup_token, `
+            window.location = '${popup_second_url}';
+        `);
+
+        // Notify the popup that its openee was loaded.
+        send(
+            popup_second_token,
+            `send('${reply_token}', 'popup navigated away');`);
+        assert_equals(await receive(reply_token), 'popup navigated away');
+
+        //assert_equals(popup.window, null);
+        assert_true(popup.closed, 'popup.closed');
+      },
+      'noopener-allow-popups ensures that the opener cannot script the openee,' +
+          ' even after a navigation: ' + popup_coop);
+};

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/tentative/noopener/coop-noopener-allow-popups.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/tentative/noopener/coop-noopener-allow-popups.https-expected.txt
@@ -1,0 +1,31 @@
+
+PASS
+    Cross-Origin-Opener-Policy: noopener-allow-popups means that the opener
+    has no access to the openee.
+
+PASS
+    Cross-Origin-Opener-Policy: noopener-allow-popups means that the opener
+    has no access to the openee.
+ 1
+PASS
+    Cross-Origin-Opener-Policy: noopener-allow-popups means that the opener
+    has no access to the openee.
+ 2
+PASS
+    Cross-Origin-Opener-Policy: noopener-allow-popups means that the opener
+    has no access to the openee.
+ 3
+PASS
+    Cross-Origin-Opener-Policy: noopener-allow-popups means that the opener
+    has no access to the openee.
+ 4
+PASS
+    Cross-Origin-Opener-Policy: noopener-allow-popups means that the opener
+    has no access to the openee.
+ 5
+PASS
+    Cross-Origin-Opener-Policy: noopener-allow-popups means that the opener
+    has no access to the openee.
+ 6
+PASS noopener-allow-popups ensures that the opener cannot script the openee, even after a navigation: unsafe-none
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/tentative/noopener/coop-noopener-allow-popups.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/tentative/noopener/coop-noopener-allow-popups.https.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<title>
+    Cross-Origin-Opener-Policy: noopener-allow-popups means that the opener
+    has no access to the openee.
+</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src="/common/dispatcher/dispatcher.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
+<script src="/common/utils.js"></script>
+<script src="../../resources/common.js"></script>
+<script src="../../resources/noopener-helper.js"></script>
+<script>
+
+
+test_noopener_opening_popup("noopener-allow-popups",
+                            "unsafe-none",
+                            SAME_ORIGIN,
+                            /*opener_expectation=*/true);
+test_noopener_opening_popup("noopener-allow-popups",
+                            "noopener-allow-popups",
+                            SAME_ORIGIN,
+                            /*opener_expectation=*/false);
+test_noopener_opening_popup("noopener-allow-popups",
+                            "same-origin",
+                            SAME_ORIGIN,
+                            /*opener_expectation=*/false);
+test_noopener_opening_popup("noopener-allow-popups",
+                            "same-origin-allow-popups",
+                            SAME_ORIGIN,
+                            /*opener_expectation=*/false);
+test_noopener_opening_popup("noopener-allow-popups",
+                            "same-origin-allow-popups",
+                            CROSS_ORIGIN,
+                            /*opener_expectation=*/false);
+test_noopener_opening_popup("same-origin-allow-popups",
+                            "noopener-allow-popups",
+                            SAME_ORIGIN,
+                            /*opener_expectation=*/false);
+test_noopener_opening_popup("same-origin",
+                            "noopener-allow-popups",
+                            SAME_ORIGIN,
+                            /*opener_expectation=*/false);
+test_noopener_navigating_away("unsafe-none");
+ </script>

--- a/Source/WebCore/loader/CrossOriginOpenerPolicy.cpp
+++ b/Source/WebCore/loader/CrossOriginOpenerPolicy.cpp
@@ -53,6 +53,8 @@ static ASCIILiteral crossOriginOpenerPolicyToString(const CrossOriginOpenerPolic
         return "same-origin"_s;
     case CrossOriginOpenerPolicyValue::SameOriginAllowPopups:
         return "same-origin-allow-popups"_s;
+    case CrossOriginOpenerPolicyValue::NoopenerAllowPopups:
+        return "noopener-allow-popups"_s;
     case CrossOriginOpenerPolicyValue::UnsafeNone:
         break;
     }
@@ -68,6 +70,8 @@ static ASCIILiteral crossOriginOpenerPolicyValueToEffectivePolicyString(CrossOri
         return "same-origin"_s;
     case CrossOriginOpenerPolicyValue::SameOriginPlusCOEP:
         return "same-origin-plus-coep"_s;
+    case CrossOriginOpenerPolicyValue::NoopenerAllowPopups:
+        return "noopener-allow-popups"_s;
     case CrossOriginOpenerPolicyValue::UnsafeNone:
         break;
     }
@@ -108,22 +112,42 @@ static void sendViolationReportWhenNavigatingAwayFromCOOPResponse(ReportingClien
     reportingClient.sendReportToEndpoints(coopURL, { }, { endpoint }, WTFMove(report), ViolationReportType::CrossOriginOpenerPolicy);
 }
 
+// https://html.spec.whatwg.org/multipage/origin.html#matching-coop
+static bool matchingCOOP(CrossOriginOpenerPolicyValue activeDocumentCOOPValue, const SecurityOrigin& activeDocumentNavigationOrigin, CrossOriginOpenerPolicyValue responseCOOPValue, const SecurityOrigin& responseOrigin)
+{
+    if (activeDocumentCOOPValue == CrossOriginOpenerPolicyValue::UnsafeNone && responseCOOPValue == CrossOriginOpenerPolicyValue::UnsafeNone)
+        return true;
+    if (activeDocumentCOOPValue == CrossOriginOpenerPolicyValue::UnsafeNone || responseCOOPValue == CrossOriginOpenerPolicyValue::UnsafeNone)
+        return false;
+    if (responseCOOPValue == CrossOriginOpenerPolicyValue::NoopenerAllowPopups)
+        return false;
+    if (activeDocumentCOOPValue == responseCOOPValue && activeDocumentNavigationOrigin.isSameOriginAs(responseOrigin))
+        return true;
+    return false;
+}
+
+// https://html.spec.whatwg.org/multipage/origin.html#check-browsing-context-group-switch-coop-value-popup
+static bool coopValuesRequireBrowsingContextGroupSwitchForPopup(CrossOriginOpenerPolicyValue activeDocumentCOOPValue, const SecurityOrigin& activeDocumentNavigationOrigin, CrossOriginOpenerPolicyValue responseCOOPValue, const SecurityOrigin& responseOrigin)
+{
+    if (responseCOOPValue == CrossOriginOpenerPolicyValue::NoopenerAllowPopups)
+        return true;
+
+    if ((activeDocumentCOOPValue == CrossOriginOpenerPolicyValue::SameOriginAllowPopups || activeDocumentCOOPValue == CrossOriginOpenerPolicyValue::NoopenerAllowPopups) && responseCOOPValue == CrossOriginOpenerPolicyValue::UnsafeNone)
+        return false;
+
+    if (matchingCOOP(activeDocumentCOOPValue, activeDocumentNavigationOrigin, responseCOOPValue, responseOrigin))
+        return false;
+
+    return true;
+}
+
 // https://html.spec.whatwg.org/multipage/origin.html#check-browsing-context-group-switch-coop-value
 bool coopValuesRequireBrowsingContextGroupSwitch(bool isInitialAboutBlank, CrossOriginOpenerPolicyValue activeDocumentCOOPValue, const SecurityOrigin& activeDocumentNavigationOrigin, CrossOriginOpenerPolicyValue responseCOOPValue, const SecurityOrigin& responseOrigin)
 {
-    // If the result of matching activeDocumentCOOPValue, activeDocumentNavigationOrigin, responseCOOPValue, and responseOrigin is true, return false.
-    // https://html.spec.whatwg.org/multipage/origin.html#matching-coop
-    if (activeDocumentCOOPValue == CrossOriginOpenerPolicyValue::UnsafeNone && responseCOOPValue == CrossOriginOpenerPolicyValue::UnsafeNone)
-        return false;
-    if (activeDocumentCOOPValue == responseCOOPValue && activeDocumentNavigationOrigin.isSameOriginAs(responseOrigin))
-        return false;
+    if (isInitialAboutBlank)
+        return coopValuesRequireBrowsingContextGroupSwitchForPopup(activeDocumentCOOPValue, activeDocumentNavigationOrigin, responseCOOPValue, responseOrigin);
 
-    // If all of the following are true:
-    // - isInitialAboutBlank,
-    // - activeDocumentCOOPValue's value is "same-origin-allow-popups".
-    // - responseCOOPValue is "unsafe-none",
-    // then return false.
-    if (isInitialAboutBlank && activeDocumentCOOPValue == CrossOriginOpenerPolicyValue::SameOriginAllowPopups && responseCOOPValue == CrossOriginOpenerPolicyValue::UnsafeNone)
+    if (matchingCOOP(activeDocumentCOOPValue, activeDocumentNavigationOrigin, responseCOOPValue, responseOrigin))
         return false;
 
     return true;
@@ -210,6 +234,8 @@ CrossOriginOpenerPolicy obtainCrossOriginOpenerPolicy(const ResourceResponse& re
                 value = CrossOriginOpenerPolicyValue::SameOrigin;
         } else if (policyString->string() == "same-origin-allow-popups"_s)
             value = CrossOriginOpenerPolicyValue::SameOriginAllowPopups;
+        else if (policyString->string() == "noopener-allow-popups"_s)
+            value = CrossOriginOpenerPolicyValue::NoopenerAllowPopups;
 
         if (auto* reportToString = coopParsingResult->second.getIf<String>("report-to"_s))
             reportingEndpoint = *reportToString;

--- a/Source/WebCore/loader/CrossOriginOpenerPolicy.h
+++ b/Source/WebCore/loader/CrossOriginOpenerPolicy.h
@@ -45,7 +45,8 @@ enum class CrossOriginOpenerPolicyValue : uint8_t {
     UnsafeNone,
     SameOrigin,
     SameOriginPlusCOEP,
-    SameOriginAllowPopups
+    SameOriginAllowPopups,
+    NoopenerAllowPopups
 };
 
 enum class COOPDisposition : bool { Reporting , Enforce };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5025,7 +5025,8 @@ enum class WebCore::CrossOriginOpenerPolicyValue : uint8_t {
     UnsafeNone,
     SameOrigin,
     SameOriginPlusCOEP,
-    SameOriginAllowPopups
+    SameOriginAllowPopups,
+    NoopenerAllowPopups
 };
 
 struct WebCore::CrossOriginOpenerPolicy {


### PR DESCRIPTION
#### 7688a5f9edc739472701f5f0d3f6ad1450104094
<pre>
COOP noopener-allow-popups

<a href="https://bugs.webkit.org/show_bug.cgi?id=275147">https://bugs.webkit.org/show_bug.cgi?id=275147</a>

Reviewed by Alex Christensen.

The `noopener-allow-popups` COOP value would enable a document to ensure it can&apos;t be scripted by other same-origin documents that have opened it.

Some origins can contain different applications with different levels of security requirements.
In those cases, it can be beneficial to prevent scripts running in one application from being able to open and script pages of another same-origin application.

The noopener-allow-popups Cross-Origin-Opener-Policy value severs the opener relationship between the document loaded with this policy and its opener.
At the same time, this document can open further documents (as the &quot;allow-popups&quot; in the name suggests) and maintain its opener relationship with them, assuming that their COOP policy allows it.

This implements <a href="https://github.com/whatwg/html/pull/10394">https://github.com/whatwg/html/pull/10394</a>

* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/resources/reporting-common.js:
(const.coopHeaders): A helper to create headers in a more succinct way.
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/tentative/access-to-noopener-page-from-no-coop-ro.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/reporting/tentative/access-to-noopener-page-from-no-coop-ro.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/resources/noopener-helper.js: Added.
(getExecutorPath):
(const.test_noopener_opening_popup): The logic for the noopener tests.
(async const):
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/tentative/noopener/coop-noopener-allow-popups.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/tentative/noopener/coop-noopener-allow-popups.https.html: Added.
* Source/WebCore/loader/CrossOriginOpenerPolicy.cpp:
(WebCore::crossOriginOpenerPolicyToString): Add the &quot;noopener-allow-popups&quot; string.
(WebCore::crossOriginOpenerPolicyValueToEffectivePolicyString): Add the &quot;noopener-allow-popups&quot; string.
(WebCore::matchingCOOP): Implement the related HTML algorithm.
(WebCore::coopValuesRequireBrowsingContextGroupSwitch): Implement the switching logic related to noopener-allow-popups.
(WebCore::obtainCrossOriginOpenerPolicy): Parse the &quot;noopener-allow-popups&quot; value.
* Source/WebCore/loader/CrossOriginOpenerPolicy.h: Add the noopener-allow-popups enum value.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in: Add the noopener-allow-popups enum value.

Canonical link: <a href="https://commits.webkit.org/284866@main">https://commits.webkit.org/284866@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc543391f99f7206173c775baecb4843b56bd5d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/70718 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/50128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/23487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/74811 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/21914 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/72834 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/57926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/21739 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/56000 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/14464 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/73784 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/45580 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/60969 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/36451 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/42237 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/18402 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/20260 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/64172 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/18764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/76529 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/14948 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/17971 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/63734 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/14992 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/61032 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/63671 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/15668 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/11734 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/5374 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/45929 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/700 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/47001 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/48282 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/46743 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->