### PR TITLE
Finalize implementation of MediaStreamTrack powerEfficient constraint

### DIFF
--- a/LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities-expected.txt
+++ b/LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities-expected.txt
@@ -11,6 +11,7 @@ video track capabilities:
   capabilities.frameRate = { max: 30, min: 1 }
   capabilities.groupId = <UUID>
   capabilities.height = { max: 1440, min: 1 }
+  capabilities.powerEfficient = [ false ]
   capabilities.width = { max: 2560, min: 1 }
 
 audio track capabilities:
@@ -29,6 +30,7 @@ video track capabilities:
   capabilities.frameRate = { max: 120, min: 1 }
   capabilities.groupId = <UUID>
   capabilities.height = { max: 2160, min: 1 }
+  capabilities.powerEfficient = [ false, true ]
   capabilities.torch = true
   capabilities.whiteBalanceMode = [ manual, single-shot, continuous ]
   capabilities.width = { max: 3840, min: 1 }
@@ -50,6 +52,7 @@ video track capabilities:
   capabilities.frameRate = { max: 120, min: 1 }
   capabilities.groupId = <UUID>
   capabilities.height = { max: 2160, min: 1 }
+  capabilities.powerEfficient = [ false, true ]
   capabilities.torch = true
   capabilities.whiteBalanceMode = [ manual, single-shot, continuous ]
   capabilities.width = { max: 3840, min: 1 }

--- a/LayoutTests/fast/mediastream/MediaStreamTrack-getSettings-expected.txt
+++ b/LayoutTests/fast/mediastream/MediaStreamTrack-getSettings-expected.txt
@@ -11,6 +11,7 @@ video track settings:
   settings.frameRate = 30
   settings.groupId = <UUID>
   settings.height = 480
+  settings.powerEfficient = false
   settings.width = 640
 
 audio track settings:
@@ -29,6 +30,7 @@ PASS "facingMode" in track.getCapabilities() is true
 PASS "frameRate" in track.getCapabilities() is true
 PASS "groupId" in track.getCapabilities() is true
 PASS "height" in track.getCapabilities() is true
+PASS "powerEfficient" in track.getCapabilities() is true
 PASS "width" in track.getCapabilities() is true
 PASS "deviceId" in track.getCapabilities() is true
 PASS "echoCancellation" in track.getCapabilities() is true

--- a/LayoutTests/fast/mediastream/camera-powerEfficient-track-expected.txt
+++ b/LayoutTests/fast/mediastream/camera-powerEfficient-track-expected.txt
@@ -1,5 +1,6 @@
 
 
+PASS Selecting a non power efficient source
 PASS Selecting a non power efficient preset
 PASS Selecting a power efficient preset
 PASS Selecting a power efficient preset and check clones

--- a/LayoutTests/fast/mediastream/camera-powerEfficient-track.html
+++ b/LayoutTests/fast/mediastream/camera-powerEfficient-track.html
@@ -13,19 +13,26 @@ promise_test(async (test) => {
         video.srcObject.getVideoTracks()[0].stop();
     });
 
