### PR TITLE
[css-ui-4] Transparent accent colors (275767)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/transparent-accent-color-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/transparent-accent-color-001-expected.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: transparent accent color</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#widget-accent">
+<style>
+
+.container {
+    border: solid orange;
+    padding: 1ch;
+    margin: 1ch;
+    float: left;
+}
+
+input, #extract-canvas { color-scheme: light; }
+#extract-canvas { background-color: canvas; }
+#t3 { background: orange; }
+
+</style>
+
+<p>Test passes if in each box below, you see a pair of identically colored check-boxes.
+
+<div id="extract-canvas"></div>
+<div id=t1 class="container">
+  <input class=test type=checkbox checked>
+  <input class=ref type=checkbox checked>
+</div>
+
+<div id=t2 class="container">
+  <input class=test type=checkbox checked>
+  <input class=ref type=checkbox checked>
+</div>
+
+<div id=t3 class="container">
+  <input class=test type=checkbox checked>
+  <input class=ref type=checkbox checked>
+</div>
+
+<script>
+
+  const testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]];
+
+  function getColorComponents(color) {
+    return color.substring(color.indexOf("(") + 1).replace(/\s/g,"").split(",").map(parseFloat);
+  }
+
+  function constructCSSColor(components) {
+    return (components.length == 4 ? "rgba(" : "rgb(") + components.join(", ") + ")";
+  }
+
+  function computeExpectedColor(canvasColor, colorWithAlpha) {
+    const expected = [];
+    for (let i = 0; i < 3; i++)
+      expected.push(canvasColor[i] - canvasColor[i] * colorWithAlpha[3] + colorWithAlpha[i] * colorWithAlpha[3]);
+    return expected;
+  }
+
+  const canvasColorComponents = getColorComponents(getComputedStyle(document.getElementById("extract-canvas")).backgroundColor);
+  for (const [i, container] of document.querySelectorAll(".container").entries()) {
+    container.getElementsByClassName("test")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents, testColors[i]));
+    container.getElementsByClassName("ref")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents, testColors[i]));
+  }
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/transparent-accent-color-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/transparent-accent-color-001.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: transparent accent color</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#widget-accent">
+<link rel="match" href="reference/transparent-accent-color-001-ref.html">
+<meta name="assert" content="If the color supplied is partially or fully transparent, it is precomposed over the color of the light mode canvas.">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-450">
+<style>
+
+.container {
+    border: solid orange;
+    padding: 1ch;
+    margin: 1ch;
+    float: left;
+}
+
+input, #extract-canvas { color-scheme: light; }
+#extract-canvas { background-color: canvas; }
+#t3 { background: orange; }
+
+</style>
+
+<p>Test passes if in each box below, you see a pair of identically colored check-boxes.
+
+<div id="extract-canvas"></div>
+<div id=t1 class="container">
+  <input class=test type=checkbox checked>
+  <input class=ref type=checkbox checked>
+</div>
+
+<div id=t2 class="container">
+  <input class=test type=checkbox checked>
+  <input class=ref type=checkbox checked>
+</div>
+
+<div id=t3 class="container">
+  <input class=test type=checkbox checked>
+  <input class=ref type=checkbox checked>
+</div>
+
+<script>
+
+  const testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]];
+
+  function getColorComponents(color) {
+    return color.substring(color.indexOf("(") + 1).replace(/\s/g,"").split(",").map(parseFloat);
+  }
+
+  function constructCSSColor(components) {
+    return (components.length == 4 ? "rgba(" : "rgb(") + components.join(", ") + ")";
+  }
+
+  function computeExpectedColor(canvasColor, colorWithAlpha) {
+    const expected = [];
+    for (let i = 0; i < 3; i++)
+      expected.push(canvasColor[i] - canvasColor[i] * colorWithAlpha[3] + colorWithAlpha[i] * colorWithAlpha[3]);
+    return expected;
+  }
+
+  const canvasColorComponents = getColorComponents(getComputedStyle(document.getElementById("extract-canvas")).backgroundColor);
+  for (const [i, container] of document.querySelectorAll(".container").entries()) {
+    container.getElementsByClassName("test")[0].style.accentColor = constructCSSColor(testColors[i]);
+    container.getElementsByClassName("ref")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents, testColors[i]));
+  }
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/transparent-accent-color-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/transparent-accent-color-002-expected.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: transparent accent color</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#widget-accent">
+<style>
+
+.container {
+    border: solid orange;
+    padding: 1ch;
+    margin: 1ch;
+    float: left;
+}
+
+input, #extract-canvas { color-scheme: dark; }
+#extract-canvas { background-color: canvas; }
+#t3 { background: orange; }
+
+</style>
+
+<p>Test passes if in each box below, you see a pair of identically colored check-boxes.
+
+<div id="extract-canvas"></div>
+<div id=t1 class="container">
+  <input class=test type=checkbox checked>
+  <input class=ref type=checkbox checked>
+</div>
+
+<div id=t2 class="container">
+  <input class=test type=checkbox checked>
+  <input class=ref type=checkbox checked>
+</div>
+
+<div id=t3 class="container">
+  <input class=test type=checkbox checked>
+  <input class=ref type=checkbox checked>
+</div>
+
+<script>
+
+  const testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]];
+
+  function getColorComponents(color) {
+    return color.substring(color.indexOf("(") + 1).replace(/\s/g,"").split(",").map(parseFloat);
+  }
+
+  function constructCSSColor(components) {
+    return (components.length == 4 ? "rgba(" : "rgb(") + components.join(", ") + ")";
+  }
+
+  function computeExpectedColor(canvasColor, colorWithAlpha) {
+    const expected = [];
+    for (let i = 0; i < 3; i++)
+      expected.push(canvasColor[i] - canvasColor[i] * colorWithAlpha[3] + colorWithAlpha[i] * colorWithAlpha[3]);
+    return expected;
+  }
+
+  const canvasColorComponents = getColorComponents(getComputedStyle(document.getElementById("extract-canvas")).backgroundColor);
+  for (const [i, container] of document.querySelectorAll(".container").entries()) {
+    container.getElementsByClassName("test")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents, testColors[i]));
+    container.getElementsByClassName("ref")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents, testColors[i]));
+  }
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/transparent-accent-color-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/transparent-accent-color-002.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: transparent accent color</title>
+<link rel="author" title="Florian Rivoal" href="https://florian.rivoal.net">
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#widget-accent">
+<link rel="match" href="reference/transparent-accent-color-002-ref.html">
+<meta name="assert" content="If the color supplied is partially or fully transparent, it is precomposed over the color of the dark mode canvas.">
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-450">
+<style>
+
+.container {
+    border: solid orange;
+    padding: 1ch;
+    margin: 1ch;
+    float: left;
+}
+
+input, #extract-canvas { color-scheme: dark; }
+#extract-canvas { background-color: canvas; }
+#t3 { background: orange; }
+
+</style>
+
+<p>Test passes if in each box below, you see a pair of identically colored check-boxes.
+
+<div id="extract-canvas"></div>
+<div id=t1 class="container">
+  <input class=test type=checkbox checked>
+  <input class=ref type=checkbox checked>
+</div>
+
+<div id=t2 class="container">
+  <input class=test type=checkbox checked>
+  <input class=ref type=checkbox checked>
+</div>
+
+<div id=t3 class="container">
+  <input class=test type=checkbox checked>
+  <input class=ref type=checkbox checked>
+</div>
+
+<script>
+
+  const testColors = [[255,0,0,0], [0,0,255,0.5], [0,0,255,0.5]];
+
+  function getColorComponents(color) {
+    return color.substring(color.indexOf("(") + 1).replace(/\s/g,"").split(",").map(parseFloat);
+  }
+
+  function constructCSSColor(components) {
+    return (components.length == 4 ? "rgba(" : "rgb(") + components.join(", ") + ")";
+  }
+
+  function computeExpectedColor(canvasColor, colorWithAlpha) {
+    const expected = [];
+    for (let i = 0; i < 3; i++)
+      expected.push(canvasColor[i] - canvasColor[i] * colorWithAlpha[3] + colorWithAlpha[i] * colorWithAlpha[3]);
+    return expected;
+  }
+
+  const canvasColorComponents = getColorComponents(getComputedStyle(document.getElementById("extract-canvas")).backgroundColor);
+  for (const [i, container] of document.querySelectorAll(".container").entries()) {
+    container.getElementsByClassName("test")[0].style.accentColor = constructCSSColor(testColors[i]);
+    container.getElementsByClassName("ref")[0].style.accentColor = constructCSSColor(computeExpectedColor(canvasColorComponents, testColors[i]));
+  }
+
+</script>

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -742,7 +742,7 @@ ControlStyle RenderTheme::extractControlStyleForRenderer(const RenderObject& ren
         extractControlStyleStatesForRendererInternal(*renderer),
         renderer->style().computedFontSize(),
         renderer->style().usedZoom(),
-        renderer->style().usedAccentColor(),
+        renderer->style().usedAccentColor(renderObject.styleColorOptions()),
         renderer->style().visitedDependentColorWithColorFilter(CSSPropertyColor),
         renderer->style().borderWidth()
     };
