### PR TITLE
[WebVTT] Apply ::cue pseudo to the correct WebVTT object (root)

### DIFF
--- a/LayoutTests/http/tests/media/hls/hls-webvtt-style-expected.txt
+++ b/LayoutTests/http/tests/media/hls/hls-webvtt-style-expected.txt
@@ -4,7 +4,7 @@ EXPECTED (video.textTracks.length == '1') OK
 RUN(video.textTracks[0].mode = 'showing')
 EVENT(cuechange)
 RUN(textTrackContainer = window.internals.shadowRoot(video).querySelector("div[useragentpart=-webkit-media-text-track-container]"))
-RUN(cue = textTrackContainer.querySelector("span[useragentpart=cue]"))
+RUN(cue = textTrackContainer.querySelector("span[useragentpart=-internal-cue-background]"))
 EXPECTED (getComputedStyle(cue).backgroundColor == 'rgba(255, 0, 0, 0.5)') OK
 EXPECTED (getComputedStyle(cue.children[0]).backgroundColor == 'rgba(0, 0, 0, 0)') OK
 EXPECTED (getComputedStyle(cue.children[1]).backgroundColor == 'rgb(0, 255, 0)') OK

--- a/LayoutTests/http/tests/media/hls/hls-webvtt-style.html
+++ b/LayoutTests/http/tests/media/hls/hls-webvtt-style.html
@@ -15,7 +15,7 @@
             await waitFor(video.textTracks[0], 'cuechange');
 
             run('textTrackContainer = window.internals.shadowRoot(video).querySelector("div[useragentpart=-webkit-media-text-track-container]")');
-            run('cue = textTrackContainer.querySelector("span[useragentpart=cue]")')
+            run('cue = textTrackContainer.querySelector("span[useragentpart=-internal-cue-background]")')
 
             testExpected('getComputedStyle(cue).backgroundColor', "rgba(255, 0, 0, 0.5)");
 

--- a/LayoutTests/http/tests/media/track/track-webvtt-vertical-multi-line-expected.txt
+++ b/LayoutTests/http/tests/media/track/track-webvtt-vertical-multi-line-expected.txt
@@ -5,7 +5,7 @@ EXPECTED (video.textTracks.length == '1') OK
 RUN(video.textTracks[0].mode = 'showing')
 RUN(video.currentTime = 1)
 EVENT(seeked)
-EXPECTED (window.internals.shadowRoot(video).querySelector('span[useragentpart=cue]') != 'null') OK
-EXPECTED (video.offsetHeight >= window.internals.shadowRoot(video).querySelector('span[useragentpart=cue]').offsetHeight == 'true') OK
+EXPECTED (window.internals.shadowRoot(video).querySelector('span[useragentpart=-internal-cue-background]') != 'null') OK
+EXPECTED (video.offsetHeight >= window.internals.shadowRoot(video).querySelector('span[useragentpart=-internal-cue-background]').offsetHeight == 'true') OK
 END OF TEST
 

--- a/LayoutTests/http/tests/media/track/track-webvtt-vertical-multi-line.html
+++ b/LayoutTests/http/tests/media/track/track-webvtt-vertical-multi-line.html
@@ -23,8 +23,8 @@
                 await waitFor(video, 'seeked');
 
                 window.internals.ensureUserAgentShadowRoot(video);
-                await testExpectedEventually("window.internals.shadowRoot(video).querySelector('span[useragentpart=cue]')", null, "!=", 1000);
-                await testExpected("video.offsetHeight >= window.internals.shadowRoot(video).querySelector('span[useragentpart=cue]').offsetHeight", true);
+                await testExpectedEventually("window.internals.shadowRoot(video).querySelector('span[useragentpart=-internal-cue-background]')", null, "!=", 1000);
+                await testExpected("video.offsetHeight >= window.internals.shadowRoot(video).querySelector('span[useragentpart=-internal-cue-background]').offsetHeight", true);
                 endTest();
             }
         </script>