+    video.srcObject = await navigator.mediaDevices.getUserMedia({ video: { powerEfficient: true, facingMode: "user" } });
+    const track = video.srcObject.getVideoTracks()[0];
+
+    assert_array_equals(track.getCapabilities().powerEfficient, [false]);
+    assert_false(track.getSettings().powerEfficient);
+}, "Selecting a non power efficient source");
+
+promise_test(async (test) => {
+    test.add_cleanup(() => {
+        video.srcObject.getVideoTracks()[0].stop();
+    });
+
     video.srcObject = await navigator.mediaDevices.getUserMedia({ video: { powerEfficient: false, facingMode: "environment" } });
     const track = video.srcObject.getVideoTracks()[0];
 
     assert_equals(track.getSettings().width, 640);
     assert_equals(track.getSettings().height, 480);
 
-    assert_equals(undefined, track.getSettings().powerEfficient);
-    assert_equals(undefined, track.getCapabilities().powerEfficient);
-
-    await video.play();
-
-    if (window.internals)
-        assert_false(internals.isMediaStreamTrackPowerEfficient(track));
+    assert_array_equals(track.getCapabilities().powerEfficient, [false, true]);
+    assert_false(track.getSettings().powerEfficient);
 }, "Selecting a non power efficient preset");
 
 promise_test(async (test) => {
@@ -38,14 +45,10 @@ promise_test(async (test) => {
 
     assert_equals(track.getSettings().width, 640);
     assert_equals(track.getSettings().height, 360);
-
-    assert_equals(undefined, track.getSettings().powerEfficient);
-    assert_equals(undefined, track.getCapabilities().powerEfficient);
-
     await video.play();
 
-    if (window.internals)
-        assert_true(internals.isMediaStreamTrackPowerEfficient(track));
+    assert_array_equals(track.getCapabilities().powerEfficient, [false, true]);
+    assert_equals(true, track.getSettings().powerEfficient);
 }, "Selecting a power efficient preset");
 
 promise_test(async (test) => {
@@ -64,14 +67,11 @@ promise_test(async (test) => {
     await video.srcObject.getVideoTracks()[0].applyConstraints({ width: 1920 });
     await video.play();
 
-    if (!window.internals)
-        return;
-
-    assert_true(internals.isMediaStreamTrackPowerEfficient(stream.getVideoTracks()[0]), "first track");
-    assert_true(internals.isMediaStreamTrackPowerEfficient(stream2.getVideoTracks()[0]), "second track");
-    assert_true(internals.isMediaStreamTrackPowerEfficient(video.srcObject.getVideoTracks()[0]));
+    assert_array_equals(stream.getVideoTracks()[0].getCapabilities().powerEfficient, [false, true]);
+    assert_true(stream.getVideoTracks()[0].getSettings().powerEfficient, "first track");
+    assert_true(stream2.getVideoTracks()[0].getSettings().powerEfficient, "second track");
+    assert_true(video.srcObject.getVideoTracks()[0].getSettings().powerEfficient);
 }, "Selecting a power efficient preset and check clones");
-
     </script>
 </body>
 </html>

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -294,6 +294,9 @@ MediaStreamTrack::TrackSettings MediaStreamTrack::getSettings() const
     if (settings.supportsBackgroundBlur())
         result.backgroundBlur = settings.backgroundBlur();
 
+    if (settings.supportsPowerEfficient())
+        result.powerEfficient = settings.powerEfficient();
+
     return result;
 }
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -123,6 +123,7 @@ public:
         std::optional<double> zoom;
         std::optional<bool> torch;
         std::optional<bool> backgroundBlur;
+        std::optional<bool> powerEfficient;
     };
     TrackSettings getSettings() const;
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.idl
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.idl
@@ -95,4 +95,5 @@ enum MediaStreamTrackState { "live", "ended" };
     boolean torch;
 
     boolean backgroundBlur;
+    boolean powerEfficient;
 };

--- a/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp
@@ -96,6 +96,17 @@ static Vector<bool> capabilityBooleanVector(RealtimeMediaSourceCapabilities::Bac
     return result;
 }
 
+static Vector<bool> powerEfficientCapabilityVector(bool powerEfficient)
+{
+    Vector<bool> result;
+    result.reserveInitialCapacity(2);
+    result.append(false);
+    if (powerEfficient)
+        result.append(true);
+
+    return result;
+}
+
 MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabilities& capabilities, const String& groupId)
 {
     MediaTrackCapabilities result;
@@ -131,6 +142,9 @@ MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabil
         result.torch = capabilities.torch();
     if (capabilities.supportsBackgroundBlur())
         result.backgroundBlur = capabilityBooleanVector(capabilities.backgroundBlur());
+
+    if (capabilities.supportsPowerEfficient())
+        result.powerEfficient = powerEfficientCapabilityVector(capabilities.powerEfficient());
 
     return result;
 }

