### PR TITLE
ReportingObserverCallbacks can leak the Document object

### DIFF
--- a/LayoutTests/fast/reporting/reporting-observer-callback-does-not-leak-expected.txt
+++ b/LayoutTests/fast/reporting/reporting-observer-callback-does-not-leak-expected.txt
@@ -1,0 +1,10 @@
+Tests that ReportingObserver callbacks do not leak documents.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The iframe document didn't leak
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/reporting/reporting-observer-callback-does-not-leak.html
+++ b/LayoutTests/fast/reporting/reporting-observer-callback-does-not-leak.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("Tests that ReportingObserver callbacks do not leak documents.");
+
+jsTestIsAsync = true;
+var framesToCreate = 20;
+var allFrames = new Array(framesToCreate);
+
+for (let i = 0; i < framesToCreate; ++i) {
+    let iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+    allFrames[i] = iframe;
+}
+
+function iframeForMessage(message)
+{
+    return allFrames.find(frame => frame.contentWindow === message.source);
+}
+
+var failCount = 0;
+function iframeLeaked()
+{
+    if (++failCount >= framesToCreate) {
+        testFailed("All iframe documents leaked.");
+        finishJSTest();
+    }
+}
+
+function iframeLoaded(iframe)
+{
+    let frameDocumentID = internals.documentIdentifier(iframe.contentWindow.document);
+    let checkCount = 0;
+
+    iframe.addEventListener("load", () => {
+        let handle = setInterval(() => {
+            gc();
+            if (!internals.isDocumentAlive(frameDocumentID)) {
+                clearInterval(handle);
+                testPassed("The iframe document didn't leak");
+                finishJSTest();
+            }
+            if (++checkCount > 5) {
+                clearInterval(handle);
+                iframeLeaked();
+            }
+        }, 10);
+    });
+
+    iframe.src = "about:blank";
+}
+
+onload = () => {
+    if (!(window.internals && window.testRunner)) {
+        testFailed("Test requires internals and testRunner.");
+        finishJSTest();
+    }
+
+    window.addEventListener("message", message => iframeLoaded(iframeForMessage(message)));
+
+    allFrames.forEach(iframe => iframe.src = "./resources/reporting-observer-with-callback.html");
+};
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/reporting/resources/reporting-observer-with-callback.html
+++ b/LayoutTests/fast/reporting/resources/reporting-observer-with-callback.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+var reportingObserver = new ReportingObserver((reports, observer) => {
+    let d = document;
+    let p = d.createElement("p");
+    p.innerText = "I hope the document doesn't leak because of this!";
+    document.body.appendChild(p);
+});
+
+onload = () => parent.postMessage("frameLoaded");
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/reporting/ReportingObserver.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingObserver.cpp
@@ -146,4 +146,9 @@ void ReportingObserver::appendQueuedReportIfCorrectType(const Ref<Report>& repor
     });
 }
 
