### PR TITLE
[iOS] Several editing-related layout tests are flaky on x86_64 simulator

### DIFF
--- a/LayoutTests/editing/selection/ios/change-selection-by-tapping.html
+++ b/LayoutTests/editing/selection/ios/change-selection-by-tapping.html
@@ -49,7 +49,7 @@ addEventListener("load", async () => {
 </script>
 </head>
 <body>
-<p contenteditable id="editor">Here's to the crazy ones, the misfits, the rebels, the trouble makers, the round pegs in the square holes, the ones who see things differently. There not fond of rules, and they have no respect for the status quo, you can quote then, disagree with them, glorify or vilify them, about the only thing you can't do is ignore them.  Because they change things. They push the human race forward. And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world are the ones who do.</p>
+<p contenteditable spellcheck="false" id="editor">Here's to the crazy ones, the misfits, the rebels, the trouble makers, the round pegs in the square holes, the ones who see things differently. There not fond of rules, and they have no respect for the status quo, you can quote then, disagree with them, glorify or vilify them, about the only thing you can't do is ignore them.  Because they change things. They push the human race forward. And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world are the ones who do.</p>
     <p id="description"></p>
     <p id="console"></p>
 </body>

--- a/LayoutTests/fast/events/ios/key-command-delete-to-end-of-paragraph.html
+++ b/LayoutTests/fast/events/ios/key-command-delete-to-end-of-paragraph.html
@@ -20,7 +20,7 @@
 <p id="description"></p>
 <p id="manual-instructions" class="hide">To run this test by hand, place the text insertion point before the 'h' in the text below and press Control + k.</p>
 <div id="console"></div>
-<div id="test" contenteditable="true">ah</div>
+<div id="test" contenteditable="true" spellcheck="false">ah</div>
 <script>
 window.jsTestIsAsync = true;
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -2766,6 +2766,9 @@ bool WebPage::applyAutocorrectionInternal(const String& correction, const String
     if (!frame->selection().isCaretOrRange())
         return false;
 
+    if (correction == originalText)
+        return false;
+
     std::optional<SimpleRange> range;
     String textForRange;
     auto originalTextWithFoldedQuoteMarks = foldQuoteMarks(originalText);


### PR DESCRIPTION
#### 868193b30419dc7d9692914ca3f8f30a7f66d16e
<pre>
[iOS] Several editing-related layout tests are flaky on x86_64 simulator
<a href="https://bugs.webkit.org/show_bug.cgi?id=276101">https://bugs.webkit.org/show_bug.cgi?id=276101</a>
<a href="https://rdar.apple.com/130607129">rdar://130607129</a>

Reviewed by Megan Gardner.

For reasons that are still unknown, keyboard autocorrection triggers very aggressively on selection
changes when both of the following conditions are true:

1. Running tests in iOS simulator on an Intel (x86_64) host machine.
2. The iOS simulator was newly created (e.g. using `xcrun simctl create`).

This causes the following two tests to fail…

• editing/selection/ios/change-selection-by-tapping.html

    This test fails because `can&apos;t` is autocorrected to `can’t` (with an apostrophe instead of a
    straight quote), leading to a text diff.

• editing/selection/ios/show-grammar-replacements-on-tap.html

    This test fails because `thing` is &quot;autocorrected&quot; to `thing` immediately upon tapping to change
    the selection, which triggers an editing command that clears the grammar markers underneath the
    word.

• fast/events/ios/key-command-delete-to-end-of-paragraph.html

    It&apos;s actually unclear why this test is failing, due to the fact that I was unable to reproduce
    this at all in any configuration.

Keep these tests passing by making a couple of minor adjustments:

* LayoutTests/editing/selection/ios/change-selection-by-tapping.html:
* LayoutTests/fast/events/ios/key-command-delete-to-end-of-paragraph.html:

Force `spellcheck=&quot;false&quot;` here to prevent correction from triggering when simulating selection
changes.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::applyAutocorrectionInternal):

Return early if the original and new strings are identical, to prevent editing commands from
triggering (which blow away the grammar markers in `show-grammar-replacements-on-tap.html`).

Canonical link: <a href="https://commits.webkit.org/280560@main">https://commits.webkit.org/280560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e4d82b7d1c4be4491368fc001dcca77f779356b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/56977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/36305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/9452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/60597 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/59/builds/7420 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/43928 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/61/builds/7610 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/46143 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wincairo-tests](https://ews-build.webkit.org/#/builders/60/builds/5211 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/59007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/34092 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/49178 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/27003 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/56503 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/42/builds/30872 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/6509 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/6425 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/52829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/6780 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/62278 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/87/builds/890 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/62/builds/6883 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/53400 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/86/builds/893 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/49233 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/53437 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/12593 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/88/builds/748 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/32134 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/33219 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/43/builds/34304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/32965 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->