--- a/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.h
+++ b/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.h
@@ -53,6 +53,7 @@ struct MediaTrackCapabilities {
     std::optional<DoubleRange> zoom;
     std::optional<bool> torch;
     std::optional<Vector<bool>> backgroundBlur;
+    std::optional<Vector<bool>> powerEfficient;
 };
 
 MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabilities&, const String& groupId);

--- a/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.idl
+++ b/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.idl
@@ -64,4 +64,5 @@
     boolean torch;
 
     sequence<boolean> backgroundBlur;
+    sequence<boolean> powerEfficient;
 };

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h
@@ -92,7 +92,7 @@ public:
         OnOff,
     };
 
-    RealtimeMediaSourceCapabilities(LongCapabilityRange width, LongCapabilityRange height, DoubleCapabilityRange aspectRatio, DoubleCapabilityRange frameRate, Vector<VideoFacingMode>&& facingMode, DoubleCapabilityRange volume, LongCapabilityRange sampleRate, LongCapabilityRange sampleSize, EchoCancellation echoCancellation, String&& deviceId, String&& groupId, DoubleCapabilityRange focusDistance, Vector<MeteringMode>&& whiteBalanceModes, DoubleCapabilityRange zoom, bool torch, BackgroundBlur backgroundBlur, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
+    RealtimeMediaSourceCapabilities(LongCapabilityRange width, LongCapabilityRange height, DoubleCapabilityRange aspectRatio, DoubleCapabilityRange frameRate, Vector<VideoFacingMode>&& facingMode, DoubleCapabilityRange volume, LongCapabilityRange sampleRate, LongCapabilityRange sampleSize, EchoCancellation echoCancellation, String&& deviceId, String&& groupId, DoubleCapabilityRange focusDistance, Vector<MeteringMode>&& whiteBalanceModes, DoubleCapabilityRange zoom, bool torch, BackgroundBlur backgroundBlur, bool powerEfficient, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
         : m_width(WTFMove(width))
         , m_height(WTFMove(height))
         , m_aspectRatio(WTFMove(aspectRatio))
@@ -109,6 +109,7 @@ public:
         , m_zoom(WTFMove(zoom))
         , m_torch(torch)
         , m_backgroundBlur(backgroundBlur)
+        , m_powerEfficient(powerEfficient)
         , m_supportedConstraints(WTFMove(supportedConstraints))
     {
     }
@@ -185,10 +186,14 @@ public:
     BackgroundBlur backgroundBlur() const { return m_backgroundBlur; }
     void setBackgroundBlur(BackgroundBlur backgroundBlur) { m_backgroundBlur = backgroundBlur; }
 
+    bool supportsPowerEfficient() const { return m_supportedConstraints.supportsPowerEfficient(); }
+    bool powerEfficient() const { return m_powerEfficient; }
+    void setPowerEfficient(bool value) { m_powerEfficient = value; }
+
     const RealtimeMediaSourceSupportedConstraints& supportedConstraints() const { return m_supportedConstraints; }
     void setSupportedConstraints(const RealtimeMediaSourceSupportedConstraints& constraints) { m_supportedConstraints = constraints; }
 
-    RealtimeMediaSourceCapabilities isolatedCopy() const { return { m_width, m_height, m_aspectRatio, m_frameRate, Vector<VideoFacingMode> { m_facingMode }, m_volume, m_sampleRate, m_sampleSize, m_echoCancellation, m_deviceId.isolatedCopy(), m_groupId.isolatedCopy(), m_focusDistance, Vector<MeteringMode> { m_whiteBalanceModes }, m_zoom, m_torch, m_backgroundBlur, RealtimeMediaSourceSupportedConstraints { m_supportedConstraints } }; }
+    RealtimeMediaSourceCapabilities isolatedCopy() const { return { m_width, m_height, m_aspectRatio, m_frameRate, Vector<VideoFacingMode> { m_facingMode }, m_volume, m_sampleRate, m_sampleSize, m_echoCancellation, m_deviceId.isolatedCopy(), m_groupId.isolatedCopy(), m_focusDistance, Vector<MeteringMode> { m_whiteBalanceModes }, m_zoom, m_torch, m_backgroundBlur, m_powerEfficient, RealtimeMediaSourceSupportedConstraints { m_supportedConstraints } }; }
 
 private:
     LongCapabilityRange m_width;
@@ -209,6 +214,7 @@ private:
     bool m_torch { false };
 
     BackgroundBlur m_backgroundBlur { BackgroundBlur::Off };
+    bool m_powerEfficient { false };
 
     RealtimeMediaSourceSupportedConstraints m_supportedConstraints;
 };

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp
@@ -40,7 +40,7 @@ namespace WebCore {
 
 RealtimeMediaSourceSettings RealtimeMediaSourceSettings::isolatedCopy() const
 {
-    return { m_width, m_height , m_frameRate, m_facingMode, m_volume , m_sampleRate, m_sampleSize, m_echoCancellation, m_deviceId.isolatedCopy(), m_groupId.isolatedCopy(), m_label.isolatedCopy(), m_displaySurface, m_logicalSurface, m_whiteBalanceMode, m_zoom, m_torch, m_backgroundBlur, RealtimeMediaSourceSupportedConstraints { m_supportedConstraints } };
+    return { m_width, m_height , m_frameRate, m_facingMode, m_volume , m_sampleRate, m_sampleSize, m_echoCancellation, m_deviceId.isolatedCopy(), m_groupId.isolatedCopy(), m_label.isolatedCopy(), m_displaySurface, m_logicalSurface, m_whiteBalanceMode, m_zoom, m_torch, m_backgroundBlur, m_powerEfficient, RealtimeMediaSourceSupportedConstraints { m_supportedConstraints } };
 }
 
 VideoFacingMode RealtimeMediaSourceSettings::videoFacingModeEnum(const String& mode)
@@ -118,6 +118,9 @@ String RealtimeMediaSourceSettings::convertFlagsToString(const OptionSet<Realtim
         case RealtimeMediaSourceSettings::BackgroundBlur:
             builder.append("BackgroundBlur"_s);
             break;
+        case RealtimeMediaSourceSettings::PowerEfficient:
+            builder.append("PowerEfficient"_s);
+            break;
         }
     }
     builder.append(" ]"_s);
@@ -163,6 +166,8 @@ OptionSet<RealtimeMediaSourceSettings::Flag> RealtimeMediaSourceSettings::differ
         difference.add(RealtimeMediaSourceSettings::Torch);
     if (backgroundBlur() != that.backgroundBlur())
         difference.add(RealtimeMediaSourceSettings::BackgroundBlur);
+    if (powerEfficient() != that.powerEfficient())
+        difference.add(RealtimeMediaSourceSettings::PowerEfficient);
 
     return difference;
 }

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h
@@ -75,14 +75,15 @@ public:
         Zoom = 1 << 14,
         Torch = 1 << 15,
         BackgroundBlur = 1 << 16,