--- a/LayoutTests/media/track/track-cue-vertical-style.html
+++ b/LayoutTests/media/track/track-cue-vertical-style.html
@@ -8,7 +8,7 @@
     <script src=../video-test.js></script>
     <script>
     function firstCueElement() {
-        return internals.shadowRoot(video).querySelector('[useragentpart="cue"]');
+        return internals.shadowRoot(video).querySelector('[useragentpart="-internal-cue-background"]');
     }
 
     async function runTest() {

--- a/LayoutTests/media/track/track-in-band-layout.html
+++ b/LayoutTests/media/track/track-in-band-layout.html
@@ -7,7 +7,7 @@
     <script src="../video-test.js"></script>
     <script>
     function firstCueElement() {
-        return internals.shadowRoot(video).querySelector('[useragentpart="cue"]');
+        return internals.shadowRoot(video).querySelector('[useragentpart="-internal-cue-background"]');
     }
 
     async function runTest() {

--- a/LayoutTests/media/track/track-user-stylesheet-override.html
+++ b/LayoutTests/media/track/track-user-stylesheet-override.html
@@ -8,7 +8,7 @@
 
         <script>
             function firstCueElement() {
-                return internals.shadowRoot(video).querySelector('[useragentpart="cue"]');
+                return internals.shadowRoot(video).querySelector('span[useragentpart="-internal-cue-background"]');
             }
 
             async function runTest()

--- a/LayoutTests/media/track/track-webvtt-no-snap-to-lines-overlap-expected.html
+++ b/LayoutTests/media/track/track-webvtt-no-snap-to-lines-overlap-expected.html
@@ -13,13 +13,12 @@
         body { margin:0 }
         .cue-box {
             position: absolute;
-            font-family: sans-serif;
+            font-family: Ahem, sans-serif;
             font-size: 12px;
+            color: green;
         }
         .cue {
-            font-family: Ahem, sans-serif;
             background-color: black;
-            color: green;
         }
     </style>
     <script>var requirePixelDump = true;</script>

--- a/LayoutTests/media/track/track-webvtt-snap-to-lines-left-right-expected.html
+++ b/LayoutTests/media/track/track-webvtt-snap-to-lines-left-right-expected.html
@@ -13,13 +13,12 @@
         body { margin:0 }
         .cue-box {
             position: absolute;
-            font-family: sans-serif;
+            font-family: Ahem, sans-serif;
             font-size: 12px;
+            color: green;
         }
         .cue {
-            font-family: Ahem, sans-serif;
             background-color: black;
-            color: green;
         }
     </style>
     <script>var requirePixelDump = true;</script>

--- a/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
@@ -52,25 +52,35 @@ video[controls]::-webkit-media-text-track-container.visible-controls-bar {
 /* https://w3c.github.io/webvtt/#applying-css-properties
    7.4. Applying CSS properties to WebVTT Node Objects */
 
-::cue {
-    background-color: rgba(0, 0, 0, 0.8);
-    overflow: visible;
-}
-
-::-webkit-media-text-track-display {
+/* These properties are not allowed via ::cue */
+[useragentpart="cue"] {
+    position: absolute;
     unicode-bidi: plaintext;
-    overflow: visible;
     writing-mode: writing-mode;
     overflow-wrap: break-word;
-    white-space: pre-line;
     text-wrap: balance;
 }
 
-::-webkit-media-text-track-display {
+[useragentpart="cue"] .hidden { display: none; }
+[useragentpart="cue"] ruby { display: ruby; }
+[useragentpart="cue"] ruby > rt { display: ruby-text; }
+
+::cue {
+    font: 5cqmin/1 sans-serif;
+    color: rgba(255, 255, 255, 1);
+    background: rgba(0, 0, 0, 0.8);
     white-space: pre-line;
-    box-sizing: border-box;
-    font: 22px sans-serif; /* Keep in sync with `DEFAULTCAPTIONFONTSIZE`. */
 }
+
+::cue(rt) {
+    background: rgba(0, 0, 0, 0.8);
+    font-size: -webkit-ruby-text;
+}
+
+::cue(i) { font-style: italic; }
+::cue(b) { font-weight: bold; }
+::cue(u) { text-decoration: underline; }
+::cue(rt) { white-space: nowrap; }
 
 ::-webkit-media-text-track-display-backdrop {
     display: inline-block;
@@ -94,15 +104,3 @@ video[controls]::-webkit-media-text-track-container.visible-controls-bar {
     color: gray;
 }
 
-[useragentpart="-webkit-media-text-track-display"] b { font-weight: bold; }
-[useragentpart="-webkit-media-text-track-display"] u { text-decoration: underline; }
-[useragentpart="-webkit-media-text-track-display"] i { font-style: italic; }
-[useragentpart="-webkit-media-text-track-display"] .hidden { display: none; }
-[useragentpart="-webkit-media-text-track-display"] ruby { display: ruby; }
-[useragentpart="-webkit-media-text-track-display"] ruby > rt {
-    display: ruby-text;
-    font-size: -webkit-ruby-text;
-    text-align: start;
-    line-height: normal;
-}
-[useragentpart="-webkit-media-text-track-display"] ruby > :not(ruby) { white-space: nowrap; }

--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -514,6 +514,11 @@
             "conditional": "ENABLE(VIDEO)",
             "user-agent-part-string": true
         },
+        "-internal-cue-background": {
+            "conditional": "ENABLE(VIDEO)",
+            "status": "non-standard",
+            "user-agent-part": true
+        },
         "file-selector-button": {
             "aliases": [
                 "-webkit-file-upload-button"

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -955,7 +955,8 @@ void VTTCue::obtainCSSBoxes()
     // background box.
 
     // Note: This is contained by default in m_cueHighlightBox.
-    m_cueHighlightBox->setUserAgentPart(UserAgentParts::cue());
+    displayTree->setUserAgentPart(UserAgentParts::cue());
+    m_cueHighlightBox->setUserAgentPart(UserAgentParts::internalCueBackground());
 
     m_cueBackdropBox->setUserAgentPart(UserAgentParts::webkitMediaTextTrackDisplayBackdrop());
     m_cueBackdropBox->appendChild(m_cueHighlightBox);

--- a/Source/WebCore/style/PropertyAllowlist.cpp
+++ b/Source/WebCore/style/PropertyAllowlist.cpp
@@ -115,6 +115,47 @@ bool isValidMarkerStyleProperty(CSSPropertyID id)
 bool isValidCueStyleProperty(CSSPropertyID id)
 {
     switch (id) {
+    case CSSPropertyColor:
+    case CSSPropertyCustom:
+    case CSSPropertyFont:
+    case CSSPropertyFontFamily:
+    case CSSPropertyFontSize:
+    case CSSPropertyFontStyle:
+    case CSSPropertyFontVariantCaps:
+    case CSSPropertyFontWeight:
+    case CSSPropertyLineHeight:
+    case CSSPropertyOpacity:
+    case CSSPropertyOutline:
+    case CSSPropertyOutlineColor:
+    case CSSPropertyOutlineOffset:
+    case CSSPropertyOutlineStyle:
+    case CSSPropertyOutlineWidth:
+    case CSSPropertyVisibility:
+    case CSSPropertyWhiteSpace:
+    case CSSPropertyWhiteSpaceCollapse:
+    case CSSPropertyTextCombineUpright:
+    case CSSPropertyTextDecorationLine:
+    case CSSPropertyTextShadow:
+    case CSSPropertyTextWrapMode:
+    case CSSPropertyTextWrapStyle:
+    case CSSPropertyBorderStyle:
+    case CSSPropertyPaintOrder:
+    case CSSPropertyStrokeLinejoin:
+    case CSSPropertyStrokeLinecap:
+    case CSSPropertyStrokeColor:
+    case CSSPropertyStrokeWidth:
+        return true;
+    default:
+        break;
+    }
+    return false;
+}
+#endif
+
+#if ENABLE(VIDEO)
+bool isValidCueSelectorStyleProperty(CSSPropertyID id)
+{
+    switch (id) {
     case CSSPropertyBackground:
     case CSSPropertyBackgroundAttachment:
     case CSSPropertyBackgroundClip:
@@ -144,6 +185,7 @@ bool isValidCueStyleProperty(CSSPropertyID id)
     case CSSPropertyVisibility:
     case CSSPropertyWhiteSpace:
     case CSSPropertyWhiteSpaceCollapse:
+    case CSSPropertyTextCombineUpright:
     case CSSPropertyTextDecorationLine:
     case CSSPropertyTextShadow:
     case CSSPropertyTextWrapMode:
@@ -154,6 +196,27 @@ bool isValidCueStyleProperty(CSSPropertyID id)
     case CSSPropertyStrokeLinecap:
     case CSSPropertyStrokeColor:
     case CSSPropertyStrokeWidth:
+        return true;
+    default:
+        break;
+    }
+    return false;
+}
+
+bool isValidCueBackgroundStyleProperty(CSSPropertyID id)
+{
+    switch (id) {
+    case CSSPropertyBackground:
+    case CSSPropertyBackgroundAttachment:
+    case CSSPropertyBackgroundClip:
+    case CSSPropertyBackgroundColor:
+    case CSSPropertyBackgroundImage:
+    case CSSPropertyBackgroundOrigin:
+    case CSSPropertyBackgroundPosition:
+    case CSSPropertyBackgroundPositionX:
+    case CSSPropertyBackgroundPositionY:
+    case CSSPropertyBackgroundRepeat:
+    case CSSPropertyBackgroundSize:
         return true;
     default:
         break;

--- a/Source/WebCore/style/PropertyAllowlist.h
+++ b/Source/WebCore/style/PropertyAllowlist.h
@@ -36,7 +36,9 @@ enum class PropertyAllowlist : uint8_t {
     None,
     Marker,
 #if ENABLE(VIDEO)
-    Cue
+    Cue,
+    CueSelector,
+    CueBackground,
 #endif
 };
 
@@ -45,6 +47,8 @@ PropertyAllowlist propertyAllowlistForPseudoId(PseudoId);
 bool isValidMarkerStyleProperty(CSSPropertyID);
 #if ENABLE(VIDEO)
 bool isValidCueStyleProperty(CSSPropertyID);
+bool isValidCueSelectorStyleProperty(CSSPropertyID);
+bool isValidCueBackgroundStyleProperty(CSSPropertyID);
 #endif
 
 }

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -211,6 +211,10 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Casca
 #if ENABLE(VIDEO)
             if (propertyAllowlist == PropertyAllowlist::Cue && !isValidCueStyleProperty(propertyID))
                 return false;
+            if (propertyAllowlist == PropertyAllowlist::CueSelector && !isValidCueSelectorStyleProperty(propertyID))
+                return false;
+            if (propertyAllowlist == PropertyAllowlist::CueBackground && !isValidCueBackgroundStyleProperty(propertyID))
+                return false;
 #endif
             if (propertyAllowlist == PropertyAllowlist::Marker && !isValidMarkerStyleProperty(propertyID))
                 return false;

--- a/Source/WebCore/style/RuleData.cpp
+++ b/Source/WebCore/style/RuleData.cpp
@@ -142,8 +142,15 @@ static inline PropertyAllowlist determinePropertyAllowlist(const CSSSelector* se
 {
     for (const CSSSelector* component = selector; component; component = component->tagHistory()) {
 #if ENABLE(VIDEO)
-        if (component->match() == CSSSelector::Match::PseudoElement && (component->pseudoElement() == CSSSelector::PseudoElement::Cue || component->value() == UserAgentParts::cue()))
+        // Property allow-list for `::cue`:
+        if (component->match() == CSSSelector::Match::PseudoElement && component->pseudoElement() == CSSSelector::PseudoElement::UserAgentPart && component->value() == UserAgentParts::cue())
             return PropertyAllowlist::Cue;
+        // Property allow-list for `::cue(selector)`:
+        if (component->match() == CSSSelector::Match::PseudoElement && component->pseudoElement() == CSSSelector::PseudoElement::Cue)
+            return PropertyAllowlist::CueSelector;
+        // Property allow-list for '::-internal-cue-background':
+        if (component->match() == CSSSelector::Match::PseudoElement && component->pseudoElement() == CSSSelector::PseudoElement::UserAgentPart && component->value() == UserAgentParts::internalCueBackground())
+            return PropertyAllowlist::CueBackground;
 #endif
         if (component->match() == CSSSelector::Match::PseudoElement && component->pseudoElement() == CSSSelector::PseudoElement::Marker)
             return propertyAllowlistForPseudoId(PseudoId::Marker);


### PR DESCRIPTION
#### 75cef4fa5fd2155fef875e02a8cee615b78e6af6
<pre>
[WebVTT] Apply ::cue pseudo to the correct WebVTT object (root)
<a href="https://bugs.webkit.org/show_bug.cgi?id=276089">https://bugs.webkit.org/show_bug.cgi?id=276089</a>
<a href="https://rdar.apple.com/130913431">rdar://130913431</a>

Reviewed by Tim Nguyen.

Previously, we applied the ::cue pseudo to the m_cueHighlightBox WebVTT object, in order to
implement the portion of the WebVTT spec where ::cue { background: foo; } applies to the &quot;cue
background box&quot; rather than the &quot;list of WebVTT node objects&quot;. However, this causes other problems,
as it means style in the page cannot override styles applied to the root (i.e., display tree)
WebVTT object.

In order to implement this &quot;exception to CSS styling&quot; for `background:` property, when an incoming
style rule targetting the ident `::cue` selector is added, clone that rule and replace the selector
with a new selector for `[useragentpart=&quot;cue-background&quot;]`, with a separate list of &quot;allowed
properties&quot; containing only `background:`.

Then change all the default styles to be in terms of `::cue` and `[useragentpart=&quot;cue&quot;]`.

* Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css:
([useragentpart=&quot;cue&quot;]):
([useragentpart=&quot;cue&quot;] .hidden):
([useragentpart=&quot;cue&quot;] ruby):
([useragentpart=&quot;cue&quot;] ruby &gt; rt):
(::cue):
(::cue(rt)):
(::cue(i)):
(::cue(b)):
(::cue(u)):
(::-webkit-media-text-track-display): Deleted.
([useragentpart=&quot;-webkit-media-text-track-display&quot;] b): Deleted.
([useragentpart=&quot;-webkit-media-text-track-display&quot;] u): Deleted.
([useragentpart=&quot;-webkit-media-text-track-display&quot;] i): Deleted.
([useragentpart=&quot;-webkit-media-text-track-display&quot;] .hidden): Deleted.
([useragentpart=&quot;-webkit-media-text-track-display&quot;] ruby): Deleted.
([useragentpart=&quot;-webkit-media-text-track-display&quot;] ruby &gt; rt): Deleted.
([useragentpart=&quot;-webkit-media-text-track-display&quot;] ruby &gt; :not(ruby)): Deleted.
* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCue::obtainCSSBoxes):
* Source/WebCore/style/PropertyAllowlist.cpp:
(WebCore::Style::isValidCueStyleProperty):
(WebCore::Style::isValidCueSelectorStyleProperty):
(WebCore::Style::isValidCueBackgroundStyleProperty):
* Source/WebCore/style/PropertyAllowlist.h:
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::addMatch):
* Source/WebCore/style/RuleData.cpp:
(WebCore::Style::determinePropertyAllowlist):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):

Canonical link: <a href="https://commits.webkit.org/282320@main">https://commits.webkit.org/282320@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d370de6d41b9d4ee1149cc1e9b7644ab52b8bc31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/60795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/40154 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/13371 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/64726 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/11342 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/62925 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/47830 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/11617 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/49165 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/7876 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/62829 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/37395 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/52673 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/29996 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/34082 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/9899 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/10255 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/55920 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/10197 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/66455 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/4739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/10026 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/56531 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/4760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/52641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/56726 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/13935 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/3934 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/35959 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/37041 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/38134 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/36786 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->