### PR TITLE
[WPE][cross-toolchain-helper] Fix issue with the icu installation and long paths

### DIFF
--- a/Tools/yocto/meta-openembedded_and_meta-webkit.patch
+++ b/Tools/yocto/meta-openembedded_and_meta-webkit.patch
@@ -39,3 +39,91 @@ index 9459f4c..e74a20c 100644
      gdk-pixbuf-xlib \
      liberation-fonts \
      atk \
+diff --git a/sources/poky/meta/recipes-support/icu/icu/ICU-22813_rise_buffer_sizes_pkgdata_PR3058.patch b/sources/poky/meta/recipes-support/icu/icu/ICU-22813_rise_buffer_sizes_pkgdata_PR3058.patch
+new file mode 100644
+index 0000000..21bc060
+--- /dev/null
++++ b/sources/poky/meta/recipes-support/icu/icu/ICU-22813_rise_buffer_sizes_pkgdata_PR3058.patch
+@@ -0,0 +1,70 @@
++From db70adaddcfa8050db6a69cdfef080a7f1423ad7 Mon Sep 17 00:00:00 2001
++From: Carlos Alberto Lopez Perez <clopez@igalia.com>
++Date: Mon, 1 Jul 2024 22:15:18 +0100
++Subject: [PATCH] ICU-22813 Rise the size of the buffers used for the command
++ strings at pkgdata
++
++The tool pkgdata uses snprintf() to build the strings of the commands that
++will execute later during the install process. But the maximum size of this
++buffers is not enough when there is a long path.
++
++This has caused issues on some CI systems that use very long paths, causing
++the install process to produce a wrong result.
++
++The maximum path on Linux is 4096 (defined as PATH_MAX at <linux/limits.h>)
++So the size of SMALL_BUFFER_MAX_SIZE should be 4096 to avoid errors related
++to truncated paths.
++
++Upstream-Status: Submitted [https://github.com/unicode-org/icu/pull/3058]
++---
++ tools/pkgdata/pkgdata.cpp | 6 +++---
++ tools/toolutil/pkg_genc.h | 5 ++---
++ 2 files changed, 5 insertions(+), 6 deletions(-)
++
++diff --git a/tools/pkgdata/pkgdata.cpp b/tools/pkgdata/pkgdata.cpp
++index c2ac112..8d08c85 100644
++--- a/tools/pkgdata/pkgdata.cpp
+++++ b/tools/pkgdata/pkgdata.cpp
++@@ -1134,7 +1134,7 @@ static int32_t pkg_createSymLinks(const char *targetDir, UBool specialHandling)
++ 
++ static int32_t pkg_installLibrary(const char *installDir, const char *targetDir, UBool noVersion) {
++     int32_t result = 0;
++-    char cmd[SMALL_BUFFER_MAX_SIZE];
+++    char cmd[LARGE_BUFFER_MAX_SIZE];
++ 
++     auto ret = snprintf(cmd,
++             sizeof(cmd),
++@@ -1205,7 +1205,7 @@ static int32_t pkg_installLibrary(const char *installDir, const char *targetDir,
++ 
++ static int32_t pkg_installCommonMode(const char *installDir, const char *fileName) {
++     int32_t result = 0;
++-    char cmd[SMALL_BUFFER_MAX_SIZE] = "";
+++    char cmd[LARGE_BUFFER_MAX_SIZE] = "";
++ 
++     if (!T_FileStream_file_exists(installDir)) {
++         UErrorCode status = U_ZERO_ERROR;
++@@ -1237,7 +1237,7 @@ static int32_t pkg_installCommonMode(const char *installDir, const char *fileNam
++ #endif
++ static int32_t pkg_installFileMode(const char *installDir, const char *srcDir, const char *fileListName) {
++     int32_t result = 0;
++-    char cmd[SMALL_BUFFER_MAX_SIZE] = "";
+++    char cmd[LARGE_BUFFER_MAX_SIZE] = "";
++ 
++     if (!T_FileStream_file_exists(installDir)) {
++         UErrorCode status = U_ZERO_ERROR;
++diff --git a/tools/toolutil/pkg_genc.h b/tools/toolutil/pkg_genc.h
++index 2dd1b45..f811fe5 100644
++--- a/tools/toolutil/pkg_genc.h
+++++ b/tools/toolutil/pkg_genc.h
++@@ -59,9 +59,8 @@
++ #define PKGDATA_FILE_SEP_STRING U_FILE_SEP_STRING
++ #endif
++ 
++-#define LARGE_BUFFER_MAX_SIZE 2048
++-#define SMALL_BUFFER_MAX_SIZE 512
++-#define SMALL_BUFFER_FLAG_NAMES 32
+++#define LARGE_BUFFER_MAX_SIZE 16384
+++#define SMALL_BUFFER_MAX_SIZE 4096
++ #define BUFFER_PADDING_SIZE 20
++ 
++ /** End platform defines **/
+diff --git a/sources/poky/meta/recipes-support/icu/icu_74-2.bb b/sources/poky/meta/recipes-support/icu/icu_74-2.bb
+index 8352bf2..c81cfe9 100644
+--- a/sources/poky/meta/recipes-support/icu/icu_74-2.bb
++++ b/sources/poky/meta/recipes-support/icu/icu_74-2.bb
+@@ -106,6 +106,7 @@ SRC_URI = "${BASE_SRC_URI};name=code \
+            file://filter.json \
+            file://fix-install-manx.patch \
+            file://0001-icu-Added-armeb-support.patch \
++           file://ICU-22813_rise_buffer_sizes_pkgdata_PR3058.patch \
+            "
+ 
+ SRC_URI:append:class-target = "\


### PR DESCRIPTION
#### 745d34f6850a4932596574036359e6aa5a8189cc
<pre>
[WPE][cross-toolchain-helper] Fix issue with the icu installation and long paths
<a href="https://bugs.webkit.org/show_bug.cgi?id=276098">https://bugs.webkit.org/show_bug.cgi?id=276098</a>

Unreviewed follow-up build-fix after 280438@main

There is a bug icu that causes libicu to be installed incorrectly when the build
system uses long paths (around 500 or more chars).
This caused that nodejs couldn&apos;t run properly on the bots because icu was unproperly
installed, making the Chromium build fail (which we try to build since 280438@main)

* Tools/yocto/meta-openembedded_and_meta-webkit.patch:

Canonical link: <a href="https://commits.webkit.org/280556@main">https://commits.webkit.org/280556@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3165551cf5f4f4d69ad9a89a00cba29e5062be0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56965 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60585 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7408 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/59093 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7598 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/46132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5204 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/58995 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34081 "Exiting early after 10 failures. 20 tests run. 1 failures") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/49162 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/26992 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/30861 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6493 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6413 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/6764 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62266 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/878 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/62/builds/6870 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/53390 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/881 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49217 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/53431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/743 "Passed tests") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/8483 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32122 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33207 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/34292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32953 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->