+        PowerEfficient = 1 << 17,
     };
 
-    static constexpr OptionSet<Flag> allFlags() { return { Width, Height, FrameRate, FacingMode, Volume, SampleRate, SampleSize, EchoCancellation, DeviceId, GroupId, Label, DisplaySurface, LogicalSurface, WhiteBalanceMode, Zoom, Torch, BackgroundBlur }; }
+    static constexpr OptionSet<Flag> allFlags() { return { Width, Height, FrameRate, FacingMode, Volume, SampleRate, SampleSize, EchoCancellation, DeviceId, GroupId, Label, DisplaySurface, LogicalSurface, WhiteBalanceMode, Zoom, Torch, BackgroundBlur, PowerEfficient }; }
 
     WEBCORE_EXPORT OptionSet<RealtimeMediaSourceSettings::Flag> difference(const RealtimeMediaSourceSettings&) const;
 
     RealtimeMediaSourceSettings() = default;
-    RealtimeMediaSourceSettings(uint32_t width, uint32_t height, float frameRate, VideoFacingMode facingMode, double volume, uint32_t sampleRate, uint32_t sampleSize, bool echoCancellation, String&& deviceId, String&& groupId, String&& label, DisplaySurfaceType displaySurface, bool logicalSurface, MeteringMode whiteBalanceMode, double zoom, bool torch, bool backgroundBlur, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
+    RealtimeMediaSourceSettings(uint32_t width, uint32_t height, float frameRate, VideoFacingMode facingMode, double volume, uint32_t sampleRate, uint32_t sampleSize, bool echoCancellation, String&& deviceId, String&& groupId, String&& label, DisplaySurfaceType displaySurface, bool logicalSurface, MeteringMode whiteBalanceMode, double zoom, bool torch, bool backgroundBlur, bool powerEfficient, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
         : m_width(width)
         , m_height(height)
         , m_frameRate(frameRate)
@@ -100,6 +101,7 @@ public:
         , m_zoom(zoom)
         , m_torch(torch)
         , m_backgroundBlur(backgroundBlur)
+        , m_powerEfficient(powerEfficient)
         , m_supportedConstraints(WTFMove(supportedConstraints))
     {
     }
@@ -170,6 +172,10 @@ public:
     bool backgroundBlur() const { return m_backgroundBlur; }
     void setBackgroundBlur(bool backgroundBlur) { m_backgroundBlur = backgroundBlur; }
 
+    bool supportsPowerEfficient() const { return m_supportedConstraints.supportsPowerEfficient(); }
+    bool powerEfficient() const { return m_powerEfficient; }
+    void setPowerEfficient(bool value) { m_powerEfficient = value; }
+
     const RealtimeMediaSourceSupportedConstraints& supportedConstraints() const { return m_supportedConstraints; }
     void setSupportedConstraints(const RealtimeMediaSourceSupportedConstraints& supportedConstraints) { m_supportedConstraints = supportedConstraints; }
 
@@ -201,6 +207,7 @@ private:
     double m_zoom { 1.0 };
     bool m_torch { false };
     bool m_backgroundBlur { false };
+    bool m_powerEfficient { false };
 
     RealtimeMediaSourceSupportedConstraints m_supportedConstraints;
 };

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.h
@@ -42,7 +42,7 @@ public:
     {
     }
     
-    RealtimeMediaSourceSupportedConstraints(bool supportsWidth, bool supportsHeight, bool supportsAspectRatio, bool supportsFrameRate, bool supportsFacingMode, bool supportsVolume, bool supportsSampleRate, bool supportsSampleSize, bool supportsEchoCancellation, bool supportsDeviceId, bool supportsGroupId, bool supportsDisplaySurface, bool supportsLogicalSurface, bool supportsFocusDistance, bool supportsWhiteBalanceMode, bool supportsZoom, bool supportsTorch, bool supportsBackgroundBlur)
+    RealtimeMediaSourceSupportedConstraints(bool supportsWidth, bool supportsHeight, bool supportsAspectRatio, bool supportsFrameRate, bool supportsFacingMode, bool supportsVolume, bool supportsSampleRate, bool supportsSampleSize, bool supportsEchoCancellation, bool supportsDeviceId, bool supportsGroupId, bool supportsDisplaySurface, bool supportsLogicalSurface, bool supportsFocusDistance, bool supportsWhiteBalanceMode, bool supportsZoom, bool supportsTorch, bool supportsBackgroundBlur, bool supportsPowerEfficient)
         : m_supportsWidth(supportsWidth)
         , m_supportsHeight(supportsHeight)
         , m_supportsAspectRatio(supportsAspectRatio)
@@ -61,6 +61,7 @@ public:
         , m_supportsZoom(supportsZoom)
         , m_supportsTorch(supportsTorch)
         , m_supportsBackgroundBlur(supportsBackgroundBlur)
+        , m_supportsPowerEfficient(supportsPowerEfficient)
     {
     }
 
@@ -120,6 +121,9 @@ public:
     bool supportsBackgroundBlur() const { return m_supportsBackgroundBlur; }
     void setSupportsBackgroundBlur(bool value) { m_supportsBackgroundBlur = value; }
 
+    bool supportsPowerEfficient() const { return m_supportsPowerEfficient; }
+    void setSupportsPowerEfficient(bool value) { m_supportsPowerEfficient = value; }
+
 private:
     bool m_supportsWidth { false };
     bool m_supportsHeight { false };
@@ -139,6 +143,7 @@ private:
     bool m_supportsZoom { false };
     bool m_supportsTorch { false };
     bool m_supportsBackgroundBlur { false };
+    bool m_supportsPowerEfficient { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp
@@ -594,6 +594,12 @@ String SizeFrameRateAndZoom::toJSONString() const
 }
 #endif
 
+bool RealtimeVideoCaptureSource::canBePowerEfficient()
+{
+    return anyOf(presets(), [] (auto& preset) { return preset.isEfficient(); }) && anyOf(presets(), [] (auto& preset) { return !preset.isEfficient(); });
+}
+
+
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h
@@ -80,6 +80,8 @@ protected:
     virtual Ref<TakePhotoNativePromise> takePhotoInternal(PhotoSettings&&);
     bool mutedForPhotoCapture() const { return m_mutedForPhotoCapture; }
 
+    bool canBePowerEfficient();
+
 private:
     struct CaptureSizeFrameRateAndZoom {
         std::optional<VideoPreset> encodingPreset;

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -486,6 +486,11 @@ const RealtimeMediaSourceSettings& AVVideoCaptureSource::settings()
         settings.setTorch([device() torchMode] == AVCaptureTorchModeOn);
     }
 
+#if PLATFORM(IOS_FAMILY)
+    supportedConstraints.setSupportsPowerEfficient(true);
+    if (canBePowerEfficient())
+        settings.setPowerEfficient(m_currentPreset ? m_currentPreset->isEfficient() : false);
+#endif
     settings.setSupportedConstraints(supportedConstraints);
 
     m_currentSettings = WTFMove(settings);
@@ -530,7 +535,11 @@ const RealtimeMediaSourceCapabilities& AVVideoCaptureSource::capabilities()
     }
 
     capabilities.setBackgroundBlur(device().portraitEffectActive ? RealtimeMediaSourceCapabilities::BackgroundBlur::On : RealtimeMediaSourceCapabilities::BackgroundBlur::Off);