@@ -809,7 +809,7 @@ bool RenderTheme::paint(const RenderBox& box, const PaintInfo& paintInfo, const 
     case StyleAppearance::Button:
     case StyleAppearance::InnerSpinButton: {
         auto states = extractControlStyleStatesForRenderer(box);
-        Theme::singleton().paint(appearance, states, paintInfo.context(), devicePixelSnappedRect, box.useDarkAppearance(), box.style().usedAccentColor());
+        Theme::singleton().paint(appearance, states, paintInfo.context(), devicePixelSnappedRect, box.useDarkAppearance(), box.style().usedAccentColor(box.styleColorOptions()));
         return false;
     }
 #else // !USE(THEME_ADWAITA)

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
@@ -107,7 +107,7 @@ static inline Color getSystemAccentColor()
 static inline Color getAccentColor(const RenderObject& renderObject)
 {
     if (!renderObject.style().hasAutoAccentColor())
-        return renderObject.style().usedAccentColor();
+        return renderObject.style().usedAccentColor(renderObject.styleColorOptions());
 
     return getSystemAccentColor();
 }
@@ -418,7 +418,7 @@ bool RenderThemeAdwaita::paintMenuList(const RenderObject& renderObject, const P
         states.add(ControlStyle::State::Pressed);
     if (isHovered(renderObject))
         states.add(ControlStyle::State::Hovered);
-    Theme::singleton().paint(StyleAppearance::Button, states, graphicsContext, rect, renderObject.useDarkAppearance(), renderObject.style().usedAccentColor());
+    Theme::singleton().paint(StyleAppearance::Button, states, graphicsContext, rect, renderObject.useDarkAppearance(), renderObject.style().usedAccentColor(renderObject.styleColorOptions()));
 
     auto zoomedArrowSize = menuListButtonArrowSize * renderObject.style().usedZoom();
     FloatRect fieldRect = rect;

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -897,7 +897,7 @@ void RenderThemeIOS::adjustButtonLikeControlStyle(RenderStyle& style, const Elem
         return;
 
     if (!style.hasAutoAccentColor()) {
-        auto tintColor = style.usedAccentColor();
+        auto tintColor = style.usedAccentColor(element.document().styleColorOptions(&style));
         if (isSubmitStyleButton(element))
             style.setBackgroundColor(tintColor);
         else
@@ -1234,7 +1234,7 @@ Color RenderThemeIOS::pictureFrameColor(const RenderObject& buttonRenderer)
 Color RenderThemeIOS::controlTintColor(const RenderStyle& style, OptionSet<StyleColorOptions> options) const
 {
     if (!style.hasAutoAccentColor())
-        return style.usedAccentColor();
+        return style.usedAccentColor(options);
 
     return systemColor(CSSValueAppleSystemBlue, options);
 }

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -198,6 +198,7 @@ enum class ScrollSnapStop : bool;
 enum class ScrollbarWidth : uint8_t;
 enum class SpeakAs : uint8_t;
 enum class StyleAppearance : uint8_t;
+enum class StyleColorOptions : uint8_t;
 enum class StyleDifference : uint8_t;
 enum class StyleDifferenceContextSensitiveProperty : uint8_t;
 enum class TableLayoutType : bool;
@@ -2157,7 +2158,7 @@ public:
     inline const StyleColor& floodColor() const;
     inline const StyleColor& lightingColor() const;
 
-    Color usedAccentColor() const;
+    Color usedAccentColor(OptionSet<StyleColorOptions>) const;
     inline const StyleColor& accentColor() const;
     inline bool hasAutoAccentColor() const;
 


### PR DESCRIPTION
#### 65d8059e3250b90b4ed2cce6303d4df55edc2627
<pre>
[css-ui-4] Transparent accent colors (275767)
<a href="https://bugs.webkit.org/show_bug.cgi?id=275767">https://bugs.webkit.org/show_bug.cgi?id=275767</a>
<a href="https://rdar.apple.com/130599744">rdar://130599744</a>

Reviewed by Tim Nguyen and Abrar Rahman Protyasha.

Transparent accent-colors are now precomposed over the canvas to conform to <a href="https://github.com/w3c/csswg-drafts/issues/9852#issuecomment-2166096835.">https://github.com/w3c/csswg-drafts/issues/9852#issuecomment-2166096835.</a> Added transparent-accent-color wpt tests from  <a href="https://github.com/web-platform-tests/wpt/commit/57308167a6128fbf7e2c80d2f5e67321f8c48eff">https://github.com/web-platform-tests/wpt/commit/57308167a6128fbf7e2c80d2f5e67321f8c48eff</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/transparent-accent-color-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/transparent-accent-color-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/transparent-accent-color-002-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/transparent-accent-color-002.html: Added.
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::extractControlStyleForRenderer const):
(WebCore::RenderTheme::paint):
* Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp:
(WebCore::getAccentColor):
(WebCore::RenderThemeAdwaita::paintMenuList):
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::adjustButtonLikeControlStyle const):
(WebCore::RenderThemeIOS::controlTintColor const):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::usedAccentColor const):
* Source/WebCore/rendering/style/RenderStyle.h:

Canonical link: <a href="https://commits.webkit.org/280631@main">https://commits.webkit.org/280631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b63409e3f7bd5aa94c17afb0cada23978a7e3f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/57079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9554 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60699 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7522 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/44031 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46225 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5293 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34184 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49267 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27086 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30965 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6599 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6527 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52919 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6869 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62380 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/992 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6971 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53482 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/996 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49322 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53532 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/memory-pressure (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12635 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/839 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32236 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33321 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34406 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/33067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->