### PR TITLE
String shows incorrectly in open model prompt

### DIFF
--- a/Source/WebCore/en.lproj/Localizable.strings
+++ b/Source/WebCore/en.lproj/Localizable.strings
@@ -175,8 +175,8 @@
 /* Allow button title in speech recognition prompt */
 "Allow (speechrecognition)" = "Allow";
 
-/* Display USDZ file */
-"Allow (usdz QuickLook Preview)" = "Allow (usdz QuickLook Preview)";
+/* Allow displaying QuickLook Preview of 3D model */
+"Allow (usdz QuickLook Preview)" = "Allow";
 
 /* Allow button title in user media prompt */
 "Allow (usermedia)" = "Allow";
@@ -289,8 +289,8 @@
 /* Button title in Device Orientation Permission API prompt */
 "Cancel (device motion and orientation access)" = "Cancel";
 
-/* Cancel USDZ file */
-"Cancel (usdz QuickLook Preview)" = "Cancel (usdz QuickLook Preview)";
+/* Cancel displaying QuickLook Preview of 3D model */
+"Cancel (usdz QuickLook Preview)" = "Cancel";
 
 /* Title for Cancel button label in button bar */
 "Cancel button label in button bar" = "Cancel";
@@ -1102,7 +1102,7 @@
 /* Title for Open in External Application Link action button */
 "Open in “%@”" = "Open in “%@”";
 
-/* Open 3D object in a new window? */
+/* Open this 3D model? */
 "Open this 3D model?" = "Open this 3D model?";
 
 /* context menu item for PDF */

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -443,14 +443,14 @@ void SystemPreviewController::begin(const URL& url, const WebCore::SecurityOrigi
         successHandler(success);
     });
     auto alert = WebKit::createUIAlertController(WEB_UI_NSSTRING(@"Open this 3D model?", "Open this 3D model?"), nil);
-    UIAlertAction* allowAction = [UIAlertAction actionWithTitle:WEB_UI_NSSTRING(@"Allow (usdz QuickLook Preview)", "Allow") style:UIAlertActionStyleDefault handler:[weakThis = WeakPtr { *this }](UIAlertAction *) mutable {
+    UIAlertAction* allowAction = [UIAlertAction actionWithTitle:WEB_UI_NSSTRING_KEY(@"Allow", @"Allow (usdz QuickLook Preview)", "Allow displaying QuickLook Preview of 3D model") style:UIAlertActionStyleDefault handler:[weakThis = WeakPtr { *this }](UIAlertAction *) mutable {
         if (!weakThis)
             return;
 
         std::exchange(weakThis->m_allowPreviewCallback, nullptr)(true);
     }];
 
-    UIAlertAction* doNotAllowAction = [UIAlertAction actionWithTitle:WEB_UI_NSSTRING(@"Cancel (usdz QuickLook Preview)", "Cancel") style:UIAlertActionStyleCancel handler:[weakThis = WeakPtr { *this }](UIAlertAction *) mutable {
+    UIAlertAction* doNotAllowAction = [UIAlertAction actionWithTitle:WEB_UI_NSSTRING_KEY(@"Cancel", @"Cancel (usdz QuickLook Preview)", "Cancel displaying QuickLook Preview of 3D model") style:UIAlertActionStyleCancel handler:[weakThis = WeakPtr { *this }](UIAlertAction *) mutable {
         if (!weakThis)
             return;
 


### PR DESCRIPTION
#### 5164703263d13baeb378f4d041fd8209569ae176
<pre>
String shows incorrectly in open model prompt
<a href="https://bugs.webkit.org/show_bug.cgi?id=276094">https://bugs.webkit.org/show_bug.cgi?id=276094</a>
&lt;radar://130919961&gt;

Reviewed by Jer Noble.

278998@main should have used WEB_UI_NSSTRING_KEY instead of WEB_UI_NSSTRING
otherwise the string in Localizable.strings could get inintentionally overwritten
by running update-webkit-localizable-strings as seen in 280128@main.

* Source/WebCore/en.lproj/Localizable.strings:
* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:

Canonical link: <a href="https://commits.webkit.org/280583@main">https://commits.webkit.org/280583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd927af0c263e8476da4e289b7aff477e7a22aa9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60580 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7403 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59088 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7593 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/46128 "Passed tests") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5197 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34077 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49157 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26987 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30857 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6488 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6408 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/52820 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6759 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62261 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/873 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6864 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53385 "Found 2 new test failures: imported/w3c/web-platform-tests/fetch/private-network-access/fetch.https.window.html imported/w3c/web-platform-tests/server-timing/server_timing_header-parsing.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/876 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49212 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53427 "Found 2 new API test failures: /WebKitGTK/TestWebKitAccessibility:/webkit/WebKitAccessibility/text/state-changed, /WebKitGTK/TestInspectorServer:/webkit/WebKitWebInspectorServer/http-test-page-list (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12612 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/737 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32117 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33202 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/34287 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32948 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->