-    supportedConstraints.setSupportsBackgroundBlur(true);
+
+#if PLATFORM(IOS_FAMILY)
+    supportedConstraints.setSupportsPowerEfficient(true);
+    capabilities.setPowerEfficient(canBePowerEfficient());
+#endif
 
     capabilities.setSupportedConstraints(supportedConstraints);
     updateCapabilities(capabilities);

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -244,6 +244,9 @@ const RealtimeMediaSourceCapabilities& MockRealtimeVideoSource::capabilities()
         capabilities.setBackgroundBlur(std::get<MockCameraProperties>(m_device.properties).hasBackgroundBlur ? RealtimeMediaSourceCapabilities::BackgroundBlur::On : RealtimeMediaSourceCapabilities::BackgroundBlur::Off);
         supportedConstraints.setSupportsBackgroundBlur(true);
 
+        capabilities.setPowerEfficient(canBePowerEfficient());
+        supportedConstraints.setSupportsPowerEfficient(true);
+
         capabilities.setSupportedConstraints(supportedConstraints);
     } else if (mockDisplay()) {
         capabilities.setWidth({ 72, std::get<MockDisplayProperties>(m_device.properties).defaultSize.width() });
@@ -364,6 +367,10 @@ const RealtimeMediaSourceSettings& MockRealtimeVideoSource::settings()
             supportedConstraints.setSupportsTorch(true);
             settings.setTorch(torch());
         }
