### PR TITLE
Crash under ServiceWorkerFetchTask::contextClosed()

### DIFF
--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -156,6 +156,13 @@ void ServiceWorkerFetchTask::start(WebSWServerToContextConnection& serviceWorker
     startFetch();
 }
 
+void ServiceWorkerFetchTask::workerClosed()
+{
+    if (CheckedPtr serviceWorkerConnection = m_serviceWorkerConnection.get())
+        serviceWorkerConnection->unregisterFetch(*this);
+    contextClosed();
+}
+
 void ServiceWorkerFetchTask::contextClosed()
 {
     SWFETCH_RELEASE_LOG("contextClosed: (m_isDone=%d, m_wasHandled=%d)", m_isDone, m_wasHandled);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
@@ -117,6 +117,8 @@ private:
     NetworkSession* session();
     void preloadResponseIsReady();
 
+    void workerClosed();
+
     template<typename Message> bool sendToServiceWorker(Message&&);
     template<typename Message> bool sendToClient(Message&&);
 

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.messages.in
@@ -29,5 +29,5 @@ messages -> ServiceWorkerFetchTask NotRefCounted {
     DidReceiveFormData(IPC::FormDataReference data)
     DidFinish(WebCore::NetworkLoadMetrics metrics)
     UsePreload()
-    ContextClosed()
+    WorkerClosed()
 }

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -61,11 +61,11 @@ WebSWServerToContextConnection::~WebSWServerToContextConnection()
 {
     auto fetches = WTFMove(m_ongoingFetches);
     for (auto& fetch : fetches.values())
-        fetch->contextClosed();
+        Ref { fetch.get() }->contextClosed();
 
     auto downloads = WTFMove(m_ongoingDownloads);
     for (auto& weakPtr : downloads.values()) {
-        if (auto download = weakPtr.get())
+        if (RefPtr download = weakPtr.get())
             download->contextClosed();
     }
 

--- a/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp
+++ b/Source/WebKit/WebProcess/Storage/WebServiceWorkerFetchTaskClient.cpp
@@ -331,7 +331,7 @@ void WebServiceWorkerFetchTaskClient::contextIsStopping()
         return;
     }
 
-    m_connection->send(Messages::ServiceWorkerFetchTask::ContextClosed { }, m_fetchIdentifier);
+    m_connection->send(Messages::ServiceWorkerFetchTask::WorkerClosed { }, m_fetchIdentifier);
     cleanup();
 }
 


### PR DESCRIPTION
#### 821d1ca973031360e9f5327c49f57fed1c0c38d7
<pre>
Crash under ServiceWorkerFetchTask::contextClosed()
<a href="https://bugs.webkit.org/show_bug.cgi?id=276079">https://bugs.webkit.org/show_bug.cgi?id=276079</a>
<a href="https://rdar.apple.com/130856919">rdar://130856919</a>

Reviewed by David Kilzer and Youenn Fablet.

This crash is a regression from 280246@main. When ServiceWorkerFetchTask::contextClosed()
was called due to receiving the ServiceWorkerFetchTask::ContextClosed IPC, the task
would fail to unregister itself from the WebSWServerToContextConnection, leaving a null
WebPtr in the map. We would then dereference this null WeakPtr in the WebSWServerToContextConnection
destructor.

To address the issue, I have renamed the IPC to WorkerClosed, and the implementation now
unregisters the task from the WebSWServerToContextConnection before calling contextClosed().

* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::workerClosed):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.messages.in:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::~WebSWServerToContextConnection):

Canonical link: <a href="https://commits.webkit.org/280600@main">https://commits.webkit.org/280600@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d00ab7fce6efb4f210e03a2c2d1856a286f910b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36372 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60664 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7487 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46201 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5270 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34153 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49235 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27061 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30933 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6492 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52897 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6837 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62345 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/957 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6941 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53456 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/960 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49290 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53504 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/810 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8505 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32201 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33286 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34371 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33032 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->