+ReportingObserverCallback& ReportingObserver::callbackConcurrently()
+{
+    return m_callback.get();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/Modules/reporting/ReportingObserver.h
+++ b/Source/WebCore/Modules/reporting/ReportingObserver.h
@@ -55,6 +55,8 @@ public:
 
     void appendQueuedReportIfCorrectType(const Ref<Report>&);
 
+    ReportingObserverCallback& callbackConcurrently();
+
 private:
     explicit ReportingObserver(ScriptExecutionContext&, Ref<ReportingObserverCallback>&&, ReportingObserver::Options&&);
 

--- a/Source/WebCore/Modules/reporting/ReportingObserver.idl
+++ b/Source/WebCore/Modules/reporting/ReportingObserver.idl
@@ -30,7 +30,8 @@ typedef sequence<Report> ReportList;
 [
     EnabledBySetting=ReportingEnabled,
     Exposed=(Window,Worker),
-    GenerateIsReachable=ImplScriptExecutionContext
+    GenerateIsReachable=ImplScriptExecutionContext,
+    JSCustomMarkFunction
 ] interface ReportingObserver {
     [CallWith=CurrentScriptExecutionContext] constructor(ReportingObserverCallback callback, optional ReportingObserverOptions options);
     undefined observe();

--- a/Source/WebCore/Modules/reporting/ReportingObserverCallback.h
+++ b/Source/WebCore/Modules/reporting/ReportingObserverCallback.h
@@ -40,6 +40,8 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent(const Vector<Ref<Report>>&, ReportingObserver&) = 0;
+
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/reporting/ReportingObserverCallback.idl
+++ b/Source/WebCore/Modules/reporting/ReportingObserverCallback.idl
@@ -27,4 +27,4 @@
 
 typedef sequence<Report> ReportList;
 
-callback ReportingObserverCallback = undefined (ReportList reports, ReportingObserver observer);
+[ IsWeakCallback ] callback ReportingObserverCallback = undefined (ReportList reports, ReportingObserver observer);

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -708,6 +708,7 @@ bindings/js/JSRTCRtpSFrameTransformCustom.cpp
 bindings/js/JSRangeCustom.cpp
 bindings/js/JSReadableStreamSourceCustom.cpp
 bindings/js/JSReportBodyCustom.cpp
+bindings/js/JSReportingObserverCustom.cpp
 bindings/js/JSResizeObserverCustom.cpp
 bindings/js/JSResizeObserverEntryCustom.cpp
 bindings/js/JSSVGPathSegCustom.cpp

--- a/Source/WebCore/bindings/js/JSReportingObserverCustom.cpp
+++ b/Source/WebCore/bindings/js/JSReportingObserverCustom.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 Apple, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSReportingObserver.h"
+
+#include "ReportingObserverCallback.h"
+
+#include <JavaScriptCore/JSCInlines.h>
+
+namespace WebCore {
+
+template <typename Visitor>
+void JSReportingObserver::visitAdditionalChildren(Visitor& visitor)
+{
+    wrapped().callbackConcurrently().visitJSFunction(visitor);
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN(JSReportingObserver);
+
+}


### PR DESCRIPTION
#### 33c1f1877fa266b544427d68f05d3e33e7a027f4
<pre>
ReportingObserverCallbacks can leak the Document object
<a href="https://bugs.webkit.org/show_bug.cgi?id=276080">https://bugs.webkit.org/show_bug.cgi?id=276080</a>
<a href="https://rdar.apple.com/130908426">rdar://130908426</a>

Reviewed by Ryosuke Niwa.

By default callbacks are held as JSC::Strong handles. This creates a GC
Root which will keep anything captured in the callback function alive.
On sites like britannica.com, many documents are captured in this way
and lead to memory leaks.

This patch makes ReportingObserverCallback Weak and keeps the callback
wrapper alive via ReportingObserver&apos;s visitAdditionalChildren.

* LayoutTests/fast/reporting/reporting-observer-callback-does-not-leak-expected.txt: Added.
* LayoutTests/fast/reporting/reporting-observer-callback-does-not-leak.html: Added.
* LayoutTests/fast/reporting/resources/reporting-observer-with-callback.html: Added.
* Source/WebCore/Modules/reporting/ReportingObserver.cpp:
(WebCore::ReportingObserver::callbackConcurrently):
* Source/WebCore/Modules/reporting/ReportingObserver.h:
* Source/WebCore/Modules/reporting/ReportingObserver.idl:
* Source/WebCore/Modules/reporting/ReportingObserverCallback.h:
* Source/WebCore/Modules/reporting/ReportingObserverCallback.idl:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSReportingObserverCustom.cpp: Added.
(WebCore::JSReportingObserver::visitAdditionalChildren):

Canonical link: <a href="https://commits.webkit.org/280557@main">https://commits.webkit.org/280557@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fc4b594aa45b0db9d024d5cfd337018959e6b9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60574 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7397 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59082 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46124 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5198 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58984 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49152 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26982 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30852 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6483 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6402 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52814 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6754 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62255 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/867 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6859 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53382 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/870 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49207 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/53424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12588 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/734 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32111 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33196 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34281 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32942 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->