+
+        if (canBePowerEfficient())
+            settings.setPowerEfficient(m_preset ? m_preset->isEfficient() : false);
+        supportedConstraints.setSupportsPowerEfficient(true);
 
         supportedConstraints.setSupportsBackgroundBlur(true);
         settings.setBackgroundBlur(std::get<MockCameraProperties>(m_device.properties).hasBackgroundBlur);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -6094,11 +6094,6 @@ bool Internals::isMediaStreamSourceEnded(MediaStreamTrack& track) const
     return track.source().isEnded();
 }
 
-bool Internals::isMediaStreamTrackPowerEfficient(const MediaStreamTrack& track) const
-{
-    return track.source().isPowerEfficient();
-}
-
 bool Internals::isMockRealtimeMediaSourceCenterEnabled()
 {
     return MockRealtimeMediaSourceCenter::mockRealtimeMediaSourceCenterEnabled();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -981,7 +981,6 @@ public:
     void setMediaStreamSourceInterrupted(MediaStreamTrack&, bool);
     bool isMediaStreamSourceInterrupted(MediaStreamTrack&) const;
     bool isMediaStreamSourceEnded(MediaStreamTrack&) const;
-    bool isMediaStreamTrackPowerEfficient(const MediaStreamTrack&) const;
     bool isMockRealtimeMediaSourceCenterEnabled();
     bool shouldAudioTrackPlay(const AudioTrack&);
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1103,7 +1103,6 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     [Conditional=MEDIA_STREAM] undefined setMediaStreamSourceInterrupted(MediaStreamTrack track, boolean interrupted);
     [Conditional=MEDIA_STREAM] boolean isMediaStreamSourceInterrupted(MediaStreamTrack track);
     [Conditional=MEDIA_STREAM] boolean isMediaStreamSourceEnded(MediaStreamTrack track);
-    [Conditional=MEDIA_STREAM] boolean isMediaStreamTrackPowerEfficient(MediaStreamTrack track);
     [Conditional=MEDIA_STREAM] boolean isMockRealtimeMediaSourceCenterEnabled();
     [Conditional=MEDIA_STREAM] boolean shouldAudioTrackPlay(AudioTrack track);
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5325,6 +5325,7 @@ class WebCore::RealtimeMediaSourceSupportedConstraints {
     bool supportsZoom();
     bool supportsTorch();
     bool supportsBackgroundBlur();
+    bool supportsPowerEfficient();
 };
 
 [Nested] enum class WebCore::RealtimeMediaSource::Type : bool;
@@ -5371,6 +5372,7 @@ class WebCore::RealtimeMediaSourceSettings {
     double zoom();
     bool torch();
     bool backgroundBlur();
+    bool powerEfficient();
     WebCore::RealtimeMediaSourceSupportedConstraints supportedConstraints();
 };
 
@@ -5436,6 +5438,7 @@ class WebCore::RealtimeMediaSourceCapabilities {
     WebCore::DoubleCapabilityRange zoom();
     bool torch();
     WebCore::RealtimeMediaSourceCapabilities::BackgroundBlur backgroundBlur();
+    bool powerEfficient();
     WebCore::RealtimeMediaSourceSupportedConstraints supportedConstraints();
 };
 


### PR DESCRIPTION
#### 312f06335038c0c43733c76223f9a53806a002c1
<pre>
Finalize implementation of MediaStreamTrack powerEfficient constraint
<a href="https://bugs.webkit.org/show_bug.cgi?id=276075">https://bugs.webkit.org/show_bug.cgi?id=276075</a>
<a href="https://rdar.apple.com/130897389">rdar://130897389</a>

Reviewed by Eric Carlson.

We were previoudly not exposing powerEfficient settings and capabilities.
Now that the spec changes have landed in <a href="https://w3c.github.io/mediacapture-extensions/#the-powerefficient-constraint">https://w3c.github.io/mediacapture-extensions/#the-powerefficient-constraint</a>,
we can expose them.
We only set powerEfficient to [false, true] if there are presets that are power efficients and others that are not.
Otherwise we set it to [false].

* LayoutTests/fast/mediastream/camera-powerEfficient-track-expected.txt:
* LayoutTests/fast/mediastream/camera-powerEfficient-track.html:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::getSettings const):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.idl:
* Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp:
(WebCore::powerEfficientCapabilityVector):
(WebCore::toMediaTrackCapabilities):
* Source/WebCore/Modules/mediastream/MediaTrackCapabilities.h:
* Source/WebCore/Modules/mediastream/MediaTrackCapabilities.idl:
* Source/WebCore/platform/mediastream/RealtimeMediaSourceCapabilities.h:
(WebCore::RealtimeMediaSourceCapabilities::RealtimeMediaSourceCapabilities):
(WebCore::RealtimeMediaSourceCapabilities::supportsPowerEfficient const):
(WebCore::RealtimeMediaSourceCapabilities::powerEfficient const):
(WebCore::RealtimeMediaSourceCapabilities::setPowerEfficient):
(WebCore::RealtimeMediaSourceCapabilities::isolatedCopy const):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp:
(WebCore::RealtimeMediaSourceSettings::isolatedCopy const):
(WebCore::RealtimeMediaSourceSettings::convertFlagsToString):
(WebCore::RealtimeMediaSourceSettings::difference const):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h:
(WebCore::RealtimeMediaSourceSettings::allFlags):
(WebCore::RealtimeMediaSourceSettings::RealtimeMediaSourceSettings):
(WebCore::RealtimeMediaSourceSettings::supportsPowerEfficient const):
(WebCore::RealtimeMediaSourceSettings::powerEfficient const):
(WebCore::RealtimeMediaSourceSettings::setPowerEfficient):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSupportedConstraints.h:
(WebCore::RealtimeMediaSourceSupportedConstraints::RealtimeMediaSourceSupportedConstraints):
(WebCore::RealtimeMediaSourceSupportedConstraints::supportsPowerEfficient const):
(WebCore::RealtimeMediaSourceSupportedConstraints::setSupportsPowerEfficient):
* Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.cpp:
(WebCore::RealtimeVideoCaptureSource::canBePowerEfficient):
* Source/WebCore/platform/mediastream/RealtimeVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::settings):
(WebCore::AVVideoCaptureSource::capabilities):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::capabilities):
(WebCore::MockRealtimeVideoSource::settings):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::isMediaStreamTrackPowerEfficient const): Deleted.
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::createMediaSourceForCaptureDeviceWithConstraints):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp:
(WebKit::RemoteRealtimeMediaSource::createRemoteMediaSource):

Canonical link: <a href="https://commits.webkit.org/280576@main">https://commits.webkit.org/280576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3dded311bd97a6a8dbba2c6212c3e45fde6377f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56998 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36326 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60618 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7441 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59126 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43949 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7631 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46163 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5228 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34112 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49195 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27023 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30892 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6526 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6446 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52853 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62299 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/911 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6902 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53420 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/914 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49250 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53459 "Found 1 new API test failure: /WebKitGTK/TestWebViewEditor:/webkit/WebKitWebView/select-all/non-editable (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12605 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/772 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32155 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33240 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34325 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32986 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->